### PR TITLE
feat: expand LoRA target presets and family hooks

### DIFF
--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -14,7 +14,7 @@ closed the original Phase 8 productization scope for this codebase.
 - local model registry management, including multi-root discovery, local import, and Hub-backed download flows
 - server session lifecycle workflows, including create, update, select, start, pause, resume, wake, and stop
 - local chat and operator workflows through the public `melix` CLI
-- LoRA and QLoRA training, adapter activation, derived-model lifecycle, and compare-ready outputs
+- LoRA and QLoRA training, adapter activation, derived-model lifecycle, compare-ready outputs, and architecture-aware LoRA target presets for stable dense text families
 - benchmark, matrix benchmark, evaluation, compare, and export flows from shared product-owned surfaces
 - a native macOS operator surface backed by the same CLI-first workflow authority used by the shipped product
 - packaging and install paths for launch agents, Homebrew service use, and preview app-bundle delivery
@@ -52,6 +52,7 @@ The current forward-looking LoRA expansion breakdown is tracked in:
 
 - Melix is intentionally scoped to macOS on Apple Silicon.
 - The current docs should be read as productized local-runtime documentation, not as a promise of cross-platform support.
+- LoRA family coverage is intentionally uneven today: `llama`, `qwen`, `gemma`, and `kimi` are the stable dense-family path; `mixtral` remains experimental through separate MoE hooks; `qwen3moe`, `deepseek-mla`, `mistral4`, `nemotron-h`, and embedding-family models are not yet productized for `train_lora`.
 - Disk-streaming remains an evidence-only boundary today. The repository documents the probes and unsupported-path evidence, but true SSD-backed runtime execution is still not shipped.
 - The historical plan archive is broader than the curated product docs. Use the execution index as an engineering record, not as shorthand for every archived plan being equally product-ready.
 - `progress.md` still tracks active repository-level verification notes. If you are working inside the repo, treat the latest progress log as the operational truth for known local issues.

--- a/docs/runbooks/phase-8-lora-adapter-workflow.md
+++ b/docs/runbooks/phase-8-lora-adapter-workflow.md
@@ -10,6 +10,7 @@ Prepare a local dataset package, train a Melix LoRA adapter, activate it into a 
 - the source model is a text-capable Melix model summary
 - the dataset exists either as a local `melix.training_dataset_package.v1` or as a supported Hugging Face dataset configuration
 - the target model family is supported by the current LoRA config mapper
+- operators understand whether the chosen family is stable, experimental, or currently blocked for LoRA training
 
 ## Window UI And CLI Entry Points
 
@@ -110,7 +111,7 @@ Use the following `ext` keys as the stable operator-facing inputs:
   "dataset_uri": "/absolute/path/to/dataset",
   "training_mode": "qlora",
   "target_repo": "melix/adapters/melix-dev-adapter",
-  "target_modules": "q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj",
+  "target_modules": "attention_mlp",
   "num_layers": "8",
   "rank": "16",
   "alpha": "32",
@@ -164,10 +165,40 @@ Expected training behavior:
 - Hugging Face dataset materialization is cached under `<jobs_root>/datasets/<cache-key>`
 - Melix supports both `lora` and `qlora` through the same `train_lora` surface
 - if `hf_valid_split` is provided, the normalized dataset snapshot persists the explicit validation source
-- Melix expands compact target modules into family-specific module paths
+- Melix expands compact target modules or preset groups into family-specific module paths
+- supported preset groups currently include `attention`, `mlp`, `attention_mlp`, and `full`; `qwen` plus `kimi` also accept `qkv`, `gemma` also accepts `gated_mlp`, and experimental `mixtral` also accepts `experts`
+- dense-family defaults stay on the family-owned `attention_mlp` baseline, while experimental MoE families default to `attention` unless the operator explicitly opts into expert modules
 - Melix writes a normalized dataset snapshot under `<jobs_root>/train_lora/<job_id>/`
 - Melix emits the stages `resolve_source`, `validate_dataset`, `normalize_config`, `prepare_training_data`, `apply_lora`, `train`, `write_adapter`, and `write_manifest`
 - the completed artifact is `train_lora.adapter.json` with schema `melix.lora_adapter_package.v1`
+
+## Family Support Boundaries
+
+Stable LoRA training families:
+
+- `llama`
+- `qwen`
+- `gemma`
+- `kimi`
+
+Experimental LoRA training families:
+
+- `mixtral` is exposed through separate MoE hooks and currently defaults to `attention` targets only; expert-module presets are available but should be treated as an operator-tuned path
+
+Explicitly unsupported or not-yet-productized LoRA families:
+
+- `qwen3moe`
+- `deepseek-mla`
+- `mistral4`
+- `nemotron-h`
+- embedding-family models and other non-text capability classes
+
+Operator guidance:
+
+- prefer the family default unless you have repeatable evaluation evidence for a narrower preset
+- use `attention` or `qkv` first when validating a new dense family rollout
+- treat MoE expert targeting as experimental and record compare evidence before promoting an adapter for wider use
+- if the registry marks `melix.lora.training_ready = false`, do not expect `train_lora` to accept that family yet
 
 ## Activate Adapter
 

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -607,7 +607,7 @@ def test_train_lora_resolves_qwen_attention_preset_and_catalog_support_metadata(
     ]
 
 
