### PR TITLE
[codex] docs: define structured output evaluation contract

### DIFF
--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -429,32 +429,49 @@ be materialized into a Melix evaluation dataset package before execution.
 The authoritative runtime contract is the materialized evaluation package rather than any external
 source schema.
 
-### Planned Structured Output Evaluation Profile
+### Evaluation Profiles
 
-This section defines the planned long-term contract for structured-output evaluation. It is not yet
-implemented by the current Melix runtime.
+This section defines the planned long-term evaluation profile contract. It is not yet implemented
+by the current Melix runtime.
 
-Structured-output evaluation packages use sample rows with these fields:
+Every evaluation dataset package declares its evaluation profile in `manifest.json`. The declared
+`profile_type` determines the sample shape, parsing rules, and scoring semantics for that package.
+
+Three profile types are defined:
+
+#### `structured_output` Profile
+
+Used for LoRA workflows that train models to emit schema-constrained JSON output.
+
+Sample rows use these fields:
 
 - `system`
 - `input`
 - `target`
 
-Structured-output package manifests must declare an evaluation profile that includes:
+`target` must be valid JSON whose root type matches the root type declared in the package
+`output_schema`. The profile must declare:
 
 - an output-schema reference or inline schema
-- scoring semantics
+- a `parser_mode`
+- a comparison policy
 - a correctness threshold
 - optional ignored field paths
 
-Structured-output requirements are:
+`parser_mode` controls how the parser interprets the model response:
 
-- `target` must be a JSON object
-- the parser must yield exactly one JSON object
-- wrapped prose before or after JSON is a parse failure
-- multiple JSON values are a parse failure
-- non-object JSON payloads are a parse failure
-- schema validation must succeed before field-level scoring begins
+- `strict`: the response must contain exactly one JSON value and no surrounding prose; any prose
+  before or after the JSON value is a parse failure; multiple JSON values are a parse failure
+- `extract`: the parser extracts the last valid JSON value from the response; prose before or after
+  the JSON value is permitted; this mode supports workflows where the model reasons before emitting
+  the structured result
+
+The accepted root type is determined by the `output_schema` root type declaration, not hardcoded
+to object. A schema with root `{type: "object"}` accepts only JSON objects. A schema with root
+`{type: "array"}` accepts only JSON arrays. In both modes, the parsed value must match the
+declared root type or the parse is a failure.
+
+Schema validation must succeed before field-level scoring begins.
 
 The default ignored field set for structured-output scoring is:
 
@@ -463,12 +480,47 @@ The default ignored field set for structured-output scoring is:
 - `closeness_logits`
 - `closeness_probs`
 
-The long-term structured-output contract does not retain a compatibility path for legacy
-`prompt`/`expected` sample rows.
+Manifest-declared `ignored_paths` extend the default ignored field set. They do not override it.
 
-Current repository fixtures for existing suites still largely use legacy `prompt`/`expected`
-shapes. Those rows are historical fixture formats for the current implementation rather than the
-long-term structured-output evaluation contract.
+#### `text_generation` Profile
+
+Used for standard benchmark suites and LoRA workflows evaluated against reference answers.
+
+Sample rows use these fields:
+
+- `prompt`
+- `expected`
+
+The profile must declare a `scoring_mode`. Supported values are:
+
+- `multiple_choice_accuracy`
+- `exact_match`
+- `numeric_match`
+- `code_exec`
+
+This is a permanent long-term evaluation path. Packages using `prompt` and `expected` sample rows
+with a declared `text_generation` profile are not subject to migration to the `structured_output`
+profile.
+
+#### `format_compliance` Profile
+
+Used for early-stage LoRA evaluation where ground-truth targets are not yet available. Measures
+format adherence without correctness scoring.
+
+Sample rows use these fields:
+
+- `system`
+- `input`
+
+No `target` field is required. The profile must declare a `format` value:
+
+- `json_object`: response must parse as a JSON object
+- `json_array`: response must parse as a JSON array
+- `json_any`: response must parse as any JSON value
+- `json_schema`: response must parse and validate against the declared `output_schema`
+
+Output metrics are `parse_success_rate` and `schema_valid_rate`. There are no `correct` or
+`incorrect` sample counts for this profile type.
 
 ### Evaluation Summary Outputs
 

--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -414,6 +414,62 @@ The first canonical `eval` suite set is:
 Multimodal evaluation datasets must package media alongside `manifest.json` and `samples.jsonl`.
 Relative media references are resolved against `dataset_root`.
 
+### Evaluation Dataset Contract
+
+Melix evaluation executes only against repository-owned evaluation dataset packages.
+
+Every execution package must provide:
+
+- `manifest.json`
+- `samples.jsonl`
+
+External datasets, including Hugging Face datasets, may be reused as source inputs, but they must
+be materialized into a Melix evaluation dataset package before execution.
+
+The authoritative runtime contract is the materialized evaluation package rather than any external
+source schema.
+
+### Planned Structured Output Evaluation Profile
+
+This section defines the planned long-term contract for structured-output evaluation. It is not yet
+implemented by the current Melix runtime.
+
+Structured-output evaluation packages use sample rows with these fields:
+
+- `system`
+- `input`
+- `target`
+
+Structured-output package manifests must declare an evaluation profile that includes:
+
+- an output-schema reference or inline schema
+- scoring semantics
+- a correctness threshold
+- optional ignored field paths
+
+Structured-output requirements are:
+
+- `target` must be a JSON object
+- the parser must yield exactly one JSON object
+- wrapped prose before or after JSON is a parse failure
+- multiple JSON values are a parse failure
+- non-object JSON payloads are a parse failure
+- schema validation must succeed before field-level scoring begins
+
+The default ignored field set for structured-output scoring is:
+
+- `evidence`
+- `confidence`
+- `closeness_logits`
+- `closeness_probs`
+
+The long-term structured-output contract does not retain a compatibility path for legacy
+`prompt`/`expected` sample rows.
+
+Current repository fixtures for existing suites still largely use legacy `prompt`/`expected`
+shapes. Those rows are historical fixture formats for the current implementation rather than the
+long-term structured-output evaluation contract.
+
 ### Evaluation Summary Outputs
 
 Each completed suite result must include:

--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -429,51 +429,59 @@ be materialized into a Melix evaluation dataset package before execution.
 The authoritative runtime contract is the materialized evaluation package rather than any external
 source schema.
 
-### Evaluation Profiles
+### Planned Final-Result Evaluation Profile
 
-This section defines the planned long-term evaluation profile contract. It is not yet implemented
-by the current Melix runtime.
+This section defines the planned long-term contract for final-result evaluation. It is not yet
+implemented by the current Melix runtime.
 
-Every evaluation dataset package declares its evaluation profile in `manifest.json`. The declared
-`profile_type` determines the sample shape, parsing rules, and scoring semantics for that package.
+Every future-oriented evaluation dataset package is expected to declare a single evaluation profile
+in `manifest.json` with these core fields:
 
-Three profile types are defined:
+- `profile_type: final_result`
+- `result_kind: json | text`
+- `extraction_mode: strict_full_response | heuristic_final`
+- `scoring_mode`
+- `threshold`
 
-#### `structured_output` Profile
-
-Used for LoRA workflows that train models to emit schema-constrained JSON output.
-
-Sample rows use these fields:
+Future `final_result` sample rows use these fields:
 
 - `system`
 - `input`
 - `target`
 
-`target` must be valid JSON whose root type matches the root type declared in the package
-`output_schema`. The profile must declare:
+The future Melix execution contract remains the materialized evaluation package rather than any
+external dataset schema.
 
-- an output-schema reference or inline schema
-- a `parser_mode`
-- a comparison policy
-- a correctness threshold
-- optional ignored field paths
+#### Final-Result Principles
 
-`parser_mode` controls how the parser interprets the model response:
+The `final_result` profile is the planned abstraction for future structured and non-structured LoRA
+evaluation.
 
-- `strict`: the response must contain exactly one JSON value and no surrounding prose; any prose
-  before or after the JSON value is a parse failure; multiple JSON values are a parse failure
-- `extract`: the parser extracts the last valid JSON value from the response; prose before or after
-  the JSON value is permitted; this mode supports workflows where the model reasons before emitting
-  the structured result
+Its contract is intentionally narrow:
 
-The accepted root type is determined by the `output_schema` root type declaration, not hardcoded
-to object. A schema with root `{type: "object"}` accepts only JSON objects. A schema with root
-`{type: "array"}` accepts only JSON arrays. In both modes, the parsed value must match the
-declared root type or the parse is a failure.
+- only the extracted final result is scored
+- `raw_response` is retained for debugging, not correctness scoring
+- CoT or other wrapper text may appear in `raw_response`, but it is not itself evaluation evidence
+- v1 covers ground-truth evaluation only; no-target or format-only evaluation is deferred
+- task names such as `extraction`, `relationship`, and `summarization` remain suite metadata rather
+  than scorer dispatch keys
 
