### PR TITLE
Polish chat waiting state, markdown rendering, and transcript autoscroll

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift
@@ -1,0 +1,434 @@
+import SwiftUI
+import MelixControlPlaneCore
+
+enum DesktopChatMarkdownLayoutMetrics {
+    static let blockSpacing: CGFloat = MelixDesignTokens.Spacing.sm
+    static let listRowSpacing: CGFloat = 4
+    static let codeBlockPadding: CGFloat = MelixDesignTokens.Spacing.md
+    static let codeBlockLineSpacing: CGFloat = 3
+    static let codeBlockBackgroundOpacity: Double = 0.03
+    static let codeBlockBorderOpacity: Double = 0.05
+    static let tableSurfaceBackgroundOpacity: Double = 0.018
+    static let tableHeaderBackgroundOpacity: Double = 0.035
+    static let tableRowSeparatorOpacity: Double = 0.04
+    static let tableColumnSeparatorOpacity: Double = 0.035
+    static let tableCellHorizontalPadding: CGFloat = MelixDesignTokens.Spacing.sm
+    static let tableCellVerticalPadding: CGFloat = 6
+}
+
+enum DesktopChatMarkdownBlock: Equatable, Sendable {
+    case paragraph(String)
+    case unorderedList([String])
+    case orderedList([String])
+    case codeBlock(language: String, code: String)
+    case table(header: [String], rows: [[String]])
+}
+
+enum DesktopChatMarkdownInlineFormatter {
+    static func attributedString(from rawText: String) -> AttributedString {
+        attributedString(fromSanitized: RichOutputSanitizer.sanitized(rawText))
+    }
+
+    static func attributedString(fromSanitized text: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        if var attributed = try? AttributedString(markdown: text, options: options) {
+            let ranges = attributed.runs.map(\.range)
+            for range in ranges {
+                attributed[range].link = nil
+            }
+            return attributed
+        }
+        return AttributedString(text)
+    }
+}
+
+enum DesktopChatMarkdownRenderer {
+    static func usesMarkdown(for kind: DesktopChatTranscriptEntry.Kind) -> Bool {
+        switch kind {
+        case .assistant, .reasoning:
+            return true
+        case .user, .tool, .error:
+            return false
+        }
+    }
+
+    static func blocks(from rawText: String) -> [DesktopChatMarkdownBlock] {
+        parseBlocks(from: RichOutputSanitizer.sanitized(rawText))
+    }
+
+    private static func parseBlocks(from text: String) -> [DesktopChatMarkdownBlock] {
+        let lines = text.components(separatedBy: .newlines)
+        var blocks: [DesktopChatMarkdownBlock] = []
+        var index = 0
+
+        while index < lines.count {
+            if lines[index].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                index += 1
+                continue
+            }
+
+            if let codeBlock = parseCodeBlock(lines: lines, index: &index) {
+                blocks.append(codeBlock)
+                continue
+            }
+            if let table = parseTable(lines: lines, index: &index) {
+                blocks.append(table)
+                continue
+            }
+            if let list = parseUnorderedList(lines: lines, index: &index) {
+                blocks.append(list)
+                continue
+            }
+            if let list = parseOrderedList(lines: lines, index: &index) {
+                blocks.append(list)
+                continue
+            }
+            blocks.append(parseParagraph(lines: lines, index: &index))
+        }
+
+        if blocks.isEmpty, text.isEmpty == false {
+            return [.paragraph(text)]
+        }
+        return blocks
+    }
+
+    private static func parseCodeBlock(lines: [String], index: inout Int) -> DesktopChatMarkdownBlock? {
+        let trimmed = lines[index].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("```") else {
+            return nil
+        }
+
+        let language = String(trimmed.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
+        index += 1
+
+        var codeLines: [String] = []
+        while index < lines.count {
+            let candidate = lines[index].trimmingCharacters(in: .whitespacesAndNewlines)
+            if candidate.hasPrefix("```") {
+                index += 1
+                break
+            }
+            codeLines.append(lines[index])
+            index += 1
+        }
+
+        return .codeBlock(language: language, code: codeLines.joined(separator: "\n"))
+    }
+
+    private static func parseTable(lines: [String], index: inout Int) -> DesktopChatMarkdownBlock? {
+        guard isTableStart(lines: lines, index: index) else {
+            return nil
+        }
+
+        let header = tableCells(from: lines[index])
+        index += 2
+
+        var rows: [[String]] = []
+        while index < lines.count {
+            let trimmed = lines[index].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.isEmpty == false else {
+                break
+            }
+            let cells = tableCells(from: lines[index])
+            guard cells.isEmpty == false, isTableSeparator(cells) == false else {
+                break
+            }
+            rows.append(cells)
+            index += 1
+        }
+
+        return .table(header: header, rows: rows)
+    }
+
+    private static func isTableStart(lines: [String], index: Int) -> Bool {
+        guard index + 1 < lines.count else {
+            return false
+        }
+        let header = tableCells(from: lines[index])
+        let separator = tableCells(from: lines[index + 1])
+        return header.isEmpty == false
+        && separator.count == header.count
+        && isTableSeparator(separator)
+    }
+
+    private static func tableCells(from line: String) -> [String] {
+        var core = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard core.contains("|") else {
+            return []
+        }
+        if core.first == "|" {
+            core.removeFirst()
+        }
+        if core.last == "|" {
+            core.removeLast()
+        }
+        return core.split(separator: "|", omittingEmptySubsequences: false).map { cell in
+            cell.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
+    private static func isTableSeparator(_ cells: [String]) -> Bool {
+        guard cells.isEmpty == false else {
+            return false
+        }
+        return cells.allSatisfy { cell in
+            let trimmed = cell.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.contains("-") else {
+                return false
+            }
+            return trimmed.allSatisfy { character in
+                character == "-" || character == ":" || character.isWhitespace
+            }
+        }
+    }
+
+    private static func parseUnorderedList(lines: [String], index: inout Int) -> DesktopChatMarkdownBlock? {
+        guard unorderedListItemText(from: lines[index]) != nil else {
+            return nil
+        }
+
+        var items: [String] = []
+        while index < lines.count, let item = unorderedListItemText(from: lines[index]) {
+            items.append(item)
+            index += 1
+        }
+        return .unorderedList(items)
+    }
+
+    private static func unorderedListItemText(from line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        for marker in ["- ", "* ", "+ "] where trimmed.hasPrefix(marker) {
+            return String(trimmed.dropFirst(marker.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return nil
+    }
+
+    private static func parseOrderedList(lines: [String], index: inout Int) -> DesktopChatMarkdownBlock? {
+        guard orderedListItemText(from: lines[index]) != nil else {
+            return nil
+        }
+
+        var items: [String] = []
+        while index < lines.count, let item = orderedListItemText(from: lines[index]) {
+            items.append(item)
+            index += 1
+        }
+        return .orderedList(items)
+    }
+
+    private static func orderedListItemText(from line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let dotIndex = trimmed.firstIndex(of: ".") else {
+            return nil
+        }
+        let number = trimmed[..<dotIndex]
+        guard number.isEmpty == false, number.allSatisfy(\.isNumber) else {
+            return nil
+        }
+        let afterDot = trimmed.index(after: dotIndex)
+        guard afterDot < trimmed.endIndex, trimmed[afterDot].isWhitespace else {
+            return nil
+        }
+        let itemStart = trimmed.index(after: afterDot)
+        return String(trimmed[itemStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func parseParagraph(lines: [String], index: inout Int) -> DesktopChatMarkdownBlock {
+        var paragraphLines: [String] = []
+        while index < lines.count {
+            let trimmed = lines[index].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.isEmpty == false, isBlockStart(lines: lines, index: index) == false else {
+                break
+            }
+            paragraphLines.append(lines[index])
+            index += 1
+        }
+        return .paragraph(paragraphLines.joined(separator: "\n"))
+    }
+
+    private static func isBlockStart(lines: [String], index: Int) -> Bool {
+        let trimmed = lines[index].trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.hasPrefix("```")
+        || isTableStart(lines: lines, index: index)
+        || unorderedListItemText(from: lines[index]) != nil
+        || orderedListItemText(from: lines[index]) != nil
+    }
+}
+
+struct DesktopChatMarkdownBodyView: View {
+    let rawText: String
+
+    private var blocks: [DesktopChatMarkdownBlock] {
+        DesktopChatMarkdownRenderer.blocks(from: rawText)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesktopChatMarkdownLayoutMetrics.blockSpacing) {
+            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+                switch block {
+                case .paragraph(let text):
+                    paragraphView(text)
+                case .unorderedList(let items):
+                    unorderedListView(items)
+                case .orderedList(let items):
+                    orderedListView(items)
+                case .codeBlock(let language, let code):
+                    codeBlockView(language: language, code: code)
+                case .table(let header, let rows):
+                    tableView(header: header, rows: rows)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .textSelection(.enabled)
+    }
+
+    private func paragraphView(_ text: String) -> some View {
+        Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: text))
+            .font(.body)
+            .lineSpacing(2)
+    }
+
+    private func unorderedListView(_ items: [String]) -> some View {
+        VStack(alignment: .leading, spacing: DesktopChatMarkdownLayoutMetrics.listRowSpacing) {
+            ForEach(items.indices, id: \.self) { index in
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text("•")
+                        .font(.body)
+                    Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: items[index]))
+                        .font(.body)
+                        .lineSpacing(2)
+                }
+            }
+        }
+    }
+
+    private func orderedListView(_ items: [String]) -> some View {
+        VStack(alignment: .leading, spacing: DesktopChatMarkdownLayoutMetrics.listRowSpacing) {
+            ForEach(items.indices, id: \.self) { index in
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text("\(index + 1).")
+                        .font(.body.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                    Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: items[index]))
+                        .font(.body)
+                        .lineSpacing(2)
+                }
+            }
+        }
+    }
+
+    private func codeBlockView(language: String, code: String) -> some View {
+        VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
+            if language.isEmpty == false {
+                Text(language)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+            Text(code.isEmpty ? " " : code)
+                .font(.caption.monospaced())
+                .lineSpacing(DesktopChatMarkdownLayoutMetrics.codeBlockLineSpacing)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(DesktopChatMarkdownLayoutMetrics.codeBlockPadding)
+        .background(
+            RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.sm)
+                .fill(Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.codeBlockBackgroundOpacity))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.sm)
+                .stroke(
+                    Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.codeBlockBorderOpacity),
+                    lineWidth: 1
+                )
+        )
+    }
+
+    private func tableView(header: [String], rows: [[String]]) -> some View {
+        let columnCount = max(header.count, 1)
+        return Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
+            GridRow {
+                ForEach(0..<columnCount, id: \.self) { column in
+                    tableCellView(
+                        text: header[safe: column] ?? "",
+                        isHeader: true,
+                        showsTrailingSeparator: column < columnCount - 1,
+                        showsBottomSeparator: true
+                    )
+                }
+            }
+            ForEach(rows.indices, id: \.self) { rowIndex in
+                GridRow {
+                    let row = normalizedTableRow(rows[rowIndex], columnCount: columnCount)
+                    ForEach(0..<columnCount, id: \.self) { column in
+                        tableCellView(
+                            text: row[column],
+                            isHeader: false,
+                            showsTrailingSeparator: column < columnCount - 1,
+                            showsBottomSeparator: rowIndex < rows.count - 1
+                        )
+                    }
+                }
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.sm)
+                .fill(Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.tableSurfaceBackgroundOpacity))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.sm)
+                .stroke(
+                    Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.codeBlockBorderOpacity),
+                    lineWidth: 1
+                )
+        )
+    }
+
+    private func tableCellView(
+        text: String,
+        isHeader: Bool,
+        showsTrailingSeparator: Bool,
+        showsBottomSeparator: Bool
+    ) -> some View {
+        ZStack(alignment: .topLeading) {
+            if isHeader {
+                Rectangle()
+                    .fill(Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.tableHeaderBackgroundOpacity))
+            }
+            Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: text))
+                .font(isHeader ? .caption.weight(.semibold) : .caption)
+                .padding(.horizontal, DesktopChatMarkdownLayoutMetrics.tableCellHorizontalPadding)
+                .padding(.vertical, DesktopChatMarkdownLayoutMetrics.tableCellVerticalPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .overlay(alignment: .bottom) {
+            if showsBottomSeparator {
+                Rectangle()
+                    .fill(Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.tableRowSeparatorOpacity))
+                    .frame(height: 1)
+            }
+        }
+        .overlay(alignment: .trailing) {
+            if showsTrailingSeparator {
+                Rectangle()
+                    .fill(Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.tableColumnSeparatorOpacity))
+                    .frame(width: 1)
+            }
+        }
+    }
+
+    private func normalizedTableRow(_ row: [String], columnCount: Int) -> [String] {
+        if row.count >= columnCount {
+            return Array(row.prefix(columnCount))
+        }
+        return row + Array(repeating: "", count: columnCount - row.count)
+    }
+}
+
+private extension Array {
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
@@ -13,6 +13,37 @@ enum DesktopChatLayoutMetrics {
     static let composerMinHeight: CGFloat = 76
 }
 
+enum DesktopChatTranscriptAutoScroll {
+    enum Anchor: String, Hashable {
+        case bottom = "desktop-chat-transcript-bottom"
+    }
+
+    struct Snapshot: Equatable {
+        let entryCount: Int
+        let lastEntryID: String
+        let lastEntryBody: String
+        let lastEntryDetail: String
+        let isStreaming: Bool
+        let statusText: String
+    }
+
+    static func snapshot(
+        transcript: [DesktopChatTranscriptEntry],
+        isStreaming: Bool,
+        statusText: String
+    ) -> Snapshot {
+        let lastEntry = transcript.last
+        return Snapshot(
+            entryCount: transcript.count,
+            lastEntryID: lastEntry?.id ?? "",
+            lastEntryBody: lastEntry?.body ?? "",
+            lastEntryDetail: lastEntry?.detail ?? "",
+            isStreaming: isStreaming,
+            statusText: isStreaming ? statusText : ""
+        )
+    }
+}
+
 enum DesktopChatComposerKeyPolicy {
     enum Action: Equatable {
         case submit
@@ -185,6 +216,26 @@ struct DesktopChatSessionWorkspace: View {
         Task { await viewModel.submitChatPrompt() }
     }
 
+    private var chatTranscriptScrollSnapshot: DesktopChatTranscriptAutoScroll.Snapshot {
+        DesktopChatTranscriptAutoScroll.snapshot(
+            transcript: viewModel.chatTranscript,
+            isStreaming: viewModel.isChatStreaming,
+            statusText: viewModel.chatStatusText
+        )
+    }
+
+    private func scrollChatTranscriptToBottom(_ proxy: ScrollViewProxy, animated: Bool) {
+        DispatchQueue.main.async {
+            if animated {
+                withAnimation(.easeOut(duration: 0.18)) {
+                    proxy.scrollTo(DesktopChatTranscriptAutoScroll.Anchor.bottom, anchor: .bottom)
+                }
+            } else {
+                proxy.scrollTo(DesktopChatTranscriptAutoScroll.Anchor.bottom, anchor: .bottom)
+            }
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .center) {
@@ -253,13 +304,29 @@ struct DesktopChatSessionWorkspace: View {
                 }
             }
 
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 12) {
-                    if viewModel.chatTranscript.isEmpty == false {
-                        ForEach(viewModel.chatTranscript) { entry in
-                            DesktopChatTranscriptRowView(entry: entry)
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 12) {
+                        if viewModel.chatTranscript.isEmpty == false {
+                            ForEach(viewModel.chatTranscript) { entry in
+                                DesktopChatTranscriptRowView(
+                                    entry: entry,
+                                    isPending: viewModel.isPendingAssistantTranscriptEntry(entry),
+                                    pendingStatusText: viewModel.chatStatusText
+                                )
+                                .id(entry.id)
+                            }
                         }
+                        Color.clear
+                            .frame(height: 1)
+                            .id(DesktopChatTranscriptAutoScroll.Anchor.bottom)
                     }
+                }
+                .onAppear {
+                    scrollChatTranscriptToBottom(proxy, animated: false)
+                }
+                .onChange(of: chatTranscriptScrollSnapshot) { _, _ in
+                    scrollChatTranscriptToBottom(proxy, animated: true)
                 }
             }
 
@@ -768,8 +835,20 @@ final class DesktopChatComposerCommandSubmitTextView: NSTextView {
     }
 }
 
-private struct DesktopChatTranscriptRowView: View {
+struct DesktopChatTranscriptRowView: View {
     let entry: DesktopChatTranscriptEntry
+    let isPending: Bool
+    let pendingStatusText: String
+
+    init(
+        entry: DesktopChatTranscriptEntry,
+        isPending: Bool = false,
+        pendingStatusText: String = ""
+    ) {
+        self.entry = entry
+        self.isPending = isPending
+        self.pendingStatusText = pendingStatusText
+    }
 
     var body: some View {
         let sanitizedTitle = RichOutputSanitizer.sanitized(entry.title)
@@ -786,13 +865,39 @@ private struct DesktopChatTranscriptRowView: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            Text(sanitizedBody.isEmpty ? "…" : sanitizedBody)
-                .font(entry.kind == .tool ? .caption.monospaced() : .body)
-                .textSelection(.enabled)
+            if isPending {
+                pendingAssistantView
+            } else if DesktopChatMarkdownRenderer.usesMarkdown(for: entry.kind) {
+                DesktopChatMarkdownBodyView(rawText: sanitizedBody.isEmpty ? "…" : sanitizedBody)
+            } else {
+                Text(sanitizedBody.isEmpty ? "…" : sanitizedBody)
+                    .font(entry.kind == .tool ? .caption.monospaced() : .body)
+                    .textSelection(.enabled)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background(backgroundStyle, in: RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.xl))
+    }
+
+    private var pendingAssistantView: some View {
+        HStack(alignment: .center, spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Thinking...")
+                    .font(.body)
+                let sanitizedStatus = RichOutputSanitizer.sanitized(pendingStatusText)
+                if sanitizedStatus.isEmpty == false {
+                    Text(sanitizedStatus)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Assistant is thinking")
     }
 
     private var backgroundStyle: some ShapeStyle {

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -1551,6 +1551,10 @@ public final class RuntimeViewModel {
         models.filter(\.isServeableServerModel)
     }
 
+    public func isPendingAssistantTranscriptEntry(_ entry: DesktopChatTranscriptEntry) -> Bool {
+        isEmptyPendingAssistantEntry(entry)
+    }
+
     private let client: any ControlPlaneXPCClient
     private let metrics: MenuBarMetricsStore
     private let operatorSessionStore: any OperatorSessionStoring
@@ -3167,6 +3171,15 @@ public final class RuntimeViewModel {
             body: prompt,
             detail: ""
         )
+        let pendingAssistantEntryID = "assistant-\(UUID().uuidString)"
+        activeAssistantEntryID = pendingAssistantEntryID
+        appendChatEntry(
+            id: pendingAssistantEntryID,
+            kind: .assistant,
+            title: "Assistant",
+            body: "",
+            detail: ""
+        )
         chatStatusText = "Preparing"
         lastChatUsageText = ""
         isChatStreaming = true
@@ -3237,11 +3250,13 @@ public final class RuntimeViewModel {
                     chatStatusText = finishReason.isEmpty ? "Completed" : "Completed • \(finishReason)"
                     finalizeAssistantText(assistantText, requestID: execution.requestID)
                     finalizeReasoningText(reasoningText, requestID: execution.requestID)
+                    removeEmptyPendingAssistantEntryIfNeeded()
                 case .failed(let code, let message):
                     flushPendingChatPresentation()
                     chatStatusText = code.isEmpty ? "Failed" : "Failed • \(code)"
                     let failureMessage = message.isEmpty ? "Chat request failed." : message
                     setLastError(failureMessage)
+                    removeEmptyPendingAssistantEntryIfNeeded()
                     appendChatEntry(
                         id: "error-\(UUID().uuidString)",
                         kind: .error,
@@ -3257,6 +3272,7 @@ public final class RuntimeViewModel {
             }
 
             flushPendingChatPresentation()
+            removeEmptyPendingAssistantEntryIfNeeded()
             await metrics.record(
                 name: "menu.chat_stream_ms",
                 valueMs: Date().timeIntervalSince(startedAt) * 1_000
@@ -3275,6 +3291,7 @@ public final class RuntimeViewModel {
             flushPendingChatPresentation()
             setLastError(String(describing: error))
             chatStatusText = "Failed"
+            removeEmptyPendingAssistantEntryIfNeeded()
             appendChatEntry(
                 id: "error-\(UUID().uuidString)",
                 kind: .error,
@@ -5806,7 +5823,7 @@ public final class RuntimeViewModel {
 
         if selectedChatSession == nil, let first = chatSessions.first {
             loadChatSession(first)
-        } else if let selectedChatSession {
+        } else if let selectedChatSession, isChatStreaming == false {
             loadChatSession(selectedChatSession)
         }
     }
@@ -6152,7 +6169,7 @@ public final class RuntimeViewModel {
             return
         }
         replaceChatSession(id: session.id) { current in
-            current.transcript = chatTranscript
+            current.transcript = persistableChatTranscript()
             current.statusText = chatStatusText
             current.usageText = lastChatUsageText
             current.requestID = lastChatRequestID
@@ -8169,6 +8186,31 @@ public final class RuntimeViewModel {
                 detail: detail
             )
         )
+    }
+
+    private func isEmptyPendingAssistantEntry(_ entry: DesktopChatTranscriptEntry) -> Bool {
+        isChatStreaming
+        && entry.kind == .assistant
+        && entry.id == activeAssistantEntryID
+        && entry.body.isEmpty
+    }
+
+    private func persistableChatTranscript() -> [DesktopChatTranscriptEntry] {
+        chatTranscript.filter { isEmptyPendingAssistantEntry($0) == false }
+    }
+
+    private func removeEmptyPendingAssistantEntryIfNeeded() {
+        guard
+            let entryID = activeAssistantEntryID,
+            let index = chatTranscript.firstIndex(where: { entry in
+                entry.id == entryID
+                && entry.kind == .assistant
+                && entry.body.isEmpty
+            })
+        else {
+            return
+        }
+        chatTranscript.remove(at: index)
     }
 
     private func appendBody(

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -2986,6 +2986,202 @@ struct DesktopFoundationViewTests {
         #expect(viewModel.chatStatusText == "Failed • runtime_error")
     }
 
+    @Test("chat transcript row renders pending assistant state")
+    @MainActor
+    func chatTranscriptRowRendersPendingAssistantState() {
+        let view = hostView(DesktopChatTranscriptRowView(
+            entry: DesktopChatTranscriptEntry(
+                id: "assistant-pending",
+                kind: .assistant,
+                title: "Assistant",
+                body: "",
+                detail: ""
+            ),
+            isPending: true,
+            pendingStatusText: "Preparing"
+        ))
+
+        #expect(view.subviews.isEmpty == false)
+    }
+
+    @Test("chat transcript auto-scroll snapshot tracks trailing content growth")
+    func chatTranscriptAutoScrollSnapshotTracksTrailingContentGrowth() {
+        let initial = DesktopChatTranscriptAutoScroll.snapshot(
+            transcript: [
+                DesktopChatTranscriptEntry(
+                    id: "assistant-1",
+                    kind: .assistant,
+                    title: "Assistant",
+                    body: "",
+                    detail: ""
+                )
+            ],
+            isStreaming: true,
+            statusText: "Preparing"
+        )
+        let advanced = DesktopChatTranscriptAutoScroll.snapshot(
+            transcript: [
+                DesktopChatTranscriptEntry(
+                    id: "assistant-1",
+                    kind: .assistant,
+                    title: "Assistant",
+                    body: "Token delta",
+                    detail: ""
+                )
+            ],
+            isStreaming: true,
+            statusText: "Decoding"
+        )
+        let completed = DesktopChatTranscriptAutoScroll.snapshot(
+            transcript: [
+                DesktopChatTranscriptEntry(
+                    id: "assistant-1",
+                    kind: .assistant,
+                    title: "Assistant",
+                    body: "Token delta",
+                    detail: ""
+                ),
+                DesktopChatTranscriptEntry(
+                    id: "assistant-2",
+                    kind: .assistant,
+                    title: "Assistant",
+                    body: "Final answer",
+                    detail: ""
+                )
+            ],
+            isStreaming: false,
+            statusText: "Completed"
+        )
+
+        #expect(initial != advanced)
+        #expect(advanced != completed)
+        #expect(completed.lastEntryID == "assistant-2")
+    }
+
+    @Test("chat transcript source wires bottom-anchor auto-scroll")
+    @MainActor
+    func chatTranscriptSourceWiresBottomAnchorAutoScroll() throws {
+        let source = try String(
+            contentsOf: repositoryRootForDesktopFoundationTests()
+                .appendingPathComponent("apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift"),
+            encoding: .utf8
+        )
+
+        #expect(source.contains("ScrollViewReader"))
+        #expect(source.contains("DesktopChatTranscriptAutoScroll.Anchor.bottom"))
+        #expect(source.contains("scrollChatTranscriptToBottom"))
+    }
+
+    @Test("chat markdown parser builds assistant display blocks")
+    func chatMarkdownParserBuildsAssistantDisplayBlocks() {
+        let blocks = DesktopChatMarkdownRenderer.blocks(from: """
+        Intro **bold** and _italic_ with `code`.
+
+        - one
+        - two
+
+        1. first
+        2. second
+
+        ```swift
+        let value = 1
+        ```
+
+        | Metric | Value |
+        | --- | ---: |
+        | TTFT | 12 ms |
+        """)
+
+        #expect(blocks == [
+            .paragraph("Intro **bold** and _italic_ with `code`."),
+            .unorderedList(["one", "two"]),
+            .orderedList(["first", "second"]),
+            .codeBlock(language: "swift", code: "let value = 1"),
+            .table(header: ["Metric", "Value"], rows: [["TTFT", "12 ms"]]),
+        ])
+    }
+
+    @Test("chat markdown inline formatter removes markdown markers while preserving readable text")
+    func chatMarkdownInlineFormatterRemovesMarkers() {
+        let attributed = DesktopChatMarkdownInlineFormatter.attributedString(
+            from: "**bold** and _italic_ and `code`"
+        )
+        let linked = DesktopChatMarkdownInlineFormatter.attributedString(
+            from: "[Melix](https://example.com)"
+        )
+
+        #expect(String(attributed.characters) == "bold and italic and code")
+        #expect(String(linked.characters) == "Melix")
+        #expect(linked.runs.allSatisfy { $0.link == nil })
+    }
+
+    @Test("chat markdown body view hosts paragraph list code and table blocks")
+    @MainActor
+    func chatMarkdownBodyViewHostsParagraphListCodeAndTableBlocks() {
+        let view = hostView(DesktopChatMarkdownBodyView(rawText: """
+        Intro **bold** and _italic_ with `code`.
+
+        - one
+        - two
+
+        1. first
+        2. second
+
+        ```swift
+        let value = 1
+        ```
+
+        | Metric | Value |
+        | --- | --- |
+        | TTFT |
+        | TPS | 20 |
+        """))
+
+        #expect(view.subviews.isEmpty == false)
+    }
+
+    @Test("chat markdown surfaces keep restrained low-border styling")
+    func chatMarkdownSurfacesKeepRestrainedLowBorderStyling() {
+        #expect(
+            DesktopChatMarkdownLayoutMetrics.codeBlockBorderOpacity < MelixDesignTokens.StrokeOpacity.interactive
+        )
+        #expect(
+            DesktopChatMarkdownLayoutMetrics.tableHeaderBackgroundOpacity < MelixDesignTokens.SurfaceOpacity.elevated
+        )
+        #expect(
+            DesktopChatMarkdownLayoutMetrics.tableSurfaceBackgroundOpacity < MelixDesignTokens.SurfaceOpacity.card
+        )
+    }
+
+    @Test("chat markdown rendering is limited to assistant and reasoning rows")
+    func chatMarkdownRenderingIsLimitedToAssistantAndReasoningRows() {
+        #expect(DesktopChatMarkdownRenderer.usesMarkdown(for: .assistant))
+        #expect(DesktopChatMarkdownRenderer.usesMarkdown(for: .reasoning))
+        #expect(DesktopChatMarkdownRenderer.usesMarkdown(for: .user) == false)
+        #expect(DesktopChatMarkdownRenderer.usesMarkdown(for: .tool) == false)
+        #expect(DesktopChatMarkdownRenderer.usesMarkdown(for: .error) == false)
+    }
+
+    @Test("chat markdown renderer sanitizes html and unsafe links before parsing")
+    func chatMarkdownRendererSanitizesHTMLAndUnsafeLinksBeforeParsing() {
+        let blocks = DesktopChatMarkdownRenderer.blocks(from: """
+        <b>Hello</b> [click](javascript:alert(1))
+
+        ```html
+        <b>keep as code</b>
+        [keep](javascript:alert(1))
+        ```
+        """)
+
+        #expect(blocks == [
+            .paragraph("Hello click"),
+            .codeBlock(
+                language: "html",
+                code: "<b>keep as code</b>\n[keep](javascript:alert(1))"
+            ),
+        ])
+    }
+
     @Test("chat session sidebar renders the empty state when no chat sessions exist")
     @MainActor
     func chatSessionSidebarRendersTheEmptyStateWhenNoChatSessionsExist() async throws {

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -7276,6 +7276,114 @@ struct RuntimeViewModelTests {
         #expect((metricsSnapshot["menu.chat_presentation_flush_count"] ?? 0) > 1)
     }
 
+    @Test("chat prompt creates a transient assistant pending row before the first token")
+    @MainActor
+    func chatPromptCreatesTransientAssistantPendingRowBeforeFirstToken() async throws {
+        let client = FakeControlPlaneXPCClient()
+        await client.configureScheduledChatEvents([
+            .init(delay: .milliseconds(120), event: .tokenDelta("Assistant final")),
+            .init(delay: .zero, event: .completed(
+                finishReason: "stop",
+                assistantText: "Assistant final",
+                reasoningText: ""
+            )),
+        ])
+        let viewModel = RuntimeViewModel(client: client)
+
+        await viewModel.start()
+        try bindSelectedChatSessionToPrimaryServer(viewModel)
+        viewModel.chatComposerText = "Wait for model"
+
+        let submitTask = Task { @MainActor in
+            await viewModel.submitChatPrompt()
+        }
+
+        try await waitForRuntimeViewModelCondition("chat should expose a pending assistant row before first token") {
+            viewModel.isChatStreaming && viewModel.chatTranscript.contains { entry in
+                entry.kind == .assistant && entry.body.isEmpty
+            }
+        }
+
+        let pendingAssistantEntries = viewModel.chatTranscript.filter { $0.kind == .assistant }
+        let persistedPendingAssistantEntries = viewModel.selectedChatSession?.transcript.filter {
+            $0.kind == .assistant && $0.body.isEmpty
+        } ?? []
+
+        #expect(pendingAssistantEntries.count == 1)
+        #expect(pendingAssistantEntries.first?.body.isEmpty == true)
+        #expect(persistedPendingAssistantEntries.isEmpty)
+
+        await submitTask.value
+
+        let finalAssistantEntries = viewModel.chatTranscript.filter { $0.kind == .assistant }
+        #expect(finalAssistantEntries.count == 1)
+        #expect(finalAssistantEntries.first?.body == "Assistant final")
+    }
+
+    @Test("chat prompt removes an empty pending assistant row after terminal stream failure")
+    @MainActor
+    func chatPromptRemovesPendingAssistantAfterTerminalStreamFailure() async throws {
+        let client = FakeControlPlaneXPCClient()
+        await client.configureScheduledChatEvents([
+            .init(delay: .milliseconds(80), event: .failed(code: "runtime_error", message: "worker failed")),
+        ])
+        let viewModel = RuntimeViewModel(client: client)
+
+        await viewModel.start()
+        try bindSelectedChatSessionToPrimaryServer(viewModel)
+        viewModel.chatComposerText = "Trigger failure"
+
+        let submitTask = Task { @MainActor in
+            await viewModel.submitChatPrompt()
+        }
+
+        try await waitForRuntimeViewModelCondition("chat should show pending assistant before failure") {
+            viewModel.chatTranscript.contains { entry in
+                entry.kind == .assistant && entry.body.isEmpty
+            }
+        }
+
+        await submitTask.value
+
+        #expect(viewModel.chatTranscript.filter { $0.kind == .assistant }.isEmpty)
+        #expect(viewModel.chatTranscript.contains { $0.kind == .error && $0.body == "worker failed" })
+        #expect(viewModel.selectedChatSession?.transcript.contains { $0.kind == .assistant && $0.body.isEmpty } == false)
+    }
+
+    @Test("chat prompt removes an empty pending assistant row after empty completion")
+    @MainActor
+    func chatPromptRemovesPendingAssistantAfterEmptyCompletion() async throws {
+        let client = FakeControlPlaneXPCClient()
+        await client.configureScheduledChatEvents([
+            .init(delay: .milliseconds(80), event: .completed(
+                finishReason: "stop",
+                assistantText: "",
+                reasoningText: ""
+            )),
+        ])
+        let viewModel = RuntimeViewModel(client: client)
+
+        await viewModel.start()
+        try bindSelectedChatSessionToPrimaryServer(viewModel)
+        viewModel.chatComposerText = "Return nothing"
+
+        let submitTask = Task { @MainActor in
+            await viewModel.submitChatPrompt()
+        }
+
+        try await waitForRuntimeViewModelCondition("chat should show pending assistant before empty completion") {
+            viewModel.chatTranscript.contains { entry in
+                entry.kind == .assistant && entry.body.isEmpty
+            }
+        }
+
+        await submitTask.value
+
+        #expect(viewModel.chatTranscript.filter { $0.kind == .assistant }.isEmpty)
+        #expect(viewModel.chatStatusText == "Completed • stop")
+        #expect(viewModel.selectedChatSession?.transcript.contains { $0.kind == .assistant && $0.body.isEmpty } == false)
+    }
+
     @Test("chat completion can synthesize transcript entries without prior deltas")
     @MainActor
     func chatCompletionSynthesizesTranscriptEntriesWithoutPriorDeltas() async throws {
@@ -7302,6 +7410,7 @@ struct RuntimeViewModelTests {
 
         #expect(hasAssistantFinal)
         #expect(hasReasoningFinal)
+        #expect(viewModel.chatTranscript.filter { $0.kind == .assistant }.count == 1)
         #expect(viewModel.chatStatusText == "Completed • stop")
     }
 

--- a/docs/plans/2026-04-23-chat-waiting-indicator-and-markdown.md
+++ b/docs/plans/2026-04-23-chat-waiting-indicator-and-markdown.md
@@ -1,0 +1,41 @@
+# Chat Waiting Indicator And Markdown Rendering
+
+## Summary
+
+This follow-up refines the macOS Chat surface from the UI/UX pass documented in
+`docs/plans/2026-04-21-macos-uiux-follow-up.md`. The Chat transcript should
+show that a submitted prompt is actively waiting for model output, and assistant
+or reasoning responses should render common Markdown instead of displaying raw
+formatting markers. As the transcript grows, the Chat view should keep the
+latest exchange in view without requiring manual scrolling.
+
+## Behavior
+
+- After a prompt is accepted, Chat inserts a transient assistant row with a
+  compact spinner and `Thinking...` before the first token arrives.
+- The pending row is presentation state only: it is replaced by the first
+  assistant token or final assistant text, and it is removed after failures or
+  empty completions.
+- Assistant and reasoning rows render sanitized Markdown for inline emphasis,
+  inline code, lists, fenced code blocks, and simple pipe tables.
+- The transcript auto-scrolls to the newest row when pending status, streamed
+  content, or completed assistant output extends the conversation.
+- User, tool, and error rows remain literal plain text so prompts, logs, and
+  diagnostics are not reformatted.
+
+## Safety And Persistence
+
+- Rich output is sanitized with `RichOutputSanitizer` before Markdown parsing.
+- Unsafe links and active HTML are never rendered as rich content.
+- Empty pending assistant rows are excluded from persisted chat session state.
+- Stored transcript text remains the raw model text; Markdown rendering is
+  view-only.
+
+## Verification
+
+- Runtime tests cover pending row creation, in-place final assistant replacement,
+  stream failure cleanup, and empty completion cleanup.
+- View tests cover Markdown block parsing, inline Markdown formatting, row-kind
+  scoping, and sanitizer integration.
+- Manual UI verification should use the Chat surface with a delayed model
+  response to confirm the pending indicator appears and then clears.


### PR DESCRIPTION
## Summary
- Add an inline assistant waiting row in Chat, keep assistant transcript updates in place while streaming, and drop empty pending rows on failure or empty completion.
- Render assistant and reasoning transcript rows with sanitized Markdown, including lists, fenced code blocks, and compact pipe tables styled to match the current macOS operator surface.
- Auto-scroll the Chat transcript to the latest exchange as pending state and streamed content extend the conversation, and cover the behavior with focused runtime/view tests.

## Plan or Spec
- [docs/plans/2026-04-23-chat-waiting-indicator-and-markdown.md](docs/plans/2026-04-23-chat-waiting-indicator-and-markdown.md)

## Commands Run
```text
swift test --package-path apps/macos-menubar --filter 'RuntimeViewModelTests|DesktopFoundationViewTests|DesktopShellStateTests|DesktopPolishSmokeTests|StatusMenuTests|AppMainBootstrapTests'
# passed: 395 tests in 7 suites

swift test --enable-code-coverage --package-path apps/macos-menubar --filter 'RuntimeViewModelTests|DesktopFoundationViewTests|DesktopPolishSmokeTests'
# passed: 327 tests in 4 suites

python3 scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
# passed: changed-line coverage 98.55% (749/760)

python3 scripts/m15_desktop_polish_smoke.py --json
# passed: ok=true

Computer Use manual pass on packaged Chat surface
# verified pending indicator, markdown rendering, and transcript stick-to-bottom behavior
```

## Coverage and Metrics
- Changed-scope coverage: `98.55%` (`749/760`)
- Chat presentation probes:
  - `presentation_lag_ms`: `210.66`
  - `presentation_flush_count`: `9`
- Operator session probes:
  - `operator_session_restore_ms`: `1.96`
  - `operator_session_persist_write_ms`: `0.89`
- Navigation probes:
  - `grounded_surface_count`: `5`
  - `grounded_tool_section_count`: `6`

## Known Gaps
- Full repository baseline commands (`make swift-test`, `make py-test`, `make integration-test`) were not rerun for this scoped Chat/UI change; verification stayed on the focused macOS menubar suite and desktop smoke path.
- `uv.lock` has unrelated pre-existing local modifications and is intentionally excluded from this PR.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
