### PR TITLE
feat(lora): experiment surfaces for CLI and menubar (issue #14 · Module 3 slice 3.3)

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -4392,7 +4392,7 @@ public actor MelixCLIRunner {
             outputDir: "",
             ext: [:]
         )
-        let groups = extractExperimentGroups(fromManifestJson: result.manifestJson)
+        let groups = try extractExperimentGroups(fromManifestJson: result.manifestJson)
         if options.json {
             return try prettyJSON(["experiment_groups": groups])
         }
@@ -4407,7 +4407,7 @@ public actor MelixCLIRunner {
             outputDir: "",
             ext: [:]
         )
-        let groups = extractExperimentGroups(fromManifestJson: result.manifestJson)
+        let groups = try extractExperimentGroups(fromManifestJson: result.manifestJson)
         guard let group = groups.first(where: { ($0["group_id"] as? String) == options.groupID }) else {
             throw MelixCLIError.missingRequired(experimentGroupNotFoundMessage(groupID: options.groupID, groups: groups))
         }
@@ -4425,7 +4425,7 @@ public actor MelixCLIRunner {
             outputDir: "",
             ext: [:]
         )
-        let groups = extractExperimentGroups(fromManifestJson: snapshot.manifestJson)
+        let groups = try extractExperimentGroups(fromManifestJson: snapshot.manifestJson)
         guard let group = groups.first(where: { ($0["group_id"] as? String) == options.groupID }) else {
             throw MelixCLIError.missingRequired(experimentGroupNotFoundMessage(groupID: options.groupID, groups: groups))
         }
@@ -4437,18 +4437,29 @@ public actor MelixCLIRunner {
             )
         }
         let manifest = try readAdapterManifestPayload(at: manifestPath)
-        let resolvedDatasetURI = options.datasetURI.isEmpty
-            ? ((manifest["dataset_uri"] as? String) ?? "")
-            : options.datasetURI
+        let manifestDatasetURI = (manifest["dataset_uri"] as? String) ?? ""
+        let manifestHFDatasetPath = (manifest["hf_dataset_path"] as? String) ?? ""
+        let inheritedSourceKind = (manifest["dataset_source_kind"] as? String) ?? ""
         let resolvedAdapterName = options.adapterName.isEmpty
             ? ((manifest["adapter_name"] as? String) ?? "")
             : options.adapterName
         let resolvedPresetID = options.presetID.isEmpty
             ? ((manifest["preset_id"] as? String) ?? "")
             : options.presetID