-Schema validation must succeed before field-level scoring begins.
+#### Result Kinds
 
-The default ignored field set for structured-output scoring is:
+The planned v1 `result_kind` set is:
+
+- `json`
+- `text`
+
+For `result_kind: json`:
+
+- `target` must be valid JSON with root type `object` or `array`
+- `output_schema` defines the accepted JSON root type and schema rules
+- schema validation is required before scoring begins
+- object roots are expected to support field-level comparison in v1
+- array roots are expected to use conservative scoring in v1 rather than broad task-specific logic
+
+The default ignored field set for JSON object scoring is:
 
 - `evidence`
 - `confidence`
@@ -482,47 +490,68 @@ The default ignored field set for structured-output scoring is:
 
 Manifest-declared `ignored_paths` extend the default ignored field set. They do not override it.
 
-#### `text_generation` Profile
+For `result_kind: text`:
 
-Used for standard benchmark suites and LoRA workflows evaluated against reference answers.
+- `target` is the expected final text result after normalization
+- v1 scoring is limited to stable text comparisons such as normalized exact match, label match, and
+  regex match
+- open-ended task-specific text scorers are out of scope for this contract
 
-Sample rows use these fields:
+#### Extraction Modes
 
-- `prompt`
-- `expected`
+The runtime owns final-result extraction. Package-specific custom extractors are not part of the v1
+contract.
 
-The profile must declare a `scoring_mode`. Supported values are:
+`extraction_mode` defines how Melix isolates the final result from `raw_response`:
 
-- `multiple_choice_accuracy`
-- `exact_match`
-- `numeric_match`
-- `code_exec`
+- `strict_full_response`: the full response must be the final result payload; wrapper prose causes
+  extraction failure
+- `heuristic_final`: Melix applies a shared runtime extractor ladder to locate the final result in a
+  response that may include CoT or other wrapper text
 
-This is a permanent long-term evaluation path. Packages using `prompt` and `expected` sample rows
-with a declared `text_generation` profile are not subject to migration to the `structured_output`
-profile.
+`heuristic_final` must be deterministic and reproducible. Ambiguous extraction is a failure rather
+than a guess.
 
-#### `format_compliance` Profile
+For `result_kind: json`, the planned shared extractor ladder is:
 
-Used for early-stage LoRA evaluation where ground-truth targets are not yet available. Measures
-format adherence without correctness scoring.
+- prefer the last contentful fenced `json` block
+- otherwise use the last contentful fenced block whose contents parse as JSON
+- otherwise use the last terminal balanced JSON suffix
+- if multiple same-priority candidates remain, record `ambiguous_extraction`
 
-Sample rows use these fields:
+For `result_kind: text`, the planned shared extractor ladder is:
 
-- `system`
-- `input`
+- prefer the last terminal `Final answer:` or `Answer:` span
+- otherwise use the last contentful fenced text block
+- otherwise use the last terminal non-empty line or paragraph
+- if multiple same-priority candidates remain, record `ambiguous_extraction`
 
-No `target` field is required. The profile must declare a `format` value:
+The current PR direction of describing extraction as "last valid JSON value" is not stable enough
+for the long-term contract because it is JSON-specific and under-specifies ambiguity handling.
 
-- `json_object`: response must parse as a JSON object
-- `json_array`: response must parse as a JSON array
-- `json_any`: response must parse as any JSON value
-- `json_schema`: response must parse and validate against the declared `output_schema`
+#### Scoring Model
 
-Output metrics are `parse_success_rate` and `schema_valid_rate`. There are no `correct` or
-`incorrect` sample counts for this profile type.
+The planned execution pipeline is:
+
+- capture `raw_response`
+- extract `extracted_result`
+- validate the extracted result for its declared `result_kind`
+- normalize as required by `scoring_mode`
+- score only the extracted result against `target`
+
+In the future `final_result` path, correctness is computed from `extracted_result` rather than the
+full response text.
+
+Current repository fixtures still largely use `prompt` and `expected` sample rows. Those are
+current-state implementation formats rather than the planned long-term `final_result` contract.
 
 ### Evaluation Summary Outputs
+
+The fields below describe the current shipped summary and sample export contract. The future
+`final_result` path is expected to extend this output surface with extraction- and
+validation-oriented evidence such as `extracted_result`, `extraction_status`, `validation_status`,
+`failure_reason`, `extraction_success_count`, and `validation_success_count`. Those additions are
+planning direction only and are not implemented by the current runtime.
 
 Each completed suite result must include:
 

--- a/docs/plans/2026-04-13-structured-output-evaluation-roadmap.md
+++ b/docs/plans/2026-04-13-structured-output-evaluation-roadmap.md
@@ -1,68 +1,56 @@
-# Structured Output Evaluation Roadmap
+# Final Result Evaluation Roadmap
 
 ## Summary
 
-Melix should add structured-output evaluation as a first-class intelligence measurement path for
-LoRA workflows that target machine-readable JSON output, while also formally designating the
-existing text-generation path as a permanent long-term profile and adding a format-compliance
-profile for early-stage evaluation without ground truth.
+Melix should add final-result evaluation as the future intelligence measurement path for LoRA
+workflows. The runtime should score only the extracted final result, not CoT or wrapper text.
 
 The roadmap keeps the runtime boundary package-based, treats external corpora as source datasets
-rather than executable contracts, and stages the work so the contract lands before parser or scorer
-implementation.
+rather than executable contracts, and stages the work so the contract lands before extractor,
+validator, or scorer implementation.
 
 This roadmap describes future milestones only. It does not claim current implementation support.
 
-## Milestone 1: Contract And Package Profile
+## Milestone 1: Final-Result Contract
 
 ### Outcome
 
-Melix has a documented evaluation profile contract that covers three profile types with stable
-package shapes and vocabulary.
+Melix has a documented future evaluation contract centered on `final_result` packages rather than
+profile splits by task style.
 
 ### Scope
 
-- define three `profile_type` values: `structured_output`, `text_generation`, and
-  `format_compliance`
-- define the `structured_output` sample shape as `system`, `input`, and `target`
-- define `target` as valid JSON whose root type matches the declared `output_schema` root type
-- define `parser_mode` as a `structured_output` profile attribute with values `strict` and
-  `extract`
-- define `strict` parsing: exactly one JSON value, no surrounding prose
-- define `extract` parsing: last valid JSON value extracted from response, prose tolerated
-- define `text_generation` as a permanent long-term profile with `prompt` and `expected` sample
-  rows and a declared `scoring_mode`
-- define `format_compliance` as a profile with `system` and `input` sample rows, no `target`, and
-  `parse_success_rate` and `schema_valid_rate` as output metrics
-- define that `ignored_paths` in the manifest extend the default ignored set rather than override
-  it
-- define the no-forced-migration rule: existing `prompt` and `expected` packages belong to
-  `text_generation` and are not subject to migration
+- define `profile_type: final_result`
+- define `result_kind` as `json | text`
+- define `extraction_mode` as `strict_full_response | heuristic_final`
+- define the sample shape as `system`, `input`, and `target`
+- define that only the extracted final result is scored
+- define that CoT is retained only as `raw_response` for debugging
+- define v1 as ground-truth only
 
 ### Exit Criteria
 
-- the canonical contract describes all three profile types with their sample shapes and scoring
-  semantics
+- the canonical contract describes the `final_result` abstraction and its core manifest fields
 - the contract explicitly separates `source dataset` from `materialized evaluation package`
-- `parser_mode` vocabulary is consistent between the contract and the design spec
-- `profile_type` naming is consistent across all documents
+- the contract explicitly states that CoT and wrapper text are not correctness evidence
+- the contract does not treat no-target or format-only evaluation as part of v1
 
 ### Risks
 
-- over-documenting implementation detail before scorer design is stable
-- `extract` mode semantics may need refinement once the JSON-in-prose extractor is implemented
+- over-documenting extraction details before scorer design is stable
+- mixing current implementation formats with future contract language
 
 ## Milestone 2: Dataset Materialization
 
 ### Outcome
 
-Melix can reuse external structured corpora, including Hugging Face datasets, by materializing them
-into repository-owned evaluation packages before execution.
+Melix can reuse external corpora, including Hugging Face datasets, by materializing them into
+repository-owned evaluation packages before execution.
 
 ### Scope
 
 - define importer and materializer responsibilities
-- define how profile metadata is attached to materialized packages
+- define how `final_result` profile metadata is attached to materialized packages
 - define failure behavior for incompatible source schemas
 - preserve the rule that worker execution consumes only Melix evaluation packages
 
