### PR TITLE
[codex] harden ci and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,16 +11,6 @@ updates:
           - "*"
 
   - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    groups:
-      workspace-python:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "pip"
     directory: "/services/mlx-worker-python"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      workspace-python:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/services/mlx-worker-python"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      worker-python:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
+  - package-ecosystem: "swift"
+    directory: "/packages/protocol/swift"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
+  - package-ecosystem: "swift"
+    directory: "/services/mlx-text-worker-swift"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
+  - package-ecosystem: "swift"
+    directory: "/services/control-plane-swift"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
+  - package-ecosystem: "swift"
+    directory: "/apps/macos-menubar"
+    schedule:
+      interval: "weekly"
+      day: "monday"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+- Describe what changed and why.
+
+## Plan or Spec
+- Link the governing plan or spec, or write `N/A: <reason>`.
+
+## Commands Run
+```text
+# paste the commands you ran and their outcomes
+```
+
+## Coverage and Metrics
+- Record changed-scope coverage and metrics, or write `N/A: <reason>`.
+
+## Known Gaps
+- Record deferred work, unrun checks, or `None`.
+
+## Evidence Checklist
+- [ ] Relevant plan or spec is identified.
+- [ ] Behavior changes are reflected in the relevant docs.
+- [ ] Protocol changes include regenerated generated artifacts.
+- [ ] Dependency changes include updated lockfiles.
+- [ ] Relevant tests were run.
+- [ ] A metrics report is included, or `N/A` is stated explicitly with the reason.
+- [ ] Deferred work and known gaps are stated explicitly.

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -85,7 +85,7 @@ jobs:
 
   integration-tests:
     runs-on: macos-15
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,94 @@
+name: ci-pr
+
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint-and-diffcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: rhysd/actionlint@v1
+
+      - name: Diff check
+        run: git diff --check
+
+  proto-drift:
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install protobuf generators
+        run: brew install protobuf swift-protobuf
+
+      - name: Bootstrap
+        run: make bootstrap
+
+      - name: Check generated protocol outputs
+        run: make proto-check
+
+  swift-tests:
+    runs-on: macos-15
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Swift tests
+        run: make swift-test
+
+  python-tests:
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Bootstrap
+        run: make bootstrap
+
+      - name: Python tests
+        run: make py-test
+
+  integration-tests:
+    runs-on: macos-15
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Bootstrap
+        run: make bootstrap
+
+      - name: Integration tests
+        run: make integration-test

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -52,6 +52,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Bootstrap
+        run: make bootstrap
+
       - name: Swift tests
         run: make swift-test
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -82,7 +82,40 @@ jobs:
       - name: Python tests
         run: make py-test
 
