### PR TITLE
feat(lora): surface runtime_mode in menubar + fixed-width CLI models table

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -3921,15 +3921,29 @@ public actor MelixCLIRunner {
                 ]
             }
         let allRows = [header] + dataRows
+        // allRows always has the header row so `.max()` is non-nil; we still
+        // pass a 0 fallback to satisfy the compiler without a force-unwrap.
         let widths = (0..<header.count).map { columnIndex in
             allRows.map { $0[columnIndex].count }.max() ?? 0
         }
         let formatted = allRows.map { row -> String in
             row.enumerated()
                 .map { index, cell in
-                    index == row.count - 1
-                        ? cell
-                        : cell.padding(toLength: widths[index], withPad: " ", startingAt: 0)
+                    // Grapheme-safe padding: ``String.count`` returns
+                    // grapheme-cluster count but Foundation's
+                    // ``padding(toLength:)`` operates on UTF‑16 code units,
+                    // so they disagree for any non-BMP character (emoji) or
+                    // multi-code-unit grapheme. Today every cell in this
+                    // table is ASCII, but padding with
+                    // ``String(repeating:)`` keeps the two length notions
+                    // aligned so a future non-ASCII runtime tag (or an
+                    // emoji-laden model_id) still produces correctly-aligned
+                    // columns.
+                    if index == row.count - 1 {
+                        return cell
+                    }
+                    let padding = max(0, widths[index] - cell.count)
+                    return cell + String(repeating: " ", count: padding)
                 }
                 .joined(separator: "  ")
         }

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -3904,12 +3904,36 @@ public actor MelixCLIRunner {
         guard models.isEmpty == false else {
             return "No models found.\n"
         }
-        let rows = models
+        // Fixed-width table: each column padded to the max width of the
+        // header + all rows in that column so the output aligns cleanly in
+        // terminals. Columns separated by two spaces. Consumers that need
+        // the column-boundary-stable JSON shape should pass ``--json``;
+        // this renderer is for human reading.
+        let header = ["MODEL_ID", "KIND", "STATE", "RUNTIME"]
+        let dataRows = models
             .sorted { $0.modelID < $1.modelID }
             .map { model in
-                "\(model.modelID)\t\(model.kind)\t\(modelStateLabel(model.state))\t\(runtimeModeLabel(model))"
+                [
+                    model.modelID,
+                    model.kind,
+                    modelStateLabel(model.state),
+                    runtimeModeLabel(model),
+                ]
             }
-        return (["model_id\tkind\tstate\truntime"] + rows).joined(separator: "\n") + "\n"
+        let allRows = [header] + dataRows
+        let widths = (0..<header.count).map { columnIndex in
+            allRows.map { $0[columnIndex].count }.max() ?? 0
+        }
+        let formatted = allRows.map { row -> String in
+            row.enumerated()
+                .map { index, cell in
+                    index == row.count - 1
+                        ? cell
+                        : cell.padding(toLength: widths[index], withPad: " ", startingAt: 0)
+                }
+                .joined(separator: "  ")
+        }
+        return formatted.joined(separator: "\n") + "\n"
     }
 
     private func renderModelSummary(_ model: Melix_Controlplane_V1_ModelSummary) -> String {

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
@@ -130,8 +130,23 @@ struct DesktopModelsTabView: View {
             List(foundation.models, id: \.modelID) { model in
                 HStack {
                     VStack(alignment: .leading, spacing: 4) {
-                        Text(model.modelID)
-                            .font(.headline)
+                        HStack(spacing: 6) {
+                            Text(model.modelID)
+                                .font(.headline)
+                            if !model.runtimeModeText.isEmpty {
+                                // Capsule badge matching the pattern used in
+                                // DesktopChatView and DesktopWorkspaceShellView
+                                // for metadata tags. Adapter-backed and fused
+                                // derived models get a visible runtime tag;
+                                // base models render without a badge.
+                                Text(model.runtimeModeText)
+                                    .font(.caption2)
+                                    .padding(.horizontal, 7)
+                                    .padding(.vertical, 3)
+                                    .background(.quaternary, in: Capsule())
+                                    .accessibilityLabel("Runtime mode: \(model.runtimeModeText)")
+                            }
+                        }
                         Text(model.alias.isEmpty ? "\(model.kind) • \(model.stateText) • \(model.maxContext) ctx" : "\(model.alias) • \(model.stateText) • \(model.maxContext) ctx")
                             .font(.caption)
                             .foregroundStyle(.secondary)

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
@@ -89,6 +89,22 @@ struct DesktopDashboardTabView: View {
     }
 }
 
+/// Map a short runtime-mode badge tag to a screen-reader-friendly label so
+/// VoiceOver announces "Runtime mode: adapter-backed" rather than letting a
+/// literal "?" sentinel be spoken as "question mark" on unknown values.
+private func runtimeModeAccessibilityLabel(_ badgeText: String) -> String {
+    switch badgeText {
+    case "adapter":
+        return "Runtime mode: adapter-backed"
+    case "fused":
+        return "Runtime mode: fused derived model"
+    case "?":
+        return "Runtime mode: unrecognized"
+    default:
+        return "Runtime mode: \(badgeText)"
+    }
+}
+
 struct DesktopModelsTabView: View {
     let foundation: DesktopFoundationState
     let viewModel: RuntimeViewModel
@@ -144,7 +160,7 @@ struct DesktopModelsTabView: View {
                                     .padding(.horizontal, 7)
                                     .padding(.vertical, 3)
                                     .background(.quaternary, in: Capsule())
-                                    .accessibilityLabel("Runtime mode: \(model.runtimeModeText)")
+                                    .accessibilityLabel(runtimeModeAccessibilityLabel(model.runtimeModeText))
                             }
                         }
                         Text(model.alias.isEmpty ? "\(model.kind) • \(model.stateText) • \(model.maxContext) ctx" : "\(model.alias) • \(model.stateText) • \(model.maxContext) ctx")

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
@@ -89,22 +89,6 @@ struct DesktopDashboardTabView: View {
     }
 }
 
-/// Map a short runtime-mode badge tag to a screen-reader-friendly label so
-/// VoiceOver announces "Runtime mode: adapter-backed" rather than letting a
-/// literal "?" sentinel be spoken as "question mark" on unknown values.
-private func runtimeModeAccessibilityLabel(_ badgeText: String) -> String {
-    switch badgeText {
-    case "adapter":
-        return "Runtime mode: adapter-backed"
-    case "fused":
-        return "Runtime mode: fused derived model"
-    case "?":
-        return "Runtime mode: unrecognized"
-    default:
-        return "Runtime mode: \(badgeText)"
-    }
-}
-
 struct DesktopModelsTabView: View {
     let foundation: DesktopFoundationState
     let viewModel: RuntimeViewModel
@@ -160,7 +144,7 @@ struct DesktopModelsTabView: View {
                                     .padding(.horizontal, 7)
                                     .padding(.vertical, 3)
                                     .background(.quaternary, in: Capsule())
-                                    .accessibilityLabel(runtimeModeAccessibilityLabel(model.runtimeModeText))
+                                    .accessibilityLabel(model.runtimeModeAccessibilityLabel)
                             }
                         }
                         Text(model.alias.isEmpty ? "\(model.kind) • \(model.stateText) • \(model.maxContext) ctx" : "\(model.alias) • \(model.stateText) • \(model.maxContext) ctx")

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -69,6 +69,11 @@ public struct RuntimeModelRow: Identifiable, Equatable, Sendable {
     /// (issue #12 Module 1) so the menubar list distinguishes adapter-backed
     /// derived models from fused derived models at a glance.
     public let runtimeModeText: String
+    /// VoiceOver-friendly phrasing paired with ``runtimeModeText``. Populated
+    /// alongside the tag by the same mapper helper so a future rename of the
+    /// short tag can't silently cause the a11y label to fall through to a
+    /// generic default — both fields travel together through the view.
+    public let runtimeModeAccessibilityLabel: String
 
     public init(
         modelID: String,
@@ -96,7 +101,8 @@ public struct RuntimeModelRow: Identifiable, Equatable, Sendable {
         imageDefaultWorkflowRole: String = "",
         imageSupportsGeneration: Bool = false,
         imageSupportsEdit: Bool = false,
-        runtimeModeText: String = ""
+        runtimeModeText: String = "",
+        runtimeModeAccessibilityLabel: String = ""
     ) {
         self.modelID = modelID
         self.kind = kind
@@ -124,6 +130,7 @@ public struct RuntimeModelRow: Identifiable, Equatable, Sendable {
         self.imageSupportsGeneration = imageSupportsGeneration
         self.imageSupportsEdit = imageSupportsEdit
         self.runtimeModeText = runtimeModeText
+        self.runtimeModeAccessibilityLabel = runtimeModeAccessibilityLabel
     }
 
     public var id: String {
@@ -9326,11 +9333,22 @@ private func runtimeTrainingPerformanceText(tokensPerSecond: Double, peakMemoryG
     return "\(throughputSummary) • \(peakMemorySummary)"
 }
 
-private func runtimeModeBadgeText(_ model: Melix_Controlplane_V1_ModelSummary) -> String {
+/// Paired runtime-mode presentation fields produced together so the visible
+/// badge tag and its VoiceOver phrasing can't drift. ``text`` is "" when the
+/// caller should hide the badge entirely (base models / legacy entries).
+struct RuntimeModeBadgeFields {
+    let text: String
+    let accessibilityLabel: String
+}
+
+private func runtimeModeBadgeFields(_ model: Melix_Controlplane_V1_ModelSummary) -> RuntimeModeBadgeFields {
     // Map the proto's free-form runtime_mode string into a short badge label
-    // suitable for the menubar list. Empty for base models and legacy
-    // entries; unknown values map to "?" so a future backend that populates
-    // a longer value can't blow out the row's visual footprint.
+    // suitable for the menubar list, paired with the VoiceOver phrasing used
+    // when the badge is rendered. Producing both fields in one switch is the
+    // structural prevention for the a11y-vs-tag drift concern raised in
+    // PR #53 review — a future rename of a short tag has to land the a11y
+    // phrasing in the same case by construction, rather than silently
+    // falling through to a default in a different file.
     //
     // Cross-reference: the CLI equivalent is ``runtimeModeLabel`` in
     // ``Sources/MelixCLICore/MelixCLI.swift``. The two functions diverge
@@ -9341,19 +9359,29 @@ private func runtimeModeBadgeText(_ model: Melix_Controlplane_V1_ModelSummary) -
     // string must land in both mappers for consistent operator UX.
     switch model.runtimeMode {
     case "adapter_backed_runtime":
-        return "adapter"
+        return RuntimeModeBadgeFields(
+            text: "adapter",
+            accessibilityLabel: "Runtime mode: adapter-backed"
+        )
     case "fused_derived_model":
-        return "fused"
+        return RuntimeModeBadgeFields(
+            text: "fused",
+            accessibilityLabel: "Runtime mode: fused derived model"
+        )
     case "":
-        return ""
+        return RuntimeModeBadgeFields(text: "", accessibilityLabel: "")
     default:
-        return "?"
+        return RuntimeModeBadgeFields(
+            text: "?",
+            accessibilityLabel: "Runtime mode: unrecognized"
+        )
     }
 }
 
 func makeRuntimeModelRow(_ model: Melix_Controlplane_V1_ModelSummary) -> RuntimeModelRow {
     let imageSupportsGeneration = runtimeImageSupportsGeneration(model)
     let imageSupportsEdit = runtimeImageSupportsEdit(model)
+    let runtimeModeBadge = runtimeModeBadgeFields(model)
     return RuntimeModelRow(
         modelID: model.modelID,
         kind: model.kind,
@@ -9383,7 +9411,8 @@ func makeRuntimeModelRow(_ model: Melix_Controlplane_V1_ModelSummary) -> Runtime
         imageDefaultWorkflowRole: model.settings.ext["melix.image.default_workflow_role"] ?? "",
         imageSupportsGeneration: imageSupportsGeneration,
         imageSupportsEdit: imageSupportsEdit,
-        runtimeModeText: runtimeModeBadgeText(model)
+        runtimeModeText: runtimeModeBadge.text,
+        runtimeModeAccessibilityLabel: runtimeModeBadge.accessibilityLabel
     )
 }
 

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -9326,11 +9326,19 @@ private func runtimeTrainingPerformanceText(tokensPerSecond: Double, peakMemoryG
     return "\(throughputSummary) • \(peakMemorySummary)"
 }
 
-private func runtimeRuntimeModeText(_ model: Melix_Controlplane_V1_ModelSummary) -> String {
+private func runtimeModeBadgeText(_ model: Melix_Controlplane_V1_ModelSummary) -> String {
     // Map the proto's free-form runtime_mode string into a short badge label
     // suitable for the menubar list. Empty for base models and legacy
     // entries; unknown values map to "?" so a future backend that populates
     // a longer value can't blow out the row's visual footprint.
+    //
+    // Cross-reference: the CLI equivalent is ``runtimeModeLabel`` in
+    // ``Sources/MelixCLICore/MelixCLI.swift``. The two functions diverge
+    // intentionally on the empty / base-model case: the CLI table renders
+    // ``"-"`` in a fixed-width column so every row has a runtime cell,
+    // while the menubar hides the badge entirely so base models render
+    // without a visual tag. Any future backend that adds a new runtime_mode
+    // string must land in both mappers for consistent operator UX.
     switch model.runtimeMode {
     case "adapter_backed_runtime":
         return "adapter"
@@ -9375,7 +9383,7 @@ func makeRuntimeModelRow(_ model: Melix_Controlplane_V1_ModelSummary) -> Runtime
         imageDefaultWorkflowRole: model.settings.ext["melix.image.default_workflow_role"] ?? "",
         imageSupportsGeneration: imageSupportsGeneration,
         imageSupportsEdit: imageSupportsEdit,
-        runtimeModeText: runtimeRuntimeModeText(model)
+        runtimeModeText: runtimeModeBadgeText(model)
     )
 }
 

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -64,6 +64,11 @@ public struct RuntimeModelRow: Identifiable, Equatable, Sendable {
     public let imageDefaultWorkflowRole: String
     public let imageSupportsGeneration: Bool
     public let imageSupportsEdit: Bool
+    /// Short human-readable runtime-mode tag: "adapter", "fused", or "" for
+    /// base/unknown. Mirrors the serving signal promoted in PR #52
+    /// (issue #12 Module 1) so the menubar list distinguishes adapter-backed
+    /// derived models from fused derived models at a glance.
+    public let runtimeModeText: String
 
     public init(
         modelID: String,
@@ -90,7 +95,8 @@ public struct RuntimeModelRow: Identifiable, Equatable, Sendable {
         imageFamilyID: String = "",
         imageDefaultWorkflowRole: String = "",
         imageSupportsGeneration: Bool = false,
-        imageSupportsEdit: Bool = false
+        imageSupportsEdit: Bool = false,
+        runtimeModeText: String = ""
     ) {
         self.modelID = modelID
         self.kind = kind
@@ -117,6 +123,7 @@ public struct RuntimeModelRow: Identifiable, Equatable, Sendable {
         self.imageDefaultWorkflowRole = imageDefaultWorkflowRole
         self.imageSupportsGeneration = imageSupportsGeneration
         self.imageSupportsEdit = imageSupportsEdit
+        self.runtimeModeText = runtimeModeText
     }
 
     public var id: String {
@@ -9319,6 +9326,23 @@ private func runtimeTrainingPerformanceText(tokensPerSecond: Double, peakMemoryG
     return "\(throughputSummary) • \(peakMemorySummary)"
 }
 
+private func runtimeRuntimeModeText(_ model: Melix_Controlplane_V1_ModelSummary) -> String {
+    // Map the proto's free-form runtime_mode string into a short badge label
+    // suitable for the menubar list. Empty for base models and legacy
+    // entries; unknown values map to "?" so a future backend that populates
+    // a longer value can't blow out the row's visual footprint.
+    switch model.runtimeMode {
+    case "adapter_backed_runtime":
+        return "adapter"
+    case "fused_derived_model":
+        return "fused"
+    case "":
+        return ""
+    default:
+        return "?"
+    }
+}
+
 func makeRuntimeModelRow(_ model: Melix_Controlplane_V1_ModelSummary) -> RuntimeModelRow {
     let imageSupportsGeneration = runtimeImageSupportsGeneration(model)
     let imageSupportsEdit = runtimeImageSupportsEdit(model)
@@ -9350,7 +9374,8 @@ func makeRuntimeModelRow(_ model: Melix_Controlplane_V1_ModelSummary) -> Runtime
         imageFamilyID: model.settings.ext["melix.image.family_id"] ?? "",
         imageDefaultWorkflowRole: model.settings.ext["melix.image.default_workflow_role"] ?? "",
         imageSupportsGeneration: imageSupportsGeneration,
-        imageSupportsEdit: imageSupportsEdit
+        imageSupportsEdit: imageSupportsEdit,
+        runtimeModeText: runtimeRuntimeModeText(model)
     )
 }
 

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -8118,6 +8118,39 @@ struct RuntimeViewModelTests {
         #expect(await metrics.snapshot()["menu.foundation_refresh_ms"] != nil)
         #expect(await metrics.snapshot()["desktop.image_refresh_ms"] != nil)
     }
+
+    @Test("runtime model row maps ModelSummary.runtime_mode to a short badge tag")
+    func runtimeModelRowMapsRuntimeModeToBadgeTag() {
+        // Adapter-backed derived model: short "adapter" tag.
+        let adapterBacked = makeModelSummary(
+            modelID: "melix-dev-text-lora-runtime",
+            state: .modelWarm,
+            runtimeMode: "adapter_backed_runtime"
+        )
+        #expect(makeRuntimeModelRow(adapterBacked).runtimeModeText == "adapter")
+
+        // Fused derived model: short "fused" tag.
+        let fused = makeModelSummary(
+            modelID: "melix-dev-text-lora-fused",
+            state: .modelWarm,
+            runtimeMode: "fused_derived_model"
+        )
+        #expect(makeRuntimeModelRow(fused).runtimeModeText == "fused")
+
+        // Base / legacy models: empty string so the view hides the badge.
+        let base = makeModelSummary(modelID: "melix-dev-text", state: .modelWarm)
+        #expect(makeRuntimeModelRow(base).runtimeModeText == "")
+
+        // Unknown values degrade gracefully to "?" so a longer future value
+        // can't blow out the row's visual footprint — matches the CLI
+        // column-width contract.
+        let unknown = makeModelSummary(
+            modelID: "melix-dev-text",
+            state: .modelWarm,
+            runtimeMode: "adapter_backed_runtime_v2"
+        )
+        #expect(makeRuntimeModelRow(unknown).runtimeModeText == "?")
+    }
 }
 
 @MainActor
@@ -8559,7 +8592,8 @@ private func makeModelSummary(
     memoryHeadroomBytes: UInt64 = 0,
     requiredBytes: UInt64 = 0,
     adaptiveThinkingMode: String = "",
-    adaptiveThinkingBudgetTokens: UInt32 = 0
+    adaptiveThinkingBudgetTokens: UInt32 = 0,
+    runtimeMode: String = ""
 ) -> Melix_Controlplane_V1_ModelSummary {
     var model = Melix_Controlplane_V1_ModelSummary()
     model.modelID = modelID
@@ -8570,6 +8604,7 @@ private func makeModelSummary(
     model.pinned = pinned
     model.inflightRequests = inflightRequests
     model.estimatedBytes = estimatedBytes
+    model.runtimeMode = runtimeMode
     model.settings.pinOnLoad = pinRequested
     model.settings.ttlSeconds = ttlSeconds
     model.settings.memoryPolicy = memoryPolicy

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -8119,37 +8119,45 @@ struct RuntimeViewModelTests {
         #expect(await metrics.snapshot()["desktop.image_refresh_ms"] != nil)
     }
 
-    @Test("runtime model row maps ModelSummary.runtime_mode to a short badge tag")
-    func runtimeModelRowMapsRuntimeModeToBadgeTag() {
-        // Adapter-backed derived model: short "adapter" tag.
+    @Test("runtime model row pairs the badge tag with its VoiceOver phrasing")
+    func runtimeModelRowPairsBadgeTagWithAccessibilityLabel() {
+        // Adapter-backed derived model: short "adapter" tag + explicit a11y.
         let adapterBacked = makeModelSummary(
             modelID: "melix-dev-text-lora-runtime",
             state: .modelWarm,
             runtimeMode: "adapter_backed_runtime"
         )
-        #expect(makeRuntimeModelRow(adapterBacked).runtimeModeText == "adapter")
+        let adapterRow = makeRuntimeModelRow(adapterBacked)
+        #expect(adapterRow.runtimeModeText == "adapter")
+        #expect(adapterRow.runtimeModeAccessibilityLabel == "Runtime mode: adapter-backed")
 
-        // Fused derived model: short "fused" tag.
+        // Fused derived model: short "fused" tag + explicit a11y.
         let fused = makeModelSummary(
             modelID: "melix-dev-text-lora-fused",
             state: .modelWarm,
             runtimeMode: "fused_derived_model"
         )
-        #expect(makeRuntimeModelRow(fused).runtimeModeText == "fused")
+        let fusedRow = makeRuntimeModelRow(fused)
+        #expect(fusedRow.runtimeModeText == "fused")
+        #expect(fusedRow.runtimeModeAccessibilityLabel == "Runtime mode: fused derived model")
 
-        // Base / legacy models: empty string so the view hides the badge.
+        // Base / legacy models: both fields empty so the view hides the
+        // badge and VoiceOver announces nothing for this element.
         let base = makeModelSummary(modelID: "melix-dev-text", state: .modelWarm)
-        #expect(makeRuntimeModelRow(base).runtimeModeText == "")
+        let baseRow = makeRuntimeModelRow(base)
+        #expect(baseRow.runtimeModeText == "")
+        #expect(baseRow.runtimeModeAccessibilityLabel == "")
 
-        // Unknown values degrade gracefully to "?" so a longer future value
-        // can't blow out the row's visual footprint — matches the CLI
-        // column-width contract.
+        // Unknown values degrade gracefully to "?" with a screen-reader
+        // friendly phrasing so VoiceOver doesn't read "question mark".
         let unknown = makeModelSummary(
             modelID: "melix-dev-text",
             state: .modelWarm,
             runtimeMode: "adapter_backed_runtime_v2"
         )
-        #expect(makeRuntimeModelRow(unknown).runtimeModeText == "?")
+        let unknownRow = makeRuntimeModelRow(unknown)
+        #expect(unknownRow.runtimeModeText == "?")
+        #expect(unknownRow.runtimeModeAccessibilityLabel == "Runtime mode: unrecognized")
     }
 }
 

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -2251,15 +2251,30 @@ struct MelixCLIRunnerTests {
         // is omitted from the payload rather than blank-strung.
         #expect(byID["melix-base-text"]?["activation_mode"] == nil)
 
-        // Text output: short-form tags ("-", "fused", "adapter") appear in
-        // the new runtime column. Header exposes the column.
+        // Text output: fixed-width table with header row and short-form
+        // runtime tags. Header column names are upper-case for legibility;
+        // columns are padded to max width with two-space separators.
         let textOutput = try await MelixCLIRunner(client: client, operatorSessionStore: store).run(
             .modelList(.init(json: false))
         )
-        #expect(textOutput.contains("model_id\tkind\tstate\truntime"))
-        #expect(textOutput.contains("melix-base-text\ttext\t") && textOutput.contains("\t-\n"))
-        #expect(textOutput.contains("\tfused\n"))
-        #expect(textOutput.contains("\tadapter\n"))
+        let lines = textOutput.split(separator: "\n").map(String.init)
+        let header = try #require(lines.first)
+        // Header exposes all four columns in padded fixed-width order.
+        #expect(header.contains("MODEL_ID"))
+        #expect(header.contains("KIND"))
+        #expect(header.contains("STATE"))
+        #expect(header.contains("RUNTIME"))
+        // Each short-form runtime tag appears exactly once on a data row.
+        let dataRows = lines.dropFirst()
+        #expect(dataRows.contains { $0.hasSuffix("-") && $0.contains("melix-base-text ") })
+        #expect(dataRows.contains { $0.hasSuffix("fused") })
+        #expect(dataRows.contains { $0.hasSuffix("adapter") })
+        // The three model_ids align in the first column (padded to the
+        // widest id: "melix-base-text-lora-runtime" is 28 chars).
+        let firstColumnWidth = 28
+        for row in dataRows where !row.isEmpty {
+            #expect(row.count > firstColumnWidth + 2, "row not padded as expected: \(row)")
+        }
     }
 
     @Test("model list primes configured registry roots before fetching the server snapshot")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -2265,15 +2265,29 @@ struct MelixCLIRunnerTests {
         #expect(header.contains("STATE"))
         #expect(header.contains("RUNTIME"))
         // Each short-form runtime tag appears exactly once on a data row.
+        // Use ``hasPrefix`` on the model_id + trailing space to unambiguously
+        // pick each row even if another id were a superstring.
         let dataRows = lines.dropFirst()
-        #expect(dataRows.contains { $0.hasSuffix("-") && $0.contains("melix-base-text ") })
-        #expect(dataRows.contains { $0.hasSuffix("fused") })
-        #expect(dataRows.contains { $0.hasSuffix("adapter") })
-        // The three model_ids align in the first column (padded to the
-        // widest id: "melix-base-text-lora-runtime" is 28 chars).
-        let firstColumnWidth = 28
-        for row in dataRows where !row.isEmpty {
-            #expect(row.count > firstColumnWidth + 2, "row not padded as expected: \(row)")
+        let baseRow = try #require(
+            dataRows.first(where: { $0.hasPrefix("melix-base-text ") && $0.hasSuffix("-") })
+        )
+        let fusedRow = try #require(
+            dataRows.first(where: { $0.hasPrefix("melix-base-text-lora-fused ") && $0.hasSuffix("fused") })
+        )
+        let adapterRow = try #require(
+            dataRows.first(where: { $0.hasPrefix("melix-base-text-lora-runtime") && $0.hasSuffix("adapter") })
+        )
+        // The first column is padded to the widest model_id
+        // ("melix-base-text-lora-runtime" = 28 chars); assert the "KIND"
+        // column actually starts at the column-separator offset. A
+        // regression that dropped padding would collapse the gap.
+        let firstColumnWidth = "melix-base-text-lora-runtime".count
+        let separator = "  "
+        let kindColumnOffset = firstColumnWidth + separator.count
+        for row in [baseRow, fusedRow, adapterRow] {
+            let indexAtKindStart = row.index(row.startIndex, offsetBy: kindColumnOffset)
+            let kindPrefix = row[indexAtKindStart...].prefix(4)
+            #expect(kindPrefix == "text", "row not padded at column offset: \(row)")
         }
     }
 


### PR DESCRIPTION
## Summary

Closes two Module 1 (issue #12) polish gaps called out in PR #52's *Known Gaps* section:

1. **Menubar UI surface.** The macOS menubar `DesktopFoundationView` model list now renders an `adapter` / `fused` capsule badge next to each model_id, matching the `.quaternary` + `Capsule()` pattern already used across `DesktopChatView` and `DesktopWorkspaceShellView` for metadata tags. Base models render without a badge; unknown future values degrade to `"?"` so the row's visual footprint stays bounded.
2. **CLI table formatter.** `melix models list` upgrades from tab-separated to a fixed-width table — headers UPPER_CASED, each column padded to the max width of header + all rows, two-space column separator. Consumers that need column-boundary-stable output should use `--json`; this renderer is explicitly for human reading.

Pure operator-experience improvements. No proto changes, no behavioral changes, no control-plane changes.

## Plan or Spec

- Referenced in PR #52 "Known Gaps" (closed issue #12): *"No Swift menubar UI change yet"* and *"CLI list is tab-separated"*.
- Part of Module 1 closeout from `docs/plans/2026-04-16-lora-capability-modules-and-commit-plan.md`.

## Commands Run

- `HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH=… xcrun swift test --filter "MelixCLIRunnerTests|MelixCLIParserTests"` — 152 tests green.
- `HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH=… xcrun swift test --package-path apps/macos-menubar --filter "RuntimeViewModelTests"` — 185 tests green.

## Coverage and Metrics

### New / updated test counts

- Menubar: **1 new test** — `runtimeModelRowMapsRuntimeModeToBadgeTag` pins all four cases (adapter_backed_runtime → "adapter", fused_derived_model → "fused", empty → "" no badge, unknown → "?").
- CLI: **existing `modelListSurfacesRuntimeModeColumn` test updated** to the new fixed-width layout — asserts UPPER_CASED header columns, runtime tags at expected row suffixes, and first-column padding to the widest model_id.

Net: 185 menubar tests green (+1 vs main), 152 root CLI tests green (no delta; test modified).

### Visual surface

`melix models list` now renders as:

```
MODEL_ID                      KIND  STATE       RUNTIME
melix-base-text               text  discovered  -
melix-base-text-lora-fused    text  discovered  fused
melix-base-text-lora-runtime  text  discovered  adapter
```

Menubar model rows now include a capsule badge right of the model_id — `adapter` for adapter-backed derived models, `fused` for fused derived models, nothing for base models.

### Churn

- 5 files changed, +128 / -14 lines.
- CLI: `renderModelList` replaced with the fixed-width formatter; existing `runtimeModeLabel` helper reused unchanged.
- Menubar: `RuntimeModelRow` gains `runtimeModeText` field (default `""`); new `runtimeRuntimeModeText` helper in the mapper; `DesktopFoundationView` inserts the capsule badge inside the existing headline HStack.

## Known Gaps

- **Other Module 1 polish items from the PR #52 gap list remain**: manifest still carries `activation_mode` string duplicating the typed enum (deliberate for backward compat), vision/embedding adapter-backed paths unexercised (Module 6 territory). Both out of scope for this polish pass.
- **Menubar detail view doesn't yet show adapter manifest / weights paths.** The badge signals the serving mode; deeper inspection still requires `melix models show <id>` or the JSON CLI output. A future slice can add an expander / detail sheet if operators ask for it.
- **Menubar badge is text-only.** No icon (e.g., SF Symbol) attached — kept minimal to match the existing tag pattern. If design input later suggests an icon pair, it's a one-line swap.

## Test plan

- [x] `swift test --filter "MelixCLIRunnerTests|MelixCLIParserTests"` — 152 passed.
- [x] `swift test --package-path apps/macos-menubar --filter "RuntimeViewModelTests"` — 185 passed (+1 new test).
- [x] `swift build` clean in the root + menubar packages.
- [x] Existing tests for the `runtimeModeLabel` CLI helper + the `_runtime_mode_from_activation` Python helper stay green (no changes to those paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)