@@ -74,67 +62,63 @@ into repository-owned evaluation packages before execution.
 
 ### Risks
 
-- source datasets may omit fields required by structured-output scoring
+- source datasets may omit fields required by typed scoring
 - profile metadata may drift if materialization is underspecified
 
-## Milestone 3: Structured Evaluation Core
+## Milestone 3: Extraction And Validation Core
 
 ### Outcome
 
-Melix has one generic runtime core for structured-output evaluation rather than task-specific scorer
-branches, with parser mode selection controlled by the declared profile.
+Melix has one generic runtime core that extracts, validates, and normalizes final results before
+scoring.
 
 ### Scope
 
-- `strict` parser: exactly one JSON value, parse failure on surrounding prose
-- `extract` parser: last valid JSON value extracted from response, prose tolerated
-- JSON root type validation against `output_schema` root type declaration
-- schema validation gate
-- profile-driven field comparison primitives
-- default ignored-path handling with manifest extension support
-- correctness threshold handling
-- `format_compliance` profile runner: parse and optionally schema-validate, emit
-  `parse_success_rate` and `schema_valid_rate`
+- implement the shared extractor ladder for `heuristic_final`
+- implement ambiguity detection and extraction failure handling
+- implement `strict_full_response`
+- implement JSON schema gating for `result_kind: json`
+- implement text normalization gates for `result_kind: text`
+- keep validation and extraction behavior runtime-owned rather than package-customized
 
 ### Exit Criteria
 
-- worker execution semantics are described in profile-driven terms rather than suite-specific terms
-- schema validity and field score are the primary `structured_output` evidence model
-- `text_generation` packages continue to execute through the existing scorer without modification
-- `format_compliance` packages execute and produce format metrics without requiring a `target` field
-- the design leaves room for new profiles without redefining the public evaluation surface
+- worker execution semantics are described in terms of extraction and validation rather than task
+  names
+- JSON and text result kinds both have deterministic extraction rules
+- ambiguity is treated as failure rather than guessed resolution
+- validation runs before scoring for both result kinds
 
 ### Risks
 
-- `extract` mode JSON extraction heuristics may require iteration before they generalize across
-  different model output styles
-- generic comparison primitives may be too weak for some tasks
-- too many early special cases would collapse the abstraction back into task-specific scoring
+- heuristic extraction may need iteration before it generalizes across model output styles
+- text extraction rules may be noisier than JSON extraction rules
 
-## Milestone 4: Compare And Reporting
+## Milestone 4: Typed Scoring And Compare
 
 ### Outcome
 
-Melix compare workflows can measure structured-output LoRA deltas using schema-valid and field-score
-evidence instead of binary proxy scores alone.
+Melix compare workflows can measure LoRA deltas through extraction, validation, and typed scoring
+rather than binary proxy scores alone.
 
 ### Scope
 
-- compare semantics for base versus derived models
-- schema-valid rate reporting
-- field-score delta reporting
-- regression counting for structured-output workflows
-- sample-level diagnostics for parse and schema failures
+- implement JSON object field scoring
+- implement conservative JSON array scoring
+- implement normalized text scoring for exact, label, and regex match modes
+- report extraction success, validation success, and typed score in compare outputs
+- report regression counts with extraction and validation failures separated from score regressions
 
 ### Exit Criteria
 
-- compare is documented in terms of schema-valid and field-score evidence
-- reporting semantics distinguish parsing failures from low-quality but schema-valid outputs
-- LoRA comparison claims are grounded in the structured-output evidence model rather than MCQ or
-  exact-match proxies
+- compare is documented in terms of extraction success, validation success, and typed score
+- v1 does not introduce task-specific scorer branches
+- v1 does not score CoT or wrapper text
+- reporting semantics distinguish extraction failure, validation failure, and low-quality but valid
+  outputs
 
 ### Risks
 
-- compare summaries may over-simplify structured-output quality if diagnostics are too thin
-- operator expectations may drift if proxy metrics and structured-output metrics coexist without
+- compare summaries may over-simplify quality if extraction and validation diagnostics are too thin
+- operator expectations may drift if current proxy metrics and future typed metrics coexist without
   clear labeling

--- a/docs/plans/2026-04-13-structured-output-evaluation-roadmap.md
+++ b/docs/plans/2026-04-13-structured-output-evaluation-roadmap.md
@@ -3,9 +3,13 @@
 ## Summary
 
 Melix should add structured-output evaluation as a first-class intelligence measurement path for
-LoRA workflows that target machine-readable JSON output. The roadmap below keeps the runtime
-boundary package-based, treats external corpora as source datasets rather than executable
-contracts, and stages the work so the contract lands before parser or scorer implementation.
+LoRA workflows that target machine-readable JSON output, while also formally designating the
+existing text-generation path as a permanent long-term profile and adding a format-compliance
+profile for early-stage evaluation without ground truth.
+
+The roadmap keeps the runtime boundary package-based, treats external corpora as source datasets
+rather than executable contracts, and stages the work so the contract lands before parser or scorer
+implementation.
 
 This roadmap describes future milestones only. It does not claim current implementation support.
 
@@ -13,28 +17,40 @@ This roadmap describes future milestones only. It does not claim current impleme
 
 ### Outcome
 
-Melix has a documented structured-output evaluation contract with a stable package shape and
-profile vocabulary.
+Melix has a documented evaluation profile contract that covers three profile types with stable
+package shapes and vocabulary.
 
 ### Scope
 
-- define the `evaluation profile` abstraction in the canonical contract
-- define the structured sample shape as `system`, `input`, and `target`
-- define `target` as a JSON object requirement
-- define strict single-object JSON parsing semantics
-- define the no-compatibility rule for legacy `prompt` and `expected` structured-output rows
+- define three `profile_type` values: `structured_output`, `text_generation`, and
+  `format_compliance`
+- define the `structured_output` sample shape as `system`, `input`, and `target`
+- define `target` as valid JSON whose root type matches the declared `output_schema` root type
+- define `parser_mode` as a `structured_output` profile attribute with values `strict` and
+  `extract`
+- define `strict` parsing: exactly one JSON value, no surrounding prose
+- define `extract` parsing: last valid JSON value extracted from response, prose tolerated
+- define `text_generation` as a permanent long-term profile with `prompt` and `expected` sample
+  rows and a declared `scoring_mode`
+- define `format_compliance` as a profile with `system` and `input` sample rows, no `target`, and
+  `parse_success_rate` and `schema_valid_rate` as output metrics
+- define that `ignored_paths` in the manifest extend the default ignored set rather than override
+  it
+- define the no-forced-migration rule: existing `prompt` and `expected` packages belong to
+  `text_generation` and are not subject to migration
 
 ### Exit Criteria
 
-- the canonical contract describes the package boundary and structured-output profile vocabulary
+- the canonical contract describes all three profile types with their sample shapes and scoring
+  semantics
 - the contract explicitly separates `source dataset` from `materialized evaluation package`
-- the contract explicitly states that wrapped prose, multiple JSON values, and non-object JSON are
-  parse failures
+- `parser_mode` vocabulary is consistent between the contract and the design spec
+- `profile_type` naming is consistent across all documents
 
 ### Risks
 
 - over-documenting implementation detail before scorer design is stable
-- allowing historical fixture language to look like a supported long-term compatibility path
+- `extract` mode semantics may need refinement once the JSON-in-prose extractor is implemented
 
 ## Milestone 2: Dataset Materialization
 
@@ -66,24 +82,32 @@ into repository-owned evaluation packages before execution.
 ### Outcome
 
 Melix has one generic runtime core for structured-output evaluation rather than task-specific scorer
-branches.
+branches, with parser mode selection controlled by the declared profile.
 
 ### Scope
 
-- strict single-object JSON parser
+- `strict` parser: exactly one JSON value, parse failure on surrounding prose
+- `extract` parser: last valid JSON value extracted from response, prose tolerated
+- JSON root type validation against `output_schema` root type declaration
 - schema validation gate
 - profile-driven field comparison primitives
-- default ignored-path handling
+- default ignored-path handling with manifest extension support
 - correctness threshold handling
+- `format_compliance` profile runner: parse and optionally schema-validate, emit
+  `parse_success_rate` and `schema_valid_rate`
 
 ### Exit Criteria
 
 - worker execution semantics are described in profile-driven terms rather than suite-specific terms
-- schema validity and field score are the primary structured-output evidence model
+- schema validity and field score are the primary `structured_output` evidence model
+- `text_generation` packages continue to execute through the existing scorer without modification
+- `format_compliance` packages execute and produce format metrics without requiring a `target` field
 - the design leaves room for new profiles without redefining the public evaluation surface
 
 ### Risks
 
