### PR TITLE
cli: contract v1 cleanup (scoring defaults, bench job chaining, trimmed state)

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -2090,7 +2090,7 @@ public enum MelixCLIParser {
             profileType: values.single["--profile-type"] ?? "final_result",
             resultKind: values.single["--result-kind"] ?? "text",
             extractionMode: values.single["--extraction-mode"] ?? "heuristic_final",
-            scoringMode: values.single["--scoring-mode"] ?? "normalized_exact_match",
+            scoringMode: values.single["--scoring-mode"] ?? "",
             threshold: try parseDoubleValue(values.single["--threshold"], option: "--threshold", defaultValue: 1.0) ?? 1.0,
             outputSchemaJSON: values.single["--output-schema-json"] ?? "",
             ignoredPaths: values.multi["--ignored-path"] ?? []
@@ -2712,7 +2712,7 @@ public actor MelixCLIRunner {
         case .modelRootsList(let options):
             let state = try loadOperatorState()
             if options.json {
-                return try prettyJSON(["registry_roots": state.registryRoots])
+                return try prettyJSON(state.registryRoots)
             }
             return renderRegistryRoots(state.registryRoots)
         case .modelRootsAdd(let options):
@@ -2723,7 +2723,7 @@ public actor MelixCLIRunner {
                 }
             }
             if options.json {
-                return try prettyJSON(["registry_roots": state.registryRoots])
+                return try prettyJSON(state.registryRoots)
             }
             return renderRegistryRoots(state.registryRoots)
         case .modelRootsRemove(let options):
@@ -2732,7 +2732,7 @@ public actor MelixCLIRunner {
                 current.registryRoots.removeAll { $0 == canonical }
             }
             if options.json {
-                return try prettyJSON(["registry_roots": state.registryRoots])
+                return try prettyJSON(state.registryRoots)
             }
             return renderRegistryRoots(state.registryRoots)
         case .modelRootsMove(let options):
@@ -2746,7 +2746,7 @@ public actor MelixCLIRunner {
                 current.registryRoots.insert(root, at: targetIndex)
             }
             if options.json {
-                return try prettyJSON(["registry_roots": state.registryRoots])
+                return try prettyJSON(state.registryRoots)
             }
             return renderRegistryRoots(state.registryRoots)
         case .modelRootsRescan(let options):

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -2763,17 +2763,29 @@ public actor MelixCLIRunner {
                 outputDir: "",
                 ext: ext
             )
-            return options.json ? result.manifestJson : result.outputPath + "\n"
+            if options.json {
+                return try prettyJSON(
+                    try filterManifestKeys(
+                        fromManifestJson: result.manifestJson,
+                        defaults: modelRegistrySnapshotDefaults()
+                    )
+                )
+            }
+            return result.outputPath + "\n"
         case .serverSnapshot(let options):
             let snapshot = try await client.serverSnapshot()
             return try renderServerSnapshot(snapshot, json: options.json)
         case .serverSessionList(let options):
             let state = try loadOperatorState()
             if options.json {
-                return try prettyJSON(state)
+                return try prettyJSON(ServerSessionListResponse(
+                    serverSessions: state.serverSessions,
+                    selectedServerSessionID: state.selectedServerSessionID
+                ))
             }
             return renderServerSessions(state)
         case .serverSessionCreate(let options):
+            var createdID = ""
             let state = try mutateOperatorState { current in
                 let nextIndex = current.serverSessions.count + 1
                 let created = MelixOperatorServerSessionState(
@@ -2788,9 +2800,13 @@ public actor MelixCLIRunner {
                 )
                 current.serverSessions.append(created)
                 current.selectedServerSessionID = created.id
+                createdID = created.id
             }
             if options.json {
-                return try prettyJSON(state)
+                guard let created = state.serverSessions.first(where: { $0.id == createdID }) else {
+                    throw MelixCLIError.runtime("Created server session \(createdID) was not found in persisted state.")
+                }
+                return try prettyJSON(created)
             }
             return renderServerSessions(state)
         case .serverSessionUpdate(let options):
@@ -2821,7 +2837,10 @@ public actor MelixCLIRunner {
                 current.serverSessions[index] = session
             }
             if options.json {
-                return try prettyJSON(state)
+                guard let updated = state.serverSessions.first(where: { $0.id == options.serverSessionID }) else {
+                    throw MelixCLIError.runtime("Server session \(options.serverSessionID) was not found.")
+                }
+                return try prettyJSON(updated)
             }
             return renderServerSessions(state)
         case .serverSessionRemove(let options):
@@ -2832,7 +2851,10 @@ public actor MelixCLIRunner {
                 }
             }
             if options.json {
-                return try prettyJSON(state)
+                return try prettyJSON([
+                    "removed_id": options.serverSessionID,
+                    "selected_server_session_id": state.selectedServerSessionID,
+                ])
             }
             return renderServerSessions(state)
         case .serverSessionSelect(let options):
@@ -2842,7 +2864,9 @@ public actor MelixCLIRunner {
                 }
             }
             if options.json {
-                return try prettyJSON(state)
+                return try prettyJSON([
+                    "selected_server_session_id": state.selectedServerSessionID,
+                ])
             }
             return renderServerSessions(state)
         case .serverStart(let options):
