### PR TITLE
[codex] Optimize window and menubar UI

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
@@ -119,6 +119,8 @@ struct DesktopChatSessionSidebar: View {
                     Image(systemName: "plus")
                 }
                 .buttonStyle(.plain)
+                .help("New Chat Session")
+                .accessibilityLabel("New Chat Session")
             }
 
             if viewModel.chatSessions.isEmpty {
@@ -186,15 +188,17 @@ struct DesktopChatSessionWorkspace: View {
                     }
                 }
                 Spacer()
-                DesktopChatPaneToggleButton(
-                    systemName: showsSidebar ? "sidebar.left" : "sidebar.left",
-                    helpText: showsSidebar ? "Hide Chat Sessions" : "Show Chat Sessions"
+                DesktopPaneToggleButton(
+                    role: .sidebar,
+                    isVisible: showsSidebar,
+                    shortcut: KeyboardShortcut("s", modifiers: [.command, .option])
                 ) {
                     showsSidebar.toggle()
                 }
-                DesktopChatPaneToggleButton(
-                    systemName: showsInspector ? "sidebar.right" : "sidebar.right",
-                    helpText: showsInspector ? "Hide Inspector" : "Show Inspector"
+                DesktopPaneToggleButton(
+                    role: .inspector,
+                    isVisible: showsInspector,
+                    shortcut: KeyboardShortcut("i", modifiers: [.command, .option])
                 ) {
                     showsInspector.toggle()
                 }
@@ -307,6 +311,7 @@ struct DesktopChatSessionWorkspace: View {
                         Task { await viewModel.submitChatPrompt() }
                     }
                     .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.return, modifiers: .command)
                     .disabled(
                         viewModel.chatComposerText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                         || viewModel.isChatStreaming

--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
@@ -456,24 +456,6 @@ private struct DesktopChatSessionRowActions: View {
     }
 }
 
-private struct DesktopChatPaneToggleButton: View {
-    let systemName: String
-    let helpText: String
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            Image(systemName: systemName)
-                .font(.caption.weight(.semibold))
-                .frame(width: 26, height: 24)
-                .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        }
-        .buttonStyle(.plain)
-        .help(helpText)
-        .accessibilityLabel(helpText)
-    }
-}
-
 private struct DesktopChatTranscriptRowView: View {
     let entry: DesktopChatTranscriptEntry
 

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationState.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationState.swift
@@ -141,6 +141,9 @@ public struct DesktopAPISurfaceRow: Identifiable, Equatable, Sendable {
 
 public struct DesktopFoundationState: Equatable, Sendable {
     public let title: String
+    public let serverStateText: String
+    public let connectionStateText: String
+    public let connectionDetailText: String
     public let dashboardCards: [DesktopDashboardCard]
     public let queueLanes: [DesktopQueueLaneRow]
     public let models: [RuntimeModelRow]
@@ -408,6 +411,9 @@ public struct DesktopFoundationState: Equatable, Sendable {
 
         return DesktopFoundationState(
             title: statusTitle,
+            serverStateText: serverStateText,
+            connectionStateText: connectionStateText,
+            connectionDetailText: connectionDetailText,
             dashboardCards: dashboardCards,
             queueLanes: queueLanes,
             models: snapshot.models

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift
@@ -91,7 +91,7 @@ struct DesktopPaneToggleButton: View {
     var body: some View {
         let label = role.accessibilityLabel(isVisible: isVisible)
         let button = Button(action: action) {
-            Image(systemName: isVisible ? role.visibleSymbolName : role.hiddenSymbolName)
+            Image(systemName: role.symbolName)
                 .font(.caption.weight(.semibold))
                 .frame(
                     width: DesktopShellChromeMetrics.paneToggleButtonWidth,

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift
@@ -5,6 +5,8 @@ enum DesktopShellChromeMetrics {
     static let titleBarTabHorizontalPadding: CGFloat = 9
     static let titleBarTabVerticalPadding: CGFloat = 4
     static let titleBarTabContainerInset: CGFloat = 3
+    static let paneToggleButtonWidth: CGFloat = 28
+    static let paneToggleButtonHeight: CGFloat = 24
 }
 
 struct DesktopWorkspaceTitleBarTabsView: View {
@@ -31,7 +33,81 @@ struct DesktopWorkspaceTitleBarCommandCenterButton: View {
         .buttonStyle(.plain)
         .help("Open Command Center")
         .accessibilityLabel("Open Command Center")
+        .keyboardShortcut("k", modifiers: .command)
         .fixedSize(horizontal: true, vertical: false)
+    }
+}
+
+struct DesktopWorkspaceHeader<Trailing: View>: View {
+    let title: String
+    let subtitle: String?
+    @ViewBuilder let trailing: () -> Trailing
+
+    init(
+        title: String,
+        subtitle: String? = nil,
+        @ViewBuilder trailing: @escaping () -> Trailing
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.trailing = trailing
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.largeTitle.weight(.semibold))
+                if let subtitle, subtitle.isEmpty == false {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: 12)
+            trailing()
+        }
+    }
+}
+
+struct DesktopPaneToggleButton: View {
+    let role: DesktopPaneRole
+    let isVisible: Bool
+    let action: () -> Void
+    var shortcut: KeyboardShortcut?
+
+    init(
+        role: DesktopPaneRole,
+        isVisible: Bool,
+        shortcut: KeyboardShortcut? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.role = role
+        self.isVisible = isVisible
+        self.shortcut = shortcut
+        self.action = action
+    }
+
+    var body: some View {
+        let label = role.accessibilityLabel(isVisible: isVisible)
+        let button = Button(action: action) {
+            Image(systemName: isVisible ? role.visibleSymbolName : role.hiddenSymbolName)
+                .font(.caption.weight(.semibold))
+                .frame(
+                    width: DesktopShellChromeMetrics.paneToggleButtonWidth,
+                    height: DesktopShellChromeMetrics.paneToggleButtonHeight
+                )
+                .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .help(label)
+        .accessibilityLabel(label)
+
+        if let shortcut {
+            button.keyboardShortcut(shortcut)
+        } else {
+            button
+        }
     }
 }
 
@@ -58,6 +134,7 @@ struct DesktopShellTabStripView: View {
                         )
                 }
                 .buttonStyle(.plain)
+                .keyboardShortcut(shortcutKey(for: surface), modifiers: .command)
                 .fixedSize(horizontal: true, vertical: false)
             }
         }
@@ -68,5 +145,20 @@ struct DesktopShellTabStripView: View {
             Capsule()
                 .stroke(Color.primary.opacity(0.06), lineWidth: 1)
         )
+    }
+
+    private func shortcutKey(for surface: DesktopSurface) -> KeyEquivalent {
+        switch surface {
+        case .chat:
+            return "1"
+        case .image:
+            return "2"
+        case .server:
+            return "3"
+        case .tools:
+            return "4"
+        case .api:
+            return "5"
+        }
     }
 }

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -139,6 +139,14 @@ struct DesktopInlineNoticeCardView: View {
 }
 
 struct DesktopCommandCenterView: View {
+    static let downloadRecoveryOverflowActionTitle = "View All Downloads"
+
+    static func downloadRecoveryOverflowText(totalCount: Int) -> String? {
+        let hiddenRecoveryCount = max(0, totalCount - 2)
+        guard hiddenRecoveryCount > 0 else { return nil }
+        return "+\(hiddenRecoveryCount) more stalled \(hiddenRecoveryCount == 1 ? "download" : "downloads")"
+    }
+
     let foundation: DesktopFoundationState
     let chatSessions: [DesktopChatSessionState]
     let serverSessions: [DesktopServerSessionState]
@@ -224,6 +232,22 @@ struct DesktopCommandCenterView: View {
                                             Task { await viewModel.resumeDownload(jobID: entry.jobID) }
                                         }
                                         .buttonStyle(.borderedProminent)
+                                        .controlSize(.small)
+                                    }
+                                }
+                                if let overflowText = Self.downloadRecoveryOverflowText(
+                                    totalCount: viewModel.recoverableDownloads.count
+                                ) {
+                                    HStack {
+                                        Text(overflowText)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                        Spacer()
+                                        Button(Self.downloadRecoveryOverflowActionTitle) {
+                                            viewModel.selectSurface(.tools)
+                                            viewModel.selectToolSection(.downloads)
+                                        }
+                                        .buttonStyle(.bordered)
                                         .controlSize(.small)
                                     }
                                 }

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -59,6 +59,8 @@ private struct DesktopShellBannerView: View {
                         .foregroundStyle(.white.opacity(0.9))
                 }
                 .buttonStyle(.plain)
+                .help("Dismiss Banner")
+                .accessibilityLabel("Dismiss Banner")
             }
         }
         .padding(.horizontal, 20)