+- `extract` mode JSON extraction heuristics may require iteration before they generalize across
+  different model output styles
 - generic comparison primitives may be too weak for some tasks
 - too many early special cases would collapse the abstraction back into task-specific scoring
 

--- a/docs/plans/2026-04-13-structured-output-evaluation-roadmap.md
+++ b/docs/plans/2026-04-13-structured-output-evaluation-roadmap.md
@@ -1,0 +1,116 @@
+# Structured Output Evaluation Roadmap
+
+## Summary
+
+Melix should add structured-output evaluation as a first-class intelligence measurement path for
+LoRA workflows that target machine-readable JSON output. The roadmap below keeps the runtime
+boundary package-based, treats external corpora as source datasets rather than executable
+contracts, and stages the work so the contract lands before parser or scorer implementation.
+
+This roadmap describes future milestones only. It does not claim current implementation support.
+
+## Milestone 1: Contract And Package Profile
+
+### Outcome
+
+Melix has a documented structured-output evaluation contract with a stable package shape and
+profile vocabulary.
+
+### Scope
+
+- define the `evaluation profile` abstraction in the canonical contract
+- define the structured sample shape as `system`, `input`, and `target`
+- define `target` as a JSON object requirement
+- define strict single-object JSON parsing semantics
+- define the no-compatibility rule for legacy `prompt` and `expected` structured-output rows
+
+### Exit Criteria
+
+- the canonical contract describes the package boundary and structured-output profile vocabulary
+- the contract explicitly separates `source dataset` from `materialized evaluation package`
+- the contract explicitly states that wrapped prose, multiple JSON values, and non-object JSON are
+  parse failures
+
+### Risks
+
+- over-documenting implementation detail before scorer design is stable
+- allowing historical fixture language to look like a supported long-term compatibility path
+
+## Milestone 2: Dataset Materialization
+
+### Outcome
+
+Melix can reuse external structured corpora, including Hugging Face datasets, by materializing them
+into repository-owned evaluation packages before execution.
+
+### Scope
+
+- define importer and materializer responsibilities
+- define how profile metadata is attached to materialized packages
+- define failure behavior for incompatible source schemas
+- preserve the rule that worker execution consumes only Melix evaluation packages
+
+### Exit Criteria
+
+- the roadmap and design specify a source-to-package conversion boundary
+- external datasets are documented as reusable source corpora rather than direct runtime contracts
+- profile metadata is defined as part of the materialized package rather than a side channel
+
+### Risks
+
+- source datasets may omit fields required by structured-output scoring
+- profile metadata may drift if materialization is underspecified
+
+## Milestone 3: Structured Evaluation Core
+
+### Outcome
+
+Melix has one generic runtime core for structured-output evaluation rather than task-specific scorer
+branches.
+
+### Scope
+
+- strict single-object JSON parser
+- schema validation gate
+- profile-driven field comparison primitives
+- default ignored-path handling
+- correctness threshold handling
+
+### Exit Criteria
+
+- worker execution semantics are described in profile-driven terms rather than suite-specific terms
+- schema validity and field score are the primary structured-output evidence model
+- the design leaves room for new profiles without redefining the public evaluation surface
+
+### Risks
+
+- generic comparison primitives may be too weak for some tasks
+- too many early special cases would collapse the abstraction back into task-specific scoring
+
+## Milestone 4: Compare And Reporting
+
+### Outcome
+
+Melix compare workflows can measure structured-output LoRA deltas using schema-valid and field-score
+evidence instead of binary proxy scores alone.
+
+### Scope
+
+- compare semantics for base versus derived models
+- schema-valid rate reporting
+- field-score delta reporting
+- regression counting for structured-output workflows
+- sample-level diagnostics for parse and schema failures
+
+### Exit Criteria
+
+- compare is documented in terms of schema-valid and field-score evidence
+- reporting semantics distinguish parsing failures from low-quality but schema-valid outputs
+- LoRA comparison claims are grounded in the structured-output evidence model rather than MCQ or
+  exact-match proxies
+
+### Risks
+
+- compare summaries may over-simplify structured-output quality if diagnostics are too thin
+- operator expectations may drift if proxy metrics and structured-output metrics coexist without
+  clear labeling

--- a/docs/runbooks/benchmark-matrix-evaluation-and-lora.md
+++ b/docs/runbooks/benchmark-matrix-evaluation-and-lora.md
@@ -228,28 +228,30 @@ Notes:
 - use `--dataset-root /absolute/path/to/evaluation-package` only when you want to override the checked-in fixture bundle
 - evaluation runs persist under `<jobs_root>/evaluation/runs/<job_id>/`
 
-## Planned Structured-Output Evaluation Workflow
+## Planned Final-Result Evaluation Workflow
 
 This section describes planned future direction rather than a shipped command path.
 
-For LoRA workflows that aim to improve JSON format adherence and extraction quality, the long-term
-Melix evaluation target is not multiple-choice accuracy or plain exact-match string scoring. Those
-proxies may help with narrow experiments, but they do not measure the intended operator outcome.
+For LoRA workflows, the long-term Melix evaluation target is final-result quality rather than CoT
+quality. A model may emit CoT or other wrapper text, but compare and eval should score only the
+final extracted result.
 
-The planned structured-output path will instead evaluate:
+That future path is not limited to schema-constrained JSON. The planned v1 final-result contract
+covers:
 
-- whether the model emits exactly one schema-valid JSON object
-- whether the extracted fields match the expected structured target
-- whether a derived model improves field quality without hiding regressions behind format failures
+- `json` final results, scored after extraction and schema-aware validation
+- `text` final results, scored after extraction and stable text normalization
 
-The future structured-output contract will use an `evaluation profile` inside a Melix evaluation
-dataset package. That package remains the execution contract. Hugging Face datasets remain reusable
-as source corpora, but not as direct execution contracts for structured-output evaluation. The
-intended path is to materialize external corpora into a Melix evaluation package before execution.
+The future evidence model will expand from binary correct or incorrect counts alone to a layered
+view of:
 
-The future compare workflow will remain base-model versus derived-model oriented, but the target
-evidence model will expand from binary correct or incorrect counts to schema-valid rate and
-field-level score.
+- extraction success
+- validation success
+- typed score against ground truth
+
+Hugging Face datasets remain reusable source corpora, but not direct execution contracts. Planned
+future execution will still require materialization into a Melix evaluation package before `eval`
+or `compare` runs.
 
 See these planning documents for the target contract and milestone sequence:
 

--- a/docs/runbooks/benchmark-matrix-evaluation-and-lora.md
+++ b/docs/runbooks/benchmark-matrix-evaluation-and-lora.md
@@ -228,6 +228,34 @@ Notes:
 - use `--dataset-root /absolute/path/to/evaluation-package` only when you want to override the checked-in fixture bundle
 - evaluation runs persist under `<jobs_root>/evaluation/runs/<job_id>/`
 
+## Planned Structured-Output Evaluation Workflow
+
+This section describes planned future direction rather than a shipped command path.
+
+For LoRA workflows that aim to improve JSON format adherence and extraction quality, the long-term
+Melix evaluation target is not multiple-choice accuracy or plain exact-match string scoring. Those
+proxies may help with narrow experiments, but they do not measure the intended operator outcome.
+
+The planned structured-output path will instead evaluate:
+
+- whether the model emits exactly one schema-valid JSON object
+- whether the extracted fields match the expected structured target
+- whether a derived model improves field quality without hiding regressions behind format failures
+
+The future structured-output contract will use an `evaluation profile` inside a Melix evaluation
+dataset package. That package remains the execution contract. Hugging Face datasets remain reusable
+as source corpora, but not as direct execution contracts for structured-output evaluation. The
+intended path is to materialize external corpora into a Melix evaluation package before execution.
+
+The future compare workflow will remain base-model versus derived-model oriented, but the target
+evidence model will expand from binary correct or incorrect counts to schema-valid rate and
+field-level score.
+
+See these planning documents for the target contract and milestone sequence:
+
+- `docs/superpowers/specs/2026-04-13-structured-output-evaluation-profile-design.md`
+- `docs/plans/2026-04-13-structured-output-evaluation-roadmap.md`
+
 ## Use LoRA With Benchmark, Matrix, Evaluation, And Compare
 
 LoRA adapters are not direct benchmark or evaluation targets. Melix benchmark and evaluation

--- a/docs/superpowers/specs/2026-04-13-structured-output-evaluation-profile-design.md
+++ b/docs/superpowers/specs/2026-04-13-structured-output-evaluation-profile-design.md
@@ -2,13 +2,17 @@
 
 ## Summary
 
