### PR TITLE
[codex] add multi-worktree runtime rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,9 @@ and a worktree-local `MELIX_HOME`.
 
 Do not run a bare `bash scripts/dev_up.sh` when another Melix worktree may be
 running or when the task expects a long-lived local stack. Each concurrently
-running worktree must use a different `MELIX_HTTP_PORT`.
+running worktree must use a different `MELIX_HTTP_PORT`. The bare
+`scripts/dev_up.sh` default HTTP port is `11434`; named instances should use
+different explicit ports, for example `12434` and `12435`.
 
 Use this shell helper pattern for starting a development instance:
 
@@ -70,6 +72,11 @@ melix-dev-instance() {
     return 2
   fi
 
+  if ! [[ "${http_port}" =~ ^[1-9][0-9]*$ ]] || (( http_port < 1024 || http_port > 65535 )); then
+    printf 'http-port must be a number between 1024 and 65535\n' >&2
+    return 2
+  fi
+
   if [[ "${instance_name}" == *[^A-Za-z0-9_-]* ]]; then
     printf 'instance-name may only contain letters, numbers, underscores, and hyphens\n' >&2
     return 2
@@ -78,7 +85,10 @@ melix-dev-instance() {
   local repo_root
   local runtime_dir
   local melix_home
-  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  if ! repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    printf 'fatal: not inside a git worktree\n' >&2
+    return 1
+  fi
   runtime_dir="${repo_root}/.runtime/sidecars/${instance_name}"
   melix_home="${repo_root}/.runtime/home-${instance_name}"
 
@@ -108,13 +118,20 @@ melix-dev-stop-instance() {
   fi
 
   local repo_root
-  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  if ! repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    printf 'fatal: not inside a git worktree\n' >&2
+    return 1
+  fi
 
   export MELIX_RUNTIME_DIR="${repo_root}/.runtime/sidecars/${instance_name}"
 
   bash "${repo_root}/scripts/dev_down.sh"
 }
 ```
+
+The stop helper only exports `MELIX_RUNTIME_DIR` because `scripts/dev_down.sh`
+stops processes by pid files and runtime artifacts under that directory; it does
+not use `MELIX_HTTP_PORT` or `MELIX_HOME`.
 
 Example concurrent worktree ports:
 
@@ -134,6 +151,10 @@ worktree-local as shown above. The start helper exports `MELIX_HOME` in the
 current shell session so later CLI commands use the same isolated state. Do not
 share the default `~/.melix` state across parallel worktrees unless shared
 operator state is intentional.
+
+The repository-local `.runtime` tree is ignored by git. Never stage or commit
+runtime pid files, sockets, logs, managed models, or worktree-local Melix home
+state from `.runtime`.
 
 ## Source of Truth Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,16 +75,19 @@ melix-dev-instance() {
     return 2
   fi
 
+  local repo_root
   local runtime_dir
   local melix_home
-  runtime_dir="$(pwd)/.runtime/sidecars/${instance_name}"
-  melix_home="$(pwd)/.runtime/home-${instance_name}"
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  runtime_dir="${repo_root}/.runtime/sidecars/${instance_name}"
+  melix_home="${repo_root}/.runtime/home-${instance_name}"
 
-  MELIX_SERVICE_INSTANCE_NAME="${instance_name}" \
-  MELIX_HTTP_PORT="${http_port}" \
-  MELIX_RUNTIME_DIR="${runtime_dir}" \
-  MELIX_HOME="${melix_home}" \
-  bash scripts/dev_up.sh
+  export MELIX_SERVICE_INSTANCE_NAME="${instance_name}"
+  export MELIX_HTTP_PORT="${http_port}"
+  export MELIX_RUNTIME_DIR="${runtime_dir}"
+  export MELIX_HOME="${melix_home}"
+
+  bash "${repo_root}/scripts/dev_up.sh"
 }
 ```
 
@@ -104,8 +107,12 @@ melix-dev-stop-instance() {
     return 2
   fi
 
-  MELIX_RUNTIME_DIR="$(pwd)/.runtime/sidecars/${instance_name}" \
-  bash scripts/dev_down.sh
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+  export MELIX_RUNTIME_DIR="${repo_root}/.runtime/sidecars/${instance_name}"
+
+  bash "${repo_root}/scripts/dev_down.sh"
 }
 ```
 
@@ -123,8 +130,10 @@ melix-dev-stop-instance wt-main
 ```
 
 If CLI or menu bar persisted state must be isolated, keep `MELIX_HOME`
-worktree-local as shown above. Do not share the default `~/.melix` state across
-parallel worktrees unless shared operator state is intentional.
+worktree-local as shown above. The start helper exports `MELIX_HOME` in the
+current shell session so later CLI commands use the same isolated state. Do not
+share the default `~/.melix` state across parallel worktrees unless shared
+operator state is intentional.
 
 ## Source of Truth Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,87 @@ make integration-test
 
 For local JavaScript or TypeScript package operations, prefer Bun and `bunx`.
 
+## Local Multi-Worktree Runtime Rules
+
+Agents may work from multiple Melix worktrees on the same MacBook Pro. Code,
+build products, and repository-local caches are worktree-scoped, but running
+Melix stacks can still interfere through shared ports, process metadata, and
+operator state. When starting a local Melix development stack from any worktree,
+use a named instance, an explicit HTTP port, a worktree-local runtime directory,
+and a worktree-local `MELIX_HOME`.
+
+Do not run a bare `bash scripts/dev_up.sh` when another Melix worktree may be
+running or when the task expects a long-lived local stack. Each concurrently
+running worktree must use a different `MELIX_HTTP_PORT`.
+
+Use this shell helper pattern for starting a development instance:
+
+```bash
+melix-dev-instance() {
+  local instance_name="${1:-}"
+  local http_port="${2:-}"
+
+  if [[ -z "${instance_name}" || -z "${http_port}" ]]; then
+    printf 'usage: melix-dev-instance <instance-name> <http-port>\n' >&2
+    return 2
+  fi
+
+  if [[ "${instance_name}" == *[^A-Za-z0-9_-]* ]]; then
+    printf 'instance-name may only contain letters, numbers, underscores, and hyphens\n' >&2
+    return 2
+  fi
+
+  local runtime_dir
+  local melix_home
+  runtime_dir="$(pwd)/.runtime/sidecars/${instance_name}"
+  melix_home="$(pwd)/.runtime/home-${instance_name}"
+
+  MELIX_SERVICE_INSTANCE_NAME="${instance_name}" \
+  MELIX_HTTP_PORT="${http_port}" \
+  MELIX_RUNTIME_DIR="${runtime_dir}" \
+  MELIX_HOME="${melix_home}" \
+  bash scripts/dev_up.sh
+}
+```
+
+Use the matching runtime directory when stopping that instance:
+
+```bash
+melix-dev-stop-instance() {
+  local instance_name="${1:-}"
+
+  if [[ -z "${instance_name}" ]]; then
+    printf 'usage: melix-dev-stop-instance <instance-name>\n' >&2
+    return 2
+  fi
+
+  if [[ "${instance_name}" == *[^A-Za-z0-9_-]* ]]; then
+    printf 'instance-name may only contain letters, numbers, underscores, and hyphens\n' >&2
+    return 2
+  fi
+
+  MELIX_RUNTIME_DIR="$(pwd)/.runtime/sidecars/${instance_name}" \
+  bash scripts/dev_down.sh
+}
+```
+
+Example concurrent worktree ports:
+
+```bash
+melix-dev-instance wt-main 12434
+melix-dev-instance wt-lora 12435
+```
+
+Stopping a named instance must use the same instance name:
+
+```bash
+melix-dev-stop-instance wt-main
+```
+
+If CLI or menu bar persisted state must be isolated, keep `MELIX_HOME`
+worktree-local as shown above. Do not share the default `~/.melix` state across
+parallel worktrees unless shared operator state is intentional.
+
 ## Source of Truth Rules
 
 - Protobuf schemas under `packages/protocol/schema` are the authoritative interface definitions.


### PR DESCRIPTION
## Summary
- Add agent-facing rules for starting Melix dev stacks safely from multiple worktrees.
- Document reusable `melix-dev-instance` and `melix-dev-stop-instance` shell helpers.
- Require explicit ports, runtime directories, and worktree-local `MELIX_HOME` for long-lived local stacks.
- Harden the helpers after review by failing outside git worktrees, validating HTTP ports, documenting the default `11434` port, and recording `.runtime` ignore/lifecycle expectations.

## Plan or Spec
Implemented the approved Multi-Worktree Melix Dev Runtime Rules plan by updating `AGENTS.md` only. Follow-up changes address Gemini review and later external feedback by resolving the repository root dynamically, exporting the instance environment for subsequent CLI commands, failing explicitly outside git worktrees, validating port inputs, and documenting runtime directory lifecycle rules.

## Commands Run
- `zsh -n -c '<melix-dev-instance and melix-dev-stop-instance snippets>'`
- `zsh -c '<invalid-port guard smoke for melix-dev-instance>'`
- `git diff --check`
- `git check-ignore -v .runtime .runtime/sidecars/foo .runtime/home-foo`
- `rg -n "npm|pnpm|npx" AGENTS.md`
- `python3 scripts/validate_pr_evidence.py` equivalent via `validate_body_text(...)` for this PR body

## Coverage and Metrics
N/A: documentation-only operational rule. No Swift, Python, protobuf, or runtime code paths changed, so automated coverage is not applicable.

## Known Gaps
No known implementation gaps. Full repository test suites were not rerun because the change is limited to agent documentation and shell helper examples.