### PR TITLE
fix(ci): align download-artifact to v7 to match upload-artifact@v7

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -30,13 +30,13 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
 
       - name: Bootstrap
         run: make bootstrap
@@ -49,13 +49,13 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
 
       - name: Bootstrap
         run: make bootstrap
@@ -68,13 +68,13 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
 
       - name: Bootstrap
         run: make bootstrap
@@ -88,7 +88,7 @@ jobs:
       should_run: ${{ steps.scope.outputs.should_run }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -120,13 +120,13 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
 
       - name: Bootstrap
         run: make bootstrap

--- a/.github/workflows/package-self-contained-app.yml
+++ b/.github/workflows/package-self-contained-app.yml
@@ -40,13 +40,13 @@ jobs:
       artifact_name: ${{ steps.compute-build-metadata.outputs.artifact_name }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
 
       - name: Bootstrap Python worker environment
         run: make bootstrap
@@ -88,7 +88,7 @@ jobs:
             --json
 
       - name: Upload app artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.compute-build-metadata.outputs.artifact_name }}
           path: ${{ runner.temp }}/${{ steps.compute-build-metadata.outputs.artifact_name }}.zip
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Download packaged app artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ needs.package-app.outputs.artifact_name }}
           path: ${{ runner.temp }}

--- a/.github/workflows/package-self-contained-app.yml
+++ b/.github/workflows/package-self-contained-app.yml
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Download packaged app artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: ${{ needs.package-app.outputs.artifact_name }}
           path: ${{ runner.temp }}

--- a/.github/workflows/pr-evidence.yml
+++ b/.github/workflows/pr-evidence.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate PR evidence
         run: python3 scripts/validate_pr_evidence.py --event-path "$GITHUB_EVENT_PATH"

--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -30,13 +30,13 @@ jobs:
     runs-on: macos-15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
 
       - name: Bootstrap
         run: make bootstrap
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload release-gate evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: phase8-release-gate-${{ github.run_id }}
           path: ${{ runner.temp }}/phase8-release-gate.json


### PR DESCRIPTION
## Plan or Spec

Merge Dependabot PR #24 (GitHub Actions version bumps) with one corrective fix: align `actions/download-artifact` to v7 to match `actions/upload-artifact@v7`. Dependabot erroneously bumped upload-artifact to v7 and download-artifact to v8, which are incompatible versions for passing artifacts between jobs.

## Commands Run

- Reviewed diff of PR #24 via GitHub API
- `git fetch origin pull/24/head:pr-24-source`
- `git merge pr-24-source --no-edit`
- Edited `.github/workflows/package-self-contained-app.yml`: changed `actions/download-artifact@v8` → `actions/download-artifact@v7`
- `git commit -m "fix(ci): align download-artifact to v7 to match upload-artifact@v7"`
- `git push -u origin claude/review-pr-24-PbmMF`

## Coverage and Metrics

This PR only modifies GitHub Actions workflow files (no application code). There are no unit tests for workflow files; correctness is validated by CI running successfully. The `package-self-contained-app` workflow exercises the upload/download artifact pair end-to-end.

## Known Gaps

The new major versions of several actions (checkout v6, setup-python v6, setup-uv v7) skip intermediate major versions. Breaking changes from those intermediate versions have not been individually audited — CI passing is the primary validation signal.

https://claude.ai/code/session_01Pfec6WPZaf1ydxpNr6M6vN