### PR TITLE
test(control-plane): allow CI_WAIT_MULTIPLIER to override the wait budget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_C := \
 	"HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierIgnoresFalseyEnvironmentValues()" \
 	"HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierWidensBudgetsForTruthyEnvironmentValues()" \
 	"HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierEnvOverrideOverridesDefault()" \
-	"HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierEnvOverrideFallsBackForMalformedValues()" \
+	"HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierEnvOverrideFallsBackForInvalidValues()" \
 	"HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierEnvOverrideRequiresCIFlag()" \
 	"HTTPGatewayTests.RequestCoordinatorTests/phaseAwareStreamEventsPreserveAccelerationMetadataAndTerminalAborts()"
 CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_D := \

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_C := \
 	"HTTPGatewayTests.RequestCoordinatorTests/progressWaitHelperSkipsSnapshotsUntilPredicateMetadataMatches()" \
 	"HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierIgnoresFalseyEnvironmentValues()" \
 	"HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierWidensBudgetsForTruthyEnvironmentValues()" \
+	"HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierEnvOverrideOverridesDefault()" \
+	"HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierEnvOverrideFallsBackForMalformedValues()" \
+	"HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierEnvOverrideRequiresCIFlag()" \
 	"HTTPGatewayTests.RequestCoordinatorTests/phaseAwareStreamEventsPreserveAccelerationMetadataAndTerminalAborts()"
 CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_D := \
 	"HTTPGatewayTests.RequestCoordinatorTests/phaseAwareTextRequestsJoinTheActiveContinuousBatchCohort()" \

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -1426,6 +1426,28 @@ struct RequestCoordinatorTests {
         #expect(computedWaitAttemptsMultiplier(environment: ["GITHUB_ACTIONS": "1"]) == 4)
     }
 