-def test_train_lora_resolves_gemma_and_kimi_family_presets(tmp_path: Path) -> None:
+def test_train_lora_resolves_gemma_gated_mlp_preset(tmp_path: Path) -> None:
     dataset_dir = _write_dataset_package(
         tmp_path / "dataset",
         samples=[
@@ -660,6 +660,24 @@ def test_train_lora_resolves_gemma_and_kimi_family_presets(tmp_path: Path) -> No
         "model.layers.0.mlp.down_proj",
         "model.layers.1.mlp.down_proj",
     ]
+
+
+def test_train_lora_resolves_kimi_qkv_preset(tmp_path: Path) -> None:
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset",
+        samples=[
+            {
+                "messages": [
+                    {"role": "user", "content": "Say hi."},
+                    {"role": "assistant", "content": "Hi there."},
+                ]
+            }
+        ],
+    )
+    runner = SuccessfulRunner()
+    service = _build_service(tmp_path, runner)
+    source_model = service._core._registry.model_catalog.get("melix-dev-text")
+    assert source_model is not None
 
     _configure_lora_family(
         source_model,
@@ -855,6 +873,14 @@ def test_training_config_helper_resolution_paths_and_limits() -> None:
     assert hooks["family_kind"] == "moe"
     assert hooks["support_tier"] == "experimental"
     assert hooks["default_target_preset"] == "attention"
+
+    mistral4_hooks = training_config_module._resolve_family_hooks(
+        common_pb2.ModelSpec(model_id="mistral4", model_kind="text"),
+        family_id="mistral4",
+    )
+    assert mistral4_hooks["family_kind"] == "dense"
+    assert mistral4_hooks["support_tier"] == "experimental"
+    assert mistral4_hooks["training_ready"] == "false"
 
     # Mixed preset aliases and literal module names should collapse to one deduplicated target set.
     qwen_targets = training_config_module._resolve_target_modules(

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -23,6 +23,7 @@ from worker.model_ops.mlx_lm_runner import (
     TrainingRequest,
     TrainingResult,
 )
+from worker.model_ops import training_config as training_config_module
 from worker.model_ops import training_dataset as training_dataset_module
 from worker.model_ops.training_dataset import (
     HFDatasetReference,
@@ -207,6 +208,26 @@ def _build_service(tmp_path: Path, runner: MLXLMRunner) -> WorkerMaintenanceServ
         adapter_activation_pipeline=AdapterActivationPipeline(runner=runner),
     )
     return service
+
+
+def _configure_lora_family(
+    source_model: common_pb2.ModelSpec,
+    *,
+    model_path: str,
+    family_id: str,
+    family_kind: str,
+    support_tier: str,
+    training_ready: bool = True,
+    default_target_preset: str,
+) -> None:
+    source_model.model_path = model_path
+    source_model.ext["text_family_id"] = family_id
+    source_model.ext["detected_family_id"] = family_id
+    source_model.ext["melix.lora.family_id"] = family_id
+    source_model.ext["melix.lora.family_kind"] = family_kind
+    source_model.ext["melix.lora.support_tier"] = support_tier
+    source_model.ext["melix.lora.training_ready"] = "true" if training_ready else "false"
+    source_model.ext["melix.lora.default_target_preset"] = default_target_preset
 
 
 class FakeHFDatasetFetcher:
@@ -517,6 +538,377 @@ def test_train_lora_rejects_qlora_for_non_quantized_base_model(tmp_path: Path) -
     )
 
     assert events[-1].failed.error.code == "unsupported_training_mode"
+
+
+def test_train_lora_resolves_qwen_attention_preset_and_catalog_support_metadata(tmp_path: Path) -> None:
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset",
+        samples=[
+            {
+                "messages": [
+                    {"role": "user", "content": "Say hi."},
+                    {"role": "assistant", "content": "Hi there."},
+                ]
+            }
+        ],
+    )
+    runner = SuccessfulRunner()
+    service = _build_service(tmp_path, runner)
+    source_model = service._core._registry.model_catalog.get("melix-dev-text")
+    assert source_model is not None
+    _configure_lora_family(
+        source_model,
+        model_path="mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+        family_id="qwen",
+        family_kind="dense",
+        support_tier="stable",
+        default_target_preset="attention_mlp",
+    )
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "train"),
+                generate_manifest=True,
+                ext={
+                    "operation": "train_lora",
+                    "adapter_name": "melix-qwen-attention-adapter",
+                    "dataset_uri": str(dataset_dir),
+                    "target_modules": "@attention",
+                    "num_layers": "2",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+
+    assert source_model.ext["melix.lora.family_id"] == "qwen"
+    assert source_model.ext["melix.lora.family_kind"] == "dense"
+    assert source_model.ext["melix.lora.support_tier"] == "stable"
+    assert source_model.ext["melix.lora.default_target_preset"] == "attention_mlp"
+    assert runner.last_train_request is not None
+    assert runner.last_train_request.config.target_modules == ["q_proj", "k_proj", "v_proj", "o_proj"]
+    assert runner.last_train_request.config.backend_target_modules == [
+        "self_attn.q_proj",
+        "self_attn.k_proj",
+        "self_attn.v_proj",
+        "self_attn.o_proj",
+    ]
+    assert payload["target_modules"] == [
+        "model.layers.0.self_attn.q_proj",
+        "model.layers.1.self_attn.q_proj",
+        "model.layers.0.self_attn.k_proj",
+        "model.layers.1.self_attn.k_proj",
+        "model.layers.0.self_attn.v_proj",
+        "model.layers.1.self_attn.v_proj",
+        "model.layers.0.self_attn.o_proj",
+        "model.layers.1.self_attn.o_proj",
+    ]
+
+
+def test_train_lora_resolves_gemma_and_kimi_family_presets(tmp_path: Path) -> None:
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset",
+        samples=[
+            {
+                "messages": [
+                    {"role": "user", "content": "Say hi."},
+                    {"role": "assistant", "content": "Hi there."},
+                ]
+            }
+        ],
+    )
+    runner = SuccessfulRunner()
+    service = _build_service(tmp_path, runner)
+    source_model = service._core._registry.model_catalog.get("melix-dev-text")
+    assert source_model is not None
+
+    _configure_lora_family(
+        source_model,
+        model_path="google/gemma-3-4b-it",
+        family_id="gemma",
+        family_kind="dense",
+        support_tier="stable",
+        default_target_preset="attention_mlp",
+    )
+    gemma_events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "gemma-train"),
+                generate_manifest=True,
+                ext={
+                    "operation": "train_lora",
+                    "adapter_name": "melix-gemma-mlp-adapter",
+                    "dataset_uri": str(dataset_dir),
+                    "target_modules": "gated_mlp",
+                },
+            ),
+            context=None,
+        )
+    )
+    gemma_payload = json.loads(next(event.manifest for event in gemma_events if event.HasField("manifest")).manifest_json)
+    assert runner.last_train_request is not None
+    assert runner.last_train_request.config.family_id == "gemma"
+    assert runner.last_train_request.config.target_modules == ["gate_proj", "up_proj", "down_proj"]
+    assert gemma_payload["target_modules"] == [
+        "model.layers.0.mlp.gate_proj",
+        "model.layers.1.mlp.gate_proj",
+        "model.layers.0.mlp.up_proj",
+        "model.layers.1.mlp.up_proj",
+        "model.layers.0.mlp.down_proj",
+        "model.layers.1.mlp.down_proj",
+    ]
+
+    _configure_lora_family(
+        source_model,
+        model_path="moonshotai/Kimi-K2-Instruct-0905",
+        family_id="kimi",
+        family_kind="dense",
+        support_tier="stable",
+        default_target_preset="attention_mlp",
+    )
+    kimi_events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "kimi-train"),
+                generate_manifest=True,
+                ext={
+                    "operation": "train_lora",
+                    "adapter_name": "melix-kimi-qkv-adapter",
+                    "dataset_uri": str(dataset_dir),
+                    "target_modules": "qkv",
+                },
+            ),
+            context=None,
+        )
+    )
+    kimi_payload = json.loads(next(event.manifest for event in kimi_events if event.HasField("manifest")).manifest_json)
+    assert runner.last_train_request is not None
+    assert runner.last_train_request.config.family_id == "kimi"
+    assert runner.last_train_request.config.target_modules == ["q_proj", "k_proj", "v_proj"]
+    assert kimi_payload["target_modules"] == [
+        "model.layers.0.self_attn.q_proj",
+        "model.layers.1.self_attn.q_proj",
+        "model.layers.0.self_attn.k_proj",
+        "model.layers.1.self_attn.k_proj",
+        "model.layers.0.self_attn.v_proj",
+        "model.layers.1.self_attn.v_proj",
+    ]
+
+
+def test_train_lora_separates_moe_hooks_from_dense_defaults(tmp_path: Path) -> None:
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset",
+        samples=[
+            {
+                "messages": [
+                    {"role": "user", "content": "Say hi."},
+                    {"role": "assistant", "content": "Hi there."},
+                ]
+            }
+        ],
+    )
+    runner = SuccessfulRunner()
+    service = _build_service(tmp_path, runner)
+    source_model = service._core._registry.model_catalog.get("melix-dev-text")
+    assert source_model is not None
+
+    _configure_lora_family(
+        source_model,
+        model_path="mlx-community/Mixtral-8x7B-Instruct-4bit",
+        family_id="mixtral",
+        family_kind="moe",
+        support_tier="experimental",
+        default_target_preset="attention",
+    )
+    mixtral_events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "mixtral-train"),
+                generate_manifest=True,
+                ext={
+                    "operation": "train_lora",
+                    "adapter_name": "melix-mixtral-attention-adapter",
+                    "dataset_uri": str(dataset_dir),
+                },
+            ),
+            context=None,
+        )
+    )
+    mixtral_payload = json.loads(next(event.manifest for event in mixtral_events if event.HasField("manifest")).manifest_json)
+    assert runner.last_train_request is not None
+    assert runner.last_train_request.config.family_id == "mixtral"
+    assert runner.last_train_request.config.target_modules == ["q_proj", "k_proj", "v_proj", "o_proj"]
+    assert all("block_sparse_moe" not in item for item in mixtral_payload["target_modules"])
+
+    _configure_lora_family(
+        source_model,
+        model_path="mlx-community/Qwen3-MoE-30B-A3B-Instruct/4bit",
+        family_id="qwen3moe",
+        family_kind="moe",
+        support_tier="experimental",
+        training_ready=False,
+        default_target_preset="attention",
+    )
+    unsupported_events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "qwen3moe-train"),
+                ext={
+                    "operation": "train_lora",
+                    "adapter_name": "melix-qwen3moe-adapter",
+                    "dataset_uri": str(dataset_dir),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert unsupported_events[-1].failed.error.code == "unsupported_model_family"
+    assert unsupported_events[-1].failed.error.details["family_id"] == "qwen3moe"
+    assert unsupported_events[-1].failed.error.details["family_kind"] == "moe"
+    assert unsupported_events[-1].failed.error.details["support_tier"] == "experimental"
+    assert unsupported_events[-1].failed.error.details["training_ready"] == "false"
+
+
+def test_training_config_validates_direct_error_paths() -> None:
+    non_text_model = common_pb2.ModelSpec(model_id="embed", model_kind="embedding")
+    with pytest.raises(Exception) as non_text_error:
+        training_config_module.normalize_training_config(
+            source_model=non_text_model,
+            ext={},
+            dataset_format="text_completion",
+            response_only_supported=True,
+            sample_count=1,
+        )
+    assert non_text_error.value.code == "unsupported_model_family"
+
+    text_model = common_pb2.ModelSpec(
+        model_id="plain-text",
+        model_path="models/plain-llama",
+        model_kind="text",
+        revision="dev",
+        max_context=2048,
+        ext={"text_family_id": "llama"},
+    )
+    with pytest.raises(Exception) as bad_mode_error:
+        training_config_module.normalize_training_config(
+            source_model=text_model,
+            ext={"training_mode": "dora"},
+            dataset_format="text_completion",
+            response_only_supported=True,
+            sample_count=1,
+        )
+    assert bad_mode_error.value.code == "unsupported_training_mode"
+
+    with pytest.raises(Exception) as preset_error:
+        training_config_module.normalize_training_config(
+            source_model=text_model,
+            ext={"preset_id": "unknown-preset"},
+            dataset_format="text_completion",
+            response_only_supported=True,
+            sample_count=1,
+        )
+    assert preset_error.value.code == "invalid_training_preset"
+
+    with pytest.raises(Exception) as response_error:
+        training_config_module.normalize_training_config(
+            source_model=text_model,
+            ext={"response_only": "true"},
+            dataset_format="prompt_completion",
+            response_only_supported=False,
+            sample_count=1,
+        )
+    assert response_error.value.code == "invalid_dataset_package"
+
+
+def test_training_config_helper_resolution_paths_and_limits() -> None:
+    assert training_config_module._resolve_family_id(
+        common_pb2.ModelSpec(model_id="explicit", model_kind="text", ext={"melix.lora.family_id": "qwen"})
+    ) == "qwen"
+    assert training_config_module._resolve_family_id(
+        common_pb2.ModelSpec(model_id="detected", model_kind="text", ext={"detected_family_id": "gemma"})
+    ) == "gemma"
+    assert training_config_module._resolve_family_id(
+        common_pb2.ModelSpec(model_id="heuristic", model_kind="text", model_path="models/deepseek-v3")
+    ) == "deepseek-mla"
+    assert training_config_module._resolve_family_id(
+        common_pb2.ModelSpec(model_id="heuristic", model_kind="text", model_path="models/mistral-small-4")
+    ) == "mistral4"
+    assert training_config_module._resolve_family_id(
+        common_pb2.ModelSpec(model_id="heuristic", model_kind="text", model_path="models/nemotron-h")
+    ) == "nemotron-h"
+
+    hooks = training_config_module._resolve_family_hooks(
+        common_pb2.ModelSpec(
+            model_id="mixtral",
+            model_kind="text",
+            ext={"melix.lora.family_kind": "moe", "melix.lora.support_tier": "experimental"},
+        ),
+        family_id="mixtral",
+    )
+    assert hooks["family_kind"] == "moe"
+    assert hooks["support_tier"] == "experimental"
+    assert hooks["default_target_preset"] == "attention"
+
+    qwen_targets = training_config_module._resolve_target_modules(
+        "@attention,q_proj,attention",
+        profile=training_config_module._FAMILY_PROFILES["qwen"],
+    )
+    assert qwen_targets == ["q_proj", "k_proj", "v_proj", "o_proj"]
+    assert training_config_module._resolve_target_modules(
+        "",
+        profile=training_config_module._FAMILY_PROFILES["mixtral"],
+    ) == ["q_proj", "k_proj", "v_proj", "o_proj"]
+    assert training_config_module._backend_target_modules(["standalone.module"]) == ["standalone.module"]
+
+    bounded = training_config_module.normalize_training_config(
+        source_model=common_pb2.ModelSpec(
+            model_id="bounded",
+            model_path="models/qwen",
+            model_kind="text",
+            revision="dev",
+            max_context=4096,
+            quant_profile_id="q4",
+            ext={
+                "text_family_id": "qwen",
+                "text_layer_count": "4",
+                "melix.lora.family_id": "qwen",
+                "melix.lora.family_kind": "dense",
+                "melix.lora.support_tier": "stable",
+                "melix.lora.training_ready": "true",
+                "melix.lora.default_target_preset": "attention_mlp",
+            },
+        ),
+        ext={
+            "training_mode": "qlora",
+            "batch_size": "4",
+            "epochs": "3",
+            "max_steps": "2",
+            "preset_id": "balanced_adapter",
+        },
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+        validation_sample_count=1,
+    )
+    assert bounded.iters == 2
+    assert bounded.steps_per_eval == 2
+
+    with pytest.raises(Exception) as int_error:
+        training_config_module._int_value("0", default=1, minimum=1, field_name="rank")
+    assert int_error.value.code == "invalid_argument"
+
+    with pytest.raises(Exception) as float_error:
+        training_config_module._float_value("-0.5", default=0.0, minimum=0.0, field_name="dropout")
+    assert float_error.value.code == "invalid_argument"
 
 
 def test_resolve_training_dataset_rejects_hf_valid_split_for_local_package(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -221,8 +221,6 @@ def _configure_lora_family(
     default_target_preset: str,
 ) -> None:
     source_model.model_path = model_path
-    source_model.ext["text_family_id"] = family_id
-    source_model.ext["detected_family_id"] = family_id
     source_model.ext["melix.lora.family_id"] = family_id
     source_model.ext["melix.lora.family_kind"] = family_kind
     source_model.ext["melix.lora.support_tier"] = support_tier
@@ -858,6 +856,7 @@ def test_training_config_helper_resolution_paths_and_limits() -> None:
     assert hooks["support_tier"] == "experimental"
     assert hooks["default_target_preset"] == "attention"
 
+    # Mixed preset aliases and literal module names should collapse to one deduplicated target set.
     qwen_targets = training_config_module._resolve_target_modules(
         "@attention,q_proj,attention",
         profile=training_config_module._FAMILY_PROFILES["qwen"],

--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -348,6 +348,11 @@ def test_registry_snapshot_applies_text_family_adapter_metadata_from_local_confi
     assert qwen3moe.ext["melix.text.moe.enabled"] == "true"
     assert qwen3moe.ext["melix.text.moe.expert_count"] == "128"
     assert qwen3moe.ext["melix.text.moe.gate_dequant"] == "true"
+    assert qwen3moe.ext["melix.lora.family_id"] == "qwen3moe"
+    assert qwen3moe.ext["melix.lora.family_kind"] == "moe"
+    assert qwen3moe.ext["melix.lora.support_tier"] == "experimental"
+    assert qwen3moe.ext["melix.lora.training_ready"] == "false"
+    assert qwen3moe.ext["melix.lora.default_target_preset"] == "attention"
 
 
 def test_registry_snapshot_ignores_invalid_model_config_payloads(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -194,7 +194,7 @@ _ADVANCED_FAMILY_HOOKS: dict[str, dict[str, str]] = {
         "default_target_preset": "attention",
     },
     "mistral4": {
-        "family_kind": "moe",
+        "family_kind": "dense",
         "support_tier": "experimental",
         "training_ready": "false",
         "default_target_preset": "attention",

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -513,9 +513,9 @@ def _resolve_family_hooks(source_model: common_pb2.ModelSpec, *, family_id: str)
 def _resolve_target_modules(raw_value: str, *, profile: dict[str, object]) -> list[str]:
     presets = {
         str(key).strip().lower(): [str(item).strip().lower() for item in value]
-        for key, value in dict(profile.get("target_module_presets", {})).items()
+        for key, value in profile.get("target_module_presets", {}).items()
     }
-    default_targets = [str(item).strip().lower() for item in list(profile["default_target_modules"])]
+    default_targets = [str(item).strip().lower() for item in profile["default_target_modules"]]
     requested = [item.strip().lower() for item in raw_value.split(",") if item.strip()]
     if not requested:
         return default_targets

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -45,18 +45,29 @@ class LoRATrainingConfig:
     target_repo: str
 
 
+_DENSE_ATTENTION_TARGETS = ["q_proj", "k_proj", "v_proj", "o_proj"]
+_DENSE_QKV_TARGETS = ["q_proj", "k_proj", "v_proj"]
+_DENSE_MLP_TARGETS = ["gate_proj", "up_proj", "down_proj"]
+_DENSE_FULL_TARGETS = [*_DENSE_ATTENTION_TARGETS, *_DENSE_MLP_TARGETS]
+
+_MIXTRAL_ATTENTION_TARGETS = ["q_proj", "k_proj", "v_proj", "o_proj"]
+_MIXTRAL_EXPERT_TARGETS = ["gate_proj", "up_proj", "down_proj"]
+_MIXTRAL_FULL_TARGETS = [*_MIXTRAL_ATTENTION_TARGETS, *_MIXTRAL_EXPERT_TARGETS]
+
 _FAMILY_PROFILES: dict[str, dict[str, object]] = {
     "llama": {
+        "family_kind": "dense",
+        "support_tier": "stable",
         "default_total_layers": 2,
-        "default_target_modules": [
-            "q_proj",
-            "k_proj",
-            "v_proj",
-            "o_proj",
-            "gate_proj",
-            "up_proj",
-            "down_proj",
-        ],
+        "default_target_preset": "attention_mlp",
+        "default_target_modules": list(_DENSE_FULL_TARGETS),
+        "target_module_presets": {
+            "default": list(_DENSE_FULL_TARGETS),
+            "attention": list(_DENSE_ATTENTION_TARGETS),
+            "mlp": list(_DENSE_MLP_TARGETS),
+            "attention_mlp": list(_DENSE_FULL_TARGETS),
+            "full": list(_DENSE_FULL_TARGETS),
+        },
         "module_templates": {
             "q_proj": "model.layers.{layer}.self_attn.q_proj",
             "k_proj": "model.layers.{layer}.self_attn.k_proj",
@@ -68,16 +79,19 @@ _FAMILY_PROFILES: dict[str, dict[str, object]] = {
         },
     },
     "qwen": {
+        "family_kind": "dense",
+        "support_tier": "stable",
         "default_total_layers": 2,
-        "default_target_modules": [
-            "q_proj",
-            "k_proj",
-            "v_proj",
-            "o_proj",
-            "gate_proj",
-            "up_proj",
-            "down_proj",
-        ],
+        "default_target_preset": "attention_mlp",
+        "default_target_modules": list(_DENSE_FULL_TARGETS),
+        "target_module_presets": {
+            "default": list(_DENSE_FULL_TARGETS),
+            "attention": list(_DENSE_ATTENTION_TARGETS),
+            "qkv": list(_DENSE_QKV_TARGETS),
+            "mlp": list(_DENSE_MLP_TARGETS),
+            "attention_mlp": list(_DENSE_FULL_TARGETS),
+            "full": list(_DENSE_FULL_TARGETS),
+        },
         "module_templates": {
             "q_proj": "model.layers.{layer}.self_attn.q_proj",
             "k_proj": "model.layers.{layer}.self_attn.k_proj",
@@ -89,16 +103,19 @@ _FAMILY_PROFILES: dict[str, dict[str, object]] = {
         },
     },
     "gemma": {
+        "family_kind": "dense",
+        "support_tier": "stable",
         "default_total_layers": 2,
-        "default_target_modules": [
-            "q_proj",
-            "k_proj",
-            "v_proj",
-            "o_proj",
-            "gate_proj",
-            "up_proj",
-            "down_proj",
-        ],
+        "default_target_preset": "attention_mlp",
+        "default_target_modules": list(_DENSE_FULL_TARGETS),
+        "target_module_presets": {
+            "default": list(_DENSE_FULL_TARGETS),
+            "attention": list(_DENSE_ATTENTION_TARGETS),
+            "gated_mlp": list(_DENSE_MLP_TARGETS),
+            "mlp": list(_DENSE_MLP_TARGETS),
+            "attention_mlp": list(_DENSE_FULL_TARGETS),
+            "full": list(_DENSE_FULL_TARGETS),
+        },
         "module_templates": {
             "q_proj": "model.layers.{layer}.self_attn.q_proj",
             "k_proj": "model.layers.{layer}.self_attn.k_proj",
@@ -110,16 +127,19 @@ _FAMILY_PROFILES: dict[str, dict[str, object]] = {
         },
     },
     "kimi": {
+        "family_kind": "dense",
+        "support_tier": "stable",
         "default_total_layers": 2,
-        "default_target_modules": [
-            "q_proj",
-            "k_proj",
-            "v_proj",
-            "o_proj",
-            "gate_proj",
-            "up_proj",
-            "down_proj",
-        ],
+        "default_target_preset": "attention_mlp",
+        "default_target_modules": list(_DENSE_FULL_TARGETS),
+        "target_module_presets": {
+            "default": list(_DENSE_FULL_TARGETS),
+            "attention": list(_DENSE_ATTENTION_TARGETS),
+            "qkv": list(_DENSE_QKV_TARGETS),
+            "mlp": list(_DENSE_MLP_TARGETS),
+            "attention_mlp": list(_DENSE_FULL_TARGETS),
+            "full": list(_DENSE_FULL_TARGETS),
+        },
         "module_templates": {
             "q_proj": "model.layers.{layer}.self_attn.q_proj",
             "k_proj": "model.layers.{layer}.self_attn.k_proj",
@@ -131,16 +151,17 @@ _FAMILY_PROFILES: dict[str, dict[str, object]] = {
         },
     },
     "mixtral": {
+        "family_kind": "moe",
+        "support_tier": "experimental",
         "default_total_layers": 2,
-        "default_target_modules": [
-            "q_proj",
-            "k_proj",
-            "v_proj",
-            "o_proj",
-            "gate_proj",
-            "up_proj",
-            "down_proj",
-        ],
+        "default_target_preset": "attention",
+        "default_target_modules": list(_MIXTRAL_ATTENTION_TARGETS),
+        "target_module_presets": {
+            "default": list(_MIXTRAL_ATTENTION_TARGETS),
+            "attention": list(_MIXTRAL_ATTENTION_TARGETS),
+            "experts": list(_MIXTRAL_EXPERT_TARGETS),
+            "full": list(_MIXTRAL_FULL_TARGETS),
+        },
         "module_templates": {
             "q_proj": "model.layers.{layer}.self_attn.q_proj",
             "k_proj": "model.layers.{layer}.self_attn.k_proj",
@@ -150,6 +171,39 @@ _FAMILY_PROFILES: dict[str, dict[str, object]] = {
             "up_proj": "model.layers.{layer}.block_sparse_moe.experts.*.w3",
             "down_proj": "model.layers.{layer}.block_sparse_moe.experts.*.w2",
         },
+    },
+}
+
+_ADVANCED_FAMILY_HOOKS: dict[str, dict[str, str]] = {
+    "mixtral": {
+        "family_kind": "moe",
+        "support_tier": "experimental",
+        "training_ready": "true",
+        "default_target_preset": "attention",
+    },
+    "qwen3moe": {
+        "family_kind": "moe",
+        "support_tier": "experimental",
+        "training_ready": "false",
+        "default_target_preset": "attention",
+    },
+    "deepseek-mla": {
+        "family_kind": "moe",
+        "support_tier": "experimental",
+        "training_ready": "false",
+        "default_target_preset": "attention",
+    },
+    "mistral4": {
+        "family_kind": "moe",
+        "support_tier": "experimental",
+        "training_ready": "false",
+        "default_target_preset": "attention",
+    },
+    "nemotron-h": {
+        "family_kind": "advanced_text",
+        "support_tier": "experimental",
+        "training_ready": "false",
+        "default_target_preset": "attention",
     },
 }
 
@@ -222,11 +276,19 @@ def normalize_training_config(
     preset = _resolve_training_preset(preset_id)
 
     family_id = _resolve_family_id(source_model)
+    family_hooks = _resolve_family_hooks(source_model, family_id=family_id)
     profile = _FAMILY_PROFILES.get(family_id)
     if profile is None:
         raise ModelOperationError(
             code="unsupported_model_family",
             message=f"Unsupported LoRA family: {family_id}",
+            details=family_hooks,
+        )
+    if family_hooks.get("training_ready", "true") != "true":
+        raise ModelOperationError(
+            code="unsupported_model_family",
+            message=f"LoRA training hooks for family {family_id} are not productized yet.",
+            details=family_hooks,
         )
 
     total_layer_count = _int_value(
@@ -249,11 +311,7 @@ def normalize_training_config(
     num_layers = min(requested_num_layers, total_layer_count)
     selected_layer_indices = list(range(total_layer_count - num_layers, total_layer_count))
 
-    configured_targets = [
-        item.strip()
-        for item in ext.get("target_modules", "").split(",")
-        if item.strip()
-    ] or list(profile["default_target_modules"])
+    configured_targets = _resolve_target_modules(ext.get("target_modules", ""), profile=profile)
 
     templates = profile["module_templates"]
     expanded_target_modules: list[str] = []
@@ -386,9 +444,17 @@ def _resolve_training_preset(preset_id: str) -> dict[str, object]:
 
 
 def _resolve_family_id(source_model: common_pb2.ModelSpec) -> str:
+    explicit_lora = source_model.ext.get("melix.lora.family_id", "").strip().lower()
+    if explicit_lora:
+        return explicit_lora
+
     explicit = source_model.ext.get("text_family_id", "").strip().lower()
     if explicit:
         return explicit
+
+    detected = source_model.ext.get("detected_family_id", "").strip().lower()
+    if detected:
+        return detected
 
     searchable = " ".join(
         [
@@ -399,15 +465,71 @@ def _resolve_family_id(source_model: common_pb2.ModelSpec) -> str:
     )
     if "mixtral" in searchable:
         return "mixtral"
+    if "qwen3" in searchable and "moe" in searchable:
+        return "qwen3moe"
     if "qwen" in searchable:
         return "qwen"
     if "gemma" in searchable:
         return "gemma"
+    if "deepseek" in searchable:
+        return "deepseek-mla"
+    if "mistral4" in searchable or "mistral-small-4" in searchable:
+        return "mistral4"
+    if "nemotron_h" in searchable or "nemotron-h" in searchable:
+        return "nemotron-h"
     if "kimi" in searchable or "moonshot" in searchable:
         return "kimi"
     if any(token in searchable for token in ("mistral", "llama", "text")):
         return "llama"
     return "llama"
+
+
+def _resolve_family_hooks(source_model: common_pb2.ModelSpec, *, family_id: str) -> dict[str, str]:
+    family_hooks = dict(_ADVANCED_FAMILY_HOOKS.get(family_id, {}))
+    ext = source_model.ext
+    family_hooks["family_id"] = family_id
+    family_hooks["family_kind"] = (
+        ext.get("melix.lora.family_kind", "").strip().lower()
+        or family_hooks.get("family_kind", "dense")
+    )
+    family_hooks["support_tier"] = (
+        ext.get("melix.lora.support_tier", "").strip().lower()
+        or family_hooks.get("support_tier", str(_FAMILY_PROFILES.get(family_id, {}).get("support_tier", "stable")))
+    )
+    family_hooks["training_ready"] = (
+        ext.get("melix.lora.training_ready", "").strip().lower()
+        or family_hooks.get("training_ready", "true")
+    )
+    family_hooks["default_target_preset"] = (
+        ext.get("melix.lora.default_target_preset", "").strip().lower()
+        or family_hooks.get(
+            "default_target_preset",
+            str(_FAMILY_PROFILES.get(family_id, {}).get("default_target_preset", "default")),
+        )
+    )
+    return family_hooks
+
+
+def _resolve_target_modules(raw_value: str, *, profile: dict[str, object]) -> list[str]:
+    presets = {
+        str(key).strip().lower(): [str(item).strip().lower() for item in value]
+        for key, value in dict(profile.get("target_module_presets", {})).items()
+    }
+    default_targets = [str(item).strip().lower() for item in list(profile["default_target_modules"])]
+    requested = [item.strip().lower() for item in raw_value.split(",") if item.strip()]
+    if not requested:
+        return default_targets
+
+    resolved_targets: list[str] = []
+    seen: set[str] = set()
+    for requested_target in requested:
+        target_key = requested_target.lstrip("@")
+        expanded_targets = presets.get(target_key, [requested_target])
+        for expanded_target in expanded_targets:
+            if expanded_target not in seen:
+                seen.add(expanded_target)
+                resolved_targets.append(expanded_target)
+    return resolved_targets
 
 
 def _backend_target_modules(expanded_target_modules: Iterable[str]) -> list[str]:

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -224,10 +224,48 @@ def _text_capability_metadata(
     )
     return {
         **resolved.capability_metadata(),
+        **_text_lora_support_metadata(resolved.family_id, moe_enabled=resolved.moe_enabled),
         "detected_architecture": detected.architecture,
         "detected_family_id": detected.family_id,
         "detected_identity_source": detected.source,
         "identity_override": "true" if identity_override else "false",
+    }
+
+
+def _text_lora_support_metadata(family_id: str, *, moe_enabled: bool) -> dict[str, str]:
+    stable_dense_families = {"llama", "qwen", "gemma", "kimi"}
+    if family_id in stable_dense_families:
+        return {
+            "melix.lora.family_id": family_id,
+            "melix.lora.family_kind": "dense",
+            "melix.lora.support_tier": "stable",
+            "melix.lora.training_ready": "true",
+            "melix.lora.default_target_preset": "attention_mlp",
+        }
+    if family_id == "mixtral":
+        return {
+            "melix.lora.family_id": family_id,
+            "melix.lora.family_kind": "moe",
+            "melix.lora.support_tier": "experimental",
+            "melix.lora.training_ready": "true",
+            "melix.lora.default_target_preset": "attention",
+        }
+    return {
+        "melix.lora.family_id": family_id,
+        "melix.lora.family_kind": "moe" if moe_enabled else "advanced_text",
+        "melix.lora.support_tier": "experimental",
+        "melix.lora.training_ready": "false",
+        "melix.lora.default_target_preset": "attention",
+    }
+
+
+def _embedding_lora_support_metadata(family_id: str) -> dict[str, str]:
+    return {
+        "melix.lora.family_id": family_id,
+        "melix.lora.family_kind": "embedding",
+        "melix.lora.support_tier": "blocked",
+        "melix.lora.training_ready": "false",
+        "melix.lora.default_target_preset": "unsupported",
     }
 
 
@@ -904,6 +942,7 @@ class WorkerModelCatalog:
             max_context=8192,
             ext={
                 **_embedding_capability_metadata(family_id),
+                **_embedding_lora_support_metadata(family_id),
                 "embedding_backend_id": backend_id,
                 "embedding_family_id": family_id,
                 "embedding_pooling_mode": pooling_mode,


### PR DESCRIPTION
## Summary
- add architecture-aware LoRA target-module preset expansion for stable dense families and safer attention-first defaults for Mixtral
- surface family-level LoRA support hooks from the model catalog so dense, MoE, and embedding paths are explicit
- document stable, experimental, and blocked LoRA family expectations for operators

## Testing
- PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_training_dataset_builder.py -q
- PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -q
- PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python python -m coverage run -m pytest services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_model_registry_catalog.py -q
- uv run --project services/mlx-worker-python python -m coverage report -m services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/model_registry/catalog.py

## Metrics
- training_config.py coverage: 95%
- catalog.py coverage: 96%
- combined touched Python scope coverage: 96%

## Risks / follow-ups
- non-productized advanced text and MoE families still reject `train_lora`; this PR only adds the hooks and operator-facing boundaries, not full training support
- Mixtral expert targeting remains experimental even though the preset plumbing now exposes it explicitly