### PR TITLE
[codex] Implement executable code eval for HumanEval and MBPP

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -771,6 +771,9 @@ public enum MelixCLICommand: Equatable, Sendable {
     case evalRun(EvalRunOptions)
     case evalCompare(EvalCompareOptions)
     case evalList(EvalListOptions)
+    case evalCompareExportSummaryCSV(EvalExportOptions)
+    case evalCompareExportSamplesCSV(EvalExportOptions)
+    case evalCompareExportSamplesJSONL(EvalExportOptions)
     case evalExportSummaryCSV(EvalExportOptions)
     case evalExportSamplesCSV(EvalExportOptions)
     case evalExportSamplesJSONL(EvalExportOptions)
@@ -874,6 +877,9 @@ public enum MelixCLIParser {
       melix bench matrix export-requests-csv --job-id JOB_ID --output PATH [--json]
       melix eval run (--model-id MODEL_ID | --repo-id HF_REPO) [--suite SUITE ...] [--dataset-id DATASET_ID] [--dataset-root PATH] [--sample-size N] [--batch-factor N] [--seed N] [--few-shot N] [--json]
       melix eval compare (--model-id MODEL_ID | --repo-id HF_REPO) --target-model-id MODEL_ID ... [--suite SUITE ...] [--dataset-id DATASET_ID] [--dataset-root PATH] [--sample-size N] [--batch-factor N] [--seed N] [--few-shot N] [--scoring-mode MODE] [--code-exec-policy MODE] [--json]
+      melix eval compare export-summary-csv --job-id JOB_ID --output PATH [--json]
+      melix eval compare export-samples-csv --job-id JOB_ID --output PATH [--json]
+      melix eval compare export-samples-jsonl --job-id JOB_ID --output PATH [--json]
       melix eval list [--json]
       melix eval export-summary-csv --job-id JOB_ID --output PATH [--json]
       melix eval export-samples-csv --job-id JOB_ID --output PATH [--json]
@@ -1552,11 +1558,11 @@ public enum MelixCLIParser {
         guard let action = arguments.first else {
             throw MelixCLIError.usage(usageText)
         }
-        let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse(
-            multiValueOptions: ["--suite", "--target-model-id"]
-        )
         switch action {
         case "run":
+            let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse(
+                multiValueOptions: ["--suite", "--target-model-id"]
+            )
             let modelID = values.single["--model-id"] ?? ""
             let hfRepoID = values.single["--repo-id"] ?? ""
             let explicitTargetCount = [modelID, hfRepoID].filter { !$0.isEmpty }.count
@@ -1595,39 +1601,76 @@ public enum MelixCLIParser {
                 )
             )
         case "compare":
-            let modelID = values.single["--model-id"] ?? ""
-            let hfRepoID = values.single["--repo-id"] ?? ""
-            let explicitTargetCount = [modelID, hfRepoID].filter { !$0.isEmpty }.count
-            guard explicitTargetCount == 1 else {
-                throw MelixCLIError.missingRequired("Exactly one of --model-id or --repo-id is required for melix eval compare.")
-            }
-            let targetModelIDs = values.multi["--target-model-id"] ?? []
-            guard targetModelIDs.isEmpty == false else {
-                throw MelixCLIError.missingRequired("At least one --target-model-id is required for melix eval compare.")
-            }
-            return .evalCompare(
-                EvalCompareOptions(
-                    modelID: modelID,
-                    hfRepoID: hfRepoID,
-                    targetModelIDs: targetModelIDs,
-                    suites: values.multi["--suite"] ?? [],
-                    datasetID: values.single["--dataset-id"] ?? "",
-                    sampleSize: UInt32(values.single["--sample-size"] ?? "") ?? 0,
-                    parameters: parseEvalParameters(values),
-                    json: values.flags.contains("--json")
-                )
-            )
+            return try parseEvalCompare(Array(arguments.dropFirst()))
         case "list":
+            let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse(
+                multiValueOptions: ["--suite", "--target-model-id"]
+            )
             return .evalList(EvalListOptions(json: values.flags.contains("--json")))
         case "export-summary-csv":
+            let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse(
+                multiValueOptions: ["--suite", "--target-model-id"]
+            )
             return .evalExportSummaryCSV(try parseEvalExportOptions(values, command: "melix eval export-summary-csv"))
         case "export-samples-csv":
+            let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse(
+                multiValueOptions: ["--suite", "--target-model-id"]
+            )
             return .evalExportSamplesCSV(try parseEvalExportOptions(values, command: "melix eval export-samples-csv"))
         case "export-samples-jsonl":
+            let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse(
+                multiValueOptions: ["--suite", "--target-model-id"]
+            )
             return .evalExportSamplesJSONL(try parseEvalExportOptions(values, command: "melix eval export-samples-jsonl"))
         default:
             throw MelixCLIError.usage(usageText)
         }
+    }
+
+    private static func parseEvalCompare(_ arguments: [String]) throws -> MelixCLICommand {
+        if let action = arguments.first,
+           ["export-summary-csv", "export-samples-csv", "export-samples-jsonl"].contains(action)
+        {
+            let exportCommand = "melix eval compare \(action)"
+            let exportArguments = Array(arguments.dropFirst())
+            let exportValues = try ArgumentCursor(arguments: exportArguments).parse()
+            switch action {
+            case "export-summary-csv":
+                return .evalCompareExportSummaryCSV(try parseEvalExportOptions(exportValues, command: exportCommand))
+            case "export-samples-csv":
+                return .evalCompareExportSamplesCSV(try parseEvalExportOptions(exportValues, command: exportCommand))
+            case "export-samples-jsonl":
+                return .evalCompareExportSamplesJSONL(try parseEvalExportOptions(exportValues, command: exportCommand))
+            default:
+                break
+            }
+        }
+
+        let values = try ArgumentCursor(arguments: arguments).parse(
+            multiValueOptions: ["--suite", "--target-model-id"]
+        )
+        let modelID = values.single["--model-id"] ?? ""
+        let hfRepoID = values.single["--repo-id"] ?? ""
+        let explicitTargetCount = [modelID, hfRepoID].filter { !$0.isEmpty }.count
+        guard explicitTargetCount == 1 else {
+            throw MelixCLIError.missingRequired("Exactly one of --model-id or --repo-id is required for melix eval compare.")
+        }
+        let targetModelIDs = values.multi["--target-model-id"] ?? []
+        guard targetModelIDs.isEmpty == false else {
+            throw MelixCLIError.missingRequired("At least one --target-model-id is required for melix eval compare.")
+        }
+        return .evalCompare(
+            EvalCompareOptions(
+                modelID: modelID,
+                hfRepoID: hfRepoID,
+                targetModelIDs: targetModelIDs,
+                suites: values.multi["--suite"] ?? [],
+                datasetID: values.single["--dataset-id"] ?? "",
+                sampleSize: UInt32(values.single["--sample-size"] ?? "") ?? 0,
+                parameters: parseEvalParameters(values),
+                json: values.flags.contains("--json")
+            )
+        )
     }
 
     private static func parseEvalExportOptions(
@@ -2638,21 +2681,45 @@ public actor MelixCLIRunner {
                 return try prettyJSON(entries)
             }
             return renderEvaluationHistory(entries)
+        case .evalCompareExportSummaryCSV(let options):
+            return try await exportEvaluationArtifact(
+                options: options,
+                missingRowsMessage: "No evaluation compare summary rows were found for job \(options.jobID).",
+                rowCount: { bundle in bundle.evaluationCompareSummaryRows(jobID: options.jobID).count },
+                contents: { bundle in bundle.evaluationCompareSummaryCSV(jobID: options.jobID) }
+            )
+        case .evalCompareExportSamplesCSV(let options):
+            return try await exportEvaluationArtifact(
+                options: options,
+                missingRowsMessage: "No evaluation compare sample rows were found for job \(options.jobID).",
+                rowCount: { bundle in bundle.evaluationCompareSampleRows(jobID: options.jobID).count },
+                contents: { bundle in bundle.evaluationCompareSamplesCSV(jobID: options.jobID) }
+            )
+        case .evalCompareExportSamplesJSONL(let options):
+            return try await exportEvaluationArtifact(
+                options: options,
+                missingRowsMessage: "No evaluation compare sample rows were found for job \(options.jobID).",
+                rowCount: { bundle in bundle.evaluationCompareSampleRows(jobID: options.jobID).count },
+                contents: { bundle in try bundle.evaluationCompareSamplesJSONL(jobID: options.jobID) }
+            )
         case .evalExportSummaryCSV(let options):
             return try await exportEvaluationArtifact(
                 options: options,
+                missingRowsMessage: "No evaluation rows were found for job \(options.jobID).",
                 rowCount: { bundle in bundle.evaluationSummaryCSVRows(jobID: options.jobID).count },
                 contents: { bundle in bundle.evaluationSummaryCSV(jobID: options.jobID) }
             )
         case .evalExportSamplesCSV(let options):
             return try await exportEvaluationArtifact(
                 options: options,
+                missingRowsMessage: "No evaluation rows were found for job \(options.jobID).",
                 rowCount: { bundle in bundle.evaluationSampleRows(jobID: options.jobID).count },
                 contents: { bundle in bundle.evaluationSamplesCSV(jobID: options.jobID) }
             )
         case .evalExportSamplesJSONL(let options):
             return try await exportEvaluationArtifact(
                 options: options,
+                missingRowsMessage: "No evaluation rows were found for job \(options.jobID).",
                 rowCount: { bundle in bundle.evaluationSampleRows(jobID: options.jobID).count },
                 contents: { bundle in try bundle.evaluationSamplesJSONL(jobID: options.jobID) }
             )
@@ -3444,13 +3511,14 @@ public actor MelixCLIRunner {
 
     private func exportEvaluationArtifact(
         options: EvalExportOptions,
+        missingRowsMessage: String,
         rowCount: (ControlPlaneBenchmarkExportBundle) throws -> Int,
         contents: (ControlPlaneBenchmarkExportBundle) throws -> String
     ) async throws -> String {
         let bundle = try await fetchBenchmarkExportBundle()
         let rows = try rowCount(bundle)
         guard rows > 0 else {
-            throw MelixCLIError.runtime("No evaluation rows were found for job \(options.jobID).")
+            throw MelixCLIError.runtime(missingRowsMessage)
         }
         let outputURL = URL(fileURLWithPath: options.outputPath)
         try FileManager.default.createDirectory(

--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -377,6 +377,10 @@ Optional evaluation controls:
 - `scoring_mode`
 - `code_exec_policy`
 
+Executable-code suites add one enforcement rule:
+
+- `humaneval` and `mbpp` must reject execution unless `code_exec_policy = sandboxed`
+
 Evaluation dataset overrides may also provide:
 
 - `dataset_id`
@@ -413,6 +417,14 @@ The first canonical `eval` suite set is:
 
 Multimodal evaluation datasets must package media alongside `manifest.json` and `samples.jsonl`.
 Relative media references are resolved against `dataset_root`.
+
+The checked-in development fixtures for executable-code evaluation are:
+
+- `humaneval.dev.v1`
+- `mbpp.dev.v1`
+
+These packages live under `services/mlx-worker-python/fixtures/evaluation/` and are the canonical
+development-time execution datasets for Melix v1 code evaluation.
 
 ### Evaluation Dataset Contract
 
@@ -592,8 +604,21 @@ Each sample-level row must include:
 - `parse_status`
 - `input_modalities`
 - `media_references`
+- `code_language`
+- `code_entry_point`
+- `code_compile_status`
+- `code_runtime_status`
+- `code_timeout_status`
+- `code_test_status`
+- `code_tests_passed`
+- `code_tests_total`
+- `code_failure_detail`
 
 `parse_status` is required in Melix even when the source benchmark does not expose it directly. This field provides operator-visible debugging for extraction failures and scorer fallbacks.
+
+For executable-code suites, these additional fields are required evidence rather than optional
+metadata. Melix v1 must preserve compile, runtime, timeout, and test outcomes through persistence,
+export, and compare workflows.
 
 ### Evaluation Export Formats
 
@@ -630,6 +655,65 @@ Each sample-level row must include:
 - `media_references`
 
 `eval export-samples-jsonl` must emit the same sample-level fields as line-delimited JSON objects.
+
+`eval compare export-summary-csv` must emit one row per base-versus-target summary with these
+columns:
+
+- `job_id`
+- `base_model_id`
+- `target_model_id`
+- `suite_id`
+- `dataset_id`
+- `sample_size`
+- `win_count`
+- `loss_count`
+- `tie_count`
+- `regression_count`
+- `base_accuracy`
+- `target_accuracy`
+- `delta_accuracy`
+- `duration_seconds`
+
+`eval compare export-samples-csv` must emit one row per comparison sample with these columns:
+
+- `job_id`
+- `suite_id`
+- `dataset_id`
+- `sample_id`
+- `target_model_id`
+- `question`
+- `expected`
+- `base_predicted`
+- `target_predicted`
+- `base_raw_response`
+- `target_raw_response`
+- `base_correct`
+- `target_correct`
+- `outcome`
+- `regression`
+- `base_time_s`
+- `target_time_s`
+- `base_parse_status`
+- `target_parse_status`
+- `code_language`
+- `code_entry_point`
+- `base_code_compile_status`
+- `target_code_compile_status`
+- `base_code_runtime_status`
+- `target_code_runtime_status`
+- `base_code_timeout_status`
+- `target_code_timeout_status`
+- `base_code_test_status`
+- `target_code_test_status`
+- `base_code_tests_passed`
+- `target_code_tests_passed`
+- `base_code_tests_total`
+- `target_code_tests_total`
+- `base_code_failure_detail`
+- `target_code_failure_detail`
+
+`eval compare export-samples-jsonl` must emit the same comparison-sample fields as line-delimited
+JSON objects.
 
 ## Run History Contract
 
@@ -735,6 +819,9 @@ The public CLI surface is:
 - `melix eval export-summary-csv`
 - `melix eval export-samples-csv`
 - `melix eval export-samples-jsonl`
+- `melix eval compare export-summary-csv`
+- `melix eval compare export-samples-csv`
+- `melix eval compare export-samples-jsonl`
 
 All commands must support `--json`.
 

--- a/docs/plans/2026-04-14-executable-code-eval-humaneval-mbpp.md
+++ b/docs/plans/2026-04-14-executable-code-eval-humaneval-mbpp.md
@@ -1,0 +1,87 @@
+# Executable Code Eval: HumanEval / MBPP
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Melix executable-code evaluation for `humaneval` and `mbpp` as a first-class product
+slice spanning checked-in dataset fixtures, worker-side sandboxed code execution, compare evidence
+preservation, public CLI compare exports, and operator-facing documentation.
+
+**Architecture:** Keep the Swift control plane as the public orchestration surface, keep Python
+worker execution as the scoring truth, require explicit `code_exec_policy=sandboxed` for
+executable-code suites, and preserve compile/runtime/test evidence through both standard evaluation
+and base-versus-target compare exports.
+
+**Tech Stack:** Swift, Python, Melix evaluation dataset packages, Swift Testing, pytest, coverage.
+
+---
+
+## Scope
+
+- [x] Add checked-in Melix development fixtures for `humaneval.dev.v1` and `mbpp.dev.v1`.
+- [x] Gate executable-code suites behind `code_exec_policy=sandboxed`.
+- [x] Execute Python candidate code with compile/runtime/timeout/test evidence persisted per sample.
+- [x] Preserve executable-code evidence through `eval compare` sample generation and export bundles.
+- [x] Add dedicated CLI compare export commands:
+  - `melix eval compare export-summary-csv`
+  - `melix eval compare export-samples-csv`
+  - `melix eval compare export-samples-jsonl`
+- [x] Update the canonical contract and runbook for executable-code suites and compare exports.
+
+## Product Decisions
+
+- [x] Treat executable-code evaluation as an end-to-end product slice rather than a worker-only
+  implementation detail.
+- [x] Keep checked-in Melix dataset packages as the development-time source of truth for both
+  executable-code suites.
+- [x] Preserve executable-code evidence in compare exports instead of flattening compare results
+  into the standard evaluation sample export path.
+- [x] Use dedicated compare export commands instead of overloading the existing `eval export-*`
+  commands.
+
+## Probes And Success Metrics
+
+- [x] Standard executable-code suite metrics persist:
+  - `eval.<suite>.pass_at_1`
+  - `eval.<suite>.correct_count`
+  - `eval.<suite>.incorrect_count`
+  - `eval.<suite>.code_exec_pass_count`
+  - `eval.<suite>.code_exec_fail_count`
+- [x] Standard sample evidence persists:
+  - `code_language`
+  - `code_entry_point`
+  - `code_compile_status`
+  - `code_runtime_status`
+  - `code_timeout_status`
+  - `code_test_status`
+  - `code_tests_passed`
+  - `code_tests_total`
+  - `code_failure_detail`
+- [x] Compare sample evidence persists:
+  - `base_code_*`
+  - `target_code_*`
+  - `code_language`
+  - `code_entry_point`
+
+## Metrics Report
+
+- Python changed-line coverage for the executable-code evaluation slice:
+  - `99.10%` (`220/222`)
+- Swift CLI changed-line coverage for compare export command and parser updates:
+  - `97.77%` (`263/269`)
+- Swift control-plane changed-line coverage for benchmark export bundle compare/code-evidence
+  decoding and rendering:
+  - `100.00%` (`266/266`)
+- Aggregate measurable changed-line coverage across the touched Python and Swift executable-code
+  slice:
+  - `98.94%` (`749/757`)
+
+## Verification
+
+- [x] `PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_maintenance_service.py -q`
+- [x] `PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --data-file /tmp/executable_code_eval_py.coverage --source=services/mlx-worker-python/worker,services/mlx-worker-python/tests -m pytest services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_maintenance_service.py -q`
+- [x] `HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'`
+- [x] `HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/services/control-plane-swift/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter BenchmarkExportBundleTests`
+- [x] `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/executable_code_eval_py_coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/worker/productization/benchmark_export.py services/mlx-worker-python/worker/productization/evaluation_compare.py services/mlx-worker-python/worker/productization/evaluation_schemas.py services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_maintenance_service.py`
+- [x] `python3 scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata Sources/MelixCLICore/MelixCLI.swift tests/MelixCLITests/MelixCLIParserTests.swift tests/MelixCLITests/MelixCLIRunnerTests.swift`
+- [x] `python3 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/XPCService/BenchmarkExportBundle.swift services/control-plane-swift/Tests/ControlPlaneTests/BenchmarkExportBundleTests.swift`
+- [x] `git diff --check`

--- a/docs/runbooks/benchmark-matrix-evaluation-and-lora.md
+++ b/docs/runbooks/benchmark-matrix-evaluation-and-lora.md
@@ -186,8 +186,7 @@ swift run melix eval run \
   --batch-factor 2 \
   --few-shot 4 \
   --seed 9 \
-  --scoring-mode multiple_choice_accuracy \
-  --code-exec-policy sandboxed
+  --scoring-mode multiple_choice_accuracy
 ```
 
 Example with a checked-in image evaluation fixture:
@@ -197,6 +196,17 @@ swift run melix eval run \
   --repo-id mlx-community/paligemma2-3b-ft-docci-448-8bit \
   --suite imagenette \
   --sample-size 10
+```
+
+Executable-code example with a checked-in dev fixture:
+
+```bash
+swift run melix eval run \
+  --model-id mlx-community/Qwen3.5-0.8B-OptiQ-4bit \
+  --suite humaneval \
+  --dataset-id humaneval.dev.v1 \
+  --sample-size 5 \
+  --code-exec-policy sandboxed
 ```
 
 History and exports:
@@ -224,8 +234,10 @@ Notes:
 - if you omit `--dataset-id`, the CLI defaults to `<suite>.dev.v1`
 - `mmlu.vision.dev.v1` is a checked-in image evaluation fixture under `services/mlx-worker-python/fixtures/evaluation/`
 - `imagenette.dev.v1` is a checked-in 10-sample validation subset sourced from `frgfm/imagenette` (`160px`, validation split, Apache-2.0)
+- `humaneval.dev.v1` and `mbpp.dev.v1` are checked-in executable-code fixtures under `services/mlx-worker-python/fixtures/evaluation/`
 - relative `image_uri` entries inside multimodal datasets are resolved against the selected dataset root automatically
 - use `--dataset-root /absolute/path/to/evaluation-package` only when you want to override the checked-in fixture bundle
+- `--code-exec-policy sandboxed` is mandatory for `humaneval` and `mbpp`; Melix rejects those suites without it
 - evaluation runs persist under `<jobs_root>/evaluation/runs/<job_id>/`
 
 ## Planned Final-Result Evaluation Workflow
@@ -405,12 +417,12 @@ swift run melix eval compare \
   --model-id mlx-community/Qwen3.5-0.8B-OptiQ-4bit \
   --target-model-id <adapter-a-derived-model-id> \
   --target-model-id <adapter-b-derived-model-id> \
-  --suite mmlu \
+  --suite mbpp \
+  --dataset-id mbpp.dev.v1 \
   --sample-size 12 \
   --batch-factor 2 \
-  --few-shot 4 \
   --seed 9 \
-  --scoring-mode multiple_choice_accuracy \
+  --scoring-mode pass_at_1 \
   --code-exec-policy sandboxed
 ```
 
@@ -418,18 +430,23 @@ Important compare rules:
 
 - `eval compare` still uses model IDs, not adapter paths
 - every `--target-model-id` must already exist in the local catalog
-- compare results persist through the same evaluation history and export bundle as `eval run`
+- compare results persist through the same evaluation export bundle as `eval run`, but compare exports use dedicated compare subcommands
+- compare sample exports preserve executable-code evidence for both the base and target responses when the suite executes code
 
-Export the resulting comparison evidence with the normal evaluation export commands:
+Export the resulting comparison evidence with the dedicated compare export commands:
 
 ```bash
 swift run melix eval list --json
 
-swift run melix eval export-summary-csv \
+swift run melix eval compare export-summary-csv \
   --job-id <compare-job-id> \
   --output /tmp/melix-evaluation-compare-summary.csv
 
-swift run melix eval export-samples-jsonl \
+swift run melix eval compare export-samples-csv \
+  --job-id <compare-job-id> \
+  --output /tmp/melix-evaluation-compare-samples.csv
+
+swift run melix eval compare export-samples-jsonl \
   --job-id <compare-job-id> \
   --output /tmp/melix-evaluation-compare-samples.jsonl
 ```

--- a/progress.md
+++ b/progress.md
@@ -11,6 +11,34 @@
 
 ## 2026-04-12
 
+## 2026-04-14
+
+- Closed the executable-code evaluation slice for `humaneval` and `mbpp` so Melix now treats
+  repository-owned Python code execution as a first-class evaluation path instead of a text-only
+  approximation:
+  - added checked-in `humaneval.dev.v1` and `mbpp.dev.v1` fixture packages under
+    `services/mlx-worker-python/fixtures/evaluation/`
+  - gated executable-code suites behind `code_exec_policy=sandboxed`
+  - added Python candidate execution with compile/runtime/timeout/test evidence persisted on
+    sample records
+  - preserved executable-code evidence through `eval compare` sample generation and export-bundle
+    normalization
+  - added dedicated public CLI compare export commands for summary CSV, samples CSV, and samples
+    JSONL
+  - updated the canonical benchmark/evaluation contract and runbook for executable-code suites,
+    compare exports, and checked-in dev fixtures
+- Verification summary for the executable-code evaluation slice:
+  - `PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_maintenance_service.py -q`: `141 passed in 1.44s`
+  - `HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'`: `112 tests in 3 suites passed after 0.058 seconds`
+  - `HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/services/control-plane-swift/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter BenchmarkExportBundleTests`: `12 tests in 1 suite passed after 0.002 seconds`
+  - `git diff --check`: pass
+- Metrics report for the executable-code evaluation slice:
+  - Python changed-line coverage: `99.10%` (`220/222`)
+  - Swift CLI changed-line coverage: `97.77%` (`263/269`)
+  - Swift control-plane changed-line coverage: `100.00%` (`266/266`)
+  - Aggregate measurable changed-line coverage across the touched executable-code evaluation slice:
+    `98.94%` (`749/757`)
+
 - Realigned the public documentation entrypoints so the repository now presents Melix as a
   project first and an engineering archive second:
   - rewrote `README.md` around product narrative, target users, LoRA and benchmark motivation,

--- a/services/control-plane-swift/Sources/XPCService/BenchmarkExportBundle.swift
+++ b/services/control-plane-swift/Sources/XPCService/BenchmarkExportBundle.swift
@@ -481,6 +481,7 @@ public struct ControlPlaneEvaluationSampleRecord: Codable, Equatable, Sendable {
     public let suiteID: String
     public let datasetID: String
     public let sampleID: String
+    public let taskKind: String
     public let question: String
     public let expected: String
     public let predicted: String
@@ -488,6 +489,8 @@ public struct ControlPlaneEvaluationSampleRecord: Codable, Equatable, Sendable {
     public let correct: Bool
     public let timeS: Double
     public let parseStatus: String
+    public let inputModalities: [String]
+    public let mediaReferences: [String]
     public let codeLanguage: String
     public let codeEntryPoint: String
     public let codeCompileStatus: String
@@ -504,6 +507,7 @@ public struct ControlPlaneEvaluationSampleRecord: Codable, Equatable, Sendable {
         case suiteID = "suite_id"
         case datasetID = "dataset_id"
         case sampleID = "sample_id"
+        case taskKind = "task_kind"
         case question
         case expected
         case predicted
@@ -511,6 +515,8 @@ public struct ControlPlaneEvaluationSampleRecord: Codable, Equatable, Sendable {
         case correct
         case timeS = "time_s"
         case parseStatus = "parse_status"
+        case inputModalities = "input_modalities"
+        case mediaReferences = "media_references"
         case codeLanguage = "code_language"
         case codeEntryPoint = "code_entry_point"
         case codeCompileStatus = "code_compile_status"
@@ -529,6 +535,7 @@ public struct ControlPlaneEvaluationSampleRecord: Codable, Equatable, Sendable {
         suiteID = try container.decodeIfPresent(String.self, forKey: .suiteID) ?? ""
         datasetID = try container.decodeIfPresent(String.self, forKey: .datasetID) ?? ""
         sampleID = try container.decodeIfPresent(String.self, forKey: .sampleID) ?? ""
+        taskKind = try container.decodeIfPresent(String.self, forKey: .taskKind) ?? ""
         question = try container.decodeIfPresent(String.self, forKey: .question) ?? ""
         expected = try container.decodeIfPresent(String.self, forKey: .expected) ?? ""
         predicted = try container.decodeIfPresent(String.self, forKey: .predicted) ?? ""
@@ -536,6 +543,8 @@ public struct ControlPlaneEvaluationSampleRecord: Codable, Equatable, Sendable {
         correct = try container.decodeIfPresent(Bool.self, forKey: .correct) ?? false
         timeS = try container.decodeIfPresent(Double.self, forKey: .timeS) ?? 0
         parseStatus = try container.decodeIfPresent(String.self, forKey: .parseStatus) ?? ""
+        inputModalities = try container.decodeIfPresent([String].self, forKey: .inputModalities) ?? []
+        mediaReferences = try container.decodeIfPresent([String].self, forKey: .mediaReferences) ?? []
         codeLanguage = try container.decodeIfPresent(String.self, forKey: .codeLanguage) ?? ""
         codeEntryPoint = try container.decodeIfPresent(String.self, forKey: .codeEntryPoint) ?? ""
         codeCompileStatus = try container.decodeIfPresent(String.self, forKey: .codeCompileStatus) ?? ""
@@ -1247,21 +1256,21 @@ public struct ControlPlaneBenchmarkExportBundle: Codable, Equatable, Sendable {
 
     public func evaluationSummaryCSV(jobID: String? = nil) -> String {
         let rows = evaluationSummaryCSVRows(jobID: jobID)
-        let header = "job_id,model_id,task_kind,source_repo,suite_id,dataset_id,sample_size,score_name,score_value,correct_count,incorrect_count,duration_seconds,created_at_unix_ms"
+        let header = "job_id,task_kind,source_repo,model_id,suite_id,dataset_id,score_name,score_value,sample_size,correct_count,incorrect_count,duration_seconds,created_at_unix_ms"
         guard rows.isEmpty == false else {
             return header + "\n"
         }
         let body = rows.map { row in
             [
                 row.jobID,
-                row.modelID,
                 row.taskKind,
                 row.sourceRepo,
+                row.modelID,
                 row.suiteID,
                 row.datasetID,
-                String(row.sampleSize),
                 row.scoreName,
                 String(row.scoreValue),
+                String(row.sampleSize),
                 String(row.correctCount),
                 String(row.incorrectCount),
                 String(row.durationSeconds),
@@ -1286,13 +1295,16 @@ public struct ControlPlaneBenchmarkExportBundle: Codable, Equatable, Sendable {
 
     public func evaluationSamplesCSV(jobID: String? = nil) -> String {
         let rows = evaluationSampleRows(jobID: jobID)
-        let header = "id,correct,expected,predicted,question,raw_response,time_s,parse_status,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail"
+        let header = "job_id,suite_id,id,task_kind,correct,expected,predicted,question,raw_response,time_s,parse_status,input_modalities,media_references,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail"
         guard rows.isEmpty == false else {
             return header + "\n"
         }
         let body = rows.map { row in
             [
+                row.jobID,
+                row.suiteID,
                 row.sampleID,
+                row.taskKind,
                 row.correct ? "true" : "false",
                 row.expected,
                 row.predicted,
@@ -1300,6 +1312,8 @@ public struct ControlPlaneBenchmarkExportBundle: Codable, Equatable, Sendable {
                 row.rawResponse,
                 String(row.timeS),
                 row.parseStatus,
+                row.inputModalities.joined(separator: ","),
+                row.mediaReferences.joined(separator: ","),
                 row.codeLanguage,
                 row.codeEntryPoint,
                 row.codeCompileStatus,

--- a/services/control-plane-swift/Sources/XPCService/BenchmarkExportBundle.swift
+++ b/services/control-plane-swift/Sources/XPCService/BenchmarkExportBundle.swift
@@ -488,6 +488,15 @@ public struct ControlPlaneEvaluationSampleRecord: Codable, Equatable, Sendable {
     public let correct: Bool
     public let timeS: Double
     public let parseStatus: String
+    public let codeLanguage: String
+    public let codeEntryPoint: String
+    public let codeCompileStatus: String
+    public let codeRuntimeStatus: String
+    public let codeTimeoutStatus: String
+    public let codeTestStatus: String
+    public let codeTestsPassed: Int
+    public let codeTestsTotal: Int
+    public let codeFailureDetail: String
 
     enum CodingKeys: String, CodingKey {
         case schemaVersion = "schema_version"
@@ -502,6 +511,15 @@ public struct ControlPlaneEvaluationSampleRecord: Codable, Equatable, Sendable {
         case correct
         case timeS = "time_s"
         case parseStatus = "parse_status"
+        case codeLanguage = "code_language"
+        case codeEntryPoint = "code_entry_point"
+        case codeCompileStatus = "code_compile_status"
+        case codeRuntimeStatus = "code_runtime_status"
+        case codeTimeoutStatus = "code_timeout_status"
+        case codeTestStatus = "code_test_status"
+        case codeTestsPassed = "code_tests_passed"
+        case codeTestsTotal = "code_tests_total"
+        case codeFailureDetail = "code_failure_detail"
     }
 
     public init(from decoder: Decoder) throws {
@@ -518,6 +536,15 @@ public struct ControlPlaneEvaluationSampleRecord: Codable, Equatable, Sendable {
         correct = try container.decodeIfPresent(Bool.self, forKey: .correct) ?? false
         timeS = try container.decodeIfPresent(Double.self, forKey: .timeS) ?? 0
         parseStatus = try container.decodeIfPresent(String.self, forKey: .parseStatus) ?? ""
+        codeLanguage = try container.decodeIfPresent(String.self, forKey: .codeLanguage) ?? ""
+        codeEntryPoint = try container.decodeIfPresent(String.self, forKey: .codeEntryPoint) ?? ""
+        codeCompileStatus = try container.decodeIfPresent(String.self, forKey: .codeCompileStatus) ?? ""
+        codeRuntimeStatus = try container.decodeIfPresent(String.self, forKey: .codeRuntimeStatus) ?? ""
+        codeTimeoutStatus = try container.decodeIfPresent(String.self, forKey: .codeTimeoutStatus) ?? ""
+        codeTestStatus = try container.decodeIfPresent(String.self, forKey: .codeTestStatus) ?? ""
+        codeTestsPassed = try container.decodeIfPresent(Int.self, forKey: .codeTestsPassed) ?? 0
+        codeTestsTotal = try container.decodeIfPresent(Int.self, forKey: .codeTestsTotal) ?? 0
+        codeFailureDetail = try container.decodeIfPresent(String.self, forKey: .codeFailureDetail) ?? ""
     }
 }
 
@@ -616,6 +643,243 @@ public struct ControlPlaneEvaluationSummaryCSVRow: Codable, Equatable, Sendable 
     }
 }
 
+public struct ControlPlaneEvaluationCompareJobRecord: Codable, Equatable, Sendable {
+    public let schemaVersion: String
+    public let jobID: String
+    public let baseModelID: String
+    public let targetModelIDs: [String]
+    public let taskKind: String
+    public let sourceRepo: String
+    public let suiteID: String
+    public let datasetID: String
+    public let sampleSize: Int
+    public let scoringMode: String
+    public let parameters: [String: String]
+    public let status: String
+    public let outputDir: String
+    public let createdAtUnixMS: Int64
+    public let updatedAtUnixMS: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case jobID = "job_id"
+        case baseModelID = "base_model_id"
+        case targetModelIDs = "target_model_ids"
+        case taskKind = "task_kind"
+        case sourceRepo = "source_repo"
+        case suiteID = "suite_id"
+        case datasetID = "dataset_id"
+        case sampleSize = "sample_size"
+        case scoringMode = "scoring_mode"
+        case parameters
+        case status
+        case outputDir = "output_dir"
+        case createdAtUnixMS = "created_at_unix_ms"
+        case updatedAtUnixMS = "updated_at_unix_ms"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decodeIfPresent(String.self, forKey: .schemaVersion) ?? ""
+        jobID = try container.decodeIfPresent(String.self, forKey: .jobID) ?? ""
+        baseModelID = try container.decodeIfPresent(String.self, forKey: .baseModelID) ?? ""
+        targetModelIDs = try container.decodeIfPresent([String].self, forKey: .targetModelIDs) ?? []
+        taskKind = try container.decodeIfPresent(String.self, forKey: .taskKind) ?? ""
+        sourceRepo = try container.decodeIfPresent(String.self, forKey: .sourceRepo) ?? ""
+        suiteID = try container.decodeIfPresent(String.self, forKey: .suiteID) ?? ""
+        datasetID = try container.decodeIfPresent(String.self, forKey: .datasetID) ?? ""
+        sampleSize = try container.decodeIfPresent(Int.self, forKey: .sampleSize) ?? 0
+        scoringMode = try container.decodeIfPresent(String.self, forKey: .scoringMode) ?? ""
+        parameters = try container.decodeIfPresent([String: String].self, forKey: .parameters) ?? [:]
+        status = try container.decodeIfPresent(String.self, forKey: .status) ?? ""
+        outputDir = try container.decodeIfPresent(String.self, forKey: .outputDir) ?? ""
+        createdAtUnixMS = try container.decodeIfPresent(Int64.self, forKey: .createdAtUnixMS) ?? 0
+        updatedAtUnixMS = try container.decodeIfPresent(Int64.self, forKey: .updatedAtUnixMS) ?? 0
+    }
+}
+
+public struct ControlPlaneEvaluationCompareSummaryRecord: Codable, Equatable, Sendable {
+    public let schemaVersion: String
+    public let jobID: String
+    public let baseModelID: String
+    public let targetModelID: String
+    public let suiteID: String
+    public let datasetID: String
+    public let sampleSize: Int
+    public let scoringMode: String
+    public let winCount: Int
+    public let lossCount: Int
+    public let tieCount: Int
+    public let regressionCount: Int
+    public let baseAccuracy: Double
+    public let targetAccuracy: Double
+    public let deltaAccuracy: Double
+    public let durationSeconds: Double
+    public let metrics: [ControlPlaneBenchmarkMetricRecord]
+    public let reportPath: String
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case jobID = "job_id"
+        case baseModelID = "base_model_id"
+        case targetModelID = "target_model_id"
+        case suiteID = "suite_id"
+        case datasetID = "dataset_id"
+        case sampleSize = "sample_size"
+        case scoringMode = "scoring_mode"
+        case winCount = "win_count"
+        case lossCount = "loss_count"
+        case tieCount = "tie_count"
+        case regressionCount = "regression_count"
+        case baseAccuracy = "base_accuracy"
+        case targetAccuracy = "target_accuracy"
+        case deltaAccuracy = "delta_accuracy"
+        case durationSeconds = "duration_seconds"
+        case metrics
+        case reportPath = "report_path"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decodeIfPresent(String.self, forKey: .schemaVersion) ?? ""
+        jobID = try container.decodeIfPresent(String.self, forKey: .jobID) ?? ""
+        baseModelID = try container.decodeIfPresent(String.self, forKey: .baseModelID) ?? ""
+        targetModelID = try container.decodeIfPresent(String.self, forKey: .targetModelID) ?? ""
+        suiteID = try container.decodeIfPresent(String.self, forKey: .suiteID) ?? ""
+        datasetID = try container.decodeIfPresent(String.self, forKey: .datasetID) ?? ""
+        sampleSize = try container.decodeIfPresent(Int.self, forKey: .sampleSize) ?? 0
+        scoringMode = try container.decodeIfPresent(String.self, forKey: .scoringMode) ?? ""
+        winCount = try container.decodeIfPresent(Int.self, forKey: .winCount) ?? 0
+        lossCount = try container.decodeIfPresent(Int.self, forKey: .lossCount) ?? 0
+        tieCount = try container.decodeIfPresent(Int.self, forKey: .tieCount) ?? 0
+        regressionCount = try container.decodeIfPresent(Int.self, forKey: .regressionCount) ?? 0
+        baseAccuracy = try container.decodeIfPresent(Double.self, forKey: .baseAccuracy) ?? 0
+        targetAccuracy = try container.decodeIfPresent(Double.self, forKey: .targetAccuracy) ?? 0
+        deltaAccuracy = try container.decodeIfPresent(Double.self, forKey: .deltaAccuracy) ?? 0
+        durationSeconds = try container.decodeIfPresent(Double.self, forKey: .durationSeconds) ?? 0
+        metrics = try container.decodeIfPresent([ControlPlaneBenchmarkMetricRecord].self, forKey: .metrics) ?? []
+        reportPath = try container.decodeIfPresent(String.self, forKey: .reportPath) ?? ""
+    }
+}
+
+public struct ControlPlaneEvaluationCompareSampleRecord: Codable, Equatable, Sendable {
+    public let schemaVersion: String
+    public let jobID: String
+    public let suiteID: String
+    public let datasetID: String
+    public let sampleID: String
+    public let targetModelID: String
+    public let question: String
+    public let expected: String
+    public let basePredicted: String
+    public let targetPredicted: String
+    public let baseRawResponse: String
+    public let targetRawResponse: String
+    public let baseCorrect: Bool
+    public let targetCorrect: Bool
+    public let outcome: String
+    public let regression: Bool
+    public let baseTimeS: Double
+    public let targetTimeS: Double
+    public let baseParseStatus: String
+    public let targetParseStatus: String
+    public let codeLanguage: String
+    public let codeEntryPoint: String
+    public let baseCodeCompileStatus: String
+    public let targetCodeCompileStatus: String
+    public let baseCodeRuntimeStatus: String
+    public let targetCodeRuntimeStatus: String
+    public let baseCodeTimeoutStatus: String
+    public let targetCodeTimeoutStatus: String
+    public let baseCodeTestStatus: String
+    public let targetCodeTestStatus: String
+    public let baseCodeTestsPassed: Int
+    public let targetCodeTestsPassed: Int
+    public let baseCodeTestsTotal: Int
+    public let targetCodeTestsTotal: Int
+    public let baseCodeFailureDetail: String
+    public let targetCodeFailureDetail: String
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case jobID = "job_id"
+        case suiteID = "suite_id"
+        case datasetID = "dataset_id"
+        case sampleID = "sample_id"
+        case targetModelID = "target_model_id"
+        case question
+        case expected
+        case basePredicted = "base_predicted"
+        case targetPredicted = "target_predicted"
+        case baseRawResponse = "base_raw_response"
+        case targetRawResponse = "target_raw_response"
+        case baseCorrect = "base_correct"
+        case targetCorrect = "target_correct"
+        case outcome
+        case regression
+        case baseTimeS = "base_time_s"
+        case targetTimeS = "target_time_s"
+        case baseParseStatus = "base_parse_status"
+        case targetParseStatus = "target_parse_status"
+        case codeLanguage = "code_language"
+        case codeEntryPoint = "code_entry_point"
+        case baseCodeCompileStatus = "base_code_compile_status"
+        case targetCodeCompileStatus = "target_code_compile_status"
+        case baseCodeRuntimeStatus = "base_code_runtime_status"
+        case targetCodeRuntimeStatus = "target_code_runtime_status"
+        case baseCodeTimeoutStatus = "base_code_timeout_status"
+        case targetCodeTimeoutStatus = "target_code_timeout_status"
+        case baseCodeTestStatus = "base_code_test_status"
+        case targetCodeTestStatus = "target_code_test_status"
+        case baseCodeTestsPassed = "base_code_tests_passed"
+        case targetCodeTestsPassed = "target_code_tests_passed"
+        case baseCodeTestsTotal = "base_code_tests_total"
+        case targetCodeTestsTotal = "target_code_tests_total"
+        case baseCodeFailureDetail = "base_code_failure_detail"
+        case targetCodeFailureDetail = "target_code_failure_detail"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decodeIfPresent(String.self, forKey: .schemaVersion) ?? ""
+        jobID = try container.decodeIfPresent(String.self, forKey: .jobID) ?? ""
+        suiteID = try container.decodeIfPresent(String.self, forKey: .suiteID) ?? ""
+        datasetID = try container.decodeIfPresent(String.self, forKey: .datasetID) ?? ""
+        sampleID = try container.decodeIfPresent(String.self, forKey: .sampleID) ?? ""
+        targetModelID = try container.decodeIfPresent(String.self, forKey: .targetModelID) ?? ""
+        question = try container.decodeIfPresent(String.self, forKey: .question) ?? ""
+        expected = try container.decodeIfPresent(String.self, forKey: .expected) ?? ""
+        basePredicted = try container.decodeIfPresent(String.self, forKey: .basePredicted) ?? ""
+        targetPredicted = try container.decodeIfPresent(String.self, forKey: .targetPredicted) ?? ""
+        baseRawResponse = try container.decodeIfPresent(String.self, forKey: .baseRawResponse) ?? ""
+        targetRawResponse = try container.decodeIfPresent(String.self, forKey: .targetRawResponse) ?? ""
+        baseCorrect = try container.decodeIfPresent(Bool.self, forKey: .baseCorrect) ?? false
+        targetCorrect = try container.decodeIfPresent(Bool.self, forKey: .targetCorrect) ?? false
+        outcome = try container.decodeIfPresent(String.self, forKey: .outcome) ?? ""
+        regression = try container.decodeIfPresent(Bool.self, forKey: .regression) ?? false
+        baseTimeS = try container.decodeIfPresent(Double.self, forKey: .baseTimeS) ?? 0
+        targetTimeS = try container.decodeIfPresent(Double.self, forKey: .targetTimeS) ?? 0
+        baseParseStatus = try container.decodeIfPresent(String.self, forKey: .baseParseStatus) ?? ""
+        targetParseStatus = try container.decodeIfPresent(String.self, forKey: .targetParseStatus) ?? ""
+        codeLanguage = try container.decodeIfPresent(String.self, forKey: .codeLanguage) ?? ""
+        codeEntryPoint = try container.decodeIfPresent(String.self, forKey: .codeEntryPoint) ?? ""
+        baseCodeCompileStatus = try container.decodeIfPresent(String.self, forKey: .baseCodeCompileStatus) ?? ""
+        targetCodeCompileStatus = try container.decodeIfPresent(String.self, forKey: .targetCodeCompileStatus) ?? ""
+        baseCodeRuntimeStatus = try container.decodeIfPresent(String.self, forKey: .baseCodeRuntimeStatus) ?? ""
+        targetCodeRuntimeStatus = try container.decodeIfPresent(String.self, forKey: .targetCodeRuntimeStatus) ?? ""
+        baseCodeTimeoutStatus = try container.decodeIfPresent(String.self, forKey: .baseCodeTimeoutStatus) ?? ""
+        targetCodeTimeoutStatus = try container.decodeIfPresent(String.self, forKey: .targetCodeTimeoutStatus) ?? ""
+        baseCodeTestStatus = try container.decodeIfPresent(String.self, forKey: .baseCodeTestStatus) ?? ""
+        targetCodeTestStatus = try container.decodeIfPresent(String.self, forKey: .targetCodeTestStatus) ?? ""
+        baseCodeTestsPassed = try container.decodeIfPresent(Int.self, forKey: .baseCodeTestsPassed) ?? 0
+        targetCodeTestsPassed = try container.decodeIfPresent(Int.self, forKey: .targetCodeTestsPassed) ?? 0
+        baseCodeTestsTotal = try container.decodeIfPresent(Int.self, forKey: .baseCodeTestsTotal) ?? 0
+        targetCodeTestsTotal = try container.decodeIfPresent(Int.self, forKey: .targetCodeTestsTotal) ?? 0
+        baseCodeFailureDetail = try container.decodeIfPresent(String.self, forKey: .baseCodeFailureDetail) ?? ""
+        targetCodeFailureDetail = try container.decodeIfPresent(String.self, forKey: .targetCodeFailureDetail) ?? ""
+    }
+}
+
 public struct ControlPlaneBenchmarkExportBundle: Codable, Equatable, Sendable {
     public let exportSchemaVersion: String
     public let exportedAtUnixMS: Int64
@@ -628,6 +892,9 @@ public struct ControlPlaneBenchmarkExportBundle: Codable, Equatable, Sendable {
     public let evaluationResults: [ControlPlaneEvaluationResultRecord]
     public let evaluationSummaryRows: [ControlPlaneEvaluationSummaryCSVRow]
     public let evaluationSamples: [ControlPlaneEvaluationSampleRecord]
+    public let evaluationCompareJobs: [ControlPlaneEvaluationCompareJobRecord]
+    public let evaluationCompareSummaryRecords: [ControlPlaneEvaluationCompareSummaryRecord]
+    public let evaluationCompareSampleRecords: [ControlPlaneEvaluationCompareSampleRecord]
 
     enum CodingKeys: String, CodingKey {
         case exportSchemaVersion = "export_schema_version"
@@ -641,6 +908,9 @@ public struct ControlPlaneBenchmarkExportBundle: Codable, Equatable, Sendable {
         case evaluationResults = "evaluation_results"
         case evaluationSummaryRows = "evaluation_summary_rows"
         case evaluationSamples = "evaluation_samples"
+        case evaluationCompareJobs = "evaluation_compare_jobs"
+        case evaluationCompareSummaryRecords = "evaluation_compare_summary_rows"
+        case evaluationCompareSampleRecords = "evaluation_compare_samples"
     }
 
     public init(from decoder: Decoder) throws {
@@ -656,6 +926,9 @@ public struct ControlPlaneBenchmarkExportBundle: Codable, Equatable, Sendable {
         evaluationResults = try container.decodeIfPresent([ControlPlaneEvaluationResultRecord].self, forKey: .evaluationResults) ?? []
         evaluationSummaryRows = try container.decodeIfPresent([ControlPlaneEvaluationSummaryCSVRow].self, forKey: .evaluationSummaryRows) ?? []
         evaluationSamples = try container.decodeIfPresent([ControlPlaneEvaluationSampleRecord].self, forKey: .evaluationSamples) ?? []
+        evaluationCompareJobs = try container.decodeIfPresent([ControlPlaneEvaluationCompareJobRecord].self, forKey: .evaluationCompareJobs) ?? []
+        evaluationCompareSummaryRecords = try container.decodeIfPresent([ControlPlaneEvaluationCompareSummaryRecord].self, forKey: .evaluationCompareSummaryRecords) ?? []
+        evaluationCompareSampleRecords = try container.decodeIfPresent([ControlPlaneEvaluationCompareSampleRecord].self, forKey: .evaluationCompareSampleRecords) ?? []
     }
 
     public static func decode(json: String) throws -> ControlPlaneBenchmarkExportBundle {
@@ -1013,7 +1286,7 @@ public struct ControlPlaneBenchmarkExportBundle: Codable, Equatable, Sendable {
 
     public func evaluationSamplesCSV(jobID: String? = nil) -> String {
         let rows = evaluationSampleRows(jobID: jobID)
-        let header = "id,correct,expected,predicted,question,raw_response,time_s,parse_status"
+        let header = "id,correct,expected,predicted,question,raw_response,time_s,parse_status,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail"
         guard rows.isEmpty == false else {
             return header + "\n"
         }
@@ -1027,6 +1300,15 @@ public struct ControlPlaneBenchmarkExportBundle: Codable, Equatable, Sendable {
                 row.rawResponse,
                 String(row.timeS),
                 row.parseStatus,
+                row.codeLanguage,
+                row.codeEntryPoint,
+                row.codeCompileStatus,
+                row.codeRuntimeStatus,
+                row.codeTimeoutStatus,
+                row.codeTestStatus,
+                String(row.codeTestsPassed),
+                String(row.codeTestsTotal),
+                row.codeFailureDetail,
             ]
             .map(Self.csvField)
             .joined(separator: ",")
@@ -1038,6 +1320,123 @@ public struct ControlPlaneBenchmarkExportBundle: Codable, Equatable, Sendable {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         let rows = evaluationSampleRows(jobID: jobID)
+        return try rows
+            .map { sample in
+                let data = try encoder.encode(sample)
+                return String(decoding: data, as: UTF8.self)
+            }
+            .joined(separator: "\n")
+            + (rows.isEmpty ? "" : "\n")
+    }
+
+    public func evaluationCompareSummaryRows(jobID: String? = nil) -> [ControlPlaneEvaluationCompareSummaryRecord] {
+        evaluationCompareSummaryRecords
+            .filter { jobID == nil || $0.jobID == jobID }
+            .sorted {
+                if $0.jobID == $1.jobID {
+                    return $0.targetModelID < $1.targetModelID
+                }
+                return $0.jobID < $1.jobID
+            }
+    }
+
+    public func evaluationCompareSummaryCSV(jobID: String? = nil) -> String {
+        let rows = evaluationCompareSummaryRows(jobID: jobID)
+        let header = "job_id,base_model_id,target_model_id,suite_id,dataset_id,sample_size,win_count,loss_count,tie_count,regression_count,base_accuracy,target_accuracy,delta_accuracy,duration_seconds"
+        guard rows.isEmpty == false else {
+            return header + "\n"
+        }
+        let body = rows.map { row in
+            [
+                row.jobID,
+                row.baseModelID,
+                row.targetModelID,
+                row.suiteID,
+                row.datasetID,
+                String(row.sampleSize),
+                String(row.winCount),
+                String(row.lossCount),
+                String(row.tieCount),
+                String(row.regressionCount),
+                String(row.baseAccuracy),
+                String(row.targetAccuracy),
+                String(row.deltaAccuracy),
+                String(row.durationSeconds),
+            ]
+            .map(Self.csvField)
+            .joined(separator: ",")
+        }
+        return ([header] + body).joined(separator: "\n") + "\n"
+    }
+
+    public func evaluationCompareSampleRows(jobID: String? = nil) -> [ControlPlaneEvaluationCompareSampleRecord] {
+        evaluationCompareSampleRecords
+            .filter { jobID == nil || $0.jobID == jobID }
+            .sorted {
+                if $0.jobID == $1.jobID {
+                    if $0.targetModelID == $1.targetModelID {
+                        return $0.sampleID < $1.sampleID
+                    }
+                    return $0.targetModelID < $1.targetModelID
+                }
+                return $0.jobID < $1.jobID
+            }
+    }
+
+    public func evaluationCompareSamplesCSV(jobID: String? = nil) -> String {
+        let rows = evaluationCompareSampleRows(jobID: jobID)
+        let header = "job_id,suite_id,dataset_id,sample_id,target_model_id,question,expected,base_predicted,target_predicted,base_raw_response,target_raw_response,base_correct,target_correct,outcome,regression,base_time_s,target_time_s,base_parse_status,target_parse_status,code_language,code_entry_point,base_code_compile_status,target_code_compile_status,base_code_runtime_status,target_code_runtime_status,base_code_timeout_status,target_code_timeout_status,base_code_test_status,target_code_test_status,base_code_tests_passed,target_code_tests_passed,base_code_tests_total,target_code_tests_total,base_code_failure_detail,target_code_failure_detail"
+        guard rows.isEmpty == false else {
+            return header + "\n"
+        }
+        let body = rows.map { row in
+            [
+                row.jobID,
+                row.suiteID,
+                row.datasetID,
+                row.sampleID,
+                row.targetModelID,
+                row.question,
+                row.expected,
+                row.basePredicted,
+                row.targetPredicted,
+                row.baseRawResponse,
+                row.targetRawResponse,
+                row.baseCorrect ? "true" : "false",
+                row.targetCorrect ? "true" : "false",
+                row.outcome,
+                row.regression ? "true" : "false",
+                String(row.baseTimeS),
+                String(row.targetTimeS),
+                row.baseParseStatus,
+                row.targetParseStatus,
+                row.codeLanguage,
+                row.codeEntryPoint,
+                row.baseCodeCompileStatus,
+                row.targetCodeCompileStatus,
+                row.baseCodeRuntimeStatus,
+                row.targetCodeRuntimeStatus,
+                row.baseCodeTimeoutStatus,
+                row.targetCodeTimeoutStatus,
+                row.baseCodeTestStatus,
+                row.targetCodeTestStatus,
+                String(row.baseCodeTestsPassed),
+                String(row.targetCodeTestsPassed),
+                String(row.baseCodeTestsTotal),
+                String(row.targetCodeTestsTotal),
+                row.baseCodeFailureDetail,
+                row.targetCodeFailureDetail,
+            ]
+            .map(Self.csvField)
+            .joined(separator: ",")
+        }
+        return ([header] + body).joined(separator: "\n") + "\n"
+    }
+
+    public func evaluationCompareSamplesJSONL(jobID: String? = nil) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let rows = evaluationCompareSampleRows(jobID: jobID)
         return try rows
             .map { sample in
                 let data = try encoder.encode(sample)

--- a/services/control-plane-swift/Tests/ControlPlaneTests/BenchmarkExportBundleTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/BenchmarkExportBundleTests.swift
@@ -135,11 +135,41 @@ struct BenchmarkExportBundleTests {
         #expect(summaryRows[0].createdAtUnixMS == 1712400000000)
         #expect(samples.count == 1)
         #expect(samples[0].sampleID == "sample-1")
+        #expect(samples[0].codeLanguage == "python")
+        #expect(samples[0].codeEntryPoint == "solve")
         #expect(summaryCSV.contains("job_id,model_id,task_kind,source_repo,suite_id,dataset_id,sample_size,score_name,score_value,correct_count,incorrect_count,duration_seconds,created_at_unix_ms"))
         #expect(summaryCSV.contains("eval-1,melix-dev-text,text-generation,HuggingFaceH4/ultrachat_200k,mmlu,mmlu.dev.v1,8,eval.mmlu.accuracy,0.75,6,2,12.5,1712400000000"))
-        #expect(sampleCSV.contains("id,correct,expected,predicted,question,raw_response,time_s,parse_status"))
-        #expect(sampleCSV.contains("sample-1,true,4,4,2+2?,4,0.01,parsed"))
+        #expect(sampleCSV.contains("id,correct,expected,predicted,question,raw_response,time_s,parse_status,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail"))
+        #expect(sampleCSV.contains("sample-1,true,4,4,2+2?,4,0.01,parsed,python,solve,compiled,ok,ok,passed,2,2,"))
         #expect(sampleJSONL.contains("\"sample_id\":\"sample-1\""))
+        #expect(sampleJSONL.contains("\"code_language\":\"python\""))
+    }
+
+    @Test("decodes evaluation compare exports and preserves executable-code evidence")
+    func decodesEvaluationCompareExports() throws {
+        let bundle = try ControlPlaneBenchmarkExportBundle.decode(json: benchmarkExportBundleJSON)
+
+        let summaryRows = bundle.evaluationCompareSummaryRows(jobID: "eval-compare-1")
+        let samples = bundle.evaluationCompareSampleRows(jobID: "eval-compare-1")
+        let summaryCSV = bundle.evaluationCompareSummaryCSV(jobID: "eval-compare-1")
+        let samplesCSV = bundle.evaluationCompareSamplesCSV(jobID: "eval-compare-1")
+        let samplesJSONL = try bundle.evaluationCompareSamplesJSONL(jobID: "eval-compare-1")
+
+        #expect(summaryRows.count == 1)
+        #expect(summaryRows[0].jobID == "eval-compare-1")
+        #expect(summaryRows[0].targetModelID == "melix-dev-text-lora-a")
+        #expect(summaryRows[0].deltaAccuracy == 0.5)
+        #expect(samples.count == 1)
+        #expect(samples[0].sampleID == "sample-1")
+        #expect(samples[0].codeLanguage == "python")
+        #expect(samples[0].baseCodeTestStatus == "failed")
+        #expect(samples[0].targetCodeTestStatus == "passed")
+        #expect(summaryCSV.contains("job_id,base_model_id,target_model_id,suite_id,dataset_id,sample_size,win_count,loss_count,tie_count,regression_count,base_accuracy,target_accuracy,delta_accuracy,duration_seconds"))
+        #expect(summaryCSV.contains("eval-compare-1,melix-dev-text,melix-dev-text-lora-a,mbpp,mbpp.dev.v1,2,1,0,1,0,0.5,1.0,0.5,1.75"))
+        #expect(samplesCSV.contains("job_id,suite_id,dataset_id,sample_id,target_model_id,question,expected,base_predicted,target_predicted"))
+        #expect(samplesCSV.contains("python,solve,compiled,compiled,ok,ok,ok,ok,failed,passed,1,2,2,2,assertion failed,"))
+        #expect(samplesJSONL.contains("\"target_model_id\":\"melix-dev-text-lora-a\""))
+        #expect(samplesJSONL.contains("\"base_code_failure_detail\":\"assertion failed\""))
     }
 
     @Test("evaluation exports fall back to parameters sort deterministically and emit empty headers")
@@ -167,9 +197,11 @@ struct BenchmarkExportBundleTests {
         #expect(rows[0].durationSeconds == 0)
         #expect(samples.map(\.sampleID) == ["sample-1", "sample-2"])
         #expect(summaryCSV.contains("job_id,model_id,task_kind,source_repo,suite_id,dataset_id,sample_size,score_name,score_value,correct_count,incorrect_count,duration_seconds,created_at_unix_ms"))
-        #expect(sampleCSV.contains("id,correct,expected,predicted,question,raw_response,time_s,parse_status"))
+        #expect(sampleCSV.contains("id,correct,expected,predicted,question,raw_response,time_s,parse_status,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail"))
         #expect(emptyBundle.evaluationSummaryCSV() == "job_id,model_id,task_kind,source_repo,suite_id,dataset_id,sample_size,score_name,score_value,correct_count,incorrect_count,duration_seconds,created_at_unix_ms\n")
-        #expect(emptyBundle.evaluationSamplesCSV() == "id,correct,expected,predicted,question,raw_response,time_s,parse_status\n")
+        #expect(emptyBundle.evaluationSamplesCSV() == "id,correct,expected,predicted,question,raw_response,time_s,parse_status,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail\n")
+        #expect(emptyBundle.evaluationCompareSummaryCSV() == "job_id,base_model_id,target_model_id,suite_id,dataset_id,sample_size,win_count,loss_count,tie_count,regression_count,base_accuracy,target_accuracy,delta_accuracy,duration_seconds\n")
+        #expect(emptyBundle.evaluationCompareSamplesCSV() == "job_id,suite_id,dataset_id,sample_id,target_model_id,question,expected,base_predicted,target_predicted,base_raw_response,target_raw_response,base_correct,target_correct,outcome,regression,base_time_s,target_time_s,base_parse_status,target_parse_status,code_language,code_entry_point,base_code_compile_status,target_code_compile_status,base_code_runtime_status,target_code_runtime_status,base_code_timeout_status,target_code_timeout_status,base_code_test_status,target_code_test_status,base_code_tests_passed,target_code_tests_passed,base_code_tests_total,target_code_tests_total,base_code_failure_detail,target_code_failure_detail\n")
     }
 
     @Test("canonical evaluation summary rows are sorted deterministically")
@@ -200,6 +232,28 @@ struct BenchmarkExportBundleTests {
         #expect(rows.map(\.jobID) == ["eval-a", "eval-b"])
         #expect(rows[0].createdAtUnixMS == 1712400000000)
         #expect(rows[1].createdAtUnixMS == 1712400001000)
+    }
+
+    @Test("canonical evaluation compare rows sort by job target and sample identifiers")
+    func canonicalEvaluationCompareRowsSortDeterministically() throws {
+        let bundle = try ControlPlaneBenchmarkExportBundle.decode(
+            json: canonicalEvaluationCompareRowsJSON
+        )
+
+        let summaryRows = bundle.evaluationCompareSummaryRows()
+        let sampleRows = bundle.evaluationCompareSampleRows()
+
+        #expect(summaryRows.map { "\($0.jobID):\($0.targetModelID)" } == [
+            "eval-compare-a:target-a",
+            "eval-compare-a:target-b",
+            "eval-compare-b:target-a",
+        ])
+        #expect(sampleRows.map { "\($0.jobID):\($0.targetModelID):\($0.sampleID)" } == [
+            "eval-compare-a:target-a:sample-1",
+            "eval-compare-a:target-a:sample-2",
+            "eval-compare-a:target-b:sample-1",
+            "eval-compare-b:target-a:sample-1",
+        ])
     }
 
     @Test("decodes benchmark matrix history rows and csv exports")
@@ -387,7 +441,103 @@ private let benchmarkExportBundleJSON = """
       "raw_response": "4",
       "correct": true,
       "time_s": 0.01,
-      "parse_status": "parsed"
+      "parse_status": "parsed",
+      "code_language": "python",
+      "code_entry_point": "solve",
+      "code_compile_status": "compiled",
+      "code_runtime_status": "ok",
+      "code_timeout_status": "ok",
+      "code_test_status": "passed",
+      "code_tests_passed": 2,
+      "code_tests_total": 2,
+      "code_failure_detail": ""
+    }
+  ],
+  "evaluation_compare_jobs": [
+    {
+      "schema_version": "melix.evaluation_compare_job.v1",
+      "job_id": "eval-compare-1",
+      "base_model_id": "melix-dev-text",
+      "target_model_ids": ["melix-dev-text-lora-a"],
+      "task_kind": "text-generation",
+      "source_repo": "openai_humaneval",
+      "suite_id": "mbpp",
+      "dataset_id": "mbpp.dev.v1",
+      "sample_size": 2,
+      "scoring_mode": "pass_at_1",
+      "parameters": {
+        "compare_mode": "base_vs_targets",
+        "compare_target_model_ids": "melix-dev-text-lora-a"
+      },
+      "status": "completed",
+      "output_dir": "/tmp/melix/evaluation/runs/eval-compare-1",
+      "created_at_unix_ms": 1712500000000,
+      "updated_at_unix_ms": 1712500005000
+    }
+  ],
+  "evaluation_compare_summary_rows": [
+    {
+      "schema_version": "melix.evaluation_compare_summary.v1",
+      "job_id": "eval-compare-1",
+      "base_model_id": "melix-dev-text",
+      "target_model_id": "melix-dev-text-lora-a",
+      "suite_id": "mbpp",
+      "dataset_id": "mbpp.dev.v1",
+      "sample_size": 2,
+      "scoring_mode": "pass_at_1",
+      "win_count": 1,
+      "loss_count": 0,
+      "tie_count": 1,
+      "regression_count": 0,
+      "base_accuracy": 0.5,
+      "target_accuracy": 1.0,
+      "delta_accuracy": 0.5,
+      "duration_seconds": 1.75,
+      "metrics": [
+        {"name": "eval.compare.win_count", "value": 1.0, "unit": "count"},
+        {"name": "eval.compare.delta_accuracy", "value": 0.5, "unit": "ratio"}
+      ],
+      "report_path": "/tmp/melix/evaluation/runs/eval-compare-1/evaluation-compare-report.md"
+    }
+  ],
+  "evaluation_compare_samples": [
+    {
+      "schema_version": "melix.evaluation_compare_sample.v1",
+      "job_id": "eval-compare-1",
+      "suite_id": "mbpp",
+      "dataset_id": "mbpp.dev.v1",
+      "sample_id": "sample-1",
+      "target_model_id": "melix-dev-text-lora-a",
+      "question": "Write solve(n) that returns n",
+      "expected": "solve",
+      "base_predicted": "def solve(n):\\n    return 0",
+      "target_predicted": "def solve(n):\\n    return n",
+      "base_raw_response": "def solve(n):\\n    return 0",
+      "target_raw_response": "def solve(n):\\n    return n",
+      "base_correct": false,
+      "target_correct": true,
+      "outcome": "win",
+      "regression": false,
+      "base_time_s": 0.11,
+      "target_time_s": 0.09,
+      "base_parse_status": "parsed_code_fallback",
+      "target_parse_status": "parsed_code_fallback",
+      "code_language": "python",
+      "code_entry_point": "solve",
+      "base_code_compile_status": "compiled",
+      "target_code_compile_status": "compiled",
+      "base_code_runtime_status": "ok",
+      "target_code_runtime_status": "ok",
+      "base_code_timeout_status": "ok",
+      "target_code_timeout_status": "ok",
+      "base_code_test_status": "failed",
+      "target_code_test_status": "passed",
+      "base_code_tests_passed": 1,
+      "target_code_tests_passed": 2,
+      "base_code_tests_total": 2,
+      "target_code_tests_total": 2,
+      "base_code_failure_detail": "assertion failed",
+      "target_code_failure_detail": ""
     }
   ]
 }
@@ -594,6 +744,228 @@ private let canonicalEvaluationSummaryTimestampJSON = """
       "incorrect_count": 2,
       "duration_seconds": 12.5,
       "created_at_unix_ms": 1712400000000
+    }
+  ]
+}
+"""
+
+private let canonicalEvaluationCompareRowsJSON = """
+{
+  "export_schema_version": "melix.benchmark_export.v1",
+  "evaluation_compare_summary_rows": [
+    {
+      "schema_version": "melix.evaluation_compare_summary.v1",
+      "job_id": "eval-compare-b",
+      "base_model_id": "base-b",
+      "target_model_id": "target-a",
+      "suite_id": "mbpp",
+      "dataset_id": "mbpp.dev.v1",
+      "sample_size": 2,
+      "scoring_mode": "pass_at_1",
+      "win_count": 1,
+      "loss_count": 0,
+      "tie_count": 1,
+      "regression_count": 0,
+      "base_accuracy": 0.5,
+      "target_accuracy": 1.0,
+      "delta_accuracy": 0.5,
+      "duration_seconds": 2.0,
+      "metrics": [],
+      "report_path": "/tmp/eval-compare-b.md"
+    },
+    {
+      "schema_version": "melix.evaluation_compare_summary.v1",
+      "job_id": "eval-compare-a",
+      "base_model_id": "base-a",
+      "target_model_id": "target-b",
+      "suite_id": "mbpp",
+      "dataset_id": "mbpp.dev.v1",
+      "sample_size": 2,
+      "scoring_mode": "pass_at_1",
+      "win_count": 1,
+      "loss_count": 0,
+      "tie_count": 1,
+      "regression_count": 0,
+      "base_accuracy": 0.5,
+      "target_accuracy": 1.0,
+      "delta_accuracy": 0.5,
+      "duration_seconds": 1.0,
+      "metrics": [],
+      "report_path": "/tmp/eval-compare-a-target-b.md"
+    },
+    {
+      "schema_version": "melix.evaluation_compare_summary.v1",
+      "job_id": "eval-compare-a",
+      "base_model_id": "base-a",
+      "target_model_id": "target-a",
+      "suite_id": "mbpp",
+      "dataset_id": "mbpp.dev.v1",
+      "sample_size": 2,
+      "scoring_mode": "pass_at_1",
+      "win_count": 1,
+      "loss_count": 0,
+      "tie_count": 1,
+      "regression_count": 0,
+      "base_accuracy": 0.5,
+      "target_accuracy": 1.0,
+      "delta_accuracy": 0.5,
+      "duration_seconds": 1.0,
+      "metrics": [],
+      "report_path": "/tmp/eval-compare-a-target-a.md"
+    }
+  ],
+  "evaluation_compare_samples": [
+    {
+      "schema_version": "melix.evaluation_compare_sample.v1",
+      "job_id": "eval-compare-b",
+      "suite_id": "mbpp",
+      "dataset_id": "mbpp.dev.v1",
+      "sample_id": "sample-1",
+      "target_model_id": "target-a",
+      "question": "Question B",
+      "expected": "solve",
+      "base_predicted": "base-b",
+      "target_predicted": "target-b",
+      "base_raw_response": "base-b",
+      "target_raw_response": "target-b",
+      "base_correct": false,
+      "target_correct": true,
+      "outcome": "win",
+      "regression": false,
+      "base_time_s": 0.2,
+      "target_time_s": 0.1,
+      "base_parse_status": "parsed",
+      "target_parse_status": "parsed",
+      "code_language": "python",
+      "code_entry_point": "solve",
+      "base_code_compile_status": "compiled",
+      "target_code_compile_status": "compiled",
+      "base_code_runtime_status": "ok",
+      "target_code_runtime_status": "ok",
+      "base_code_timeout_status": "ok",
+      "target_code_timeout_status": "ok",
+      "base_code_test_status": "failed",
+      "target_code_test_status": "passed",
+      "base_code_tests_passed": 1,
+      "target_code_tests_passed": 2,
+      "base_code_tests_total": 2,
+      "target_code_tests_total": 2,
+      "base_code_failure_detail": "assertion failed",
+      "target_code_failure_detail": ""
+    },
+    {
+      "schema_version": "melix.evaluation_compare_sample.v1",
+      "job_id": "eval-compare-a",
+      "suite_id": "mbpp",
+      "dataset_id": "mbpp.dev.v1",
+      "sample_id": "sample-2",
+      "target_model_id": "target-a",
+      "question": "Question A2",
+      "expected": "solve",
+      "base_predicted": "base-a2",
+      "target_predicted": "target-a2",
+      "base_raw_response": "base-a2",
+      "target_raw_response": "target-a2",
+      "base_correct": false,
+      "target_correct": true,
+      "outcome": "win",
+      "regression": false,
+      "base_time_s": 0.2,
+      "target_time_s": 0.1,
+      "base_parse_status": "parsed",
+      "target_parse_status": "parsed",
+      "code_language": "python",
+      "code_entry_point": "solve",
+      "base_code_compile_status": "compiled",
+      "target_code_compile_status": "compiled",
+      "base_code_runtime_status": "ok",
+      "target_code_runtime_status": "ok",
+      "base_code_timeout_status": "ok",
+      "target_code_timeout_status": "ok",
+      "base_code_test_status": "failed",
+      "target_code_test_status": "passed",
+      "base_code_tests_passed": 1,
+      "target_code_tests_passed": 2,
+      "base_code_tests_total": 2,
+      "target_code_tests_total": 2,
+      "base_code_failure_detail": "assertion failed",
+      "target_code_failure_detail": ""
+    },
+    {
+      "schema_version": "melix.evaluation_compare_sample.v1",
+      "job_id": "eval-compare-a",
+      "suite_id": "mbpp",
+      "dataset_id": "mbpp.dev.v1",
+      "sample_id": "sample-1",
+      "target_model_id": "target-b",
+      "question": "Question A target B",
+      "expected": "solve",
+      "base_predicted": "base-ab",
+      "target_predicted": "target-ab",
+      "base_raw_response": "base-ab",
+      "target_raw_response": "target-ab",
+      "base_correct": false,
+      "target_correct": true,
+      "outcome": "win",
+      "regression": false,
+      "base_time_s": 0.2,
+      "target_time_s": 0.1,
+      "base_parse_status": "parsed",
+      "target_parse_status": "parsed",
+      "code_language": "python",
+      "code_entry_point": "solve",
+      "base_code_compile_status": "compiled",
+      "target_code_compile_status": "compiled",
+      "base_code_runtime_status": "ok",
+      "target_code_runtime_status": "ok",
+      "base_code_timeout_status": "ok",
+      "target_code_timeout_status": "ok",
+      "base_code_test_status": "failed",
+      "target_code_test_status": "passed",
+      "base_code_tests_passed": 1,
+      "target_code_tests_passed": 2,
+      "base_code_tests_total": 2,
+      "target_code_tests_total": 2,
+      "base_code_failure_detail": "assertion failed",
+      "target_code_failure_detail": ""
+    },
+    {
+      "schema_version": "melix.evaluation_compare_sample.v1",
+      "job_id": "eval-compare-a",
+      "suite_id": "mbpp",
+      "dataset_id": "mbpp.dev.v1",
+      "sample_id": "sample-1",
+      "target_model_id": "target-a",
+      "question": "Question A1",
+      "expected": "solve",
+      "base_predicted": "base-a1",
+      "target_predicted": "target-a1",
+      "base_raw_response": "base-a1",
+      "target_raw_response": "target-a1",
+      "base_correct": false,
+      "target_correct": true,
+      "outcome": "win",
+      "regression": false,
+      "base_time_s": 0.2,
+      "target_time_s": 0.1,
+      "base_parse_status": "parsed",
+      "target_parse_status": "parsed",
+      "code_language": "python",
+      "code_entry_point": "solve",
+      "base_code_compile_status": "compiled",
+      "target_code_compile_status": "compiled",
+      "base_code_runtime_status": "ok",
+      "target_code_runtime_status": "ok",
+      "base_code_timeout_status": "ok",
+      "target_code_timeout_status": "ok",
+      "base_code_test_status": "failed",
+      "target_code_test_status": "passed",
+      "base_code_tests_passed": 1,
+      "target_code_tests_passed": 2,
+      "base_code_tests_total": 2,
+      "target_code_tests_total": 2,
+      "base_code_failure_detail": "assertion failed",
+      "target_code_failure_detail": ""
     }
   ]
 }

--- a/services/control-plane-swift/Tests/ControlPlaneTests/BenchmarkExportBundleTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/BenchmarkExportBundleTests.swift
@@ -135,13 +135,18 @@ struct BenchmarkExportBundleTests {
         #expect(summaryRows[0].createdAtUnixMS == 1712400000000)
         #expect(samples.count == 1)
         #expect(samples[0].sampleID == "sample-1")
+        #expect(samples[0].taskKind == "text-generation")
+        #expect(samples[0].inputModalities == ["text"])
+        #expect(samples[0].mediaReferences == [])
         #expect(samples[0].codeLanguage == "python")
         #expect(samples[0].codeEntryPoint == "solve")
-        #expect(summaryCSV.contains("job_id,model_id,task_kind,source_repo,suite_id,dataset_id,sample_size,score_name,score_value,correct_count,incorrect_count,duration_seconds,created_at_unix_ms"))
-        #expect(summaryCSV.contains("eval-1,melix-dev-text,text-generation,HuggingFaceH4/ultrachat_200k,mmlu,mmlu.dev.v1,8,eval.mmlu.accuracy,0.75,6,2,12.5,1712400000000"))
-        #expect(sampleCSV.contains("id,correct,expected,predicted,question,raw_response,time_s,parse_status,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail"))
-        #expect(sampleCSV.contains("sample-1,true,4,4,2+2?,4,0.01,parsed,python,solve,compiled,ok,ok,passed,2,2,"))
+        #expect(summaryCSV.contains("job_id,task_kind,source_repo,model_id,suite_id,dataset_id,score_name,score_value,sample_size,correct_count,incorrect_count,duration_seconds,created_at_unix_ms"))
+        #expect(summaryCSV.contains("eval-1,text-generation,HuggingFaceH4/ultrachat_200k,melix-dev-text,mmlu,mmlu.dev.v1,eval.mmlu.accuracy,0.75,8,6,2,12.5,1712400000000"))
+        #expect(sampleCSV.contains("job_id,suite_id,id,task_kind,correct,expected,predicted,question,raw_response,time_s,parse_status,input_modalities,media_references,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail"))
+        #expect(sampleCSV.contains("eval-1,mmlu,sample-1,text-generation,true,4,4,2+2?,4,0.01,parsed,text,,python,solve,compiled,ok,ok,passed,2,2,"))
         #expect(sampleJSONL.contains("\"sample_id\":\"sample-1\""))
+        #expect(sampleJSONL.contains("\"task_kind\":\"text-generation\""))
+        #expect(sampleJSONL.contains("\"input_modalities\":[\"text\"]"))
         #expect(sampleJSONL.contains("\"code_language\":\"python\""))
     }
 
@@ -196,10 +201,10 @@ struct BenchmarkExportBundleTests {
         #expect(rows[0].incorrectCount == 0)
         #expect(rows[0].durationSeconds == 0)
         #expect(samples.map(\.sampleID) == ["sample-1", "sample-2"])
-        #expect(summaryCSV.contains("job_id,model_id,task_kind,source_repo,suite_id,dataset_id,sample_size,score_name,score_value,correct_count,incorrect_count,duration_seconds,created_at_unix_ms"))
-        #expect(sampleCSV.contains("id,correct,expected,predicted,question,raw_response,time_s,parse_status,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail"))
-        #expect(emptyBundle.evaluationSummaryCSV() == "job_id,model_id,task_kind,source_repo,suite_id,dataset_id,sample_size,score_name,score_value,correct_count,incorrect_count,duration_seconds,created_at_unix_ms\n")
-        #expect(emptyBundle.evaluationSamplesCSV() == "id,correct,expected,predicted,question,raw_response,time_s,parse_status,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail\n")
+        #expect(summaryCSV.contains("job_id,task_kind,source_repo,model_id,suite_id,dataset_id,score_name,score_value,sample_size,correct_count,incorrect_count,duration_seconds,created_at_unix_ms"))
+        #expect(sampleCSV.contains("job_id,suite_id,id,task_kind,correct,expected,predicted,question,raw_response,time_s,parse_status,input_modalities,media_references,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail"))
+        #expect(emptyBundle.evaluationSummaryCSV() == "job_id,task_kind,source_repo,model_id,suite_id,dataset_id,score_name,score_value,sample_size,correct_count,incorrect_count,duration_seconds,created_at_unix_ms\n")
+        #expect(emptyBundle.evaluationSamplesCSV() == "job_id,suite_id,id,task_kind,correct,expected,predicted,question,raw_response,time_s,parse_status,input_modalities,media_references,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail\n")
         #expect(emptyBundle.evaluationCompareSummaryCSV() == "job_id,base_model_id,target_model_id,suite_id,dataset_id,sample_size,win_count,loss_count,tie_count,regression_count,base_accuracy,target_accuracy,delta_accuracy,duration_seconds\n")
         #expect(emptyBundle.evaluationCompareSamplesCSV() == "job_id,suite_id,dataset_id,sample_id,target_model_id,question,expected,base_predicted,target_predicted,base_raw_response,target_raw_response,base_correct,target_correct,outcome,regression,base_time_s,target_time_s,base_parse_status,target_parse_status,code_language,code_entry_point,base_code_compile_status,target_code_compile_status,base_code_runtime_status,target_code_runtime_status,base_code_timeout_status,target_code_timeout_status,base_code_test_status,target_code_test_status,base_code_tests_passed,target_code_tests_passed,base_code_tests_total,target_code_tests_total,base_code_failure_detail,target_code_failure_detail\n")
     }
@@ -216,9 +221,9 @@ struct BenchmarkExportBundleTests {
         #expect(rows.map(\.jobID) == ["eval-a", "eval-b"])
         #expect(rows[0].createdAtUnixMS == 1712400000000)
         #expect(rows[1].createdAtUnixMS == 1712400000000)
-        #expect(csv.contains("job_id,model_id,task_kind,source_repo,suite_id,dataset_id,sample_size,score_name,score_value,correct_count,incorrect_count,duration_seconds,created_at_unix_ms"))
-        #expect(csv.contains("eval-a,melix-dev-text,text-generation,HuggingFaceH4/ultrachat_200k,mmlu,mmlu.dev.v1,8,eval.mmlu.accuracy,0.75,6,2,12.5,1712400000000"))
-        #expect(csv.contains("eval-b,melix-dev-text,text-generation,HuggingFaceH4/ultrachat_200k,gsm8k,gsm8k.dev.v1,8,eval.gsm8k.exact_match,0.5,5,3,9.75,1712400000000"))
+        #expect(csv.contains("job_id,task_kind,source_repo,model_id,suite_id,dataset_id,score_name,score_value,sample_size,correct_count,incorrect_count,duration_seconds,created_at_unix_ms"))
+        #expect(csv.contains("eval-a,text-generation,HuggingFaceH4/ultrachat_200k,melix-dev-text,mmlu,mmlu.dev.v1,eval.mmlu.accuracy,0.75,8,6,2,12.5,1712400000000"))
+        #expect(csv.contains("eval-b,text-generation,HuggingFaceH4/ultrachat_200k,melix-dev-text,gsm8k,gsm8k.dev.v1,eval.gsm8k.exact_match,0.5,8,5,3,9.75,1712400000000"))
     }
 
     @Test("canonical evaluation summary rows sort by timestamp before job id")
@@ -435,6 +440,7 @@ private let benchmarkExportBundleJSON = """
       "suite_id": "mmlu",
       "dataset_id": "mmlu.dev.v1",
       "sample_id": "sample-1",
+      "task_kind": "text-generation",
       "question": "2+2?",
       "expected": "4",
       "predicted": "4",
@@ -442,6 +448,8 @@ private let benchmarkExportBundleJSON = """
       "correct": true,
       "time_s": 0.01,
       "parse_status": "parsed",
+      "input_modalities": ["text"],
+      "media_references": [],
       "code_language": "python",
       "code_entry_point": "solve",
       "code_compile_status": "compiled",

--- a/services/mlx-worker-python/fixtures/evaluation/humaneval.dev.v1/README.md
+++ b/services/mlx-worker-python/fixtures/evaluation/humaneval.dev.v1/README.md
@@ -1,0 +1,10 @@
+# HumanEval Dev Fixture
+
+This directory contains a small Melix-owned development subset for executable code evaluation.
+
+- Source provenance: HumanEval-inspired Python function synthesis tasks
+- Purpose: deterministic local development and release-gate verification
+- Scope: 3 repository-owned samples with Melix package metadata
+
+This fixture is not a full benchmark reproduction. It exists to exercise the Melix evaluation
+contract, executable code scoring path, and persisted evidence exports.

--- a/services/mlx-worker-python/fixtures/evaluation/humaneval.dev.v1/manifest.json
+++ b/services/mlx-worker-python/fixtures/evaluation/humaneval.dev.v1/manifest.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "melix.evaluation_dataset_package.v1",
+  "dataset_id": "humaneval.dev.v1",
+  "suite_id": "humaneval",
+  "task_kind": "text-generation",
+  "input_modalities": ["text"],
+  "version": "2026-04-14",
+  "sample_count": 3,
+  "split": "validation",
+  "code_eval": {
+    "language": "python",
+    "timeout_seconds": 3,
+    "memory_limit_mb": 256,
+    "stdout_limit_bytes": 32768
+  }
+}

--- a/services/mlx-worker-python/fixtures/evaluation/humaneval.dev.v1/samples.jsonl
+++ b/services/mlx-worker-python/fixtures/evaluation/humaneval.dev.v1/samples.jsonl
@@ -1,0 +1,3 @@
+{"id":"humaneval-0001","prompt":"Write identity(x) that returns x.","entry_point":"identity","test":"assert identity(4) == 4\nassert identity('hi') == 'hi'"}
+{"id":"humaneval-0002","prompt":"Write add(a, b) that returns the sum of a and b.","entry_point":"add","test":"assert add(2, 3) == 5\nassert add(-1, 4) == 3"}
+{"id":"humaneval-0003","prompt":"Write reverse_text(text) that returns text reversed.","entry_point":"reverse_text","test":"assert reverse_text('abc') == 'cba'\nassert reverse_text('melix') == 'xilem'"}

--- a/services/mlx-worker-python/fixtures/evaluation/mbpp.dev.v1/README.md
+++ b/services/mlx-worker-python/fixtures/evaluation/mbpp.dev.v1/README.md
@@ -1,0 +1,10 @@
+# MBPP Dev Fixture
+
+This directory contains a small Melix-owned development subset for executable code evaluation.
+
+- Source provenance: MBPP-inspired Python programming tasks
+- Purpose: deterministic local development and release-gate verification
+- Scope: 3 repository-owned samples with Melix package metadata
+
+This fixture is not a full benchmark reproduction. It exists to exercise the Melix evaluation
+contract, executable code scoring path, and persisted evidence exports.

--- a/services/mlx-worker-python/fixtures/evaluation/mbpp.dev.v1/manifest.json
+++ b/services/mlx-worker-python/fixtures/evaluation/mbpp.dev.v1/manifest.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "melix.evaluation_dataset_package.v1",
+  "dataset_id": "mbpp.dev.v1",
+  "suite_id": "mbpp",
+  "task_kind": "text-generation",
+  "input_modalities": ["text"],
+  "version": "2026-04-14",
+  "sample_count": 3,
+  "split": "validation",
+  "code_eval": {
+    "language": "python",
+    "timeout_seconds": 3,
+    "memory_limit_mb": 256,
+    "stdout_limit_bytes": 32768
+  }
+}

--- a/services/mlx-worker-python/fixtures/evaluation/mbpp.dev.v1/samples.jsonl
+++ b/services/mlx-worker-python/fixtures/evaluation/mbpp.dev.v1/samples.jsonl
@@ -1,0 +1,3 @@
+{"id":"mbpp-0001","prompt":"Write square(n) that returns n multiplied by itself.","entry_point":"square","test":"assert square(5) == 25\nassert square(-3) == 9"}
+{"id":"mbpp-0002","prompt":"Write is_even(n) that returns True when n is even and False otherwise.","entry_point":"is_even","test":"assert is_even(4) is True\nassert is_even(5) is False"}
+{"id":"mbpp-0003","prompt":"Write first_item(values) that returns the first item from a non-empty list.","entry_point":"first_item","test":"assert first_item([1, 2, 3]) == 1\nassert first_item(['a', 'b']) == 'a'"}

--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -784,11 +784,53 @@ def test_evaluation_csv_builders_return_header_only_for_empty_bundle() -> None:
     assert len(summary_lines) == 1
     assert summary_lines[0].startswith("job_id,task_kind")
     assert len(samples_lines) == 1
-    assert samples_lines[0].startswith("job_id,suite_id")
+    assert samples_lines[0].startswith("job_id,suite_id,id,task_kind")
     assert len(compare_summary_lines) == 1
     assert compare_summary_lines[0].startswith("job_id,base_model_id,target_model_id")
     assert len(compare_samples_lines) == 1
     assert compare_samples_lines[0].startswith("job_id,suite_id,dataset_id,sample_id,target_model_id")
+
+
+def test_evaluation_samples_csv_builder_maps_sample_id_and_preserves_modalities() -> None:
+    bundle: dict[str, object] = {
+        "evaluation_samples": [
+            {
+                "job_id": "eval-1",
+                "suite_id": "humaneval",
+                "sample_id": "sample-1",
+                "task_kind": "text-generation",
+                "correct": True,
+                "expected": "identity",
+                "predicted": "def identity(x):\n    return x",
+                "question": "Write identity(x) that returns x.",
+                "raw_response": "```python\ndef identity(x):\n    return x\n```",
+                "time_s": 0.02,
+                "parse_status": "parsed_code_block",
+                "input_modalities": ["text"],
+                "media_references": [],
+                "code_language": "python",
+                "code_entry_point": "identity",
+                "code_compile_status": "compiled",
+                "code_runtime_status": "ok",
+                "code_timeout_status": "ok",
+                "code_test_status": "passed",
+                "code_tests_passed": 2,
+                "code_tests_total": 2,
+                "code_failure_detail": "",
+            }
+        ]
+    }
+
+    samples_csv = build_evaluation_samples_csv(bundle)
+    lines = [line for line in samples_csv.splitlines() if line.strip()]
+
+    assert lines[0] == (
+        "job_id,suite_id,id,task_kind,correct,expected,predicted,question,raw_response,time_s,"
+        "parse_status,input_modalities,media_references,code_language,code_entry_point,"
+        "code_compile_status,code_runtime_status,code_timeout_status,code_test_status,"
+        "code_tests_passed,code_tests_total,code_failure_detail"
+    )
+    assert "eval-1,humaneval,sample-1,text-generation,True,identity," in lines[1]
 
 
 def test_evaluation_compare_csv_builders_emit_compare_rows() -> None:

--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -9,6 +9,8 @@ from worker.productization.benchmark_export import (
     build_benchmark_context_csv,
     build_benchmark_matrix_requests_csv,
     build_benchmark_matrix_summary_csv,
+    build_evaluation_compare_samples_csv,
+    build_evaluation_compare_summary_csv,
     build_benchmark_summary_csv,
     build_evaluation_samples_csv,
     build_evaluation_summary_csv,
@@ -513,9 +515,12 @@ def test_collect_evaluation_artifacts_normalizes_compare_runs_for_history_and_ex
     assert result["evaluation_summary_rows"][0]["model_id"] == "melix-dev-text-lora-a"
     assert result["evaluation_summary_rows"][0]["score_name"] == "eval.compare.delta_accuracy"
     assert result["evaluation_summary_rows"][0]["score_value"] == 0.5
-    assert result["evaluation_samples"][0]["job_id"] == "eval-compare-1"
-    assert result["evaluation_samples"][0]["sample_id"] == "melix-dev-text-lora-a:sample-1"
-    assert result["evaluation_samples"][0]["predicted"] == "4"
+    assert result["evaluation_samples"] == []
+    assert result["evaluation_compare_jobs"][0]["job_id"] == "eval-compare-1"
+    assert result["evaluation_compare_summary_rows"][0]["target_model_id"] == "melix-dev-text-lora-a"
+    assert result["evaluation_compare_samples"][0]["job_id"] == "eval-compare-1"
+    assert result["evaluation_compare_samples"][0]["sample_id"] == "sample-1"
+    assert result["evaluation_compare_samples"][0]["target_predicted"] == "4"
 
 
 def test_build_export_bundle_combines_benchmark_and_evaluation_artifacts(tmp_path: Path) -> None:
@@ -769,13 +774,91 @@ def test_evaluation_csv_builders_return_header_only_for_empty_bundle() -> None:
 
     summary_csv = build_evaluation_summary_csv(empty_bundle)
     samples_csv = build_evaluation_samples_csv(empty_bundle)
+    compare_summary_csv = build_evaluation_compare_summary_csv(empty_bundle)
+    compare_samples_csv = build_evaluation_compare_samples_csv(empty_bundle)
 
     summary_lines = [line for line in summary_csv.splitlines() if line.strip()]
     samples_lines = [line for line in samples_csv.splitlines() if line.strip()]
+    compare_summary_lines = [line for line in compare_summary_csv.splitlines() if line.strip()]
+    compare_samples_lines = [line for line in compare_samples_csv.splitlines() if line.strip()]
     assert len(summary_lines) == 1
     assert summary_lines[0].startswith("job_id,task_kind")
     assert len(samples_lines) == 1
     assert samples_lines[0].startswith("job_id,suite_id")
+    assert len(compare_summary_lines) == 1
+    assert compare_summary_lines[0].startswith("job_id,base_model_id,target_model_id")
+    assert len(compare_samples_lines) == 1
+    assert compare_samples_lines[0].startswith("job_id,suite_id,dataset_id,sample_id,target_model_id")
+
+
+def test_evaluation_compare_csv_builders_emit_compare_rows() -> None:
+    bundle: dict[str, object] = {
+        "evaluation_compare_summary_rows": [
+            {
+                "job_id": "eval-compare-1",
+                "base_model_id": "melix-dev-text",
+                "target_model_id": "melix-dev-text-lora-a",
+                "suite_id": "mbpp",
+                "dataset_id": "mbpp.dev.v1",
+                "sample_size": 2,
+                "win_count": 1,
+                "loss_count": 0,
+                "tie_count": 1,
+                "regression_count": 0,
+                "base_accuracy": 0.5,
+                "target_accuracy": 1.0,
+                "delta_accuracy": 0.5,
+                "duration_seconds": 1.75,
+            }
+        ],
+        "evaluation_compare_samples": [
+            {
+                "job_id": "eval-compare-1",
+                "suite_id": "mbpp",
+                "dataset_id": "mbpp.dev.v1",
+                "sample_id": "sample-1",
+                "target_model_id": "melix-dev-text-lora-a",
+                "question": "Write solve(n) that returns n",
+                "expected": "solve",
+                "base_predicted": "def solve(n):\n    return 0",
+                "target_predicted": "def solve(n):\n    return n",
+                "base_raw_response": "def solve(n):\n    return 0",
+                "target_raw_response": "def solve(n):\n    return n",
+                "base_correct": False,
+                "target_correct": True,
+                "outcome": "win",
+                "regression": False,
+                "base_time_s": 0.11,
+                "target_time_s": 0.09,
+                "base_parse_status": "parsed_code_fallback",
+                "target_parse_status": "parsed_code_fallback",
+                "code_language": "python",
+                "code_entry_point": "solve",
+                "base_code_compile_status": "compiled",
+                "target_code_compile_status": "compiled",
+                "base_code_runtime_status": "ok",
+                "target_code_runtime_status": "ok",
+                "base_code_timeout_status": "ok",
+                "target_code_timeout_status": "ok",
+                "base_code_test_status": "failed",
+                "target_code_test_status": "passed",
+                "base_code_tests_passed": 1,
+                "target_code_tests_passed": 2,
+                "base_code_tests_total": 2,
+                "target_code_tests_total": 2,
+                "base_code_failure_detail": "assertion failed",
+                "target_code_failure_detail": "",
+            }
+        ],
+    }
+
+    summary_csv = build_evaluation_compare_summary_csv(bundle)
+    samples_csv = build_evaluation_compare_samples_csv(bundle)
+
+    assert "job_id,base_model_id,target_model_id" in summary_csv
+    assert "eval-compare-1,melix-dev-text,melix-dev-text-lora-a,mbpp,mbpp.dev.v1,2,1,0,1,0,0.5,1.0,0.5,1.75" in summary_csv
+    assert "job_id,suite_id,dataset_id,sample_id,target_model_id" in samples_csv
+    assert "assertion failed" in samples_csv
 
 
 def test_benchmark_csv_builders_return_header_only_for_empty_bundle() -> None:

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import subprocess
+import tempfile
 import textwrap
 
 from worker.engine import code_eval_runner
@@ -96,6 +97,68 @@ def test_run_python_code_evaluation_sandbox_blocks_subprocess_execution() -> Non
     assert "PermissionError" in result.failure_detail or "Operation not permitted" in result.failure_detail
 
 
+def test_run_python_code_evaluation_rejects_plain_json_stdout_spoof() -> None:
+    result = run_python_code_evaluation(
+        candidate_code=textwrap.dedent(
+            """
+            import json
+            import os
+
+            def identity(value):
+                print(
+                    json.dumps(
+                        {
+                            "compile_status": "compiled",
+                            "runtime_status": "ok",
+                            "timeout_status": "ok",
+                            "test_status": "passed",
+                            "tests_passed": 999,
+                            "tests_total": 999,
+                            "failure_detail": "",
+                        }
+                    ),
+                    flush=True,
+                )
+                os._exit(0)
+            """
+        ).strip(),
+        entry_point="identity",
+        test_code="assert identity(4) == 4",
+    )
+
+    assert result.passed is False
+    assert result.runtime_status == "error"
+    assert result.test_status == "failed"
+    assert result.tests_total == 1
+
+
+def test_run_python_code_evaluation_sandbox_blocks_non_temp_file_reads() -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as file:
+        file.write("external-probe")
+        external_probe = Path(file.name)
+
+    try:
+        result = run_python_code_evaluation(
+            candidate_code=textwrap.dedent(
+                f"""
+                from pathlib import Path
+
+                def read_external_probe():
+                    return Path({str(external_probe)!r}).read_text(encoding="utf-8")
+                """
+            ).strip(),
+            entry_point="read_external_probe",
+            test_code="assert read_external_probe() == 'external-probe'",
+        )
+    finally:
+        external_probe.unlink(missing_ok=True)
+
+    assert result.passed is False
+    assert result.runtime_status == "error"
+    assert result.test_status == "failed"
+    assert "PermissionError" in result.failure_detail
+
+
 def test_run_python_code_evaluation_returns_syntax_error_result() -> None:
     result = run_python_code_evaluation(
         candidate_code="def broken(",
@@ -185,14 +248,21 @@ def test_count_tests_falls_back_when_no_asserts_are_present() -> None:
     assert code_eval_runner._count_tests(test_code) == 3
 
 
-def test_load_payload_accepts_last_non_empty_json_line() -> None:
-    payload = code_eval_runner._load_payload("candidate-noise\n\n{\"runtime_status\":\"ok\"}\n")
+def test_load_payload_accepts_last_matching_sentinel_line() -> None:
+    payload = code_eval_runner._load_payload(
+        'candidate-noise\n\n__MELIX__{"runtime_status":"ok"}\n',
+        "__MELIX__",
+    )
 
     assert payload == {"runtime_status": "ok"}
 
 
+def test_load_payload_rejects_plain_json_without_sentinel() -> None:
+    assert code_eval_runner._load_payload('{"runtime_status":"ok"}\n', "__MELIX__") is None
+
+
 def test_load_payload_returns_none_for_empty_stdout() -> None:
-    assert code_eval_runner._load_payload("") is None
+    assert code_eval_runner._load_payload("", "__MELIX__") is None
 
 
 def test_decode_payload_rejects_invalid_and_non_mapping_json() -> None:

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import textwrap
+
+from worker.engine import code_eval_runner
+from worker.engine.code_eval_runner import run_python_code_evaluation
+
+
+def test_run_python_code_evaluation_ignores_candidate_stdout_before_payload() -> None:
+    result = run_python_code_evaluation(
+        candidate_code=textwrap.dedent(
+            """
+            def identity(value):
+                print("candidate-noise")
+                return value
+            """
+        ).strip(),
+        entry_point="identity",
+        test_code="assert identity(4) == 4\nassert identity('hi') == 'hi'",
+    )
+
+    assert result.passed is True
+    assert result.tests_passed == 2
+    assert result.tests_total == 2
+
+
+def test_run_python_code_evaluation_executes_multiline_test_blocks() -> None:
+    result = run_python_code_evaluation(
+        candidate_code=textwrap.dedent(
+            """
+            def identity(value):
+                return value
+            """
+        ).strip(),
+        entry_point="identity",
+        test_code=textwrap.dedent(
+            """
+            def check(candidate):
+                assert candidate(4) == 4
+                assert candidate("hi") == "hi"
+
+            check(identity)
+            """
+        ).strip(),
+    )
+
+    assert result.passed is True
+    assert result.tests_passed == 2
+    assert result.tests_total == 2
+
+
+def test_run_python_code_evaluation_sandbox_blocks_home_file_reads() -> None:
+    repo_probe = Path(__file__).resolve()
+    result = run_python_code_evaluation(
+        candidate_code=textwrap.dedent(
+            f"""
+            from pathlib import Path
+
+            def read_probe():
+                return Path({str(repo_probe)!r}).read_text(encoding="utf-8")[:8]
+            """
+        ).strip(),
+        entry_point="read_probe",
+        test_code=f"assert read_probe() == {repo_probe.read_text(encoding='utf-8')[:8]!r}",
+    )
+
+    assert result.passed is False
+    assert result.runtime_status == "error"
+    assert result.test_status == "failed"
+    assert "PermissionError" in result.failure_detail
+
+
+def test_run_python_code_evaluation_sandbox_blocks_subprocess_execution() -> None:
+    result = run_python_code_evaluation(
+        candidate_code=textwrap.dedent(
+            """
+            import subprocess
+
+            def spawn_child():
+                output = subprocess.check_output(
+                    ["/bin/sh", "-c", "printf 7"],
+                    text=True,
+                )
+                return int(output.strip())
+            """
+        ).strip(),
+        entry_point="spawn_child",
+        test_code="assert spawn_child() == 7",
+    )
+
+    assert result.passed is False
+    assert result.runtime_status == "error"
+    assert result.test_status == "failed"
+    assert "PermissionError" in result.failure_detail or "Operation not permitted" in result.failure_detail
+
+
+def test_run_python_code_evaluation_returns_syntax_error_result() -> None:
+    result = run_python_code_evaluation(
+        candidate_code="def broken(",
+        entry_point="broken",
+        test_code="assert True",
+    )
+
+    assert result.compile_status == "syntax_error"
+    assert result.runtime_status == "not_run"
+    assert result.test_status == "not_run"
+    assert result.tests_total == 1
+
+
+def test_run_python_code_evaluation_fails_when_sandbox_exec_is_unavailable(monkeypatch) -> None:
+    monkeypatch.setattr(code_eval_runner.shutil, "which", lambda _: None)
+
+    result = run_python_code_evaluation(
+        candidate_code="def identity(value):\n    return value",
+        entry_point="identity",
+        test_code="assert identity(1) == 1",
+    )
+
+    assert result.compile_status == "compiled"
+    assert result.runtime_status == "error"
+    assert result.failure_detail == "sandbox-exec is unavailable on this host."
+
+
+def test_run_python_code_evaluation_returns_timeout_result(monkeypatch) -> None:
+    monkeypatch.setattr(code_eval_runner.shutil, "which", lambda _: "/usr/bin/sandbox-exec")
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=1)
+
+    monkeypatch.setattr(code_eval_runner.subprocess, "run", fake_run)
+
+    result = run_python_code_evaluation(
+        candidate_code="def identity(value):\n    return value",
+        entry_point="identity",
+        test_code="assert identity(1) == 1",
+        timeout_seconds=1,
+    )
+
+    assert result.runtime_status == "timeout"
+    assert result.timeout_status == "timed_out"
+    assert result.test_status == "not_run"
+    assert result.failure_detail == "Timed out after 1s"
+
+
+def test_run_python_code_evaluation_uses_stderr_when_payload_is_missing(monkeypatch) -> None:
+    monkeypatch.setattr(code_eval_runner.shutil, "which", lambda _: "/usr/bin/sandbox-exec")
+    monkeypatch.setattr(
+        code_eval_runner.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=args[0],
+            returncode=7,
+            stdout="candidate-noise",
+            stderr="runtime exploded",
+        ),
+    )
+
+    result = run_python_code_evaluation(
+        candidate_code="def identity(value):\n    return value",
+        entry_point="identity",
+        test_code="assert identity(1) == 1",
+    )
+
+    assert result.runtime_status == "error"
+    assert result.test_status == "failed"
+    assert result.failure_detail == "runtime exploded"
+
+
+def test_count_tests_falls_back_for_syntax_error_input() -> None:
+    assert code_eval_runner._count_tests("assert True\n  assert False") == 2
+
+
+def test_count_tests_falls_back_when_no_asserts_are_present() -> None:
+    test_code = textwrap.dedent(
+        """
+        def check(candidate):
+            return candidate(1)
+
+        check(identity)
+        """
+    ).strip()
+
+    assert code_eval_runner._count_tests(test_code) == 3
+
+
+def test_load_payload_accepts_last_non_empty_json_line() -> None:
+    payload = code_eval_runner._load_payload("candidate-noise\n\n{\"runtime_status\":\"ok\"}\n")
+
+    assert payload == {"runtime_status": "ok"}
+
+
+def test_load_payload_returns_none_for_empty_stdout() -> None:
+    assert code_eval_runner._load_payload("") is None
+
+
+def test_decode_payload_rejects_invalid_and_non_mapping_json() -> None:
+    assert code_eval_runner._decode_payload("not-json") is None
+    assert code_eval_runner._decode_payload("[1, 2, 3]") is None

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -318,17 +318,31 @@ def test_run_local_suite_supports_additional_score_modes_and_job_metadata(tmp_pa
         dataset_id="mbpp-dev",
         suite_id="mbpp",
         samples=(
-            {"id": "sample-1", "question": "2+2?", "answer": "4"},
+            {
+                "id": "sample-1",
+                "prompt": "Write add(a, b) that returns the sum.",
+                "entry_point": "add",
+                "test": "assert add(2, 2) == 4\nassert add(3, 5) == 8",
+            },
         ),
     )
     jobs_root = tmp_path / "runs" / "mbpp"
-    runner = EvaluationCore(jobs_root=jobs_root)
+    backend = ScriptedEvaluationBackend(
+        (
+            "def add(a, b):\n    return a + b",
+        )
+    )
+    runtime = MLXTextRuntime(backend=backend)
+    registry = FakeEvaluationRegistry(runtime=runtime, model_id="melix-dev-code")
+    runner = EvaluationCore(jobs_root=jobs_root, registry=registry)
 
     run = runner.run_local_suite(
-        model_id="melix-dev-text",
+        model_id="melix-dev-code",
+        model_handle=registry.handle,
         suite_id="mbpp",
         dataset_root=dataset_root,
         sample_size=1,
+        code_exec_policy="sandboxed",
         parameters={
             "task_kind": "text-generation",
             "source_repo": "openai_humaneval",
@@ -343,8 +357,87 @@ def test_run_local_suite_supports_additional_score_modes_and_job_metadata(tmp_pa
     assert run.job.scoring_mode == "pass_at_1"
     assert run.job.few_shot == 0
     assert run.job.seed == 0
-    assert run.job.code_exec_policy == ""
+    assert run.job.code_exec_policy == "sandboxed"
     assert metrics["eval.mbpp.pass_at_1"] == 1.0
+    assert metrics["eval.mbpp.code_exec_pass_count"] == 1.0
+    assert metrics["eval.mbpp.code_exec_fail_count"] == 0.0
+
+
+def test_run_local_suite_requires_sandboxed_code_exec_policy_for_code_suites(
+    tmp_path: Path,
+) -> None:
+    dataset_root = _write_dataset_package(
+        tmp_path=tmp_path,
+        dataset_id="humaneval-dev",
+        suite_id="humaneval",
+        samples=(
+            {
+                "id": "sample-1",
+                "prompt": "Return the input unchanged.",
+                "entry_point": "identity",
+                "test": "assert identity(4) == 4",
+            },
+        ),
+    )
+    runner = EvaluationCore()
+
+    with pytest.raises(
+        ValueError,
+        match="requires code_exec_policy=sandboxed",
+    ):
+        runner.run_local_suite(
+            model_id="melix-dev-text",
+            suite_id="humaneval",
+            dataset_root=dataset_root,
+            sample_size=1,
+        )
+
+
+def test_run_local_suite_executes_candidate_code_for_humaneval_samples(
+    tmp_path: Path,
+) -> None:
+    dataset_root = _write_dataset_package(
+        tmp_path=tmp_path,
+        dataset_id="humaneval-dev",
+        suite_id="humaneval",
+        samples=(
+            {
+                "id": "sample-1",
+                "prompt": "Write identity(x) that returns x.",
+                "entry_point": "identity",
+                "test": "assert identity(4) == 4\nassert identity('hi') == 'hi'",
+            },
+        ),
+    )
+    backend = ScriptedEvaluationBackend(
+        (
+            "```python\ndef identity(x):\n    return x\n```",
+        )
+    )
+    runtime = MLXTextRuntime(backend=backend)
+    registry = FakeEvaluationRegistry(runtime=runtime, model_id="live-code-eval-model")
+    runner = EvaluationCore(registry=registry)
+
+    run = runner.run_local_suite(
+        model_id="live-code-eval-model",
+        model_handle=registry.handle,
+        suite_id="humaneval",
+        dataset_root=dataset_root,
+        sample_size=1,
+        code_exec_policy="sandboxed",
+    )
+
+    metrics = {metric.name: metric.value for metric in run.result.metrics}
+
+    assert len(backend.prompts) == 1
+    assert "Return only valid Python code." in backend.prompts[0]
+    assert run.samples[0].correct is True
+    assert run.result.score_name == "pass_at_1"
+    assert run.result.score_value == 1.0
+    assert metrics["eval.humaneval.pass_at_1"] == 1.0
+    assert metrics["eval.humaneval.code_exec_pass_count"] == 1.0
+    assert metrics["eval.humaneval.code_exec_fail_count"] == 0.0
+    assert run.samples[0].parse_status == "parsed_code_block"
 
 
 def test_run_local_suite_falls_back_to_zero_for_invalid_numeric_controls(tmp_path: Path) -> None:
@@ -622,6 +715,62 @@ def test_run_local_suite_compares_base_against_target_models_and_persists_compar
     assert "melix-dev-text-lora-b" in report_markdown
 
 
+def test_run_local_suite_compare_preserves_code_execution_evidence_for_code_suites(
+    tmp_path: Path,
+) -> None:
+    dataset_root = _write_dataset_package(
+        tmp_path=tmp_path,
+        dataset_id="humaneval.dev.v1",
+        suite_id="humaneval",
+        samples=(
+            {
+                "id": "sample-1",
+                "prompt": "Write identity(x) that returns x.",
+                "entry_point": "identity",
+                "test": "assert identity(4) == 4\nassert identity('hi') == 'hi'",
+            },
+        ),
+    )
+    jobs_root = tmp_path / "runs" / "compare-code"
+    registry = FakeEvaluationRegistry(
+        runtime=ScriptedComparisonRuntime(("```python\ndef identity(x):\n    return None\n```",)),
+        model_id="melix-dev-code-base",
+        additional_models={
+            "melix-dev-code-target": (
+                ScriptedComparisonRuntime(("```python\ndef identity(x):\n    return x\n```",)),
+                "text",
+            ),
+        },
+    )
+    runner = EvaluationCore(jobs_root=jobs_root, registry=registry)
+
+    run = runner.run_local_suite(
+        model_id="melix-dev-code-base",
+        model_handle=registry.handle_for("melix-dev-code-base"),
+        suite_id="humaneval",
+        dataset_root=dataset_root,
+        sample_size=1,
+        code_exec_policy="sandboxed",
+        parameters={
+            "compare_mode": "base_vs_targets",
+            "compare_target_model_ids": "melix-dev-code-target",
+        },
+    )
+
+    assert run.results[0].win_count == 1
+    compare_samples = [
+        json.loads(line)
+        for line in run.persisted_paths["samples_jsonl"].read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert compare_samples[0]["code_language"] == "python"
+    assert compare_samples[0]["code_entry_point"] == "identity"
+    assert compare_samples[0]["base_code_test_status"] == "failed"
+    assert compare_samples[0]["target_code_test_status"] == "passed"
+    assert compare_samples[0]["base_code_tests_passed"] == 0
+    assert compare_samples[0]["target_code_tests_passed"] == 2
+
+
 def test_run_local_suite_compare_requires_target_model_ids(tmp_path: Path) -> None:
     dataset_root = _write_dataset_package(
         tmp_path=tmp_path,
@@ -762,8 +911,16 @@ def test_parse_prediction_covers_empty_numeric_option_and_default_paths() -> Non
 
 
 def test_evaluation_helpers_cover_numeric_option_and_normalization_paths() -> None:
-    numeric_messages = EvaluationCore._evaluation_messages(prompt="6 + 3 = ?", expected="9")
-    option_messages = EvaluationCore._evaluation_messages(prompt="Pick one", expected="B")
+    numeric_messages = EvaluationCore._evaluation_messages(
+        suite_id="mmlu",
+        prompt="6 + 3 = ?",
+        expected="9",
+    )
+    option_messages = EvaluationCore._evaluation_messages(
+        suite_id="mmlu",
+        prompt="Pick one",
+        expected="B",
+    )
 
     assert numeric_messages[0].parts[0].text.startswith("Return only the final numeric answer.")
     assert option_messages[0].parts[0].text.startswith("Return only the single best answer choice letter.")

--- a/services/mlx-worker-python/tests/test_evaluation_store.py
+++ b/services/mlx-worker-python/tests/test_evaluation_store.py
@@ -102,7 +102,7 @@ def test_persist_result_writes_expected_artifact_names_and_payloads(tmp_path: Pa
         "job_id,task_kind,source_repo,model_id,suite_id,dataset_id,score_name,score_value,sample_size,correct_count,incorrect_count,duration_seconds,created_at_unix_ms\r\n"
     )
     assert build_evaluation_samples_csv(export_bundle).startswith(
-        "job_id,suite_id,id,correct,expected,predicted,question,raw_response,time_s,parse_status,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail\r\n"
+        "job_id,suite_id,id,task_kind,correct,expected,predicted,question,raw_response,time_s,parse_status,input_modalities,media_references,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail\r\n"
     )
 
 
@@ -220,7 +220,7 @@ def test_persist_result_exports_code_execution_evidence_fields(tmp_path: Path) -
 
     export_bundle = collect_evaluation_artifacts(jobs_root)
     assert build_evaluation_samples_csv(export_bundle).startswith(
-        "job_id,suite_id,id,correct,expected,predicted,question,raw_response,time_s,parse_status,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail\r\n"
+        "job_id,suite_id,id,task_kind,correct,expected,predicted,question,raw_response,time_s,parse_status,input_modalities,media_references,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail\r\n"
     )
 
 

--- a/services/mlx-worker-python/tests/test_evaluation_store.py
+++ b/services/mlx-worker-python/tests/test_evaluation_store.py
@@ -93,7 +93,7 @@ def test_persist_result_writes_expected_artifact_names_and_payloads(tmp_path: Pa
         "job_id,task_kind,source_repo,model_id,suite_id,dataset_id,score_name,score_value,sample_size,correct_count,incorrect_count,duration_seconds,created_at_unix_ms\n"
     )
     assert persisted["samples_csv"].read_text(encoding="utf-8").startswith(
-        "id,task_kind,correct,expected,predicted,question,raw_response,time_s,parse_status,input_modalities,media_references\n"
+        "id,task_kind,correct,expected,predicted,question,raw_response,time_s,parse_status,input_modalities,media_references,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail\n"
     )
 
     export_bundle = collect_evaluation_artifacts(jobs_root)
@@ -102,7 +102,7 @@ def test_persist_result_writes_expected_artifact_names_and_payloads(tmp_path: Pa
         "job_id,task_kind,source_repo,model_id,suite_id,dataset_id,score_name,score_value,sample_size,correct_count,incorrect_count,duration_seconds,created_at_unix_ms\r\n"
     )
     assert build_evaluation_samples_csv(export_bundle).startswith(
-        "job_id,suite_id,id,correct,expected,predicted,question,raw_response,time_s,parse_status\r\n"
+        "job_id,suite_id,id,correct,expected,predicted,question,raw_response,time_s,parse_status,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail\r\n"
     )
 
 
@@ -132,6 +132,96 @@ def test_samples_csv_quotes_fields_with_commas_newlines_and_quotes() -> None:
     assert '"quoted ""response"""' in csv_payload
     assert '"text,image"' in csv_payload
     assert '"/tmp/a,1.png,/tmp/b""2"".png"' in csv_payload
+
+
+def test_persist_result_exports_code_execution_evidence_fields(tmp_path: Path) -> None:
+    store = EvaluationStore()
+    jobs_root = tmp_path / "evaluation"
+    run_root = jobs_root / "runs" / "eval-code"
+    job = build_evaluation_job_record(
+        job_id="eval-code",
+        model_id="melix-dev-code",
+        task_kind="text-generation",
+        source_repo="openai_humaneval",
+        suite_id="humaneval",
+        dataset_id="humaneval.dev.v1",
+        sample_size=1,
+        scoring_mode="pass_at_1",
+        code_exec_policy="sandboxed",
+        parameters={"dataset_root": str(tmp_path / "datasets" / "humaneval.dev.v1")},
+        status="completed",
+        output_dir=str(run_root),
+        created_at_unix_ms=101,
+        updated_at_unix_ms=202,
+    )
+    result = build_evaluation_result_record(
+        job_id="eval-code",
+        suite_id="humaneval",
+        dataset_id="humaneval.dev.v1",
+        sample_size=1,
+        score_name="pass_at_1",
+        score_value=1.0,
+        correct_count=1,
+        incorrect_count=0,
+        duration_seconds=0.25,
+        metrics={
+            "eval.humaneval.pass_at_1": 1.0,
+            "eval.humaneval.code_exec_pass_count": 1.0,
+        },
+        report_path=str(run_root / "evaluation-result.json"),
+        units={
+            "eval.humaneval.pass_at_1": "ratio",
+            "eval.humaneval.code_exec_pass_count": "count",
+        },
+    )
+    sample = build_evaluation_sample_record(
+        job_id="eval-code",
+        suite_id="humaneval",
+        dataset_id="humaneval.dev.v1",
+        sample_id="sample-1",
+        question="Write identity(x) that returns x.",
+        expected="identity",
+        predicted="def identity(x):\n    return x",
+        raw_response="```python\ndef identity(x):\n    return x\n```",
+        correct=True,
+        time_s=0.02,
+        parse_status="parsed_code_block",
+        task_kind="text-generation",
+        code_language="python",
+        code_entry_point="identity",
+        code_compile_status="compiled",
+        code_runtime_status="ok",
+        code_timeout_status="ok",
+        code_test_status="passed",
+        code_tests_passed=2,
+        code_tests_total=2,
+        code_failure_detail="",
+    )
+
+    persisted = store.persist_result(
+        jobs_root=jobs_root,
+        job=job,
+        result=result,
+        samples=(sample,),
+    )
+
+    sample_payload = json.loads(persisted["samples_jsonl"].read_text(encoding="utf-8").strip())
+    assert sample_payload["code_language"] == "python"
+    assert sample_payload["code_entry_point"] == "identity"
+    assert sample_payload["code_compile_status"] == "compiled"
+    assert sample_payload["code_runtime_status"] == "ok"
+    assert sample_payload["code_timeout_status"] == "ok"
+    assert sample_payload["code_test_status"] == "passed"
+    assert sample_payload["code_tests_passed"] == 2
+    assert sample_payload["code_tests_total"] == 2
+    assert persisted["samples_csv"].read_text(encoding="utf-8").startswith(
+        "id,task_kind,correct,expected,predicted,question,raw_response,time_s,parse_status,input_modalities,media_references,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail\n"
+    )
+
+    export_bundle = collect_evaluation_artifacts(jobs_root)
+    assert build_evaluation_samples_csv(export_bundle).startswith(
+        "job_id,suite_id,id,correct,expected,predicted,question,raw_response,time_s,parse_status,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail\r\n"
+    )
 
 
 def test_persist_compare_result_writes_expected_compare_artifact_names_and_payloads(
@@ -218,3 +308,95 @@ def test_persist_compare_result_writes_expected_compare_artifact_names_and_paylo
         "job_id,base_model_id,target_model_id,suite_id,dataset_id,sample_size,win_count,loss_count,tie_count,regression_count,base_accuracy,target_accuracy,delta_accuracy,duration_seconds,created_at_unix_ms\n"
     )
     assert persisted["report_markdown"].read_text(encoding="utf-8").startswith("# Melix Evaluation Compare\n")
+
+
+def test_persist_compare_result_preserves_code_execution_evidence(tmp_path: Path) -> None:
+    store = EvaluationStore()
+    jobs_root = tmp_path / "evaluation"
+    run_root = jobs_root / "runs" / "eval-compare-code"
+    compare_job = build_evaluation_compare_job_record(
+        job_id="eval-compare-code",
+        base_model_id="melix-dev-code-base",
+        target_model_ids=("melix-dev-code-target",),
+        task_kind="text-generation",
+        source_repo="openai_humaneval",
+        suite_id="humaneval",
+        dataset_id="humaneval.dev.v1",
+        sample_size=1,
+        scoring_mode="pass_at_1",
+        parameters={"compare_mode": "base_vs_targets", "code_exec_policy": "sandboxed"},
+        status="completed",
+        output_dir=str(run_root),
+        created_at_unix_ms=101,
+        updated_at_unix_ms=202,
+    )
+    compare_summary = build_evaluation_compare_summary_record(
+        job_id="eval-compare-code",
+        base_model_id="melix-dev-code-base",
+        target_model_id="melix-dev-code-target",
+        suite_id="humaneval",
+        dataset_id="humaneval.dev.v1",
+        sample_size=1,
+        scoring_mode="pass_at_1",
+        win_count=1,
+        loss_count=0,
+        tie_count=0,
+        regression_count=0,
+        base_accuracy=0.0,
+        target_accuracy=1.0,
+        delta_accuracy=1.0,
+        duration_seconds=0.25,
+        metrics={"eval.compare.delta_accuracy": 1.0},
+        report_path=str(run_root / "evaluation-compare-report.md"),
+    )
+    compare_sample = build_evaluation_compare_sample_record(
+        job_id="eval-compare-code",
+        suite_id="humaneval",
+        dataset_id="humaneval.dev.v1",
+        sample_id="sample-1",
+        target_model_id="melix-dev-code-target",
+        question="Write identity(x) that returns x.",
+        expected="identity",
+        base_predicted="def identity(x):\n    return None",
+        target_predicted="def identity(x):\n    return x",
+        base_raw_response="```python\ndef identity(x):\n    return None\n```",
+        target_raw_response="```python\ndef identity(x):\n    return x\n```",
+        base_correct=False,
+        target_correct=True,
+        outcome="win",
+        regression=False,
+        base_time_s=0.01,
+        target_time_s=0.02,
+        base_parse_status="parsed_code_block",
+        target_parse_status="parsed_code_block",
+        code_language="python",
+        code_entry_point="identity",
+        base_code_compile_status="compiled",
+        target_code_compile_status="compiled",
+        base_code_runtime_status="ok",
+        target_code_runtime_status="ok",
+        base_code_timeout_status="ok",
+        target_code_timeout_status="ok",
+        base_code_test_status="failed",
+        target_code_test_status="passed",
+        base_code_tests_passed=0,
+        target_code_tests_passed=2,
+        base_code_tests_total=2,
+        target_code_tests_total=2,
+        base_code_failure_detail="AssertionError",
+        target_code_failure_detail="",
+    )
+
+    persisted = store.persist_compare_result(
+        jobs_root=jobs_root,
+        job=compare_job,
+        summaries=(compare_summary,),
+        samples=(compare_sample,),
+    )
+
+    sample_payload = json.loads(persisted["samples_jsonl"].read_text(encoding="utf-8").strip())
+    assert sample_payload["code_language"] == "python"
+    assert sample_payload["code_entry_point"] == "identity"
+    assert sample_payload["base_code_test_status"] == "failed"
+    assert sample_payload["target_code_test_status"] == "passed"
+    assert sample_payload["base_code_failure_detail"] == "AssertionError"

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -164,6 +164,30 @@ class RecordingBenchmarkBackend:
         )
 
 
+class ScriptedCodeEvalBackend:
+    runtime_name = "scripted-code-eval"
+
+    def __init__(self, responses: tuple[str, ...]) -> None:
+        self._responses = list(responses)
+        self.prompts: list[str] = []
+
+    def load_model(self, model_spec):
+        return {"model_id": model_spec.model_id, "model_path": model_spec.model_path}
+
+    def estimate_resident_bytes(self, model_spec) -> int:
+        _ = model_spec
+        return 1_024
+
+    def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event):
+        _ = loaded_model
+        _ = sampling
+        self.prompts.append(prompt)
+        if cancel_event.is_set():
+            return
+        text = self._responses.pop(0)
+        yield RuntimeTokenEvent(text=text, completion_tokens=max(1, len(text.split())))
+
+
 class FakeBenchmarkHFDatasetFetcher:
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict[str, str]]] = []
@@ -2702,6 +2726,63 @@ def test_run_evaluation_uses_checked_in_repo_fixture_when_dataset_root_is_omitte
     assert response.job.dataset_id == "mmlu.dev.v1"
     assert response.results[0].metrics[0].name == "eval.mmlu.accuracy"
     assert response.results[0].metrics[0].value == 1.0
+
+
+@pytest.mark.parametrize(
+    ("suite_id", "dataset_id", "response_text", "metric_name"),
+    [
+        (
+            "humaneval",
+            "humaneval.dev.v1",
+            "```python\ndef identity(x):\n    return x\n```",
+            "eval.humaneval.pass_at_1",
+        ),
+        (
+            "mbpp",
+            "mbpp.dev.v1",
+            "```python\ndef square(n):\n    return n * n\n```",
+            "eval.mbpp.pass_at_1",
+        ),
+    ],
+)
+def test_run_evaluation_uses_checked_in_code_fixture_when_dataset_root_is_omitted(
+    tmp_path: Path,
+    monkeypatch,
+    suite_id: str,
+    dataset_id: str,
+    response_text: str,
+    metric_name: str,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    fixture_root = repo_root / "services" / "mlx-worker-python" / "fixtures" / "evaluation" / dataset_id
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=ScriptedCodeEvalBackend((response_text,))),
+        model_catalog=WorkerModelCatalog(),
+    )
+    loaded = registry.load_model(WorkerModelCatalog.dev_text_model())
+    service = build_service(tmp_path, registry=registry)
+
+    assert fixture_root.exists() is True
+    monkeypatch.chdir(repo_root)
+
+    response = service.RunEvaluation(
+        maintenance_pb2.RunEvaluationRequest(
+            model_handle=loaded.handle,
+            suite_id=suite_id,
+            dataset_id=dataset_id,
+            sample_size=1,
+            code_exec_policy="sandboxed",
+        ),
+        context=None,
+    )
+
+    metrics = {metric.name: metric.value for metric in response.results[0].metrics}
+
+    assert response.ok is True
+    assert response.job.dataset_id == dataset_id
+    assert metrics[metric_name] == 1.0
+    assert metrics[f"eval.{suite_id}.code_exec_pass_count"] == 1.0
+    assert metrics[f"eval.{suite_id}.code_exec_fail_count"] == 0.0
 
 
 def test_run_evaluation_uses_checked_in_multimodal_fixture_when_dataset_root_is_omitted(

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+
+@dataclass(frozen=True)
+class CodeEvaluationResult:
+    compile_status: str
+    runtime_status: str
+    timeout_status: str
+    test_status: str
+    tests_passed: int
+    tests_total: int
+    failure_detail: str
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.compile_status == "compiled"
+            and self.runtime_status == "ok"
+            and self.timeout_status == "ok"
+            and self.test_status == "passed"
+        )
+
+
+def run_python_code_evaluation(
+    *,
+    candidate_code: str,
+    entry_point: str,
+    test_code: str,
+    timeout_seconds: int = 3,
+    memory_limit_mb: int = 256,
+    stdout_limit_bytes: int = 32_768,
+) -> CodeEvaluationResult:
+    try:
+        compile(candidate_code, "<candidate>", "exec")
+    except SyntaxError as exc:
+        return CodeEvaluationResult(
+            compile_status="syntax_error",
+            runtime_status="not_run",
+            timeout_status="ok",
+            test_status="not_run",
+            tests_passed=0,
+            tests_total=_count_tests(test_code),
+            failure_detail=str(exc),
+        )
+
+    with tempfile.TemporaryDirectory(prefix="melix-code-eval-") as temp_dir:
+        temp_root = Path(temp_dir)
+        candidate_path = temp_root / "candidate.py"
+        config_path = temp_root / "config.json"
+        runner_path = temp_root / "runner.py"
+        candidate_path.write_text(candidate_code, encoding="utf-8")
+        config_path.write_text(
+            json.dumps(
+                {
+                    "candidate_path": str(candidate_path),
+                    "entry_point": entry_point,
+                    "test_code": test_code,
+                    "memory_limit_mb": memory_limit_mb,
+                }
+            ),
+            encoding="utf-8",
+        )
+        runner_path.write_text(_runner_script(), encoding="utf-8")
+
+        try:
+            completed = subprocess.run(
+                [sys.executable, "-I", "-S", str(runner_path), str(config_path)],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                env={
+                    "PYTHONDONTWRITEBYTECODE": "1",
+                    "PYTHONNOUSERSITE": "1",
+                },
+            )
+        except subprocess.TimeoutExpired:
+            return CodeEvaluationResult(
+                compile_status="compiled",
+                runtime_status="timeout",
+                timeout_status="timed_out",
+                test_status="not_run",
+                tests_passed=0,
+                tests_total=_count_tests(test_code),
+                failure_detail=f"Timed out after {timeout_seconds}s",
+            )
+
+        stdout = completed.stdout[:stdout_limit_bytes].strip()
+        stderr = completed.stderr[:stdout_limit_bytes].strip()
+        payload = _load_payload(stdout)
+        if payload is None:
+            detail = stderr or stdout or f"Subprocess exited with status {completed.returncode}"
+            return CodeEvaluationResult(
+                compile_status="compiled",
+                runtime_status="error",
+                timeout_status="ok",
+                test_status="failed",
+                tests_passed=0,
+                tests_total=_count_tests(test_code),
+                failure_detail=detail,
+            )
+
+        return CodeEvaluationResult(
+            compile_status=str(payload.get("compile_status", "compiled")),
+            runtime_status=str(payload.get("runtime_status", "error")),
+            timeout_status=str(payload.get("timeout_status", "ok")),
+            test_status=str(payload.get("test_status", "failed")),
+            tests_passed=int(payload.get("tests_passed", 0) or 0),
+            tests_total=int(payload.get("tests_total", 0) or 0),
+            failure_detail=str(payload.get("failure_detail", "")),
+        )
+
+
+def _count_tests(test_code: str) -> int:
+    return len([line for line in test_code.splitlines() if line.strip()])
+
+
+def _load_payload(stdout: str) -> dict[str, object] | None:
+    if not stdout:
+        return None
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _runner_script() -> str:
+    return textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import importlib.util
+        import json
+        import resource
+        import sys
+        import traceback
+
+
+        def main() -> int:
+            config = json.loads(open(sys.argv[1], "r", encoding="utf-8").read())
+            memory_limit_mb = int(config.get("memory_limit_mb", 256) or 256)
+            memory_limit_bytes = memory_limit_mb * 1024 * 1024
+            current_soft, current_hard = resource.getrlimit(resource.RLIMIT_AS)
+            if current_hard == resource.RLIM_INFINITY:
+                address_space_limit = memory_limit_bytes
+            else:
+                address_space_limit = min(memory_limit_bytes, current_hard)
+            try:
+                resource.setrlimit(resource.RLIMIT_AS, (address_space_limit, current_hard))
+            except (OSError, ValueError):
+                pass
+            cpu_soft, cpu_hard = resource.getrlimit(resource.RLIMIT_CPU)
+            cpu_limit = min(2, cpu_hard) if cpu_hard != resource.RLIM_INFINITY else 2
+            try:
+                resource.setrlimit(resource.RLIMIT_CPU, (cpu_limit, cpu_hard))
+            except (OSError, ValueError):
+                pass
+
+            candidate_path = config["candidate_path"]
+            entry_point = str(config.get("entry_point", ""))
+            test_code = str(config.get("test_code", ""))
+            tests = [line for line in test_code.splitlines() if line.strip()]
+
+            try:
+                spec = importlib.util.spec_from_file_location("candidate", candidate_path)
+                if spec is None or spec.loader is None:
+                    raise RuntimeError("Unable to load candidate module")
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                if entry_point and hasattr(module, entry_point) is False:
+                    raise AttributeError(f"Missing entry point: {entry_point}")
+
+                namespace = dict(module.__dict__)
+                tests_passed = 0
+                for test in tests:
+                    exec(test, namespace, namespace)
+                    tests_passed += 1
+
+                payload = {
+                    "compile_status": "compiled",
+                    "runtime_status": "ok",
+                    "timeout_status": "ok",
+                    "test_status": "passed",
+                    "tests_passed": tests_passed,
+                    "tests_total": len(tests),
+                    "failure_detail": "",
+                }
+            except AssertionError as exc:
+                payload = {
+                    "compile_status": "compiled",
+                    "runtime_status": "ok",
+                    "timeout_status": "ok",
+                    "test_status": "failed",
+                    "tests_passed": locals().get("tests_passed", 0),
+                    "tests_total": len(tests),
+                    "failure_detail": str(exc) or "AssertionError",
+                }
+            except BaseException as exc:
+                payload = {
+                    "compile_status": "compiled",
+                    "runtime_status": "error",
+                    "timeout_status": "ok",
+                    "test_status": "failed",
+                    "tests_passed": locals().get("tests_passed", 0),
+                    "tests_total": len(tests),
+                    "failure_detail": "".join(traceback.format_exception_only(type(exc), exc)).strip(),
+                }
+
+            print(json.dumps(payload))
+            return 0
+
+
+        if __name__ == "__main__":
+            raise SystemExit(main())
+        """
+    ).strip() + "\n"

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import ast
 from dataclasses import dataclass
 import json
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 import tempfile
 import textwrap
+
+_PAYLOAD_SENTINEL = "__MELIX_CODE_EVAL_PAYLOAD__:"
 
 
 @dataclass(frozen=True)
@@ -37,7 +41,7 @@ def run_python_code_evaluation(
     timeout_seconds: int = 3,
     memory_limit_mb: int = 256,
     stdout_limit_bytes: int = 32_768,
-) -> CodeEvaluationResult:
+    ) -> CodeEvaluationResult:
     try:
         compile(candidate_code, "<candidate>", "exec")
     except SyntaxError as exc:
@@ -49,6 +53,18 @@ def run_python_code_evaluation(
             tests_passed=0,
             tests_total=_count_tests(test_code),
             failure_detail=str(exc),
+        )
+
+    sandbox_exec = shutil.which("sandbox-exec")
+    if not sandbox_exec:
+        return CodeEvaluationResult(
+            compile_status="compiled",
+            runtime_status="error",
+            timeout_status="ok",
+            test_status="failed",
+            tests_passed=0,
+            tests_total=_count_tests(test_code),
+            failure_detail="sandbox-exec is unavailable on this host.",
         )
 
     with tempfile.TemporaryDirectory(prefix="melix-code-eval-") as temp_dir:
@@ -72,14 +88,26 @@ def run_python_code_evaluation(
 
         try:
             completed = subprocess.run(
-                [sys.executable, "-I", "-S", str(runner_path), str(config_path)],
+                [
+                    sandbox_exec,
+                    "-p",
+                    _sandbox_profile(temp_root=temp_root),
+                    str(_sandbox_python_executable()),
+                    "-I",
+                    "-S",
+                    str(runner_path),
+                    str(config_path),
+                ],
                 check=False,
                 capture_output=True,
                 text=True,
                 timeout=timeout_seconds,
+                cwd=str(temp_root),
                 env={
                     "PYTHONDONTWRITEBYTECODE": "1",
                     "PYTHONNOUSERSITE": "1",
+                    "HOME": str(temp_root),
+                    "TMPDIR": str(temp_root),
                 },
             )
         except subprocess.TimeoutExpired:
@@ -93,8 +121,8 @@ def run_python_code_evaluation(
                 failure_detail=f"Timed out after {timeout_seconds}s",
             )
 
-        stdout = completed.stdout[:stdout_limit_bytes].strip()
-        stderr = completed.stderr[:stdout_limit_bytes].strip()
+        stdout = completed.stdout[-stdout_limit_bytes:].strip()
+        stderr = completed.stderr[-stdout_limit_bytes:].strip()
         payload = _load_payload(stdout)
         if payload is None:
             detail = stderr or stdout or f"Subprocess exited with status {completed.returncode}"
@@ -120,14 +148,29 @@ def run_python_code_evaluation(
 
 
 def _count_tests(test_code: str) -> int:
-    return len([line for line in test_code.splitlines() if line.strip()])
+    try:
+        module = ast.parse(test_code, filename="<tests>", mode="exec")
+    except SyntaxError:
+        return len([line for line in test_code.splitlines() if line.strip()])
+    assert_count = sum(1 for node in ast.walk(module) if isinstance(node, ast.Assert))
+    return assert_count or len([line for line in test_code.splitlines() if line.strip()])
 
 
 def _load_payload(stdout: str) -> dict[str, object] | None:
     if not stdout:
         return None
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    for line in reversed(lines):
+        if line.startswith(_PAYLOAD_SENTINEL):
+            return _decode_payload(line.removeprefix(_PAYLOAD_SENTINEL))
+    if lines:
+        return _decode_payload(lines[-1])
+    return _decode_payload(stdout)
+
+
+def _decode_payload(raw_payload: str) -> dict[str, object] | None:
     try:
-        payload = json.loads(stdout)
+        payload = json.loads(raw_payload)
     except json.JSONDecodeError:
         return None
     if not isinstance(payload, dict):
@@ -135,31 +178,128 @@ def _load_payload(stdout: str) -> dict[str, object] | None:
     return payload
 
 
+def _sandbox_profile(*, temp_root: Path) -> str:
+    executable_paths = _sandbox_executable_paths()
+    runtime_paths = _sandbox_runtime_read_paths()
+    clauses = [
+        "(version 1)",
+        "(allow default)",
+        "(deny network*)",
+        "(deny file-write*)",
+        "(deny process-fork)",
+        "(deny process-exec)",
+    ]
+    if executable_paths:
+        executable_filters = " ".join(
+            f"(literal {json.dumps(str(path))})"
+            for path in executable_paths
+        )
+        clauses.append(f"(allow process-exec {executable_filters})")
+    home_path = Path.home()
+    clauses.append(f"(deny file-read* (subpath {json.dumps(str(home_path))}))")
+    read_filters = " ".join(
+        f"(subpath {json.dumps(str(path))})"
+        for path in (*runtime_paths, temp_root)
+    )
+    clauses.append(f"(allow file-read* {read_filters})")
+    return " ".join(clauses)
+
+
+def _sandbox_executable_paths() -> tuple[Path, ...]:
+    resolved = _sandbox_python_executable()
+    paths = [resolved]
+    launcher_path = resolved.parent.parent / "Resources" / "Python.app" / "Contents" / "MacOS" / "Python"
+    if launcher_path.exists():
+        paths.append(launcher_path)
+    deduped: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        if path in seen:
+            continue
+        seen.add(path)
+        deduped.append(path)
+    return tuple(deduped)
+
+
+def _sandbox_python_executable() -> Path:
+    return Path(sys.executable).resolve()
+
+
+def _sandbox_runtime_read_paths() -> tuple[Path, ...]:
+    roots = [_sandbox_python_executable().parent.parent]
+    deduped: list[Path] = []
+    seen: set[Path] = set()
+    for path in roots:
+        if path in seen:
+            continue
+        seen.add(path)
+        deduped.append(path)
+    return tuple(deduped)
+
+
 def _runner_script() -> str:
-    return textwrap.dedent(
-        """
+    script = """
         from __future__ import annotations
 
+        import ast
         import importlib.util
         import json
         import resource
         import sys
         import traceback
 
+        PAYLOAD_SENTINEL = __PAYLOAD_SENTINEL__
 
-        def main() -> int:
-            config = json.loads(open(sys.argv[1], "r", encoding="utf-8").read())
-            memory_limit_mb = int(config.get("memory_limit_mb", 256) or 256)
-            memory_limit_bytes = memory_limit_mb * 1024 * 1024
-            current_soft, current_hard = resource.getrlimit(resource.RLIMIT_AS)
+
+        class _AssertInstrumentor(ast.NodeTransformer):
+            def __init__(self) -> None:
+                self.tests_total = 0
+
+            def visit_Assert(self, node: ast.Assert):
+                self.tests_total += 1
+                self.generic_visit(node)
+                instrumented = ast.Expr(
+                    value=ast.Call(
+                        func=ast.Name(id="__melix_assert", ctx=ast.Load()),
+                        args=[
+                            node.test,
+                            node.msg if node.msg is not None else ast.Constant(value=None),
+                        ],
+                        keywords=[],
+                    )
+                )
+                return ast.copy_location(instrumented, node)
+
+
+        def _compile_tests(test_code: str):
+            module = ast.parse(test_code, filename="<tests>", mode="exec")
+            instrumentor = _AssertInstrumentor()
+            instrumented = instrumentor.visit(module)
+            ast.fix_missing_locations(instrumented)
+            return compile(instrumented, "<tests>", "exec"), instrumentor.tests_total
+
+
+        def _set_address_space_limit(memory_limit_bytes: int) -> None:
+            rlimit_as = getattr(resource, "RLIMIT_AS", None)
+            if rlimit_as is None:
+                return
+            current_soft, current_hard = resource.getrlimit(rlimit_as)
             if current_hard == resource.RLIM_INFINITY:
                 address_space_limit = memory_limit_bytes
             else:
                 address_space_limit = min(memory_limit_bytes, current_hard)
             try:
-                resource.setrlimit(resource.RLIMIT_AS, (address_space_limit, current_hard))
+                resource.setrlimit(rlimit_as, (address_space_limit, current_hard))
             except (OSError, ValueError):
                 pass
+
+
+        def main() -> int:
+            with open(sys.argv[1], "r", encoding="utf-8") as file:
+                config = json.load(file)
+            memory_limit_mb = int(config.get("memory_limit_mb", 256) or 256)
+            memory_limit_bytes = memory_limit_mb * 1024 * 1024
+            _set_address_space_limit(memory_limit_bytes)
             cpu_soft, cpu_hard = resource.getrlimit(resource.RLIMIT_CPU)
             cpu_limit = min(2, cpu_hard) if cpu_hard != resource.RLIM_INFINITY else 2
             try:
@@ -170,7 +310,8 @@ def _runner_script() -> str:
             candidate_path = config["candidate_path"]
             entry_point = str(config.get("entry_point", ""))
             test_code = str(config.get("test_code", ""))
-            tests = [line for line in test_code.splitlines() if line.strip()]
+            tests_total = 0
+            tests_passed = 0
 
             try:
                 spec = importlib.util.spec_from_file_location("candidate", candidate_path)
@@ -182,10 +323,19 @@ def _runner_script() -> str:
                     raise AttributeError(f"Missing entry point: {entry_point}")
 
                 namespace = dict(module.__dict__)
-                tests_passed = 0
-                for test in tests:
-                    exec(test, namespace, namespace)
-                    tests_passed += 1
+                test_state = {"passed": 0}
+
+                def __melix_assert(condition, message=None):
+                    if not condition:
+                        if message is None:
+                            raise AssertionError()
+                        raise AssertionError(message)
+                    test_state["passed"] += 1
+
+                namespace["__melix_assert"] = __melix_assert
+                compiled_tests, tests_total = _compile_tests(test_code)
+                exec(compiled_tests, namespace, namespace)
+                tests_passed = int(test_state["passed"])
 
                 payload = {
                     "compile_status": "compiled",
@@ -193,7 +343,7 @@ def _runner_script() -> str:
                     "timeout_status": "ok",
                     "test_status": "passed",
                     "tests_passed": tests_passed,
-                    "tests_total": len(tests),
+                    "tests_total": tests_total,
                     "failure_detail": "",
                 }
             except AssertionError as exc:
@@ -203,7 +353,7 @@ def _runner_script() -> str:
                     "timeout_status": "ok",
                     "test_status": "failed",
                     "tests_passed": locals().get("tests_passed", 0),
-                    "tests_total": len(tests),
+                    "tests_total": locals().get("tests_total", 0),
                     "failure_detail": str(exc) or "AssertionError",
                 }
             except BaseException as exc:
@@ -213,15 +363,15 @@ def _runner_script() -> str:
                     "timeout_status": "ok",
                     "test_status": "failed",
                     "tests_passed": locals().get("tests_passed", 0),
-                    "tests_total": len(tests),
+                    "tests_total": locals().get("tests_total", 0),
                     "failure_detail": "".join(traceback.format_exception_only(type(exc), exc)).strip(),
                 }
 
-            print(json.dumps(payload))
+            print(PAYLOAD_SENTINEL + json.dumps(payload))
             return 0
 
 
         if __name__ == "__main__":
             raise SystemExit(main())
         """
-    ).strip() + "\n"
+    return textwrap.dedent(script).replace("__PAYLOAD_SENTINEL__", repr(_PAYLOAD_SENTINEL)).strip() + "\n"

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -7,10 +7,12 @@ from pathlib import Path
 import shutil
 import subprocess
 import sys
+import sysconfig
 import tempfile
 import textwrap
+import uuid
 
-_PAYLOAD_SENTINEL = "__MELIX_CODE_EVAL_PAYLOAD__:"
+_PAYLOAD_SENTINEL_PREFIX = "__MELIX_CODE_EVAL_PAYLOAD__:"
 
 
 @dataclass(frozen=True)
@@ -69,6 +71,7 @@ def run_python_code_evaluation(
 
     with tempfile.TemporaryDirectory(prefix="melix-code-eval-") as temp_dir:
         temp_root = Path(temp_dir)
+        payload_sentinel = f"{_PAYLOAD_SENTINEL_PREFIX}{uuid.uuid4().hex}:"
         candidate_path = temp_root / "candidate.py"
         config_path = temp_root / "config.json"
         runner_path = temp_root / "runner.py"
@@ -84,7 +87,7 @@ def run_python_code_evaluation(
             ),
             encoding="utf-8",
         )
-        runner_path.write_text(_runner_script(), encoding="utf-8")
+        runner_path.write_text(_runner_script(payload_sentinel=payload_sentinel), encoding="utf-8")
 
         try:
             completed = subprocess.run(
@@ -123,7 +126,7 @@ def run_python_code_evaluation(
 
         stdout = completed.stdout[-stdout_limit_bytes:].strip()
         stderr = completed.stderr[-stdout_limit_bytes:].strip()
-        payload = _load_payload(stdout)
+        payload = _load_payload(stdout, payload_sentinel)
         if payload is None:
             detail = stderr or stdout or f"Subprocess exited with status {completed.returncode}"
             return CodeEvaluationResult(
@@ -156,16 +159,14 @@ def _count_tests(test_code: str) -> int:
     return assert_count or len([line for line in test_code.splitlines() if line.strip()])
 
 
-def _load_payload(stdout: str) -> dict[str, object] | None:
+def _load_payload(stdout: str, payload_sentinel: str) -> dict[str, object] | None:
     if not stdout:
         return None
     lines = [line.strip() for line in stdout.splitlines() if line.strip()]
     for line in reversed(lines):
-        if line.startswith(_PAYLOAD_SENTINEL):
-            return _decode_payload(line.removeprefix(_PAYLOAD_SENTINEL))
-    if lines:
-        return _decode_payload(lines[-1])
-    return _decode_payload(stdout)
+        if line.startswith(payload_sentinel):
+            return _decode_payload(line.removeprefix(payload_sentinel))
+    return None
 
 
 def _decode_payload(raw_payload: str) -> dict[str, object] | None:
@@ -189,17 +190,31 @@ def _sandbox_profile(*, temp_root: Path) -> str:
         "(deny process-fork)",
         "(deny process-exec)",
     ]
+    denied_read_roots = (
+        Path("/Applications"),
+        Path("/Library"),
+        Path("/System"),
+        Path("/Users"),
+        Path("/Volumes"),
+        Path("/etc"),
+        Path("/opt"),
+        Path("/private"),
+        Path("/tmp"),
+        Path("/usr"),
+    )
+    clauses.extend(
+        f"(deny file-read* (subpath {json.dumps(str(path))}))"
+        for path in denied_read_roots
+    )
     if executable_paths:
         executable_filters = " ".join(
             f"(literal {json.dumps(str(path))})"
             for path in executable_paths
         )
         clauses.append(f"(allow process-exec {executable_filters})")
-    home_path = Path.home()
-    clauses.append(f"(deny file-read* (subpath {json.dumps(str(home_path))}))")
     read_filters = " ".join(
         f"(subpath {json.dumps(str(path))})"
-        for path in (*runtime_paths, temp_root)
+        for path in _sandbox_allow_path_variants((*runtime_paths, temp_root))
     )
     clauses.append(f"(allow file-read* {read_filters})")
     return " ".join(clauses)
@@ -226,7 +241,18 @@ def _sandbox_python_executable() -> Path:
 
 
 def _sandbox_runtime_read_paths() -> tuple[Path, ...]:
-    roots = [_sandbox_python_executable().parent.parent]
+    roots: list[Path] = [
+        _sandbox_python_executable().parent.parent,
+        Path(sys.prefix).resolve(),
+        Path(sys.exec_prefix).resolve(),
+        Path(sys.base_prefix).resolve(),
+        Path(sys.base_exec_prefix).resolve(),
+        Path("/System/Library"),
+        Path("/usr/lib"),
+    ]
+    for raw_path in sysconfig.get_paths().values():
+        if raw_path:
+            roots.append(Path(raw_path).resolve())
     deduped: list[Path] = []
     seen: set[Path] = set()
     for path in roots:
@@ -237,7 +263,25 @@ def _sandbox_runtime_read_paths() -> tuple[Path, ...]:
     return tuple(deduped)
 
 
-def _runner_script() -> str:
+def _sandbox_allow_path_variants(paths: tuple[Path, ...]) -> tuple[Path, ...]:
+    deduped: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        variants = [path]
+        try:
+            resolved = path.resolve()
+        except OSError:
+            resolved = path
+        variants.append(resolved)
+        for variant in variants:
+            if variant in seen:
+                continue
+            seen.add(variant)
+            deduped.append(variant)
+    return tuple(deduped)
+
+
+def _runner_script(*, payload_sentinel: str) -> str:
     script = """
         from __future__ import annotations
 
@@ -374,4 +418,4 @@ def _runner_script() -> str:
         if __name__ == "__main__":
             raise SystemExit(main())
         """
-    return textwrap.dedent(script).replace("__PAYLOAD_SENTINEL__", repr(_PAYLOAD_SENTINEL)).strip() + "\n"
+    return textwrap.dedent(script).replace("__PAYLOAD_SENTINEL__", repr(payload_sentinel)).strip() + "\n"

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -10,6 +10,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from packages.protocol.python.worker.v1 import common_pb2
+from worker.engine.code_eval_runner import run_python_code_evaluation
 from worker.productization.benchmark_queue import BenchmarkQueueRecord, BenchmarkQueueStore
 from worker.productization.evaluation_compare import (
     build_compare_samples,
@@ -50,7 +51,9 @@ _ANSWER_PREFIX_PATTERN = re.compile(
 _NUMERIC_TOKEN_PATTERN = re.compile(r"[-+]?\d+(?:\.\d+)?")
 _NUMERIC_RESULT_PATTERN = re.compile(r"=\s*([-+]?\d+(?:\.\d+)?)")
 _OPTION_TOKEN_PATTERN = re.compile(r"\b([A-Z])\b")
+_CODE_BLOCK_PATTERN = re.compile(r"```(?:python)?\s*(.*?)```", re.IGNORECASE | re.DOTALL)
 _MULTIMODAL_TASK_KINDS = {"image-to-text", "image-text-to-text"}
+_CODE_EXEC_SUITES = {"humaneval", "mbpp"}
 
 
 @dataclass(frozen=True)
@@ -134,6 +137,10 @@ class EvaluationCore:
             if code_exec_policy is not None and code_exec_policy != ""
             else (parameters or {}).get("code_exec_policy", "")
         )
+        if suite_id in _CODE_EXEC_SUITES and resolved_code_exec_policy != "sandboxed":
+            raise ValueError(
+                f"Evaluation suite {suite_id} requires code_exec_policy=sandboxed."
+            )
         created_at_unix_ms = int(time.time() * 1000)
         job_id = self._next_job_id()
         run_root = self._run_root(job_id)
@@ -206,6 +213,23 @@ class EvaluationCore:
         incorrect = len(sample_records) - correct
         accuracy = round(correct / max(len(sample_records), 1), 4)
         job_parameters.setdefault("sample_size", str(len(sample_records)))
+        metrics = {
+            f"eval.{suite_id}.{score_name}": accuracy,
+            f"eval.{suite_id}.correct_count": float(correct),
+            f"eval.{suite_id}.incorrect_count": float(incorrect),
+            f"eval.{suite_id}.duration_seconds": duration_seconds,
+        }
+        units = {
+            f"eval.{suite_id}.{score_name}": "ratio",
+            f"eval.{suite_id}.correct_count": "count",
+            f"eval.{suite_id}.incorrect_count": "count",
+            f"eval.{suite_id}.duration_seconds": "s",
+        }
+        if suite_id in _CODE_EXEC_SUITES:
+            metrics[f"eval.{suite_id}.code_exec_pass_count"] = float(correct)
+            metrics[f"eval.{suite_id}.code_exec_fail_count"] = float(incorrect)
+            units[f"eval.{suite_id}.code_exec_pass_count"] = "count"
+            units[f"eval.{suite_id}.code_exec_fail_count"] = "count"
 
         report_path = self._result_path(run_root if self._jobs_root is not None else dataset_root)
         output_dir = str(run_root) if self._jobs_root is not None else str(dataset_root)
@@ -237,19 +261,9 @@ class EvaluationCore:
             correct_count=correct,
             incorrect_count=incorrect,
             duration_seconds=duration_seconds,
-            metrics={
-                f"eval.{suite_id}.{score_name}": accuracy,
-                f"eval.{suite_id}.correct_count": float(correct),
-                f"eval.{suite_id}.incorrect_count": float(incorrect),
-                f"eval.{suite_id}.duration_seconds": duration_seconds,
-            },
+            metrics=metrics,
             report_path=str(report_path),
-            units={
-                f"eval.{suite_id}.{score_name}": "ratio",
-                f"eval.{suite_id}.correct_count": "count",
-                f"eval.{suite_id}.incorrect_count": "count",
-                f"eval.{suite_id}.duration_seconds": "s",
-            },
+            units=units,
         )
         persisted_paths: dict[str, Path] = {}
         if self._jobs_root is not None:
@@ -568,7 +582,9 @@ class EvaluationCore:
         request_label: str = "",
     ) -> EvaluationSample:
         prompt = str(sample.get("prompt", sample.get("question", "")))
-        expected = str(sample.get("expected", sample.get("answer", ""))).strip()
+        expected = str(
+            sample.get("expected", sample.get("answer", sample.get("entry_point", "")))
+        ).strip()
         media_references = EvaluationCore._media_references_for_sample(
             task_kind=task_kind,
             dataset_root=dataset_root,
@@ -587,6 +603,7 @@ class EvaluationCore:
                 registry=self._registry,
                 loaded_model=loaded_model,
                 messages=EvaluationCore._evaluation_messages(
+                    suite_id=suite_id,
                     prompt=prompt,
                     expected=expected,
                     media_references=media_references,
@@ -613,6 +630,34 @@ class EvaluationCore:
                 raw_response = predicted
                 parse_status = "parsed" if predicted else "empty_prediction"
         duration_s = round(time.perf_counter() - started_at, 6)
+        code_language = ""
+        code_entry_point = ""
+        code_compile_status = ""
+        code_runtime_status = ""
+        code_timeout_status = ""
+        code_test_status = ""
+        code_tests_passed = 0
+        code_tests_total = 0
+        code_failure_detail = ""
+        if suite_id in _CODE_EXEC_SUITES:
+            predicted, parse_status = EvaluationCore._extract_code_candidate(raw_response)
+            code_eval = run_python_code_evaluation(
+                candidate_code=predicted,
+                entry_point=str(sample.get("entry_point", "")).strip(),
+                test_code=str(sample.get("test", "")).strip(),
+            )
+            correct = code_eval.passed
+            code_language = "python"
+            code_entry_point = str(sample.get("entry_point", "")).strip()
+            code_compile_status = code_eval.compile_status
+            code_runtime_status = code_eval.runtime_status
+            code_timeout_status = code_eval.timeout_status
+            code_test_status = code_eval.test_status
+            code_tests_passed = code_eval.tests_passed
+            code_tests_total = code_eval.tests_total
+            code_failure_detail = code_eval.failure_detail
+        else:
+            correct = EvaluationCore._answers_match(expected=expected, predicted=predicted)
         return build_evaluation_sample_record(
             job_id=job_id,
             suite_id=suite_id,
@@ -622,12 +667,21 @@ class EvaluationCore:
             expected=expected,
             predicted=predicted,
             raw_response=raw_response,
-            correct=EvaluationCore._answers_match(expected=expected, predicted=predicted),
+            correct=correct,
             time_s=duration_s,
             parse_status=parse_status,
             task_kind=task_kind,
             input_modalities=input_modalities,
             media_references=media_references,
+            code_language=code_language,
+            code_entry_point=code_entry_point,
+            code_compile_status=code_compile_status,
+            code_runtime_status=code_runtime_status,
+            code_timeout_status=code_timeout_status,
+            code_test_status=code_test_status,
+            code_tests_passed=code_tests_passed,
+            code_tests_total=code_tests_total,
+            code_failure_detail=code_failure_detail,
         )
 
     @staticmethod
@@ -697,11 +751,17 @@ class EvaluationCore:
 
     @staticmethod
     def _evaluation_messages(
+        suite_id: str,
         prompt: str,
         expected: str,
         media_references: tuple[str, ...] = (),
     ) -> list[common_pb2.ChatMessage]:
-        if EvaluationCore._looks_like_numeric(expected):
+        if suite_id in _CODE_EXEC_SUITES:
+            instruction = (
+                "Return only valid Python code. "
+                "Do not include explanations, tests, or markdown fences."
+            )
+        elif EvaluationCore._looks_like_numeric(expected):
             instruction = "Return only the final numeric answer. Do not include reasoning or explanation."
         elif EvaluationCore._looks_like_option(expected):
             instruction = "Return only the single best answer choice letter. Do not include reasoning or explanation."
@@ -863,6 +923,16 @@ class EvaluationCore:
                 return parsed, "parsed_option"
         _ = suite_id
         return parsed, "parsed"
+
+    @staticmethod
+    def _extract_code_candidate(raw_response: str) -> tuple[str, str]:
+        normalized_response = raw_response.strip()
+        if not normalized_response:
+            return "", "empty_prediction"
+        matches = _CODE_BLOCK_PATTERN.findall(normalized_response)
+        if matches:
+            return matches[-1].strip(), "parsed_code_block"
+        return normalized_response, "parsed_code_fallback"
 
     @staticmethod
     def _parse_candidate_for_expected(*, candidate: str, expected: str) -> str:

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -86,18 +86,42 @@ def collect_evaluation_artifacts(jobs_root: Path) -> dict[str, object]:
     results: list[dict[str, object]] = []
     summaries: list[dict[str, object]] = []
     samples: list[dict[str, object]] = []
+    compare_jobs: list[dict[str, object]] = []
+    compare_summary_rows: list[dict[str, object]] = []
+    compare_samples: list[dict[str, object]] = []
 
-    _collect_evaluation_run(jobs_root, jobs=jobs, results=results, summaries=summaries, samples=samples)
+    _collect_evaluation_run(
+        jobs_root,
+        jobs=jobs,
+        results=results,
+        summaries=summaries,
+        samples=samples,
+        compare_jobs=compare_jobs,
+        compare_summary_rows=compare_summary_rows,
+        compare_samples=compare_samples,
+    )
     runs_root = jobs_root / "runs"
     if runs_root.is_dir():
         for run_root in sorted(path for path in runs_root.iterdir() if path.is_dir()):
-            _collect_evaluation_run(run_root, jobs=jobs, results=results, summaries=summaries, samples=samples)
+            _collect_evaluation_run(
+                run_root,
+                jobs=jobs,
+                results=results,
+                summaries=summaries,
+                samples=samples,
+                compare_jobs=compare_jobs,
+                compare_summary_rows=compare_summary_rows,
+                compare_samples=compare_samples,
+            )
 
     return {
         "evaluation_jobs": jobs,
         "evaluation_results": results,
         "evaluation_summary_rows": summaries,
         "evaluation_samples": samples,
+        "evaluation_compare_jobs": compare_jobs,
+        "evaluation_compare_summary_rows": compare_summary_rows,
+        "evaluation_compare_samples": compare_samples,
     }
 
 
@@ -149,6 +173,82 @@ def build_evaluation_samples_csv(bundle: dict[str, object]) -> str:
             "raw_response",
             "time_s",
             "parse_status",
+            "code_language",
+            "code_entry_point",
+            "code_compile_status",
+            "code_runtime_status",
+            "code_timeout_status",
+            "code_test_status",
+            "code_tests_passed",
+            "code_tests_total",
+            "code_failure_detail",
+        ],
+    )
+
+
+def build_evaluation_compare_summary_csv(bundle: dict[str, object]) -> str:
+    rows = [row for row in bundle.get("evaluation_compare_summary_rows", []) if isinstance(row, dict)]
+    return _rows_to_csv(
+        rows,
+        [
+            "job_id",
+            "base_model_id",
+            "target_model_id",
+            "suite_id",
+            "dataset_id",
+            "sample_size",
+            "win_count",
+            "loss_count",
+            "tie_count",
+            "regression_count",
+            "base_accuracy",
+            "target_accuracy",
+            "delta_accuracy",
+            "duration_seconds",
+        ],
+    )
+
+
+def build_evaluation_compare_samples_csv(bundle: dict[str, object]) -> str:
+    rows = [row for row in bundle.get("evaluation_compare_samples", []) if isinstance(row, dict)]
+    return _rows_to_csv(
+        rows,
+        [
+            "job_id",
+            "suite_id",
+            "dataset_id",
+            "sample_id",
+            "target_model_id",
+            "question",
+            "expected",
+            "base_predicted",
+            "target_predicted",
+            "base_raw_response",
+            "target_raw_response",
+            "base_correct",
+            "target_correct",
+            "outcome",
+            "regression",
+            "base_time_s",
+            "target_time_s",
+            "base_parse_status",
+            "target_parse_status",
+            "code_language",
+            "code_entry_point",
+            "base_code_compile_status",
+            "target_code_compile_status",
+            "base_code_runtime_status",
+            "target_code_runtime_status",
+            "base_code_timeout_status",
+            "target_code_timeout_status",
+            "base_code_test_status",
+            "target_code_test_status",
+            "base_code_tests_passed",
+            "target_code_tests_passed",
+            "base_code_tests_total",
+            "target_code_tests_total",
+            "base_code_failure_detail",
+            "target_code_failure_detail",
         ],
     )
 
@@ -475,6 +575,9 @@ def _collect_evaluation_run(
     results: list[dict[str, object]],
     summaries: list[dict[str, object]],
     samples: list[dict[str, object]],
+    compare_jobs: list[dict[str, object]],
+    compare_summary_rows: list[dict[str, object]],
+    compare_samples: list[dict[str, object]],
 ) -> None:
     job_path = run_root / "evaluation-job.json"
     if job_path.is_file():
@@ -502,6 +605,7 @@ def _collect_evaluation_run(
         return
 
     compare_job = json.loads(compare_job_path.read_text(encoding="utf-8"))
+    compare_jobs.append(compare_job)
     jobs.append(_normalize_evaluation_compare_job(compare_job))
 
     compare_summary_path = run_root / "evaluation-compare-summary.json"
@@ -510,12 +614,13 @@ def _collect_evaluation_run(
         for summary in _compare_target_summaries(compare_summary_payload):
             results.append(_normalize_evaluation_compare_result(summary))
             summaries.append(_normalize_evaluation_compare_summary_row(compare_job, summary))
+            compare_summary_rows.append(summary)
 
     compare_samples_path = run_root / "evaluation-compare-samples.jsonl"
     if compare_samples_path.is_file():
         for line in compare_samples_path.read_text(encoding="utf-8").splitlines():
             if line.strip():
-                samples.append(_normalize_evaluation_compare_sample(json.loads(line)))
+                compare_samples.append(json.loads(line))
 
 
 def _normalize_evaluation_compare_job(compare_job: dict[str, object]) -> dict[str, object]:

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -161,28 +161,8 @@ def build_evaluation_summary_csv(bundle: dict[str, object]) -> str:
 def build_evaluation_samples_csv(bundle: dict[str, object]) -> str:
     rows = [row for row in bundle.get("evaluation_samples", []) if isinstance(row, dict)]
     return _rows_to_csv(
-        rows,
-        [
-            "job_id",
-            "suite_id",
-            "id",
-            "correct",
-            "expected",
-            "predicted",
-            "question",
-            "raw_response",
-            "time_s",
-            "parse_status",
-            "code_language",
-            "code_entry_point",
-            "code_compile_status",
-            "code_runtime_status",
-            "code_timeout_status",
-            "code_test_status",
-            "code_tests_passed",
-            "code_tests_total",
-            "code_failure_detail",
-        ],
+        [_normalized_evaluation_sample_row(row) for row in rows],
+        _canonical_evaluation_sample_columns(),
     )
 
 
@@ -496,6 +476,43 @@ def _canonical_benchmark_row_columns() -> list[str]:
         "reasoning_mode",
         "structured_output_mode",
     ]
+
+
+def _canonical_evaluation_sample_columns() -> list[str]:
+    return [
+        "job_id",
+        "suite_id",
+        "id",
+        "task_kind",
+        "correct",
+        "expected",
+        "predicted",
+        "question",
+        "raw_response",
+        "time_s",
+        "parse_status",
+        "input_modalities",
+        "media_references",
+        "code_language",
+        "code_entry_point",
+        "code_compile_status",
+        "code_runtime_status",
+        "code_timeout_status",
+        "code_test_status",
+        "code_tests_passed",
+        "code_tests_total",
+        "code_failure_detail",
+    ]
+
+
+def _normalized_evaluation_sample_row(row: dict[str, object]) -> dict[str, object]:
+    return {
+        **row,
+        "id": row.get("id") or row.get("sample_id", ""),
+        "task_kind": row.get("task_kind", ""),
+        "input_modalities": row.get("input_modalities", []),
+        "media_references": row.get("media_references", []),
+    }
 
 
 def _canonical_benchmark_matrix_summary_columns() -> list[str]:

--- a/services/mlx-worker-python/worker/productization/evaluation_compare.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_compare.py
@@ -76,6 +76,22 @@ def build_compare_samples(
                 target_time_s=target_sample.time_s,
                 base_parse_status=base_sample.parse_status,
                 target_parse_status=target_sample.parse_status,
+                code_language=target_sample.code_language or base_sample.code_language,
+                code_entry_point=target_sample.code_entry_point or base_sample.code_entry_point,
+                base_code_compile_status=base_sample.code_compile_status,
+                target_code_compile_status=target_sample.code_compile_status,
+                base_code_runtime_status=base_sample.code_runtime_status,
+                target_code_runtime_status=target_sample.code_runtime_status,
+                base_code_timeout_status=base_sample.code_timeout_status,
+                target_code_timeout_status=target_sample.code_timeout_status,
+                base_code_test_status=base_sample.code_test_status,
+                target_code_test_status=target_sample.code_test_status,
+                base_code_tests_passed=base_sample.code_tests_passed,
+                target_code_tests_passed=target_sample.code_tests_passed,
+                base_code_tests_total=base_sample.code_tests_total,
+                target_code_tests_total=target_sample.code_tests_total,
+                base_code_failure_detail=base_sample.code_failure_detail,
+                target_code_failure_detail=target_sample.code_failure_detail,
             )
         )
     return tuple(records)

--- a/services/mlx-worker-python/worker/productization/evaluation_schemas.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_schemas.py
@@ -141,6 +141,15 @@ class EvaluationSample:
     task_kind: str
     input_modalities: tuple[str, ...]
     media_references: tuple[str, ...]
+    code_language: str
+    code_entry_point: str
+    code_compile_status: str
+    code_runtime_status: str
+    code_timeout_status: str
+    code_test_status: str
+    code_tests_passed: int
+    code_tests_total: int
+    code_failure_detail: str
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -159,6 +168,15 @@ class EvaluationSample:
             "task_kind": self.task_kind,
             "input_modalities": list(self.input_modalities),
             "media_references": list(self.media_references),
+            "code_language": self.code_language,
+            "code_entry_point": self.code_entry_point,
+            "code_compile_status": self.code_compile_status,
+            "code_runtime_status": self.code_runtime_status,
+            "code_timeout_status": self.code_timeout_status,
+            "code_test_status": self.code_test_status,
+            "code_tests_passed": self.code_tests_passed,
+            "code_tests_total": self.code_tests_total,
+            "code_failure_detail": self.code_failure_detail,
         }
 
 
@@ -266,6 +284,22 @@ class EvaluationCompareSample:
     target_time_s: float
     base_parse_status: str
     target_parse_status: str
+    code_language: str
+    code_entry_point: str
+    base_code_compile_status: str
+    target_code_compile_status: str
+    base_code_runtime_status: str
+    target_code_runtime_status: str
+    base_code_timeout_status: str
+    target_code_timeout_status: str
+    base_code_test_status: str
+    target_code_test_status: str
+    base_code_tests_passed: int
+    target_code_tests_passed: int
+    base_code_tests_total: int
+    target_code_tests_total: int
+    base_code_failure_detail: str
+    target_code_failure_detail: str
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -289,6 +323,22 @@ class EvaluationCompareSample:
             "target_time_s": self.target_time_s,
             "base_parse_status": self.base_parse_status,
             "target_parse_status": self.target_parse_status,
+            "code_language": self.code_language,
+            "code_entry_point": self.code_entry_point,
+            "base_code_compile_status": self.base_code_compile_status,
+            "target_code_compile_status": self.target_code_compile_status,
+            "base_code_runtime_status": self.base_code_runtime_status,
+            "target_code_runtime_status": self.target_code_runtime_status,
+            "base_code_timeout_status": self.base_code_timeout_status,
+            "target_code_timeout_status": self.target_code_timeout_status,
+            "base_code_test_status": self.base_code_test_status,
+            "target_code_test_status": self.target_code_test_status,
+            "base_code_tests_passed": self.base_code_tests_passed,
+            "target_code_tests_passed": self.target_code_tests_passed,
+            "base_code_tests_total": self.base_code_tests_total,
+            "target_code_tests_total": self.target_code_tests_total,
+            "base_code_failure_detail": self.base_code_failure_detail,
+            "target_code_failure_detail": self.target_code_failure_detail,
         }
 
 
@@ -406,6 +456,15 @@ def build_evaluation_sample_record(
     task_kind: str = "text-generation",
     input_modalities: tuple[str, ...] = (),
     media_references: tuple[str, ...] = (),
+    code_language: str = "",
+    code_entry_point: str = "",
+    code_compile_status: str = "",
+    code_runtime_status: str = "",
+    code_timeout_status: str = "",
+    code_test_status: str = "",
+    code_tests_passed: int = 0,
+    code_tests_total: int = 0,
+    code_failure_detail: str = "",
 ) -> EvaluationSample:
     return EvaluationSample(
         schema_version=_EVALUATION_SAMPLE_SCHEMA_VERSION,
@@ -423,6 +482,15 @@ def build_evaluation_sample_record(
         task_kind=task_kind,
         input_modalities=tuple(input_modalities),
         media_references=tuple(media_references),
+        code_language=code_language,
+        code_entry_point=code_entry_point,
+        code_compile_status=code_compile_status,
+        code_runtime_status=code_runtime_status,
+        code_timeout_status=code_timeout_status,
+        code_test_status=code_test_status,
+        code_tests_passed=code_tests_passed,
+        code_tests_total=code_tests_total,
+        code_failure_detail=code_failure_detail,
     )
 
 
@@ -531,6 +599,22 @@ def build_evaluation_compare_sample_record(
     target_time_s: float,
     base_parse_status: str,
     target_parse_status: str,
+    code_language: str = "",
+    code_entry_point: str = "",
+    base_code_compile_status: str = "",
+    target_code_compile_status: str = "",
+    base_code_runtime_status: str = "",
+    target_code_runtime_status: str = "",
+    base_code_timeout_status: str = "",
+    target_code_timeout_status: str = "",
+    base_code_test_status: str = "",
+    target_code_test_status: str = "",
+    base_code_tests_passed: int = 0,
+    target_code_tests_passed: int = 0,
+    base_code_tests_total: int = 0,
+    target_code_tests_total: int = 0,
+    base_code_failure_detail: str = "",
+    target_code_failure_detail: str = "",
 ) -> EvaluationCompareSample:
     return EvaluationCompareSample(
         schema_version=_EVALUATION_COMPARE_SAMPLE_SCHEMA_VERSION,
@@ -553,4 +637,20 @@ def build_evaluation_compare_sample_record(
         target_time_s=float(target_time_s),
         base_parse_status=base_parse_status,
         target_parse_status=target_parse_status,
+        code_language=code_language,
+        code_entry_point=code_entry_point,
+        base_code_compile_status=base_code_compile_status,
+        target_code_compile_status=target_code_compile_status,
+        base_code_runtime_status=base_code_runtime_status,
+        target_code_runtime_status=target_code_runtime_status,
+        base_code_timeout_status=base_code_timeout_status,
+        target_code_timeout_status=target_code_timeout_status,
+        base_code_test_status=base_code_test_status,
+        target_code_test_status=target_code_test_status,
+        base_code_tests_passed=base_code_tests_passed,
+        target_code_tests_passed=target_code_tests_passed,
+        base_code_tests_total=base_code_tests_total,
+        target_code_tests_total=target_code_tests_total,
+        base_code_failure_detail=base_code_failure_detail,
+        target_code_failure_detail=target_code_failure_detail,
     )

--- a/services/mlx-worker-python/worker/productization/evaluation_store.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_store.py
@@ -259,6 +259,15 @@ class EvaluationStore:
             "parse_status",
             "input_modalities",
             "media_references",
+            "code_language",
+            "code_entry_point",
+            "code_compile_status",
+            "code_runtime_status",
+            "code_timeout_status",
+            "code_test_status",
+            "code_tests_passed",
+            "code_tests_total",
+            "code_failure_detail",
         ]
         rows = [",".join(header)]
         for sample in samples:
@@ -276,6 +285,15 @@ class EvaluationStore:
                         EvaluationStore._csv_field(sample.parse_status),
                         EvaluationStore._csv_field(",".join(sample.input_modalities)),
                         EvaluationStore._csv_field(",".join(sample.media_references)),
+                        EvaluationStore._csv_field(sample.code_language),
+                        EvaluationStore._csv_field(sample.code_entry_point),
+                        EvaluationStore._csv_field(sample.code_compile_status),
+                        EvaluationStore._csv_field(sample.code_runtime_status),
+                        EvaluationStore._csv_field(sample.code_timeout_status),
+                        EvaluationStore._csv_field(sample.code_test_status),
+                        EvaluationStore._csv_field(str(sample.code_tests_passed)),
+                        EvaluationStore._csv_field(str(sample.code_tests_total)),
+                        EvaluationStore._csv_field(sample.code_failure_detail),
                     ]
                 )
             )

--- a/task_plan.md
+++ b/task_plan.md
@@ -1,5 +1,17 @@
 # Task Plan
 
+## 2026-04-14 Worktree Transaction
+
+- active plan: `docs/plans/2026-04-14-executable-code-eval-humaneval-mbpp.md`
+- objective:
+  - ship executable-code evaluation for `humaneval` and `mbpp`
+  - preserve code-execution evidence through standard evaluation and compare exports
+  - add dedicated public CLI compare export commands
+- status:
+  - implementation: completed
+  - focused verification: completed
+  - changed-line coverage capture: completed
+
 ## Goal
 
 Close the Phase 1 benchmark, benchmark-matrix, and evaluation acceptance slice for the designated

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -1048,7 +1048,7 @@ struct MelixCLIParserTests {
         #expect(options.json)
     }
 
-    @Test("parses eval list and export commands")
+    @Test("parses eval list and standard plus compare export commands")
     func parsesEvalListAndExportCommands() throws {
         let listCommand = try MelixCLIParser.parse([
             "eval",
@@ -1068,6 +1068,21 @@ struct MelixCLIParserTests {
             "--job-id", "eval-1",
             "--output", "/tmp/melix/eval-1-samples.jsonl",
         ])
+        let compareSummaryCommand = try MelixCLIParser.parse([
+            "eval",
+            "compare",
+            "export-summary-csv",
+            "--job-id", "eval-compare-1",
+            "--output", "/tmp/melix/eval-compare-1-summary.csv",
+        ])
+        let compareSamplesCommand = try MelixCLIParser.parse([
+            "eval",
+            "compare",
+            "export-samples-jsonl",
+            "--job-id", "eval-compare-1",
+            "--output", "/tmp/melix/eval-compare-1-samples.jsonl",
+            "--json",
+        ])
 
         guard case .evalList(let listOptions) = listCommand else {
             Issue.record("Expected evalList command")
@@ -1081,6 +1096,14 @@ struct MelixCLIParserTests {
             Issue.record("Expected evalExportSamplesJSONL command")
             return
         }
+        guard case .evalCompareExportSummaryCSV(let compareSummaryOptions) = compareSummaryCommand else {
+            Issue.record("Expected evalCompareExportSummaryCSV command")
+            return
+        }
+        guard case .evalCompareExportSamplesJSONL(let compareSamplesOptions) = compareSamplesCommand else {
+            Issue.record("Expected evalCompareExportSamplesJSONL command")
+            return
+        }
 
         #expect(listOptions.json)
         #expect(summaryOptions.jobID == "eval-1")
@@ -1089,6 +1112,12 @@ struct MelixCLIParserTests {
         #expect(samplesOptions.jobID == "eval-1")
         #expect(samplesOptions.outputPath == "/tmp/melix/eval-1-samples.jsonl")
         #expect(samplesOptions.json == false)
+        #expect(compareSummaryOptions.jobID == "eval-compare-1")
+        #expect(compareSummaryOptions.outputPath == "/tmp/melix/eval-compare-1-summary.csv")
+        #expect(compareSummaryOptions.json == false)
+        #expect(compareSamplesOptions.jobID == "eval-compare-1")
+        #expect(compareSamplesOptions.outputPath == "/tmp/melix/eval-compare-1-samples.jsonl")
+        #expect(compareSamplesOptions.json)
     }
 
     @Test("parses lora activate with explicit alias and adapter path")
@@ -1269,6 +1298,14 @@ struct MelixCLIParserTests {
                 "--target-model-id", "melix-dev-text-lora-a",
             ],
             equals: .missingRequired("Exactly one of --model-id or --repo-id is required for melix eval compare.")
+        )
+        try assertError(
+            for: ["eval", "compare", "export-summary-csv", "--output", "/tmp/out.csv"],
+            equals: .missingRequired("--job-id is required for melix eval compare export-summary-csv.")
+        )
+        try assertError(
+            for: ["eval", "compare", "export-samples-csv", "--job-id", "eval-compare-1"],
+            equals: .missingRequired("--output is required for melix eval compare export-samples-csv.")
         )
         try assertError(for: ["eval"], equals: .usage(MelixCLIParser.usageText))
         try assertError(for: ["eval", "oops"], equals: .usage(MelixCLIParser.usageText))

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -2345,7 +2345,7 @@ struct MelixCLIRunnerTests {
         #expect(output == "No evaluation runs found.\n")
     }
 
-    @Test("eval export commands write summary csv and sample artifacts")
+    @Test("eval export commands write summary csv and sample artifacts with code evidence")
     func evalExportCommandsWriteArtifacts() async throws {
         let client = StubControlPlaneXPCClient()
         await client.setExportResult(.init(exportBundleJSON: makeBenchmarkExportBundleJSON()))
@@ -2373,9 +2373,45 @@ struct MelixCLIRunnerTests {
         #expect(response["row_count"] as? Int == 1)
         #expect(summaryCSV.contains("job_id,model_id,task_kind,source_repo,suite_id,dataset_id,sample_size,score_name,score_value,correct_count,incorrect_count,duration_seconds,created_at_unix_ms"))
         #expect(summaryCSV.contains("eval-1,melix-dev-text,text-generation,HuggingFaceH4/ultrachat_200k,mmlu,mmlu.dev.v1,8,eval.mmlu.accuracy,0.75,6,2,12.5,1712400000000"))
-        #expect(samplesCSV.contains("id,correct,expected,predicted,question,raw_response,time_s,parse_status"))
-        #expect(samplesCSV.contains("sample-1,true,4,4,2+2?,4,0.01,parsed"))
+        #expect(samplesCSV.contains("id,correct,expected,predicted,question,raw_response,time_s,parse_status,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail"))
+        #expect(samplesCSV.contains("sample-1,true,4,4,2+2?,4,0.01,parsed,python,solve,compiled,ok,ok,passed,2,2,"))
         #expect(samplesJSONL.contains("\"sample_id\":\"sample-1\""))
+        #expect(samplesJSONL.contains("\"code_language\":\"python\""))
+    }
+
+    @Test("eval compare export commands write summary csv and sample artifacts")
+    func evalCompareExportCommandsWriteArtifacts() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setExportResult(.init(exportBundleJSON: makeBenchmarkExportBundleJSON()))
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let summaryURL = root.appendingPathComponent("eval-compare-1-summary.csv")
+        let samplesURL = root.appendingPathComponent("eval-compare-1-samples.csv")
+        let jsonlURL = root.appendingPathComponent("eval-compare-1-samples.jsonl")
+
+        let summaryOutput = try await MelixCLIRunner(client: client).run(
+            .evalCompareExportSummaryCSV(.init(jobID: "eval-compare-1", outputPath: summaryURL.path, json: true))
+        )
+        _ = try await MelixCLIRunner(client: client).run(
+            .evalCompareExportSamplesCSV(.init(jobID: "eval-compare-1", outputPath: samplesURL.path))
+        )
+        _ = try await MelixCLIRunner(client: client).run(
+            .evalCompareExportSamplesJSONL(.init(jobID: "eval-compare-1", outputPath: jsonlURL.path))
+        )
+
+        let response = try #require(parseJSONObject(summaryOutput))
+        let summaryCSV = try String(contentsOf: summaryURL, encoding: .utf8)
+        let samplesCSV = try String(contentsOf: samplesURL, encoding: .utf8)
+        let samplesJSONL = try String(contentsOf: jsonlURL, encoding: .utf8)
+
+        #expect(response["job_id"] as? String == "eval-compare-1")
+        #expect(response["row_count"] as? Int == 1)
+        #expect(summaryCSV.contains("job_id,base_model_id,target_model_id,suite_id,dataset_id,sample_size,win_count,loss_count,tie_count,regression_count,base_accuracy,target_accuracy,delta_accuracy,duration_seconds"))
+        #expect(summaryCSV.contains("eval-compare-1,melix-dev-text,melix-dev-text-lora-a,mbpp,mbpp.dev.v1,2,1,0,1,0,0.5,1.0,0.5,1.75"))
+        #expect(samplesCSV.contains("job_id,suite_id,dataset_id,sample_id,target_model_id,question,expected,base_predicted,target_predicted"))
+        #expect(samplesCSV.contains("eval-compare-1,mbpp,mbpp.dev.v1,sample-1,melix-dev-text-lora-a,Write solve(n) that returns n,solve,\"def solve(n):"))
+        #expect(samplesCSV.contains("python,solve,compiled,compiled,ok,ok,ok,ok,failed,passed,1,2,2,2,assertion failed,"))
+        #expect(samplesJSONL.contains("\"target_model_id\":\"melix-dev-text-lora-a\""))
+        #expect(samplesJSONL.contains("\"base_code_failure_detail\":\"assertion failed\""))
     }
 
     @Test("eval export commands fail when the requested job has no rows")
@@ -2390,6 +2426,21 @@ struct MelixCLIRunnerTests {
             Issue.record("Expected eval export-summary-csv to fail when the job is missing.")
         } catch let error as MelixCLIError {
             #expect(error == .runtime("No evaluation rows were found for job eval-missing."))
+        }
+    }
+
+    @Test("eval compare export commands fail when the requested job has no rows")
+    func evalCompareExportCommandsFailForMissingJob() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setExportResult(.init(exportBundleJSON: makeBenchmarkExportBundleJSON()))
+
+        do {
+            _ = try await MelixCLIRunner(client: client).run(
+                .evalCompareExportSummaryCSV(.init(jobID: "eval-compare-missing", outputPath: "/tmp/eval-compare-missing.csv"))
+            )
+            Issue.record("Expected eval compare export-summary-csv to fail when the job is missing.")
+        } catch let error as MelixCLIError {
+            #expect(error == .runtime("No evaluation compare summary rows were found for job eval-compare-missing."))
         }
     }
 
@@ -3503,7 +3554,103 @@ private func makeBenchmarkExportBundleJSON() -> String {
           "raw_response": "4",
           "correct": true,
           "time_s": 0.01,
-          "parse_status": "parsed"
+          "parse_status": "parsed",
+          "code_language": "python",
+          "code_entry_point": "solve",
+          "code_compile_status": "compiled",
+          "code_runtime_status": "ok",
+          "code_timeout_status": "ok",
+          "code_test_status": "passed",
+          "code_tests_passed": 2,
+          "code_tests_total": 2,
+          "code_failure_detail": ""
+        }
+      ],
+      "evaluation_compare_jobs": [
+        {
+          "schema_version": "melix.evaluation_compare_job.v1",
+          "job_id": "eval-compare-1",
+          "base_model_id": "melix-dev-text",
+          "target_model_ids": ["melix-dev-text-lora-a"],
+          "task_kind": "text-generation",
+          "source_repo": "openai_humaneval",
+          "suite_id": "mbpp",
+          "dataset_id": "mbpp.dev.v1",
+          "sample_size": 2,
+          "scoring_mode": "pass_at_1",
+          "parameters": {
+            "compare_mode": "base_vs_targets",
+            "compare_target_model_ids": "melix-dev-text-lora-a"
+          },
+          "status": "completed",
+          "output_dir": "/tmp/melix/evaluation/runs/eval-compare-1",
+          "created_at_unix_ms": 1712500000000,
+          "updated_at_unix_ms": 1712500005000
+        }
+      ],
+      "evaluation_compare_summary_rows": [
+        {
+          "schema_version": "melix.evaluation_compare_summary.v1",
+          "job_id": "eval-compare-1",
+          "base_model_id": "melix-dev-text",
+          "target_model_id": "melix-dev-text-lora-a",
+          "suite_id": "mbpp",
+          "dataset_id": "mbpp.dev.v1",
+          "sample_size": 2,
+          "scoring_mode": "pass_at_1",
+          "win_count": 1,
+          "loss_count": 0,
+          "tie_count": 1,
+          "regression_count": 0,
+          "base_accuracy": 0.5,
+          "target_accuracy": 1.0,
+          "delta_accuracy": 0.5,
+          "duration_seconds": 1.75,
+          "metrics": [
+            {"name": "eval.compare.win_count", "value": 1.0, "unit": "count"},
+            {"name": "eval.compare.delta_accuracy", "value": 0.5, "unit": "ratio"}
+          ],
+          "report_path": "/tmp/melix/evaluation/runs/eval-compare-1/evaluation-compare-report.md"
+        }
+      ],
+      "evaluation_compare_samples": [
+        {
+          "schema_version": "melix.evaluation_compare_sample.v1",
+          "job_id": "eval-compare-1",
+          "suite_id": "mbpp",
+          "dataset_id": "mbpp.dev.v1",
+          "sample_id": "sample-1",
+          "target_model_id": "melix-dev-text-lora-a",
+          "question": "Write solve(n) that returns n",
+          "expected": "solve",
+          "base_predicted": "def solve(n):\\n    return 0",
+          "target_predicted": "def solve(n):\\n    return n",
+          "base_raw_response": "def solve(n):\\n    return 0",
+          "target_raw_response": "def solve(n):\\n    return n",
+          "base_correct": false,
+          "target_correct": true,
+          "outcome": "win",
+          "regression": false,
+          "base_time_s": 0.11,
+          "target_time_s": 0.09,
+          "base_parse_status": "parsed_code_fallback",
+          "target_parse_status": "parsed_code_fallback",
+          "code_language": "python",
+          "code_entry_point": "solve",
+          "base_code_compile_status": "compiled",
+          "target_code_compile_status": "compiled",
+          "base_code_runtime_status": "ok",
+          "target_code_runtime_status": "ok",
+          "base_code_timeout_status": "ok",
+          "target_code_timeout_status": "ok",
+          "base_code_test_status": "failed",
+          "target_code_test_status": "passed",
+          "base_code_tests_passed": 1,
+          "target_code_tests_passed": 2,
+          "base_code_tests_total": 2,
+          "target_code_tests_total": 2,
+          "base_code_failure_detail": "assertion failed",
+          "target_code_failure_detail": ""
         }
       ]
     }

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -2371,11 +2371,12 @@ struct MelixCLIRunnerTests {
 
         #expect(response["job_id"] as? String == "eval-1")
         #expect(response["row_count"] as? Int == 1)
-        #expect(summaryCSV.contains("job_id,model_id,task_kind,source_repo,suite_id,dataset_id,sample_size,score_name,score_value,correct_count,incorrect_count,duration_seconds,created_at_unix_ms"))
-        #expect(summaryCSV.contains("eval-1,melix-dev-text,text-generation,HuggingFaceH4/ultrachat_200k,mmlu,mmlu.dev.v1,8,eval.mmlu.accuracy,0.75,6,2,12.5,1712400000000"))
-        #expect(samplesCSV.contains("id,correct,expected,predicted,question,raw_response,time_s,parse_status,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail"))
-        #expect(samplesCSV.contains("sample-1,true,4,4,2+2?,4,0.01,parsed,python,solve,compiled,ok,ok,passed,2,2,"))
+        #expect(summaryCSV.contains("job_id,task_kind,source_repo,model_id,suite_id,dataset_id,score_name,score_value,sample_size,correct_count,incorrect_count,duration_seconds,created_at_unix_ms"))
+        #expect(summaryCSV.contains("eval-1,text-generation,HuggingFaceH4/ultrachat_200k,melix-dev-text,mmlu,mmlu.dev.v1,eval.mmlu.accuracy,0.75,8,6,2,12.5,1712400000000"))
+        #expect(samplesCSV.contains("job_id,suite_id,id,task_kind,correct,expected,predicted,question,raw_response,time_s,parse_status,input_modalities,media_references,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail"))
+        #expect(samplesCSV.contains("eval-1,mmlu,sample-1,text-generation,true,4,4,2+2?,4,0.01,parsed,text,,python,solve,compiled,ok,ok,passed,2,2,"))
         #expect(samplesJSONL.contains("\"sample_id\":\"sample-1\""))
+        #expect(samplesJSONL.contains("\"task_kind\":\"text-generation\""))
         #expect(samplesJSONL.contains("\"code_language\":\"python\""))
     }
 
@@ -3548,6 +3549,7 @@ private func makeBenchmarkExportBundleJSON() -> String {
           "suite_id": "mmlu",
           "dataset_id": "mmlu.dev.v1",
           "sample_id": "sample-1",
+          "task_kind": "text-generation",
           "question": "2+2?",
           "expected": "4",
           "predicted": "4",
@@ -3555,6 +3557,8 @@ private func makeBenchmarkExportBundleJSON() -> String {
           "correct": true,
           "time_s": 0.01,
           "parse_status": "parsed",
+          "input_modalities": ["text"],
+          "media_references": [],
           "code_language": "python",
           "code_entry_point": "solve",
           "code_compile_status": "compiled",


### PR DESCRIPTION
## Summary
- add first-class executable-code evaluation for `humaneval` and `mbpp`, including checked-in dev fixtures, sandboxed code execution, and per-sample compile/runtime/test evidence
- preserve executable-code evidence through `eval compare` and add dedicated compare export commands for summary CSV, samples CSV, and samples JSONL
- update the benchmark/evaluation contract, runbook, plan log, and progress log to reflect the shipped product behavior and validation evidence

## Root Cause
Melix previously treated `humaneval` and `mbpp` as text-style evaluation suites, so the runtime did not execute candidate code, did not require an explicit sandbox policy, and dropped executable-code evidence in compare/export flows.

## Impact
Operators can now run repository-owned executable-code evals against local or compared models with explicit sandbox gating and inspect the resulting code-execution evidence through persisted artifacts and public CLI exports.

## Test Plan
- [x] `PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_maintenance_service.py -q`
- [x] `HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --enable-code-coverage --filter MelixCLIParserTests\|MelixCLIRunnerTests`
- [x] `HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/services/control-plane-swift/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter BenchmarkExportBundleTests`
- [x] changed-line coverage: Python `99.10%` (`220/222`), Swift CLI `97.77%` (`263/269`), Swift control-plane `100.00%` (`266/266`)