@@ -2955,7 +2979,15 @@ public actor MelixCLIRunner {
                 outputDir: "",
                 ext: [:]
             )
-            return options.json ? result.manifestJson : renderRegistrySnapshot(result.manifestJson)
+            if options.json {
+                return try prettyJSON(
+                    try filterManifestKeys(
+                        fromManifestJson: result.manifestJson,
+                        defaults: loraRegistryDefaults()
+                    )
+                )
+            }
+            return renderRegistrySnapshot(result.manifestJson)
         case .loraTrain(let options):
             var ext = options.parameters
             ext["adapter_name"] = options.adapterName
@@ -4011,6 +4043,51 @@ public actor MelixCLIRunner {
         }
     }
 
+    private func filterManifestKeys(
+        fromManifestJson manifestJSON: String,
+        defaults: [String: Any]
+    ) throws -> [String: Any] {
+        guard let data = manifestJSON.data(using: .utf8) else {
+            throw MelixCLIError.runtime("Registry manifest could not be decoded as UTF-8.")
+        }
+        let object: Any
+        do {
+            object = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw MelixCLIError.runtime("Registry manifest is not valid JSON: \((error as NSError).localizedDescription)")
+        }
+        guard let payload = object as? [String: Any] else {
+            throw MelixCLIError.runtime("Registry manifest must be a JSON object.")
+        }
+        var result = defaults
+        for key in defaults.keys {
+            if let value = payload[key] {
+                result[key] = value
+            }
+        }
+        return result
+    }
+
+    private func loraRegistryDefaults() -> [String: Any] {
+        [
+            "adapters": [] as [Any],
+            "experiment_groups": [] as [Any],
+            "derived_models": [] as [Any],
+            "downloads": [] as [Any],
+        ]
+    }
+
+    private func modelRegistrySnapshotDefaults() -> [String: Any] {
+        [
+            "adapters": [] as [Any],
+            "derived_models": [] as [Any],
+            "experiment_groups": [] as [Any],
+            "downloads": [] as [Any],
+            "model_registry": [:] as [String: Any],
+            "warnings": [] as [Any],
+        ]
+    }
+
     private func renderRegistrySnapshot(_ manifestJSON: String) -> String {
         guard
             let data = manifestJSON.data(using: .utf8),
@@ -4684,6 +4761,16 @@ private struct BenchExportCSVResponse: Encodable {
     let jobID: String
     let outputPath: String
     let rowCount: Int
+}
+
+private struct ServerSessionListResponse: Encodable {
+    let serverSessions: [MelixOperatorServerSessionState]
+    let selectedServerSessionID: String
+
+    enum CodingKeys: String, CodingKey {
+        case serverSessions = "server_sessions"
+        case selectedServerSessionID = "selected_server_session_id"
+    }
 }
 
 private struct EvalExportResponse: Encodable {

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -3052,13 +3052,15 @@ public actor MelixCLIRunner {
         case .benchRun(let options):
             let result = try await runBenchmark(options)
             if options.json {
-                return try prettyJSON(
-                    [
-                        "report_path": result.reportPath,
-                        "report_markdown": result.reportMarkdown,
-                        "metrics": result.metrics,
-                    ]
-                )
+                var payload: [String: Any] = [
+                    "report_path": result.reportPath,
+                    "report_markdown": result.reportMarkdown,
+                    "metrics": result.metrics,
+                ]
+                if let job = result.job {
+                    payload["job"] = makeBenchmarkJobPayload(job)
+                }
+                return try prettyJSON(payload)
             }
             return result.reportMarkdown.isEmpty ? result.reportPath : result.reportMarkdown
         case .benchList(let options):
@@ -4474,6 +4476,23 @@ public actor MelixCLIRunner {
                     },
                 ]
             },
+        ]
+    }
+
+    private func makeBenchmarkJobPayload(_ job: Melix_Controlplane_V1_BenchmarkJobSummary) -> [String: Any] {
+        [
+            "schema_version": job.schemaVersion,
+            "job_id": job.jobID,
+            "model_id": job.modelID,
+            "task_kind": job.taskKind,
+            "source_repo": job.sourceRepo,
+            "suites": job.suites,
+            "benchmark_mode": job.benchmarkMode,
+            "status": job.status,
+            "output_dir": job.outputDir,
+            "created_at_unix_ms": job.createdAtUnixMs,
+            "updated_at_unix_ms": job.updatedAtUnixMs,
+            "parameters": job.parameters,
         ]
     }
 