+  integration-scope:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.scope.outputs.should_run }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine whether integration tests are affected
+        id: scope
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          should_run=false
+          while IFS= read -r path; do
+            case "$path" in
+              .github/workflows/ci-pr.yml|Makefile|Package.swift|Package.resolved|pyproject.toml|uv.lock|buf.yaml|buf.gen.yaml|packages/protocol/*|scripts/*|services/control-plane-swift/*|services/mlx-text-worker-swift/*|services/mlx-worker-python/*|tests/integration/*)
+                should_run=true
+                break
+                ;;
+            esac
+          done < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+
   integration-tests:
+    if: github.event_name == 'merge_group' || needs.integration-scope.outputs.should_run == 'true'
+    needs:
+      - integration-scope
     runs-on: macos-15
     timeout-minutes: 60
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -17,11 +17,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - uses: rhysd/actionlint@v1.7.12
 
       - name: Diff check
-        run: git diff --check
+        run: git diff --check HEAD^1 HEAD
 
   proto-drift:
     runs-on: macos-15
@@ -35,9 +37,6 @@ jobs:
           python-version: "3.12"
 
       - uses: astral-sh/setup-uv@v5
-
-      - name: Install protobuf generators
-        run: brew install protobuf swift-protobuf
 
       - name: Bootstrap
         run: make bootstrap

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: rhysd/actionlint@v1
+      - uses: rhysd/actionlint@v1.7.12
 
       - name: Diff check
         run: git diff --check
@@ -89,6 +89,9 @@ jobs:
 
       - name: Bootstrap
         run: make bootstrap
+
+      - name: Build Swift integration prerequisites
+        run: make swift-build-integration-prereqs
 
       - name: Integration tests
         run: make integration-test

--- a/.github/workflows/package-self-contained-app.yml
+++ b/.github/workflows/package-self-contained-app.yml
@@ -2,6 +2,15 @@ name: package-self-contained-app
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/package-self-contained-app.yml"
+      - "apps/macos-menubar/**"
+      - "packages/protocol/**"
+      - "scripts/package_macos_menubar_app.py"
+      - "services/control-plane-swift/**"
+      - "services/mlx-text-worker-swift/**"
+      - "services/mlx-worker-python/**"
   push:
     branches:
       - main
@@ -16,6 +25,13 @@ on:
       - "services/control-plane-swift/**"
       - "services/mlx-text-worker-swift/**"
       - "services/mlx-worker-python/**"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: package-self-contained-app-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   package-app:
@@ -39,11 +55,8 @@ jobs:
       - name: Build menu bar app executable
         run: swift build --package-path apps/macos-menubar --disable-automatic-resolution
 
-      - name: Verify packaging helpers
-        run: |
-          PYTHONPATH="$GITHUB_WORKSPACE:$GITHUB_WORKSPACE/services/mlx-worker-python" \
-          UV_CACHE_DIR="$GITHUB_WORKSPACE/.uv-cache" \
-          uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_build_metadata.py -q
+      - name: Packaging smoke checks
+        run: make package-smoke
 
       - name: Compute build metadata
         id: compute-build-metadata
@@ -78,3 +91,10 @@ jobs:
           name: ${{ steps.compute-build-metadata.outputs.artifact_name }}
           path: ${{ runner.temp }}/${{ steps.compute-build-metadata.outputs.artifact_name }}.zip
           if-no-files-found: error
+
+      - name: Attach app to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ runner.temp }}/${{ steps.compute-build-metadata.outputs.artifact_name }}.zip
+          generate_release_notes: true

--- a/.github/workflows/package-self-contained-app.yml
+++ b/.github/workflows/package-self-contained-app.yml
@@ -27,7 +27,7 @@ on:
       - "services/mlx-worker-python/**"
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: package-self-contained-app-${{ github.ref }}
@@ -36,6 +36,8 @@ concurrency:
 jobs:
   package-app:
     runs-on: macos-15
+    outputs:
+      artifact_name: ${{ steps.compute-build-metadata.outputs.artifact_name }}
 
     steps:
       - uses: actions/checkout@v4
@@ -92,9 +94,22 @@ jobs:
           path: ${{ runner.temp }}/${{ steps.compute-build-metadata.outputs.artifact_name }}.zip
           if-no-files-found: error
 
+  attach-release-artifact:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: package-app
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download packaged app artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.package-app.outputs.artifact_name }}
+          path: ${{ runner.temp }}
+
       - name: Attach app to GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ runner.temp }}/${{ steps.compute-build-metadata.outputs.artifact_name }}.zip
+          files: ${{ runner.temp }}/${{ needs.package-app.outputs.artifact_name }}.zip
           generate_release_notes: true

--- a/.github/workflows/package-self-contained-app.yml
+++ b/.github/workflows/package-self-contained-app.yml
@@ -109,7 +109,8 @@ jobs:
           path: ${{ runner.temp }}
 
       - name: Attach app to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaff05c3d0a71e06a66f # v2
         with:
           files: ${{ runner.temp }}/${{ needs.package-app.outputs.artifact_name }}.zip
+          # Tag pushes are the release source of truth for this workflow, so generated notes own the body.
           generate_release_notes: true

--- a/.github/workflows/pr-evidence.yml
+++ b/.github/workflows/pr-evidence.yml
@@ -1,0 +1,28 @@
+name: pr-evidence
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-evidence-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-evidence:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate PR evidence
+        run: python3 scripts/validate_pr_evidence.py --event-path "$GITHUB_EVENT_PATH"

--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-gates-${{ github.ref }}
+  group: release-gates-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -53,7 +53,13 @@ jobs:
       - name: Phase 8 release gate
         id: phase8-release-gate
         continue-on-error: true
-        run: make phase8-release-gate PHASE8_RELEASE_GATE_ARGS="--json" > "$RUNNER_TEMP/phase8-release-gate.json"
+        run: |
+          if ! make phase8-release-gate PHASE8_RELEASE_GATE_ARGS="--json" > "$RUNNER_TEMP/phase8-release-gate.json"; then
+            if [ ! -s "$RUNNER_TEMP/phase8-release-gate.json" ]; then
+              printf '{\n  "passed": false,\n  "failures": ["phase8-release-gate failed before emitting JSON"],\n  "runner_failure": true\n}\n' > "$RUNNER_TEMP/phase8-release-gate.json"
+            fi
+            exit 1
+          fi
 
       - name: Upload release-gate evidence
         if: always()

--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -2,6 +2,8 @@ name: release-gates
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * *"
   push:
     branches:
       - main
@@ -15,6 +17,13 @@ on:
       - "services/mlx-text-worker-swift/**"
       - "services/mlx-worker-python/**"
       - "tests/integration/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-gates-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   release-gates:
@@ -42,4 +51,18 @@ jobs:
         run: make integration-test
 
       - name: Phase 8 release gate
-        run: make phase8-release-gate PHASE8_RELEASE_GATE_ARGS="--json"
+        id: phase8-release-gate
+        continue-on-error: true
+        run: make phase8-release-gate PHASE8_RELEASE_GATE_ARGS="--json" > "$RUNNER_TEMP/phase8-release-gate.json"
+
+      - name: Upload release-gate evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase8-release-gate-${{ github.run_id }}
+          path: ${{ runner.temp }}/phase8-release-gate.json
+          if-no-files-found: error
+
+      - name: Fail if release gate failed
+        if: steps.phase8-release-gate.outcome == 'failure'
+        run: exit 1

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,13 @@ integration-test:
 
 package-smoke:
 	mkdir -p "$(UV_CACHE_DIR)"
-	PYTHONPATH="$(ROOT):$(ROOT)/services/mlx-worker-python" UV_CACHE_DIR="$(UV_CACHE_DIR)" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_build_metadata.py services/mlx-worker-python/tests/test_packaging_targets.py services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py services/mlx-worker-python/tests/test_m8_packaging_target_smoke.py -q
+	PYTHONPATH="$(ROOT):$(ROOT)/services/mlx-worker-python" UV_CACHE_DIR="$(UV_CACHE_DIR)" uv run --project services/mlx-worker-python --extra mlx pytest \
+		services/mlx-worker-python/tests/test_build_metadata.py \
+		services/mlx-worker-python/tests/test_packaging_targets.py \
+		services/mlx-worker-python/tests/test_macos_app_bundle.py \
+		services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py \
+		services/mlx-worker-python/tests/test_m8_packaging_target_smoke.py \
+		-q
 	PYTHONPATH="$(ROOT):$(ROOT)/services/mlx-worker-python" UV_CACHE_DIR="$(UV_CACHE_DIR)" uv run --project services/mlx-worker-python --extra mlx python scripts/m8_packaging_target_smoke.py --json
 
 swift-coverage:

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_E := \
 CONTROL_PLANE_TEST_FILTER_OPENAI := OpenAIHandlerTests
 CONTROL_PLANE_TEST_FILTER_HTTP_REST := RichOutputSanitizerTests|PersistentAuthSessionStoreTests|ProtocolCompatibilityMatrixTests|ConnectionLifecyclePolicyTests|SSEStreamWriterTests
 
-.PHONY: bootstrap proto proto-check swift-test py-test integration-test package-smoke swift-coverage py-coverage coverage phase1-metrics phase2-metrics phase5-metrics phase6-metrics phase7-metrics phase8-acceptance phase8-real-e2e phase8-install-smoke phase8-release-gate phase8-metrics phase17-metrics
+.PHONY: bootstrap proto proto-check swift-build-integration-prereqs swift-test py-test integration-test package-smoke swift-coverage py-coverage coverage phase1-metrics phase2-metrics phase5-metrics phase6-metrics phase7-metrics phase8-acceptance phase8-real-e2e phase8-install-smoke phase8-release-gate phase8-metrics phase17-metrics
 
 PHASE1_METRICS_ARGS ?=
 PHASE2_METRICS_ARGS ?=
@@ -87,6 +87,13 @@ proto:
 
 proto-check: proto
 	git diff --exit-code -- packages/protocol/descriptors packages/protocol/python packages/protocol/swift
+
+swift-build-integration-prereqs:
+	/bin/zsh -lc 'set -e; \
+	mkdir -p "$(TEXT_WORKER_SWIFT_HOME)" "$(CONTROL_PLANE_SWIFT_HOME)"; \
+	mkdir -p "$(TEXT_WORKER_MODULE_CACHE_PATH)" "$(CONTROL_PLANE_MODULE_CACHE_PATH)"; \
+	HOME="$(TEXT_WORKER_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(TEXT_WORKER_MODULE_CACHE_PATH)" xcrun swift build --package-path services/mlx-text-worker-swift --product melix-text-worker-swift --disable-automatic-resolution; \
+	HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift build --package-path services/control-plane-swift --product melix-control-plane --disable-automatic-resolution'
 
 swift-test:
 	/bin/zsh -lc 'set -e; \

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_E := \
 CONTROL_PLANE_TEST_FILTER_OPENAI := OpenAIHandlerTests
 CONTROL_PLANE_TEST_FILTER_HTTP_REST := RichOutputSanitizerTests|PersistentAuthSessionStoreTests|ProtocolCompatibilityMatrixTests|ConnectionLifecyclePolicyTests|SSEStreamWriterTests
 
-.PHONY: bootstrap proto swift-test py-test integration-test swift-coverage py-coverage coverage phase1-metrics phase2-metrics phase5-metrics phase6-metrics phase7-metrics phase8-acceptance phase8-real-e2e phase8-install-smoke phase8-release-gate phase8-metrics phase17-metrics
+.PHONY: bootstrap proto proto-check swift-test py-test integration-test package-smoke swift-coverage py-coverage coverage phase1-metrics phase2-metrics phase5-metrics phase6-metrics phase7-metrics phase8-acceptance phase8-real-e2e phase8-install-smoke phase8-release-gate phase8-metrics phase17-metrics
 
 PHASE1_METRICS_ARGS ?=
 PHASE2_METRICS_ARGS ?=
@@ -84,6 +84,9 @@ bootstrap:
 
 proto:
 	./scripts/proto_gen.sh
+
+proto-check: proto
+	git diff --exit-code -- packages/protocol/descriptors packages/protocol/python packages/protocol/swift
 
 swift-test:
 	/bin/zsh -lc 'set -e; \
@@ -107,6 +110,11 @@ py-test:
 integration-test:
 	mkdir -p "$(UV_CACHE_DIR)"
 	PYTHONPATH="$(ROOT):$(ROOT)/services/mlx-worker-python" UV_CACHE_DIR="$(UV_CACHE_DIR)" uv run --project services/mlx-worker-python --extra mlx pytest tests/integration -q
+
+package-smoke:
+	mkdir -p "$(UV_CACHE_DIR)"
+	PYTHONPATH="$(ROOT):$(ROOT)/services/mlx-worker-python" UV_CACHE_DIR="$(UV_CACHE_DIR)" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_build_metadata.py services/mlx-worker-python/tests/test_packaging_targets.py services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py services/mlx-worker-python/tests/test_m8_packaging_target_smoke.py -q
+	PYTHONPATH="$(ROOT):$(ROOT)/services/mlx-worker-python" UV_CACHE_DIR="$(UV_CACHE_DIR)" uv run --project services/mlx-worker-python --extra mlx python scripts/m8_packaging_target_smoke.py --json
 
 swift-coverage:
 	/bin/zsh -lc 'set -e; \

--- a/apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift
+++ b/apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift
@@ -18,6 +18,7 @@ private let phase8MatrixStructuredOutputMode = "plain_text"
 private let phase8MatrixConcurrencyLevel: UInt32 = 1
 private let phase8MatrixRequests: UInt32 = 4
 private let phase8EvaluationSampleSize: UInt32 = 4
+private let phase8EvaluationScoringMode = "multiple_choice_accuracy"
 
 public enum Phase8WindowUIAcceptanceError: Error, LocalizedError {
     case missingCLIEvidenceBundle(String)
@@ -702,6 +703,9 @@ public final class Phase8WindowUIAcceptanceRunner {
                     suites: config.evaluationSuites,
                     datasetID: config.evaluationDataset,
                     sampleSize: phase8EvaluationSampleSize,
+                    parameters: [
+                        "scoring_mode": phase8EvaluationScoringMode,
+                    ],
                     json: true
                 )
             )

--- a/apps/macos-menubar/Sources/AppMain/Branding/MelixBranding.swift
+++ b/apps/macos-menubar/Sources/AppMain/Branding/MelixBranding.swift
@@ -6,16 +6,20 @@ enum MelixBranding {
     static let workspaceLogoResourceName = "melix-logo-workspace"
     static let trayTemplateResourceName = "melix-status-template"
     static let appIconFileName = "MelixAppIcon.icns"
+    @MainActor
     private static let cachedTrayTemplateIcon = makeTrimmedTrayTemplateIcon()
 
+    @MainActor
     static func workspaceLogo() -> NSImage {
         loadImage(named: workspaceLogoResourceName)
     }
 
+    @MainActor
     static func trayTemplateIcon() -> NSImage {
         (cachedTrayTemplateIcon.copy() as? NSImage) ?? cachedTrayTemplateIcon
     }
 
+    @MainActor
     private static func loadImage(named resourceName: String) -> NSImage {
         guard
             let resourceURL = Bundle.module.url(forResource: resourceName, withExtension: "png"),
@@ -27,6 +31,7 @@ enum MelixBranding {
         return image
     }
 
+    @MainActor
     private static func makeTrimmedTrayTemplateIcon() -> NSImage {
         let image = loadImage(named: trayTemplateResourceName)
         let trimmed = trimTransparentPadding(from: image)
@@ -34,6 +39,7 @@ enum MelixBranding {
         return trimmed
     }
 
+    @MainActor
     private static func trimTransparentPadding(from image: NSImage) -> NSImage {
         guard let bounds = alphaBounds(for: image) else {
             return image
@@ -46,6 +52,7 @@ enum MelixBranding {
         return trimmed
     }
 
+    @MainActor
     private static func alphaBounds(for image: NSImage) -> NSRect? {
         guard
             let tiffRepresentation = image.tiffRepresentation,
@@ -82,4 +89,16 @@ enum MelixBranding {
             height: maxY - minY + 1
         )
     }
+
+#if DEBUG
+    @MainActor
+    static func _testTrimTransparentPadding(from image: NSImage) -> NSImage {
+        trimTransparentPadding(from: image)
+    }
+
+    @MainActor
+    static func _testAlphaBounds(for image: NSImage) -> NSRect? {
+        alphaBounds(for: image)
+    }
+#endif
 }

--- a/apps/macos-menubar/Sources/AppMain/CLI/MelixCLIWorkflowRunning.swift
+++ b/apps/macos-menubar/Sources/AppMain/CLI/MelixCLIWorkflowRunning.swift
@@ -403,6 +403,8 @@ extension MelixCLICommand {
             return "lora.activate"
         case .loraRemoveDerived:
             return "lora.remove-derived"
+        case .loraPublish:
+            return "lora.publish"
         case .loraDatasetInspect:
             return "lora.dataset.inspect"
         case .loraDatasetBuild:

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -3567,6 +3567,15 @@ struct Phase8WindowUIAcceptanceRunnerTests {
             if case .evalRun = $0 { return true }
             return false
         }))
+        let evaluationCommand = try #require(recordedCommands.first(where: {
+            if case .evalRun = $0 { return true }
+            return false
+        }))
+        guard case .evalRun(let evaluationOptions) = evaluationCommand else {
+            Issue.record("Expected the phase 8 acceptance runner to record an evalRun command.")
+            return
+        }
+        #expect(evaluationOptions.parameters["scoring_mode"] == "multiple_choice_accuracy")
     }
 
     @Test("phase 8 window ui acceptance runner routes lora workflows through the materialized model id")

--- a/apps/macos-menubar/Tests/MenuBarTests/MelixSubprocessCLIWorkflowRunnerTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/MelixSubprocessCLIWorkflowRunnerTests.swift
@@ -25,6 +25,22 @@ struct MelixSubprocessCLIWorkflowRunnerTests {
         )
     }
 
+    @Test("lora publish exposes a stable workflow command id")
+    func loraPublishExposesAStableWorkflowCommandID() {
+        #expect(
+            MelixCLICommand.loraPublish(
+                    .init(
+                        modelID: "melix-dev-qwen-local",
+                        targetRepo: "melix/adapters/melix-dev-adapter",
+                        exportKind: .adapterExport,
+                        artifactPath: "/tmp/melix-dev-adapter",
+                        artifactManifestPath: "/tmp/melix-dev-adapter/manifest.json",
+                        json: true
+                    )
+            ).workflowCommandID == "lora.publish"
+        )
+    }
+
     @Test("download hub model shells out through the melix cli and decodes a managed receipt")
     func downloadHubModelShellsOutThroughTheMelixCLIAndDecodesAManagedReceipt() async throws {
         let processExecutor = RecordingCLIProcessExecutor()

--- a/apps/macos-menubar/Tests/MenuBarTests/StatusMenuTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/StatusMenuTests.swift
@@ -407,6 +407,36 @@ struct StatusMenuTests {
         #expect(menu.items[0].title == "Error: Operator session persistence failed")
         #expect(menu.items[0].toolTip == "Error: \(message)")
     }
+
+    @Test("branding workspace logo loads the packaged asset")
+    @MainActor
+    func brandingWorkspaceLogoLoadsPackagedAsset() async throws {
+        let image = MelixBranding.workspaceLogo()
+
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+    }
+
+    @Test("branding helpers return the original image when no bitmap representation is available")
+    @MainActor
+    func brandingHelpersReturnOriginalImageWithoutBitmapRepresentation() async throws {
+        let image = NSImage(size: .zero)
+
+        #expect(MelixBranding._testAlphaBounds(for: image) == nil)
+        #expect(MelixBranding._testTrimTransparentPadding(from: image) === image)
+    }
+
+    @Test("branding alpha bounds return nil for fully transparent images")
+    @MainActor
+    func brandingAlphaBoundsReturnNilForTransparentImages() async throws {
+        let image = NSImage(size: NSSize(width: 6, height: 6))
+        image.lockFocus()
+        NSColor.clear.setFill()
+        NSBezierPath(rect: NSRect(x: 0, y: 0, width: 6, height: 6)).fill()
+        image.unlockFocus()
+
+        #expect(MelixBranding._testAlphaBounds(for: image) == nil)
+    }
 }
 
 private func makeStatusMenuNamedModelOperationResult(

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,6 +33,11 @@ make py-test
 make integration-test
 ```
 
+Repository pull requests are expected to keep the same baseline green in GitHub Actions. The PR
+template is also part of the review contract: include the governing plan or spec, the commands you
+ran, the coverage or metrics result (or explicit `N/A` reason), and any known gaps or deferred
+checks.
+
 If you are working in a specific subsystem, add the relevant focused commands, smoke scripts, or
 runbook verification steps to your handoff note as well.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,8 +8,9 @@ This guide is the shortest path from a fresh checkout to a working local Melix d
 - `swift`
 - `python3`
 - `uv`
-- `protoc`
-- `protoc-gen-swift` for Swift protobuf generation
+
+`make proto` builds and uses the pinned protobuf generators from the repository's locked Python and
+Swift dependencies, so no separate `protoc` or `protoc-gen-swift` installation is required.
 
 ## Bootstrap The Repository
 

--- a/docs/plans/2026-04-15-ci-failure-remediation.md
+++ b/docs/plans/2026-04-15-ci-failure-remediation.md
@@ -26,6 +26,8 @@ This slice does not add:
   macOS runners, which fails under `sandbox-exec` before the evaluation payload is emitted.
 - `integration-tests` run before the required Swift products are built, so the suite fails on
   missing `melix-control-plane` and `melix-text-worker-swift` executables.
+- `integration-tests` also need a larger timeout budget once the required Swift prerequisite build
+  runs in the same job on GitHub macOS runners.
 - `swift-tests` invoke Python bridge fixture processes through `uv run`, but the workflow does not
   provision Python or `uv`, so worker-client bridge tests fail even when the Swift code is valid.
 - `package-app` fails under Xcode 16.4 concurrency checks because a cached `NSImage` static
@@ -39,6 +41,8 @@ This slice does not add:
 
 - Pin `actionlint` to a resolvable published version.
 - Update the integration workflow path so Swift artifacts are built before `make integration-test`.
+- Increase the integration workflow timeout so the prerequisite build and full Python suite can both
+  complete on GitHub macOS runners.
 - Provision Python, `uv`, and the locked worker environment before running `make swift-test`.
 
 ### Python sandbox execution
@@ -62,6 +66,8 @@ Measurement points for this remediation:
 - Python sandbox regression: evaluator completes and emits its payload under the selected
   interpreter path.
 - Integration workflow preparation: required Swift binaries exist before integration tests launch.
+- Integration workflow budget: the combined prerequisite build and test duration stays within the
+  configured CI timeout window.
 - Swift worker bridge fixture execution: `uv`-backed bridge commands remain dispatchable inside the
   Swift test job.
 - Disconnect-grace test determinism: terminal failure metrics are observed before assertions run.
@@ -104,6 +110,7 @@ This remediation is complete when:
 
 - the workflow definitions no longer contain the invalid `actionlint` reference
 - integration CI provisions the Swift binaries it depends on before running the Python suite
+- integration CI has enough timeout headroom for the prerequisite Swift build plus the full suite
 - swift test CI provisions the Python bridge runtime dependencies before worker-client tests launch
 - sandboxed Python code evaluation succeeds on runner-compatible interpreter paths
 - the menu bar app package builds under the current Xcode concurrency checks

--- a/docs/plans/2026-04-15-ci-failure-remediation.md
+++ b/docs/plans/2026-04-15-ci-failure-remediation.md
@@ -26,6 +26,8 @@ This slice does not add:
   macOS runners, which fails under `sandbox-exec` before the evaluation payload is emitted.
 - `integration-tests` run before the required Swift products are built, so the suite fails on
   missing `melix-control-plane` and `melix-text-worker-swift` executables.
+- `swift-tests` invoke Python bridge fixture processes through `uv run`, but the workflow does not
+  provision Python or `uv`, so worker-client bridge tests fail even when the Swift code is valid.
 - `package-app` fails under Xcode 16.4 concurrency checks because a cached `NSImage` static
   property is not isolated to the main actor.
 - `swift-tests` expose a timing-sensitive request coordinator test that assumes disconnect-grace
@@ -37,6 +39,7 @@ This slice does not add:
 
 - Pin `actionlint` to a resolvable published version.
 - Update the integration workflow path so Swift artifacts are built before `make integration-test`.
+- Provision Python, `uv`, and the locked worker environment before running `make swift-test`.
 
 ### Python sandbox execution
 
@@ -59,6 +62,8 @@ Measurement points for this remediation:
 - Python sandbox regression: evaluator completes and emits its payload under the selected
   interpreter path.
 - Integration workflow preparation: required Swift binaries exist before integration tests launch.
+- Swift worker bridge fixture execution: `uv`-backed bridge commands remain dispatchable inside the
+  Swift test job.
 - Disconnect-grace test determinism: terminal failure metrics are observed before assertions run.
 
 Success targets:
@@ -99,6 +104,7 @@ This remediation is complete when:
 
 - the workflow definitions no longer contain the invalid `actionlint` reference
 - integration CI provisions the Swift binaries it depends on before running the Python suite
+- swift test CI provisions the Python bridge runtime dependencies before worker-client tests launch
 - sandboxed Python code evaluation succeeds on runner-compatible interpreter paths
 - the menu bar app package builds under the current Xcode concurrency checks
 - the request coordinator disconnect-grace test no longer depends on a fixed sleep race

--- a/docs/plans/2026-04-15-ci-failure-remediation.md
+++ b/docs/plans/2026-04-15-ci-failure-remediation.md
@@ -8,6 +8,7 @@ This plan remediates the failing GitHub Actions checks currently blocking PR val
 The slice is intentionally narrow:
 
 - restore `ci-pr` workflow reliability
+- harden the PR-only validation and packaging workflows after self-review findings
 - restore macOS packaging compatibility with the current GitHub runner image and Xcode toolchain
 - keep fixes limited to the failing workflow, Python sandbox execution path, and Swift request and
   branding code that the workflows exercise
@@ -22,6 +23,12 @@ This slice does not add:
 
 - `actionlint-and-diffcheck` references `rhysd/actionlint@v1`, which is not a resolvable GitHub
   Action version.
+- `actionlint-and-diffcheck` currently runs `git diff --check` against a clean checkout, which does
+  not validate the proposed PR patch and misses whitespace or conflict-marker defects introduced by
+  the reviewed change.
+- `proto-drift` installs `protobuf` and `swift-protobuf` directly from Homebrew on every run, so
+  the protocol generators can drift independently of the repository's locked Python and Swift
+  dependency graph.
 - `python-tests` execute the sandboxed evaluator via the framework wrapper interpreter on GitHub
   macOS runners, which fails under `sandbox-exec` before the evaluation payload is emitted.
 - `integration-tests` run before the required Swift products are built, so the suite fails on
@@ -34,16 +41,25 @@ This slice does not add:
   property is not isolated to the main actor.
 - `swift-tests` expose a timing-sensitive request coordinator test that assumes disconnect-grace
   expiry has already completed after a fixed sleep.
+- `validate_pr_evidence.py` currently accepts empty fenced code blocks and loose placeholder text
+  such as `TODO: fill later`, which weakens the mandatory PR evidence gate.
+- `package-self-contained-app` grants `contents: write` for the full workflow even though only the
+  tag-release attachment path needs repository write access.
 
 ## Planned Changes
 
 ### Workflow fixes
 
 - Pin `actionlint` to a resolvable published version.
+- Make the diff check validate the checked-out merge patch rather than the empty worktree state.
 - Update the integration workflow path so Swift artifacts are built before `make integration-test`.
 - Increase the integration workflow timeout so the prerequisite build and full Python suite can both
   complete on GitHub macOS runners.
 - Provision Python, `uv`, and the locked worker environment before running `make swift-test`.
+- Move protocol generation to repository-pinned toolchains so `proto-drift` is deterministic across
+  runs.
+- Reduce packaging workflow permissions to `contents: read` by default and isolate release-asset
+  publication in a tag-only write-scoped job.
 
 ### Python sandbox execution
 
@@ -51,6 +67,8 @@ This slice does not add:
   framework wrapper binary under sandboxing.
 - Add regression coverage for the executable-selection behavior so the runner-specific path stays
   stable.
+- Tighten PR evidence parsing so empty fenced blocks and placeholder-prefixed bullets fail
+  validation.
 
 ### Swift compatibility and determinism
 
@@ -71,6 +89,11 @@ Measurement points for this remediation:
 - Swift worker bridge fixture execution: `uv`-backed bridge commands remain dispatchable inside the
   Swift test job.
 - Disconnect-grace test determinism: terminal failure metrics are observed before assertions run.
+- PR evidence gate strength: required sections reject empty code fences and placeholder-prefixed
+  items while still accepting justified `N/A:` coverage statements.
+- Protocol generation determinism: the same repository-locked protobuf toolchain is used in CI and
+  local regeneration paths.
+- Packaging workflow permissions: pull request execution paths stay read-only.
 
 Success targets:
 
@@ -86,8 +109,12 @@ Targeted verification:
 
 ```bash
 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_code_eval_runner.py -q
+uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_validate_pr_evidence.py -q
 xcrun swift test --package-path services/control-plane-swift --filter "HTTPGatewayTests.RequestCoordinatorTests/disconnectGraceExpiryAbortsTheWorkerAndRecordsATerminalLifecycleFailure()"
 xcrun swift test --package-path apps/macos-menubar
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python python -m grpc_tools.protoc --version
+HOME="$PWD/.swift-home/protocol" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/protocol" xcrun swift build --package-path packages/protocol/swift --product protoc-gen-swift --disable-automatic-resolution
+HOME="$PWD/.swift-home/protocol" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/protocol" xcrun swift build --package-path packages/protocol/swift --product protoc-gen-grpc-swift-2 --disable-automatic-resolution
 ```
 
 Broader regression checks:

--- a/docs/plans/2026-04-15-ci-failure-remediation.md
+++ b/docs/plans/2026-04-15-ci-failure-remediation.md
@@ -1,0 +1,104 @@
+# Melix CI Failure Remediation Plan
+
+## Scope
+
+This plan remediates the failing GitHub Actions checks currently blocking PR validation for the
+`ci-github-actions-hardening` branch.
+
+The slice is intentionally narrow:
+
+- restore `ci-pr` workflow reliability
+- restore macOS packaging compatibility with the current GitHub runner image and Xcode toolchain
+- keep fixes limited to the failing workflow, Python sandbox execution path, and Swift request and
+  branding code that the workflows exercise
+
+This slice does not add:
+
+- new CI jobs or matrix expansion
+- non-blocking workflow modernization beyond the failing checks
+- unrelated runtime behavior changes outside the failing code paths
+
+## Root Causes
+
+- `actionlint-and-diffcheck` references `rhysd/actionlint@v1`, which is not a resolvable GitHub
+  Action version.
+- `python-tests` execute the sandboxed evaluator via the framework wrapper interpreter on GitHub
+  macOS runners, which fails under `sandbox-exec` before the evaluation payload is emitted.
+- `integration-tests` run before the required Swift products are built, so the suite fails on
+  missing `melix-control-plane` and `melix-text-worker-swift` executables.
+- `package-app` fails under Xcode 16.4 concurrency checks because a cached `NSImage` static
+  property is not isolated to the main actor.
+- `swift-tests` expose a timing-sensitive request coordinator test that assumes disconnect-grace
+  expiry has already completed after a fixed sleep.
+
+## Planned Changes
+
+### Workflow fixes
+
+- Pin `actionlint` to a resolvable published version.
+- Update the integration workflow path so Swift artifacts are built before `make integration-test`.
+
+### Python sandbox execution
+
+- Prefer the direct Python launcher inside `Python.app` when present, instead of invoking the
+  framework wrapper binary under sandboxing.
+- Add regression coverage for the executable-selection behavior so the runner-specific path stays
+  stable.
+
+### Swift compatibility and determinism
+
+- Isolate tray-icon caching behind the main actor so AppKit image state satisfies current Swift
+  concurrency checks.
+- Make the disconnect-grace expiry test wait on the terminal signal rather than rely on a fixed
+  timing window.
+
+## Performance Probes And Metrics
+
+Measurement points for this remediation:
+
+- Python sandbox regression: evaluator completes and emits its payload under the selected
+  interpreter path.
+- Integration workflow preparation: required Swift binaries exist before integration tests launch.
+- Disconnect-grace test determinism: terminal failure metrics are observed before assertions run.
+
+Success targets:
+
+- all previously failing checks have a concrete local verification command
+- touched measurable code paths remain at or above 95 percent automated coverage where the tooling
+  supports measurement
+- changed-scope metrics report is included in the handoff, with `N/A` explicitly called out for
+  workflow YAML where coverage is not meaningful
+
+## Verification Plan
+
+Targeted verification:
+
+```bash
+uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_code_eval_runner.py -q
+xcrun swift test --package-path services/control-plane-swift --filter "HTTPGatewayTests.RequestCoordinatorTests/disconnectGraceExpiryAbortsTheWorkerAndRecordsATerminalLifecycleFailure()"
+xcrun swift test --package-path apps/macos-menubar
+```
+
+Broader regression checks:
+
+```bash
+make py-test
+make swift-test
+```
+
+Workflow sanity checks:
+
+```bash
+gh workflow view ci-pr --yaml
+gh workflow view package-self-contained-app --yaml
+```
+
+## Exit Conditions
+
+This remediation is complete when:
+
+- the workflow definitions no longer contain the invalid `actionlint` reference
+- integration CI provisions the Swift binaries it depends on before running the Python suite
+- sandboxed Python code evaluation succeeds on runner-compatible interpreter paths
+- the menu bar app package builds under the current Xcode concurrency checks
+- the request coordinator disconnect-grace test no longer depends on a fixed sleep race

--- a/docs/plans/2026-04-15-ci-failure-remediation.md
+++ b/docs/plans/2026-04-15-ci-failure-remediation.md
@@ -43,8 +43,23 @@ This slice does not add:
   expiry has already completed after a fixed sleep.
 - `validate_pr_evidence.py` currently accepts empty fenced code blocks and loose placeholder text
   such as `TODO: fill later`, which weakens the mandatory PR evidence gate.
+- `validate_pr_evidence.py` also accepts the shipped `Commands Run` placeholder comment inside a
+  fenced block, so a template-only PR body can still pass validation.
 - `package-self-contained-app` grants `contents: write` for the full workflow even though only the
   tag-release attachment path needs repository write access.
+- the release-gate evaluation policy now requires `eval.<suite>.typed_score_mean`, but legacy
+  evidence producers and fixtures still emit `eval.<suite>.accuracy`, so the gate currently fails
+  valid historical evidence during the metric migration.
+- the scheduled and push-triggered `release-gates` runs on `main` currently share the same
+  concurrency key and can cancel each other.
+- the release attachment job references `softprops/action-gh-release` by mutable tag instead of an
+  immutable commit SHA.
+- the root Dependabot `pip` entry duplicates the worker Python ecosystem even though the workspace
+  root has no direct Python dependencies.
+- `ci-pr` still runs the full `integration-tests` job for docs-only pull requests because the job
+  has no change-scope gate.
+- the packaging workflow relies on generated GitHub release notes by design, but that assumption is
+  not documented near the write-scoped release action.
 
 ## Planned Changes
 
@@ -60,6 +75,15 @@ This slice does not add:
   runs.
 - Reduce packaging workflow permissions to `contents: read` by default and isolate release-asset
   publication in a tag-only write-scoped job.
+- Separate scheduled and push-triggered release-gate workflow concurrency keys on `main`.
+- Pin the release-attachment action to an immutable commit SHA.
+- Drop the redundant root Dependabot `pip` updater so the worker remains the single Python package
+  update surface.
+- Gate `integration-tests` behind a PR diff scope check so docs-only pull requests skip the 18-minute
+  integration suite while merge-queue runs still execute it unconditionally.
+- Document that tag pushes are the source of truth for release body generation in the packaging
+  workflow so `generate_release_notes: true` is an explicit policy choice rather than an implicit
+  default.
 
 ### Python sandbox execution
 
@@ -69,6 +93,11 @@ This slice does not add:
   stable.
 - Tighten PR evidence parsing so empty fenced blocks and placeholder-prefixed bullets fail
   validation.
+- Ignore placeholder comment lines inside fenced `Commands Run` blocks so the shipped template text
+  cannot satisfy the evidence gate by itself.
+- Normalize release-gate evaluation evidence so both `eval.<suite>.accuracy` and
+  `eval.<suite>.typed_score_mean` remain accepted during the metric migration, while keeping the
+  canonical `typed_score_mean` output.
 
 ### Swift compatibility and determinism
 
@@ -91,9 +120,16 @@ Measurement points for this remediation:
 - Disconnect-grace test determinism: terminal failure metrics are observed before assertions run.
 - PR evidence gate strength: required sections reject empty code fences and placeholder-prefixed
   items while still accepting justified `N/A:` coverage statements.
+- Release-gate metric migration: canonical and legacy evaluation metric names both satisfy the
+  gate during the transition period, and the deterministic smoke fixture remains green.
 - Protocol generation determinism: the same repository-locked protobuf toolchain is used in CI and
   local regeneration paths.
 - Packaging workflow permissions: pull request execution paths stay read-only.
+- Workflow scheduling isolation: scheduled and push-triggered release-gate runs do not cancel each
+  other on `main`.
+- Supply-chain hardening: write-scoped release publication uses an immutable action revision.
+- Pull-request CI scope control: docs-only pull requests skip the integration suite, while
+  merge-group validation continues to run the full integration path.
 
 Success targets:
 

--- a/docs/runbooks/phase-1-local-stack.md
+++ b/docs/runbooks/phase-1-local-stack.md
@@ -14,7 +14,8 @@ Use this runbook when you need to:
 - macOS on Apple Silicon
 - `make bootstrap` has completed successfully
 - `make proto` has completed successfully
-- `uv`, `swift`, `protoc`, and `protoc-gen-swift` are available
+- `uv` and `swift` are available; `make proto` builds the pinned protobuf generators from the
+  repository's locked dependencies
 
 ## Diagnosis
 

--- a/docs/runbooks/phase-2-queue-pressure.md
+++ b/docs/runbooks/phase-2-queue-pressure.md
@@ -14,7 +14,8 @@ Use this runbook when you need to:
 - macOS on Apple Silicon
 - `make bootstrap` has completed successfully
 - `make proto` has completed successfully
-- `uv`, `swift`, `protoc`, and `protoc-gen-swift` are available
+- `uv` and `swift` are available; `make proto` builds the pinned protobuf generators from the
+  repository's locked dependencies
 
 ## Diagnosis
 

--- a/docs/runbooks/phase-6-chat-panel.md
+++ b/docs/runbooks/phase-6-chat-panel.md
@@ -14,7 +14,8 @@ Use this runbook when you need to:
 - macOS on Apple Silicon
 - `make bootstrap` has completed successfully
 - `make proto` has completed successfully
-- `uv`, `swift`, `protoc`, and `protoc-gen-swift` are available
+- `uv` and `swift` are available; `make proto` builds the pinned protobuf generators from the
+  repository's locked dependencies
 - the Phase 6 stack can already serve `/v1/models`
 
 ## Diagnosis

--- a/docs/runbooks/phase-8-release-gates.md
+++ b/docs/runbooks/phase-8-release-gates.md
@@ -65,7 +65,7 @@ infra/release/phase8-release-gate-policy.json
 Update the policy in the same change as any intentional benchmark or release-threshold adjustment.
 
 The checked-in policy now includes an `evaluation` section for deterministic suite metrics such as
-`eval.mmlu.accuracy`. Treat benchmark and evaluation regressions as first-class release inputs.
+`eval.mmlu.typed_score_mean`. Treat benchmark and evaluation regressions as first-class release inputs.
 
 The checked-in policy also includes an `evaluation_compare` section for paired compare suites such
 as `mmlu`. Each suite policy owns:

--- a/infra/release/phase8-release-gate-policy.json
+++ b/infra/release/phase8-release-gate-policy.json
@@ -204,7 +204,7 @@
     }
   },
   "evaluation": {
-    "eval.mmlu.accuracy": {
+    "eval.mmlu.typed_score_mean": {
       "min": 0.5
     }
   },

--- a/scripts/m15_desktop_polish_smoke.py
+++ b/scripts/m15_desktop_polish_smoke.py
@@ -7,6 +7,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -14,6 +15,11 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 import swift_root_package
+
+
+_SWIFTPM_LOCK_MARKER = "Another instance of SwiftPM"
+_SWIFTPM_LOCK_RETRIES = 3
+_SWIFTPM_LOCK_BACKOFF_SECONDS = 2.0
 
 
 def run_swift_smoke(repo_root: Path) -> dict[str, object]:
@@ -37,14 +43,34 @@ def run_swift_smoke(repo_root: Path) -> dict[str, object]:
             "DesktopPolishSmokeTests",
         ],
     )
-    completed = subprocess.run(
-        command,
-        cwd=repo_root,
-        check=True,
-        capture_output=True,
-        text=True,
-        env=env,
-    )
+    completed = None
+    for attempt in range(_SWIFTPM_LOCK_RETRIES + 1):
+        completed = subprocess.run(
+            command,
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        if getattr(completed, "returncode", 0) == 0:
+            break
+        if (
+            attempt < _SWIFTPM_LOCK_RETRIES
+            and _SWIFTPM_LOCK_MARKER in "\n".join(
+                part for part in [getattr(completed, "stdout", ""), getattr(completed, "stderr", "")] if part
+            )
+        ):
+            time.sleep(_SWIFTPM_LOCK_BACKOFF_SECONDS * (attempt + 1))
+            continue
+        raise subprocess.CalledProcessError(
+            getattr(completed, "returncode", 1),
+            command,
+            output=getattr(completed, "stdout", ""),
+            stderr=getattr(completed, "stderr", ""),
+        )
+    else:
+        raise RuntimeError("Swift smoke did not complete successfully.")
 
     for stream in (completed.stdout, completed.stderr):
         if not stream:

--- a/scripts/m15_desktop_polish_smoke.py
+++ b/scripts/m15_desktop_polish_smoke.py
@@ -53,24 +53,22 @@ def run_swift_smoke(repo_root: Path) -> dict[str, object]:
             text=True,
             env=env,
         )
-        if getattr(completed, "returncode", 0) == 0:
+        if completed.returncode == 0:
             break
         if (
             attempt < _SWIFTPM_LOCK_RETRIES
             and _SWIFTPM_LOCK_MARKER in "\n".join(
-                part for part in [getattr(completed, "stdout", ""), getattr(completed, "stderr", "")] if part
+                part for part in [completed.stdout, completed.stderr] if part
             )
         ):
             time.sleep(_SWIFTPM_LOCK_BACKOFF_SECONDS * (attempt + 1))
             continue
         raise subprocess.CalledProcessError(
-            getattr(completed, "returncode", 1),
+            completed.returncode,
             command,
-            output=getattr(completed, "stdout", ""),
-            stderr=getattr(completed, "stderr", ""),
+            output=completed.stdout,
+            stderr=completed.stderr,
         )
-    else:
-        raise RuntimeError("Swift smoke did not complete successfully.")
 
     for stream in (completed.stdout, completed.stderr):
         if not stream:

--- a/scripts/m9_release_gate_smoke.py
+++ b/scripts/m9_release_gate_smoke.py
@@ -132,9 +132,12 @@ def _build_fixture_report(
         },
         "evaluation": {
             "metrics": {
+                "eval.mmlu.typed_score_mean": 1.0,
                 "eval.mmlu.accuracy": 1.0,
             },
         },
+        "evaluation_compare": _build_passing_evaluation_compare_report(),
+        "real_workload": _build_passing_real_workload_report(),
         "m9": m9,
     }
     if fixture_mode == "passing" and m9_failures:
@@ -195,6 +198,109 @@ def _build_passing_m9_report() -> dict[str, object]:
                 "closure_audit.blocker_count": 0.0,
                 "closure_audit.evidence_gap_count": 0.0,
             }
+        },
+    }
+
+
+def _build_passing_evaluation_compare_report() -> dict[str, object]:
+    return {
+        "suite_id": "mmlu",
+        "base_model_id": "melix-dev-text",
+        "target_model_id": "melix-dev-text-lora-a",
+        "sample_size": 8,
+        "effect_threshold": 0.1,
+        "verdict": "improvement",
+        "metrics": {
+            "eval.compare.delta_accuracy": 0.5,
+            "eval.compare.effect_threshold": 0.1,
+        },
+        "category_breakdown": {
+            "math": {
+                "sample_size": 8,
+                "base_accuracy": 0.5,
+                "target_accuracy": 1.0,
+                "delta_accuracy": 0.5,
+            }
+        },
+        "statistical_evidence": {
+            "sample_size": 8,
+            "delta_accuracy": 0.5,
+            "bootstrap": {
+                "method": "paired_bootstrap_percentile",
+                "confidence_level": 0.95,
+                "lower_bound": 0.12,
+                "upper_bound": 0.84,
+                "crosses_zero": False,
+                "iterations": 400,
+                "seed": 9,
+            },
+            "analytical": {
+                "method": "paired_difference_normal_approximation",
+                "confidence_level": 0.95,
+                "lower_bound": 0.18,
+                "upper_bound": 0.82,
+                "crosses_zero": False,
+            },
+        },
+        "release_gate_summary": {
+            "verdict": "improvement",
+            "reason": "delta_exceeds_threshold_with_supported_intervals",
+            "effect_threshold": 0.1,
+            "delta_accuracy": 0.5,
+            "threshold_passed": True,
+            "both_intervals_same_side": True,
+        },
+        "report_path": "/tmp/evaluation-compare-report.md",
+    }
+
+
+def _build_passing_real_workload_report() -> dict[str, object]:
+    return {
+        "summary": {
+            "pass_count": 3.0,
+            "failure_count": 0.0,
+            "family_count": 3.0,
+        },
+        "families": {
+            "qwen": {
+                "family_id": "qwen",
+                "model_id": "melix-dev-qwen-local",
+                "scenario_id": "support-triage",
+                "dataset_id": "melix.release.real_workload.qwen.v1",
+                "metrics": {
+                    "passed": 1.0,
+                    "sample_count": 24.0,
+                    "latency_ms": 842.0,
+                    "throughput_tps": 31.4,
+                    "peak_memory_gb": 8.6,
+                },
+            },
+            "gemma": {
+                "family_id": "gemma",
+                "model_id": "melix-dev-gemma-local",
+                "scenario_id": "product-qa",
+                "dataset_id": "melix.release.real_workload.gemma.v1",
+                "metrics": {
+                    "passed": 1.0,
+                    "sample_count": 18.0,
+                    "latency_ms": 918.0,
+                    "throughput_tps": 28.7,
+                    "peak_memory_gb": 10.4,
+                },
+            },
+            "kimi": {
+                "family_id": "kimi",
+                "model_id": "melix-dev-kimi-local",
+                "scenario_id": "long-context-rewrite",
+                "dataset_id": "melix.release.real_workload.kimi.v1",
+                "metrics": {
+                    "passed": 1.0,
+                    "sample_count": 20.0,
+                    "latency_ms": 887.0,
+                    "throughput_tps": 29.9,
+                    "peak_memory_gb": 9.8,
+                },
+            },
         },
     }
 

--- a/scripts/phase6_metrics_report.py
+++ b/scripts/phase6_metrics_report.py
@@ -7,7 +7,9 @@ import time
 import urllib.request
 from pathlib import Path
 
-from tests.integration.helpers import LiveMelixStack, read_metrics_export
+from tests.integration.helpers import LiveMelixStack, read_metrics_export, wait_for_metric_value
+
+INTERFERENCE_TRANSCRIPTION_DELAY_MS = "500"
 
 
 def timed_request(url: str, payload: dict[str, object], *, timeout: float = 15.0) -> tuple[float, bytes, str]:
@@ -43,7 +45,7 @@ def main() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     stack = LiveMelixStack(
         repo_root,
-        environment_overrides={"MELIX_DETERMINISTIC_TRANSCRIPTION_DELAY_MS": "150"},
+        environment_overrides={"MELIX_DETERMINISTIC_TRANSCRIPTION_DELAY_MS": INTERFERENCE_TRANSCRIPTION_DELAY_MS},
     )
     stack.start()
 
@@ -161,7 +163,12 @@ def main() -> None:
 
         worker = threading.Thread(target=run_transcription_load, daemon=True)
         worker.start()
-        time.sleep(0.05)
+        wait_for_metric_value(
+            stack.control_plane_metrics_path,
+            "scheduler.multimodal_active_requests",
+            minimum=1,
+            timeout_seconds=5.0,
+        )
         text_ms, text_body, _ = timed_request(
             stack.chat_url(),
             {

--- a/scripts/proto_gen.sh
+++ b/scripts/proto_gen.sh
@@ -10,6 +10,9 @@ DESCRIPTOR_OUT="$ROOT_DIR/packages/protocol/descriptors"
 UV_CACHE_DIR="$ROOT_DIR/.uv-cache"
 SWIFT_HOME="$ROOT_DIR/.swift-home"
 CLANG_MODULE_CACHE_PATH="$ROOT_DIR/.build/ModuleCache.noindex"
+PROTOCOL_SWIFT_HOME="$SWIFT_HOME/protocol"
+PROTOCOL_MODULE_CACHE_PATH="$CLANG_MODULE_CACHE_PATH/protocol"
+PYTHON_PROJECT="$ROOT_DIR/services/mlx-worker-python"
 
 PROTO_FILES=(
   "$SCHEMA_DIR/controlplane/v1/control_plane.proto"
@@ -23,40 +26,56 @@ PROTO_FILES=(
 mkdir -p "$SWIFT_OUT" "$PYTHON_OUT" "$DESCRIPTOR_OUT"
 mkdir -p "$UV_CACHE_DIR"
 mkdir -p "$SWIFT_HOME" "$CLANG_MODULE_CACHE_PATH"
+mkdir -p "$PROTOCOL_SWIFT_HOME" "$PROTOCOL_MODULE_CACHE_PATH"
 
-if ! command -v protoc >/dev/null 2>&1; then
-  echo "error: protoc is required" >&2
+if ! command -v uv >/dev/null 2>&1; then
+  echo "error: uv is required" >&2
   exit 1
 fi
 
-if ! command -v protoc-gen-swift >/dev/null 2>&1; then
-  echo "error: protoc-gen-swift is required. Install it before running make proto." >&2
+if ! command -v xcrun >/dev/null 2>&1; then
+  echo "error: xcrun is required" >&2
   exit 1
 fi
 
-HOME="$SWIFT_HOME" CLANG_MODULE_CACHE_PATH="$CLANG_MODULE_CACHE_PATH" xcrun swift build \
+HOME="$PROTOCOL_SWIFT_HOME" CLANG_MODULE_CACHE_PATH="$PROTOCOL_MODULE_CACHE_PATH" xcrun swift build \
   --package-path "$SWIFT_OUT" \
-  --product protoc-gen-grpc-swift-2 >/dev/null
+  --product protoc-gen-swift \
+  --disable-automatic-resolution >/dev/null
 
-GRPC_SWIFT_PLUGIN_BIN="$(
-  HOME="$SWIFT_HOME" CLANG_MODULE_CACHE_PATH="$CLANG_MODULE_CACHE_PATH" xcrun swift build \
+HOME="$PROTOCOL_SWIFT_HOME" CLANG_MODULE_CACHE_PATH="$PROTOCOL_MODULE_CACHE_PATH" xcrun swift build \
+  --package-path "$SWIFT_OUT" \
+  --product protoc-gen-grpc-swift-2 \
+  --disable-automatic-resolution >/dev/null
+
+SWIFT_PLUGIN_BIN_DIR="$(
+  HOME="$PROTOCOL_SWIFT_HOME" CLANG_MODULE_CACHE_PATH="$PROTOCOL_MODULE_CACHE_PATH" xcrun swift build \
     --package-path "$SWIFT_OUT" \
+    --disable-automatic-resolution \
     --show-bin-path
-)/protoc-gen-grpc-swift-2"
+)"
+SWIFT_PLUGIN_BIN="$SWIFT_PLUGIN_BIN_DIR/protoc-gen-swift"
+GRPC_SWIFT_PLUGIN_BIN="$SWIFT_PLUGIN_BIN_DIR/protoc-gen-grpc-swift-2"
+
+if [[ ! -x "$SWIFT_PLUGIN_BIN" ]]; then
+  echo "error: protoc-gen-swift is unavailable at $SWIFT_PLUGIN_BIN" >&2
+  exit 1
+fi
 
 if [[ ! -x "$GRPC_SWIFT_PLUGIN_BIN" ]]; then
   echo "error: protoc-gen-grpc-swift-2 is unavailable at $GRPC_SWIFT_PLUGIN_BIN" >&2
   exit 1
 fi
 
-protoc \
+UV_CACHE_DIR="$UV_CACHE_DIR" uv run --project "$PYTHON_PROJECT" python -m grpc_tools.protoc \
+  --plugin="protoc-gen-swift=$SWIFT_PLUGIN_BIN" \
   --proto_path="$SCHEMA_DIR" \
   --swift_opt=Visibility=Public \
   --swift_out="$SWIFT_OUT" \
   "${PROTO_FILES[@]}"
 
-protoc \
-  --plugin="$GRPC_SWIFT_PLUGIN_BIN" \
+UV_CACHE_DIR="$UV_CACHE_DIR" uv run --project "$PYTHON_PROJECT" python -m grpc_tools.protoc \
+  --plugin="protoc-gen-grpc-swift-2=$GRPC_SWIFT_PLUGIN_BIN" \
   --proto_path="$SCHEMA_DIR" \
   --grpc-swift-2_opt=Visibility=Public \
   --grpc-swift-2_opt=Availability=macOS\ 15.0 \
@@ -66,7 +85,7 @@ protoc \
   "$SCHEMA_DIR/worker/v1/cache.proto" \
   "$SCHEMA_DIR/worker/v1/maintenance.proto"
 
-UV_CACHE_DIR="$UV_CACHE_DIR" uv run --project "$ROOT_DIR/services/mlx-worker-python" python -m grpc_tools.protoc \
+UV_CACHE_DIR="$UV_CACHE_DIR" uv run --project "$PYTHON_PROJECT" python -m grpc_tools.protoc \
   --proto_path="$SCHEMA_DIR" \
   --python_out="$PYTHON_OUT" \
   --grpc_python_out="$PYTHON_OUT" \
@@ -91,7 +110,7 @@ for path in python_out.rglob("*.py"):
         path.write_text(updated)
 PY
 
-protoc \
+UV_CACHE_DIR="$UV_CACHE_DIR" uv run --project "$PYTHON_PROJECT" python -m grpc_tools.protoc \
   --proto_path="$SCHEMA_DIR" \
   --include_imports \
   --descriptor_set_out="$DESCRIPTOR_OUT/melix.pb" \

--- a/scripts/validate_pr_evidence.py
+++ b/scripts/validate_pr_evidence.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+REQUIRED_SECTIONS = (
+    "Plan or Spec",
+    "Commands Run",
+    "Coverage and Metrics",
+    "Known Gaps",
+)
+PLACEHOLDER_MARKERS = ("tbd", "todo", "_no response_")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate that a pull request body includes Melix evidence sections."
+    )
+    parser.add_argument(
+        "--body-file",
+        help="Path to a file containing the pull request body text.",
+    )
+    parser.add_argument(
+        "--event-path",
+        help="Path to a GitHub event JSON file containing pull_request.body.",
+    )
+    return parser.parse_args()
+
+
+def load_body_text(args: argparse.Namespace) -> str:
+    if args.body_file:
+        return Path(args.body_file).read_text(encoding="utf-8")
+    if not args.event_path:
+        raise ValueError("Either --body-file or --event-path is required.")
+    payload = json.loads(Path(args.event_path).read_text(encoding="utf-8"))
+    pull_request = payload.get("pull_request", {})
+    body = pull_request.get("body", "")
+    if not isinstance(body, str):
+        raise ValueError("pull_request.body must be a string.")
+    return body
+
+
+def _extract_sections(body_text: str) -> dict[str, str]:
+    sections: dict[str, list[str]] = {}
+    current_section: str | None = None
+    for line in body_text.splitlines():
+        if line.startswith("## "):
+            current_section = line[3:].strip()
+            sections.setdefault(current_section, [])
+            continue
+        if current_section is not None:
+            sections[current_section].append(line)
+    return {
+        name: "\n".join(lines).strip()
+        for name, lines in sections.items()
+    }
+
+
+def _normalized_tokens(body_text: str) -> list[str]:
+    cleaned = []
+    for raw_line in body_text.splitlines():
+        line = raw_line.strip()
+        if not line or line in {"```", "```text"}:
+            continue
+        if line.startswith("- "):
+            line = line[2:].strip()
+        cleaned.append(line)
+    return cleaned
+
+
+def validate_body_text(body_text: str) -> list[str]:
+    sections = _extract_sections(body_text)
+    errors: list[str] = []
+    for section_name in REQUIRED_SECTIONS:
+        if section_name not in sections:
+            errors.append(f"Section '{section_name}' is missing.")
+            continue
+        content = sections[section_name]
+        tokens = _normalized_tokens(content)
+        if not tokens:
+            errors.append(f"Section '{section_name}' is missing meaningful content.")
+            continue
+        lowered = " ".join(tokens).lower()
+        if any(token == marker for token in (item.lower() for item in tokens) for marker in PLACEHOLDER_MARKERS):
+            errors.append(f"Section '{section_name}' must not be placeholder text.")
+            continue
+        if section_name == "Coverage and Metrics" and lowered == "n/a":
+            errors.append("Section 'Coverage and Metrics' must explain N/A.")
+    return errors
+
+
+def main() -> int:
+    args = parse_args()
+    body_text = load_body_text(args)
+    errors = validate_body_text(body_text)
+    if errors:
+        for error in errors:
+            print(error)
+        return 1
+    print("PR evidence looks valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_pr_evidence.py
+++ b/scripts/validate_pr_evidence.py
@@ -60,11 +60,17 @@ def _extract_sections(body_text: str) -> dict[str, str]:
 
 def _normalized_tokens(body_text: str) -> list[str]:
     cleaned = []
+    in_fence = False
     for raw_line in body_text.splitlines():
         line = raw_line.strip()
-        if not line or line.startswith("```"):
+        if not line:
             continue
-        if line.startswith("- "):
+        if line.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence and line.startswith("#"):
+            continue
+        if not in_fence and line.startswith("- "):
             line = line[2:].strip()
         cleaned.append(line)
     return cleaned

--- a/scripts/validate_pr_evidence.py
+++ b/scripts/validate_pr_evidence.py
@@ -62,12 +62,23 @@ def _normalized_tokens(body_text: str) -> list[str]:
     cleaned = []
     for raw_line in body_text.splitlines():
         line = raw_line.strip()
-        if not line or line in {"```", "```text"}:
+        if not line or line.startswith("```"):
             continue
         if line.startswith("- "):
             line = line[2:].strip()
         cleaned.append(line)
     return cleaned
+
+
+def _is_placeholder_token(token: str) -> bool:
+    lowered = token.strip().lower()
+    for marker in PLACEHOLDER_MARKERS:
+        if lowered == marker:
+            return True
+        if lowered.startswith(marker) and len(lowered) > len(marker):
+            if not lowered[len(marker)].isalnum():
+                return True
+    return False
 
 
 def validate_body_text(body_text: str) -> list[str]:
@@ -83,7 +94,7 @@ def validate_body_text(body_text: str) -> list[str]:
             errors.append(f"Section '{section_name}' is missing meaningful content.")
             continue
         lowered = " ".join(tokens).lower()
-        if any(token == marker for token in (item.lower() for item in tokens) for marker in PLACEHOLDER_MARKERS):
+        if any(_is_placeholder_token(token) for token in tokens):
             errors.append(f"Section '{section_name}' must not be placeholder text.")
             continue
         if section_name == "Coverage and Metrics" and lowered == "n/a":

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -174,7 +174,25 @@ struct RequestCoordinatorTests {
         initialConsumer.cancel()
         _ = await initialConsumer.result
 
-        try? await Task.sleep(nanoseconds: 80_000_000)
+        for _ in 0..<100 {
+            let metrics = await metricsStore.snapshot()
+            if metrics.values["http.stream_disconnect_count", default: 0] >= 1 {
+                break
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        let terminalProgress = try #require(await waitForProgress(
+            schedulerReadModel: schedulerReadModel,
+            requestID: "req-resume-timeout",
+            phase: .requestFailed
+        ))
+
+        var metrics = await metricsStore.snapshot()
+        for _ in 0..<100 where metrics.values["disconnect.terminal_failure_count", default: 0] < 1 {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+            metrics = await metricsStore.snapshot()
+        }
 
         do {
             _ = try await coordinator.resumeChatCompletion(requestID: "req-resume-timeout")
@@ -183,21 +201,10 @@ struct RequestCoordinatorTests {
             #expect(error == .requestNotResumable)
         }
 
-        var metrics = await metricsStore.snapshot()
-        for _ in 0..<100 where metrics.values["disconnect.terminal_failure_count", default: 0] < 1 {
-            try? await Task.sleep(nanoseconds: 10_000_000)
-            metrics = await metricsStore.snapshot()
-        }
-        let terminalProgress = await waitForProgress(
-            schedulerReadModel: schedulerReadModel,
-            requestID: "req-resume-timeout",
-            phase: .requestFailed
-        )
-
         #expect(await workerClient.abortedRequestIDs == ["req-resume-timeout"])
         #expect(metrics.values["disconnect.terminal_failure_count", default: 0] == 1)
         #expect(metrics.values["disconnect.resume_success_rate", default: 0] == 0)
-        #expect(terminalProgress?.phase == .requestFailed)
+        #expect(terminalProgress.phase == .requestFailed)
     }
 
     @Test("queued request cancellation succeeds before a worker is bound")

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -1174,14 +1174,9 @@ struct RequestCoordinatorTests {
         }
         defer { consumer.cancel() }
 
-        let admittedProgress = await waitForProgress(
-            schedulerReadModel: schedulerReadModel,
-            requestID: "req-hot",
-            phase: .requestAdmitted
-        )
-        #expect(admittedProgress?.lane == "text.prefill.hot")
-
         _ = try #require(await waitForDecodeRequest(workerClient: workerClient))
+        let laneProgress = await schedulerReadModel.progressSnapshot(for: "req-hot")
+        #expect(laneProgress?.lane == "text.prefill.hot")
         await workerClient.emitDecodeStarted(requestID: "req-hot", decodeHandle: "decode-hot")
         await workerClient.emitToken(requestID: "req-hot", text: "hot")
         await workerClient.finishDecode(requestID: "req-hot")
@@ -1255,14 +1250,9 @@ struct RequestCoordinatorTests {
         }
         defer { consumer.cancel() }
 
-        let admittedProgress = await waitForProgress(
-            schedulerReadModel: schedulerReadModel,
-            requestID: "req-partial-restore",
-            phase: .requestAdmitted
-        )
-        #expect(admittedProgress?.lane == "text.prefill.hot")
-
         _ = try #require(await waitForDecodeRequest(workerClient: workerClient))
+        let laneProgress = await schedulerReadModel.progressSnapshot(for: "req-partial-restore")
+        #expect(laneProgress?.lane == "text.prefill.hot")
         await workerClient.emitDecodeStarted(requestID: "req-partial-restore", decodeHandle: "decode-req-partial-restore")
         await workerClient.emitToken(requestID: "req-partial-restore", text: "partial")
         await workerClient.finishDecode(requestID: "req-partial-restore")
@@ -1687,14 +1677,9 @@ struct RequestCoordinatorTests {
         }
         defer { consumer.cancel() }
 
-        let admittedProgress = await waitForProgress(
-            schedulerReadModel: schedulerReadModel,
-            requestID: "req-cold-prefill",
-            phase: .requestAdmitted
-        )
-        #expect(admittedProgress?.lane == "text.prefill.background")
-
         _ = try #require(await waitForDecodeRequest(workerClient: workerClient))
+        let laneProgress = await schedulerReadModel.progressSnapshot(for: "req-cold-prefill")
+        #expect(laneProgress?.lane == "text.prefill.background")
         await workerClient.emitDecodeStarted(requestID: "req-cold-prefill", decodeHandle: "decode-cold")
         await workerClient.finishDecode(requestID: "req-cold-prefill")
         _ = await consumer.result

--- a/services/mlx-worker-python/tests/test_benchmark_schemas.py
+++ b/services/mlx-worker-python/tests/test_benchmark_schemas.py
@@ -333,9 +333,9 @@ def test_build_evaluation_job_and_result_remain_distinct_from_serving_shape() ->
         suite_id="mmlu",
         dataset_id="mmlu-dev",
         sample_size=64,
-        metrics={"eval.mmlu.accuracy": 0.72, "eval.mmlu.loss": 0.18},
+        metrics={"eval.mmlu.threshold_pass_rate": 0.72, "eval.mmlu.typed_score_mean": 0.18},
         report_path="/tmp/melix-eval/mmlu.json",
-        units={"eval.mmlu.accuracy": "ratio", "eval.mmlu.loss": "loss"},
+        units={"eval.mmlu.threshold_pass_rate": "ratio", "eval.mmlu.typed_score_mean": "ratio"},
     )
 
     job_payload = job.to_dict()
@@ -350,6 +350,6 @@ def test_build_evaluation_job_and_result_remain_distinct_from_serving_shape() ->
     assert job_payload["output_dir"] == "/tmp/melix-eval/runs/eval-7"
     assert result_payload["schema_version"] == "melix.evaluation_result.v2"
     assert result_payload["metrics"] == [
-        {"name": "eval.mmlu.accuracy", "unit": "ratio", "value": 0.72},
-        {"name": "eval.mmlu.loss", "unit": "loss", "value": 0.18},
+        {"name": "eval.mmlu.threshold_pass_rate", "unit": "ratio", "value": 0.72},
+        {"name": "eval.mmlu.typed_score_mean", "unit": "ratio", "value": 0.18},
     ]

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -10,6 +10,24 @@ from worker.engine import code_eval_runner
 from worker.engine.code_eval_runner import run_python_code_evaluation
 
 
+def test_extract_candidate_code_handles_empty_plaintext_and_code_blocks() -> None:
+    assert code_eval_runner.extract_candidate_code("   ") == ("", "empty_prediction")
+    assert code_eval_runner.extract_candidate_code("print('hi')") == ("print('hi')", "parsed_code")
+    assert code_eval_runner.extract_candidate_code("```python\nprint('hi')\n```") == (
+        "print('hi')",
+        "parsed_code_block",
+    )
+
+
+def test_is_code_execution_policy_supported_requires_sandboxed_policy_and_binary(monkeypatch) -> None:
+    monkeypatch.setattr(code_eval_runner.shutil, "which", lambda _: "/usr/bin/sandbox-exec")
+    assert code_eval_runner.is_code_execution_policy_supported(" sandboxed ") is True
+    assert code_eval_runner.is_code_execution_policy_supported("host") is False
+
+    monkeypatch.setattr(code_eval_runner.shutil, "which", lambda _: None)
+    assert code_eval_runner.is_code_execution_policy_supported("sandboxed") is False
+
+
 def test_run_python_code_evaluation_ignores_candidate_stdout_before_payload() -> None:
     result = run_python_code_evaluation(
         candidate_code=textwrap.dedent(
@@ -258,6 +276,97 @@ def test_run_python_code_evaluation_uses_stderr_when_payload_is_missing(monkeypa
 
 def test_count_tests_falls_back_for_syntax_error_input() -> None:
     assert code_eval_runner._count_tests("assert True\n  assert False") == 2
+
+
+def test_read_limited_text_handles_missing_and_oversized_files(tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing.txt"
+    assert code_eval_runner._read_limited_text(missing_path, 8) == ""
+
+    output_path = tmp_path / "output.txt"
+    output_path.write_text("0123456789abcdef", encoding="utf-8")
+
+    assert code_eval_runner._read_limited_text(output_path, 4) == "cdef"
+
+
+def test_timeout_and_output_limit_failure_details_include_stdio_when_present() -> None:
+    assert code_eval_runner._timeout_failure_detail(
+        timeout_seconds=2,
+        stdout_tail="out",
+        stderr_tail="err",
+    ) == "Timed out after 2s. stdout tail: out | stderr tail: err"
+    assert code_eval_runner._output_limit_failure_detail(
+        stdio_limit_bytes=128,
+        stdout_tail="",
+        stderr_tail="",
+    ) == "Code execution exceeded the 128-byte stdio limit."
+
+
+def test_sandbox_python_executable_prefers_python_app_launcher_when_present(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    resolved = tmp_path / "Frameworks" / "Python.framework" / "Versions" / "3.12" / "bin" / "python3.12"
+    resolved.parent.mkdir(parents=True)
+    resolved.write_text("", encoding="utf-8")
+    launcher = (
+        resolved.parent.parent
+        / "Resources"
+        / "Python.app"
+        / "Contents"
+        / "MacOS"
+        / "Python"
+    )
+    launcher.parent.mkdir(parents=True)
+    launcher.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(code_eval_runner.sys, "executable", str(resolved))
+
+    assert code_eval_runner._sandbox_python_executable() == launcher.resolve()
+
+
+def test_sandbox_executable_paths_keep_wrapper_allowed_when_launcher_is_preferred(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    resolved = tmp_path / "Frameworks" / "Python.framework" / "Versions" / "3.12" / "bin" / "python3.12"
+    resolved.parent.mkdir(parents=True)
+    resolved.write_text("", encoding="utf-8")
+    launcher = (
+        resolved.parent.parent
+        / "Resources"
+        / "Python.app"
+        / "Contents"
+        / "MacOS"
+        / "Python"
+    )
+    launcher.parent.mkdir(parents=True)
+    launcher.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(code_eval_runner.sys, "executable", str(resolved))
+
+    paths = code_eval_runner._sandbox_executable_paths()
+
+    assert paths[0] == launcher.resolve()
+    assert resolved.resolve() in paths
+
+
+def test_sandbox_allow_path_variants_falls_back_when_resolve_raises() -> None:
+    class BrokenPath:
+        def __init__(self, label: str) -> None:
+            self.label = label
+
+        def resolve(self):
+            raise OSError("broken resolve")
+
+        def __hash__(self) -> int:
+            return hash(self.label)
+
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, BrokenPath) and self.label == other.label
+
+    broken = BrokenPath("broken")
+
+    assert code_eval_runner._sandbox_allow_path_variants((broken,)) == (broken,)
 
 
 def test_count_tests_falls_back_when_no_asserts_are_present() -> None:

--- a/services/mlx-worker-python/tests/test_integration_helpers.py
+++ b/services/mlx-worker-python/tests/test_integration_helpers.py
@@ -257,3 +257,56 @@ def test_read_metrics_export_parses_json_payload(tmp_path: Path) -> None:
     metrics_path.write_text(json.dumps(payload), encoding="utf-8")
 
     assert helpers.read_metrics_export(metrics_path) == payload
+
+
+def test_wait_for_metric_value_returns_payload_once_threshold_is_reached(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text("{}", encoding="utf-8")
+    payloads = iter(
+        [
+            {"values": {"scheduler.multimodal_active_requests": 0}},
+            {"values": {"scheduler.multimodal_active_requests": 1}},
+        ]
+    )
+    perf_times = iter([0.0, 0.01, 0.02, 0.03])
+
+    monkeypatch.setattr(helpers, "read_metrics_export", lambda path: next(payloads))
+    monkeypatch.setattr(helpers.time, "time", lambda: next(perf_times))
+    monkeypatch.setattr(helpers.time, "sleep", lambda seconds: None)
+
+    payload = helpers.wait_for_metric_value(
+        metrics_path,
+        "scheduler.multimodal_active_requests",
+        minimum=1,
+        timeout_seconds=0.05,
+    )
+
+    assert payload == {"values": {"scheduler.multimodal_active_requests": 1}}
+
+
+def test_wait_for_metric_value_raises_when_threshold_is_never_reached(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text("{}", encoding="utf-8")
+    perf_times = iter([0.0, 0.02, 0.04, 0.06])
+
+    monkeypatch.setattr(
+        helpers,
+        "read_metrics_export",
+        lambda path: {"values": {"scheduler.multimodal_active_requests": 0}},
+    )
+    monkeypatch.setattr(helpers.time, "time", lambda: next(perf_times))
+    monkeypatch.setattr(helpers.time, "sleep", lambda seconds: None)
+
+    with pytest.raises(AssertionError, match="scheduler.multimodal_active_requests"):
+        helpers.wait_for_metric_value(
+            metrics_path,
+            "scheduler.multimodal_active_requests",
+            minimum=1,
+            timeout_seconds=0.05,
+        )

--- a/services/mlx-worker-python/tests/test_m15_desktop_polish_smoke_script.py
+++ b/services/mlx-worker-python/tests/test_m15_desktop_polish_smoke_script.py
@@ -28,6 +28,7 @@ def test_run_swift_smoke_uses_menubar_specific_swift_harness(
     captured: dict[str, object] = {}
 
     class _Completed:
+        returncode = 0
         stdout = (
             'M15_DESKTOP_POLISH_SMOKE={"chat":{"presentation_lag_ms":1,"presentation_flush_count":2},'
             '"signals":{"top_banner_title":"Download Recovery Available","download_recovery_visible":1,'
@@ -109,6 +110,7 @@ def test_run_swift_smoke_requires_marker(
     module = _load_module()
 
     class _Completed:
+        returncode = 0
         stdout = "ok"
         stderr = ""
 

--- a/services/mlx-worker-python/tests/test_m15_desktop_polish_smoke_script.py
+++ b/services/mlx-worker-python/tests/test_m15_desktop_polish_smoke_script.py
@@ -116,3 +116,50 @@ def test_run_swift_smoke_requires_marker(
 
     with pytest.raises(RuntimeError, match="M15_DESKTOP_POLISH_SMOKE"):
         module.run_swift_smoke(tmp_path)
+
+
+def test_run_swift_smoke_retries_transient_swiftpm_lock_conflicts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    calls: list[list[str]] = []
+    sleep_calls: list[float] = []
+
+    class _Completed:
+        def __init__(self, *, returncode: int, stdout: str = "", stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    responses = [
+        _Completed(
+            returncode=1,
+            stderr="Another instance of SwiftPM (PID: 12345) is already running using '/tmp/melix/apps/macos-menubar'",
+        ),
+        _Completed(
+            returncode=0,
+            stdout=(
+                'M15_DESKTOP_POLISH_SMOKE={"chat":{"presentation_lag_ms":1,"presentation_flush_count":2},'
+                '"signals":{"top_banner_title":"Download Recovery Available","download_recovery_visible":1,'
+                '"update_signal_visible":1,"update_signal_dismissible":1},'
+                '"persistence":{"operator_session_restore_ms":3,"operator_session_persist_write_ms":4,'
+                '"persisted_download_queue_count":1,"restored_download_queue_count":1,'
+                '"restored_selected_tool_section":"downloads"},'
+                '"navigation":{"grounded_surface_count":5,"grounded_tool_section_count":6}}\n'
+            ),
+        ),
+    ]
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return responses.pop(0)
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.setattr(module.time, "sleep", sleep_calls.append)
+
+    payload = module.run_swift_smoke(tmp_path)
+
+    assert payload["navigation"]["grounded_surface_count"] == 5
+    assert len(calls) == 2
+    assert sleep_calls == [module._SWIFTPM_LOCK_BACKOFF_SECONDS]

--- a/services/mlx-worker-python/tests/test_m9_release_gate_smoke.py
+++ b/services/mlx-worker-python/tests/test_m9_release_gate_smoke.py
@@ -7,6 +7,7 @@ import pytest
 
 
 MODULE_PATH = Path(__file__).resolve().parents[3] / "scripts" / "m9_release_gate_smoke.py"
+REPO_ROOT = Path(__file__).resolve().parents[3]
 MODULE_SPEC = importlib.util.spec_from_file_location("m9_release_gate_smoke", MODULE_PATH)
 assert MODULE_SPEC is not None
 assert MODULE_SPEC.loader is not None
@@ -82,3 +83,9 @@ def test_main_returns_nonzero_for_failing_fixture(
 
     assert '"passed": false' in output
     assert '"release_gate.m9_missing_probe_count": 1.0' in output
+
+
+def test_run_smoke_passes_for_passing_fixture() -> None:
+    payload = m9_release_gate_smoke.run_smoke(REPO_ROOT, "passing")
+
+    assert payload["passed"] is True

--- a/services/mlx-worker-python/tests/test_release_gates.py
+++ b/services/mlx-worker-python/tests/test_release_gates.py
@@ -1557,8 +1557,8 @@ def test_default_policy_includes_audio_section() -> None:
 
 def test_default_policy_includes_evaluation_section() -> None:
     assert "evaluation" in DEFAULT_RELEASE_GATE_POLICY
-    assert "eval.mmlu.accuracy" in DEFAULT_RELEASE_GATE_POLICY["evaluation"]
-    assert DEFAULT_RELEASE_GATE_POLICY["evaluation"]["eval.mmlu.accuracy"]["min"] == 0.5
+    assert "eval.mmlu.typed_score_mean" in DEFAULT_RELEASE_GATE_POLICY["evaluation"]
+    assert DEFAULT_RELEASE_GATE_POLICY["evaluation"]["eval.mmlu.typed_score_mean"]["min"] == 0.5
     assert "evaluation_compare" in DEFAULT_RELEASE_GATE_POLICY
     assert DEFAULT_RELEASE_GATE_POLICY["evaluation_compare"]["mmlu"]["effect_threshold"] == 0.1
     assert DEFAULT_RELEASE_GATE_POLICY["evaluation_compare"]["mmlu"]["required_verdict"] == "improvement"
@@ -1572,7 +1572,7 @@ def test_checked_in_release_gate_policy_includes_evaluation_thresholds() -> None
     assert "audio" in policy
     assert policy["audio"]["slim.audio_runtime_pack_recovery_success_rate"]["min"] == 100.0
     assert "evaluation" in policy
-    assert policy["evaluation"]["eval.mmlu.accuracy"]["min"] == 0.5
+    assert policy["evaluation"]["eval.mmlu.typed_score_mean"]["min"] == 0.5
     assert "evaluation_compare" in policy
     assert policy["evaluation_compare"]["mmlu"]["bootstrap_iterations"] == 400
     assert "m9" in policy
@@ -1584,7 +1584,7 @@ def test_collect_evaluation_evidence_returns_metrics(tmp_path: Path) -> None:
     evidence = collect_evaluation_evidence(tmp_path / "jobs")
 
     assert "metrics" in evidence
-    assert evidence["metrics"]["eval.mmlu.accuracy"] == 1.0
+    assert evidence["metrics"]["eval.mmlu.typed_score_mean"] == 1.0
     assert evidence["job"]["suite_id"] == "mmlu"
     assert evidence["result"]["suite_id"] == "mmlu"
 
@@ -1795,7 +1795,7 @@ def test_evaluate_evaluation_compare_evidence_checks_each_target_summary() -> No
     )
 
 
-def test_evaluate_release_gate_fails_on_low_eval_accuracy() -> None:
+def test_evaluate_release_gate_fails_on_low_eval_primary_score() -> None:
     policy = load_release_gate_policy()
     report = {
         "install": {
@@ -1866,7 +1866,7 @@ def test_evaluate_release_gate_fails_on_low_eval_accuracy() -> None:
         },
         "evaluation": {
             "metrics": {
-                "eval.mmlu.accuracy": 0.3,
+                "eval.mmlu.typed_score_mean": 0.3,
             },
         },
         "evaluation_compare": _passing_evaluation_compare_evidence(),
@@ -1876,7 +1876,7 @@ def test_evaluate_release_gate_fails_on_low_eval_accuracy() -> None:
 
     failures = evaluate_release_gate(report, policy)
 
-    assert "eval.mmlu.accuracy=0.30 fell below minimum 0.50" in failures
+    assert "eval.mmlu.typed_score_mean=0.30 fell below minimum 0.50" in failures
 
 
 def test_evaluate_release_gate_fails_on_compare_regression_verdict() -> None:
@@ -1950,7 +1950,7 @@ def test_evaluate_release_gate_fails_on_compare_regression_verdict() -> None:
         },
         "evaluation": {
             "metrics": {
-                "eval.mmlu.accuracy": 0.75,
+                "eval.mmlu.typed_score_mean": 0.75,
             },
         },
         "evaluation_compare": _passing_evaluation_compare_evidence(verdict="regression"),
@@ -1963,7 +1963,7 @@ def test_evaluate_release_gate_fails_on_compare_regression_verdict() -> None:
     assert "evaluation_compare.mmlu verdict=regression did not satisfy required verdict improvement" in failures
 
 
-def test_evaluate_release_gate_passes_with_sufficient_eval_accuracy() -> None:
+def test_evaluate_release_gate_passes_with_sufficient_eval_primary_score() -> None:
     policy = load_release_gate_policy()
     report = {
         "install": {
@@ -2012,7 +2012,7 @@ def test_evaluate_release_gate_passes_with_sufficient_eval_accuracy() -> None:
         },
         "evaluation": {
             "metrics": {
-                "eval.mmlu.accuracy": 0.75,
+                "eval.mmlu.typed_score_mean": 0.75,
             },
         },
         "evaluation_compare": _passing_evaluation_compare_evidence(),

--- a/services/mlx-worker-python/tests/test_release_gates.py
+++ b/services/mlx-worker-python/tests/test_release_gates.py
@@ -1041,6 +1041,7 @@ def test_evaluate_release_gate_fails_closed_for_missing_real_workload_evidence()
 
     failures = evaluate_release_gate(report, policy)
 
+    assert "eval.mmlu.typed_score_mean is missing" not in failures
     assert "real_workload evidence is missing" in failures
 
 
@@ -1596,6 +1597,63 @@ def test_release_gate_evaluation_backend_covers_cancel_and_non_arithmetic_prompt
 
     assert list(backend.generate_tokens({}, "2 + 2 ?", None, canceled)) == []
     assert list(backend.generate_tokens({}, "hello world", None, active)) == ["Answer: 0"]
+
+
+def test_evaluation_metric_alias_helper_backfills_canonical_and_legacy_names() -> None:
+    metrics = {"eval.mmlu.accuracy": 0.75}
+
+    normalized = release_gates_module._with_evaluation_metric_aliases(
+        metrics,
+        suite_id="mmlu",
+        primary_score_value=0.5,
+    )
+
+    assert normalized["eval.mmlu.typed_score_mean"] == 0.75
+    assert normalized["eval.mmlu.accuracy"] == 0.75
+
+
+def test_evaluation_metric_alias_helper_uses_primary_score_when_metrics_are_missing() -> None:
+    normalized = release_gates_module._with_evaluation_metric_aliases(
+        {},
+        suite_id="mmlu",
+        primary_score_value=0.5,
+    )
+
+    assert normalized["eval.mmlu.typed_score_mean"] == 0.5
+    assert normalized["eval.mmlu.accuracy"] == 0.5
+
+
+def test_evaluation_metric_alias_helper_leaves_metrics_unchanged_without_numeric_source() -> None:
+    metrics = {"eval.mmlu.label": "n/a"}
+
+    normalized = release_gates_module._with_evaluation_metric_aliases(
+        metrics,
+        suite_id="mmlu",
+        primary_score_value="unknown",
+    )
+
+    assert normalized == metrics
+
+
+def test_normalize_evaluation_metrics_for_policy_handles_non_dict_inputs() -> None:
+    assert release_gates_module._normalize_evaluation_metrics_for_policy([], {}) == {}
+    assert release_gates_module._normalize_evaluation_metrics_for_policy(
+        {"eval.mmlu.accuracy": 0.75},
+        [],
+    ) == {"eval.mmlu.accuracy": 0.75}
+
+
+def test_normalize_evaluation_metrics_for_policy_ignores_non_metric_rules() -> None:
+    normalized = release_gates_module._normalize_evaluation_metrics_for_policy(
+        {"eval.mmlu.accuracy": 0.75},
+        {
+            "eval.mmlu.typed_score_mean": {"min": 0.5},
+            "non_metric_rule": {"min": 1.0},
+        },
+    )
+
+    assert normalized["eval.mmlu.typed_score_mean"] == 0.75
+    assert normalized["eval.mmlu.accuracy"] == 0.75
 
 
 def test_collect_evaluation_compare_evidence_returns_release_summary(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_validate_pr_evidence.py
+++ b/services/mlx-worker-python/tests/test_validate_pr_evidence.py
@@ -158,6 +158,28 @@ make py-test
     assert "Section 'Known Gaps' must not be placeholder text." in errors
 
 
+def test_validate_body_text_rejects_placeholder_comment_inside_commands_fence() -> None:
+    body = """
+## Plan or Spec
+- docs/plans/2026-04-15-ci-failure-remediation.md
+
+## Commands Run
+```text
+# paste the commands you ran and their outcomes
+```
+
+## Coverage and Metrics
+- N/A: workflow-only change.
+
+## Known Gaps
+- GitHub validation still pending.
+"""
+
+    errors = validate_pr_evidence.validate_body_text(body)
+
+    assert "Section 'Commands Run' is missing meaningful content." in errors
+
+
 def test_main_returns_non_zero_when_body_is_invalid(monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         validate_pr_evidence,

--- a/services/mlx-worker-python/tests/test_validate_pr_evidence.py
+++ b/services/mlx-worker-python/tests/test_validate_pr_evidence.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import runpy
+import sys
 from pathlib import Path
+
+import pytest
 
 
 MODULE_PATH = Path(__file__).resolve().parents[3] / "scripts" / "validate_pr_evidence.py"
@@ -27,6 +31,38 @@ def test_load_body_text_reads_pull_request_body_from_event(tmp_path: Path) -> No
         )
         == "## Plan or Spec\n- docs/plans/example.md\n"
     )
+
+
+def test_load_body_text_reads_body_file_when_provided(tmp_path: Path) -> None:
+    body_path = tmp_path / "body.md"
+    body_path.write_text("## Plan or Spec\n- docs/plans/example.md\n", encoding="utf-8")
+
+    assert (
+        validate_pr_evidence.load_body_text(
+            argparse.Namespace(body_file=str(body_path), event_path=None)
+        )
+        == "## Plan or Spec\n- docs/plans/example.md\n"
+    )
+
+
+def test_load_body_text_requires_an_input_source() -> None:
+    with pytest.raises(ValueError, match="Either --body-file or --event-path is required."):
+        validate_pr_evidence.load_body_text(
+            argparse.Namespace(body_file=None, event_path=None)
+        )
+
+
+def test_load_body_text_rejects_non_string_pr_body(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps({"pull_request": {"body": ["not", "a", "string"]}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="pull_request.body must be a string."):
+        validate_pr_evidence.load_body_text(
+            argparse.Namespace(body_file=None, event_path=str(event_path))
+        )
 
 
 def test_validate_body_text_accepts_complete_sections() -> None:
@@ -78,6 +114,50 @@ def test_validate_body_text_reports_missing_or_placeholder_sections() -> None:
     assert "Section 'Known Gaps' must not be placeholder text." in errors
 
 
+def test_validate_body_text_rejects_empty_non_text_code_fence() -> None:
+    body = """
+## Plan or Spec
+- docs/plans/2026-04-15-ci-failure-remediation.md
+
+## Commands Run
+```bash
+```
+
+## Coverage and Metrics
+- N/A: workflow-only change.
+
+## Known Gaps
+- GitHub-hosted validation still required.
+"""
+
+    errors = validate_pr_evidence.validate_body_text(body)
+
+    assert "Section 'Commands Run' is missing meaningful content." in errors
+
+
+def test_validate_body_text_rejects_placeholder_prefixes() -> None:
+    body = """
+## Plan or Spec
+- TBD: add final plan reference.
+
+## Commands Run
+```text
+make py-test
+```
+
+## Coverage and Metrics
+- N/A: validation-only change.
+
+## Known Gaps
+- TODO: fill later.
+"""
+
+    errors = validate_pr_evidence.validate_body_text(body)
+
+    assert "Section 'Plan or Spec' must not be placeholder text." in errors
+    assert "Section 'Known Gaps' must not be placeholder text." in errors
+
+
 def test_main_returns_non_zero_when_body_is_invalid(monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         validate_pr_evidence,
@@ -91,3 +171,68 @@ def test_main_returns_non_zero_when_body_is_invalid(monkeypatch, capsys) -> None
     output = capsys.readouterr().out
     assert "Section 'Plan or Spec' is missing." in output
     assert "Section 'Commands Run' is missing." in output
+
+
+def test_main_returns_zero_when_body_is_valid(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        validate_pr_evidence,
+        "parse_args",
+        lambda: argparse.Namespace(body_file="/tmp/body.md", event_path=None),
+    )
+    monkeypatch.setattr(
+        validate_pr_evidence,
+        "load_body_text",
+        lambda args: """
+## Plan or Spec
+- docs/plans/2026-04-15-ci-failure-remediation.md
+
+## Commands Run
+```text
+make proto-check
+```
+
+## Coverage and Metrics
+- N/A: workflow-only change.
+
+## Known Gaps
+- GitHub validation still pending.
+""",
+    )
+
+    assert validate_pr_evidence.main() == 0
+
+    output = capsys.readouterr().out
+    assert "PR evidence looks valid." in output
+
+
+def test_script_entrypoint_exits_zero_for_valid_body_file(tmp_path: Path, monkeypatch, capsys) -> None:
+    body_path = tmp_path / "body.md"
+    body_path.write_text(
+        """
+## Plan or Spec
+- docs/plans/2026-04-15-ci-failure-remediation.md
+
+## Commands Run
+```text
+make proto-check
+```
+
+## Coverage and Metrics
+- N/A: workflow-only change.
+
+## Known Gaps
+- GitHub validation still pending.
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["validate_pr_evidence.py", "--body-file", str(body_path)],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(MODULE_PATH), run_name="__main__")
+
+    assert excinfo.value.code == 0
+    assert "PR evidence looks valid." in capsys.readouterr().out

--- a/services/mlx-worker-python/tests/test_validate_pr_evidence.py
+++ b/services/mlx-worker-python/tests/test_validate_pr_evidence.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / "scripts" / "validate_pr_evidence.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("validate_pr_evidence", MODULE_PATH)
+assert MODULE_SPEC is not None
+assert MODULE_SPEC.loader is not None
+validate_pr_evidence = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(validate_pr_evidence)
+
+
+def test_load_body_text_reads_pull_request_body_from_event(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps({"pull_request": {"body": "## Plan or Spec\n- docs/plans/example.md\n"}}),
+        encoding="utf-8",
+    )
+
+    assert (
+        validate_pr_evidence.load_body_text(
+            argparse.Namespace(body_file=None, event_path=str(event_path))
+        )
+        == "## Plan or Spec\n- docs/plans/example.md\n"
+    )
+
+
+def test_validate_body_text_accepts_complete_sections() -> None:
+    body = """
+## Summary
+- Add CI workflows.
+
+## Plan or Spec
+- docs/plans/2026-04-15-ci-github-actions.md
+
+## Commands Run
+```text
+make py-test
+make integration-test
+```
+
+## Coverage and Metrics
+- N/A: CI configuration change only.
+
+## Known Gaps
+- Swift gate still pending a clean baseline run on GitHub-hosted macOS.
+"""
+
+    assert validate_pr_evidence.validate_body_text(body) == []
+
+
+def test_validate_body_text_reports_missing_or_placeholder_sections() -> None:
+    body = """
+## Summary
+- Add CI workflows.
+
+## Plan or Spec
+- TBD
+
+## Commands Run
+
+## Coverage and Metrics
+- N/A
+
+## Known Gaps
+- TODO
+"""
+
+    errors = validate_pr_evidence.validate_body_text(body)
+
+    assert "Section 'Plan or Spec' must not be placeholder text." in errors
+    assert "Section 'Commands Run' is missing meaningful content." in errors
+    assert "Section 'Coverage and Metrics' must explain N/A." in errors
+    assert "Section 'Known Gaps' must not be placeholder text." in errors
+
+
+def test_main_returns_non_zero_when_body_is_invalid(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        validate_pr_evidence,
+        "parse_args",
+        lambda: argparse.Namespace(body_file=None, event_path="/tmp/event.json"),
+    )
+    monkeypatch.setattr(validate_pr_evidence, "load_body_text", lambda args: "## Summary\n- hi\n")
+
+    assert validate_pr_evidence.main() == 1
+
+    output = capsys.readouterr().out
+    assert "Section 'Plan or Spec' is missing." in output
+    assert "Section 'Commands Run' is missing." in output

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -302,10 +302,11 @@ def _sandbox_profile(*, temp_root: Path) -> str:
 
 
 def _sandbox_executable_paths() -> tuple[Path, ...]:
-    resolved = _sandbox_python_executable()
-    paths = [resolved]
-    launcher_path = resolved.parent.parent / "Resources" / "Python.app" / "Contents" / "MacOS" / "Python"
-    if launcher_path.exists():
+    resolved = _resolved_python_executable()
+    preferred = _sandbox_python_executable()
+    paths = [preferred, resolved]
+    launcher_path = _python_framework_launcher_path(resolved)
+    if launcher_path is not None:
         paths.append(launcher_path)
     deduped: list[Path] = []
     seen: set[Path] = set()
@@ -318,12 +319,27 @@ def _sandbox_executable_paths() -> tuple[Path, ...]:
 
 
 def _sandbox_python_executable() -> Path:
+    resolved = _resolved_python_executable()
+    launcher_path = _python_framework_launcher_path(resolved)
+    return launcher_path or resolved
+
+
+def _resolved_python_executable() -> Path:
     return Path(sys.executable).resolve()
+
+
+def _python_framework_launcher_path(resolved_executable: Path) -> Path | None:
+    launcher_path = (
+        resolved_executable.parent.parent / "Resources" / "Python.app" / "Contents" / "MacOS" / "Python"
+    )
+    if launcher_path.exists():
+        return launcher_path.resolve()
+    return None
 
 
 def _sandbox_runtime_read_paths() -> tuple[Path, ...]:
     roots: list[Path] = [
-        _sandbox_python_executable().parent.parent,
+        _resolved_python_executable().parent.parent,
         Path(sys.prefix).resolve(),
         Path(sys.exec_prefix).resolve(),
         Path(sys.base_prefix).resolve(),

--- a/services/mlx-worker-python/worker/productization/release_gates.py
+++ b/services/mlx-worker-python/worker/productization/release_gates.py
@@ -486,10 +486,11 @@ def collect_evaluation_evidence(jobs_root: str | Path) -> dict[str, Any]:
     metrics: dict[str, float] = {}
     for metric in run.result.metrics:
         metrics[metric.name] = metric.value
-    suite_metric_alias = f"eval.{run.result.suite_id}.accuracy"
-    if suite_metric_alias not in metrics:
-        if isinstance(run.result.primary_score_value, (int, float)):
-            metrics[suite_metric_alias] = float(run.result.primary_score_value)
+    metrics = _with_evaluation_metric_aliases(
+        metrics,
+        suite_id=run.result.suite_id,
+        primary_score_value=run.result.primary_score_value,
+    )
     return {
         "job": run.job.to_dict(),
         "result": run.result.to_dict(),
@@ -784,8 +785,12 @@ def evaluate_release_gate(report: dict[str, Any], policy: dict[str, Any]) -> lis
 
     evaluation = report.get("evaluation")
     if isinstance(evaluation, dict):
+        evaluation_metrics = _normalize_evaluation_metrics_for_policy(
+            evaluation.get("metrics", {}),
+            policy.get("evaluation", {}),
+        )
         failures.extend(
-            _evaluate_section_metrics(evaluation.get("metrics", {}), policy.get("evaluation", {}))
+            _evaluate_section_metrics(evaluation_metrics, policy.get("evaluation", {}))
         )
 
     evaluation_compare = report.get("evaluation_compare")
@@ -1445,6 +1450,56 @@ def _evaluate_section_metrics(
                 f"{display_name}={numeric:.2f} exceeded maximum {float(maximum):.2f}"
             )
     return failures
+
+
+def _with_evaluation_metric_aliases(
+    metrics: dict[str, float],
+    *,
+    suite_id: str,
+    primary_score_value: Any | None = None,
+) -> dict[str, float]:
+    normalized = dict(metrics)
+    typed_metric_name = f"eval.{suite_id}.typed_score_mean"
+    legacy_metric_name = f"eval.{suite_id}.accuracy"
+
+    candidate_value: float | None = None
+    for metric_name in (typed_metric_name, legacy_metric_name):
+        metric_value = normalized.get(metric_name)
+        if isinstance(metric_value, (int, float)):
+            candidate_value = float(metric_value)
+            break
+
+    if candidate_value is None and isinstance(primary_score_value, (int, float)):
+        candidate_value = float(primary_score_value)
+
+    if candidate_value is None:
+        return normalized
+
+    normalized.setdefault(typed_metric_name, candidate_value)
+    normalized.setdefault(legacy_metric_name, candidate_value)
+    return normalized
+
+
+def _normalize_evaluation_metrics_for_policy(
+    values: Any,
+    rules: Any,
+) -> dict[str, Any]:
+    if not isinstance(values, dict):
+        return {}
+    if not isinstance(rules, dict):
+        return dict(values)
+
+    normalized = dict(values)
+    for metric_name in rules:
+        if not (
+            isinstance(metric_name, str)
+            and metric_name.startswith("eval.")
+            and metric_name.endswith(".typed_score_mean")
+        ):
+            continue
+        suite_id = metric_name[len("eval.") : -len(".typed_score_mean")]
+        normalized = _with_evaluation_metric_aliases(normalized, suite_id=suite_id)
+    return normalized
 
 
 def _require_true(payload: dict[str, Any], dotted_key: str) -> list[str]:

--- a/services/mlx-worker-python/worker/productization/release_gates.py
+++ b/services/mlx-worker-python/worker/productization/release_gates.py
@@ -191,7 +191,7 @@ DEFAULT_RELEASE_GATE_POLICY: dict[str, Any] = {
     },
     "quantization": copy.deepcopy(DEFAULT_QUANTIZATION_GATE_POLICY),
     "evaluation": {
-        "eval.mmlu.accuracy": {"min": 0.5},
+        "eval.mmlu.typed_score_mean": {"min": 0.5},
     },
     "evaluation_compare": {
         "mmlu": {

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -605,6 +605,34 @@ def read_metrics_export(path: Path) -> dict[str, object]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def wait_for_metric_value(
+    path: Path,
+    key: str,
+    *,
+    minimum: float,
+    timeout_seconds: float = 10.0,
+    poll_interval_seconds: float = 0.1,
+) -> dict[str, object]:
+    deadline = time.time() + timeout_seconds
+    last_seen = 0.0
+
+    while time.time() < deadline:
+        if path.exists():
+            payload = read_metrics_export(path)
+            values = payload.get("values", {})
+            if isinstance(values, dict):
+                candidate = values.get(key, last_seen)
+                if isinstance(candidate, (int, float)):
+                    last_seen = float(candidate)
+                    if last_seen >= minimum:
+                        return payload
+        time.sleep(poll_interval_seconds)
+
+    raise AssertionError(
+        f"Metric {key} never reached {minimum} at {path}; last value was {last_seen}."
+    )
+
+
 def _format_process_failure(message: str, stdout_path: Path | None, stderr_path: Path | None) -> str:
     stdout = stdout_path.read_text(encoding="utf-8") if isinstance(stdout_path, Path) and stdout_path.exists() else ""
     stderr = stderr_path.read_text(encoding="utf-8") if isinstance(stderr_path, Path) and stderr_path.exists() else ""

--- a/tests/integration/test_phase6_operator_workflows.py
+++ b/tests/integration/test_phase6_operator_workflows.py
@@ -8,8 +8,10 @@ import threading
 import time
 import urllib.request
 
-from tests.integration.helpers import LiveMelixStack, read_metrics_export
+from tests.integration.helpers import LiveMelixStack, read_metrics_export, wait_for_metric_value
 from worker.productization.acceptance_metrics import build_phase6_vision_metrics_report
+
+INTERFERENCE_TRANSCRIPTION_DELAY_MS = "500"
 
 
 def _post_json(url: str, payload: dict[str, object], *, timeout: float = 10.0) -> tuple[int, object]:
@@ -61,7 +63,7 @@ def _start_image_fixture_server(payload: bytes, *, content_type: str = "image/pn
 def test_text_requests_record_interference_metrics_during_multimodal_load() -> None:
     stack = LiveMelixStack(
         Path(__file__).resolve().parents[2],
-        environment_overrides={"MELIX_DETERMINISTIC_TRANSCRIPTION_DELAY_MS": "150"},
+        environment_overrides={"MELIX_DETERMINISTIC_TRANSCRIPTION_DELAY_MS": INTERFERENCE_TRANSCRIPTION_DELAY_MS},
     )
 
     transcription_response: dict[str, object] = {}
@@ -84,7 +86,12 @@ def test_text_requests_record_interference_metrics_during_multimodal_load() -> N
 
         worker = threading.Thread(target=run_transcription, daemon=True)
         worker.start()
-        time.sleep(0.05)
+        wait_for_metric_value(
+            stack.control_plane_metrics_path,
+            "scheduler.multimodal_active_requests",
+            minimum=1,
+            timeout_seconds=5.0,
+        )
 
         chat_status, chat_payload = _post_json(
             stack.chat_url(),


### PR DESCRIPTION
## Summary
This PR hardens the repository CI and GitHub Actions surface for pull requests and release gates.

It adds a PR CI workflow, a PR evidence validation workflow, a repository PR template, Dependabot configuration, and helper make targets for proto drift and packaging smoke validation. It also tightens existing release and packaging workflows with concurrency controls, artifact capture, PR triggers, and release attachment behavior.

During implementation, validation exposed two baseline issues outside the YAML itself: stale MMLU evaluation defaults still using `normalized_exact_match`, and transient SwiftPM lock conflicts in the desktop polish smoke path. This PR fixes those validation-path regressions so the new CI checks pass end to end.

## Plan or Spec
- Implement the CI/GitHub Actions hardening plan in repo files only.
- Add PR validation and evidence enforcement to match the repository handoff contract.
- Keep branch protection and required-check configuration out of scope for this repo-only change.

## Commands Run
- `python3 scripts/validate_pr_evidence.py --body-file .github/pull_request_template.md`
- `make package-smoke`
- `make py-test`
- `xcrun swift test --package-path apps/macos-menubar --filter Phase8WindowUIAcceptanceRunnerTests`
- `make integration-test`

## Coverage and Metrics
- Coverage: `N/A` for this change set. The touched scope spans GitHub workflow YAML, repo scripts, and a small Swift acceptance path, and the repository does not currently expose a unified measured coverage command for that mixed surface.
- Validation metrics:
  - `make py-test`: `752 passed in 14.34s`
  - `xcrun swift test --package-path apps/macos-menubar --filter Phase8WindowUIAcceptanceRunnerTests`: `5 passed`
  - `make integration-test`: `85 passed in 17m41s`

## Known Gaps
- Remote GitHub settings were not changed. Branch protection, required checks, and merge policy still need to be applied in the GitHub repository settings or via API.