-Melix needs a real evaluation path for LoRA workflows that tune models to emit schema-constrained
-structured output. The current `eval` path is good enough for text-style suites with simple
-`prompt` and `expected` rows, but it does not define a durable contract for format adherence,
-single-object JSON parsing, schema validity, or field-level extraction quality.
+Melix needs real evaluation paths for LoRA workflows that cover three distinct scenarios: models
+tuned to emit schema-constrained structured output, models evaluated against reference answers, and
+early-stage models where only format adherence can be measured.
 
-This design defines the target documentation contract for a future structured-output evaluation
-profile. It does not claim current implementation support.
+The current `eval` path is good enough for text-style suites with simple `prompt` and `expected`
+rows, but it does not define a durable contract for format adherence, JSON parsing semantics,
+schema validity, or field-level extraction quality. It also does not formally name the existing
+text-generation path as a permanent long-term contract.
+
+This design defines three evaluation profiles: `structured_output`, `text_generation`, and
+`format_compliance`. It does not claim current implementation support for the new profiles.
 
 ## Problem
 
@@ -21,8 +25,17 @@ the wrong incentives:
 - task-specific scorer branches for `extraction`, `relationship`, or `summarization` would turn
   each new use case into a product-surface change
 
-Melix needs one reusable abstraction that can evaluate format adherence and extraction quality
-across multiple structured tasks without making the evaluation core depend on task names.
+A second problem is that the current eval path has no formal contract designation. Packages using
+`prompt` and `expected` rows are implicitly treated as a legacy or transitional format, which
+creates pressure to migrate working evaluation datasets without a clear benefit.
+
+A third problem is that early-stage LoRA experiments often cannot produce ground-truth target data.
+Without a format-only evaluation path, operators have no automated way to measure whether a newly
+trained model is emitting valid structured output at all.
+
+Melix needs three reusable abstractions: one for schema-constrained output evaluation, one that
+formally names the existing text-generation path as permanent, and one for format-compliance
+measurement without ground truth.
 
 ## Current State
 
@@ -38,36 +51,50 @@ That means the current Melix boundary is:
 
 - evaluation runs execute against Melix-defined local packages
 - training can materialize external Hugging Face datasets
-- existing evaluation fixtures use historical `prompt` and `expected` rows
+- existing evaluation fixtures use `prompt` and `expected` rows
 
 This design keeps the package boundary but replaces the long-term structured-output row shape and
 scoring semantics.
 
 ## Design Goals
 
-- define one reusable `evaluation profile` abstraction for structured-output evaluation
+- define three `evaluation profile` types that cover the full range of current LoRA evaluation
+  scenarios without making the eval core depend on task names
 - keep external datasets reusable as source corpora without making their raw schemas part of the
   Melix runtime contract
-- require strict single-object JSON parsing so format failures are visible and machine-readable
-- make schema validity and field-level quality the target evidence for LoRA comparison
-- avoid tying scorer behavior to task names or suite-specific hardcoded branches
+- support both strict bare-JSON parsing and prose-tolerant JSON extraction through a declared
+  `parser_mode`, so the eval path matches the training format
+- let the declared `output_schema` root type determine what JSON shapes are valid targets, rather
+  than hardcoding object-only acceptance
+- make schema validity and field-level quality the target evidence for structured-output LoRA
+  comparison
+- formally designate the `prompt`/`expected` path as a permanent long-term profile so that
+  non-structured LoRA has a stable evaluation home
+- provide a format-compliance profile for early-stage evaluation without ground-truth targets
 
 ## Non-Goals
 
-- implementing the profile in the current transaction
-- redefining the current non-structured suite contracts
+- implementing the new profiles in the current transaction
 - adding new CLI, protocol, or export fields now
 - making Hugging Face raw dataset schemas executable without materialization
+- evaluating subjective quality such as creativity or conversational naturalness without a
+  reference answer
 
 ## Core Terms
 
-These terms are the authoritative vocabulary for the future structured-output path:
+These terms are the authoritative vocabulary for the future evaluation profile path:
 
 - `source dataset`: an external or local corpus used as the origin of evaluation content
 - `materialized evaluation package`: the repository-owned package Melix executes against
 - `evaluation profile`: the manifest-declared parsing, schema, and scoring contract for one package
-- `strict single-object JSON parsing`: the parsing rule that accepts exactly one JSON object and
-  rejects wrapped prose, multiple JSON values, and non-object JSON payloads
+- `profile_type`: the top-level profile selector declared in `manifest.json`; one of
+  `structured_output`, `text_generation`, or `format_compliance`
+- `parser_mode`: a `structured_output` profile attribute that controls whether prose surrounding
+  the JSON value is a parse failure (`strict`) or is tolerated (`extract`)
+- `strict parsing`: the `strict` parser mode; accepts exactly one JSON value and no surrounding
+  prose
+- `extract parsing`: the `extract` parser mode; extracts the last valid JSON value from the
+  response; permits surrounding prose
 
 ## Recommended Contract
 
@@ -82,76 +109,132 @@ Melix should continue to separate dataset origin from runtime execution:
 This keeps the runtime boundary deterministic and lets Melix evolve one package format without
 importing the variability of external schemas into the worker core.
 
-### Evaluation Profile
+### Profile Type Selection
 
-Each structured-output package should declare an `evaluation profile` in its manifest. The profile
-defines:
+Each evaluation package must declare a `profile_type` in its manifest. The declared type
+determines the sample shape, parsing rules, and scoring semantics for that package.
 
-- the expected output schema
-- the parser mode
-- the field-level comparison policy
-- the threshold used for correctness decisions
-- the ignored paths that do not contribute to scoring
+The three profile types are described below. Task names such as `extraction`, `relationship`, and
+`summarization` may still appear as suite labels or dataset metadata, but they must not be the
+primary hook for scorer implementation.
 
-The evaluation profile is the abstraction layer. Task names such as `extraction`,
-`relationship`, and `summarization` may still appear as suite labels or dataset metadata, but they
-must not be the primary hook for scorer implementation.
+### `structured_output` Profile
 
-### Structured Sample Shape
-
-The planned structured-output sample shape is:
+#### Sample Shape
 
 - `system`
 - `input`
 - `target`
 
-`target` must be a JSON object. The long-term structured-output contract does not preserve a
-compatibility path for legacy `prompt` and `expected` rows.
+`target` must be valid JSON whose root type matches the root type declared in the package
+`output_schema`. The profile declares:
 
-### Strict Single-Object Parsing
+- `output_schema`: a JSON Schema reference or inline schema
+- `parser_mode`: `strict` or `extract`
+- `comparison_policy`: `field_f1`, `field_precision`, `field_recall`, or `exact_match`
+- `threshold`: the minimum score required for a sample to be counted correct
+- `ignored_paths`: paths excluded from field-level scoring (extends the default ignored set)
 
-Structured-output parsing must be intentionally narrow:
+#### Parser Mode
 
-- exactly one JSON object is accepted
-- any wrapped prose before or after the JSON object is rejected
-- multiple JSON values are rejected
-- JSON arrays, strings, numbers, booleans, and `null` are rejected
+`parser_mode` should match how the model was trained to emit output:
 
-This is stricter than some current LLM-evaluation conventions, but it matches the LoRA tuning goal:
-the model should emit a schema-constrained machine-readable object, not a loosely parseable answer.
+- use `strict` when the model is trained to emit bare JSON with no surrounding prose; in this mode
+  any response that contains prose before or after the JSON value is a parse failure
+- use `extract` when the model is trained with a reasoning prefix before the structured output; in
+  this mode the parser extracts the last valid JSON value from the response and ignores surrounding
+  prose
 
-### Schema And Field Scoring
+`extract` mode supports CoT-style LoRA workflows where the model reasons through the task and then
+emits the structured result. It does not relax schema or field-level scoring requirements.
 
-Structured-output evaluation should use schema validation as a gate and field-level comparison as
-the score:
+#### Accepted JSON Root Type
 
-- parse success is required before validation
-- schema success is required before field scoring
+The accepted root type for `target` and for parsed model responses is determined by the
+`output_schema` root type declaration, not hardcoded to object:
+
+- schema root `{type: "object"}` requires a JSON object
+- schema root `{type: "array"}` requires a JSON array
+
+Multiple JSON values in one response are a parse failure in both `strict` and `extract` modes.
+Non-JSON payloads are a parse failure in both modes.
+
+#### Schema And Field Scoring
+
+- parse success is required before schema validation
+- schema validation success is required before field-level scoring
 - default ignored fields are `evidence`, `confidence`, `closeness_logits`, and `closeness_probs`
-- the primary score should be a field-level precision or recall or F1 style measure rather than
-  plain string equality
+- manifest-declared `ignored_paths` extend the default ignored set; they do not override it
+- the primary score is a field-level F1, precision, or recall measure rather than plain string
+  equality
 
