### PR TITLE
test(control-plane): widen wait-helper budget on CI to reduce RequestCoordinator flakes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_C := \
 	"HTTPGatewayTests.RequestCoordinatorTests/multimodalVisionRequestsUseBackgroundLanes()" \
 	"HTTPGatewayTests.RequestCoordinatorTests/ocrRequestsPublishVisionMetrics()" \
 	"HTTPGatewayTests.RequestCoordinatorTests/partialRestorePlansRecordWalkBackMetricsAndMetadata()" \
+	"HTTPGatewayTests.RequestCoordinatorTests/progressWaitHelperCanMatchFinalSnapshotAfterPollingAttempts()" \
+	"HTTPGatewayTests.RequestCoordinatorTests/progressWaitHelperSkipsSnapshotsUntilPredicateMetadataMatches()" \
+	"HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierIgnoresFalseyEnvironmentValues()" \
+	"HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierWidensBudgetsForTruthyEnvironmentValues()" \
 	"HTTPGatewayTests.RequestCoordinatorTests/phaseAwareStreamEventsPreserveAccelerationMetadataAndTerminalAborts()"
 CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_D := \
 	"HTTPGatewayTests.RequestCoordinatorTests/phaseAwareTextRequestsJoinTheActiveContinuousBatchCohort()" \

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -3228,6 +3228,21 @@ private func makeCoordinatorTextModel(
     return model
 }
 