-        guard !resolvedDatasetURI.isEmpty else {
+        let resolvedDatasetURI: String
+        let resolvedSourceKind: String
+        if options.datasetURI.isEmpty == false {
+            resolvedDatasetURI = options.datasetURI
+            resolvedSourceKind = inheritedSourceKind.isEmpty ? "local_package" : inheritedSourceKind
+        } else if manifestDatasetURI.isEmpty == false {
+            resolvedDatasetURI = manifestDatasetURI
+            resolvedSourceKind = inheritedSourceKind.isEmpty ? "local_package" : inheritedSourceKind
+        } else if manifestHFDatasetPath.isEmpty == false {
+            resolvedDatasetURI = manifestHFDatasetPath
+            resolvedSourceKind = "hf_dataset"
+        } else {
             throw MelixCLIError.missingRequired(
-                "Recommended manifest for \(options.groupID) did not carry a dataset_uri; pass --dataset-uri explicitly."
+                "Recommended manifest for \(options.groupID) did not carry a dataset_uri or hf_dataset_path; pass --dataset-uri explicitly."
             )
         }
         guard !resolvedAdapterName.isEmpty else {
@@ -4458,7 +4469,7 @@ public actor MelixCLIRunner {
         }
         var ext: [String: String] = [
             "adapter_name": resolvedAdapterName,
-            "dataset_source_kind": "local_package",
+            "dataset_source_kind": resolvedSourceKind,
             "dataset_uri": resolvedDatasetURI,
             "resume_manifest_path": manifestPath,
             "experiment_group_id": options.groupID,
@@ -4468,6 +4479,23 @@ public actor MelixCLIRunner {
         }
         if let groupTitle = manifest["experiment_group_title"] as? String, !groupTitle.isEmpty {
             ext["experiment_group_title"] = groupTitle
+        }
+        if resolvedSourceKind == "hf_dataset" {
+            for key in [
+                "hf_dataset_path",
+                "hf_dataset_name",
+                "hf_dataset_revision",
+                "hf_train_split",
+                "hf_valid_split",
+                "text_feature",
+                "prompt_feature",
+                "completion_feature",
+                "chat_feature",
+            ] {
+                if let value = manifest[key] as? String, !value.isEmpty {
+                    ext[key] = value
+                }
+            }
         }
         let result = try await performModelOperation(
             modelID: modelID,
@@ -4489,12 +4517,18 @@ public actor MelixCLIRunner {
         return result.outputPath
     }
 
-    private func extractExperimentGroups(fromManifestJson manifestJson: String) -> [[String: Any]] {
-        guard
-            let data = manifestJson.data(using: .utf8),
-            let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else {
-            return []
+    private func extractExperimentGroups(fromManifestJson manifestJson: String) throws -> [[String: Any]] {
+        guard let data = manifestJson.data(using: .utf8) else {
+            throw MelixCLIError.runtime("registry_snapshot payload was not valid UTF-8.")
+        }
+        let parsed: Any
+        do {
+            parsed = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw MelixCLIError.runtime("registry_snapshot payload was not valid JSON: \(error.localizedDescription)")
+        }
+        guard let payload = parsed as? [String: Any] else {
+            throw MelixCLIError.runtime("registry_snapshot payload was not a JSON object.")
         }
         return payload["experiment_groups"] as? [[String: Any]] ?? []
     }
@@ -4530,14 +4564,14 @@ public actor MelixCLIRunner {
             let groupID = (group["group_id"] as? String) ?? ""
             let title = (group["title"] as? String) ?? ""
             let runCount = (group["run_count"] as? Int) ?? 0
-            let bestLoss = coerceDouble(group["best_loss"]) ?? 0.0
-            let resumeReadyIDs = (group["resume_ready_run_ids"] as? [Any] ?? []).count
+            let bestLossText = coerceDouble(group["best_loss"]).map { String(format: "%.4f", $0) } ?? "n/a"
+            let resumeReadyCount = (group["resume_ready_run_ids"] as? [Any] ?? []).count
             return [
                 groupID,
                 title,
                 String(runCount),
-                String(format: "%.4f", bestLoss),
-                "\(resumeReadyIDs) of \(runCount)",
+                bestLossText,
+                "\(resumeReadyCount) of \(runCount)",
             ]
         }
         return renderFixedWidthTable(header: header, rows: rows) + "\n"
@@ -4569,11 +4603,16 @@ public actor MelixCLIRunner {
         if lineage.isEmpty {
             lines.append("  (no per-run detail available)")
         } else {
-            for entry in lineage {
+            let lineageHeader = ["RUN_ID", "CHECKPOINTS", "RESUME_READY"]
+            let lineageRows: [[String]] = lineage.map { entry in
                 let runID = (entry["run_id"] as? String) ?? ""
                 let checkpointCount = (entry["checkpoint_count"] as? Int) ?? 0
                 let resumeReady = (entry["resume_ready"] as? Bool) ?? false
-                lines.append("  \(runID)\tcheckpoints=\(checkpointCount)\tresume_ready=\(resumeReady ? "yes" : "no")")
+                return [runID, String(checkpointCount), resumeReady ? "yes" : "no"]
+            }
+            let table = renderFixedWidthTable(header: lineageHeader, rows: lineageRows)
+            for tableLine in table.split(separator: "\n", omittingEmptySubsequences: false) {
+                lines.append("  " + String(tableLine))
             }
         }
         if !resumeReadyIDs.isEmpty {
@@ -4583,11 +4622,11 @@ public actor MelixCLIRunner {
 
         let bestRunID = (best["run_id"] as? String) ?? ""
         let bestManifestPath = (best["manifest_path"] as? String) ?? ""
-        let bestLoss = coerceDouble(best["loss_best"]) ?? 0.0
+        let bestLossText = coerceDouble(best["loss_best"]).map { String(format: "%.4f", $0) } ?? "n/a"
         if !bestRunID.isEmpty, !bestManifestPath.isEmpty {
             lines.append("")
             lines.append("Best known adapter:")
-            lines.append("  Run \(bestRunID) (loss \(String(format: "%.4f", bestLoss)))")
+            lines.append("  Run \(bestRunID) (loss \(bestLossText))")
             lines.append("  Manifest: \(bestManifestPath)")
             lines.append("  Resume via: melix lora resume --group-id \(groupID)")
         }

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -161,6 +161,53 @@ public struct LoraPublishOptions: Equatable, Sendable {
     }
 }
 
+public struct LoraExperimentsListOptions: Equatable, Sendable {
+    public let modelID: String
+    public let json: Bool
+
+    public init(modelID: String = "", json: Bool = false) {
+        self.modelID = modelID
+        self.json = json
+    }
+}
+
+public struct LoraExperimentsShowOptions: Equatable, Sendable {
+    public let modelID: String
+    public let groupID: String
+    public let json: Bool
+
+    public init(modelID: String = "", groupID: String, json: Bool = false) {
+        self.modelID = modelID
+        self.groupID = groupID
+        self.json = json
+    }
+}
+
+public struct LoraResumeOptions: Equatable, Sendable {
+    public let modelID: String
+    public let groupID: String
+    public let presetID: String
+    public let adapterName: String
+    public let datasetURI: String
+    public let json: Bool
+
+    public init(
+        modelID: String = "",
+        groupID: String,
+        presetID: String = "",
+        adapterName: String = "",
+        datasetURI: String = "",
+        json: Bool = false
+    ) {
+        self.modelID = modelID
+        self.groupID = groupID
+        self.presetID = presetID
+        self.adapterName = adapterName
+        self.datasetURI = datasetURI
+        self.json = json
+    }
+}
+
 public struct BenchRunOptions: Equatable, Sendable {
     public let modelID: String
     public let hfRepoID: String
@@ -918,6 +965,9 @@ public enum MelixCLICommand: Equatable, Sendable {
     case loraActivate(LoraActivateOptions)
     case loraRemoveDerived(LoraRemoveDerivedOptions)
     case loraPublish(LoraPublishOptions)
+    case loraExperimentsList(LoraExperimentsListOptions)
+    case loraExperimentsShow(LoraExperimentsShowOptions)
+    case loraResume(LoraResumeOptions)
     case benchRun(BenchRunOptions)
     case benchList(BenchListOptions)
     case benchExportCSV(BenchExportCSVOptions)
@@ -1055,6 +1105,9 @@ public enum MelixCLIParser {
       melix lora activate --model-id MODEL_ID --adapter-path PATH [--activation-mode (fused_derived_model|adapter_backed_runtime)] [--alias NAME] [--json]
       melix lora remove-derived --model-id MODEL_ID (--derived-model-id ID | --manifest-path PATH) [--json]
       melix lora publish --model-id MODEL_ID --target-repo REPO (--adapter-path PATH | --merged-model-path PATH | --manifest-path PATH) [--json]
+      melix lora experiments list [--model-id MODEL_ID] [--json]
+      melix lora experiments show --group-id GROUP_ID [--model-id MODEL_ID] [--json]
+      melix lora resume --group-id GROUP_ID [--model-id MODEL_ID] [--preset PRESET] [--adapter-name NAME] [--dataset-uri URI] [--json]
       melix bench run (--model-id MODEL_ID | --repo-id HF_REPO) [--suite SUITE ...] [--context-length N ...] [--generation-length N] [--batch-size N ...] [--repeats N] [--cache-profile MODE] [--reasoning-mode MODE] [--structured-output-mode MODE] [--sample-size N] [--batch-factor N] [--json]
       melix bench list [--json]
       melix bench export-csv --job-id JOB_ID --output PATH [--json]
@@ -1645,6 +1698,54 @@ public enum MelixCLIParser {
                     exportKind: exportKind,
                     artifactPath: artifactPath,
                     artifactManifestPath: artifactManifestPath,
+                    json: values.flags.contains("--json")
+                )
+            )
+        case "experiments":
+            return try parseLoraExperiments(Array(arguments.dropFirst()))
+        case "resume":
+            let values = try cursor.parse()
+            guard let groupID = values.single["--group-id"], !groupID.isEmpty else {
+                throw MelixCLIError.missingRequired("--group-id is required for melix lora resume.")
+            }
+            return .loraResume(
+                LoraResumeOptions(
+                    modelID: values.single["--model-id"] ?? "",
+                    groupID: groupID,
+                    presetID: values.single["--preset"] ?? "",
+                    adapterName: values.single["--adapter-name"] ?? "",
+                    datasetURI: values.single["--dataset-uri"] ?? "",
+                    json: values.flags.contains("--json")
+                )
+            )
+        default:
+            throw MelixCLIError.usage(usageText)
+        }
+    }
+
+    private static func parseLoraExperiments(_ arguments: [String]) throws -> MelixCLICommand {
+        guard let action = arguments.first else {
+            throw MelixCLIError.usage(usageText)
+        }
+        let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse()
+        switch action {
+        case "list":
+            return .loraExperimentsList(
+                LoraExperimentsListOptions(
+                    modelID: values.single["--model-id"] ?? "",
+                    json: values.flags.contains("--json")
+                )
+            )
+        case "show":
+            guard let groupID = values.single["--group-id"], !groupID.isEmpty else {
+                throw MelixCLIError.missingRequired(
+                    "--group-id is required for melix lora experiments show."
+                )
+            }
+            return .loraExperimentsShow(
+                LoraExperimentsShowOptions(
+                    modelID: values.single["--model-id"] ?? "",
+                    groupID: groupID,
                     json: values.flags.contains("--json")
                 )
             )
@@ -3119,6 +3220,12 @@ public actor MelixCLIRunner {
                 ext: ext
             )
             return options.json ? result.manifestJson : result.outputPath
+        case .loraExperimentsList(let options):
+            return try await runLoraExperimentsList(options)
+        case .loraExperimentsShow(let options):
+            return try await runLoraExperimentsShow(options)
+        case .loraResume(let options):
+            return try await runLoraResume(options)
         case .benchRun(let options):
             let result = try await runBenchmark(options)
             if options.json {
@@ -3680,6 +3787,9 @@ public actor MelixCLIRunner {
              .loraTrain,
              .loraActivate,
              .loraRemoveDerived,
+             .loraExperimentsList,
+             .loraExperimentsShow,
+             .loraResume,
              .benchRun,
              .benchMatrixRun,
              .evalRun,
@@ -4272,6 +4382,256 @@ public actor MelixCLIRunner {
         }
 
         return sections.joined(separator: "\n\n") + "\n"
+    }
+
+    private func runLoraExperimentsList(_ options: LoraExperimentsListOptions) async throws -> String {
+        let modelID = try await resolveModelID(preferred: options.modelID)
+        let result = try await performModelOperation(
+            modelID: modelID,
+            operation: "registry_snapshot",
+            outputDir: "",
+            ext: [:]
+        )
+        let groups = extractExperimentGroups(fromManifestJson: result.manifestJson)
+        if options.json {
+            return try prettyJSON(["experiment_groups": groups])
+        }
+        return renderExperimentsList(groups)
+    }
+
+    private func runLoraExperimentsShow(_ options: LoraExperimentsShowOptions) async throws -> String {
+        let modelID = try await resolveModelID(preferred: options.modelID)
+        let result = try await performModelOperation(
+            modelID: modelID,
+            operation: "registry_snapshot",
+            outputDir: "",
+            ext: [:]
+        )
+        let groups = extractExperimentGroups(fromManifestJson: result.manifestJson)
+        guard let group = groups.first(where: { ($0["group_id"] as? String) == options.groupID }) else {
+            throw MelixCLIError.missingRequired(experimentGroupNotFoundMessage(groupID: options.groupID, groups: groups))
+        }
+        if options.json {
+            return try prettyJSON(group)
+        }
+        return renderExperimentsShow(group)
+    }
+
+    private func runLoraResume(_ options: LoraResumeOptions) async throws -> String {
+        let modelID = try await resolveModelID(preferred: options.modelID)
+        let snapshot = try await performModelOperation(
+            modelID: modelID,
+            operation: "registry_snapshot",
+            outputDir: "",
+            ext: [:]
+        )
+        let groups = extractExperimentGroups(fromManifestJson: snapshot.manifestJson)
+        guard let group = groups.first(where: { ($0["group_id"] as? String) == options.groupID }) else {
+            throw MelixCLIError.missingRequired(experimentGroupNotFoundMessage(groupID: options.groupID, groups: groups))
+        }
+        let best = group["best_known_adapter"] as? [String: Any] ?? [:]
+        let manifestPath = (best["manifest_path"] as? String) ?? ""
+        guard !manifestPath.isEmpty else {
+            throw MelixCLIError.missingRequired(
+                "Group \(options.groupID) has no recommended adapter; use `melix lora experiments show --group-id \(options.groupID)` to inspect runs."
+            )
+        }
+        let manifest = try readAdapterManifestPayload(at: manifestPath)
+        let resolvedDatasetURI = options.datasetURI.isEmpty
+            ? ((manifest["dataset_uri"] as? String) ?? "")
+            : options.datasetURI
+        let resolvedAdapterName = options.adapterName.isEmpty
+            ? ((manifest["adapter_name"] as? String) ?? "")
+            : options.adapterName
+        let resolvedPresetID = options.presetID.isEmpty
+            ? ((manifest["preset_id"] as? String) ?? "")
+            : options.presetID
+        guard !resolvedDatasetURI.isEmpty else {
+            throw MelixCLIError.missingRequired(
+                "Recommended manifest for \(options.groupID) did not carry a dataset_uri; pass --dataset-uri explicitly."
+            )
+        }
+        guard !resolvedAdapterName.isEmpty else {
+            throw MelixCLIError.missingRequired(
+                "Recommended manifest for \(options.groupID) did not carry an adapter_name; pass --adapter-name explicitly."
+            )
+        }
+        var ext: [String: String] = [
+            "adapter_name": resolvedAdapterName,
+            "dataset_source_kind": "local_package",
+            "dataset_uri": resolvedDatasetURI,
+            "resume_manifest_path": manifestPath,
+            "experiment_group_id": options.groupID,
+        ]
+        if !resolvedPresetID.isEmpty {
+            ext["preset_id"] = resolvedPresetID
+        }
+        if let groupTitle = manifest["experiment_group_title"] as? String, !groupTitle.isEmpty {
+            ext["experiment_group_title"] = groupTitle
+        }
+        let result = try await performModelOperation(
+            modelID: modelID,
+            operation: "train_lora",
+            outputDir: "",
+            ext: ext
+        )
+        if options.json {
+            return try prettyJSON([
+                "group_id": options.groupID,
+                "resume_manifest_path": manifestPath,
+                "dataset_uri": resolvedDatasetURI,
+                "adapter_name": resolvedAdapterName,
+                "preset_id": resolvedPresetID,
+                "training_manifest_path": result.outputPath,
+                "training_manifest_json": result.manifestJson,
+            ])
+        }
+        return result.outputPath
+    }
+
+    private func extractExperimentGroups(fromManifestJson manifestJson: String) -> [[String: Any]] {
+        guard
+            let data = manifestJson.data(using: .utf8),
+            let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return []
+        }
+        return payload["experiment_groups"] as? [[String: Any]] ?? []
+    }
+
+    private func readAdapterManifestPayload(at path: String) throws -> [String: Any] {
+        let url = URL(fileURLWithPath: path)
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw MelixCLIError.runtime("Unable to read adapter manifest at \(path): \(error.localizedDescription)")
+        }
+        guard let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw MelixCLIError.runtime("Adapter manifest at \(path) was not a JSON object.")
+        }
+        return payload
+    }
+
+    private func experimentGroupNotFoundMessage(groupID: String, groups: [[String: Any]]) -> String {
+        let knownIDs = groups.compactMap { $0["group_id"] as? String }.filter { $0.isEmpty == false }
+        if knownIDs.isEmpty {
+            return "Unknown experiment group \(groupID); no groups are recorded yet."
+        }
+        return "Unknown experiment group \(groupID). Known groups: \(knownIDs.joined(separator: ", "))."
+    }
+
+    private func renderExperimentsList(_ groups: [[String: Any]]) -> String {
+        if groups.isEmpty {
+            return "No experiment groups found.\n"
+        }
+        let header = ["GROUP_ID", "TITLE", "RUNS", "BEST_LOSS", "RESUME_READY"]
+        let rows: [[String]] = groups.map { group in
+            let groupID = (group["group_id"] as? String) ?? ""
+            let title = (group["title"] as? String) ?? ""
+            let runCount = (group["run_count"] as? Int) ?? 0
+            let bestLoss = coerceDouble(group["best_loss"]) ?? 0.0
+            let resumeReadyIDs = (group["resume_ready_run_ids"] as? [Any] ?? []).count
+            return [
+                groupID,
+                title,
+                String(runCount),
+                String(format: "%.4f", bestLoss),
+                "\(resumeReadyIDs) of \(runCount)",
+            ]
+        }
+        return renderFixedWidthTable(header: header, rows: rows) + "\n"
+    }
+
+    private func renderExperimentsShow(_ group: [String: Any]) -> String {
+        let groupID = (group["group_id"] as? String) ?? ""
+        let title = (group["title"] as? String) ?? ""
+        let sourceModel = (group["source_model"] as? String) ?? ""
+        let adapterName = (group["adapter_name"] as? String) ?? ""
+        let runCount = (group["run_count"] as? Int) ?? 0
+        let resumeReadyIDs = (group["resume_ready_run_ids"] as? [Any] ?? []).compactMap { $0 as? String }
+        let lineage = (group["checkpoint_lineage"] as? [[String: Any]]) ?? []
+        let best = group["best_known_adapter"] as? [String: Any] ?? [:]
+
+        var lines: [String] = []
+        lines.append("Group: \(groupID)")
+        if !title.isEmpty {
+            lines.append("Title: \(title)")
+        }
+        if !sourceModel.isEmpty {
+            lines.append("Source model: \(sourceModel)")
+        }
+        if !adapterName.isEmpty {
+            lines.append("Adapter name: \(adapterName)")
+        }
+        lines.append("")
+        lines.append("Runs (\(runCount)):")
+        if lineage.isEmpty {
+            lines.append("  (no per-run detail available)")
+        } else {
+            for entry in lineage {
+                let runID = (entry["run_id"] as? String) ?? ""
+                let checkpointCount = (entry["checkpoint_count"] as? Int) ?? 0
+                let resumeReady = (entry["resume_ready"] as? Bool) ?? false
+                lines.append("  \(runID)\tcheckpoints=\(checkpointCount)\tresume_ready=\(resumeReady ? "yes" : "no")")
+            }
+        }
+        if !resumeReadyIDs.isEmpty {
+            lines.append("")
+            lines.append("Resume-ready runs: \(resumeReadyIDs.joined(separator: ", "))")
+        }
+
+        let bestRunID = (best["run_id"] as? String) ?? ""
+        let bestManifestPath = (best["manifest_path"] as? String) ?? ""
+        let bestLoss = coerceDouble(best["loss_best"]) ?? 0.0
+        if !bestRunID.isEmpty, !bestManifestPath.isEmpty {
+            lines.append("")
+            lines.append("Best known adapter:")
+            lines.append("  Run \(bestRunID) (loss \(String(format: "%.4f", bestLoss)))")
+            lines.append("  Manifest: \(bestManifestPath)")
+            lines.append("  Resume via: melix lora resume --group-id \(groupID)")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private func renderFixedWidthTable(header: [String], rows: [[String]]) -> String {
+        let columnCount = header.count
+        var widths = header.map { $0.count }
+        for row in rows {
+            for (index, cell) in row.enumerated() where index < columnCount {
+                widths[index] = max(widths[index], cell.count)
+            }
+        }
+        func pad(_ row: [String]) -> String {
+            var segments: [String] = []
+            for index in 0..<columnCount {
+                let value = index < row.count ? row[index] : ""
+                if index == columnCount - 1 {
+                    segments.append(value)
+                } else {
+                    segments.append(value.padding(toLength: widths[index], withPad: " ", startingAt: 0))
+                }
+            }
+            return segments.joined(separator: "  ")
+        }
+        var lines = [pad(header)]
+        for row in rows {
+            lines.append(pad(row))
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func coerceDouble(_ value: Any?) -> Double? {
+        if let number = value as? Double {
+            return number
+        }
+        if let number = value as? Int {
+            return Double(number)
+        }
+        if let string = value as? String, let number = Double(string) {
+            return number
+        }
+        return nil
     }
 
     private func renderTrainingDatasetManifest(_ manifestJSON: String) -> String {

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -80,6 +80,12 @@ public enum MelixCLICommandCodec {
             return "lora.remove-derived"
         case .loraPublish:
             return "lora.publish"
+        case .loraExperimentsList:
+            return "lora.experiments.list"
+        case .loraExperimentsShow:
+            return "lora.experiments.show"
+        case .loraResume:
+            return "lora.resume"
         case .benchRun:
             return "bench.run"
         case .benchList:

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -1559,6 +1559,7 @@ struct DesktopTrainingToolSectionView: View {
                                     Spacer()
                                     Button("Use Group") {
                                         viewModel.loraExperimentGroupID = group.groupID
+                                        viewModel.loraResumeFromManifestPath = ""
                                     }
                                     .buttonStyle(.bordered)
                                     .controlSize(.small)

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -1562,6 +1562,13 @@ struct DesktopTrainingToolSectionView: View {
                                     }
                                     .buttonStyle(.bordered)
                                     .controlSize(.small)
+                                    Button("Resume From Best") {
+                                        viewModel.loraExperimentGroupID = group.groupID
+                                        viewModel.loraResumeFromManifestPath = group.recommendedManifestPath
+                                    }
+                                    .buttonStyle(.bordered)
+                                    .controlSize(.small)
+                                    .disabled(group.recommendedManifestPath.isEmpty)
                                 }
                                 Text(group.experimentSummaryText)
                                     .font(.caption)
@@ -1572,6 +1579,22 @@ struct DesktopTrainingToolSectionView: View {
                                 Text("Best loss \(String(format: "%.3f", group.bestLoss)) • \(group.recommendedManifestPath)")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
+                                Text(group.resumeReadySummaryText)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                if !group.checkpointLineage.isEmpty {
+                                    DisclosureGroup("Checkpoint lineage") {
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            ForEach(group.checkpointLineage) { entry in
+                                                Text("\(entry.runID) • \(entry.checkpointCount) checkpoints • \(entry.resumeReady ? "resume ready" : "resume unavailable")")
+                                                    .font(.caption)
+                                                    .foregroundStyle(.secondary)
+                                            }
+                                        }
+                                        .padding(.top, 4)
+                                    }
+                                    .font(.caption)
+                                }
                             }
                             .padding(.vertical, 4)
                         }

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -882,9 +882,7 @@ public struct RuntimeLoraExperimentGroupState: Identifiable, Equatable, Sendable
     }
 
     public var resumeReadySummaryText: String {
-        let ready = resumeReadyRunIDs.count
-        let total = max(runCount, ready)
-        return "\(ready) of \(total) runs resume-ready"
+        "\(resumeReadyRunIDs.count) of \(runCount) runs resume-ready"
     }
 }
 
@@ -4248,6 +4246,7 @@ public final class RuntimeViewModel {
                     metricName: "menu.model_operation_ms",
                     refreshProductToolingState: true
                 )
+                loraResumeFromManifestPath = ""
                 return
             } catch {
                 recordCLIWorkflowErrorIfNeeded(error)
@@ -4263,6 +4262,7 @@ public final class RuntimeViewModel {
             ext: loraTrainingExt(),
             refreshProductToolingState: true
         )
+        loraResumeFromManifestPath = ""
     }
 
     public func activateLatestAdapter() async {

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -835,6 +835,20 @@ public struct RuntimeTrainingHistoryEntryState: Identifiable, Equatable, Sendabl
     }
 }
 
+public struct RuntimeLoraCheckpointLineageEntry: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let runID: String
+    public let checkpointCount: Int
+    public let resumeReady: Bool
+
+    public init(runID: String, checkpointCount: Int, resumeReady: Bool) {
+        self.id = runID
+        self.runID = runID
+        self.checkpointCount = checkpointCount
+        self.resumeReady = resumeReady
+    }
+}
+
 public struct RuntimeLoraExperimentGroupState: Identifiable, Equatable, Sendable {
     public let id: String
     public let groupID: String
@@ -849,6 +863,9 @@ public struct RuntimeLoraExperimentGroupState: Identifiable, Equatable, Sendable
     public let latestResumeReady: Bool
     public let bestLoss: Double
     public let recommendedManifestPath: String
+    public let bestRunID: String
+    public let resumeReadyRunIDs: [String]
+    public let checkpointLineage: [RuntimeLoraCheckpointLineageEntry]
 
     public var experimentSummaryText: String {
         runtimeExperimentSummaryText(
@@ -862,6 +879,12 @@ public struct RuntimeLoraExperimentGroupState: Identifiable, Equatable, Sendable
             tokensPerSecond: latestTokensPerSecond,
             peakMemoryGB: latestPeakMemoryGB
         )
+    }
+
+    public var resumeReadySummaryText: String {
+        let ready = resumeReadyRunIDs.count
+        let total = max(runCount, ready)
+        return "\(ready) of \(total) runs resume-ready"
     }
 }
 
@@ -1412,6 +1435,7 @@ public final class RuntimeViewModel {
     public var loraAdapterName = "melix-dev-adapter"
     public var loraTargetRepo = "melix/adapters/melix-dev-adapter"
     public var loraExperimentGroupID = ""
+    public var loraResumeFromManifestPath = ""
     public var loraRank = "8"
     public var loraAlpha = "16"
     public var loraDropout = "0.0"
@@ -7662,6 +7686,7 @@ public final class RuntimeViewModel {
 
         Self.assignOptional(loraTargetRepo, for: "target_repo", into: &ext)
         Self.assignOptional(loraExperimentGroupID, for: "experiment_group_id", into: &ext)
+        Self.assignOptional(loraResumeFromManifestPath, for: "resume_manifest_path", into: &ext)
         Self.assignOptional(loraRank, for: "rank", into: &ext)
         Self.assignOptional(loraAlpha, for: "alpha", into: &ext)
         Self.assignOptional(loraDropout, for: "dropout", into: &ext)
@@ -8384,6 +8409,21 @@ public final class RuntimeViewModel {
         guard groupID.isEmpty == false else {
             return nil
         }
+        let resumeReadyRunIDs = (payload["resume_ready_run_ids"] as? [Any] ?? [])
+            .compactMap { $0 as? String }
+            .filter { $0.isEmpty == false }
+        let lineagePayloads = (payload["checkpoint_lineage"] as? [[String: Any]]) ?? []
+        let checkpointLineage: [RuntimeLoraCheckpointLineageEntry] = lineagePayloads.compactMap { entry in
+            let runID = stringValue("run_id", from: entry)
+            guard runID.isEmpty == false else {
+                return nil
+            }
+            return RuntimeLoraCheckpointLineageEntry(
+                runID: runID,
+                checkpointCount: intValue("checkpoint_count", from: entry),
+                resumeReady: boolValue("resume_ready", from: entry)
+            )
+        }
         return RuntimeLoraExperimentGroupState(
             id: groupID,
             groupID: groupID,
@@ -8397,7 +8437,10 @@ public final class RuntimeViewModel {
             latestCheckpointCount: intValue("latest_checkpoint_count", from: payload),
             latestResumeReady: boolValue("latest_resume_ready", from: payload),
             bestLoss: doubleValue("best_loss", from: payload),
-            recommendedManifestPath: stringValue("recommended_manifest_path", from: payload)
+            recommendedManifestPath: stringValue("recommended_manifest_path", from: payload),
+            bestRunID: stringValue("best_run_id", from: payload),
+            resumeReadyRunIDs: resumeReadyRunIDs,
+            checkpointLineage: checkpointLineage
         )
     }
 

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -6783,7 +6783,7 @@ struct RuntimeViewModelTests {
         #expect(group.checkpointLineage.last?.resumeReady == false)
     }
 
-    @Test("resume-from-manifest path flows into the lora training request ext")
+    @Test("resume-from-manifest path flows into the lora training request ext and is cleared after training")
     @MainActor
     func resumeFromManifestFlowsIntoTrainingExt() async throws {
         let client = FakeControlPlaneXPCClient()
@@ -6807,6 +6807,7 @@ struct RuntimeViewModelTests {
         )
         #expect(call.ext["experiment_group_id"] == "nightly-qwen35")
         #expect(call.ext["resume_manifest_path"] == "/tmp/prior/manifest.json")
+        #expect(viewModel.loraResumeFromManifestPath == "")
     }
 
     @Test("model tooling snapshot skips invalid experiment groups and parses string-backed doubles")

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -6755,6 +6755,60 @@ struct RuntimeViewModelTests {
         #expect(viewModel.loraGradientCheckpointing)
     }
 
+    @Test("experiment group state surfaces resume-ready run ids and checkpoint lineage")
+    @MainActor
+    func experimentGroupStateSurfacesResumeReadyAndLineage() async throws {
+        let client = FakeControlPlaneXPCClient()
+        let viewModel = RuntimeViewModel(client: client)
+        await client.configureModelOperation(
+            makeNamedModelOperationResult(
+                operation: "registry_snapshot",
+                outputPath: "/tmp/melix-model-ops-registry/registry_snapshot.json",
+                manifestJSON: makeExperimentLineageRegistrySnapshotManifest()
+            ),
+            forNamedOperation: "registry_snapshot"
+        )
+
+        await viewModel.start()
+        await viewModel.refreshModelOpsProductState()
+
+        let group = try #require(viewModel.loraExperimentGroups.first)
+        #expect(group.bestRunID == "model-ops-0012")
+        #expect(group.resumeReadyRunIDs == ["model-ops-0012", "model-ops-0009"])
+        #expect(group.resumeReadySummaryText == "2 of 3 runs resume-ready")
+        #expect(group.checkpointLineage.count == 3)
+        #expect(group.checkpointLineage.first?.runID == "model-ops-0012")
+        #expect(group.checkpointLineage.first?.checkpointCount == 5)
+        #expect(group.checkpointLineage.first?.resumeReady == true)
+        #expect(group.checkpointLineage.last?.resumeReady == false)
+    }
+
+    @Test("resume-from-manifest path flows into the lora training request ext")
+    @MainActor
+    func resumeFromManifestFlowsIntoTrainingExt() async throws {
+        let client = FakeControlPlaneXPCClient()
+        let viewModel = RuntimeViewModel(client: client)
+        await client.configureModelOperation(
+            makeNamedModelOperationResult(
+                operation: "train_lora",
+                outputPath: "/tmp/melix-train-lora/resume.adapter.json",
+                manifestJSON: #"{"operation":"train_lora"}"#
+            ),
+            forNamedOperation: "train_lora"
+        )
+
+        await viewModel.start()
+        viewModel.loraExperimentGroupID = "nightly-qwen35"
+        viewModel.loraResumeFromManifestPath = "/tmp/prior/manifest.json"
+        await viewModel.trainPrimaryModel()
+
+        let call = try #require(
+            await client.recordedModelOperationRequests.last(where: { $0.operation == "train_lora" })
+        )
+        #expect(call.ext["experiment_group_id"] == "nightly-qwen35")
+        #expect(call.ext["resume_manifest_path"] == "/tmp/prior/manifest.json")
+    }
+
     @Test("model tooling snapshot skips invalid experiment groups and parses string-backed doubles")
     @MainActor
     func modelToolingSnapshotSkipsInvalidExperimentGroupsAndParsesStringBackedDoubles() async throws {
@@ -8921,6 +8975,38 @@ private func makePendingRegistrySnapshotManifest() -> String {
           "best_run_id": "model-ops-0008",
           "best_loss": 0.42,
           "recommended_manifest_path": "/tmp/melix-train-lora/pending.adapter.json"
+        }
+      ],
+      "derived_models": []
+    }
+    """#
+}
+
+private func makeExperimentLineageRegistrySnapshotManifest() -> String {
+    #"""
+    {
+      "operation": "registry_snapshot",
+      "jobs": [],
+      "adapters": [],
+      "experiment_groups": [
+        {
+          "group_id": "nightly-qwen35",
+          "title": "Nightly Qwen35",
+          "adapter_name": "nightly-qwen35",
+          "source_model": "melix-dev-text",
+          "run_count": 3,
+          "latest_preset_title": "Balanced Adapter",
+          "latest_resume_ready": true,
+          "latest_checkpoint_count": 5,
+          "best_run_id": "model-ops-0012",
+          "best_loss": 0.3287,
+          "recommended_manifest_path": "/tmp/melix-train-lora/model-ops-0012/train_lora.adapter.json",
+          "resume_ready_run_ids": ["model-ops-0012", "model-ops-0009"],
+          "checkpoint_lineage": [
+            {"run_id": "model-ops-0012", "checkpoint_count": 5, "resume_ready": true},
+            {"run_id": "model-ops-0009", "checkpoint_count": 3, "resume_ready": true},
+            {"run_id": "model-ops-0007", "checkpoint_count": 1, "resume_ready": false}
+          ]
         }
       ],
       "derived_models": []

--- a/docs/plans/2026-04-21-lora-experiment-surfaces.md
+++ b/docs/plans/2026-04-21-lora-experiment-surfaces.md
@@ -1,0 +1,78 @@
+# LoRA Module 3 (Slice 3.3) — Experiment surfaces (issue #14)
+
+## Context
+
+Issue [#14](https://github.com/Keith-CY/melix/issues/14) tracks Module 3 from `docs/plans/2026-04-16-lora-capability-modules-and-commit-plan.md`: teach the operator surfaces to discover, compare, and resume LoRA experiment groups.
+
+The backend halves already landed:
+
+- **Slice 3.1 (PR #45)** — `TrainingMetrics` carries checkpoint + resume fields; the `melix.lora_adapter_package.v1` manifest persists them.
+- **Slice 3.2** — `worker/productization/lora_experiment_store.py` writes per-run records and a per-root index that computes `best_known_adapter` by loss, a `resume_ready_run_ids` list, and `checkpoint_lineage` entries. `worker/model_ops/job_registry.py::_experiment_groups()` surfaces the index via the `registry_snapshot` RPC. The menubar already renders a summary card via `RuntimeLoraExperimentGroupState`.
+
+This doc covers **Slice 3.3** — the operator-facing CLI and menubar surfaces that turn the index into something usable without opening the JSON by hand.
+
+## Scope
+
+**In (one PR, three commit slices):**
+
+- **3.3A — CLI `lora experiments list` / `show`.** Two new subcommands that read `experiment_groups` out of the existing `registry_snapshot` payload. `list` renders a fixed-width `GROUP_ID / TITLE / RUNS / BEST_LOSS / RESUME_READY` table; `show --group-id ID` renders the per-group detail (runs list, resume-ready roster, best-known adapter block with the `melix lora resume` pointer). Both support `--json`.
+- **3.3B — CLI `lora resume --group-id ID`.** Resolves `best_known_adapter.manifest_path` via the snapshot, reads that manifest off disk to pull dataset / adapter / preset defaults, applies operator overrides, and invokes `train_lora` with `resume_manifest_path` set. Unknown-group, no-best-adapter, and missing-manifest paths surface explicit errors.
+- **3.3C — Menubar experiment group detail.** `RuntimeLoraExperimentGroupState` gains `bestRunID`, `resumeReadyRunIDs`, `checkpointLineage` fields (with a new `RuntimeLoraCheckpointLineageEntry`). `DesktopWorkspaceShellView`'s Experiment Groups card renders a checkpoint-lineage disclosure and a "Resume From Best" button that preloads `loraResumeFromManifestPath` + `loraExperimentGroupID` into the training form. A new `resume_manifest_path` key flows through `loraTrainingExt()` into the `train_lora` RPC.
+
+**Out:**
+
+- Backend changes — 3.1 and 3.2 already shipped. `lora resume` and `experiments show` render only the fields currently in the snapshot payload.
+- Proto schema changes — `experiment_groups` is already a JSON dict in the snapshot RPC; no typed proto surface is needed for v1.
+- Env-gated real-training experiment test — the Phase 8 acceptance bundle already exercises experiment index population end-to-end.
+
+## Design notes
+
+### CLI style: `--group-id` not positional
+
+The existing CLI `ArgumentCursor` rejects non-`--flag` tokens, and all other lora subcommands use `--flag value` throughout. To stay consistent rather than thread a one-off positional path through the cursor, `experiments show` and `resume` take `--group-id ID`.
+
+### Per-run detail in `experiments show`
+
+The snapshot's `checkpoint_lineage` entries carry `{run_id, checkpoint_count, resume_ready}` — that's what the `Runs (N):` list renders. Per-run `loss` / `status` / `preset` are not in the current snapshot, and surfacing them would require enriching `_checkpoint_lineage_entry` in Python (a backend change explicitly out of scope). The best-known-adapter block still reports loss + manifest path, so the operator has the key comparison signal without a deeper backend dive.
+
+### Dataset-uri inheritance on resume
+
+`lora resume` pulls `dataset_uri` from the recommended run's manifest by default — i.e. "resume from where the best run left off." An operator who wants to swap datasets must pass `--dataset-uri` explicitly; this is documented in the subcommand help text and validated via `loraResumeAppliesCLIOverrides`.
+
+### Registry priming
+
+`.loraResume`, `.loraExperimentsList`, and `.loraExperimentsShow` all join the set of commands that get a registry-root rescan before the main call (same behavior as `.loraList`). Tests filter priming calls out via `ext["melix.registry_rescan"]`.
+
+### Menubar wiring
+
+The "Resume From Best" button only mutates `RuntimeViewModel` form state — it does not call out to the CLI `lora resume` logic. That keeps the two code paths independent: the CLI `resume` is a one-shot discovery + training operation, the menubar `Resume From Best` is form-preload. Concurrent invocation is safe because each resolves against its own snapshot read.
+
+## Critical files
+
+```
+Sources/MelixCLICore/MelixCLI.swift                                         (+~260 lines)
+Sources/MelixCLICore/MelixCLICommandCodec.swift                             (+~8 lines)
+Tests/MelixCLITests/MelixCLIParserTests.swift                               (+~75 lines)
+Tests/MelixCLITests/MelixCLIRunnerTests.swift                               (+~230 lines)
+apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift            (+~45 lines)
+apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift (+~30 lines)
+apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift           (+~85 lines)
+docs/plans/2026-04-21-lora-experiment-surfaces.md                           (this file)
+```
+
+## Verification
+
+1. `make swift-test` — all lora parser + runner + menubar view-model tests pass, including the new `lora experiments list/show`, `lora resume`, `experimentGroupStateSurfacesResumeReadyAndLineage`, and `resumeFromManifestFlowsIntoTrainingExt` coverage.
+2. `make py-test` — unchanged; no worker-side changes in this slice.
+3. `make proto-check` — clean; no proto changes.
+4. Manual smoke (optional, after `make swift-build`):
+   - `melix lora experiments list --json`
+   - `melix lora experiments show --group-id <id> --json`
+   - `melix lora resume --group-id <id> --json`
+
+## Risks
+
+- **Unknown group handling.** `experiments show` / `resume` surface `missingRequired` errors listing the known group ids — avoids silent empty output. Covered by `loraExperimentsShowErrorsForUnknownGroup`.
+- **Missing best-known adapter.** A group where every run reported infinite loss has `best_known_adapter.manifest_path == ""`. `resume` refuses cleanly with a pointer to `experiments show`. Covered by `loraResumeErrorsWhenGroupHasNoBestAdapter`.
+- **Stale manifest path.** The manifest path in the snapshot could be deleted out-of-band. `resume` reads the file at invocation time; missing-file surfaces as a `runtime` error carrying the path. Covered by `loraResumeErrorsWhenManifestMissing`.
+- **Dataset-uri drift on resume.** Documented in the subcommand help + design notes above; tested via `loraResumeAppliesCLIOverrides`.

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -250,6 +250,9 @@ struct MelixCLIParserTests {
             (.loraActivate(.init(modelID: "model", adapterPath: "/tmp/adapter.json", derivedModelAlias: "derived", activationMode: "adapter_backed_runtime", json: true)), "lora.activate"),
             (.loraRemoveDerived(.init(modelID: "model", derivedModelID: "derived", json: true)), "lora.remove-derived"),
             (.loraPublish(.init(modelID: "model", targetRepo: "melix/adapter", exportKind: .adapterExport, artifactPath: "/tmp/adapter", artifactManifestPath: "/tmp/adapter/manifest.json", json: true)), "lora.publish"),
+            (.loraExperimentsList(.init(modelID: "model", json: true)), "lora.experiments.list"),
+            (.loraExperimentsShow(.init(modelID: "model", groupID: "nightly-qwen35", json: true)), "lora.experiments.show"),
+            (.loraResume(.init(modelID: "model", groupID: "nightly-qwen35", presetID: "balanced_adapter", adapterName: "resumed", datasetURI: "/tmp/data.jsonl", json: true)), "lora.resume"),
             (.benchRun(.init(modelID: "model", suites: ["smoke"], contextLengths: [1024], generationLength: 128, batchSizes: [1], repeats: 2, cacheProfile: "cold", reasoningMode: "disabled", structuredOutputMode: "disabled", parameters: ["sample_size": "4", "batch_factor": "1"], json: true)), "bench.run"),
             (.benchList(.init(json: true)), "bench.list"),
             (.benchExportCSV(.init(jobID: "bench-1", outputPath: "/tmp/bench.csv", json: true)), "bench.export-csv"),
@@ -922,6 +925,79 @@ struct MelixCLIParserTests {
         #expect(options.parameters["hf_valid_split"] == "test_sft")
         #expect(options.parameters["template"] == "chat_messages")
         #expect(options.parameters["dataset_id"] == "melix-ultrachat-built")
+    }
+
+    @Test("parses lora experiments list with optional model id")
+    func parsesLoraExperimentsListCommand() throws {
+        let command = try MelixCLIParser.parse([
+            "lora", "experiments", "list",
+            "--model-id", "melix-dev-text",
+            "--json",
+        ])
+
+        guard case .loraExperimentsList(let options) = command else {
+            Issue.record("Expected loraExperimentsList command")
+            return
+        }
+
+        #expect(options.modelID == "melix-dev-text")
+        #expect(options.json)
+    }
+
+    @Test("parses lora experiments show with explicit group id")
+    func parsesLoraExperimentsShowCommand() throws {
+        let command = try MelixCLIParser.parse([
+            "lora", "experiments", "show",
+            "--group-id", "nightly-qwen35",
+            "--json",
+        ])
+
+        guard case .loraExperimentsShow(let options) = command else {
+            Issue.record("Expected loraExperimentsShow command")
+            return
+        }
+
+        #expect(options.groupID == "nightly-qwen35")
+        #expect(options.json)
+    }
+
+    @Test("lora experiments show requires a group id")
+    func loraExperimentsShowRequiresGroupID() throws {
+        #expect(throws: MelixCLIError.self) {
+            _ = try MelixCLIParser.parse(["lora", "experiments", "show"])
+        }
+    }
+
+    @Test("parses lora resume with overrides")
+    func parsesLoraResumeCommand() throws {
+        let command = try MelixCLIParser.parse([
+            "lora", "resume",
+            "--group-id", "nightly-qwen35",
+            "--model-id", "melix-dev-text",
+            "--preset", "quality_adapter",
+            "--adapter-name", "resumed",
+            "--dataset-uri", "/tmp/new-dataset.jsonl",
+            "--json",
+        ])
+
+        guard case .loraResume(let options) = command else {
+            Issue.record("Expected loraResume command")
+            return
+        }
+
+        #expect(options.groupID == "nightly-qwen35")
+        #expect(options.modelID == "melix-dev-text")
+        #expect(options.presetID == "quality_adapter")
+        #expect(options.adapterName == "resumed")
+        #expect(options.datasetURI == "/tmp/new-dataset.jsonl")
+        #expect(options.json)
+    }
+
+    @Test("lora resume requires a group id")
+    func loraResumeRequiresGroupID() throws {
+        #expect(throws: MelixCLIError.self) {
+            _ = try MelixCLIParser.parse(["lora", "resume"])
+        }
     }
 
     @Test("parses bench run with an explicit model target suites and tuning parameters")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -2705,6 +2705,229 @@ struct MelixCLIRunnerTests {
         #expect(output == "No adapters or derived models found.\n")
     }
 
+    @Test("lora experiments list renders a fixed-width table")
+    func loraExperimentsListRendersFixedWidthTable() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(makeModelOperationResult(
+            manifestJSON: makeExperimentsRegistryManifest()
+        ))
+
+        let output = try await MelixCLIRunner(client: client).run(
+            .loraExperimentsList(.init(modelID: "melix-dev-text"))
+        )
+        let call = try #require(await client.lastModelOperationCall)
+
+        #expect(call.operation == "registry_snapshot")
+        #expect(output.contains("GROUP_ID"))
+        #expect(output.contains("TITLE"))
+        #expect(output.contains("RUNS"))
+        #expect(output.contains("BEST_LOSS"))
+        #expect(output.contains("RESUME_READY"))
+        #expect(output.contains("nightly-qwen35"))
+        #expect(output.contains("Nightly Qwen35"))
+        #expect(output.contains("2 of 3"))
+    }
+
+    @Test("lora experiments list emits JSON when requested")
+    func loraExperimentsListEmitsJSON() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(makeModelOperationResult(
+            manifestJSON: makeExperimentsRegistryManifest()
+        ))
+
+        let output = try await MelixCLIRunner(client: client).run(
+            .loraExperimentsList(.init(modelID: "melix-dev-text", json: true))
+        )
+
+        let payload = try #require(parseJSONObject(output))
+        let groups = try #require(payload["experiment_groups"] as? [[String: Any]])
+        #expect(groups.count == 1)
+        #expect(groups.first?["group_id"] as? String == "nightly-qwen35")
+    }
+
+    @Test("lora experiments show renders detail for a known group")
+    func loraExperimentsShowRendersDetail() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(makeModelOperationResult(
+            manifestJSON: makeExperimentsRegistryManifest()
+        ))
+
+        let output = try await MelixCLIRunner(client: client).run(
+            .loraExperimentsShow(.init(modelID: "melix-dev-text", groupID: "nightly-qwen35"))
+        )
+
+        #expect(output.contains("Group: nightly-qwen35"))
+        #expect(output.contains("Title: Nightly Qwen35"))
+        #expect(output.contains("Runs (3):"))
+        #expect(output.contains("model-ops-0012"))
+        #expect(output.contains("resume_ready=yes"))
+        #expect(output.contains("Best known adapter:"))
+        #expect(output.contains("Manifest: /tmp/melix-train-lora/model-ops-0012/train_lora.adapter.json"))
+        #expect(output.contains("Resume via: melix lora resume --group-id nightly-qwen35"))
+    }
+
+    @Test("lora experiments show errors for an unknown group and lists known ids")
+    func loraExperimentsShowErrorsForUnknownGroup() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(makeModelOperationResult(
+            manifestJSON: makeExperimentsRegistryManifest()
+        ))
+
+        do {
+            _ = try await MelixCLIRunner(client: client).run(
+                .loraExperimentsShow(.init(modelID: "melix-dev-text", groupID: "missing"))
+            )
+            Issue.record("Expected experiments show to throw for an unknown group")
+        } catch let error as MelixCLIError {
+            if case .missingRequired(let message) = error {
+                #expect(message.contains("missing"))
+                #expect(message.contains("nightly-qwen35"))
+            } else {
+                Issue.record("Expected missingRequired error, got \(error)")
+            }
+        }
+    }
+
+    @Test("lora resume resolves the best adapter manifest and invokes train_lora")
+    func loraResumeResolvesBestAdapterAndTrains() async throws {
+        let client = StubControlPlaneXPCClient()
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-lora-resume-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let manifestURL = tempDir.appendingPathComponent("train_lora.adapter.json")
+        try writeJSONObjectForTest(
+            [
+                "adapter_name": "nightly-qwen35",
+                "dataset_uri": "/tmp/datasets/nightly.jsonl",
+                "preset_id": "balanced_adapter",
+                "experiment_group_id": "nightly-qwen35",
+                "experiment_group_title": "Nightly Qwen35",
+            ],
+            to: manifestURL
+        )
+
+        await client.setModelOperationResult(
+            makeModelOperationResult(manifestJSON: makeExperimentsRegistryManifest(bestManifestPath: manifestURL.path)),
+            forOperation: "registry_snapshot"
+        )
+        await client.setModelOperationResult(
+            makeModelOperationResult(
+                outputPath: "/tmp/melix-train-lora/resume-out/train_lora.adapter.json",
+                manifestJSON: #"{"operation":"train_lora","resume_manifest_path":"\#(manifestURL.path)"}"#
+            ),
+            forOperation: "train_lora"
+        )
+
+        let output = try await MelixCLIRunner(client: client).run(
+            .loraResume(.init(modelID: "melix-dev-text", groupID: "nightly-qwen35"))
+        )
+
+        let calls = await client.modelOperationCalls.filter { $0.ext["melix.registry_rescan"] != "true" }
+        #expect(calls.count == 2)
+        #expect(calls.first?.operation == "registry_snapshot")
+        let trainCall = try #require(calls.last)
+        #expect(trainCall.operation == "train_lora")
+        #expect(trainCall.ext["resume_manifest_path"] == manifestURL.path)
+        #expect(trainCall.ext["dataset_uri"] == "/tmp/datasets/nightly.jsonl")
+        #expect(trainCall.ext["adapter_name"] == "nightly-qwen35")
+        #expect(trainCall.ext["preset_id"] == "balanced_adapter")
+        #expect(trainCall.ext["experiment_group_id"] == "nightly-qwen35")
+        #expect(output == "/tmp/melix-train-lora/resume-out/train_lora.adapter.json")
+    }
+
+    @Test("lora resume applies CLI overrides over manifest defaults")
+    func loraResumeAppliesCLIOverrides() async throws {
+        let client = StubControlPlaneXPCClient()
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-lora-resume-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let manifestURL = tempDir.appendingPathComponent("train_lora.adapter.json")
+        try writeJSONObjectForTest(
+            [
+                "adapter_name": "nightly-qwen35",
+                "dataset_uri": "/tmp/datasets/nightly.jsonl",
+                "preset_id": "balanced_adapter",
+            ],
+            to: manifestURL
+        )
+
+        await client.setModelOperationResult(
+            makeModelOperationResult(manifestJSON: makeExperimentsRegistryManifest(bestManifestPath: manifestURL.path)),
+            forOperation: "registry_snapshot"
+        )
+        await client.setModelOperationResult(
+            makeModelOperationResult(outputPath: "/tmp/resume.adapter.json"),
+            forOperation: "train_lora"
+        )
+
+        _ = try await MelixCLIRunner(client: client).run(
+            .loraResume(.init(
+                modelID: "melix-dev-text",
+                groupID: "nightly-qwen35",
+                presetID: "quality_adapter",
+                adapterName: "resumed-adapter",
+                datasetURI: "/tmp/datasets/new.jsonl"
+            ))
+        )
+
+        let calls = await client.modelOperationCalls
+        let trainCall = try #require(calls.last)
+        #expect(trainCall.ext["dataset_uri"] == "/tmp/datasets/new.jsonl")
+        #expect(trainCall.ext["adapter_name"] == "resumed-adapter")
+        #expect(trainCall.ext["preset_id"] == "quality_adapter")
+    }
+
+    @Test("lora resume surfaces error when the group has no recommended adapter")
+    func loraResumeErrorsWhenGroupHasNoBestAdapter() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(
+            makeModelOperationResult(manifestJSON: makeExperimentsRegistryManifest(bestManifestPath: "")),
+            forOperation: "registry_snapshot"
+        )
+
+        do {
+            _ = try await MelixCLIRunner(client: client).run(
+                .loraResume(.init(modelID: "melix-dev-text", groupID: "nightly-qwen35"))
+            )
+            Issue.record("Expected resume to throw when no best adapter exists")
+        } catch let error as MelixCLIError {
+            if case .missingRequired(let message) = error {
+                #expect(message.contains("no recommended adapter"))
+            } else {
+                Issue.record("Expected missingRequired error, got \(error)")
+            }
+        }
+    }
+
+    @Test("lora resume surfaces a readable error when the manifest path is missing on disk")
+    func loraResumeErrorsWhenManifestMissing() async throws {
+        let client = StubControlPlaneXPCClient()
+        let missingPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-missing-\(UUID().uuidString).json")
+            .path
+        await client.setModelOperationResult(
+            makeModelOperationResult(manifestJSON: makeExperimentsRegistryManifest(bestManifestPath: missingPath)),
+            forOperation: "registry_snapshot"
+        )
+
+        do {
+            _ = try await MelixCLIRunner(client: client).run(
+                .loraResume(.init(modelID: "melix-dev-text", groupID: "nightly-qwen35"))
+            )
+            Issue.record("Expected resume to throw for a missing manifest")
+        } catch let error as MelixCLIError {
+            if case .runtime(let message) = error {
+                #expect(message.contains(missingPath))
+            } else {
+                Issue.record("Expected runtime error, got \(error)")
+            }
+        }
+    }
+
     @Test("lora train forwards dataset, adapter, repo, and tuning parameters")
     func loraTrainForwardsExpectedOperationPayload() async throws {
         let client = StubControlPlaneXPCClient()
@@ -5185,6 +5408,8 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
 
     private var snapshot = makeServerSnapshot(models: [makeModelSummary(id: "melix-dev-text", kind: "text")])
     private var modelOperationResult = makeModelOperationResult()
+    private var modelOperationResultsByOperation: [String: Melix_Controlplane_V1_ModelOperationResult] = [:]
+    private(set) var modelOperationCalls: [ModelOperationCall] = []
     private var benchResult = ControlPlaneBenchResult(reportPath: "", reportMarkdown: "", metrics: [:])
     private var benchMatrixResult = ControlPlaneBenchMatrixResult(
         job: makeBenchmarkMatrixJobSummary(jobID: "", modelID: "", taskKind: "", sourceRepo: ""),
@@ -5207,6 +5432,13 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
 
     func setModelOperationResult(_ result: Melix_Controlplane_V1_ModelOperationResult) {
         self.modelOperationResult = result
+    }
+
+    func setModelOperationResult(
+        _ result: Melix_Controlplane_V1_ModelOperationResult,
+        forOperation operation: String
+    ) {
+        modelOperationResultsByOperation[operation] = result
     }
 
     func setModelOperationError(_ error: Error?) {
@@ -5391,7 +5623,7 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
         if let modelOperationError {
             throw modelOperationError
         }
-        lastModelOperationCall = ModelOperationCall(
+        let call = ModelOperationCall(
             modelID: modelID,
             operation: operation,
             outputDir: outputDir,
@@ -5400,6 +5632,11 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
             kvQuant: kvQuant,
             ext: ext
         )
+        lastModelOperationCall = call
+        modelOperationCalls.append(call)
+        if let perOperation = modelOperationResultsByOperation[operation] {
+            return perOperation
+        }
         return modelOperationResult
     }
 
@@ -5618,6 +5855,54 @@ private func makeDoctorReport(
         return item
     }
     return report
+}
+
+private func makeExperimentsRegistryManifest(
+    bestManifestPath: String = "/tmp/melix-train-lora/model-ops-0012/train_lora.adapter.json"
+) -> String {
+    #"""
+    {
+      "operation": "registry_snapshot",
+      "adapters": [],
+      "derived_models": [],
+      "experiment_groups": [
+        {
+          "group_id": "nightly-qwen35",
+          "title": "Nightly Qwen35",
+          "adapter_name": "nightly-qwen35",
+          "source_model": "melix-dev-text",
+          "run_count": 3,
+          "latest_run_id": "model-ops-0012",
+          "latest_status": "activated",
+          "latest_dataset_uri": "/tmp/datasets/nightly.jsonl",
+          "latest_preset_id": "balanced_adapter",
+          "latest_preset_title": "Balanced Adapter",
+          "latest_tokens_per_second": 128.5,
+          "latest_peak_memory_gb": 5.25,
+          "latest_checkpoint_count": 5,
+          "latest_resume_ready": true,
+          "resume_ready_run_ids": ["model-ops-0012", "model-ops-0009"],
+          "checkpoint_lineage": [
+            { "run_id": "model-ops-0012", "checkpoint_count": 5, "resume_ready": true },
+            { "run_id": "model-ops-0009", "checkpoint_count": 3, "resume_ready": true },
+            { "run_id": "model-ops-0007", "checkpoint_count": 1, "resume_ready": false }
+          ],
+          "best_run_id": "model-ops-0012",
+          "best_loss": 0.3287,
+          "recommended_manifest_path": "\#(bestManifestPath)",
+          "best_known_adapter": {
+            "run_id": "model-ops-0012",
+            "manifest_path": "\#(bestManifestPath)",
+            "adapter_name": "nightly-qwen35",
+            "checkpoint_count": 5,
+            "latest_checkpoint_path": "/tmp/melix-train-lora/model-ops-0012/checkpoint",
+            "resume_ready": true,
+            "loss_best": 0.3287
+          }
+        }
+      ]
+    }
+    """#
 }
 
 private func parseJSONObject(_ text: String) -> [String: Any]? {

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -2759,11 +2759,92 @@ struct MelixCLIRunnerTests {
         #expect(output.contains("Group: nightly-qwen35"))
         #expect(output.contains("Title: Nightly Qwen35"))
         #expect(output.contains("Runs (3):"))
+        #expect(output.contains("RUN_ID"))
+        #expect(output.contains("CHECKPOINTS"))
+        #expect(output.contains("RESUME_READY"))
         #expect(output.contains("model-ops-0012"))
-        #expect(output.contains("resume_ready=yes"))
         #expect(output.contains("Best known adapter:"))
         #expect(output.contains("Manifest: /tmp/melix-train-lora/model-ops-0012/train_lora.adapter.json"))
         #expect(output.contains("Resume via: melix lora resume --group-id nightly-qwen35"))
+        #expect(output.contains("\t") == false)
+    }
+
+    @Test("lora experiments list renders n/a when best loss is missing")
+    func loraExperimentsListRendersNotAvailableBestLoss() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(makeModelOperationResult(
+            manifestJSON: makeExperimentsRegistryManifestWithoutBestLoss()
+        ))
+
+        let output = try await MelixCLIRunner(client: client).run(
+            .loraExperimentsList(.init(modelID: "melix-dev-text"))
+        )
+
+        #expect(output.contains("n/a"))
+        #expect(output.contains("0.0000") == false)
+    }
+
+    @Test("lora experiments list surfaces a runtime error when snapshot JSON is malformed")
+    func loraExperimentsListErrorsOnMalformedSnapshot() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(makeModelOperationResult(manifestJSON: "not-json-at-all"))
+
+        do {
+            _ = try await MelixCLIRunner(client: client).run(
+                .loraExperimentsList(.init(modelID: "melix-dev-text"))
+            )
+            Issue.record("Expected experiments list to throw for malformed JSON")
+        } catch let error as MelixCLIError {
+            if case .runtime(let message) = error {
+                #expect(message.contains("registry_snapshot payload"))
+            } else {
+                Issue.record("Expected runtime error, got \(error)")
+            }
+        }
+    }
+
+    @Test("lora resume inherits hf dataset fields from the manifest when dataset_uri is absent")
+    func loraResumeInheritsHFDatasetFields() async throws {
+        let client = StubControlPlaneXPCClient()
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-lora-resume-hf-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let manifestURL = tempDir.appendingPathComponent("train_lora.adapter.json")
+        try writeJSONObjectForTest(
+            [
+                "adapter_name": "nightly-qwen35",
+                "dataset_source_kind": "hf_dataset",
+                "hf_dataset_path": "HuggingFaceH4/ultrachat_200k",
+                "hf_dataset_name": "default",
+                "hf_train_split": "train_sft",
+                "preset_id": "balanced_adapter",
+            ],
+            to: manifestURL
+        )
+
+        await client.setModelOperationResult(
+            makeModelOperationResult(manifestJSON: makeExperimentsRegistryManifest(bestManifestPath: manifestURL.path)),
+            forOperation: "registry_snapshot"
+        )
+        await client.setModelOperationResult(
+            makeModelOperationResult(outputPath: "/tmp/resume-hf.adapter.json"),
+            forOperation: "train_lora"
+        )
+
+        _ = try await MelixCLIRunner(client: client).run(
+            .loraResume(.init(modelID: "melix-dev-text", groupID: "nightly-qwen35"))
+        )
+
+        let calls = await client.modelOperationCalls.filter { $0.ext["melix.registry_rescan"] != "true" }
+        let trainCall = try #require(calls.last)
+        #expect(trainCall.operation == "train_lora")
+        #expect(trainCall.ext["dataset_source_kind"] == "hf_dataset")
+        #expect(trainCall.ext["dataset_uri"] == "HuggingFaceH4/ultrachat_200k")
+        #expect(trainCall.ext["hf_dataset_path"] == "HuggingFaceH4/ultrachat_200k")
+        #expect(trainCall.ext["hf_dataset_name"] == "default")
+        #expect(trainCall.ext["hf_train_split"] == "train_sft")
     }
 
     @Test("lora experiments show errors for an unknown group and lists known ids")
@@ -5855,6 +5936,30 @@ private func makeDoctorReport(
         return item
     }
     return report
+}
+
+private func makeExperimentsRegistryManifestWithoutBestLoss() -> String {
+    #"""
+    {
+      "operation": "registry_snapshot",
+      "adapters": [],
+      "derived_models": [],
+      "experiment_groups": [
+        {
+          "group_id": "cold-start",
+          "title": "Cold Start",
+          "adapter_name": "cold-start-adapter",
+          "source_model": "melix-dev-text",
+          "run_count": 1,
+          "latest_preset_title": "Debug Fast",
+          "resume_ready_run_ids": [],
+          "checkpoint_lineage": [
+            {"run_id": "model-ops-9999", "checkpoint_count": 0, "resume_ready": false}
+          ]
+        }
+      ]
+    }
+    """#
 }
 
 private func makeExperimentsRegistryManifest(


### PR DESCRIPTION
## Summary

- Adds CLI `lora experiments list`/`show --group-id ID` and `lora resume --group-id ID` on top of the already-shipped experiment index (slices 3.1 + 3.2 via PR #45 + `lora_experiment_store.py`).
- Surfaces `resume_ready_run_ids` and `checkpoint_lineage` in the menubar Experiment Groups card via a new disclosure, adds a "Resume From Best" button that preloads `loraResumeFromManifestPath` into the training form, and flows the new field through `loraTrainingExt` as `resume_manifest_path`.
- Honors the plan's "no backend change" scope: everything reads fields already exposed by `registry_snapshot`. Full design notes in `docs/plans/2026-04-21-lora-experiment-surfaces.md`.

## Plan or Spec

- `docs/plans/2026-04-21-lora-experiment-surfaces.md` (this PR) — slice 3.3 of Module 3.
- Parent plan: `docs/plans/2026-04-16-lora-capability-modules-and-commit-plan.md` (Module 3).
- Issue: #14.

## Commands Run

- `swift test --filter "MelixCLIParserTests|MelixCLIRunnerTests"` → 169 tests green (4 new parser, 7 new runner).
- `HOME=.swift-home/macos-menubar xcrun swift test --package-path apps/macos-menubar --filter "RuntimeViewModelTests"` → 187 tests green (2 new: lineage mapping, resume-manifest ext wiring).
- `git diff --exit-code -- packages/protocol` → clean (no proto drift).
- `swift build --target MelixCLICore` and menubar `swift build` → green.

## Coverage and Metrics

- New Swift tests: 4 parser + 7 runner + 2 menubar view-model = 13 new tests, all green.
- Error-path coverage:
  - Unknown group on `experiments show`/`resume` (`loraExperimentsShowErrorsForUnknownGroup`).
  - Group with no recommended adapter (`loraResumeErrorsWhenGroupHasNoBestAdapter`).
  - Stale manifest path on disk (`loraResumeErrorsWhenManifestMissing`).
  - CLI overrides beat manifest defaults (`loraResumeAppliesCLIOverrides`).
- Diff footprint: 959 insertions, 2 deletions across 7 code files + 1 new plan doc.

## Known Gaps

- `lora experiments show` renders per-run detail only for fields the `registry_snapshot` payload already exposes (`run_id`, `checkpoint_count`, `resume_ready`). Per-run loss / status / preset would require enriching `_checkpoint_lineage_entry` in Python — explicitly out of scope for slice 3.3 (no backend changes), documented in the plan doc. Follow-up can enrich the entry and extend the show output.
- Manual CLI smoke (`melix lora experiments list/show/resume`) against a live worker is not run in this PR; the automated Swift tests cover the runner logic, and `make phase8-real-e2e` continues to exercise the underlying experiment index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)