-This gives Melix a truthful way to compare base models and LoRA-derived models on both format
-adherence and extraction quality.
+### `text_generation` Profile
 
-## Why This Is Better Than Task-Specific Scorers
+#### Sample Shape
 
-The structured-output profile is the reusable layer because it:
+- `prompt`
+- `expected`
 
-- avoids one-off scorer branches per task name
-- keeps new structured tasks primarily data- and manifest-driven
-- leaves room for a future importer or materializer from Hugging Face without changing worker
-  execution semantics
-- creates one stable place to document and test parsing and schema rules
+#### Scoring
 
-The remaining task differences belong in profile configuration, not in the public evaluation
-surface.
+The profile declares a `scoring_mode`. Supported values are:
 
-## Migration Boundary
+- `multiple_choice_accuracy`
+- `exact_match`
+- `numeric_match`
+- `code_exec`
 
-The repository should treat existing `prompt` and `expected` evaluation fixtures as historical
-formats. They remain part of current implementation history, but they are not the desired contract
-for future structured-output evaluation.
+This profile is a permanent long-term evaluation path. Existing packages using `prompt` and
+`expected` rows are not subject to migration. LoRA workflows evaluated against reference answers
+should use this profile regardless of whether the underlying task involves structured data.
 
-That migration should happen through new package profiles and new materialized packages rather than
-by widening the structured-output contract to support both historical and future row shapes.
+### `format_compliance` Profile
+
+#### Sample Shape
+
+- `system`
+- `input`
+
+No `target` field is required. This profile measures format adherence without correctness scoring.
+
+#### Format Declaration
+
+The profile declares a `format` value:
+
+- `json_object`: the response must parse as a JSON object
+- `json_array`: the response must parse as a JSON array
+- `json_any`: the response must parse as any valid JSON value
+- `json_schema`: the response must parse and validate against the declared `output_schema`
+
+#### Metrics
+
+Output metrics are `parse_success_rate` and `schema_valid_rate`. There are no `correct` or
+`incorrect` sample counts for this profile type.
+
+This profile is intended for early-stage LoRA evaluation where ground-truth target data is not yet
+available. It answers the question of whether the model is producing validly formatted output,
+before annotation effort is invested in field-level correctness scoring.
+
+## Why Three Profiles Instead Of One
+
+The three-profile design avoids a false choice between structured and non-structured LoRA. Each
+profile covers a distinct evaluation scenario:
+
+- `structured_output` makes schema validity and field quality the primary evidence for LoRA
+  comparison, and `parser_mode` ensures the eval contract matches the training format
+- `text_generation` gives non-structured LoRA a stable long-term home without forcing a migration
+  to structured packages
+- `format_compliance` unblocks early-stage evaluation that would otherwise require fully annotated
+  target data
+
+Profile differences belong in manifest configuration, not in the public evaluation surface or
+scorer implementation.
+
+## Profile Boundary
+
+Existing `prompt` and `expected` evaluation fixtures belong to the `text_generation` profile. They
+are not historical formats. New structured-output packages should use the `structured_output`
+profile with an appropriate `parser_mode`. New early-stage packages should use the
+`format_compliance` profile.
+
+New package creation drives profile adoption. There is no forced migration of existing packages.

--- a/docs/superpowers/specs/2026-04-13-structured-output-evaluation-profile-design.md
+++ b/docs/superpowers/specs/2026-04-13-structured-output-evaluation-profile-design.md
@@ -1,0 +1,157 @@
+# Structured Output Evaluation Profile Design
+
+## Summary
+
+Melix needs a real evaluation path for LoRA workflows that tune models to emit schema-constrained
+structured output. The current `eval` path is good enough for text-style suites with simple
+`prompt` and `expected` rows, but it does not define a durable contract for format adherence,
+single-object JSON parsing, schema validity, or field-level extraction quality.
+
+This design defines the target documentation contract for a future structured-output evaluation
+profile. It does not claim current implementation support.
+
+## Problem
+
+Using `multiple_choice_accuracy` or `exact_match` as a proxy for structured-output quality creates
+the wrong incentives:
+
+- multiple-choice scoring changes the task rather than evaluating the intended output format
+- exact-match scoring is too brittle for structured JSON unless the runtime also owns full
+  canonicalization
+- task-specific scorer branches for `extraction`, `relationship`, or `summarization` would turn
+  each new use case into a product-surface change
+
+Melix needs one reusable abstraction that can evaluate format adherence and extraction quality
+across multiple structured tasks without making the evaluation core depend on task names.
+
+## Current State
+
+Current `eval` execution is already package-based. The worker reads `manifest.json` and
+`samples.jsonl` from a local `dataset_root`, and the checked-in fixtures for current suites are
+repository-owned package directories.
+
+Current `eval` execution is not runtime-dependent on Hugging Face datasets. By contrast, LoRA
+training already supports direct Hugging Face dataset materialization through the training dataset
+pipeline.
+
+That means the current Melix boundary is:
+
+- evaluation runs execute against Melix-defined local packages
+- training can materialize external Hugging Face datasets
+- existing evaluation fixtures use historical `prompt` and `expected` rows
+
+This design keeps the package boundary but replaces the long-term structured-output row shape and
+scoring semantics.
+
+## Design Goals
+
+- define one reusable `evaluation profile` abstraction for structured-output evaluation
+- keep external datasets reusable as source corpora without making their raw schemas part of the
+  Melix runtime contract
+- require strict single-object JSON parsing so format failures are visible and machine-readable
+- make schema validity and field-level quality the target evidence for LoRA comparison
+- avoid tying scorer behavior to task names or suite-specific hardcoded branches
+
+## Non-Goals
+
+- implementing the profile in the current transaction
+- redefining the current non-structured suite contracts
+- adding new CLI, protocol, or export fields now
+- making Hugging Face raw dataset schemas executable without materialization
+
+## Core Terms
+
+These terms are the authoritative vocabulary for the future structured-output path:
+
+- `source dataset`: an external or local corpus used as the origin of evaluation content
+- `materialized evaluation package`: the repository-owned package Melix executes against
+- `evaluation profile`: the manifest-declared parsing, schema, and scoring contract for one package
+- `strict single-object JSON parsing`: the parsing rule that accepts exactly one JSON object and
+  rejects wrapped prose, multiple JSON values, and non-object JSON payloads
+
+## Recommended Contract
+
+### Source And Execution Boundary
+
+Melix should continue to separate dataset origin from runtime execution:
+
+- source datasets may come from Hugging Face, local annotation sets, or repository fixtures
+- execution must always consume a Melix evaluation dataset package
+- Hugging Face remains reusable as a source, but not as the direct runtime contract
+
+This keeps the runtime boundary deterministic and lets Melix evolve one package format without
+importing the variability of external schemas into the worker core.
+
+### Evaluation Profile
+
+Each structured-output package should declare an `evaluation profile` in its manifest. The profile
+defines:
+
+- the expected output schema
+- the parser mode
+- the field-level comparison policy
+- the threshold used for correctness decisions
+- the ignored paths that do not contribute to scoring
+
+The evaluation profile is the abstraction layer. Task names such as `extraction`,
+`relationship`, and `summarization` may still appear as suite labels or dataset metadata, but they
+must not be the primary hook for scorer implementation.
+
+### Structured Sample Shape
+
+The planned structured-output sample shape is:
+
+- `system`
+- `input`
+- `target`
+
+`target` must be a JSON object. The long-term structured-output contract does not preserve a
+compatibility path for legacy `prompt` and `expected` rows.
+
+### Strict Single-Object Parsing
+
+Structured-output parsing must be intentionally narrow:
+
+- exactly one JSON object is accepted
+- any wrapped prose before or after the JSON object is rejected
+- multiple JSON values are rejected
+- JSON arrays, strings, numbers, booleans, and `null` are rejected
+
+This is stricter than some current LLM-evaluation conventions, but it matches the LoRA tuning goal:
+the model should emit a schema-constrained machine-readable object, not a loosely parseable answer.
+
+### Schema And Field Scoring
+
+Structured-output evaluation should use schema validation as a gate and field-level comparison as
+the score:
+
+- parse success is required before validation
+- schema success is required before field scoring
+- default ignored fields are `evidence`, `confidence`, `closeness_logits`, and `closeness_probs`
+- the primary score should be a field-level precision or recall or F1 style measure rather than
+  plain string equality
+
+This gives Melix a truthful way to compare base models and LoRA-derived models on both format
+adherence and extraction quality.
+
+## Why This Is Better Than Task-Specific Scorers
+
+The structured-output profile is the reusable layer because it:
+
+- avoids one-off scorer branches per task name
+- keeps new structured tasks primarily data- and manifest-driven
+- leaves room for a future importer or materializer from Hugging Face without changing worker
+  execution semantics
+- creates one stable place to document and test parsing and schema rules
+
+The remaining task differences belong in profile configuration, not in the public evaluation
+surface.
+
+## Migration Boundary
+
+The repository should treat existing `prompt` and `expected` evaluation fixtures as historical
+formats. They remain part of current implementation history, but they are not the desired contract
+for future structured-output evaluation.
+
+That migration should happen through new package profiles and new materialized packages rather than
+by widening the structured-output contract to support both historical and future row shapes.