+    @Test("CI_WAIT_MULTIPLIER overrides the default when set to a positive integer")
+    func ciWaitMultiplierEnvOverrideOverridesDefault() {
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": "8"]) == 8)
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": "  16 "]) == 16)
+        #expect(computedWaitAttemptsMultiplier(environment: ["GITHUB_ACTIONS": "true", "CI_WAIT_MULTIPLIER": "2"]) == 2)
+    }
+
+    @Test("CI_WAIT_MULTIPLIER falls back to the default when malformed or non-positive")
+    func ciWaitMultiplierEnvOverrideFallsBackForMalformedValues() {
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": "abc"]) == 4)
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": "0"]) == 4)
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": "-3"]) == 4)
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": ""]) == 4)
+    }
+
+    @Test("CI_WAIT_MULTIPLIER without a CI flag stays at the local default")
+    func ciWaitMultiplierEnvOverrideRequiresCIFlag() {
+        // The env var alone shouldn't widen budgets on a developer laptop —
+        // the operator has to opt in explicitly via CI/GITHUB_ACTIONS.
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI_WAIT_MULTIPLIER": "8"]) == 1)
+    }
+
     @Test("chunked prefills emit progress events and scheduler metrics for long prompts")
     func chunkedPrefillsEmitProgressEventsAndSchedulerMetricsForLongPrompts() async throws {
         let workerClient = PhaseAwareWorkerClient()
@@ -3250,16 +3272,29 @@ private func makeCoordinatorTextModel(
 /// phase-transition polls can't race the scheduler under contention. The
 /// actual numerical default still passes locally in a few tens of ms — the
 /// multiplier only affects the *ceiling* before a timeout returns nil.
+///
+/// `CI_WAIT_MULTIPLIER` overrides the default when set to a positive integer,
+/// so future tuning doesn't require a code change.
 private let waitAttemptsMultiplier: Int = {
     computedWaitAttemptsMultiplier(environment: ProcessInfo.processInfo.environment)
 }()
 
+private let defaultCIWaitMultiplier = 4
+
 private func computedWaitAttemptsMultiplier(environment: [String: String]) -> Int {
-    if isTruthyEnvironmentFlag(environment["CI"])
-        || isTruthyEnvironmentFlag(environment["GITHUB_ACTIONS"]) {
-        return 4
+    let ciActive = isTruthyEnvironmentFlag(environment["CI"])
+        || isTruthyEnvironmentFlag(environment["GITHUB_ACTIONS"])
+    guard ciActive else {
+        return 1
     }
-    return 1
+    if let raw = environment["CI_WAIT_MULTIPLIER"]?
+        .trimmingCharacters(in: .whitespacesAndNewlines),
+       raw.isEmpty == false,
+       let parsed = Int(raw),
+       parsed > 0 {
+        return parsed
+    }
+    return defaultCIWaitMultiplier
 }
 
 private func isTruthyEnvironmentFlag(_ value: String?) -> Bool {

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -1426,19 +1426,23 @@ struct RequestCoordinatorTests {
         #expect(computedWaitAttemptsMultiplier(environment: ["GITHUB_ACTIONS": "1"]) == 4)
     }
 
-    @Test("CI_WAIT_MULTIPLIER overrides the default when set to a positive integer")
+    @Test("CI_WAIT_MULTIPLIER overrides the default when set within range")
     func ciWaitMultiplierEnvOverrideOverridesDefault() {
         #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": "8"]) == 8)
         #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": "  16 "]) == 16)
         #expect(computedWaitAttemptsMultiplier(environment: ["GITHUB_ACTIONS": "true", "CI_WAIT_MULTIPLIER": "2"]) == 2)
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": "100"]) == 100)
     }
 
-    @Test("CI_WAIT_MULTIPLIER falls back to the default when malformed or non-positive")
-    func ciWaitMultiplierEnvOverrideFallsBackForMalformedValues() {
+    @Test("CI_WAIT_MULTIPLIER falls back to the default when invalid")
+    func ciWaitMultiplierEnvOverrideFallsBackForInvalidValues() {
         #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": "abc"]) == 4)
         #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": "0"]) == 4)
         #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": "-3"]) == 4)
         #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": ""]) == 4)
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": "   "]) == 4)
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": "101"]) == 4)
+        #expect(computedWaitAttemptsMultiplier(environment: ["CI": "true", "CI_WAIT_MULTIPLIER": "100000"]) == 4)
     }
 
     @Test("CI_WAIT_MULTIPLIER without a CI flag stays at the local default")
@@ -3273,13 +3277,14 @@ private func makeCoordinatorTextModel(
 /// actual numerical default still passes locally in a few tens of ms — the
 /// multiplier only affects the *ceiling* before a timeout returns nil.
 ///
-/// `CI_WAIT_MULTIPLIER` overrides the default when set to a positive integer,
-/// so future tuning doesn't require a code change.
+/// `CI_WAIT_MULTIPLIER` overrides the default when set to a positive integer
+/// within the accepted range, so future tuning doesn't require a code change.
 private let waitAttemptsMultiplier: Int = {
     computedWaitAttemptsMultiplier(environment: ProcessInfo.processInfo.environment)
 }()
 
-private let defaultCIWaitMultiplier = 4
+private let defaultCIWaitMultiplier: Int = 4
+private let maximumCIWaitMultiplier: Int = 100
 
 private func computedWaitAttemptsMultiplier(environment: [String: String]) -> Int {
     let ciActive = isTruthyEnvironmentFlag(environment["CI"])
@@ -3289,9 +3294,8 @@ private func computedWaitAttemptsMultiplier(environment: [String: String]) -> In
     }
     if let raw = environment["CI_WAIT_MULTIPLIER"]?
         .trimmingCharacters(in: .whitespacesAndNewlines),
-       raw.isEmpty == false,
        let parsed = Int(raw),
-       parsed > 0 {
+       (1...maximumCIWaitMultiplier).contains(parsed) {
         return parsed
     }
     return defaultCIWaitMultiplier


### PR DESCRIPTION
## Summary

- Follow-up to #60 and the PR #57 review feedback: allow `CI_WAIT_MULTIPLIER` to tune the CI wait budget without a code change.
- The override remains gated by truthy `CI` / `GITHUB_ACTIONS`, so developer-machine runs stay on the local multiplier of `1` unless CI is explicitly active.
- Addressed PR #66 review feedback by capping accepted override values at `100`, falling back to the default `4` for malformed, non-positive, whitespace-only, or out-of-range values, and simplifying the parsing branch.

## Plan or Spec

- N/A: surgical test-helper follow-up to the multiplier introduced in #60. The behavior was requested during PR #57 / PR #66 code review and is contained to `RequestCoordinatorTests.swift` plus the Makefile test specifier list.

## Commands Run

```text
HOME="$PWD/.runtime/swift-home/control-plane" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/module-cache/control-plane" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "RequestCoordinatorTests/ciWaitMultiplierEnvOverride"
# passed: 3 Swift Testing cases in RequestCoordinator.

HOME="$PWD/.swift-home/control-plane-swift" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/control-plane-swift" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "HTTPGatewayTests.RequestCoordinatorTests/ciWaitMultiplierEnvOverrideFallsBackForInvalidValues()"
# passed: the renamed Makefile specifier matches and the invalid-value case passes.

git diff --check
# passed: no whitespace errors.

git diff --exit-code -- packages/protocol
# passed: no protocol or generated artifact changes.

make swift-test
# failed before the control-plane RequestCoordinator slice while running services/mlx-text-worker-swift: MLX could not load a default metallib because no local mlx.metallib is present on this machine.
```

## Coverage and Metrics

- Changed-scope coverage: N/A. This is a test-only helper and Makefile specifier update; no production source path was changed.
- Review-update footprint: 13 insertions and 9 deletions across `RequestCoordinatorTests.swift` and `Makefile`.
- Test metrics covered by the focused Swift cases:
  - valid overrides: `8`, whitespace-padded `16`, `2`, and upper-bound `100`.
  - invalid fallbacks: `abc`, `0`, `-3`, empty, whitespace-only, `101`, and `100000` fall back to `4`.
  - local safety: `CI_WAIT_MULTIPLIER` alone still returns `1` without `CI` / `GITHUB_ACTIONS`.

## Known Gaps

- Full local `make swift-test` is blocked by an environment prerequisite outside this PR: the Swift text worker test process cannot find `mlx.metallib` and aborts in `testFusedDecodeQuantizerRejectsUnsupportedInputs` before reaching the control-plane RequestCoordinator test loop.
- No PR review threads have been resolved from the local workflow; the pushed code update should make the affected inline threads outdated or ready for reviewer resolution.

## Evidence Checklist

- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or marked N/A above.
- [x] Protocol changes include regenerated generated artifacts, or no protocol changes were made.
- [x] Dependency changes include updated lockfiles, or no dependency changes were made.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