+/// Multiplier applied to polling-based wait helpers in this test file.
+///
+/// Local runs stay on the fast defaults; CI machines (GitHub-hosted macOS
+/// runners are slower and noisier than developer laptops) get a 4× budget so
+/// phase-transition polls can't race the scheduler under contention. The
+/// actual numerical default still passes locally in a few tens of ms — the
+/// multiplier only affects the *ceiling* before a timeout returns nil.
+private let waitAttemptsMultiplier: Int = {
+    let env = ProcessInfo.processInfo.environment
+    if env["CI"] != nil || env["GITHUB_ACTIONS"] != nil {
+        return 4
+    }
+    return 1
+}()
+
 private func waitForProgress(
     schedulerReadModel: SchedulerReadModel,
     requestID: String,
@@ -3236,7 +3251,8 @@ private func waitForProgress(
     attempts: Int = 300,
     matching predicate: ((Melix_Controlplane_V1_RequestProgressEvent) -> Bool)? = nil
 ) async -> Melix_Controlplane_V1_RequestProgressEvent? {
-    for _ in 0..<attempts {
+    let effectiveAttempts = attempts * waitAttemptsMultiplier
+    for _ in 0..<effectiveAttempts {
         let progress = await schedulerReadModel.progressSnapshot(for: requestID)
         if let progress,
            progress.phase == phase,
@@ -3260,7 +3276,8 @@ private func waitForPrefillRequest(
     workerClient: PhaseAwareWorkerClient,
     attempts: Int = 100
 ) async -> Melix_Worker_V1_PrefillRequest? {
-    for _ in 0..<attempts {
+    let effectiveAttempts = attempts * waitAttemptsMultiplier
+    for _ in 0..<effectiveAttempts {
         if let request = await workerClient.lastPrefillRequest() {
             return request
         }
@@ -3273,7 +3290,8 @@ private func waitForDecodeRequest(
     workerClient: PhaseAwareWorkerClient,
     attempts: Int = 100
 ) async -> Melix_Worker_V1_DecodeRequest? {
-    for _ in 0..<attempts {
+    let effectiveAttempts = attempts * waitAttemptsMultiplier
+    for _ in 0..<effectiveAttempts {
         if let request = await workerClient.lastDecodeRequest() {
             return request
         }
@@ -3287,8 +3305,9 @@ private func waitForDecodeRequests(
     requestIDs: [String],
     attempts: Int = 100
 ) async -> [String] {
+    let effectiveAttempts = attempts * waitAttemptsMultiplier
     let expected = Set(requestIDs)
-    for _ in 0..<attempts {
+    for _ in 0..<effectiveAttempts {
         let observed = await workerClient.decodeRequestIDs()
         if Set(observed).isSuperset(of: expected) {
             return observed

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -1411,6 +1411,21 @@ struct RequestCoordinatorTests {
         #expect(progress.accelerationMode == .acceleratedPrefill)
     }
 
+    @Test("CI wait multiplier ignores falsey environment values")
+    func ciWaitMultiplierIgnoresFalseyEnvironmentValues() {
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI": "false"]) == 1)
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI": "0"]) == 1)
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI": ""]) == 1)
+        #expect(computedWaitAttemptsMultiplier(environment: ["GITHUB_ACTIONS": "false"]) == 1)
+    }
+
+    @Test("CI wait multiplier widens budgets for truthy environment values")
+    func ciWaitMultiplierWidensBudgetsForTruthyEnvironmentValues() {
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true"]) == 4)
+        #expect(computedWaitAttemptsMultiplier(environment: ["GITHUB_ACTIONS": "true"]) == 4)
+        #expect(computedWaitAttemptsMultiplier(environment: ["GITHUB_ACTIONS": "1"]) == 4)
+    }
+
     @Test("chunked prefills emit progress events and scheduler metrics for long prompts")
     func chunkedPrefillsEmitProgressEventsAndSchedulerMetricsForLongPrompts() async throws {
         let workerClient = PhaseAwareWorkerClient()
@@ -3236,12 +3251,29 @@ private func makeCoordinatorTextModel(
 /// actual numerical default still passes locally in a few tens of ms — the
 /// multiplier only affects the *ceiling* before a timeout returns nil.
 private let waitAttemptsMultiplier: Int = {
-    let env = ProcessInfo.processInfo.environment
-    if env["CI"] != nil || env["GITHUB_ACTIONS"] != nil {
+    computedWaitAttemptsMultiplier(environment: ProcessInfo.processInfo.environment)
+}()
+
+private func computedWaitAttemptsMultiplier(environment: [String: String]) -> Int {
+    if isTruthyEnvironmentFlag(environment["CI"])
+        || isTruthyEnvironmentFlag(environment["GITHUB_ACTIONS"]) {
         return 4
     }
     return 1
-}()
+}
+
+private func isTruthyEnvironmentFlag(_ value: String?) -> Bool {
+    guard let value else {
+        return false
+    }
+
+    switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+    case "1", "true", "yes", "on":
+        return true
+    default:
+        return false
+    }
+}
 
 private func waitForProgress(
     schedulerReadModel: SchedulerReadModel,


### PR DESCRIPTION
## Summary

- Rebased PR #60 onto current `main` so the branch is mergeable with the latest RequestCoordinator test-helper changes.
- Kept the CI wait-helper budget multiplier scoped to RequestCoordinator polling helpers, with explicit truthy parsing for `CI` and `GITHUB_ACTIONS`.
- Added regression coverage so `CI=false`, `CI=0`, empty `CI`, and `GITHUB_ACTIONS=false` do not trigger the slower CI path, while truthy values still get the 4x budget.
- Updated the `make swift-test` RequestCoordinator specifier list so the new helper tests run under the repository Swift workflow.

## Plan or Spec

- N/A: test-only CI flake mitigation for PR #60. No product behavior or canonical interface changes.

## Commands Run

- `swift package --package-path services/control-plane-swift clean` -> completed after a stale local Swift build cache produced a Swift 6.3.1-vs-6.2.3 module mismatch.
- `swift test --no-parallel --package-path services/control-plane-swift --filter HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierIgnoresFalseyEnvironmentValues` -> passed, 1 test.
- `swift test --no-parallel --package-path services/control-plane-swift --filter HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierWidensBudgetsForTruthyEnvironmentValues` -> passed, 1 test.
- `CI=true swift test --no-parallel --package-path services/control-plane-swift --filter HTTPGatewayTests.RequestCoordinatorTests/chunkedPrefillsEmitProgressEventsAndSchedulerMetricsForLongPrompts` -> passed, 1 test.
- `swift test --no-parallel --package-path services/control-plane-swift --filter HTTPGatewayTests.RequestCoordinatorTests` -> passed, 50 tests.
- `xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierWidensBudgetsForTruthyEnvironmentValues()"` -> passed, 1 test with the Makefile-style specifier format.
- `git diff --check origin/main...HEAD` -> clean.
- `make swift-test` -> did not complete locally: `packages/protocol/swift` passed, then `services/mlx-text-worker-swift` stopped at `testFusedDecodeQuantizerRejectsUnsupportedInputs` with `MLX error: Failed to load the default metallib`; this happens before the control-plane RequestCoordinator segment and is unrelated to this PR's changed scope.

## Coverage and Metrics

- Coverage: N/A for product code because this change only touches test helpers, RequestCoordinator tests, and the Makefile test list.
- Metrics: `RequestCoordinatorTests` passed 50/50 locally; both CI-env multiplier tests passed; the original failing chunked-prefill RequestCoordinator test passed with `CI=true`; the Makefile-style specifier for the new truthy CI multiplier test passed.

## Known Gaps

- Full local `make swift-test` is blocked by the existing local `mlx.metallib` availability issue in `mlx-text-worker-swift`, not by this control-plane change.
- The longer-term async subscription refactor for scheduler progress waits remains deferred; this PR keeps the mitigation scoped to the polling helper and tests.