--- a/docs/superpowers/specs/2026-04-13-structured-output-evaluation-profile-design.md
+++ b/docs/superpowers/specs/2026-04-13-structured-output-evaluation-profile-design.md
@@ -1,41 +1,31 @@
-# Structured Output Evaluation Profile Design
+# Final Result Evaluation Profile Design
 
 ## Summary
 
-Melix needs real evaluation paths for LoRA workflows that cover three distinct scenarios: models
-tuned to emit schema-constrained structured output, models evaluated against reference answers, and
-early-stage models where only format adherence can be measured.
+Melix needs a future evaluation contract for LoRA workflows that score only the final result, even
+when the model emits CoT or other wrapper text. The current `eval` path is good enough for shipped
+text-style suites with simple `prompt` and `expected` rows, but it does not define a durable
+contract for final-result extraction, typed validation, or typed scoring.
 
-The current `eval` path is good enough for text-style suites with simple `prompt` and `expected`
-rows, but it does not define a durable contract for format adherence, JSON parsing semantics,
-schema validity, or field-level extraction quality. It also does not formally name the existing
-text-generation path as a permanent long-term contract.
-
-This design defines three evaluation profiles: `structured_output`, `text_generation`, and
-`format_compliance`. It does not claim current implementation support for the new profiles.
+This design defines one future-facing evaluation profile, `final_result`. It does not claim current
+implementation support.
 
 ## Problem
 
-Using `multiple_choice_accuracy` or `exact_match` as a proxy for structured-output quality creates
-the wrong incentives:
+Using task-specific scorers or scoring the entire raw response creates the wrong incentives:
 
-- multiple-choice scoring changes the task rather than evaluating the intended output format
-- exact-match scoring is too brittle for structured JSON unless the runtime also owns full
-  canonicalization
-- task-specific scorer branches for `extraction`, `relationship`, or `summarization` would turn
-  each new use case into a product-surface change
+- the runtime ends up coupled to task names such as `extraction`, `relationship`, and
+  `summarization`
+- CoT or wrapper prose can change the score even when the final answer is unchanged
+- JSON-specific extraction rules do not solve the general problem of evaluating final text answers
+- no-target or format-only ideas can distract the first implementation from the real LoRA compare
+  path, which is ground-truth evaluation of the final result
 
-A second problem is that the current eval path has no formal contract designation. Packages using
-`prompt` and `expected` rows are implicitly treated as a legacy or transitional format, which
-creates pressure to migrate working evaluation datasets without a clear benefit.
+Melix needs one reusable abstraction that answers three questions:
 
-A third problem is that early-stage LoRA experiments often cannot produce ground-truth target data.
-Without a format-only evaluation path, operators have no automated way to measure whether a newly
-trained model is emitting valid structured output at all.
-
-Melix needs three reusable abstractions: one for schema-constrained output evaluation, one that
-formally names the existing text-generation path as permanent, and one for format-compliance
-measurement without ground truth.
+- what is the final artifact being evaluated
+- how is that final artifact extracted from the raw response
+- how is the extracted artifact validated and scored against ground truth
 
 ## Current State
 
@@ -50,51 +40,46 @@ pipeline.
 That means the current Melix boundary is:
 
 - evaluation runs execute against Melix-defined local packages
-- training can materialize external Hugging Face datasets
-- existing evaluation fixtures use `prompt` and `expected` rows
+- external corpora such as Hugging Face datasets are reusable source datasets rather than runtime
+  contracts
+- current evaluation fixtures still largely use `prompt` and `expected` sample rows
 
-This design keeps the package boundary but replaces the long-term structured-output row shape and
-scoring semantics.
+This design keeps the package boundary and replaces the future evaluation abstraction.
 
 ## Design Goals
 
-- define three `evaluation profile` types that cover the full range of current LoRA evaluation
-  scenarios without making the eval core depend on task names
+- define one future-facing `evaluation profile` that scores only the extracted final result
 - keep external datasets reusable as source corpora without making their raw schemas part of the
   Melix runtime contract
-- support both strict bare-JSON parsing and prose-tolerant JSON extraction through a declared
-  `parser_mode`, so the eval path matches the training format
-- let the declared `output_schema` root type determine what JSON shapes are valid targets, rather
-  than hardcoding object-only acceptance
-- make schema validity and field-level quality the target evidence for structured-output LoRA
-  comparison
-- formally designate the `prompt`/`expected` path as a permanent long-term profile so that
-  non-structured LoRA has a stable evaluation home
-- provide a format-compliance profile for early-stage evaluation without ground-truth targets
+- make final-result extraction a runtime-owned, deterministic contract rather than a best-effort
+  prompt convention
+- support both JSON and text final results in v1
+- make validation and scoring typed by `result_kind` rather than task name
+- keep v1 ground-truth oriented so base-model versus LoRA comparison is the primary path
 
 ## Non-Goals
 
-- implementing the new profiles in the current transaction
-- adding new CLI, protocol, or export fields now
-- making Hugging Face raw dataset schemas executable without materialization
-- evaluating subjective quality such as creativity or conversational naturalness without a
-  reference answer
+- implementing the profile in the current transaction
+- changing the shipped CLI, protocol, or export surface now
+- defining task-specific scorer branches for individual downstream tasks
+- adding no-target or format-only evaluation to v1
+- expanding v1 text scoring to open-ended semantic similarity or subjective quality measures
 
 ## Core Terms
 
-These terms are the authoritative vocabulary for the future evaluation profile path:
+These terms are the authoritative vocabulary for the future final-result path:
 
 - `source dataset`: an external or local corpus used as the origin of evaluation content
 - `materialized evaluation package`: the repository-owned package Melix executes against
-- `evaluation profile`: the manifest-declared parsing, schema, and scoring contract for one package
-- `profile_type`: the top-level profile selector declared in `manifest.json`; one of
-  `structured_output`, `text_generation`, or `format_compliance`
-- `parser_mode`: a `structured_output` profile attribute that controls whether prose surrounding
-  the JSON value is a parse failure (`strict`) or is tolerated (`extract`)
-- `strict parsing`: the `strict` parser mode; accepts exactly one JSON value and no surrounding
-  prose
-- `extract parsing`: the `extract` parser mode; extracts the last valid JSON value from the
-  response; permits surrounding prose
+- `evaluation profile`: the manifest-declared extraction, validation, and scoring contract for one
+  package
+- `profile_type`: the top-level profile selector declared in `manifest.json`; v1 uses
+  `final_result`
+- `result_kind`: the type of final artifact being scored; v1 supports `json` and `text`
+- `extraction_mode`: the rule for isolating the final artifact from `raw_response`
+- `raw_response`: the full model response captured for debugging
+- `extracted_result`: the final artifact selected by the runtime and passed to validation and
+  scoring
 
 ## Recommended Contract
 
@@ -109,132 +94,145 @@ Melix should continue to separate dataset origin from runtime execution:
 This keeps the runtime boundary deterministic and lets Melix evolve one package format without
 importing the variability of external schemas into the worker core.
 
-### Profile Type Selection
+### Future Profile Shape
 
-Each evaluation package must declare a `profile_type` in its manifest. The declared type
-determines the sample shape, parsing rules, and scoring semantics for that package.
+Each future-oriented evaluation package should declare a single `final_result` profile in its
+manifest. The planned core fields are:
 
-The three profile types are described below. Task names such as `extraction`, `relationship`, and
-`summarization` may still appear as suite labels or dataset metadata, but they must not be the
-primary hook for scorer implementation.
+- `profile_type: final_result`
+- `result_kind: json | text`
+- `extraction_mode: strict_full_response | heuristic_final`
+- `scoring_mode`
+- `threshold`
 
-### `structured_output` Profile
-
-#### Sample Shape
+Future `final_result` sample rows use:
 
 - `system`
 - `input`
 - `target`
 
-`target` must be valid JSON whose root type matches the root type declared in the package
-`output_schema`. The profile declares:
+Task names such as `extraction`, `relationship`, and `summarization` may still appear as suite
+labels or dataset metadata, but they must not be the primary hook for scorer implementation.
 
-- `output_schema`: a JSON Schema reference or inline schema
-- `parser_mode`: `strict` or `extract`
-- `comparison_policy`: `field_f1`, `field_precision`, `field_recall`, or `exact_match`
-- `threshold`: the minimum score required for a sample to be counted correct
-- `ignored_paths`: paths excluded from field-level scoring (extends the default ignored set)
+### Extraction And Scoring Pipeline
 