@@ -169,6 +171,93 @@ struct DesktopCommandCenterView: View {
             VStack(alignment: .leading, spacing: 20) {
                 Text("Command Center")
                     .font(.largeTitle.weight(.semibold))
+
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 260), spacing: 12)], spacing: 12) {
+                    GroupBox("Runtime Health") {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(foundation.serverStateText)
+                                .font(.headline)
+                            Text(foundation.connectionStateText)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(foundation.connectionDetailText)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    GroupBox("Primary Model") {
+                        VStack(alignment: .leading, spacing: 6) {
+                            if let model = foundation.models.first {
+                                Text(model.modelID)
+                                    .font(.headline)
+                                    .lineLimit(1)
+                                Text("\(model.stateText) • \(model.memoryPolicyText)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(model.memoryText)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(2)
+                            } else {
+                                Text("No model discovered.")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    if let viewModel, viewModel.recoverableDownloads.isEmpty == false {
+                        GroupBox("Download Recovery") {
+                            VStack(alignment: .leading, spacing: 8) {
+                                ForEach(viewModel.recoverableDownloads.prefix(2)) { entry in
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(entry.sourceModel)
+                                            .font(.headline)
+                                            .lineLimit(1)
+                                        Text(entry.progressText)
+                                            .font(.caption.monospacedDigit())
+                                            .foregroundStyle(.secondary)
+                                        Button("Resume Download") {
+                                            Task { await viewModel.resumeDownload(jobID: entry.jobID) }
+                                        }
+                                        .buttonStyle(.borderedProminent)
+                                        .controlSize(.small)
+                                    }
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+
+                    if let operation = viewModel?.lastModelOperation {
+                        GroupBox("Last Operation") {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text(operation.operation)
+                                    .font(.headline)
+                                Text(operation.modelID)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(operation.outputPath)
+                                    .font(.caption2.monospaced())
+                                    .foregroundStyle(.tertiary)
+                                    .lineLimit(2)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+
+                    if let lastError = viewModel?.lastError {
+                        GroupBox("Latest Error") {
+                            Text(lastError)
+                                .foregroundStyle(.red)
+                                .lineLimit(3)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                }
 
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 220), spacing: 12)], spacing: 12) {
                     ForEach(foundation.dashboardCards.filter { ["server", "connection", "backpressure", "memory"].contains($0.id) }) { card in
@@ -313,7 +402,7 @@ private struct DesktopServerWorkspaceView: View {
     let viewModel: RuntimeViewModel
     @State private var showsSidebar = true
     @State private var showsInspector = true
-    @State private var showsAdvanced = true
+    @State private var showsAdvanced = DesktopServerWorkspaceDefaults.showsAdvancedServingDefaults
 
     var body: some View {
         HSplitView {
@@ -337,6 +426,11 @@ private struct DesktopServerWorkspaceView: View {
     }
 }
 
+enum DesktopServerWorkspaceDefaults {
+    static let showsAdvancedServingDefaults = false
+    static let advancedServingDefaultsTitle = "Advanced Serving Defaults"
+}
+
 private struct DesktopServerSessionSidebar: View {
     let viewModel: RuntimeViewModel
 
@@ -352,6 +446,8 @@ private struct DesktopServerSessionSidebar: View {
                     Image(systemName: "plus")
                 }
                 .buttonStyle(.plain)
+                .help("New Server Session")
+                .accessibilityLabel("New Server Session")
             }
 
             if viewModel.serverSessions.isEmpty {
@@ -415,22 +511,27 @@ private struct DesktopServerSessionEditor: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
-                HStack {
-                    Text("Server")
-                        .font(.largeTitle.weight(.semibold))
-                    Spacer()
-                    Button(showsSidebar ? "Hide List" : "Show List") {
+                DesktopWorkspaceHeader(
+                    title: "Server",
+                    subtitle: "Choose model, configure listener, then start the server session."
+                ) {
+                    DesktopPaneToggleButton(
+                        role: .sidebar,
+                        isVisible: showsSidebar,
+                        shortcut: KeyboardShortcut("s", modifiers: [.command, .option])
+                    ) {
                         showsSidebar.toggle()
                     }
-                    Button(showsInspector ? "Hide Inspector" : "Show Inspector") {
+                    DesktopPaneToggleButton(
+                        role: .inspector,
+                        isVisible: showsInspector,
+                        shortcut: KeyboardShortcut("i", modifiers: [.command, .option])
+                    ) {
                         showsInspector.toggle()
                     }
                 }
 
                 if let session = viewModel.selectedServerSession {
-                    Text("Choose model, configure listener, then start the server session.")
-                        .foregroundStyle(.secondary)
-
                     if let notice = session.lifecycleBannerState {
                         DesktopInlineNoticeCardView(notice: notice)
                     }
@@ -514,9 +615,119 @@ private struct DesktopServerSessionEditor: View {
                     }
 
                     GroupBox {
-                        DisclosureGroup("Advanced Defaults", isExpanded: $showsAdvanced) {
-                            VStack(alignment: .leading, spacing: 12) {
-                                HStack {
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text(servingDefaultsCompactSummary(for: session))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            DisclosureGroup(DesktopServerWorkspaceDefaults.advancedServingDefaultsTitle, isExpanded: $showsAdvanced) {
+                                advancedServingDefaultsForm(for: session)
+                                    .padding(.top, 12)
+                            }
+                        }
+                    }
+
+                    GroupBox("Lifecycle Controls") {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text(session.runtimeDetailText)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+
+                            HStack {
+                                Button("Start") {
+                                    Task { await viewModel.startSelectedServerSession() }
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .disabled(session.canStart == false)
+
+                                Button("Pause") {
+                                    Task { await viewModel.pauseSelectedServerSession() }
+                                }
+                                .buttonStyle(.bordered)
+                                .disabled(session.canPause == false)
+
+                                Button("Resume") {
+                                    Task { await viewModel.resumeSelectedServerSession() }
+                                }
+                                .buttonStyle(.bordered)
+                                .disabled(session.canResume == false)
+
+                                Button("Wake") {
+                                    Task { await viewModel.wakeSelectedServerSession() }
+                                }
+                                .buttonStyle(.bordered)
+                                .disabled(session.canWake == false)
+
+                                Button("Stop") {
+                                    Task { await viewModel.stopSelectedServerSession() }
+                                }
+                                .buttonStyle(.bordered)
+                                .disabled(session.canStop == false)
+                            }
+
+                            Toggle(
+                                "Auto Sleep",
+                                isOn: Binding(
+                                    get: { viewModel.selectedServerSession?.autoSleepEnabled ?? false },
+                                    set: { viewModel.updateSelectedServerSessionAutoSleepEnabled($0) }
+                                )
+                            )
+
+                            HStack {
+                                TextField(
+                                    "Light sleep after (s)",
+                                    value: Binding(
+                                        get: { viewModel.selectedServerSession?.lightSleepAfterSeconds ?? 0 },
+                                        set: { viewModel.updateSelectedServerSessionLightSleepAfterSeconds($0) }
+                                    ),
+                                    format: .number
+                                )
+                                .textFieldStyle(.roundedBorder)
+
+                                TextField(
+                                    "Deep sleep after (s)",
+                                    value: Binding(
+                                        get: { viewModel.selectedServerSession?.deepSleepAfterSeconds ?? 0 },
+                                        set: { viewModel.updateSelectedServerSessionDeepSleepAfterSeconds($0) }
+                                    ),
+                                    format: .number
+                                )
+                                .textFieldStyle(.roundedBorder)
+
+                                Button("Apply Idle Policy") {
+                                    Task { await viewModel.applySelectedServerIdlePolicy() }
+                                }
+                                .buttonStyle(.bordered)
+                            }
+
+                            Text(session.idlePolicySummaryText)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                } else {
+                    ContentUnavailableView(
+                        "No Server Session Selected",
+                        systemImage: "server.rack",
+                        description: Text("Choose a server session from the list or create a new one.")
+                    )
+                }
+
+                Spacer()
+            }
+            .padding(20)
+        }
+    }
+
+    private func servingDefaultsCompactSummary(for session: DesktopServerSessionState) -> String {
+        let servingDefaults = session.servingDefaults
+        return "Source: \(servingDefaults.sourceText) • requested temp \(String(format: "%.2f", servingDefaults.temperature)) • top_p \(String(format: "%.2f", servingDefaults.topP)) • max \(servingDefaults.maxTokens) • stream \(servingDefaults.streamIntervalTokens) • sequences \(servingDefaults.maxConcurrentRequests)"
+    }
+
+    @ViewBuilder
+    private func advancedServingDefaultsForm(for session: DesktopServerSessionState) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
                                     TextField(
                                         "Temperature",
                                         value: Binding(
@@ -647,101 +858,6 @@ private struct DesktopServerSessionEditor: View {
                                     .foregroundStyle(.secondary)
                                 }
                             }
-                            .padding(.top, 12)
-                        }
-                    }
-
-                    GroupBox("Lifecycle Controls") {
-                        VStack(alignment: .leading, spacing: 12) {
-                            Text(session.runtimeDetailText)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-
-                            HStack {
-                                Button("Start") {
-                                    Task { await viewModel.startSelectedServerSession() }
-                                }
-                                .buttonStyle(.borderedProminent)
-                                .disabled(session.canStart == false)
-
-                                Button("Pause") {
-                                    Task { await viewModel.pauseSelectedServerSession() }
-                                }
-                                .buttonStyle(.bordered)
-                                .disabled(session.canPause == false)
-
-                                Button("Resume") {
-                                    Task { await viewModel.resumeSelectedServerSession() }
-                                }
-                                .buttonStyle(.bordered)
-                                .disabled(session.canResume == false)
-
-                                Button("Wake") {
-                                    Task { await viewModel.wakeSelectedServerSession() }
-                                }
-                                .buttonStyle(.bordered)
-                                .disabled(session.canWake == false)
-
-                                Button("Stop") {
-                                    Task { await viewModel.stopSelectedServerSession() }
-                                }
-                                .buttonStyle(.bordered)
-                                .disabled(session.canStop == false)
-                            }
-
-                            Toggle(
-                                "Auto Sleep",
-                                isOn: Binding(
-                                    get: { viewModel.selectedServerSession?.autoSleepEnabled ?? false },
-                                    set: { viewModel.updateSelectedServerSessionAutoSleepEnabled($0) }
-                                )
-                            )
-
-                            HStack {
-                                TextField(
-                                    "Light sleep after (s)",
-                                    value: Binding(
-                                        get: { viewModel.selectedServerSession?.lightSleepAfterSeconds ?? 0 },
-                                        set: { viewModel.updateSelectedServerSessionLightSleepAfterSeconds($0) }
-                                    ),
-                                    format: .number
-                                )
-                                .textFieldStyle(.roundedBorder)
-
-                                TextField(
-                                    "Deep sleep after (s)",
-                                    value: Binding(
-                                        get: { viewModel.selectedServerSession?.deepSleepAfterSeconds ?? 0 },
-                                        set: { viewModel.updateSelectedServerSessionDeepSleepAfterSeconds($0) }
-                                    ),
-                                    format: .number
-                                )
-                                .textFieldStyle(.roundedBorder)
-
-                                Button("Apply Idle Policy") {
-                                    Task { await viewModel.applySelectedServerIdlePolicy() }
-                                }
-                                .buttonStyle(.bordered)
-                            }
-
-                            Text(session.idlePolicySummaryText)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                } else {
-                    ContentUnavailableView(
-                        "No Server Session Selected",
-                        systemImage: "server.rack",
-                        description: Text("Choose a server session from the list or create a new one.")
-                    )
-                }
-
-                Spacer()
-            }
-            .padding(20)
-        }
     }
 }
 
@@ -831,42 +947,29 @@ private struct DesktopToolsWorkspaceView: View {
     var body: some View {
         HSplitView {
             if showsSidebar {
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("Tools")
-                        .font(.headline)
-                    ForEach(DesktopToolSection.allCases) { section in
-                        Button {
-                            viewModel.selectToolSection(section)
-                        } label: {
-                            Label(section.rawValue, systemImage: section.symbolName)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 10)
-                                .background(
-                                    viewModel.selectedToolSection == section
-                                    ? Color.accentColor.opacity(0.14)
-                                    : Color.secondary.opacity(0.06),
-                                    in: RoundedRectangle(cornerRadius: 12)
-                                )
-                        }
-                        .buttonStyle(.plain)
-                    }
-                    Spacer()
-                }
+                DesktopToolsCategorySidebarView(
+                    selectedToolSection: viewModel.selectedToolSection,
+                    selectToolSection: viewModel.selectToolSection
+                )
                 .padding(20)
                 .frame(minWidth: 240, idealWidth: 250)
             }
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
-                    HStack {
-                        Text(viewModel.selectedToolSection.rawValue)
-                            .font(.largeTitle.weight(.semibold))
-                        Spacer()
-                        Button(showsSidebar ? "Hide List" : "Show List") {
+                    DesktopWorkspaceHeader(title: viewModel.selectedToolSection.rawValue) {
+                        DesktopPaneToggleButton(
+                            role: .sidebar,
+                            isVisible: showsSidebar,
+                            shortcut: KeyboardShortcut("s", modifiers: [.command, .option])
+                        ) {
                             showsSidebar.toggle()
                         }
-                        Button(showsInspector ? "Hide Inspector" : "Show Inspector") {
+                        DesktopPaneToggleButton(
+                            role: .inspector,
+                            isVisible: showsInspector,
+                            shortcut: KeyboardShortcut("i", modifiers: [.command, .option])
+                        ) {
                             showsInspector.toggle()
                         }
                     }
@@ -927,6 +1030,50 @@ private struct DesktopToolsWorkspaceView: View {
                 .padding(20)
                 .frame(minWidth: 280, idealWidth: 300)
             }
+        }
+    }
+}
+
+struct DesktopToolsCategorySidebarView: View {
+    let selectedToolSection: DesktopToolSection
+    let selectToolSection: (DesktopToolSection) -> Void
+
+    static func accessibilityLabel(category: DesktopToolCategory, section: DesktopToolSection) -> String {
+        "\(category.rawValue) \(section.rawValue)"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Tools")
+                .font(.headline)
+            ForEach(DesktopToolCategory.allCases) { category in
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(category.rawValue)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 4)
+                    ForEach(category.sections) { section in
+                        Button {
+                            selectToolSection(section)
+                        } label: {
+                            Label(section.rawValue, systemImage: section.symbolName)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 10)
+                                .background(
+                                    selectedToolSection == section
+                                    ? Color.accentColor.opacity(0.14)
+                                    : Color.secondary.opacity(0.06),
+                                    in: RoundedRectangle(cornerRadius: 12)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .help(section.rawValue)
+                        .accessibilityLabel(Self.accessibilityLabel(category: category, section: section))
+                    }
+                }
+            }
+            Spacer()
         }
     }
 }
@@ -1097,6 +1244,7 @@ struct DesktopAudioSetupNoticeRow: View {
 
 struct DesktopTrainingToolSectionView: View {
     let viewModel: RuntimeViewModel
+    @State private var showsAdvanced = DesktopTrainingWorkspaceDefaults.showsAdvancedParameters
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -1201,36 +1349,6 @@ struct DesktopTrainingToolSectionView: View {
                             .textFieldStyle(.roundedBorder)
                     }
 
-                    HStack {
-                        TextField("Rank", text: stringBinding(\.loraRank))
-                            .textFieldStyle(.roundedBorder)
-                        TextField("Alpha", text: stringBinding(\.loraAlpha))
-                            .textFieldStyle(.roundedBorder)
-                        TextField("Dropout", text: stringBinding(\.loraDropout))
-                            .textFieldStyle(.roundedBorder)
-                    }
-
-                    HStack {
-                        TextField("Batch Size", text: stringBinding(\.loraBatchSize))
-                            .textFieldStyle(.roundedBorder)
-                        TextField("Epochs", text: stringBinding(\.loraEpochs))
-                            .textFieldStyle(.roundedBorder)
-                        TextField("Learning Rate", text: stringBinding(\.loraLearningRate))
-                            .textFieldStyle(.roundedBorder)
-                        TextField("Max Seq Length", text: stringBinding(\.loraMaxSeqLength))
-                            .textFieldStyle(.roundedBorder)
-                    }
-
-                    HStack {
-                        TextField("Target Modules", text: stringBinding(\.loraTargetModules))
-                            .textFieldStyle(.roundedBorder)
-                        TextField("Num Layers", text: stringBinding(\.loraNumLayers))
-                            .textFieldStyle(.roundedBorder)
-                    }
-
-                    TextField("Derived Model Alias", text: stringBinding(\.loraDerivedModelAlias))
-                        .textFieldStyle(.roundedBorder)
-
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Activation Mode")
                             .font(.caption.weight(.semibold))
@@ -1243,10 +1361,45 @@ struct DesktopTrainingToolSectionView: View {
                         .pickerStyle(.segmented)
                     }
 
-                    HStack {
-                        Toggle("Response Only", isOn: boolBinding(\.loraResponseOnly))
-                        Toggle("Mask Prompt", isOn: boolBinding(\.loraMaskPrompt))
-                        Toggle("Gradient Checkpointing", isOn: boolBinding(\.loraGradientCheckpointing))
+                    DisclosureGroup(DesktopTrainingWorkspaceDefaults.advancedParametersTitle, isExpanded: $showsAdvanced) {
+                        VStack(alignment: .leading, spacing: 12) {
+                            HStack {
+                                TextField("Rank", text: stringBinding(\.loraRank))
+                                    .textFieldStyle(.roundedBorder)
+                                TextField("Alpha", text: stringBinding(\.loraAlpha))
+                                    .textFieldStyle(.roundedBorder)
+                                TextField("Dropout", text: stringBinding(\.loraDropout))
+                                    .textFieldStyle(.roundedBorder)
+                            }
+
+                            HStack {
+                                TextField("Batch Size", text: stringBinding(\.loraBatchSize))
+                                    .textFieldStyle(.roundedBorder)
+                                TextField("Epochs", text: stringBinding(\.loraEpochs))
+                                    .textFieldStyle(.roundedBorder)
+                                TextField("Learning Rate", text: stringBinding(\.loraLearningRate))
+                                    .textFieldStyle(.roundedBorder)
+                                TextField("Max Seq Length", text: stringBinding(\.loraMaxSeqLength))
+                                    .textFieldStyle(.roundedBorder)
+                            }
+
+                            HStack {
+                                TextField("Target Modules", text: stringBinding(\.loraTargetModules))
+                                    .textFieldStyle(.roundedBorder)
+                                TextField("Num Layers", text: stringBinding(\.loraNumLayers))
+                                    .textFieldStyle(.roundedBorder)
+                            }
+
+                            TextField("Derived Model Alias", text: stringBinding(\.loraDerivedModelAlias))
+                                .textFieldStyle(.roundedBorder)
+
+                            HStack {
+                                Toggle("Response Only", isOn: boolBinding(\.loraResponseOnly))
+                                Toggle("Mask Prompt", isOn: boolBinding(\.loraMaskPrompt))
+                                Toggle("Gradient Checkpointing", isOn: boolBinding(\.loraGradientCheckpointing))
+                            }
+                        }
+                        .padding(.top, 8)
                     }
 
                     HStack {
@@ -1478,6 +1631,11 @@ struct DesktopTrainingToolSectionView: View {
     private func startRemoveDerivedModelTask() {
         Task { await removeDerivedModel() }
     }
+}
+
+enum DesktopTrainingWorkspaceDefaults {
+    static let showsAdvancedParameters = false
+    static let advancedParametersTitle = "Advanced Training Parameters"
 }
 
 struct DesktopDiagnosticsToolSectionView: View {
@@ -3659,14 +3817,19 @@ struct DesktopAPIWorkspaceView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
-                    HStack {
-                        Text("API")
-                            .font(.largeTitle.weight(.semibold))
-                        Spacer()
-                        Button(showsSidebar ? "Hide List" : "Show List") {
+                    DesktopWorkspaceHeader(title: "API") {
+                        DesktopPaneToggleButton(
+                            role: .sidebar,
+                            isVisible: showsSidebar,
+                            shortcut: KeyboardShortcut("s", modifiers: [.command, .option])
+                        ) {
                             showsSidebar.toggle()
                         }
-                        Button(showsInspector ? "Hide Inspector" : "Show Inspector") {
+                        DesktopPaneToggleButton(
+                            role: .inspector,
+                            isVisible: showsInspector,
+                            shortcut: KeyboardShortcut("i", modifiers: [.command, .option])
+                        ) {
                             showsInspector.toggle()
                         }
                     }

--- a/apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift
@@ -105,6 +105,7 @@ struct DesktopImageWorkspace: View {
     @Binding var selectedMode: DesktopImageWorkspaceMode
     @Binding var showsSidebar: Bool
     @Binding var showsInspector: Bool
+    @State private var showsAdvancedDefaults = DesktopImageWorkspaceDefaults.showsAdvancedDefaults
 
     private var workflowRole: RuntimeImageWorkflowRole {
         selectedMode == .generate ? .generate : .edit
@@ -121,14 +122,19 @@ struct DesktopImageWorkspace: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                HStack {
-                    Text("Image")
-                        .font(.largeTitle.weight(.semibold))
-                    Spacer()
-                    Button(showsSidebar ? "Hide List" : "Show List") {
+                DesktopWorkspaceHeader(title: "Image") {
+                    DesktopPaneToggleButton(
+                        role: .sidebar,
+                        isVisible: showsSidebar,
+                        shortcut: KeyboardShortcut("s", modifiers: [.command, .option])
+                    ) {
                         showsSidebar.toggle()
                     }
-                    Button(showsInspector ? "Hide Inspector" : "Show Inspector") {
+                    DesktopPaneToggleButton(
+                        role: .inspector,
+                        isVisible: showsInspector,
+                        shortcut: KeyboardShortcut("i", modifiers: [.command, .option])
+                    ) {
                         showsInspector.toggle()
                     }
                 }
@@ -223,45 +229,58 @@ struct DesktopImageWorkspace: View {
                             )
                         }
 
-                        HStack {
-                            TextField(
-                                "Steps",
-                                text: Binding(
-                                    get: { viewModel.imageSteps },
-                                    set: { viewModel.imageSteps = $0 }
-                                )
-                            )
-                            .textFieldStyle(.roundedBorder)
+                        DisclosureGroup(DesktopImageWorkspaceDefaults.advancedDefaultsTitle, isExpanded: $showsAdvancedDefaults) {
+                            VStack(alignment: .leading, spacing: 10) {
+                                HStack {
+                                    TextField(
+                                        "Steps",
+                                        text: Binding(
+                                            get: { viewModel.imageSteps },
+                                            set: { viewModel.imageSteps = $0 }
+                                        )
+                                    )
+                                    .textFieldStyle(.roundedBorder)
 
-                            TextField(
-                                "Guidance",
-                                text: Binding(
-                                    get: { viewModel.imageGuidance },
-                                    set: { viewModel.imageGuidance = $0 }
-                                )
-                            )
-                            .textFieldStyle(.roundedBorder)
+                                    TextField(
+                                        "Guidance",
+                                        text: Binding(
+                                            get: { viewModel.imageGuidance },
+                                            set: { viewModel.imageGuidance = $0 }
+                                        )
+                                    )
+                                    .textFieldStyle(.roundedBorder)
 
-                            if selectedMode == .edit {
+                                    if selectedMode == .edit {
+                                        TextField(
+                                            "Strength",
+                                            text: Binding(
+                                                get: { viewModel.imageStrength },
+                                                set: { viewModel.imageStrength = $0 }
+                                            )
+                                        )
+                                        .textFieldStyle(.roundedBorder)
+                                    }
+                                }
+
                                 TextField(
-                                    "Strength",
+                                    "Negative prompt",
                                     text: Binding(
-                                        get: { viewModel.imageStrength },
-                                        set: { viewModel.imageStrength = $0 }
+                                        get: { viewModel.imageNegativePrompt },
+                                        set: { viewModel.imageNegativePrompt = $0 }
                                     )
                                 )
                                 .textFieldStyle(.roundedBorder)
-                            }
-                        }
 
-                        TextField(
-                            "Negative prompt",
-                            text: Binding(
-                                get: { viewModel.imageNegativePrompt },
-                                set: { viewModel.imageNegativePrompt = $0 }
-                            )
-                        )
-                        .textFieldStyle(.roundedBorder)
+                                HStack {
+                                    Button("Save Defaults", action: viewModel.applyImageDefaultsFromUI)
+                                        .buttonStyle(.bordered)
+                                    Text(effectiveDefaultsSummary)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .padding(.top, 8)
+                        }
 
                         if selectedMode == .edit {
                             Picker(
@@ -307,8 +326,6 @@ struct DesktopImageWorkspace: View {
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                             Spacer()
-                            Button("Save Defaults", action: viewModel.applyImageDefaultsFromUI)
-                                .buttonStyle(.bordered)
                             Button("Run") {
                                 Task {
                                     if selectedMode == .generate {
@@ -319,6 +336,7 @@ struct DesktopImageWorkspace: View {
                                 }
                             }
                             .buttonStyle(.borderedProminent)
+                            .keyboardShortcut(.return, modifiers: .command)
                             .disabled(isActionDisabled)
                         }
                     }
@@ -405,6 +423,11 @@ struct DesktopImageWorkspace: View {
         negative \(negativePrompt)
         """
     }
+}
+
+enum DesktopImageWorkspaceDefaults {
+    static let showsAdvancedDefaults = false
+    static let advancedDefaultsTitle = "Advanced Image Defaults"
 }
 
 struct DesktopImageInspector: View {

--- a/apps/macos-menubar/Sources/AppMain/MenuBar/StatusMenu.swift
+++ b/apps/macos-menubar/Sources/AppMain/MenuBar/StatusMenu.swift
@@ -155,13 +155,7 @@ public final class StatusMenu: NSObject {
             .info("Server: \(viewModel.serverStateText)")
         ]
 
-        let prioritizedSignals = viewModel.desktopSignalStates.sorted { lhs, rhs in
-            if lhs.priority == rhs.priority {
-                return lhs.title < rhs.title
-            }
-            return lhs.priority > rhs.priority
-        }
-        for banner in prioritizedSignals.prefix(3) {
+        for banner in viewModel.desktopSignalStates.prefix(3) {
             switch banner.severity {
             case .critical:
                 items.append(.error(banner.title))

--- a/apps/macos-menubar/Sources/AppMain/MenuBar/StatusMenu.swift
+++ b/apps/macos-menubar/Sources/AppMain/MenuBar/StatusMenu.swift
@@ -2,7 +2,13 @@ import AppKit
 import Foundation
 
 public enum StatusMenuAction: String, Equatable, Sendable {
+    case openCommandCenter
     case openConsole
+    case openDownloads
+    case openServer
+    case resumeFirstDownload
+    case startSelectedServer
+    case wakeSelectedServer
     case loadPrimaryModel
     case unloadPrimaryModel
     case quit
@@ -148,7 +154,14 @@ public final class StatusMenu: NSObject {
         var items: [StatusMenuContentItem] = [
             .info("Server: \(viewModel.serverStateText)")
         ]
-        if let banner = viewModel.desktopBannerState {
+
+        let prioritizedSignals = viewModel.desktopSignalStates.sorted { lhs, rhs in
+            if lhs.priority == rhs.priority {
+                return lhs.title < rhs.title
+            }
+            return lhs.priority > rhs.priority
+        }
+        for banner in prioritizedSignals.prefix(3) {
             switch banner.severity {
             case .critical:
                 items.append(.error(banner.title))
@@ -156,6 +169,8 @@ public final class StatusMenu: NSObject {
                 items.append(.info(banner.title))
             }
         }
+
+        appendRecoveryActions(to: &items)
 
         if let model = viewModel.primaryModel {
             items.append(.info("\(model.modelID): \(model.stateText)"))
@@ -167,6 +182,7 @@ public final class StatusMenu: NSObject {
             )
         }
 
+        items.append(.action("Open Command Center", .openCommandCenter))
         items.append(.action("Open Melix Console", .openConsole))
 
         if let lastError = viewModel.lastError {
@@ -181,8 +197,28 @@ public final class StatusMenu: NSObject {
 
     func perform(_ action: StatusMenuAction) {
         switch action {
+        case .openCommandCenter:
+            viewModel.openCommandCenter()
         case .openConsole:
             openConsoleHandler()
+        case .openDownloads:
+            viewModel.selectToolSection(.downloads)
+        case .openServer:
+            viewModel.selectSurface(.server)
+        case .resumeFirstDownload:
+            Task { @MainActor in
+                if let download = viewModel.recoverableDownloads.first {
+                    await viewModel.resumeDownload(jobID: download.jobID)
+                }
+            }
+        case .startSelectedServer:
+            Task { @MainActor in
+                await viewModel.startSelectedServerSession()
+            }
+        case .wakeSelectedServer:
+            Task { @MainActor in
+                await viewModel.wakeSelectedServerSession()
+            }
         case .loadPrimaryModel:
             Task { @MainActor in
                 await viewModel.loadPrimaryModel()
@@ -198,6 +234,31 @@ public final class StatusMenu: NSObject {
 
     private func render() {
         renderer.render(content: content(), target: self, action: #selector(handleMenuAction(_:)))
+    }
+
+    private func appendRecoveryActions(to items: inout [StatusMenuContentItem]) {
+        if viewModel.recoverableDownloads.isEmpty == false {
+            items.append(.action("Resume Download", .resumeFirstDownload))
+            items.append(.action("Open Downloads", .openDownloads))
+        } else if viewModel.activeDownloads.isEmpty == false {
+            items.append(.action("Open Downloads", .openDownloads))
+        }
+
+        guard let session = viewModel.selectedServerSession else {
+            return
+        }
+        switch session.lifecycle {
+        case .sleeping:
+            items.append(.action("Wake Server", .wakeSelectedServer))
+            items.append(.action("Open Server", .openServer))
+        case .stopped, .error, .unavailable:
+            items.append(.action("Start Server", .startSelectedServer))
+            items.append(.action("Open Server", .openServer))
+        case .paused:
+            items.append(.action("Open Server", .openServer))
+        case .draft, .starting, .running, .stopping:
+            break
+        }
     }
 
     @objc func handleMenuAction(_ sender: NSMenuItem) {

--- a/apps/macos-menubar/Sources/AppMain/Models/DesktopShellState.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/DesktopShellState.swift
@@ -57,6 +57,79 @@ public enum DesktopToolSection: String, CaseIterable, Identifiable, Codable, Sen
     }
 }
 
+public enum DesktopToolCategory: String, CaseIterable, Identifiable, Codable, Sendable {
+    case models = "Models"
+    case build = "Build"
+    case validate = "Validate"
+    case system = "System"
+
+    public var id: String { rawValue }
+
+    public var sections: [DesktopToolSection] {
+        switch self {
+        case .models:
+            return [.modelsLibrary, .downloads]
+        case .build:
+            return [.training]
+        case .validate:
+            return [.diagnostics]
+        case .system:
+            return [.logs, .settings]
+        }
+    }
+}
+
+public enum DesktopPaneRole: String, CaseIterable, Identifiable, Sendable {
+    case sidebar
+    case inspector
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .sidebar:
+            return "Sidebar"
+        case .inspector:
+            return "Inspector"
+        }
+    }
+
+    public var visibleSymbolName: String {
+        switch self {
+        case .sidebar:
+            return "sidebar.left"
+        case .inspector:
+            return "sidebar.right"
+        }
+    }
+
+    public var hiddenSymbolName: String {
+        visibleSymbolName
+    }
+
+    public func accessibilityLabel(isVisible: Bool) -> String {
+        "\(isVisible ? "Hide" : "Show") \(title)"
+    }
+}
+
+@MainActor
+public enum DesktopWorkspaceCommand: Equatable, Sendable {
+    case selectSurface(DesktopSurface)
+    case selectToolSection(DesktopToolSection)
+    case openCommandCenter
+
+    public func perform(on viewModel: RuntimeViewModel) {
+        switch self {
+        case .selectSurface(let surface):
+            viewModel.selectSurface(surface)
+        case .selectToolSection(let section):
+            viewModel.selectToolSection(section)
+        case .openCommandCenter:
+            viewModel.openCommandCenter()
+        }
+    }
+}
+
 public enum DesktopServerAuthMode: String, CaseIterable, Identifiable, Codable, Sendable {
     case none = "None"
     case bearerToken = "Bearer Token"
@@ -634,6 +707,17 @@ public enum DesktopBannerSeverity: Sendable {
     case critical
 }
 
+public enum DesktopSignalPriority: Int, Comparable, Sendable {
+    case info = 0
+    case recovery = 10
+    case warning = 20
+    case critical = 30
+
+    public static func < (lhs: DesktopSignalPriority, rhs: DesktopSignalPriority) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
 public struct DesktopBannerState: Equatable, Sendable {
     public let id: String
     public let title: String
@@ -669,6 +753,17 @@ public struct DesktopBannerState: Equatable, Sendable {
             "critical"
         }
         return "\(severityKey)-\(title)-\(detail)"
+    }
+
+    public var priority: DesktopSignalPriority {
+        switch severity {
+        case .critical:
+            return .critical
+        case .warning:
+            return id == "download-recovery" ? .recovery : .warning
+        case .info:
+            return .info
+        }
     }
 }
 

--- a/apps/macos-menubar/Sources/AppMain/Models/DesktopShellState.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/DesktopShellState.swift
@@ -94,17 +94,13 @@ public enum DesktopPaneRole: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
-    public var visibleSymbolName: String {
+    public var symbolName: String {
         switch self {
         case .sidebar:
             return "sidebar.left"
         case .inspector:
             return "sidebar.right"
         }
-    }
-
-    public var hiddenSymbolName: String {
-        visibleSymbolName
     }
 
     public func accessibilityLabel(isVisible: Bool) -> String {
@@ -724,19 +720,22 @@ public struct DesktopBannerState: Equatable, Sendable {
     public let detail: String
     public let severity: DesktopBannerSeverity
     public let isDismissible: Bool
+    public let isRecoverable: Bool
 
     public init(
         id: String = "",
         title: String,
         detail: String,
         severity: DesktopBannerSeverity,
-        isDismissible: Bool = false
+        isDismissible: Bool = false,
+        isRecoverable: Bool = false
     ) {
         self.id = id.isEmpty ? Self.defaultID(title: title, detail: detail, severity: severity) : id
         self.title = title
         self.detail = detail
         self.severity = severity
         self.isDismissible = isDismissible
+        self.isRecoverable = isRecoverable
     }
 
     private static func defaultID(
@@ -760,7 +759,7 @@ public struct DesktopBannerState: Equatable, Sendable {
         case .critical:
             return .critical
         case .warning:
-            return id == "download-recovery" ? .recovery : .warning
+            return isRecoverable ? .recovery : .warning
         case .info:
             return .info
         }

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -2469,7 +2469,8 @@ public final class RuntimeViewModel {
                     id: "download-recovery",
                     title: "Download Recovery Available",
                     detail: detail,
-                    severity: .warning
+                    severity: .warning,
+                    isRecoverable: true
                 )
             )
         } else if let activeDownload = activeDownloads.first {

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -2377,12 +2377,17 @@ public final class RuntimeViewModel {
     }
 
     public var desktopBannerState: DesktopBannerState? {
-        desktopSignalStates.first
+        desktopSignalStates.first { $0.priority >= .recovery }
     }
 
     public var desktopSignalStates: [DesktopBannerState] {
         resolvedDesktopSignals().filter { banner in
             banner.isDismissible == false || dismissedBannerIDs.contains(banner.id) == false
+        }.sorted { lhs, rhs in
+            if lhs.priority == rhs.priority {
+                return lhs.title < rhs.title
+            }
+            return lhs.priority > rhs.priority
         }
     }
 

--- a/apps/macos-menubar/Tests/MenuBarTests/AppMainBootstrapTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/AppMainBootstrapTests.swift
@@ -498,6 +498,27 @@ struct AppMainBootstrapTests {
         #expect(commandCenterPresenter.showCount == 1)
     }
 
+    @Test("bootstrap wires command center action before creating the status menu")
+    @MainActor
+    func bootstrapWiresCommandCenterActionBeforeCreatingStatusMenu() {
+        let menu = RecordingInstallStatusMenu()
+        let commandCenterPresenter = RecordingDesktopFoundationPresenter()
+        var actionWasPresentWhenStatusMenuWasCreated = false
+
+        _ = MelixMenuBarBootstrap(
+            client: FakeControlPlaneXPCClient(),
+            commandCenterPresenterFactory: { _, _ in commandCenterPresenter },
+            statusMenuFactory: { viewModel, _, _ in
+                actionWasPresentWhenStatusMenuWasCreated = viewModel.openCommandCenterAction != nil
+                viewModel.openCommandCenter()
+                return menu
+            }
+        )
+
+        #expect(actionWasPresentWhenStatusMenuWasCreated)
+        #expect(commandCenterPresenter.showCount == 1)
+    }
+
     @Test("bootstrap environment honors explicit overrides")
     @MainActor
     func bootstrapEnvironmentHonorsExplicitOverrides() {

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -46,8 +46,30 @@ struct DesktopFoundationViewTests {
 
         #expect(hideSidebar.fittingSize.width <= DesktopShellChromeMetrics.paneToggleButtonWidth + 8)
         #expect(showInspector.fittingSize.width <= DesktopShellChromeMetrics.paneToggleButtonWidth + 8)
+        #expect(DesktopPaneRole.sidebar.symbolName == "sidebar.left")
+        #expect(DesktopPaneRole.inspector.symbolName == "sidebar.right")
         #expect(DesktopPaneRole.sidebar.accessibilityLabel(isVisible: true) == "Hide Sidebar")
         #expect(DesktopPaneRole.inspector.accessibilityLabel(isVisible: false) == "Show Inspector")
+    }
+
+    @Test("desktop banner recovery priority is explicit")
+    func desktopBannerRecoveryPriorityIsExplicit() {
+        let recoverableWarning = DesktopBannerState(
+            id: "arbitrary-recovery-id",
+            title: "Recoverable",
+            detail: "Can resume",
+            severity: .warning,
+            isRecoverable: true
+        )
+        let regularWarning = DesktopBannerState(
+            id: "download-recovery",
+            title: "Regular Warning",
+            detail: "Not recoverable",
+            severity: .warning
+        )
+
+        #expect(recoverableWarning.priority == .recovery)
+        #expect(regularWarning.priority == .warning)
     }
 
     @Test("workspace commands update surface selection and command center")
@@ -298,6 +320,36 @@ struct DesktopFoundationViewTests {
                             downloadedBytes: 1024,
                             totalBytes: 2048,
                             resumeReady: true
+                        ),
+                        MenuBarDownloadFixture(
+                            jobID: "model-ops-command-center-2",
+                            sourceModel: "melix-dev-vision",
+                            status: "stalled",
+                            stage: "download",
+                            pct: 0.25,
+                            outputDir: "/tmp/melix-downloads/melix-dev-vision",
+                            outputPath: "/tmp/melix-downloads/melix-dev-vision/download.artifact",
+                            partialPath: "/tmp/melix-downloads/melix-dev-vision/download.artifact.partial",
+                            statePath: "/tmp/melix-downloads/melix-dev-vision/download.state.json",
+                            selectedMirror: "https://mirror.example/command-center-2",
+                            downloadedBytes: 512,
+                            totalBytes: 2048,
+                            resumeReady: true
+                        ),
+                        MenuBarDownloadFixture(
+                            jobID: "model-ops-command-center-3",
+                            sourceModel: "melix-dev-audio",
+                            status: "stalled",
+                            stage: "download",
+                            pct: 0.75,
+                            outputDir: "/tmp/melix-downloads/melix-dev-audio",
+                            outputPath: "/tmp/melix-downloads/melix-dev-audio/download.artifact",
+                            partialPath: "/tmp/melix-downloads/melix-dev-audio/download.artifact.partial",
+                            statePath: "/tmp/melix-downloads/melix-dev-audio/download.state.json",
+                            selectedMirror: "https://mirror.example/command-center-3",
+                            downloadedBytes: 1536,
+                            totalBytes: 2048,
+                            resumeReady: true
                         )
                     ]
                 )
@@ -312,8 +364,11 @@ struct DesktopFoundationViewTests {
 
         #expect(view.subviews.isEmpty == false)
         #expect(viewModel.desktopFoundationState.models.isEmpty == false)
-        #expect(viewModel.recoverableDownloads.isEmpty == false)
+        #expect(viewModel.recoverableDownloads.count == 3)
         #expect(viewModel.desktopSignalStates.contains { $0.title == "Download Recovery Available" })
+        #expect(DesktopCommandCenterView.downloadRecoveryOverflowText(totalCount: 2) == nil)
+        #expect(DesktopCommandCenterView.downloadRecoveryOverflowText(totalCount: 3) == "+1 more stalled download")
+        #expect(DesktopCommandCenterView.downloadRecoveryOverflowActionTitle == "View All Downloads")
     }
 
     @Test("workspace shell keeps dismissible update signals out of the top banner")

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -100,6 +100,22 @@ struct DesktopFoundationViewTests {
         #expect(DesktopToolCategory.system.sections == [.logs, .settings])
     }
 
+    @Test("tool categories cover every tool section exactly once")
+    @MainActor
+    func toolCategoriesCoverEveryToolSectionExactlyOnce() {
+        let categorizedSections = DesktopToolCategory.allCases.flatMap(\.sections)
+        let missingSections = DesktopToolSection.allCases.filter { section in
+            categorizedSections.contains(section) == false
+        }
+        let duplicateSections = DesktopToolSection.allCases.filter { section in
+            categorizedSections.filter { $0 == section }.count > 1
+        }
+
+        #expect(missingSections.isEmpty)
+        #expect(duplicateSections.isEmpty)
+        #expect(categorizedSections.count == DesktopToolSection.allCases.count)
+    }
+
     @Test("workspace surfaces use shared icon pane controls")
     @MainActor
     func workspaceSurfacesUseSharedIconPaneControls() async throws {

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -34,6 +34,70 @@ struct DesktopFoundationViewTests {
         #expect(viewModel.selectedSurface == .chat)
     }
 
+    @Test("shared pane chrome exposes labeled icon controls")
+    @MainActor
+    func sharedPaneChromeExposesLabeledIconControls() {
+        let hideSidebar = hostView(
+            DesktopPaneToggleButton(role: .sidebar, isVisible: true, action: {})
+        )
+        let showInspector = hostView(
+            DesktopPaneToggleButton(role: .inspector, isVisible: false, action: {})
+        )
+
+        #expect(hideSidebar.fittingSize.width <= DesktopShellChromeMetrics.paneToggleButtonWidth + 8)
+        #expect(showInspector.fittingSize.width <= DesktopShellChromeMetrics.paneToggleButtonWidth + 8)
+        #expect(DesktopPaneRole.sidebar.accessibilityLabel(isVisible: true) == "Hide Sidebar")
+        #expect(DesktopPaneRole.inspector.accessibilityLabel(isVisible: false) == "Show Inspector")
+    }
+
+    @Test("workspace commands update surface selection and command center")
+    @MainActor
+    func workspaceCommandsUpdateSurfaceSelectionAndCommandCenter() async throws {
+        let viewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        let commandCenter = CommandCenterOpenRecorder()
+        viewModel.openCommandCenterAction = { commandCenter.open() }
+        await viewModel.start()
+
+        DesktopWorkspaceCommand.selectSurface(.image).perform(on: viewModel)
+        #expect(viewModel.selectedSurface == .image)
+
+        DesktopWorkspaceCommand.selectToolSection(.downloads).perform(on: viewModel)
+        #expect(viewModel.selectedSurface == .tools)
+        #expect(viewModel.selectedToolSection == .downloads)
+
+        DesktopWorkspaceCommand.openCommandCenter.perform(on: viewModel)
+        #expect(commandCenter.wasOpened)
+    }
+
+    @Test("tools categories map sections into staged workflow groups")
+    @MainActor
+    func toolsCategoriesMapSectionsIntoStagedWorkflowGroups() {
+        #expect(DesktopToolCategory.models.sections == [.modelsLibrary, .downloads])
+        #expect(DesktopToolCategory.build.sections == [.training])
+        #expect(DesktopToolCategory.validate.sections == [.diagnostics])
+        #expect(DesktopToolCategory.system.sections == [.logs, .settings])
+    }
+
+    @Test("workspace surfaces use shared icon pane controls")
+    @MainActor
+    func workspaceSurfacesUseSharedIconPaneControls() async throws {
+        let client = FakeControlPlaneXPCClient()
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+
+        for surface in [DesktopSurface.server, .image, .tools, .api] {
+            viewModel.selectSurface(surface)
+            let hosted = hostView(DesktopWorkspaceShellView(viewModel: viewModel))
+            let renderedTexts = renderedTextValues(in: hosted)
+
+            #expect(hosted.subviews.isEmpty == false)
+            #expect(renderedTexts.contains("Hide List") == false)
+            #expect(renderedTexts.contains("Hide Inspector") == false)
+            #expect(DesktopPaneRole.sidebar.accessibilityLabel(isVisible: true) == "Hide Sidebar")
+            #expect(DesktopPaneRole.inspector.accessibilityLabel(isVisible: true) == "Hide Inspector")
+        }
+    }
+
     @Test("root view renders workspace content without in-content shell chrome")
     @MainActor
     func rootViewRendersWorkspaceContentWithoutInContentShellChrome() async throws {
@@ -157,14 +221,38 @@ struct DesktopFoundationViewTests {
         viewModel.selectSurface(.server)
 
         let view = hostView(DesktopWorkspaceShellView(viewModel: viewModel))
+
+        #expect(view.subviews.isEmpty == false)
+        #expect(viewModel.selectedServerSession?.servingDefaults.temperature == 0.44)
+        #expect(viewModel.selectedServerSession?.servingDefaults.topP == 0.91)
+        #expect(viewModel.selectedServerSession?.servingDefaults.maxTokens == 320)
+        #expect(viewModel.selectedServerSession?.servingDefaults.streamIntervalTokens == 2)
+        #expect(viewModel.selectedServerSession?.servingDefaults.maxConcurrentRequests == 6)
+        #expect(viewModel.selectedServerSession?.servingDefaults.sourceText == "Environment Defaults")
+    }
+
+    @Test("server workspace folds advanced serving defaults by default")
+    @MainActor
+    func serverWorkspaceFoldsAdvancedServingDefaultsByDefault() async throws {
+        let client = FakeControlPlaneXPCClient()
+        var snapshot = Melix_Controlplane_V1_ServerSnapshot()
+        snapshot.serverState = .serverReady
+        snapshot.models = [ModelCatalog.devTextModel()]
+        snapshot.runtimeSessions = [makeDesktopRuntimeSession()]
+        await client.configureSnapshot(snapshot)
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+        viewModel.selectSurface(.server)
+
+        let view = hostView(DesktopWorkspaceShellView(viewModel: viewModel))
         let renderedTexts = renderedTextValues(in: view)
 
-        #expect(renderedTexts.contains("0.44"))
-        #expect(renderedTexts.contains("0.91"))
-        #expect(renderedTexts.contains("320"))
-        #expect(renderedTexts.contains("2"))
-        #expect(renderedTexts.contains("6"))
-        #expect(viewModel.selectedServerSession?.servingDefaults.sourceText == "Environment Defaults")
+        #expect(view.subviews.isEmpty == false)
+        #expect(DesktopServerWorkspaceDefaults.showsAdvancedServingDefaults == false)
+        #expect(DesktopServerWorkspaceDefaults.advancedServingDefaultsTitle == "Advanced Serving Defaults")
+        #expect(renderedTexts.contains("Apply Serving Defaults") == false)
+        #expect(renderedTexts.contains("Temperature") == false)
+        #expect(renderedTexts.contains("Top P") == false)
     }
 
     @Test("command center view renders global operator summaries")
@@ -185,9 +273,52 @@ struct DesktopFoundationViewTests {
         #expect(view.subviews.isEmpty == false)
     }
 
-    @Test("workspace shell renders dismissible update banners from shared signal state")
+    @Test("command center renders state-first recovery and workflow summaries")
     @MainActor
-    func workspaceShellRendersDismissibleUpdateBanner() async throws {
+    func commandCenterRendersStateFirstRecoveryAndWorkflowSummaries() async throws {
+        let client = FakeControlPlaneXPCClient()
+        await client.configureModelOperation(
+            makeNamedModelOperationResult(
+                operation: "registry_snapshot",
+                outputPath: "/tmp/melix-model-ops-registry/registry_snapshot.json",
+                manifestJSON: makeModelOpsRegistrySnapshotManifestJSON(
+                    roots: [],
+                    downloads: [
+                        MenuBarDownloadFixture(
+                            jobID: "model-ops-command-center",
+                            sourceModel: "melix-dev-text",
+                            status: "stalled",
+                            stage: "download",
+                            pct: 0.5,
+                            outputDir: "/tmp/melix-downloads/melix-dev-text",
+                            outputPath: "/tmp/melix-downloads/melix-dev-text/download.artifact",
+                            partialPath: "/tmp/melix-downloads/melix-dev-text/download.artifact.partial",
+                            statePath: "/tmp/melix-downloads/melix-dev-text/download.state.json",
+                            selectedMirror: "https://mirror.example/command-center",
+                            downloadedBytes: 1024,
+                            totalBytes: 2048,
+                            resumeReady: true
+                        )
+                    ]
+                )
+            ),
+            forNamedOperation: "registry_snapshot"
+        )
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+        await viewModel.refreshDownloadQueueState()
+
+        let view = hostView(DesktopCommandCenterView(viewModel: viewModel))
+
+        #expect(view.subviews.isEmpty == false)
+        #expect(viewModel.desktopFoundationState.models.isEmpty == false)
+        #expect(viewModel.recoverableDownloads.isEmpty == false)
+        #expect(viewModel.desktopSignalStates.contains { $0.title == "Download Recovery Available" })
+    }
+
+    @Test("workspace shell keeps dismissible update signals out of the top banner")
+    @MainActor
+    func workspaceShellKeepsDismissibleUpdateSignalsOutOfTopBanner() async throws {
         let client = FakeControlPlaneXPCClient()
         let viewModel = RuntimeViewModel(
             client: client,
@@ -205,17 +336,20 @@ struct DesktopFoundationViewTests {
         await viewModel.start()
 
         let initialView = hostView(DesktopWorkspaceShellView(viewModel: viewModel))
-        let banner = try #require(viewModel.desktopBannerState)
+        let signal = try #require(viewModel.desktopSignalStates.first { $0.title == "Update available: 0.2.0" })
+        let initialTexts = renderedTextValues(in: initialView)
 
         #expect(initialView.subviews.isEmpty == false)
-        #expect(banner.isDismissible)
-        #expect(banner.title == "Update available: 0.2.0")
-        #expect(banner.detail == "Current 0.1.0 on stable")
+        #expect(viewModel.desktopBannerState == nil)
+        #expect(signal.isDismissible)
+        #expect(signal.detail == "Current 0.1.0 on stable")
+        #expect(initialTexts.contains("Update available: 0.2.0") == false)
 
-        viewModel.dismissDesktopBanner(id: banner.id)
+        viewModel.dismissDesktopBanner(id: signal.id)
 
         let dismissedView = hostView(DesktopWorkspaceShellView(viewModel: viewModel))
         let dismissedTexts = renderedTextValues(in: dismissedView)
+        #expect(viewModel.desktopSignalStates.contains { $0.title == "Update available: 0.2.0" } == false)
         #expect(dismissedTexts.contains("Update available: 0.2.0") == false)
     }
 
@@ -797,8 +931,51 @@ struct DesktopFoundationViewTests {
         #expect(renderedTexts.contains("Hugging Face"))
         #expect(renderedTexts.contains("QLoRA"))
         #expect(renderedTexts.contains("LoRA"))
-        #expect(renderedTexts.contains("Adapter-backed Runtime"))
-        #expect(renderedTexts.contains("Fused Derived Model"))
+        #expect(DesktopTrainingWorkspaceDefaults.showsAdvancedParameters == false)
+        #expect(DesktopTrainingWorkspaceDefaults.advancedParametersTitle == "Advanced Training Parameters")
+    }
+
+    @Test("tools workspace renders category-first navigation")
+    @MainActor
+    func toolsWorkspaceRendersCategoryFirstNavigation() async throws {
+        let view = hostView(
+            DesktopToolsCategorySidebarView(
+                selectedToolSection: .training,
+                selectToolSection: { _ in }
+            )
+        )
+
+        #expect(view.subviews.isEmpty == false)
+        for category in DesktopToolCategory.allCases {
+            for section in category.sections {
+                #expect(
+                    DesktopToolsCategorySidebarView.accessibilityLabel(category: category, section: section)
+                        == "\(category.rawValue) \(section.rawValue)"
+                )
+            }
+        }
+    }
+
+    @Test("training defaults to preset-first primary fields with advanced folded")
+    @MainActor
+    func trainingDefaultsToPresetFirstPrimaryFieldsWithAdvancedFolded() async throws {
+        let client = FakeControlPlaneXPCClient()
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+
+        let view = hostView(DesktopTrainingToolSectionView(viewModel: viewModel))
+        let renderedTexts = renderedTextValues(in: view)
+
+        #expect(view.subviews.isEmpty == false)
+        #expect(DesktopTrainingWorkspaceDefaults.showsAdvancedParameters == false)
+        #expect(DesktopTrainingWorkspaceDefaults.advancedParametersTitle == "Advanced Training Parameters")
+        #expect(renderedTexts.contains(viewModel.selectedLoraModelID))
+        #expect(renderedTexts.contains(viewModel.loraAdapterName))
+        #expect(renderedTexts.contains(viewModel.loraTargetRepo))
+        #expect(renderedTexts.contains("Rank") == false)
+        #expect(renderedTexts.contains("Alpha") == false)
+        #expect(renderedTexts.contains("Dropout") == false)
+        #expect(renderedTexts.contains(RuntimeLoraActivationMode.adapterBackedRuntime.title))
     }
 
     @Test("training tool section renders populated adapter activation state and dispatches actions")
@@ -1015,6 +1192,9 @@ struct DesktopFoundationViewTests {
     func apiQuickStartPanelCoversEmptySurfaceAndMissingSessionStates() throws {
         let emptyFoundation = DesktopFoundationState(
             title: "Melix Ready",
+            serverStateText: "Ready",
+            connectionStateText: "Connected",
+            connectionDetailText: "Snapshot hydrated",
             dashboardCards: [],
             queueLanes: [],
             models: [],
@@ -2871,6 +3051,36 @@ struct DesktopFoundationViewTests {
         #expect(viewModel.imageEditMaskURL == "file:///tmp/mask.png")
     }
 
+    @Test("image workspace folds advanced defaults by default")
+    @MainActor
+    func imageWorkspaceFoldsAdvancedDefaultsByDefault() async throws {
+        let client = FakeControlPlaneXPCClient()
+        var snapshot = Melix_Controlplane_V1_ServerSnapshot()
+        snapshot.serverState = .serverReady
+        snapshot.models = [makeMenuBarImageModelSummary()]
+        await client.configureSnapshot(snapshot)
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+
+        let view = hostView(
+            DesktopImageWorkspace(
+                viewModel: viewModel,
+                selectedMode: .constant(.generate),
+                showsSidebar: .constant(true),
+                showsInspector: .constant(true)
+            )
+        )
+        let renderedTexts = renderedTextValues(in: view)
+
+        #expect(view.subviews.isEmpty == false)
+        #expect(DesktopImageWorkspaceDefaults.showsAdvancedDefaults == false)
+        #expect(DesktopImageWorkspaceDefaults.advancedDefaultsTitle == "Advanced Image Defaults")
+        #expect(renderedTexts.contains(viewModel.imageSize))
+        #expect(renderedTexts.contains("Steps") == false)
+        #expect(renderedTexts.contains("Guidance") == false)
+        #expect(renderedTexts.contains("Negative prompt") == false)
+    }
+
     @Test("image inspector renders timeout redo and reiterate branches")
     @MainActor
     func imageInspectorRendersTimeoutRedoAndReiterateBranches() async throws {
@@ -4213,6 +4423,15 @@ private func renderedTextValues(in rootView: NSView) -> [String] {
 
     visit(rootView)
     return values
+}
+
+@MainActor
+private final class CommandCenterOpenRecorder {
+    private(set) var wasOpened = false
+
+    func open() {
+        wasOpened = true
+    }
 }
 
 private func waitForDesktopFoundationCondition(

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -2830,12 +2830,13 @@ struct RuntimeViewModelTests {
 
         await viewModel.start()
 
-        let initialBanner = try #require(viewModel.desktopBannerState)
-        #expect(initialBanner.isDismissible)
-        #expect(initialBanner.title == "Update available: 0.2.0")
-
-        viewModel.dismissDesktopBanner()
+        let initialSignal = try #require(viewModel.desktopSignalStates.first { $0.title == "Update available: 0.2.0" })
+        #expect(initialSignal.isDismissible)
         #expect(viewModel.desktopBannerState == nil)
+
+        viewModel.dismissDesktopBanner(id: initialSignal.id)
+        #expect(viewModel.desktopBannerState == nil)
+        #expect(viewModel.desktopSignalStates.contains { $0.title == "Update available: 0.2.0" } == false)
 
         let restoredViewModel = RuntimeViewModel(
             client: FakeControlPlaneXPCClient(),
@@ -2844,6 +2845,7 @@ struct RuntimeViewModelTests {
         )
         await restoredViewModel.start()
         #expect(restoredViewModel.desktopBannerState == nil)
+        #expect(restoredViewModel.desktopSignalStates.contains { $0.title == "Update available: 0.2.0" } == false)
 
         let upgradedProvider = StubProductInstallStateProvider(
             updateStatusResponse: ProductUpdateStatus(
@@ -2861,7 +2863,8 @@ struct RuntimeViewModelTests {
         )
         await upgradedViewModel.start()
 
-        #expect(upgradedViewModel.desktopBannerState?.title == "Update available: 0.3.0")
+        #expect(upgradedViewModel.desktopBannerState == nil)
+        #expect(upgradedViewModel.desktopSignalStates.contains { $0.title == "Update available: 0.3.0" })
     }
 
     @Test("critical runtime banners ignore dismiss requests")

--- a/apps/macos-menubar/Tests/MenuBarTests/StatusMenuTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/StatusMenuTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 
 @testable import AppMain
+import MelixControlPlaneCore
 import MelixControlPlaneProtocol
 
 @Suite("Status Menu", .serialized)
@@ -25,6 +26,7 @@ struct StatusMenuTests {
                 .info("Server: Ready"),
                 .info("melix-dev-text: Discovered"),
                 .action("Load", .loadPrimaryModel),
+                .action("Open Command Center", .openCommandCenter),
                 .action("Open Melix Console", .openConsole),
                 .separator,
                 .action("Quit Melix", .quit),
@@ -147,6 +149,95 @@ struct StatusMenuTests {
 
         let content = try #require(renderer.lastContent)
         #expect(content.items.contains(.info("Download Recovery Available")))
+    }
+
+    @Test("download recovery menu actions are prioritized before model actions")
+    @MainActor
+    func downloadRecoveryMenuActionsArePrioritizedBeforeModelActions() async throws {
+        let client = FakeControlPlaneXPCClient()
+        await client.configureModelOperation(
+            makeStatusMenuNamedModelOperationResult(
+                operation: "registry_snapshot",
+                outputPath: "/tmp/melix-model-ops-registry/registry_snapshot.json",
+                manifestJSON: makeModelOpsRegistrySnapshotManifestJSON(
+                    roots: [],
+                    downloads: [
+                        MenuBarDownloadFixture(
+                            jobID: "model-ops-0200",
+                            sourceModel: "melix-dev-text",
+                            status: "stalled",
+                            stage: "download",
+                            pct: 0.5,
+                            outputDir: "/tmp/melix-downloads/melix-dev-text",
+                            outputPath: "/tmp/melix-downloads/melix-dev-text/download.artifact",
+                            partialPath: "/tmp/melix-downloads/melix-dev-text/download.artifact.partial",
+                            statePath: "/tmp/melix-downloads/melix-dev-text/download.state.json",
+                            selectedMirror: "https://mirror.example/status-menu",
+                            downloadedBytes: 1024,
+                            totalBytes: 2048,
+                            resumeReady: true
+                        )
+                    ]
+                )
+            ),
+            forNamedOperation: "registry_snapshot"
+        )
+        let viewModel = RuntimeViewModel(client: client)
+        let renderer = RecordingStatusMenuRenderer()
+        let menu = StatusMenu(viewModel: viewModel, renderer: renderer)
+
+        await viewModel.start()
+        await viewModel.refreshDownloadQueueState()
+        menu.install()
+
+        let content = try #require(renderer.lastContent)
+        let recoveryIndex = try #require(content.items.firstIndex(of: .info("Download Recovery Available")))
+        let modelIndex = try #require(content.items.firstIndex(of: .info("melix-dev-text: Discovered")))
+
+        #expect(recoveryIndex < modelIndex)
+        #expect(content.items.contains(.action("Resume Download", .resumeFirstDownload)))
+        #expect(content.items.contains(.action("Open Downloads", .openDownloads)))
+    }
+
+    @Test("perform routes state-first navigation and recovery actions")
+    @MainActor
+    func performRoutesStateFirstNavigationAndRecoveryActions() async throws {
+        let client = FakeControlPlaneXPCClient()
+        var snapshot = Melix_Controlplane_V1_ServerSnapshot()
+        snapshot.serverState = .serverReady
+        snapshot.models = [ModelCatalog.devTextModel()]
+        var runtimeSession = Melix_Controlplane_V1_ServerSessionRuntimeState()
+        runtimeSession.serverSessionID = "server-session-1"
+        runtimeSession.lifecycleState = .sleeping
+        runtimeSession.powerState = .deepSleep
+        runtimeSession.wakeReason = .policyApply
+        snapshot.runtimeSessions = [runtimeSession]
+        await client.configureSnapshot(snapshot)
+
+        let viewModel = RuntimeViewModel(client: client)
+        let commandCenter = OpenConsoleRecorder()
+        viewModel.openCommandCenterAction = { commandCenter.open() }
+        let menu = StatusMenu(
+            viewModel: viewModel,
+            renderer: RecordingStatusMenuRenderer()
+        )
+
+        await viewModel.start()
+        menu.perform(.openDownloads)
+        #expect(viewModel.selectedSurface == .tools)
+        #expect(viewModel.selectedToolSection == .downloads)
+
+        menu.perform(.openServer)
+        #expect(viewModel.selectedSurface == .server)
+
+        menu.perform(.openCommandCenter)
+        #expect(commandCenter.wasCalled)
+
+        menu.perform(.wakeSelectedServer)
+        try await eventually("wake action should reach the selected server", timeout: .seconds(2)) {
+            viewModel.selectedServerSession?.lifecycle == .running
+        }
+        #expect(await client.recordedActions.contains("server.wake:server-session-1"))
     }
 
     @Test("perform routes primary model actions to the view model")

--- a/apps/macos-menubar/Tests/MenuBarTests/StatusMenuTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/StatusMenuTests.swift
@@ -12,7 +12,13 @@ struct StatusMenuTests {
     @MainActor
     func installRendersCurrentState() async throws {
         let client = FakeControlPlaneXPCClient()
-        let viewModel = RuntimeViewModel(client: client)
+        let viewModel = RuntimeViewModel(
+            client: client,
+            productInstallStateProvider: StubProductInstallStateProvider(
+                updateStatusResponse: nil,
+                startupDiagnosticResponse: nil
+            )
+        )
         let renderer = RecordingStatusMenuRenderer()
         let menu = StatusMenu(viewModel: viewModel, renderer: renderer)
 

--- a/docs/plans/2026-04-18-window-menubar-ui-optimization.md
+++ b/docs/plans/2026-04-18-window-menubar-ui-optimization.md
@@ -1,0 +1,91 @@
+# Window UI And Menubar UI Optimization Implementation Plan
+
+> **For agentic workers:** Implement this plan task-by-task and keep the checkboxes current as
+> verification evidence changes.
+
+**Goal:** Improve the native Melix Window UI and Menubar UI through shared window chrome,
+state-first operator triage, and clearer Tools workflows without changing backend ownership or
+protocol contracts.
+
+**Architecture:** Keep the macOS app as an operator shell over `RuntimeViewModel` and the existing
+CLI/control-plane boundaries. Add app-local UI composition types for shared pane chrome, state
+priority, menu recovery actions, and Tools categorization. Preserve the existing write-path
+semantics and route workflow actions through the current app/client/CLI bridge APIs.
+
+**Tech Stack:** SwiftUI, AppKit `NSMenu`, Swift Testing, existing Melix menu bar smoke scripts.
+
+---
+
+## Scope
+
+- [x] Low-risk polish: shared split workspace chrome, icon-only pane controls, keyboard shortcuts,
+  accessibility labels, and visual-quality smoke coverage.
+- [x] State-first redesign: Command Center and Menubar expose runtime health, recovery actions,
+  active workflow signals, and latest errors before lower-priority informational notices.
+- [x] Tools workflow redesign: group Tools into Models, Build, Validate, and System categories;
+  fold advanced fields behind disclosure groups; keep primary task fields visible.
+
+## Non-Goals
+
+- [x] No protobuf schema changes.
+- [x] No generated protocol artifact changes.
+- [x] No control-plane, worker, or model-operation behavior changes.
+- [x] No second orchestration engine inside the app.
+
+## Verification
+
+Targeted checks:
+
+```bash
+swift test --package-path apps/macos-menubar --filter DesktopFoundationViewTests
+swift test --package-path apps/macos-menubar --filter StatusMenuTests
+swift test --package-path apps/macos-menubar --filter DesktopPolishSmokeTests
+python3 scripts/m15_desktop_polish_smoke.py --json
+```
+
+Broader handoff checks, when time and environment permit:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+```
+
+Metrics report:
+
+- Runtime performance probes: `N/A` for pure UI layout changes.
+- UI evidence: targeted Swift tests, desktop polish smoke JSON, and Window UI render/smoke tests for
+  compact and wide sizes.
+
+Executed verification:
+
+- `xcrun swift test --package-path apps/macos-menubar --filter Phase8LoRAWindowSmokeTests`: passed.
+- `xcrun swift test --package-path apps/macos-menubar --filter DesktopFoundationViewTests`: passed, 105 tests.
+- `xcrun swift test --package-path apps/macos-menubar --filter "StatusMenuTests|DesktopPolishSmokeTests"`: passed, 23 tests.
+- `python3 scripts/m15_desktop_polish_smoke.py --json`: passed with `ok: true`,
+  `grounded_surface_count: 5`, `grounded_tool_section_count: 6`,
+  `top_banner_title: "Download Recovery Available"`, `presentation_lag_ms: 205.667`.
+- `make swift-test`: passed.
+- `make py-test`: passed, 821 tests.
+- `make integration-test`: passed, 85 tests, 1 skipped.
+
+Integration helper note:
+
+- Phase 8 CLI/window integration build helpers now use the repository's scoped `xcrun swift`
+  command and scratch-path isolation to avoid mixing local `swift` and `xcrun swift` toolchains.
+
+## Acceptance Criteria
+
+- [x] The five top-level Window UI surfaces render with shared pane chrome and no in-content shell
+  regression.
+- [x] Icon-only actions have help and accessibility labels.
+- [x] Keyboard shortcuts cover surface navigation, Command Center, primary run/send actions, and
+  sidebar/inspector toggles where a surface supports them.
+- [x] Menubar content prioritizes recovery/error/runtime state ahead of model actions and general
+  console access.
+- [x] Command Center shows global runtime health, primary model, queue/download recovery, active
+  workflow, and latest error summaries.
+- [x] Tools sections are grouped by Models, Build, Validate, and System while preserving all
+  existing underlying actions.
+- [x] Training, Server defaults, and Image defaults expose primary fields first and advanced fields
+  behind disclosure groups.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -387,12 +387,65 @@ def root_package_swift_environment(
     return swift_root_package.root_package_swift_environment(repo_root, base_env=base_env)
 
 
+def swift_package_environment(
+    repo_root: Path,
+    scope: str,
+    *,
+    base_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    return swift_root_package.swift_package_environment(
+        repo_root,
+        scope,
+        base_env=base_env,
+    )
+
+
 def root_package_swift_command(
     repo_root: Path,
     subcommand: str,
     arguments: list[str],
 ) -> list[str]:
     return swift_root_package.root_package_swift_command(repo_root, subcommand, arguments)
+
+
+def swift_package_command(
+    package_root: Path,
+    repo_root: Path,
+    scope: str,
+    subcommand: str,
+    arguments: list[str],
+) -> list[str]:
+    return swift_root_package.swift_package_command(
+        package_root,
+        repo_root,
+        scope,
+        subcommand,
+        arguments,
+    )
+
+
+def resolve_scoped_swift_product_binary(repo_root: Path, *, scope: str, product_name: str) -> Path:
+    layout = swift_root_package.swift_package_layout(repo_root, scope)
+    build_root = layout.scratch_path
+    candidates = [build_root / "debug" / product_name]
+    candidates.extend(sorted(build_root.glob(f"*/debug/{product_name}")))
+
+    executable_candidates = [
+        candidate
+        for candidate in candidates
+        if candidate.is_file() and os.access(candidate, os.X_OK)
+    ]
+    if executable_candidates:
+        return max(
+            executable_candidates,
+            key=lambda candidate: (candidate.stat().st_mtime, len(candidate.parts)),
+        )
+
+    raise AssertionError(
+        "Required Swift product binary is missing. "
+        f"Expected a built executable for {product_name!r} under {build_root}. "
+        "Run `make swift-test` or the scoped Swift package command before integration tests."
+    )
 
 
 def resolve_swift_product_binary(repo_root: Path, *, package_path: Path, product_name: str) -> Path:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -436,6 +436,7 @@ def resolve_scoped_swift_product_binary(repo_root: Path, *, scope: str, product_
         if candidate.is_file() and os.access(candidate, os.X_OK)
     ]
     if executable_candidates:
+        # Prefer architecture-specific SwiftPM outputs over flat debug outputs when mtimes tie.
         return max(
             executable_candidates,
             key=lambda candidate: (candidate.stat().st_mtime, len(candidate.parts)),

--- a/tests/integration/test_phase8_cli_acceptance.py
+++ b/tests/integration/test_phase8_cli_acceptance.py
@@ -12,6 +12,9 @@ import sys
 import uuid
 
 from tests.integration.helpers import LiveMelixStack
+from tests.integration.helpers import resolve_scoped_swift_product_binary
+from tests.integration.helpers import root_package_swift_command
+from tests.integration.helpers import root_package_swift_environment
 from tests.integration.helpers import wait_for_worker_handshake
 
 
@@ -22,14 +25,20 @@ _REAL_SMALL_MODEL_E2E_ENV = "MELIX_PHASE8_REAL_SMALL_MODEL_E2E"
 
 @lru_cache(maxsize=1)
 def build_cli_binary(repo_root: Path) -> Path:
+    environment = root_package_swift_environment(repo_root, base_env=os.environ.copy())
     subprocess.run(
-        ["swift", "build", "--product", "melix"],
+        root_package_swift_command(repo_root, "build", ["--product", "melix"]),
         cwd=repo_root,
         check=True,
         capture_output=True,
         text=True,
+        env=environment,
     )
-    return repo_root / ".build" / "arm64-apple-macosx" / "debug" / "melix"
+    return resolve_scoped_swift_product_binary(
+        repo_root,
+        scope="root-package",
+        product_name="melix",
+    )
 
 
 def run_cli(

--- a/tests/integration/test_phase8_window_ui_acceptance.py
+++ b/tests/integration/test_phase8_window_ui_acceptance.py
@@ -7,20 +7,39 @@ from functools import lru_cache
 from pathlib import Path
 
 from tests.integration.helpers import LiveMelixStack
+from tests.integration.helpers import resolve_scoped_swift_product_binary
+from tests.integration.helpers import swift_package_command
+from tests.integration.helpers import swift_package_environment
 from tests.integration.test_phase8_cli_acceptance import build_cli_binary
 from tests.integration.test_phase8_cli_acceptance import write_local_model_fixture
 
 
 @lru_cache(maxsize=1)
 def build_menubar_binary(repo_root: Path) -> Path:
+    environment = swift_package_environment(
+        repo_root,
+        "macos-menubar",
+        base_env=os.environ.copy(),
+    )
     subprocess.run(
-        ["swift", "build", "--package-path", "apps/macos-menubar", "--product", "melix-menubar"],
+        swift_package_command(
+            repo_root / "apps" / "macos-menubar",
+            repo_root,
+            "macos-menubar",
+            "build",
+            ["--product", "melix-menubar"],
+        ),
         cwd=repo_root,
         check=True,
         capture_output=True,
         text=True,
+        env=environment,
     )
-    return repo_root / "apps/macos-menubar/.build/arm64-apple-macosx/debug/melix-menubar"
+    return resolve_scoped_swift_product_binary(
+        repo_root,
+        scope="macos-menubar",
+        product_name="melix-menubar",
+    )
 
 
 def run_window_ui_acceptance(


### PR DESCRIPTION
## Summary
- Introduce shared desktop chrome primitives for workspace headers and pane toggle controls, then apply them across Chat, Image, Server, Tools, and API surfaces.
- Make Command Center and the menubar state-first by prioritizing runtime health, recovery actions, active workflow context, latest errors, and download/server recovery paths.
- Rework Tools into Models, Build, Validate, and System categories with primary fields visible first and advanced Server, Image, and Training controls folded behind disclosures.
- Align Phase 8 CLI/window integration helpers with scoped `xcrun swift` scratch-path isolation so acceptance builds do not mix local Swift toolchains.
- Address review feedback by removing stale Chat pane-toggle code, simplifying pane symbol state, making recovery priority explicit, avoiding duplicate status-menu sorting, adding recoverable-download overflow UI, and isolating updater-dependent menu tests.

## Plan or Spec
- `docs/plans/2026-04-18-window-menubar-ui-optimization.md`

## Commands Run
```text
xcrun swift test --package-path apps/macos-menubar --filter Phase8LoRAWindowSmokeTests -> passed
xcrun swift test --package-path apps/macos-menubar --filter DesktopFoundationViewTests -> passed
xcrun swift test --package-path apps/macos-menubar --filter "StatusMenuTests|DesktopPolishSmokeTests" -> passed
python3 scripts/m15_desktop_polish_smoke.py --json -> passed, ok: true
make swift-test -> passed before review follow-up
make py-test -> passed before review follow-up
make integration-test -> passed before review follow-up
git diff --check -> passed
xcrun swift test --package-path apps/macos-menubar --filter StatusMenuTests -> passed after review follow-up, 22 tests
xcrun swift test --package-path apps/macos-menubar --filter DesktopFoundationViewTests -> passed after review follow-up, 106 tests
xcrun swift test --package-path apps/macos-menubar --enable-code-coverage --filter "DesktopFoundationViewTests|StatusMenuTests" -> passed after review follow-up, 128 tests
python3 scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Sources/AppMain/MenuBar/StatusMenu.swift apps/macos-menubar/Sources/AppMain/Models/DesktopShellState.swift apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift apps/macos-menubar/Tests/MenuBarTests/StatusMenuTests.swift -> passed, 96.63% changed-line coverage
xcrun swift test --package-path apps/macos-menubar --filter toolCategoriesCoverEveryToolSectionExactlyOnce -> failed with temporary missing .settings mapping, then passed after restore
xcrun swift test --package-path apps/macos-menubar --filter bootstrapWiresCommandCenterActionBeforeCreatingStatusMenu -> failed with temporary deferred command-center wiring, then passed after restore
xcrun swift test --package-path apps/macos-menubar --filter DesktopFoundationViewTests -> passed after latest regression-test follow-up, 107 tests
xcrun swift test --package-path apps/macos-menubar --filter AppMainBootstrapTests -> passed after latest regression-test follow-up, 36 tests
```

## Coverage and Metrics
- Swift touched changed-line coverage: `96.63% (86/89)` across the changed macOS menubar source and test files.
- Desktop polish smoke metrics: `python3 scripts/m15_desktop_polish_smoke.py --json` returned `ok: true`, `presentation_lag_ms` about `203.68`, `presentation_flush_count` `8`, `top_banner_title` `Download Recovery Available`, `grounded_surface_count` `5`, and `grounded_tool_section_count` `6`.
- Runtime performance metrics are `N/A: this slice changes UI layout, navigation, and menu state projection rather than runtime scheduling or worker execution paths`.
- Python changed-line coverage is `N/A: tests/integration/helpers.py only gained a clarifying comment in the review follow-up`.
- Latest follow-up coverage is `N/A: it only adds regression tests and does not modify production source`.

## Known Gaps
- The PR remains draft, so the external WIP check is expected to stay pending until the PR is marked ready for review.
- After the review follow-up commit, full `make swift-test`, `make py-test`, and `make integration-test` were not rerun; focused Swift UI tests, coverage, `git diff --check`, and the desktop polish smoke were rerun for the touched follow-up scope.
- The non-blocking keyboard shortcut collision note is deferred until there is user evidence that `Option+Command+S` conflicts with a real operator workflow.
- Extracting `servingDefaultsCompactSummary` into a data-model helper is deferred because the current summary remains a single view-local presentation concern.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, not applicable because no protobuf schema changed.
- [x] Dependency changes include updated lockfiles, not applicable because no dependencies changed.
- [x] Relevant tests were run.
- [x] A metrics report is included, with explicit N/A reasons where applicable.
- [x] Deferred work and known gaps are stated explicitly.