--- a/Sources/MelixCLICore/MelixPipelineRunner.swift
+++ b/Sources/MelixCLICore/MelixPipelineRunner.swift
@@ -568,8 +568,19 @@ private struct MelixPipelineDocument {
         guard path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
             throw MelixCLIError.missingRequired("--file is required for melix pipeline run.")
         }
-        let data = try Data(contentsOf: URL(fileURLWithPath: path))
-        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        let data: Data
+        do {
+            data = try Data(contentsOf: URL(fileURLWithPath: path))
+        } catch {
+            throw MelixCLIError.runtime("Failed to read pipeline file \(path): \((error as NSError).localizedDescription)")
+        }
+        let jsonObject: Any
+        do {
+            jsonObject = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw MelixCLIError.usage("Pipeline file is not valid JSON: \((error as NSError).localizedDescription)")
+        }
+        guard let object = jsonObject as? [String: Any] else {
             throw MelixCLIError.usage("Pipeline file must be a JSON object.")
         }
         guard object["schema_version"] as? String == "melix.pipeline.v1" else {
@@ -606,8 +617,19 @@ private struct MelixPipelineDocument {
         guard path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
             return [:]
         }
-        let data = try Data(contentsOf: URL(fileURLWithPath: path))
-        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        let data: Data
+        do {
+            data = try Data(contentsOf: URL(fileURLWithPath: path))
+        } catch {
+            throw MelixCLIError.runtime("Failed to read pipeline inputs file \(path): \((error as NSError).localizedDescription)")
+        }
+        let jsonObject: Any
+        do {
+            jsonObject = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw MelixCLIError.usage("Pipeline inputs file is not valid JSON: \((error as NSError).localizedDescription)")
+        }
+        guard let object = jsonObject as? [String: Any] else {
             throw MelixCLIError.usage("Pipeline inputs file must be a JSON object.")
         }
         return object
@@ -1232,7 +1254,7 @@ private enum MelixPipelineCommandBuilder {
             profileType: string("profile_type", args) ?? "final_result",
             resultKind: string("result_kind", args) ?? "text",
             extractionMode: string("extraction_mode", args) ?? "heuristic_final",
-            scoringMode: string("scoring_mode", args) ?? "normalized_exact_match",
+            scoringMode: string("scoring_mode", args) ?? "",
             threshold: Double(string("threshold", args) ?? "") ?? 1.0,
             outputSchemaJSON: string("output_schema_json", args) ?? "",
             ignoredPaths: try stringArray("ignored_paths", args) ?? []

--- a/docs/examples/pipelines/phase8-acceptance.pipeline.json
+++ b/docs/examples/pipelines/phase8-acceptance.pipeline.json
@@ -45,7 +45,7 @@
       1
     ],
     "matrix_cache_profiles": [
-      "none"
+      "cold"
     ],
     "matrix_reasoning_modes": [
       "disabled"
@@ -63,6 +63,7 @@
     "eval_dataset_id": "mmlu.dev.v1",
     "eval_sample_size": 4,
     "eval_batch_factor": 1,
+    "eval_scoring_mode": "multiple_choice_accuracy",
     "acceptance_output_dir": "/tmp/melix-phase8-acceptance"
   },
   "steps": [
@@ -241,7 +242,8 @@
         "suites": "${inputs.eval_suites}",
         "dataset_id": "${inputs.eval_dataset_id}",
         "sample_size": "${inputs.eval_sample_size}",
-        "batch_factor": "${inputs.eval_batch_factor}"
+        "batch_factor": "${inputs.eval_batch_factor}",
+        "scoring_mode": "${inputs.eval_scoring_mode}"
       },
       "checks": {
         "required_result_fields": [

--- a/docs/examples/pipelines/phase8-acceptance.pipeline.json
+++ b/docs/examples/pipelines/phase8-acceptance.pipeline.json
@@ -31,7 +31,6 @@
     "bench_repeats": 1,
     "bench_sample_size": 4,
     "bench_batch_factor": 1,
-    "bench_job_id": "replace-with-benchmark-job-id-when-exporting-history",
     "matrix_suites": [
       "smoke"
     ],
@@ -208,7 +207,8 @@
       "checks": {
         "required_result_fields": [
           "report_path",
-          "metrics"
+          "metrics",
+          "job.job_id"
         ]
       }
     },
@@ -255,7 +255,7 @@
       "id": "export_benchmark_csv",
       "command": "bench.export-csv",
       "args": {
-        "job_id": "${inputs.bench_job_id}",
+        "job_id": "${steps.run_benchmark.result.job.job_id}",
         "output": "${inputs.acceptance_output_dir}/benchmark.csv"
       },
       "checks": {

--- a/services/control-plane-swift/Sources/XPCService/ControlPlaneXPCClient.swift
+++ b/services/control-plane-swift/Sources/XPCService/ControlPlaneXPCClient.swift
@@ -132,11 +132,18 @@ public struct ControlPlaneBenchResult: Equatable, Sendable {
     public let reportPath: String
     public let reportMarkdown: String
     public let metrics: [String: Double]
+    public let job: Melix_Controlplane_V1_BenchmarkJobSummary?
 
-    public init(reportPath: String, reportMarkdown: String, metrics: [String: Double]) {
+    public init(
+        reportPath: String,
+        reportMarkdown: String,
+        metrics: [String: Double],
+        job: Melix_Controlplane_V1_BenchmarkJobSummary? = nil
+    ) {
         self.reportPath = reportPath
         self.reportMarkdown = reportMarkdown
         self.metrics = metrics
+        self.job = job
     }
 }
 
@@ -990,7 +997,8 @@ public actor LocalControlPlaneXPCClient: ControlPlaneXPCClient {
             ControlPlaneBenchResult(
                 reportPath: response.ops.reportPath,
                 reportMarkdown: response.ops.reportMarkdown,
-                metrics: response.ops.metrics.values
+                metrics: response.ops.metrics.values,
+                job: response.ops.hasBenchmarkJob ? response.ops.benchmarkJob : nil
             )
         }
     }

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -803,9 +803,22 @@ struct MelixCLIRunnerTests {
             )
         )
 
+        let store = MelixOperatorSessionStore(
+            melixHome: MelixHome(environment: ["MELIX_HOME": root.path])
+        )
+        try await store.save(
+            MelixOperatorSessionState(
+                selectedServerSessionID: "server-session-1",
+                serverSessions: [
+                    .init(id: "server-session-1", title: "Fake Phase 8", modelID: "melix-dev-text")
+                ]
+            )
+        )
+
         let output = try await MelixCLIRunner(
             client: client,
-            environment: ["MELIX_HOME": root.path]
+            environment: ["MELIX_HOME": root.path],
+            operatorSessionStore: store
         ).run(
             .pipelineRun(
                 .init(
@@ -2566,7 +2579,12 @@ struct MelixCLIRunnerTests {
         let call = try #require(await client.lastModelOperationCall)
 
         #expect(call.modelID == "mlx-community/Qwen3.5-0.8B-OptiQ-4bit")
-        #expect(output == #"{"adapters":[{"adapter_name":"demo-adapter"}]}"#)
+        let payload = try #require(parseJSONObject(output))
+        let adapters = try #require(payload["adapters"] as? [[String: Any]])
+        #expect(adapters.count == 1)
+        #expect(adapters.first?["adapter_name"] as? String == "demo-adapter")
+        #expect(payload["experiment_groups"] as? [Any] != nil)
+        #expect(payload["jobs"] == nil)
     }
 
     @Test("lora list falls back to raw manifest text when the registry payload is not tabular")

--- a/tests/integration/test_phase8_cli_acceptance.py
+++ b/tests/integration/test_phase8_cli_acceptance.py
@@ -375,7 +375,7 @@ def test_cli_chat_run_rebinds_primary_session_without_dev_text_model_path(tmp_pa
             ],
             env_overrides=env,
         )
-        assert created_state["server_sessions"][0]["id"] == "server-session-1"
+        assert created_state["id"] == "server-session-1"
 
         run_cli_json(
             repo_root,
@@ -490,7 +490,7 @@ def test_phase8_acceptance_bundle_closes_lora_bench_eval_and_export_paths(tmp_pa
             ],
             env_overrides=env,
         )
-        assert created_state["server_sessions"][0]["id"] == "server-session-1"
+        assert created_state["id"] == "server-session-1"
 
         payload = run_python_script_json(
             repo_root,
@@ -605,7 +605,7 @@ def test_phase8_acceptance_bundle_real_small_model_profile_closes_real_lora_chai
             ],
             env_overrides=env,
         )
-        assert created_state["server_sessions"][0]["id"] == "server-session-1"
+        assert created_state["id"] == "server-session-1"
 
         bundle_args = [
             "--execution-profile",


### PR DESCRIPTION
## Summary

Three-commit cleanup of CLI contract surfaces surfaced by a live-model verification round against `mlx-community/Qwen3.5-0.8B-OptiQ-4bit` after #36. Each commit is standalone and reversible.

- **Phase 1** (`5dcb2b57`) — `eval run --scoring-mode` CLI default changes from `normalized_exact_match` (unsupported for most suites) to `""`, letting the worker's per-suite default apply. `model roots list/add/remove/move --json` emit bare arrays to align with the other `* list` commands. Pipeline file-open errors get wrapped in `MelixCLIError.runtime` instead of leaking `NSCocoaErrorDomain` strings. `docs/examples/pipelines/phase8-acceptance.pipeline.json` fixes the invalid `matrix_cache_profiles: ["none"]` → `["cold"]` and adds an explicit `eval_scoring_mode` input + step arg.
- **Phase 2** (`14b402a2`) — `bench run` now returns a `job` object alongside `{report_path, report_markdown, metrics}`, using the `BenchmarkJobSummary` field already present on the XPC response but previously dropped in `ControlPlaneBenchResult`. Pipelines can chain `${steps.run_benchmark.result.job.job_id}` into `bench.export-csv`; the phase8 sample drops the placeholder `bench_job_id` input accordingly.
- **Phase 3** (`bf0f2c17`) — `server session list/create/update/remove/select`, `lora list`, and `model roots rescan` stop returning the entire operator state / registry manifest and instead return the entity you asked about. Drops historical `jobs[]` from the rescan manifest. Downstream test updates: CLI runner test + 3 sites in `test_phase8_cli_acceptance.py`.

## Plan or Spec

Followed the plan at `.claude/plans/velvet-questing-floyd.md` (authored and approved in-session). Three phases mapped 1:1 to the three commits:

1. CLI defaults + `model roots` JSON shape.
2. `bench run` exposes the `BenchmarkJobSummary` that's already on the XPC wire.
3. Trim fat state blobs on `server session *` / `lora list` / `model roots rescan`.

No canonical top-level spec changes; this cleans up behavior that was implicit / undocumented before PR #36 and surfaces contract expectations each command emits.

## Commands Run

- `xcrun swift build --product melix`
- `xcrun swift test --filter MelixCLI` (on each commit, 172 tests)
- `cd services/control-plane-swift && xcrun swift build`
- `cd apps/macos-menubar && xcrun swift build`
- `MELIX_PHASE8_REAL_SMALL_MODEL_E2E=1 MELIX_PHASE8_REAL_SMALL_MODEL_PATH="$HOME/.cache/huggingface/hub/models--mlx-community--Qwen3.5-0.8B-OptiQ-4bit/snapshots/9ce89f2a58cb50cc57a38b3dab37b713f85447fa" make phase8-real-e2e` (passed after Phase 2 and Phase 3)
- Live dev stack CLI regression against Qwen3.5-0.8B-OptiQ-4bit covering `doctor`, `model list/inspect/hub search/hub show/import`, `chat run`, `bench run` (with chained `job.job_id`), `bench matrix run`, `bench export-csv`, `eval run` (default scoring), `server session list/create/select/update/remove`, `lora list`, `model roots list/add/rescan`, and `pipeline run` (dry-run / real / resume / from-step / error paths)

## Coverage and Metrics

- `xcrun swift test --filter MelixCLI`: **172 tests passed** on each of the three commits (baseline).
- `make phase8-real-e2e`: **1 passed** (189s cold build + 59–67s warm runs) — full phase8 acceptance bundle (import → rescan → server → chat → lora.train → lora.activate → chat → bench → bench.matrix → eval → 4×csv export).
- Control-plane and menubar Swift packages build clean.
- Changed-line coverage not separately measured on this PR; the touched CLI paths are covered by the 172-test `MelixCLI` suite and the live phase8 E2E. If required, Makefile `swift-coverage` target is available.

## Known Gaps

- `lora list` still triggers a `registry_snapshot` model-ops job on every invocation (side-effect from the underlying XPC operation). This PR only trims the JSON shape; removing the list → job side effect is a separate follow-up.
- `MelixCLIJSONMetricPatch` placeholder-rewriting fragility flagged in the #36 review isn't addressed here; remains a follow-up.
- `ControlPlaneXPCClient.swift:364` helper default `scoringMode: String = "normalized_exact_match"` (internal test convenience) stays as-is — only CLI-facing defaults changed.
- Dry-run pipeline receipts still contain literal `${...}` when a referenced step hasn't run yet; tracked in the #36 findings, not in scope here.

## Test plan

- [ ] `xcrun swift test --filter MelixCLI`
- [ ] `make phase8-real-e2e` (opt-in env)
- [ ] Manual: `melix bench run ... --json | jq .job.job_id` returns the just-run job id
- [ ] Manual: `melix eval run --suite mmlu --sample-size 2 --json` no longer needs explicit `--scoring-mode`
- [ ] Manual: `melix server session list --json | jq keys` → `["selected_server_session_id","server_sessions"]` (no operator-state bloat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)