-#### Parser Mode
+The planned runtime pipeline is:
 
-`parser_mode` should match how the model was trained to emit output:
+- capture `raw_response`
+- extract `extracted_result`
+- validate the extracted result for its declared `result_kind`
+- normalize as required by `scoring_mode`
+- score only `extracted_result` against `target`
 
-- use `strict` when the model is trained to emit bare JSON with no surrounding prose; in this mode
-  any response that contains prose before or after the JSON value is a parse failure
-- use `extract` when the model is trained with a reasoning prefix before the structured output; in
-  this mode the parser extracts the last valid JSON value from the response and ignores surrounding
-  prose
+CoT or wrapper text may appear in `raw_response`, but it is not itself evaluation evidence.
+Correctness is computed only from `extracted_result`.
 
-`extract` mode supports CoT-style LoRA workflows where the model reasons through the task and then
-emits the structured result. It does not relax schema or field-level scoring requirements.
+### `result_kind: json`
 
-#### Accepted JSON Root Type
+For JSON final results:
 
-The accepted root type for `target` and for parsed model responses is determined by the
-`output_schema` root type declaration, not hardcoded to object:
+- `target` must be valid JSON with root type `object` or `array`
+- `output_schema` defines the accepted JSON root type and schema rules
+- schema validation is required before scoring begins
+- JSON object roots are expected to support field-level comparison in v1
+- JSON array roots are expected to use conservative scoring in v1 rather than broad task-specific
+  logic
 
-- schema root `{type: "object"}` requires a JSON object
-- schema root `{type: "array"}` requires a JSON array
+The default ignored field set for JSON object scoring is:
 
-Multiple JSON values in one response are a parse failure in both `strict` and `extract` modes.
-Non-JSON payloads are a parse failure in both modes.
+- `evidence`
+- `confidence`
+- `closeness_logits`
+- `closeness_probs`
 
-#### Schema And Field Scoring
+Manifest-declared `ignored_paths` extend the default ignored field set. They do not override it.
+
+### `result_kind: text`
+
+For text final results:
+
+- `target` is the expected final text after normalization
+- v1 text scoring is intentionally narrow:
+  - `normalized_exact_match`
+  - `label_match`
+  - `regex_match`
+- task-specific text scorers are out of scope for v1
+- open-ended semantic scoring is deferred until a later design pass
+
+### Extraction Modes
+
+The runtime owns final-result extraction. Package-specific custom extractors are not part of the v1
+contract.
+
+`extraction_mode` defines how Melix isolates the final result from `raw_response`:
+
+- `strict_full_response`: the full response must be the final result payload; wrapper prose causes
+  extraction failure
+- `heuristic_final`: Melix applies a shared runtime extractor ladder to locate the final result in a
+  response that may include CoT or other wrapper text
+
+`heuristic_final` must be deterministic and reproducible. Ambiguous extraction is a failure rather
+than a guess.
+
+For `result_kind: json`, the planned shared extractor ladder is:
+
+- prefer the last contentful fenced `json` block
+- otherwise use the last contentful fenced block whose contents parse as JSON
+- otherwise use the last terminal balanced JSON suffix
+- if multiple same-priority candidates remain, record `ambiguous_extraction`
+
+For `result_kind: text`, the planned shared extractor ladder is:
+
+- prefer the last terminal `Final answer:` or `Answer:` span
+- otherwise use the last contentful fenced text block
+- otherwise use the last terminal non-empty line or paragraph
+- if multiple same-priority candidates remain, record `ambiguous_extraction`
+
+The current PR direction of describing extraction as "last valid JSON value" is not stable enough
+for the long-term contract because it is JSON-specific and under-specifies ambiguity handling.
+
+### Validation And Scoring
+
+Validation and scoring are typed by `result_kind`, not by task name.
+
+For `json`:
 
 - parse success is required before schema validation
-- schema validation success is required before field-level scoring
-- default ignored fields are `evidence`, `confidence`, `closeness_logits`, and `closeness_probs`
-- manifest-declared `ignored_paths` extend the default ignored set; they do not override it
-- the primary score is a field-level F1, precision, or recall measure rather than plain string
-  equality
+- schema validation success is required before scoring
+- object roots should use field-level comparison in v1
+- array roots should use conservative comparison in v1
 
-### `text_generation` Profile
+For `text`:
 
-#### Sample Shape
+- normalization happens before scoring
+- v1 text scoring remains deterministic and reference-based
+- normalization and scoring should not inspect CoT or wrapper text outside `extracted_result`
 
-- `prompt`
-- `expected`
+### Reporting Direction
 
-#### Scoring
+The current shipped export contract remains current-state behavior. The future `final_result` path
+should extend reporting with extraction- and validation-oriented evidence so LoRA compare can see:
 
-The profile declares a `scoring_mode`. Supported values are:
+- extraction success rate
+- validation success rate
+- typed score against ground truth
+- sample-level extraction or validation failure reasons
 
-- `multiple_choice_accuracy`
-- `exact_match`
-- `numeric_match`
-- `code_exec`
+## Why This Abstraction
 
-This profile is a permanent long-term evaluation path. Existing packages using `prompt` and
-`expected` rows are not subject to migration. LoRA workflows evaluated against reference answers
-should use this profile regardless of whether the underlying task involves structured data.
+The `final_result` abstraction is preferred because it keeps the critical axes separate:
 
-### `format_compliance` Profile
+- `result_kind` defines what artifact is being scored
+- `extraction_mode` defines how Melix isolates that artifact from `raw_response`
+- `scoring_mode` defines how the extracted artifact is compared to `target`
 
-#### Sample Shape
+This is cleaner than encoding result type, ground-truth presence, and extraction behavior into
+separate top-level profile names.
 
-- `system`
-- `input`
+## Migration Boundary
 
-No `target` field is required. This profile measures format adherence without correctness scoring.
+Current repository fixtures that use `prompt` and `expected` remain current-state implementation
+formats. They are not the primary long-term abstraction for the future final-result contract.
 
-#### Format Declaration
-
-The profile declares a `format` value:
-
-- `json_object`: the response must parse as a JSON object
-- `json_array`: the response must parse as a JSON array
-- `json_any`: the response must parse as any valid JSON value
-- `json_schema`: the response must parse and validate against the declared `output_schema`
-
-#### Metrics
-
-Output metrics are `parse_success_rate` and `schema_valid_rate`. There are no `correct` or
-`incorrect` sample counts for this profile type.
-
-This profile is intended for early-stage LoRA evaluation where ground-truth target data is not yet
-available. It answers the question of whether the model is producing validly formatted output,
-before annotation effort is invested in field-level correctness scoring.
-
-## Why Three Profiles Instead Of One
-
-The three-profile design avoids a false choice between structured and non-structured LoRA. Each
-profile covers a distinct evaluation scenario:
-
-- `structured_output` makes schema validity and field quality the primary evidence for LoRA
-  comparison, and `parser_mode` ensures the eval contract matches the training format
-- `text_generation` gives non-structured LoRA a stable long-term home without forcing a migration
-  to structured packages
-- `format_compliance` unblocks early-stage evaluation that would otherwise require fully annotated
-  target data
-
-Profile differences belong in manifest configuration, not in the public evaluation surface or
-scorer implementation.
-
-## Profile Boundary
-
-Existing `prompt` and `expected` evaluation fixtures belong to the `text_generation` profile. They
-are not historical formats. New structured-output packages should use the `structured_output`
-profile with an appropriate `parser_mode`. New early-stage packages should use the
-`format_compliance` profile.
-
-New package creation drives profile adoption. There is no forced migration of existing packages.
+New package creation should drive future adoption. This document does not claim that the future
+contract is already implemented.


### PR DESCRIPTION
## Summary
- define the future structured-output evaluation contract in the canonical benchmark/evaluation spec
- document the planned LoRA structured-output workflow and the Hugging Face source-to-package boundary in the runbook
- add a design spec and milestone roadmap for evaluation profiles, materialization, and compare/reporting

## Why
- tighten the long-term eval contract around repository-owned execution packages
- separate reusable source datasets from the runtime execution contract
- document that future structured-output parsing requires exactly one JSON object and does not preserve the legacy prompt/expected path

## Validation
- `git diff --check -- docs/benchmark-evaluation-contract.md docs/runbooks/benchmark-matrix-evaluation-and-lora.md docs/superpowers/specs/2026-04-13-structured-output-evaluation-profile-design.md docs/plans/2026-04-13-structured-output-evaluation-roadmap.md`

## Metrics
- Changed-scope metrics report: `N/A` (documentation-only change)
