### PR TITLE
Improve chat Markdown rendering

### DIFF
--- a/apps/macos-menubar/Package.resolved
+++ b/apps/macos-menubar/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5ba86c72edea75940275b8950bde017ea5fb711a00c6da102380217faba70417",
+  "originHash" : "2915e09fd3753369ac5be3f6b217ee3e80255d7884003731c2e82603120c031f",
   "pins" : [
     {
       "identity" : "grpc-swift-2",
@@ -74,6 +74,15 @@
       }
     },
     {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
+        "version" : "0.7.1"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -116,6 +125,15 @@
       "state" : {
         "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
         "version" : "1.10.1"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-markdown.git",
+      "state" : {
+        "revision" : "7d9a5ce307528578dfa777d505496bd5f544ad94",
+        "version" : "0.7.3"
       }
     },
     {

--- a/apps/macos-menubar/Package.swift
+++ b/apps/macos-menubar/Package.swift
@@ -38,7 +38,8 @@ let package = Package(
                 .product(name: "MelixControlPlaneCore", package: "control-plane-swift"),
                 .product(name: "MelixControlPlaneProtocol", package: "swift"),
             ],
-            path: "Tests/MenuBarTests"
+            path: "Tests/MenuBarTests",
+            exclude: ["Fixtures"]
         ),
     ]
 )

--- a/apps/macos-menubar/Package.swift
+++ b/apps/macos-menubar/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .package(name: "melix", path: "../.."),
         .package(path: "../../services/control-plane-swift"),
         .package(path: "../../packages/protocol/swift"),
+        .package(url: "https://github.com/swiftlang/swift-markdown.git", exact: "0.7.3"),
     ],
     targets: [
         .executableTarget(
@@ -22,6 +23,7 @@ let package = Package(
                 .product(name: "MelixCLICore", package: "melix"),
                 .product(name: "MelixControlPlaneCore", package: "control-plane-swift"),
                 .product(name: "MelixControlPlaneProtocol", package: "swift"),
+                .product(name: "Markdown", package: "swift-markdown"),
             ],
             path: "Sources/AppMain",
             resources: [

--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift
@@ -459,13 +459,17 @@ private enum DesktopChatMarkdownChunker {
 
         var chunks: [DesktopChatMarkdownSourceChunk] = []
         var current = ""
-        var insideFence = false
+        var fence: MarkdownFence?
         let lines = sanitized.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
 
         for (index, line) in lines.enumerated() {
             let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
-                insideFence.toggle()
+            if let activeFence = fence {
+                if activeFence.isClosingLine(trimmed) {
+                    fence = nil
+                }
+            } else if let openedFence = MarkdownFence(openingLine: trimmed) {
+                fence = openedFence
             }
 
             if current.isEmpty == false {
@@ -474,7 +478,7 @@ private enum DesktopChatMarkdownChunker {
             current += line
 
             let isLastLine = index == lines.count - 1
-            if insideFence == false,
+            if fence == nil,
                current.count >= DesktopChatMarkdownLayoutMetrics.renderChunkTargetCharacterCount,
                trimmed.isEmpty,
                isLastLine == false {
@@ -498,6 +502,35 @@ private enum DesktopChatMarkdownChunker {
 
         return chunks
     }
+
+    private struct MarkdownFence {
+        let character: Character
+        let length: Int
+
+        init?(openingLine: String) {
+            guard let first = openingLine.first, first == "`" || first == "~" else {
+                return nil
+            }
+            let runLength = openingLine.prefix { $0 == first }.count
+            guard runLength >= 3 else {
+                return nil
+            }
+            self.character = first
+            self.length = runLength
+        }
+
+        func isClosingLine(_ line: String) -> Bool {
+            guard line.first == character else {
+                return false
+            }
+            let runLength = line.prefix { $0 == character }.count
+            guard runLength >= length else {
+                return false
+            }
+            let remainder = line.dropFirst(runLength)
+            return remainder.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
 }
 
 private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
@@ -520,6 +553,7 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
     private var latestParseDurationMS: Double
 
     init(capacity: Int = 128) {
+        // Capacity is per sub-cache; parsed blocks, chunks, and inline strings are evicted independently.
         self.capacity = max(1, capacity)
         self.parsedBlocks = [:]
         self.parsedBlockOrder = []
@@ -613,10 +647,13 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
         }
         lock.unlock()
 
+        let startedAt = Date()
         let rendered = build()
+        let duration = max(0, Date().timeIntervalSince(startedAt) * 1000)
 
         lock.lock()
         inlineMissCount += 1
+        latestParseDurationMS = duration
         inlineAttributedStrings[key] = rendered
         touch(key, in: &inlineAttributedStringOrder)
         evictIfNeeded()
@@ -664,6 +701,7 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
     }
 
     private func touch(_ key: String, in order: inout [String]) {
+        // The default cache size is small, so linear promotion keeps LRU bookkeeping simple.
         order.removeAll { $0 == key }
         order.append(key)
     }
@@ -790,23 +828,13 @@ private struct DesktopChatMarkdownBlockVisitor: MarkupVisitor {
     }
 
     private mutating func listItem(from item: ListItem) -> DesktopChatMarkdownListItem {
-        var textParts: [String] = []
-        var childBlocks: [DesktopChatMarkdownBlock] = []
-
-        for child in item.children {
-            if let paragraph = child as? Paragraph {
-                let text = DesktopChatMarkdownInlineSourceRenderer.string(from: paragraph)
-                if text.isEmpty == false {
-                    textParts.append(text)
-                }
-            } else {
-                childBlocks.append(contentsOf: visit(child))
-            }
+        let childBlocks = item.children.flatMap { visit($0) }
+        guard case .paragraph(let text) = childBlocks.first else {
+            return DesktopChatMarkdownListItem(text: "", children: childBlocks)
         }
-
         return DesktopChatMarkdownListItem(
-            text: textParts.joined(separator: "\n"),
-            children: childBlocks
+            text: text,
+            children: Array(childBlocks.dropFirst())
         )
     }
 
@@ -835,7 +863,7 @@ private struct DesktopChatMarkdownInlineSourceRenderer: MarkupVisitor {
     }
 
     mutating func visitText(_ text: Markdown.Text) -> String {
-        text.string
+        escapedText(text.string)
     }
 
     mutating func visitSoftBreak(_ softBreak: SoftBreak) -> String {
@@ -847,7 +875,8 @@ private struct DesktopChatMarkdownInlineSourceRenderer: MarkupVisitor {
     }
 
     mutating func visitInlineCode(_ inlineCode: InlineCode) -> String {
-        "`\(inlineCode.code)`"
+        let delimiter = inlineCodeDelimiter(for: inlineCode.code)
+        return "\(delimiter)\(inlineCode.code)\(delimiter)"
     }
 
     mutating func visitStrong(_ strong: Strong) -> String {
@@ -876,6 +905,33 @@ private struct DesktopChatMarkdownInlineSourceRenderer: MarkupVisitor {
 
     mutating func visitInlineHTML(_ inlineHTML: InlineHTML) -> String {
         ""
+    }
+
+    private func escapedText(_ text: String) -> String {
+        let specialCharacters: Set<Character> = [
+            "\\", "`", "*", "_", "{", "}", "[", "]", "(", ")",
+            "#", "+", "-", ".", "!", "|", "~",
+        ]
+        return text.reduce(into: "") { result, character in
+            if specialCharacters.contains(character) {
+                result.append("\\")
+            }
+            result.append(character)
+        }
+    }
+
+    private func inlineCodeDelimiter(for code: String) -> String {
+        var longestRun = 0
+        var currentRun = 0
+        for character in code {
+            if character == "`" {
+                currentRun += 1
+                longestRun = max(longestRun, currentRun)
+            } else {
+                currentRun = 0
+            }
+        }
+        return String(repeating: "`", count: max(1, longestRun + 1))
     }
 }
 
@@ -1272,8 +1328,10 @@ private struct DesktopChatMarkdownBlocksView: View {
             return .title3.weight(.semibold)
         case 2:
             return .headline
+        case 3:
+            return .body.weight(.semibold)
         default:
-            return .subheadline.weight(.semibold)
+            return .body
         }
     }
 

--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift
@@ -65,7 +65,7 @@ struct DesktopChatMarkdownCacheStats: Equatable, Sendable {
     let chunkMissCount: Int
     let stableChunkReuseCount: Int
     let evictionCount: Int
-    let latestParseDurationMS: Double
+    let latestBuildDurationMS: Double
 }
 
 enum DesktopChatMarkdownRenderPlanMode: Equatable, Sendable {
@@ -134,6 +134,7 @@ struct DesktopChatMarkdownTableLayout: Equatable, Sendable {
         self.columnWidths = (0..<columnCount).map { column in
             let cells = [header[safe: column] ?? ""] + rows.map { $0[safe: column] ?? "" }
             let longest = cells.map(\.count).max() ?? 0
+            // Calibrated as a compact menu-bar estimate; min/max bounds handle font and content variance.
             let rawWidth = CGFloat(longest * 7) + (DesktopChatMarkdownLayoutMetrics.tableCellHorizontalPadding * 2)
             return min(
                 max(rawWidth, DesktopChatMarkdownLayoutMetrics.tableColumnMinWidth),
@@ -717,7 +718,7 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
     private var chunkMissCount: Int
     private var stableChunkReuseCount: Int
     private var evictionCount: Int
-    private var latestParseDurationMS: Double
+    private var latestBuildDurationMS: Double
 
     init(capacity: Int = 128) {
         // Capacity is per sub-cache; parsed blocks, chunks, and inline strings are evicted independently.
@@ -736,7 +737,7 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
         self.chunkMissCount = 0
         self.stableChunkReuseCount = 0
         self.evictionCount = 0
-        self.latestParseDurationMS = 0
+        self.latestBuildDurationMS = 0
     }
 
     func blocks(
@@ -758,7 +759,7 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
 
         lock.lock()
         parseMissCount += 1
-        latestParseDurationMS = duration
+        latestBuildDurationMS = duration
         parsedBlocks[key] = rendered
         touch(key, in: &parsedBlockOrder)
         evictIfNeeded()
@@ -790,7 +791,7 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
 
         lock.lock()
         chunkMissCount += 1
-        latestParseDurationMS = duration
+        latestBuildDurationMS = duration
         if isStable {
             parsedChunkBlocks[key] = rendered
             touch(key, in: &parsedChunkBlockOrder)
@@ -820,7 +821,7 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
 
         lock.lock()
         inlineMissCount += 1
-        latestParseDurationMS = duration
+        latestBuildDurationMS = duration
         inlineAttributedStrings[key] = rendered
         touch(key, in: &inlineAttributedStringOrder)
         evictIfNeeded()
@@ -846,7 +847,7 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
         chunkMissCount = 0
         stableChunkReuseCount = 0
         evictionCount = 0
-        latestParseDurationMS = 0
+        latestBuildDurationMS = 0
         lock.unlock()
     }
 
@@ -861,7 +862,7 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
             chunkMissCount: chunkMissCount,
             stableChunkReuseCount: stableChunkReuseCount,
             evictionCount: evictionCount,
-            latestParseDurationMS: latestParseDurationMS
+            latestBuildDurationMS: latestBuildDurationMS
         )
         lock.unlock()
         return snapshot

--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift
@@ -179,6 +179,22 @@ enum DesktopChatMarkdownCodeSyntaxHighlighter {
         "switch", "throw", "throws", "true", "try", "var", "while",
     ]
 
+    private static let jsKeywords: Set<String> = [
+        "async", "await", "break", "case", "catch", "class", "const", "continue",
+        "debugger", "default", "delete", "do", "else", "export", "extends",
+        "false", "finally", "for", "function", "if", "import", "in", "instanceof",
+        "let", "new", "null", "of", "return", "static", "super", "switch", "this",
+        "throw", "true", "try", "typeof", "undefined", "var", "void", "while", "yield",
+    ]
+
+    private static let pythonKeywords: Set<String> = [
+        "and", "as", "assert", "async", "await", "break", "class", "continue",
+        "def", "del", "elif", "else", "except", "False", "finally", "for",
+        "from", "global", "if", "import", "in", "is", "lambda", "None",
+        "nonlocal", "not", "or", "pass", "raise", "return", "True", "try",
+        "while", "with", "yield",
+    ]
+
     private static let shellKeywords: Set<String> = [
         "awk", "bun", "cd", "curl", "echo", "export", "git", "grep",
         "make", "mkdir", "rg", "sed", "swift", "xcrun",
@@ -192,8 +208,14 @@ enum DesktopChatMarkdownCodeSyntaxHighlighter {
         if ["sh", "shell", "bash", "zsh"].contains(normalized) {
             return highlightedWords(code, keywords: shellKeywords)
         }
-        if ["swift", "js", "javascript", "ts", "typescript", "py", "python"].contains(normalized) {
+        if ["swift"].contains(normalized) {
             return highlightedWords(code, keywords: swiftKeywords)
+        }
+        if ["js", "javascript", "ts", "typescript"].contains(normalized) {
+            return highlightedWords(code, keywords: jsKeywords)
+        }
+        if ["py", "python"].contains(normalized) {
+            return highlightedWords(code, keywords: pythonKeywords)
         }
         if ["diff", "patch"].contains(normalized) {
             return highlightedDiff(code)
@@ -217,21 +239,37 @@ enum DesktopChatMarkdownCodeSyntaxHighlighter {
         _ code: String,
         keywords: Set<String>
     ) -> AttributedString {
-        build(code) { token in
-            if token.hasPrefix("//") || token.hasPrefix("#") {
-                return .secondary
+        var result = AttributedString()
+        let lines = code.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        for (index, lineText) in lines.enumerated() {
+            let trimmed = lineText.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("//") || trimmed.hasPrefix("#") {
+                var segment = AttributedString(lineText)
+                segment.foregroundColor = .secondary
+                result += segment
+            } else {
+                result += build(lineText) { token in
+                    // Colour trailing comment delimiters (e.g. `let x = 1 // note`).
+                    if token.hasPrefix("//") || token.hasPrefix("#") {
+                        return .secondary
+                    }
+                    if token.hasPrefix("\"") || token.hasPrefix("'") {
+                        return .teal
+                    }
+                    if keywords.contains(token) {
+                        return .purple
+                    }
+                    if token.first?.isNumber == true {
+                        return .orange
+                    }
+                    return nil
+                }
             }
-            if token.hasPrefix("\"") || token.hasPrefix("'") {
-                return .teal
+            if index < lines.count - 1 {
+                result += AttributedString("\n")
             }
-            if keywords.contains(token) {
-                return .purple
-            }
-            if token.first?.isNumber == true {
-                return .orange
-            }
-            return nil
         }
+        return result
     }
 
     private static func highlightedDiff(_ code: String) -> AttributedString {
@@ -372,6 +410,7 @@ private struct DesktopChatMarkdownSourceChunk: Equatable, Sendable {
     let isStable: Bool
 }
 
+#if DEBUG
 struct DesktopChatMarkdownPerformanceReport: Equatable, Sendable {
     let samples: [DesktopChatMarkdownPerformanceSample]
 }
@@ -445,6 +484,7 @@ enum DesktopChatMarkdownPerformanceProbe {
         return text
     }
 }
+#endif
 
 private enum DesktopChatMarkdownChunker {
     static func chunks(
@@ -829,6 +869,7 @@ private struct DesktopChatMarkdownBlockVisitor: MarkupVisitor {
 
     private mutating func listItem(from item: ListItem) -> DesktopChatMarkdownListItem {
         let childBlocks = item.children.flatMap { visit($0) }
+        // Leading paragraph becomes the marker label; all other children are kept as nested blocks.
         guard case .paragraph(let text) = childBlocks.first else {
             return DesktopChatMarkdownListItem(text: "", children: childBlocks)
         }
@@ -1041,9 +1082,13 @@ private extension DesktopChatMarkdownTableAlignment {
 
 struct DesktopChatMarkdownBodyView: View {
     let rawText: String
+    var isStreaming: Bool = false
 
     private var renderPlan: DesktopChatMarkdownRenderPlan {
-        DesktopChatMarkdownRenderer.renderPlan(from: rawText, mode: .streaming)
+        DesktopChatMarkdownRenderer.renderPlan(
+            from: rawText,
+            mode: isStreaming ? .streaming : .complete
+        )
     }
 
     var body: some View {

--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Markdown
+import AppKit
 import SwiftUI
 import MelixControlPlaneCore
 
@@ -7,15 +8,24 @@ enum DesktopChatMarkdownLayoutMetrics {
     static let blockSpacing: CGFloat = MelixDesignTokens.Spacing.sm
     static let listRowSpacing: CGFloat = 4
     static let codeBlockPadding: CGFloat = MelixDesignTokens.Spacing.md
+    static let codeBlockHeaderSpacing: CGFloat = MelixDesignTokens.Spacing.sm
     static let codeBlockLineSpacing: CGFloat = 3
     static let codeBlockBackgroundOpacity: Double = 0.03
     static let codeBlockBorderOpacity: Double = 0.05
+    static let codeBlockBadgeBackgroundOpacity: Double = 0.055
     static let tableSurfaceBackgroundOpacity: Double = 0.018
     static let tableHeaderBackgroundOpacity: Double = 0.035
     static let tableRowSeparatorOpacity: Double = 0.04
     static let tableColumnSeparatorOpacity: Double = 0.035
     static let tableCellHorizontalPadding: CGFloat = MelixDesignTokens.Spacing.sm
     static let tableCellVerticalPadding: CGFloat = 6
+    static let tableColumnMinWidth: CGFloat = 88
+    static let tableColumnMaxWidth: CGFloat = 260
+    static let tableCellMaximumLineCount: Int = 4
+    static let tableCellTruncationCharacterCount: Int = 96
+    static let lazyRenderBlockThreshold: Int = 96
+    static let lazyRenderCharacterThreshold: Int = 24_000
+    static let renderChunkTargetCharacterCount: Int = 2_000
 }
 
 enum DesktopChatMarkdownTableAlignment: Equatable, Sendable {
@@ -51,8 +61,76 @@ struct DesktopChatMarkdownCacheStats: Equatable, Sendable {
     let parseMissCount: Int
     let inlineHitCount: Int
     let inlineMissCount: Int
+    let chunkHitCount: Int
+    let chunkMissCount: Int
+    let stableChunkReuseCount: Int
     let evictionCount: Int
     let latestParseDurationMS: Double
+}
+
+enum DesktopChatMarkdownRenderPlanMode: Equatable, Sendable {
+    case complete
+    case streaming
+}
+
+struct DesktopChatMarkdownRenderChunk: Equatable, Sendable {
+    let source: String
+    let blocks: [DesktopChatMarkdownBlock]
+    let isStable: Bool
+}
+
+struct DesktopChatMarkdownRenderPlan: Equatable, Sendable {
+    let chunks: [DesktopChatMarkdownRenderChunk]
+    let usesLazyRendering: Bool
+
+    var blocks: [DesktopChatMarkdownBlock] {
+        chunks.flatMap(\.blocks)
+    }
+}
+
+struct DesktopChatMarkdownCodeBlockPresentation: Equatable, Sendable {
+    let languageBadge: String
+    let copyAccessibilityLabel: String
+    let highlightedCode: AttributedString
+
+    init(language: String, code: String) {
+        self.languageBadge = DesktopChatMarkdownCodeLanguage.badge(for: language)
+        self.copyAccessibilityLabel = "Copy code"
+        self.highlightedCode = DesktopChatMarkdownCodeSyntaxHighlighter.attributedString(
+            code: code,
+            language: language
+        )
+    }
+}
+
+enum DesktopChatMarkdownCodeBlockClipboard {
+    static func copy(_ code: String, to pasteboard: NSPasteboard = .general) {
+        pasteboard.clearContents()
+        pasteboard.setString(code, forType: .string)
+    }
+}
+
+struct DesktopChatMarkdownTableLayout: Equatable, Sendable {
+    let columnWidths: [CGFloat]
+
+    init(header: [String], rows: [[String]]) {
+        let columnCount = max(header.count, rows.map(\.count).max() ?? 0, 1)
+        self.columnWidths = (0..<columnCount).map { column in
+            let cells = [header[safe: column] ?? ""] + rows.map { $0[safe: column] ?? "" }
+            let longest = cells.map(\.count).max() ?? 0
+            let rawWidth = CGFloat(longest * 7) + (DesktopChatMarkdownLayoutMetrics.tableCellHorizontalPadding * 2)
+            return min(
+                max(rawWidth, DesktopChatMarkdownLayoutMetrics.tableColumnMinWidth),
+                DesktopChatMarkdownLayoutMetrics.tableColumnMaxWidth
+            )
+        }
+    }
+
+    func lineLimit(for text: String) -> Int? {
+        text.count > DesktopChatMarkdownLayoutMetrics.tableCellTruncationCharacterCount
+            ? DesktopChatMarkdownLayoutMetrics.tableCellMaximumLineCount
+            : nil
+    }
 }
 
 enum DesktopChatMarkdownInlineFormatter {
@@ -62,6 +140,159 @@ enum DesktopChatMarkdownInlineFormatter {
 
     static func attributedString(fromSanitized text: String) -> AttributedString {
         DesktopChatMarkdownRenderer.cachedInlineAttributedString(fromSanitized: text)
+    }
+}
+
+enum DesktopChatMarkdownCodeLanguage {
+    static func badge(for language: String) -> String {
+        let normalized = language
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        switch normalized {
+        case "swift":
+            return "Swift"
+        case "json":
+            return "JSON"
+        case "js", "javascript":
+            return "JavaScript"
+        case "ts", "typescript":
+            return "TypeScript"
+        case "sh", "shell", "bash", "zsh":
+            return "Shell"
+        case "py", "python":
+            return "Python"
+        case "diff", "patch":
+            return "Diff"
+        case "":
+            return "Plain Text"
+        default:
+            return normalized.uppercased()
+        }
+    }
+}
+
+enum DesktopChatMarkdownCodeSyntaxHighlighter {
+    private static let swiftKeywords: Set<String> = [
+        "actor", "as", "async", "await", "case", "catch", "class", "else",
+        "enum", "false", "for", "func", "guard", "if", "import", "in",
+        "let", "nil", "private", "public", "return", "static", "struct",
+        "switch", "throw", "throws", "true", "try", "var", "while",
+    ]
+
+    private static let shellKeywords: Set<String> = [
+        "awk", "bun", "cd", "curl", "echo", "export", "git", "grep",
+        "make", "mkdir", "rg", "sed", "swift", "xcrun",
+    ]
+
+    static func attributedString(code: String, language: String) -> AttributedString {
+        let normalized = language.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if normalized == "json" {
+            return highlightedJSON(code)
+        }
+        if ["sh", "shell", "bash", "zsh"].contains(normalized) {
+            return highlightedWords(code, keywords: shellKeywords)
+        }
+        if ["swift", "js", "javascript", "ts", "typescript", "py", "python"].contains(normalized) {
+            return highlightedWords(code, keywords: swiftKeywords)
+        }
+        if ["diff", "patch"].contains(normalized) {
+            return highlightedDiff(code)
+        }
+        return AttributedString(code)
+    }
+
+    private static func highlightedJSON(_ code: String) -> AttributedString {
+        build(code) { token in
+            if token.hasPrefix("\"") {
+                return .teal
+            }
+            if ["true", "false", "null"].contains(token) || token.first?.isNumber == true {
+                return .purple
+            }
+            return nil
+        }
+    }
+
+    private static func highlightedWords(
+        _ code: String,
+        keywords: Set<String>
+    ) -> AttributedString {
+        build(code) { token in
+            if token.hasPrefix("//") || token.hasPrefix("#") {
+                return .secondary
+            }
+            if token.hasPrefix("\"") || token.hasPrefix("'") {
+                return .teal
+            }
+            if keywords.contains(token) {
+                return .purple
+            }
+            if token.first?.isNumber == true {
+                return .orange
+            }
+            return nil
+        }
+    }
+
+    private static func highlightedDiff(_ code: String) -> AttributedString {
+        var result = AttributedString()
+        let lines = code.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        for (index, lineText) in lines.enumerated() {
+            var segment = AttributedString(lineText)
+            if lineText.hasPrefix("+") {
+                segment.foregroundColor = .green
+            } else if lineText.hasPrefix("-") {
+                segment.foregroundColor = .red
+            } else if lineText.hasPrefix("@@") {
+                segment.foregroundColor = .purple
+            }
+            result += segment
+            if index < lines.count - 1 {
+                result += AttributedString("\n")
+            }
+        }
+        return result
+    }
+
+    private static func build(
+        _ code: String,
+        colorForToken: (String) -> Color?
+    ) -> AttributedString {
+        var result = AttributedString()
+        var current = ""
+        var currentIsToken: Bool?
+
+        func appendCurrent() {
+            guard current.isEmpty == false else {
+                return
+            }
+            var segment = AttributedString(current)
+            if currentIsToken == true, let color = colorForToken(current) {
+                segment.foregroundColor = color
+            }
+            result += segment
+            current = ""
+        }
+
+        for scalar in code.unicodeScalars {
+            let character = Character(scalar)
+            let isToken = CharacterSet.alphanumerics.contains(scalar)
+                || scalar == "_"
+                || scalar == "\""
+                || scalar == "'"
+                || scalar == "/"
+                || scalar == "#"
+            if currentIsToken == nil {
+                currentIsToken = isToken
+            } else if currentIsToken != isToken {
+                appendCurrent()
+                currentIsToken = isToken
+            }
+            current.append(character)
+        }
+        appendCurrent()
+
+        return result
     }
 }
 
@@ -82,6 +313,36 @@ enum DesktopChatMarkdownRenderer {
         return cache.blocks(for: sanitized) {
             parseBlocks(fromSanitized: sanitized)
         }
+    }
+
+    static func renderPlan(
+        from rawText: String,
+        mode: DesktopChatMarkdownRenderPlanMode = .complete
+    ) -> DesktopChatMarkdownRenderPlan {
+        let sanitized = RichOutputSanitizer.sanitized(rawText)
+        let sourceChunks = DesktopChatMarkdownChunker.chunks(from: sanitized, mode: mode)
+        let renderChunks = sourceChunks.map { sourceChunk in
+            let blocks = cache.chunkBlocks(
+                for: sourceChunk.source,
+                isStable: sourceChunk.isStable
+            ) {
+                parseBlocks(fromSanitized: sourceChunk.source)
+            }
+            return DesktopChatMarkdownRenderChunk(
+                source: sourceChunk.source,
+                blocks: blocks,
+                isStable: sourceChunk.isStable
+            )
+        }
+        let blockCount = renderChunks.reduce(0) { count, chunk in
+            count + chunk.blocks.count
+        }
+        return DesktopChatMarkdownRenderPlan(
+            chunks: renderChunks,
+            usesLazyRendering: renderChunks.count > 1
+                || blockCount >= DesktopChatMarkdownLayoutMetrics.lazyRenderBlockThreshold
+                || sanitized.count >= DesktopChatMarkdownLayoutMetrics.lazyRenderCharacterThreshold
+        )
     }
 
     static func cachedInlineAttributedString(fromSanitized text: String) -> AttributedString {
@@ -106,17 +367,155 @@ enum DesktopChatMarkdownRenderer {
     }
 }
 
+private struct DesktopChatMarkdownSourceChunk: Equatable, Sendable {
+    let source: String
+    let isStable: Bool
+}
+
+struct DesktopChatMarkdownPerformanceReport: Equatable, Sendable {
+    let samples: [DesktopChatMarkdownPerformanceSample]
+}
+
+struct DesktopChatMarkdownPerformanceSample: Equatable, Sendable {
+    let targetByteCount: Int
+    let blockCount: Int
+    let chunkCount: Int
+    let firstParseDurationMS: Double
+    let cachedParseDurationMS: Double
+    let cacheHitDelta: Int
+    let cacheMissDelta: Int
+    let evictionDelta: Int
+}
+
+enum DesktopChatMarkdownPerformanceProbe {
+    static func measure(sampleSizes: [Int]) -> DesktopChatMarkdownPerformanceReport {
+        let samples = sampleSizes.map { targetSize in
+            let source = makeSampleMarkdown(targetByteCount: targetSize)
+            let before = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+
+            let firstStartedAt = Date()
+            let firstPlan = DesktopChatMarkdownRenderer.renderPlan(from: source, mode: .complete)
+            let firstDuration = Date().timeIntervalSince(firstStartedAt) * 1000
+            let afterFirst = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+
+            let cachedStartedAt = Date()
+            _ = DesktopChatMarkdownRenderer.renderPlan(from: source, mode: .complete)
+            let cachedDuration = Date().timeIntervalSince(cachedStartedAt) * 1000
+            let afterCached = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+
+            return DesktopChatMarkdownPerformanceSample(
+                targetByteCount: targetSize,
+                blockCount: firstPlan.blocks.count,
+                chunkCount: firstPlan.chunks.count,
+                firstParseDurationMS: max(0, firstDuration),
+                cachedParseDurationMS: max(0, cachedDuration),
+                cacheHitDelta: afterCached.chunkHitCount - afterFirst.chunkHitCount,
+                cacheMissDelta: afterFirst.chunkMissCount - before.chunkMissCount,
+                evictionDelta: afterCached.evictionCount - before.evictionCount
+            )
+        }
+        return DesktopChatMarkdownPerformanceReport(samples: samples)
+    }
+
+    private static func makeSampleMarkdown(targetByteCount: Int) -> String {
+        let section = """
+        ## Benchmark Section
+
+        A paragraph with **strong text**, _emphasis_, `inline code`, and a readable [label](https://example.com).
+
+        - Alpha item
+          - Nested beta item
+        - Gamma item
+
+        ```swift
+        let value = 42
+        print(value)
+        ```
+
+        | Metric | Value | Note |
+        | :--- | ---: | :---: |
+        | TTFT | 12 ms | cached |
+        | TPS | 41 | steady |
+
+        """
+        var text = ""
+        while text.utf8.count < targetByteCount {
+            text += section
+        }
+        return text
+    }
+}
+
+private enum DesktopChatMarkdownChunker {
+    static func chunks(
+        from sanitized: String,
+        mode: DesktopChatMarkdownRenderPlanMode
+    ) -> [DesktopChatMarkdownSourceChunk] {
+        guard sanitized.count > DesktopChatMarkdownLayoutMetrics.renderChunkTargetCharacterCount else {
+            return [
+                DesktopChatMarkdownSourceChunk(source: sanitized, isStable: mode == .complete),
+            ]
+        }
+
+        var chunks: [DesktopChatMarkdownSourceChunk] = []
+        var current = ""
+        var insideFence = false
+        let lines = sanitized.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+
+        for (index, line) in lines.enumerated() {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
+                insideFence.toggle()
+            }
+
+            if current.isEmpty == false {
+                current += "\n"
+            }
+            current += line
+
+            let isLastLine = index == lines.count - 1
+            if insideFence == false,
+               current.count >= DesktopChatMarkdownLayoutMetrics.renderChunkTargetCharacterCount,
+               trimmed.isEmpty,
+               isLastLine == false {
+                chunks.append(DesktopChatMarkdownSourceChunk(source: current, isStable: true))
+                current = ""
+            }
+        }
+
+        if current.isEmpty == false || chunks.isEmpty {
+            chunks.append(
+                DesktopChatMarkdownSourceChunk(
+                    source: current,
+                    isStable: mode == .complete
+                )
+            )
+        }
+
+        if mode == .streaming, let last = chunks.indices.last {
+            chunks[last] = DesktopChatMarkdownSourceChunk(source: chunks[last].source, isStable: false)
+        }
+
+        return chunks
+    }
+}
+
 private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
     private let lock = NSLock()
     private var capacity: Int
     private var parsedBlocks: [String: [DesktopChatMarkdownBlock]]
     private var parsedBlockOrder: [String]
+    private var parsedChunkBlocks: [String: [DesktopChatMarkdownBlock]]
+    private var parsedChunkBlockOrder: [String]
     private var inlineAttributedStrings: [String: AttributedString]
     private var inlineAttributedStringOrder: [String]
     private var parseHitCount: Int
     private var parseMissCount: Int
     private var inlineHitCount: Int
     private var inlineMissCount: Int
+    private var chunkHitCount: Int
+    private var chunkMissCount: Int
+    private var stableChunkReuseCount: Int
     private var evictionCount: Int
     private var latestParseDurationMS: Double
 
@@ -124,12 +523,17 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
         self.capacity = max(1, capacity)
         self.parsedBlocks = [:]
         self.parsedBlockOrder = []
+        self.parsedChunkBlocks = [:]
+        self.parsedChunkBlockOrder = []
         self.inlineAttributedStrings = [:]
         self.inlineAttributedStringOrder = []
         self.parseHitCount = 0
         self.parseMissCount = 0
         self.inlineHitCount = 0
         self.inlineMissCount = 0
+        self.chunkHitCount = 0
+        self.chunkMissCount = 0
+        self.stableChunkReuseCount = 0
         self.evictionCount = 0
         self.latestParseDurationMS = 0
     }
@@ -157,6 +561,40 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
         parsedBlocks[key] = rendered
         touch(key, in: &parsedBlockOrder)
         evictIfNeeded()
+        lock.unlock()
+
+        return rendered
+    }
+
+    func chunkBlocks(
+        for key: String,
+        isStable: Bool,
+        build: () -> [DesktopChatMarkdownBlock]
+    ) -> [DesktopChatMarkdownBlock] {
+        if isStable {
+            lock.lock()
+            if let cached = parsedChunkBlocks[key] {
+                chunkHitCount += 1
+                stableChunkReuseCount += 1
+                touch(key, in: &parsedChunkBlockOrder)
+                lock.unlock()
+                return cached
+            }
+            lock.unlock()
+        }
+
+        let startedAt = Date()
+        let rendered = build()
+        let duration = max(0, Date().timeIntervalSince(startedAt) * 1000)
+
+        lock.lock()
+        chunkMissCount += 1
+        latestParseDurationMS = duration
+        if isStable {
+            parsedChunkBlocks[key] = rendered
+            touch(key, in: &parsedChunkBlockOrder)
+            evictIfNeeded()
+        }
         lock.unlock()
 
         return rendered
@@ -192,12 +630,17 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
         self.capacity = max(1, capacity)
         parsedBlocks.removeAll()
         parsedBlockOrder.removeAll()
+        parsedChunkBlocks.removeAll()
+        parsedChunkBlockOrder.removeAll()
         inlineAttributedStrings.removeAll()
         inlineAttributedStringOrder.removeAll()
         parseHitCount = 0
         parseMissCount = 0
         inlineHitCount = 0
         inlineMissCount = 0
+        chunkHitCount = 0
+        chunkMissCount = 0
+        stableChunkReuseCount = 0
         evictionCount = 0
         latestParseDurationMS = 0
         lock.unlock()
@@ -210,6 +653,9 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
             parseMissCount: parseMissCount,
             inlineHitCount: inlineHitCount,
             inlineMissCount: inlineMissCount,
+            chunkHitCount: chunkHitCount,
+            chunkMissCount: chunkMissCount,
+            stableChunkReuseCount: stableChunkReuseCount,
             evictionCount: evictionCount,
             latestParseDurationMS: latestParseDurationMS
         )
@@ -226,6 +672,12 @@ private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
         while parsedBlockOrder.count > capacity, let key = parsedBlockOrder.first {
             parsedBlockOrder.removeFirst()
             parsedBlocks.removeValue(forKey: key)
+            evictionCount += 1
+        }
+
+        while parsedChunkBlockOrder.count > capacity, let key = parsedChunkBlockOrder.first {
+            parsedChunkBlockOrder.removeFirst()
+            parsedChunkBlocks.removeValue(forKey: key)
             evictionCount += 1
         }
 
@@ -534,14 +986,30 @@ private extension DesktopChatMarkdownTableAlignment {
 struct DesktopChatMarkdownBodyView: View {
     let rawText: String
 
-    private var blocks: [DesktopChatMarkdownBlock] {
-        DesktopChatMarkdownRenderer.blocks(from: rawText)
+    private var renderPlan: DesktopChatMarkdownRenderPlan {
+        DesktopChatMarkdownRenderer.renderPlan(from: rawText, mode: .streaming)
     }
 
     var body: some View {
-        DesktopChatMarkdownBlocksView(blocks: blocks)
+        DesktopChatMarkdownRenderPlanView(plan: renderPlan)
             .frame(maxWidth: .infinity, alignment: .leading)
             .textSelection(.enabled)
+    }
+}
+
+private struct DesktopChatMarkdownRenderPlanView: View {
+    let plan: DesktopChatMarkdownRenderPlan
+
+    var body: some View {
+        if plan.usesLazyRendering {
+            LazyVStack(alignment: .leading, spacing: DesktopChatMarkdownLayoutMetrics.blockSpacing) {
+                ForEach(Array(plan.chunks.enumerated()), id: \.offset) { _, chunk in
+                    DesktopChatMarkdownBlocksView(blocks: chunk.blocks)
+                }
+            }
+        } else {
+            DesktopChatMarkdownBlocksView(blocks: plan.blocks)
+        }
     }
 }
 
@@ -587,18 +1055,25 @@ private struct DesktopChatMarkdownBlocksView: View {
     private func headingView(level: Int, text: String) -> some View {
         SwiftUI.Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: text))
             .font(headingFont(level: level))
-            .lineSpacing(2)
-            .padding(.top, level == 1 ? MelixDesignTokens.Spacing.xs : 0)
+            .foregroundStyle(level == 1 ? .primary : .secondary)
+            .lineSpacing(3)
+            .padding(.top, headingTopPadding(level: level))
+            .padding(.bottom, level == 1 ? 1 : 0)
     }
 
     private func blockQuoteView(_ children: [DesktopChatMarkdownBlock]) -> some View {
         HStack(alignment: .top, spacing: MelixDesignTokens.Spacing.sm) {
             Rectangle()
-                .fill(Color.secondary.opacity(0.28))
+                .fill(Color.accentColor.opacity(0.35))
                 .frame(width: 3)
             DesktopChatMarkdownBlocksView(blocks: children)
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, MelixDesignTokens.Spacing.xs)
+        .padding(.horizontal, MelixDesignTokens.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.sm)
+                .fill(Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.tableSurfaceBackgroundOpacity))
+        )
     }
 
     private func unorderedListView(_ items: [DesktopChatMarkdownListItem]) -> some View {
@@ -624,11 +1099,11 @@ private struct DesktopChatMarkdownBlocksView: View {
         marker: String,
         item: DesktopChatMarkdownListItem
     ) -> some View {
-        HStack(alignment: .top, spacing: 8) {
+        HStack(alignment: .top, spacing: MelixDesignTokens.Spacing.sm) {
             SwiftUI.Text(marker)
                 .font(.body.monospacedDigit())
                 .foregroundStyle(.secondary)
-                .frame(minWidth: 18, alignment: .trailing)
+                .frame(minWidth: 22, alignment: .trailing)
             VStack(alignment: .leading, spacing: DesktopChatMarkdownLayoutMetrics.listRowSpacing) {
                 if item.text.isEmpty == false {
                     SwiftUI.Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: item.text))
@@ -638,22 +1113,43 @@ private struct DesktopChatMarkdownBlocksView: View {
                 if item.children.isEmpty == false {
                     DesktopChatMarkdownBlocksView(blocks: item.children)
                         .padding(.top, 1)
+                        .padding(.leading, MelixDesignTokens.Spacing.xs)
                 }
             }
         }
     }
 
     private func codeBlockView(language: String, code: String) -> some View {
-        VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
-            if language.isEmpty == false {
-                SwiftUI.Text(language)
-                    .font(.caption2.monospaced())
+        let presentation = DesktopChatMarkdownCodeBlockPresentation(language: language, code: code)
+        return VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
+            HStack(spacing: DesktopChatMarkdownLayoutMetrics.codeBlockHeaderSpacing) {
+                SwiftUI.Text(presentation.languageBadge)
+                    .font(.caption2.monospaced().weight(.semibold))
                     .foregroundStyle(.secondary)
+                    .padding(.horizontal, MelixDesignTokens.Spacing.xs)
+                    .padding(.vertical, 3)
+                    .background(
+                        Capsule()
+                            .fill(Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.codeBlockBadgeBackgroundOpacity))
+                    )
+                Spacer(minLength: MelixDesignTokens.Spacing.sm)
+                Button {
+                    DesktopChatMarkdownCodeBlockClipboard.copy(code)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                        .imageScale(.small)
+                }
+                .buttonStyle(.borderless)
+                .help(presentation.copyAccessibilityLabel)
+                .accessibilityLabel(presentation.copyAccessibilityLabel)
             }
-            SwiftUI.Text(code.isEmpty ? " " : code)
-                .font(.caption.monospaced())
-                .lineSpacing(DesktopChatMarkdownLayoutMetrics.codeBlockLineSpacing)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            ScrollView(.horizontal, showsIndicators: true) {
+                SwiftUI.Text(code.isEmpty ? AttributedString(" ") : presentation.highlightedCode)
+                    .font(.caption.monospaced())
+                    .lineSpacing(DesktopChatMarkdownLayoutMetrics.codeBlockLineSpacing)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
         .padding(DesktopChatMarkdownLayoutMetrics.codeBlockPadding)
         .background(
@@ -676,48 +1172,58 @@ private struct DesktopChatMarkdownBlocksView: View {
     ) -> some View {
         let columnCount = max(header.count, rows.map(\.count).max() ?? 0, 1)
         let normalizedAlignments = DesktopChatMarkdownTableAlignment.normalized(alignments, count: columnCount)
-        return Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
-            GridRow {
-                ForEach(0..<columnCount, id: \.self) { column in
-                    tableCellView(
-                        text: header[safe: column] ?? "",
-                        alignment: normalizedAlignments[column],
-                        isHeader: true,
-                        showsTrailingSeparator: column < columnCount - 1,
-                        showsBottomSeparator: true
-                    )
-                }
-            }
-            ForEach(rows.indices, id: \.self) { rowIndex in
+        let layout = DesktopChatMarkdownTableLayout(header: header, rows: rows)
+        return ScrollView(.horizontal, showsIndicators: true) {
+            Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
                 GridRow {
-                    let row = normalizedTableRow(rows[rowIndex], columnCount: columnCount)
                     ForEach(0..<columnCount, id: \.self) { column in
                         tableCellView(
-                            text: row[column],
+                            text: header[safe: column] ?? "",
+                            width: layout.columnWidths[column],
+                            lineLimit: layout.lineLimit(for: header[safe: column] ?? ""),
                             alignment: normalizedAlignments[column],
-                            isHeader: false,
+                            isHeader: true,
                             showsTrailingSeparator: column < columnCount - 1,
-                            showsBottomSeparator: rowIndex < rows.count - 1
+                            showsBottomSeparator: true
                         )
                     }
                 }
+                ForEach(rows.indices, id: \.self) { rowIndex in
+                    GridRow {
+                        let row = normalizedTableRow(rows[rowIndex], columnCount: columnCount)
+                        ForEach(0..<columnCount, id: \.self) { column in
+                            tableCellView(
+                                text: row[column],
+                                width: layout.columnWidths[column],
+                                lineLimit: layout.lineLimit(for: row[column]),
+                                alignment: normalizedAlignments[column],
+                                isHeader: false,
+                                showsTrailingSeparator: column < columnCount - 1,
+                                showsBottomSeparator: rowIndex < rows.count - 1
+                            )
+                        }
+                    }
+                }
             }
+            .fixedSize(horizontal: true, vertical: false)
+            .background(
+                RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.sm)
+                    .fill(Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.tableSurfaceBackgroundOpacity))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.sm)
+                    .stroke(
+                        Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.codeBlockBorderOpacity),
+                        lineWidth: 1
+                    )
+            )
         }
-        .background(
-            RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.sm)
-                .fill(Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.tableSurfaceBackgroundOpacity))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.sm)
-                .stroke(
-                    Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.codeBlockBorderOpacity),
-                    lineWidth: 1
-                )
-        )
     }
 
     private func tableCellView(
         text: String,
+        width: CGFloat,
+        lineLimit: Int?,
         alignment: DesktopChatMarkdownTableAlignment,
         isHeader: Bool,
         showsTrailingSeparator: Bool,
@@ -731,9 +1237,11 @@ private struct DesktopChatMarkdownBlocksView: View {
             SwiftUI.Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: text))
                 .font(isHeader ? .caption.weight(.semibold) : .caption)
                 .multilineTextAlignment(alignment.textAlignment)
+                .lineLimit(lineLimit)
+                .truncationMode(.tail)
                 .padding(.horizontal, DesktopChatMarkdownLayoutMetrics.tableCellHorizontalPadding)
                 .padding(.vertical, DesktopChatMarkdownLayoutMetrics.tableCellVerticalPadding)
-                .frame(maxWidth: .infinity, alignment: alignment.frameAlignment)
+                .frame(width: width, alignment: alignment.frameAlignment)
         }
         .overlay(alignment: .bottom) {
             if showsBottomSeparator {
@@ -761,11 +1269,22 @@ private struct DesktopChatMarkdownBlocksView: View {
     private func headingFont(level: Int) -> Font {
         switch level {
         case 1:
-            return .headline
+            return .title3.weight(.semibold)
         case 2:
-            return .subheadline.weight(.semibold)
+            return .headline
         default:
-            return .caption.weight(.semibold)
+            return .subheadline.weight(.semibold)
+        }
+    }
+
+    private func headingTopPadding(level: Int) -> CGFloat {
+        switch level {
+        case 1:
+            return MelixDesignTokens.Spacing.sm
+        case 2:
+            return MelixDesignTokens.Spacing.xs
+        default:
+            return 0
         }
     }
 

--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift
@@ -88,6 +88,22 @@ struct DesktopChatMarkdownRenderPlan: Equatable, Sendable {
     }
 }
 
+struct DesktopChatMarkdownIdentifiedRenderChunk: Identifiable, Equatable, Sendable {
+    let id: String
+    let chunk: DesktopChatMarkdownRenderChunk
+}
+
+struct DesktopChatMarkdownIdentifiedBlock: Identifiable, Equatable, Sendable {
+    let id: String
+    let block: DesktopChatMarkdownBlock
+}
+
+struct DesktopChatMarkdownIdentifiedListItem: Identifiable, Equatable, Sendable {
+    let id: String
+    let offset: Int
+    let item: DesktopChatMarkdownListItem
+}
+
 struct DesktopChatMarkdownCodeBlockPresentation: Equatable, Sendable {
     let languageBadge: String
     let copyAccessibilityLabel: String
@@ -167,6 +183,117 @@ enum DesktopChatMarkdownCodeLanguage {
             return "Plain Text"
         default:
             return normalized.uppercased()
+        }
+    }
+}
+
+enum DesktopChatMarkdownStableIdentity {
+    static func identifiedChunks(_ chunks: [DesktopChatMarkdownRenderChunk]) -> [DesktopChatMarkdownIdentifiedRenderChunk] {
+        uniqued(chunks, baseID: { $0.stableIdentityComponent }).map { entry in
+            DesktopChatMarkdownIdentifiedRenderChunk(id: entry.id, chunk: entry.value)
+        }
+    }
+
+    static func identifiedBlocks(_ blocks: [DesktopChatMarkdownBlock]) -> [DesktopChatMarkdownIdentifiedBlock] {
+        uniqued(blocks, baseID: { $0.stableIdentityComponent }).map { entry in
+            DesktopChatMarkdownIdentifiedBlock(id: entry.id, block: entry.value)
+        }
+    }
+
+    static func identifiedListItems(_ items: [DesktopChatMarkdownListItem]) -> [DesktopChatMarkdownIdentifiedListItem] {
+        uniqued(items, baseID: { $0.stableIdentityComponent }).map { entry in
+            DesktopChatMarkdownIdentifiedListItem(id: entry.id, offset: entry.offset, item: entry.value)
+        }
+    }
+
+    private static func uniqued<Value>(
+        _ values: [Value],
+        baseID: (Value) -> String
+    ) -> [(id: String, offset: Int, value: Value)] {
+        var occurrences: [String: Int] = [:]
+        return values.enumerated().map { offset, value in
+            let base = baseID(value)
+            let occurrence = occurrences[base, default: 0]
+            occurrences[base] = occurrence + 1
+            return (id: "\(base)#\(occurrence)", offset: offset, value: value)
+        }
+    }
+
+    fileprivate static func hash(_ components: [String]) -> String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for component in components {
+            for byte in component.utf8 {
+                hash ^= UInt64(byte)
+                hash &*= 1_099_511_628_211
+            }
+            hash ^= 0xff
+            hash &*= 1_099_511_628_211
+        }
+        return String(hash, radix: 16)
+    }
+}
+
+private extension DesktopChatMarkdownRenderChunk {
+    var stableIdentityComponent: String {
+        DesktopChatMarkdownStableIdentity.hash(
+            ["chunk", source, "\(isStable)"] + blocks.map(\.stableIdentityComponent)
+        )
+    }
+}
+
+private extension DesktopChatMarkdownBlock {
+    var stableIdentityComponent: String {
+        switch self {
+        case .paragraph(let text):
+            return DesktopChatMarkdownStableIdentity.hash(["paragraph", text])
+        case .heading(let level, let text):
+            return DesktopChatMarkdownStableIdentity.hash(["heading", "\(level)", text])
+        case .blockQuote(let children):
+            return DesktopChatMarkdownStableIdentity.hash(
+                ["quote"] + children.map(\.stableIdentityComponent)
+            )
+        case .unorderedList(let items):
+            return DesktopChatMarkdownStableIdentity.hash(
+                ["unordered"] + items.map(\.stableIdentityComponent)
+            )
+        case .orderedList(let start, let items):
+            return DesktopChatMarkdownStableIdentity.hash(
+                ["ordered", "\(start)"] + items.map(\.stableIdentityComponent)
+            )
+        case .codeBlock(let language, let code):
+            return DesktopChatMarkdownStableIdentity.hash(["code", language, code])
+        case .table(let header, let alignments, let rows):
+            return DesktopChatMarkdownStableIdentity.hash(
+                ["table"]
+                    + header
+                    + alignments.map(\.stableIdentityComponent)
+                    + rows.flatMap { ["row"] + $0 }
+            )
+        case .thematicBreak:
+            return DesktopChatMarkdownStableIdentity.hash(["thematicBreak"])
+        }
+    }
+}
+
+private extension DesktopChatMarkdownListItem {
+    var stableIdentityComponent: String {
+        DesktopChatMarkdownStableIdentity.hash(
+            ["listItem", text] + children.map(\.stableIdentityComponent)
+        )
+    }
+}
+
+private extension DesktopChatMarkdownTableAlignment {
+    var stableIdentityComponent: String {
+        switch self {
+        case .none:
+            return "none"
+        case .leading:
+            return "leading"
+        case .center:
+            return "center"
+        case .trailing:
+            return "trailing"
         }
     }
 }
@@ -1104,8 +1231,8 @@ private struct DesktopChatMarkdownRenderPlanView: View {
     var body: some View {
         if plan.usesLazyRendering {
             LazyVStack(alignment: .leading, spacing: DesktopChatMarkdownLayoutMetrics.blockSpacing) {
-                ForEach(Array(plan.chunks.enumerated()), id: \.offset) { _, chunk in
-                    DesktopChatMarkdownBlocksView(blocks: chunk.blocks)
+                ForEach(DesktopChatMarkdownStableIdentity.identifiedChunks(plan.chunks)) { item in
+                    DesktopChatMarkdownBlocksView(blocks: item.chunk.blocks)
                 }
             }
         } else {
@@ -1119,8 +1246,8 @@ private struct DesktopChatMarkdownBlocksView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: DesktopChatMarkdownLayoutMetrics.blockSpacing) {
-            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
-                blockView(block)
+            ForEach(DesktopChatMarkdownStableIdentity.identifiedBlocks(blocks)) { item in
+                blockView(item.block)
             }
         }
     }
@@ -1179,8 +1306,8 @@ private struct DesktopChatMarkdownBlocksView: View {
 
     private func unorderedListView(_ items: [DesktopChatMarkdownListItem]) -> some View {
         VStack(alignment: .leading, spacing: DesktopChatMarkdownLayoutMetrics.listRowSpacing) {
-            ForEach(Array(items.enumerated()), id: \.offset) { _, item in
-                listRow(marker: "•", item: item)
+            ForEach(DesktopChatMarkdownStableIdentity.identifiedListItems(items)) { item in
+                listRow(marker: "•", item: item.item)
             }
         }
     }
@@ -1190,8 +1317,8 @@ private struct DesktopChatMarkdownBlocksView: View {
         items: [DesktopChatMarkdownListItem]
     ) -> some View {
         VStack(alignment: .leading, spacing: DesktopChatMarkdownLayoutMetrics.listRowSpacing) {
-            ForEach(Array(items.enumerated()), id: \.offset) { index, item in
-                listRow(marker: "\(start + index).", item: item)
+            ForEach(DesktopChatMarkdownStableIdentity.identifiedListItems(items)) { item in
+                listRow(marker: "\(start + item.offset).", item: item.item)
             }
         }
     }

--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatMarkdownView.swift
@@ -1,3 +1,5 @@
+import Foundation
+import Markdown
 import SwiftUI
 import MelixControlPlaneCore
 
@@ -16,12 +18,41 @@ enum DesktopChatMarkdownLayoutMetrics {
     static let tableCellVerticalPadding: CGFloat = 6
 }
 
-enum DesktopChatMarkdownBlock: Equatable, Sendable {
+enum DesktopChatMarkdownTableAlignment: Equatable, Sendable {
+    case none
+    case leading
+    case center
+    case trailing
+}
+
+struct DesktopChatMarkdownListItem: Equatable, Sendable {
+    let text: String
+    let children: [DesktopChatMarkdownBlock]
+
+    init(text: String, children: [DesktopChatMarkdownBlock] = []) {
+        self.text = text
+        self.children = children
+    }
+}
+
+indirect enum DesktopChatMarkdownBlock: Equatable, Sendable {
     case paragraph(String)
-    case unorderedList([String])
-    case orderedList([String])
+    case heading(level: Int, text: String)
+    case blockQuote([DesktopChatMarkdownBlock])
+    case unorderedList([DesktopChatMarkdownListItem])
+    case orderedList(start: Int, items: [DesktopChatMarkdownListItem])
     case codeBlock(language: String, code: String)
-    case table(header: [String], rows: [[String]])
+    case table(header: [String], alignments: [DesktopChatMarkdownTableAlignment], rows: [[String]])
+    case thematicBreak
+}
+
+struct DesktopChatMarkdownCacheStats: Equatable, Sendable {
+    let parseHitCount: Int
+    let parseMissCount: Int
+    let inlineHitCount: Int
+    let inlineMissCount: Int
+    let evictionCount: Int
+    let latestParseDurationMS: Double
 }
 
 enum DesktopChatMarkdownInlineFormatter {
@@ -30,21 +61,13 @@ enum DesktopChatMarkdownInlineFormatter {
     }
 
     static func attributedString(fromSanitized text: String) -> AttributedString {
-        let options = AttributedString.MarkdownParsingOptions(
-            interpretedSyntax: .inlineOnlyPreservingWhitespace
-        )
-        if var attributed = try? AttributedString(markdown: text, options: options) {
-            let ranges = attributed.runs.map(\.range)
-            for range in ranges {
-                attributed[range].link = nil
-            }
-            return attributed
-        }
-        return AttributedString(text)
+        DesktopChatMarkdownRenderer.cachedInlineAttributedString(fromSanitized: text)
     }
 }
 
 enum DesktopChatMarkdownRenderer {
+    private static let cache = DesktopChatMarkdownRenderCache()
+
     static func usesMarkdown(for kind: DesktopChatTranscriptEntry.Kind) -> Bool {
         switch kind {
         case .assistant, .reasoning:
@@ -55,205 +78,456 @@ enum DesktopChatMarkdownRenderer {
     }
 
     static func blocks(from rawText: String) -> [DesktopChatMarkdownBlock] {
-        parseBlocks(from: RichOutputSanitizer.sanitized(rawText))
+        let sanitized = RichOutputSanitizer.sanitized(rawText)
+        return cache.blocks(for: sanitized) {
+            parseBlocks(fromSanitized: sanitized)
+        }
     }
 
-    private static func parseBlocks(from text: String) -> [DesktopChatMarkdownBlock] {
-        let lines = text.components(separatedBy: .newlines)
-        var blocks: [DesktopChatMarkdownBlock] = []
-        var index = 0
+    static func cachedInlineAttributedString(fromSanitized text: String) -> AttributedString {
+        cache.inlineAttributedString(for: text) {
+            let renderer = DesktopChatMarkdownInlineAttributedRenderer()
+            return renderer.attributedString(from: Document(parsing: text))
+        }
+    }
 
-        while index < lines.count {
-            if lines[index].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                index += 1
-                continue
-            }
+    static func resetCacheForTesting(capacity: Int = 128) {
+        cache.reset(capacity: capacity)
+    }
 
-            if let codeBlock = parseCodeBlock(lines: lines, index: &index) {
-                blocks.append(codeBlock)
-                continue
-            }
-            if let table = parseTable(lines: lines, index: &index) {
-                blocks.append(table)
-                continue
-            }
-            if let list = parseUnorderedList(lines: lines, index: &index) {
-                blocks.append(list)
-                continue
-            }
-            if let list = parseOrderedList(lines: lines, index: &index) {
-                blocks.append(list)
-                continue
-            }
-            blocks.append(parseParagraph(lines: lines, index: &index))
+    static func cacheStatsForTesting() -> DesktopChatMarkdownCacheStats {
+        cache.stats()
+    }
+
+    private static func parseBlocks(fromSanitized text: String) -> [DesktopChatMarkdownBlock] {
+        let document = Document(parsing: text)
+        var visitor = DesktopChatMarkdownBlockVisitor()
+        return visitor.visit(document)
+    }
+}
+
+private final class DesktopChatMarkdownRenderCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var capacity: Int
+    private var parsedBlocks: [String: [DesktopChatMarkdownBlock]]
+    private var parsedBlockOrder: [String]
+    private var inlineAttributedStrings: [String: AttributedString]
+    private var inlineAttributedStringOrder: [String]
+    private var parseHitCount: Int
+    private var parseMissCount: Int
+    private var inlineHitCount: Int
+    private var inlineMissCount: Int
+    private var evictionCount: Int
+    private var latestParseDurationMS: Double
+
+    init(capacity: Int = 128) {
+        self.capacity = max(1, capacity)
+        self.parsedBlocks = [:]
+        self.parsedBlockOrder = []
+        self.inlineAttributedStrings = [:]
+        self.inlineAttributedStringOrder = []
+        self.parseHitCount = 0
+        self.parseMissCount = 0
+        self.inlineHitCount = 0
+        self.inlineMissCount = 0
+        self.evictionCount = 0
+        self.latestParseDurationMS = 0
+    }
+
+    func blocks(
+        for key: String,
+        build: () -> [DesktopChatMarkdownBlock]
+    ) -> [DesktopChatMarkdownBlock] {
+        lock.lock()
+        if let cached = parsedBlocks[key] {
+            parseHitCount += 1
+            touch(key, in: &parsedBlockOrder)
+            lock.unlock()
+            return cached
+        }
+        lock.unlock()
+
+        let startedAt = Date()
+        let rendered = build()
+        let duration = max(0, Date().timeIntervalSince(startedAt) * 1000)
+
+        lock.lock()
+        parseMissCount += 1
+        latestParseDurationMS = duration
+        parsedBlocks[key] = rendered
+        touch(key, in: &parsedBlockOrder)
+        evictIfNeeded()
+        lock.unlock()
+
+        return rendered
+    }
+
+    func inlineAttributedString(
+        for key: String,
+        build: () -> AttributedString
+    ) -> AttributedString {
+        lock.lock()
+        if let cached = inlineAttributedStrings[key] {
+            inlineHitCount += 1
+            touch(key, in: &inlineAttributedStringOrder)
+            lock.unlock()
+            return cached
+        }
+        lock.unlock()
+
+        let rendered = build()
+
+        lock.lock()
+        inlineMissCount += 1
+        inlineAttributedStrings[key] = rendered
+        touch(key, in: &inlineAttributedStringOrder)
+        evictIfNeeded()
+        lock.unlock()
+
+        return rendered
+    }
+
+    func reset(capacity: Int) {
+        lock.lock()
+        self.capacity = max(1, capacity)
+        parsedBlocks.removeAll()
+        parsedBlockOrder.removeAll()
+        inlineAttributedStrings.removeAll()
+        inlineAttributedStringOrder.removeAll()
+        parseHitCount = 0
+        parseMissCount = 0
+        inlineHitCount = 0
+        inlineMissCount = 0
+        evictionCount = 0
+        latestParseDurationMS = 0
+        lock.unlock()
+    }
+
+    func stats() -> DesktopChatMarkdownCacheStats {
+        lock.lock()
+        let snapshot = DesktopChatMarkdownCacheStats(
+            parseHitCount: parseHitCount,
+            parseMissCount: parseMissCount,
+            inlineHitCount: inlineHitCount,
+            inlineMissCount: inlineMissCount,
+            evictionCount: evictionCount,
+            latestParseDurationMS: latestParseDurationMS
+        )
+        lock.unlock()
+        return snapshot
+    }
+
+    private func touch(_ key: String, in order: inout [String]) {
+        order.removeAll { $0 == key }
+        order.append(key)
+    }
+
+    private func evictIfNeeded() {
+        while parsedBlockOrder.count > capacity, let key = parsedBlockOrder.first {
+            parsedBlockOrder.removeFirst()
+            parsedBlocks.removeValue(forKey: key)
+            evictionCount += 1
         }
 
-        if blocks.isEmpty, text.isEmpty == false {
-            return [.paragraph(text)]
+        while inlineAttributedStringOrder.count > capacity, let key = inlineAttributedStringOrder.first {
+            inlineAttributedStringOrder.removeFirst()
+            inlineAttributedStrings.removeValue(forKey: key)
+            evictionCount += 1
+        }
+    }
+}
+
+private struct DesktopChatMarkdownBlockVisitor: MarkupVisitor {
+    typealias Result = [DesktopChatMarkdownBlock]
+
+    mutating func defaultVisit(_ markup: Markup) -> [DesktopChatMarkdownBlock] {
+        var blocks: [DesktopChatMarkdownBlock] = []
+        for child in markup.children {
+            blocks.append(contentsOf: visit(child))
         }
         return blocks
     }
 
-    private static func parseCodeBlock(lines: [String], index: inout Int) -> DesktopChatMarkdownBlock? {
-        let trimmed = lines[index].trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.hasPrefix("```") else {
-            return nil
-        }
-
-        let language = String(trimmed.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
-        index += 1
-
-        var codeLines: [String] = []
-        while index < lines.count {
-            let candidate = lines[index].trimmingCharacters(in: .whitespacesAndNewlines)
-            if candidate.hasPrefix("```") {
-                index += 1
-                break
-            }
-            codeLines.append(lines[index])
-            index += 1
-        }
-
-        return .codeBlock(language: language, code: codeLines.joined(separator: "\n"))
+    mutating func visitDocument(_ document: Document) -> [DesktopChatMarkdownBlock] {
+        defaultVisit(document)
     }
 
-    private static func parseTable(lines: [String], index: inout Int) -> DesktopChatMarkdownBlock? {
-        guard isTableStart(lines: lines, index: index) else {
-            return nil
-        }
-
-        let header = tableCells(from: lines[index])
-        index += 2
-
-        var rows: [[String]] = []
-        while index < lines.count {
-            let trimmed = lines[index].trimmingCharacters(in: .whitespacesAndNewlines)
-            guard trimmed.isEmpty == false else {
-                break
-            }
-            let cells = tableCells(from: lines[index])
-            guard cells.isEmpty == false, isTableSeparator(cells) == false else {
-                break
-            }
-            rows.append(cells)
-            index += 1
-        }
-
-        return .table(header: header, rows: rows)
-    }
-
-    private static func isTableStart(lines: [String], index: Int) -> Bool {
-        guard index + 1 < lines.count else {
-            return false
-        }
-        let header = tableCells(from: lines[index])
-        let separator = tableCells(from: lines[index + 1])
-        return header.isEmpty == false
-        && separator.count == header.count
-        && isTableSeparator(separator)
-    }
-
-    private static func tableCells(from line: String) -> [String] {
-        var core = line.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard core.contains("|") else {
+    mutating func visitParagraph(_ paragraph: Paragraph) -> [DesktopChatMarkdownBlock] {
+        let text = DesktopChatMarkdownInlineSourceRenderer.string(from: paragraph)
+        guard text.isEmpty == false else {
             return []
         }
-        if core.first == "|" {
-            core.removeFirst()
-        }
-        if core.last == "|" {
-            core.removeLast()
-        }
-        return core.split(separator: "|", omittingEmptySubsequences: false).map { cell in
-            cell.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
+        return [.paragraph(text)]
     }
 
-    private static func isTableSeparator(_ cells: [String]) -> Bool {
-        guard cells.isEmpty == false else {
-            return false
+    mutating func visitHeading(_ heading: Heading) -> [DesktopChatMarkdownBlock] {
+        let text = DesktopChatMarkdownInlineSourceRenderer.string(from: heading)
+        guard text.isEmpty == false else {
+            return []
         }
-        return cells.allSatisfy { cell in
-            let trimmed = cell.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard trimmed.contains("-") else {
-                return false
+        return [.heading(level: heading.level, text: text)]
+    }
+
+    mutating func visitBlockQuote(_ blockQuote: BlockQuote) -> [DesktopChatMarkdownBlock] {
+        let children = defaultVisit(blockQuote)
+        guard children.isEmpty == false else {
+            return []
+        }
+        return [.blockQuote(children)]
+    }
+
+    mutating func visitUnorderedList(_ unorderedList: UnorderedList) -> [DesktopChatMarkdownBlock] {
+        let items = listItems(from: unorderedList)
+        guard items.isEmpty == false else {
+            return []
+        }
+        return [.unorderedList(items)]
+    }
+
+    mutating func visitOrderedList(_ orderedList: OrderedList) -> [DesktopChatMarkdownBlock] {
+        let items = listItems(from: orderedList)
+        guard items.isEmpty == false else {
+            return []
+        }
+        return [.orderedList(start: Int(orderedList.startIndex), items: items)]
+    }
+
+    mutating func visitCodeBlock(_ codeBlock: CodeBlock) -> [DesktopChatMarkdownBlock] {
+        [
+            .codeBlock(
+                language: codeBlock.language?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
+                code: normalizedCodeBlockText(codeBlock.code)
+            ),
+        ]
+    }
+
+    mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) -> [DesktopChatMarkdownBlock] {
+        [.thematicBreak]
+    }
+
+    mutating func visitHTMLBlock(_ html: HTMLBlock) -> [DesktopChatMarkdownBlock] {
+        []
+    }
+
+    mutating func visitTable(_ table: Markdown.Table) -> [DesktopChatMarkdownBlock] {
+        let header = Array(table.head.cells.map { DesktopChatMarkdownInlineSourceRenderer.string(from: $0) })
+        let rows = table.body.children.compactMap { child -> [String]? in
+            guard let row = child as? Markdown.Table.Row else {
+                return nil
             }
-            return trimmed.allSatisfy { character in
-                character == "-" || character == ":" || character.isWhitespace
+            return Array(row.cells.map { DesktopChatMarkdownInlineSourceRenderer.string(from: $0) })
+        }
+        let alignments = table.columnAlignments.map(DesktopChatMarkdownTableAlignment.init)
+
+        return [
+            .table(
+                header: header,
+                alignments: DesktopChatMarkdownTableAlignment.normalized(alignments, count: header.count),
+                rows: rows
+            ),
+        ]
+    }
+
+    private mutating func listItems(from list: some ListItemContainer) -> [DesktopChatMarkdownListItem] {
+        list.children.compactMap { child in
+            guard let item = child as? ListItem else {
+                return nil
+            }
+            return listItem(from: item)
+        }
+    }
+
+    private mutating func listItem(from item: ListItem) -> DesktopChatMarkdownListItem {
+        var textParts: [String] = []
+        var childBlocks: [DesktopChatMarkdownBlock] = []
+
+        for child in item.children {
+            if let paragraph = child as? Paragraph {
+                let text = DesktopChatMarkdownInlineSourceRenderer.string(from: paragraph)
+                if text.isEmpty == false {
+                    textParts.append(text)
+                }
+            } else {
+                childBlocks.append(contentsOf: visit(child))
             }
         }
+
+        return DesktopChatMarkdownListItem(
+            text: textParts.joined(separator: "\n"),
+            children: childBlocks
+        )
     }
 
-    private static func parseUnorderedList(lines: [String], index: inout Int) -> DesktopChatMarkdownBlock? {
-        guard unorderedListItemText(from: lines[index]) != nil else {
-            return nil
+    private func normalizedCodeBlockText(_ code: String) -> String {
+        if code.hasSuffix("\r\n") {
+            return String(code.dropLast(2))
         }
+        if code.hasSuffix("\n") {
+            return String(code.dropLast())
+        }
+        return code
+    }
+}
 
-        var items: [String] = []
-        while index < lines.count, let item = unorderedListItemText(from: lines[index]) {
-            items.append(item)
-            index += 1
-        }
-        return .unorderedList(items)
+private struct DesktopChatMarkdownInlineSourceRenderer: MarkupVisitor {
+    typealias Result = String
+
+    static func string(from markup: Markup) -> String {
+        var renderer = DesktopChatMarkdownInlineSourceRenderer()
+        return renderer.visit(markup)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private static func unorderedListItemText(from line: String) -> String? {
-        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-        for marker in ["- ", "* ", "+ "] where trimmed.hasPrefix(marker) {
-            return String(trimmed.dropFirst(marker.count)).trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        return nil
+    mutating func defaultVisit(_ markup: Markup) -> String {
+        markup.children.map { visit($0) }.joined()
     }
 
-    private static func parseOrderedList(lines: [String], index: inout Int) -> DesktopChatMarkdownBlock? {
-        guard orderedListItemText(from: lines[index]) != nil else {
-            return nil
-        }
-
-        var items: [String] = []
-        while index < lines.count, let item = orderedListItemText(from: lines[index]) {
-            items.append(item)
-            index += 1
-        }
-        return .orderedList(items)
+    mutating func visitText(_ text: Markdown.Text) -> String {
+        text.string
     }
 
-    private static func orderedListItemText(from line: String) -> String? {
-        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let dotIndex = trimmed.firstIndex(of: ".") else {
-            return nil
-        }
-        let number = trimmed[..<dotIndex]
-        guard number.isEmpty == false, number.allSatisfy(\.isNumber) else {
-            return nil
-        }
-        let afterDot = trimmed.index(after: dotIndex)
-        guard afterDot < trimmed.endIndex, trimmed[afterDot].isWhitespace else {
-            return nil
-        }
-        let itemStart = trimmed.index(after: afterDot)
-        return String(trimmed[itemStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
+    mutating func visitSoftBreak(_ softBreak: SoftBreak) -> String {
+        " "
     }
 
-    private static func parseParagraph(lines: [String], index: inout Int) -> DesktopChatMarkdownBlock {
-        var paragraphLines: [String] = []
-        while index < lines.count {
-            let trimmed = lines[index].trimmingCharacters(in: .whitespacesAndNewlines)
-            guard trimmed.isEmpty == false, isBlockStart(lines: lines, index: index) == false else {
-                break
-            }
-            paragraphLines.append(lines[index])
-            index += 1
-        }
-        return .paragraph(paragraphLines.joined(separator: "\n"))
+    mutating func visitLineBreak(_ lineBreak: LineBreak) -> String {
+        "\n"
     }
 
-    private static func isBlockStart(lines: [String], index: Int) -> Bool {
-        let trimmed = lines[index].trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.hasPrefix("```")
-        || isTableStart(lines: lines, index: index)
-        || unorderedListItemText(from: lines[index]) != nil
-        || orderedListItemText(from: lines[index]) != nil
+    mutating func visitInlineCode(_ inlineCode: InlineCode) -> String {
+        "`\(inlineCode.code)`"
+    }
+
+    mutating func visitStrong(_ strong: Strong) -> String {
+        "**\(defaultVisit(strong))**"
+    }
+
+    mutating func visitEmphasis(_ emphasis: Emphasis) -> String {
+        "_\(defaultVisit(emphasis))_"
+    }
+
+    mutating func visitStrikethrough(_ strikethrough: Strikethrough) -> String {
+        "~~\(defaultVisit(strikethrough))~~"
+    }
+
+    mutating func visitLink(_ link: Markdown.Link) -> String {
+        defaultVisit(link)
+    }
+
+    mutating func visitImage(_ image: Markdown.Image) -> String {
+        let altText = defaultVisit(image)
+        if altText.isEmpty == false {
+            return altText
+        }
+        return image.title ?? ""
+    }
+
+    mutating func visitInlineHTML(_ inlineHTML: InlineHTML) -> String {
+        ""
+    }
+}
+
+private struct DesktopChatMarkdownInlineAttributedRenderer: MarkupVisitor {
+    typealias Result = AttributedString
+
+    func attributedString(from markup: Markup) -> AttributedString {
+        var renderer = self
+        return renderer.visit(markup)
+    }
+
+    mutating func defaultVisit(_ markup: Markup) -> AttributedString {
+        var attributed = AttributedString()
+        for child in markup.children {
+            attributed += visit(child)
+        }
+        return attributed
+    }
+
+    mutating func visitText(_ text: Markdown.Text) -> AttributedString {
+        AttributedString(text.string)
+    }
+
+    mutating func visitSoftBreak(_ softBreak: SoftBreak) -> AttributedString {
+        AttributedString(" ")
+    }
+
+    mutating func visitLineBreak(_ lineBreak: LineBreak) -> AttributedString {
+        AttributedString("\n")
+    }
+
+    mutating func visitInlineCode(_ inlineCode: InlineCode) -> AttributedString {
+        adding(.code, to: AttributedString(inlineCode.code))
+    }
+
+    mutating func visitStrong(_ strong: Strong) -> AttributedString {
+        adding(.stronglyEmphasized, to: defaultVisit(strong))
+    }
+
+    mutating func visitEmphasis(_ emphasis: Emphasis) -> AttributedString {
+        adding(.emphasized, to: defaultVisit(emphasis))
+    }
+
+    mutating func visitStrikethrough(_ strikethrough: Strikethrough) -> AttributedString {
+        adding(.strikethrough, to: defaultVisit(strikethrough))
+    }
+
+    mutating func visitLink(_ link: Markdown.Link) -> AttributedString {
+        defaultVisit(link)
+    }
+
+    mutating func visitImage(_ image: Markdown.Image) -> AttributedString {
+        let altText = defaultVisit(image)
+        if altText.characters.isEmpty == false {
+            return altText
+        }
+        return AttributedString(image.title ?? "")
+    }
+
+    mutating func visitInlineHTML(_ inlineHTML: InlineHTML) -> AttributedString {
+        AttributedString()
+    }
+
+    private func adding(
+        _ intent: InlinePresentationIntent,
+        to attributed: AttributedString
+    ) -> AttributedString {
+        var result = attributed
+        let runs = result.runs.map { run in
+            (run.range, run.inlinePresentationIntent)
+        }
+        for (range, existingIntent) in runs {
+            let mergedIntent: InlinePresentationIntent = existingIntent ?? []
+            result[range].inlinePresentationIntent = mergedIntent.union(intent)
+        }
+        return result
+    }
+}
+
+private extension DesktopChatMarkdownTableAlignment {
+    init(_ alignment: Markdown.Table.ColumnAlignment?) {
+        switch alignment {
+        case .left:
+            self = .leading
+        case .center:
+            self = .center
+        case .right:
+            self = .trailing
+        case nil:
+            self = .none
+        }
+    }
+
+    static func normalized(
+        _ alignments: [DesktopChatMarkdownTableAlignment],
+        count: Int
+    ) -> [DesktopChatMarkdownTableAlignment] {
+        guard count > 0 else {
+            return []
+        }
+        if alignments.count >= count {
+            return Array(alignments.prefix(count))
+        }
+        return alignments + Array(repeating: .none, count: count - alignments.count)
     }
 }
 
@@ -265,56 +539,105 @@ struct DesktopChatMarkdownBodyView: View {
     }
 
     var body: some View {
+        DesktopChatMarkdownBlocksView(blocks: blocks)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .textSelection(.enabled)
+    }
+}
+
+private struct DesktopChatMarkdownBlocksView: View {
+    let blocks: [DesktopChatMarkdownBlock]
+
+    var body: some View {
         VStack(alignment: .leading, spacing: DesktopChatMarkdownLayoutMetrics.blockSpacing) {
             ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
-                switch block {
-                case .paragraph(let text):
-                    paragraphView(text)
-                case .unorderedList(let items):
-                    unorderedListView(items)
-                case .orderedList(let items):
-                    orderedListView(items)
-                case .codeBlock(let language, let code):
-                    codeBlockView(language: language, code: code)
-                case .table(let header, let rows):
-                    tableView(header: header, rows: rows)
-                }
+                blockView(block)
             }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .textSelection(.enabled)
+    }
+
+    @ViewBuilder
+    private func blockView(_ block: DesktopChatMarkdownBlock) -> some View {
+        switch block {
+        case .paragraph(let text):
+            paragraphView(text)
+        case .heading(let level, let text):
+            headingView(level: level, text: text)
+        case .blockQuote(let children):
+            blockQuoteView(children)
+        case .unorderedList(let items):
+            unorderedListView(items)
+        case .orderedList(let start, let items):
+            orderedListView(start: start, items: items)
+        case .codeBlock(let language, let code):
+            codeBlockView(language: language, code: code)
+        case .table(let header, let alignments, let rows):
+            tableView(header: header, alignments: alignments, rows: rows)
+        case .thematicBreak:
+            thematicBreakView()
+        }
     }
 
     private func paragraphView(_ text: String) -> some View {
-        Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: text))
+        SwiftUI.Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: text))
             .font(.body)
             .lineSpacing(2)
     }
 
-    private func unorderedListView(_ items: [String]) -> some View {
+    private func headingView(level: Int, text: String) -> some View {
+        SwiftUI.Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: text))
+            .font(headingFont(level: level))
+            .lineSpacing(2)
+            .padding(.top, level == 1 ? MelixDesignTokens.Spacing.xs : 0)
+    }
+
+    private func blockQuoteView(_ children: [DesktopChatMarkdownBlock]) -> some View {
+        HStack(alignment: .top, spacing: MelixDesignTokens.Spacing.sm) {
+            Rectangle()
+                .fill(Color.secondary.opacity(0.28))
+                .frame(width: 3)
+            DesktopChatMarkdownBlocksView(blocks: children)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func unorderedListView(_ items: [DesktopChatMarkdownListItem]) -> some View {
         VStack(alignment: .leading, spacing: DesktopChatMarkdownLayoutMetrics.listRowSpacing) {
-            ForEach(items.indices, id: \.self) { index in
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text("•")
-                        .font(.body)
-                    Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: items[index]))
-                        .font(.body)
-                        .lineSpacing(2)
-                }
+            ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                listRow(marker: "•", item: item)
             }
         }
     }
 
-    private func orderedListView(_ items: [String]) -> some View {
+    private func orderedListView(
+        start: Int,
+        items: [DesktopChatMarkdownListItem]
+    ) -> some View {
         VStack(alignment: .leading, spacing: DesktopChatMarkdownLayoutMetrics.listRowSpacing) {
-            ForEach(items.indices, id: \.self) { index in
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text("\(index + 1).")
-                        .font(.body.monospacedDigit())
-                        .foregroundStyle(.secondary)
-                    Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: items[index]))
+            ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                listRow(marker: "\(start + index).", item: item)
+            }
+        }
+    }
+
+    private func listRow(
+        marker: String,
+        item: DesktopChatMarkdownListItem
+    ) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            SwiftUI.Text(marker)
+                .font(.body.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .frame(minWidth: 18, alignment: .trailing)
+            VStack(alignment: .leading, spacing: DesktopChatMarkdownLayoutMetrics.listRowSpacing) {
+                if item.text.isEmpty == false {
+                    SwiftUI.Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: item.text))
                         .font(.body)
                         .lineSpacing(2)
+                }
+                if item.children.isEmpty == false {
+                    DesktopChatMarkdownBlocksView(blocks: item.children)
+                        .padding(.top, 1)
                 }
             }
         }
@@ -323,11 +646,11 @@ struct DesktopChatMarkdownBodyView: View {
     private func codeBlockView(language: String, code: String) -> some View {
         VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
             if language.isEmpty == false {
-                Text(language)
+                SwiftUI.Text(language)
                     .font(.caption2.monospaced())
                     .foregroundStyle(.secondary)
             }
-            Text(code.isEmpty ? " " : code)
+            SwiftUI.Text(code.isEmpty ? " " : code)
                 .font(.caption.monospaced())
                 .lineSpacing(DesktopChatMarkdownLayoutMetrics.codeBlockLineSpacing)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -346,13 +669,19 @@ struct DesktopChatMarkdownBodyView: View {
         )
     }
 
-    private func tableView(header: [String], rows: [[String]]) -> some View {
-        let columnCount = max(header.count, 1)
+    private func tableView(
+        header: [String],
+        alignments: [DesktopChatMarkdownTableAlignment],
+        rows: [[String]]
+    ) -> some View {
+        let columnCount = max(header.count, rows.map(\.count).max() ?? 0, 1)
+        let normalizedAlignments = DesktopChatMarkdownTableAlignment.normalized(alignments, count: columnCount)
         return Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
             GridRow {
                 ForEach(0..<columnCount, id: \.self) { column in
                     tableCellView(
                         text: header[safe: column] ?? "",
+                        alignment: normalizedAlignments[column],
                         isHeader: true,
                         showsTrailingSeparator: column < columnCount - 1,
                         showsBottomSeparator: true
@@ -365,6 +694,7 @@ struct DesktopChatMarkdownBodyView: View {
                     ForEach(0..<columnCount, id: \.self) { column in
                         tableCellView(
                             text: row[column],
+                            alignment: normalizedAlignments[column],
                             isHeader: false,
                             showsTrailingSeparator: column < columnCount - 1,
                             showsBottomSeparator: rowIndex < rows.count - 1
@@ -388,6 +718,7 @@ struct DesktopChatMarkdownBodyView: View {
 
     private func tableCellView(
         text: String,
+        alignment: DesktopChatMarkdownTableAlignment,
         isHeader: Bool,
         showsTrailingSeparator: Bool,
         showsBottomSeparator: Bool
@@ -397,11 +728,12 @@ struct DesktopChatMarkdownBodyView: View {
                 Rectangle()
                     .fill(Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.tableHeaderBackgroundOpacity))
             }
-            Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: text))
+            SwiftUI.Text(DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: text))
                 .font(isHeader ? .caption.weight(.semibold) : .caption)
+                .multilineTextAlignment(alignment.textAlignment)
                 .padding(.horizontal, DesktopChatMarkdownLayoutMetrics.tableCellHorizontalPadding)
                 .padding(.vertical, DesktopChatMarkdownLayoutMetrics.tableCellVerticalPadding)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: alignment.frameAlignment)
         }
         .overlay(alignment: .bottom) {
             if showsBottomSeparator {
@@ -419,11 +751,53 @@ struct DesktopChatMarkdownBodyView: View {
         }
     }
 
+    private func thematicBreakView() -> some View {
+        Rectangle()
+            .fill(Color.primary.opacity(DesktopChatMarkdownLayoutMetrics.tableRowSeparatorOpacity))
+            .frame(height: 1)
+            .padding(.vertical, MelixDesignTokens.Spacing.xs)
+    }
+
+    private func headingFont(level: Int) -> Font {
+        switch level {
+        case 1:
+            return .headline
+        case 2:
+            return .subheadline.weight(.semibold)
+        default:
+            return .caption.weight(.semibold)
+        }
+    }
+
     private func normalizedTableRow(_ row: [String], columnCount: Int) -> [String] {
         if row.count >= columnCount {
             return Array(row.prefix(columnCount))
         }
         return row + Array(repeating: "", count: columnCount - row.count)
+    }
+}
+
+private extension DesktopChatMarkdownTableAlignment {
+    var frameAlignment: Alignment {
+        switch self {
+        case .none, .leading:
+            return .leading
+        case .center:
+            return .center
+        case .trailing:
+            return .trailing
+        }
+    }
+
+    var textAlignment: TextAlignment {
+        switch self {
+        case .none, .leading:
+            return .leading
+        case .center:
+            return .center
+        case .trailing:
+            return .trailing
+        }
     }
 }
 

--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
@@ -312,6 +312,7 @@ struct DesktopChatSessionWorkspace: View {
                                 DesktopChatTranscriptRowView(
                                     entry: entry,
                                     isPending: viewModel.isPendingAssistantTranscriptEntry(entry),
+                                    isStreaming: viewModel.isStreamingAssistantTranscriptEntry(entry),
                                     pendingStatusText: viewModel.chatStatusText
                                 )
                                 .id(entry.id)
@@ -838,15 +839,18 @@ final class DesktopChatComposerCommandSubmitTextView: NSTextView {
 struct DesktopChatTranscriptRowView: View {
     let entry: DesktopChatTranscriptEntry
     let isPending: Bool
+    let isStreaming: Bool
     let pendingStatusText: String
 
     init(
         entry: DesktopChatTranscriptEntry,
         isPending: Bool = false,
+        isStreaming: Bool = false,
         pendingStatusText: String = ""
     ) {
         self.entry = entry
         self.isPending = isPending
+        self.isStreaming = isStreaming
         self.pendingStatusText = pendingStatusText
     }
 
@@ -868,7 +872,10 @@ struct DesktopChatTranscriptRowView: View {
             if isPending {
                 pendingAssistantView
             } else if DesktopChatMarkdownRenderer.usesMarkdown(for: entry.kind) {
-                DesktopChatMarkdownBodyView(rawText: sanitizedBody.isEmpty ? "…" : sanitizedBody)
+                DesktopChatMarkdownBodyView(
+                    rawText: sanitizedBody.isEmpty ? "…" : sanitizedBody,
+                    isStreaming: isStreaming
+                )
             } else {
                 Text(sanitizedBody.isEmpty ? "…" : sanitizedBody)
                     .font(entry.kind == .tool ? .caption.monospaced() : .body)

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -1857,6 +1857,12 @@ public final class RuntimeViewModel {
         isEmptyPendingAssistantEntry(entry)
     }
 
+    public func isStreamingAssistantTranscriptEntry(_ entry: DesktopChatTranscriptEntry) -> Bool {
+        isChatStreaming
+            && entry.kind == .assistant
+            && entry.id == activeAssistantEntryID
+    }
+
     private let client: any ControlPlaneXPCClient
     private let metrics: MenuBarMetricsStore
     private let operatorSessionStore: any OperatorSessionStoring

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -4165,7 +4165,7 @@ struct DesktopFoundationViewTests {
             language: "json"
         )
         let shell = DesktopChatMarkdownCodeSyntaxHighlighter.attributedString(
-            code: "git status\n# comment\nvalue",
+            code: "git status\n# comment line here\nvalue",
             language: "bash"
         )
         let diff = DesktopChatMarkdownCodeSyntaxHighlighter.attributedString(
@@ -4184,9 +4184,67 @@ struct DesktopFoundationViewTests {
 
         #expect(String(json.characters).contains(#""enabled""#))
         #expect(json.runs.contains { $0.foregroundColor != nil })
-        #expect(shell.runs.contains { $0.foregroundColor != nil })
+        // Entire comment line is colored, not just the '#' delimiter.
+        let shellText = String(shell.characters)
+        let commentLineStart = shellText.range(of: "# comment line here").map { r in
+            shellText.distance(from: shellText.startIndex, to: r.lowerBound)
+        } ?? 0
+        let commentRun = shell.runs.first { run in
+            let runStart = shell.characters.distance(
+                from: shell.characters.startIndex,
+                to: run.range.lowerBound
+            )
+            return runStart >= commentLineStart && run.foregroundColor != nil
+        }
+        #expect(commentRun != nil, "Full comment line should be colored, not just the delimiter")
         #expect(diff.runs.contains { $0.foregroundColor != nil })
         #expect(String(plain.characters).isEmpty)
+    }
+
+    @Test("chat markdown JS and Python keywords are colored with language-specific sets")
+    func chatMarkdownJSAndPythonKeywordsAreColoredWithLanguageSpecificSets() {
+        let js = DesktopChatMarkdownCodeSyntaxHighlighter.attributedString(
+            code: "function foo() { return null; }",
+            language: "javascript"
+        )
+        let py = DesktopChatMarkdownCodeSyntaxHighlighter.attributedString(
+            code: "def foo():\n    pass\n    return None",
+            language: "python"
+        )
+        let swift = DesktopChatMarkdownCodeSyntaxHighlighter.attributedString(
+            code: "func foo() -> Void { return }",
+            language: "swift"
+        )
+
+        // JS-specific keywords like `function` and `null` must be colored.
+        let jsText = String(js.characters)
+        let functionRange = jsText.range(of: "function")
+        #expect(functionRange != nil)
+        if let range = functionRange {
+            let charIndex = jsText.distance(from: jsText.startIndex, to: range.lowerBound)
+            let colored = js.runs.contains { run in
+                let start = js.characters.distance(from: js.characters.startIndex, to: run.range.lowerBound)
+                return start == charIndex && run.foregroundColor != nil
+            }
+            #expect(colored, "`function` should be highlighted in JavaScript")
+        }
+
+        // Python-specific keywords like `def` and `None` must be colored.
+        let pyText = String(py.characters)
+        let defRange = pyText.range(of: "def")
+        #expect(defRange != nil)
+        if let range = defRange {
+            let charIndex = pyText.distance(from: pyText.startIndex, to: range.lowerBound)
+            let colored = py.runs.contains { run in
+                let start = py.characters.distance(from: py.characters.startIndex, to: run.range.lowerBound)
+                return start == charIndex && run.foregroundColor != nil
+            }
+            #expect(colored, "`def` should be highlighted in Python")
+        }
+
+        // `func` is a Swift keyword and should be colored in Swift but not be
+        // incorrectly used to color JS/Python (they have `function`/`def`).
+        #expect(swift.runs.contains { $0.foregroundColor != nil })
     }
 
     @Test("chat markdown table layout bounds wide content")
@@ -4330,6 +4388,7 @@ struct DesktopFoundationViewTests {
         #expect(snapshot == expected.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
+    #if DEBUG
     @Test("chat markdown performance probe reports large sample cache benefit")
     func chatMarkdownPerformanceProbeReportsLargeSampleCacheBenefit() {
         DesktopChatMarkdownRenderer.resetCacheForTesting(capacity: 256)
@@ -4355,6 +4414,7 @@ struct DesktopFoundationViewTests {
 
         DesktopChatMarkdownRenderer.resetCacheForTesting()
     }
+    #endif
 
     @Test("chat markdown surfaces keep restrained low-border styling")
     func chatMarkdownSurfacesKeepRestrainedLowBorderStyling() {

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -4068,6 +4068,181 @@ struct DesktopFoundationViewTests {
         #expect(view.subviews.isEmpty == false)
     }
 
+    @Test("chat markdown code blocks expose badge highlight and copy behavior")
+    func chatMarkdownCodeBlocksExposeBadgeHighlightAndCopyBehavior() throws {
+        let code = """
+        let enabled = true
+        // keep comments readable
+        """
+        let presentation = DesktopChatMarkdownCodeBlockPresentation(language: " swift ", code: code)
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("melix.chat.markdown.copy.\(UUID().uuidString)"))
+
+        DesktopChatMarkdownCodeBlockClipboard.copy(code, to: pasteboard)
+
+        #expect(presentation.languageBadge == "Swift")
+        #expect(presentation.copyAccessibilityLabel == "Copy code")
+        #expect(String(presentation.highlightedCode.characters) == code)
+        #expect(presentation.highlightedCode.runs.contains { $0.foregroundColor != nil })
+        #expect(pasteboard.string(forType: .string) == code)
+    }
+
+    @Test("chat markdown code language badges and highlighter branches")
+    func chatMarkdownCodeLanguageBadgesAndHighlighterBranches() {
+        #expect(DesktopChatMarkdownCodeLanguage.badge(for: "javascript") == "JavaScript")
+        #expect(DesktopChatMarkdownCodeLanguage.badge(for: "ts") == "TypeScript")
+        #expect(DesktopChatMarkdownCodeLanguage.badge(for: "bash") == "Shell")
+        #expect(DesktopChatMarkdownCodeLanguage.badge(for: "python") == "Python")
+        #expect(DesktopChatMarkdownCodeLanguage.badge(for: "patch") == "Diff")
+        #expect(DesktopChatMarkdownCodeLanguage.badge(for: "toml") == "TOML")
+        #expect(DesktopChatMarkdownCodeLanguage.badge(for: "") == "Plain Text")
+
+        let json = DesktopChatMarkdownCodeSyntaxHighlighter.attributedString(
+            code: #"{"enabled": true, "count": 12, "label": "ok"}"#,
+            language: "json"
+        )
+        let shell = DesktopChatMarkdownCodeSyntaxHighlighter.attributedString(
+            code: "git status\n# comment\nvalue",
+            language: "bash"
+        )
+        let diff = DesktopChatMarkdownCodeSyntaxHighlighter.attributedString(
+            code: """
+            @@ -1 +1 @@
+            -old
+            +new
+             context
+            """,
+            language: "diff"
+        )
+        let plain = DesktopChatMarkdownCodeSyntaxHighlighter.attributedString(
+            code: "",
+            language: "text"
+        )
+
+        #expect(String(json.characters).contains(#""enabled""#))
+        #expect(json.runs.contains { $0.foregroundColor != nil })
+        #expect(shell.runs.contains { $0.foregroundColor != nil })
+        #expect(diff.runs.contains { $0.foregroundColor != nil })
+        #expect(String(plain.characters).isEmpty)
+    }
+
+    @Test("chat markdown table layout bounds wide content")
+    func chatMarkdownTableLayoutBoundsWideContent() {
+        let layout = DesktopChatMarkdownTableLayout(
+            header: ["Name", "Very Long Column", "Status"],
+            rows: [[
+                "alpha",
+                String(repeating: "wide-content-", count: 24),
+                "ready",
+            ]]
+        )
+
+        #expect(layout.columnWidths.count == 3)
+        #expect(layout.columnWidths.allSatisfy { $0 >= DesktopChatMarkdownLayoutMetrics.tableColumnMinWidth })
+        #expect(layout.columnWidths.contains(DesktopChatMarkdownLayoutMetrics.tableColumnMaxWidth))
+        #expect(
+            layout.lineLimit(for: String(repeating: "wide-content-", count: 24)) ==
+                DesktopChatMarkdownLayoutMetrics.tableCellMaximumLineCount
+        )
+    }
+
+    @Test("chat markdown body view hosts code and table polish controls")
+    @MainActor
+    func chatMarkdownBodyViewHostsCodeAndTablePolishControls() {
+        let view = hostView(DesktopChatMarkdownBodyView(rawText: """
+        ```json
+        {"enabled": true, "mode": "local"}
+        ```
+
+        | Column | Long |
+        | --- | --- |
+        | A | \(String(repeating: "wide ", count: 80)) |
+        """))
+
+        #expect(view.subviews.isEmpty == false)
+    }
+
+    @Test("chat markdown body view hosts lazy long response plans")
+    @MainActor
+    func chatMarkdownBodyViewHostsLazyLongResponsePlans() {
+        let view = hostView(DesktopChatMarkdownBodyView(rawText: chatMarkdownLongStreamingSample(sectionCount: 56)))
+
+        #expect(view.subviews.isEmpty == false)
+    }
+
+    @Test("chat markdown renderer builds lazy streaming render plans")
+    func chatMarkdownRendererBuildsLazyStreamingRenderPlans() {
+        DesktopChatMarkdownRenderer.resetCacheForTesting(capacity: 64)
+        let stableBlocks = chatMarkdownLongStreamingSample(sectionCount: 48)
+        let firstStream = stableBlocks + "\n\nPartial tail"
+        let secondStream = firstStream + " still streaming"
+
+        let firstPlan = DesktopChatMarkdownRenderer.renderPlan(from: firstStream, mode: .streaming)
+        let firstStats = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+        let secondPlan = DesktopChatMarkdownRenderer.renderPlan(from: secondStream, mode: .streaming)
+        let secondStats = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+
+        #expect(firstPlan.usesLazyRendering)
+        #expect(firstPlan.chunks.count > 1)
+        #expect(firstPlan.blocks == DesktopChatMarkdownRenderer.blocks(from: firstStream))
+        #expect(secondPlan.chunks.count == firstPlan.chunks.count)
+        #expect(secondStats.chunkHitCount > firstStats.chunkHitCount)
+        #expect(secondStats.chunkMissCount - firstStats.chunkMissCount <= 1)
+
+        DesktopChatMarkdownRenderer.resetCacheForTesting()
+    }
+
+    @Test("chat markdown renderer evicts old chunk cache entries")
+    func chatMarkdownRendererEvictsOldChunkCacheEntries() {
+        DesktopChatMarkdownRenderer.resetCacheForTesting(capacity: 1)
+
+        _ = DesktopChatMarkdownRenderer.renderPlan(
+            from: chatMarkdownLongStreamingSample(sectionCount: 36),
+            mode: .complete
+        )
+        let stats = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+
+        #expect(stats.chunkMissCount > 1)
+        #expect(stats.evictionCount > 0)
+
+        DesktopChatMarkdownRenderer.resetCacheForTesting()
+    }
+
+    @Test("chat markdown fixture snapshot stays stable")
+    func chatMarkdownFixtureSnapshotStaysStable() throws {
+        let source = try chatMarkdownFixture(named: "chat-markdown-rich.md")
+        let expected = try chatMarkdownFixture(named: "chat-markdown-rich.snapshot.txt")
+
+        let snapshot = chatMarkdownBlockSnapshot(DesktopChatMarkdownRenderer.blocks(from: source))
+
+        #expect(snapshot == expected.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    @Test("chat markdown performance probe reports large sample cache benefit")
+    func chatMarkdownPerformanceProbeReportsLargeSampleCacheBenefit() {
+        DesktopChatMarkdownRenderer.resetCacheForTesting(capacity: 256)
+
+        let report = DesktopChatMarkdownPerformanceProbe.measure(sampleSizes: [5_000, 50_000, 200_000])
+
+        #expect(report.samples.map(\.targetByteCount) == [5_000, 50_000, 200_000])
+        #expect(report.samples.allSatisfy { $0.blockCount > 0 })
+        #expect(report.samples.allSatisfy { $0.chunkCount > 0 })
+        #expect(report.samples.allSatisfy { $0.firstParseDurationMS >= 0 })
+        #expect(report.samples.allSatisfy { $0.cachedParseDurationMS >= 0 })
+        #expect(report.samples.allSatisfy { $0.cacheHitDelta > 0 })
+
+        let stats = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+        let sampleMetrics = report.samples
+            .map {
+                "\($0.targetByteCount):first_ms=\(String(format: "%.3f", $0.firstParseDurationMS)),cached_ms=\(String(format: "%.3f", $0.cachedParseDurationMS)),hits=\($0.cacheHitDelta),misses=\($0.cacheMissDelta),evictions=\($0.evictionDelta),chunks=\($0.chunkCount)"
+            }
+            .joined(separator: ";")
+        print(
+            "M16_CHAT_MARKDOWN_PERF=samples=[\(sampleMetrics)] eviction_count=\(stats.evictionCount) latest_parse_ms=\(String(format: "%.3f", stats.latestParseDurationMS))"
+        )
+
+        DesktopChatMarkdownRenderer.resetCacheForTesting()
+    }
+
     @Test("chat markdown surfaces keep restrained low-border styling")
     func chatMarkdownSurfacesKeepRestrainedLowBorderStyling() {
         #expect(
@@ -6672,6 +6847,83 @@ private func makeExperimentGroupRegistrySnapshotManifest() -> String {
       ]
     }
     """#
+}
+
+private func chatMarkdownFixture(named name: String) throws -> String {
+    let fixtureURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .appendingPathComponent("Fixtures")
+        .appendingPathComponent(name)
+    return try String(contentsOf: fixtureURL, encoding: .utf8)
+}
+
+private func chatMarkdownBlockSnapshot(_ blocks: [DesktopChatMarkdownBlock]) -> String {
+    blocks.flatMap { chatMarkdownBlockSnapshotLines($0, indent: 0) }
+        .joined(separator: "\n")
+}
+
+private func chatMarkdownLongStreamingSample(sectionCount: Int) -> String {
+    (1...sectionCount)
+        .map { index in
+            """
+            ## Section \(index)
+
+            - item \(index)
+            - cached \(index)
+
+            ```swift
+            let value\(index) = \(index)
+            ```
+            """
+        }
+        .joined(separator: "\n\n")
+}
+
+private func chatMarkdownBlockSnapshotLines(
+    _ block: DesktopChatMarkdownBlock,
+    indent: Int
+) -> [String] {
+    let prefix = String(repeating: "  ", count: indent)
+    switch block {
+    case .paragraph(let text):
+        return ["\(prefix)paragraph: \(text)"]
+    case .heading(let level, let text):
+        return ["\(prefix)heading\(level): \(text)"]
+    case .blockQuote(let children):
+        return ["\(prefix)quote:"] + children.flatMap {
+            chatMarkdownBlockSnapshotLines($0, indent: indent + 1)
+        }
+    case .unorderedList(let items):
+        return ["\(prefix)unordered:"] + chatMarkdownListItemSnapshotLines(items, indent: indent + 1)
+    case .orderedList(let start, let items):
+        return ["\(prefix)ordered(\(start)):"]
+            + chatMarkdownListItemSnapshotLines(items, indent: indent + 1)
+    case .codeBlock(let language, let code):
+        return [
+            "\(prefix)code[\(language.isEmpty ? "plain" : language)]:",
+            "\(prefix)  \(code.replacingOccurrences(of: "\n", with: "\\n"))",
+        ]
+    case .table(let header, let alignments, let rows):
+        let alignmentText = alignments.map(String.init(describing:)).joined(separator: ",")
+        let rowLines = rows.map { "\(prefix)  row: \($0.joined(separator: " | "))" }
+        return [
+            "\(prefix)table[\(alignmentText)]: \(header.joined(separator: " | "))",
+        ] + rowLines
+    case .thematicBreak:
+        return ["\(prefix)thematic-break"]
+    }
+}
+
+private func chatMarkdownListItemSnapshotLines(
+    _ items: [DesktopChatMarkdownListItem],
+    indent: Int
+) -> [String] {
+    items.flatMap { item -> [String] in
+        let prefix = String(repeating: "  ", count: indent)
+        return ["\(prefix)- \(item.text)"] + item.children.flatMap {
+            chatMarkdownBlockSnapshotLines($0, indent: indent + 1)
+        }
+    }
 }
 
 private actor EmptyToolsSnapshotControlPlaneXPCClient: ControlPlaneXPCClient {

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -3902,24 +3902,113 @@ struct DesktopFoundationViewTests {
 
         #expect(blocks == [
             .paragraph("Intro **bold** and _italic_ with `code`."),
-            .unorderedList(["one", "two"]),
-            .orderedList(["first", "second"]),
+            .unorderedList([
+                DesktopChatMarkdownListItem(text: "one"),
+                DesktopChatMarkdownListItem(text: "two"),
+            ]),
+            .orderedList(start: 1, items: [
+                DesktopChatMarkdownListItem(text: "first"),
+                DesktopChatMarkdownListItem(text: "second"),
+            ]),
             .codeBlock(language: "swift", code: "let value = 1"),
-            .table(header: ["Metric", "Value"], rows: [["TTFT", "12 ms"]]),
+            .table(
+                header: ["Metric", "Value"],
+                alignments: [.none, .trailing],
+                rows: [["TTFT", "12 ms"]]
+            ),
+        ])
+    }
+
+    @Test("chat markdown parser builds AST backed blocks")
+    func chatMarkdownParserBuildsASTBackedBlocks() {
+        let blocks = DesktopChatMarkdownRenderer.blocks(from: """
+        # Result
+
+        > quoted **answer**
+
+        - parent
+          - child
+
+        3. first
+           1. child
+
+        ---
+
+        ![diagram alt](https://example.com/diagram.png)
+
+        | Name | Alignment | Note |
+        | :--- | ---: | :---: |
+        | Alpha \\| Beta | Right | Center |
+        """)
+
+        #expect(blocks == [
+            .heading(level: 1, text: "Result"),
+            .blockQuote([
+                .paragraph("quoted **answer**"),
+            ]),
+            .unorderedList([
+                DesktopChatMarkdownListItem(
+                    text: "parent",
+                    children: [
+                        .unorderedList([
+                            DesktopChatMarkdownListItem(text: "child"),
+                        ]),
+                    ]
+                ),
+            ]),
+            .orderedList(
+                start: 3,
+                items: [
+                    DesktopChatMarkdownListItem(
+                        text: "first",
+                        children: [
+                            .orderedList(
+                                start: 1,
+                                items: [
+                                    DesktopChatMarkdownListItem(text: "child"),
+                                ]
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+            .thematicBreak,
+            .paragraph("diagram alt"),
+            .table(
+                header: ["Name", "Alignment", "Note"],
+                alignments: [.leading, .trailing, .center],
+                rows: [["Alpha | Beta", "Right", "Center"]]
+            ),
         ])
     }
 
     @Test("chat markdown inline formatter removes markdown markers while preserving readable text")
     func chatMarkdownInlineFormatterRemovesMarkers() {
         let attributed = DesktopChatMarkdownInlineFormatter.attributedString(
-            from: "**bold** and _italic_ and `code`"
+            from: "**bold** and _italic_ and `code` and ~~strike~~"
         )
         let linked = DesktopChatMarkdownInlineFormatter.attributedString(
             from: "[Melix](https://example.com)"
         )
+        let image = DesktopChatMarkdownInlineFormatter.attributedString(
+            from: "![Diagram](https://example.com/diagram.png)"
+        )
+        let imageTitle = DesktopChatMarkdownInlineFormatter.attributedString(
+            from: "![](https://example.com/diagram.png \"Diagram title\")"
+        )
+        let lineBreaks = DesktopChatMarkdownInlineFormatter.attributedString(
+            fromSanitized: "soft\nbreak and hard  \nbreak"
+        )
+        let inlineHTML = DesktopChatMarkdownInlineFormatter.attributedString(
+            fromSanitized: "Hello <span>ignored</span>"
+        )
 
-        #expect(String(attributed.characters) == "bold and italic and code")
+        #expect(String(attributed.characters) == "bold and italic and code and strike")
         #expect(String(linked.characters) == "Melix")
+        #expect(String(image.characters) == "Diagram")
+        #expect(String(imageTitle.characters) == "Diagram title")
+        #expect(String(lineBreaks.characters) == "soft break and hard\nbreak")
+        #expect(String(inlineHTML.characters) == "Hello ignored")
         #expect(linked.runs.allSatisfy { $0.link == nil })
     }
 
@@ -3943,6 +4032,37 @@ struct DesktopFoundationViewTests {
         | --- | --- |
         | TTFT |
         | TPS | 20 |
+        """))
+
+        #expect(view.subviews.isEmpty == false)
+    }
+
+    @Test("chat markdown body view hosts rich AST backed block branches")
+    @MainActor
+    func chatMarkdownBodyViewHostsRichASTBackedBlockBranches() {
+        let view = hostView(DesktopChatMarkdownBodyView(rawText: """
+        # Heading
+        ## Subheading
+        ### Minor
+
+        > quoted
+
+        ---
+
+        - parent
+          - child
+
+        3. first
+           1. child
+
+        ```
+        blank language
+        ```
+
+        | Left | Center | Right |
+        | :--- | :---: | ---: |
+        | A | B | C |
+        | Long | Row | Extra | Trimmed |
         """))
 
         #expect(view.subviews.isEmpty == false)
@@ -3988,6 +4108,63 @@ struct DesktopFoundationViewTests {
                 code: "<b>keep as code</b>\n[keep](javascript:alert(1))"
             ),
         ])
+    }
+
+    @Test("chat markdown renderer preserves inline source edge cases")
+    func chatMarkdownRendererPreservesInlineSourceEdgeCases() {
+        let softBreak = DesktopChatMarkdownRenderer.blocks(from: "soft\nbreak")
+        let hardBreak = DesktopChatMarkdownRenderer.blocks(from: "hard  \nbreak")
+        let strikeLinkAndTitleImage = DesktopChatMarkdownRenderer.blocks(from: """
+        ~~gone~~ [label](https://example.com) ![](https://example.com/image.png "fallback")
+        """)
+        let unclosedFence = DesktopChatMarkdownRenderer.blocks(from: """
+        ```swift
+        let value = 2
+        """)
+
+        #expect(softBreak == [.paragraph("soft break")])
+        #expect(hardBreak == [.paragraph("hard\nbreak")])
+        #expect(strikeLinkAndTitleImage == [.paragraph("~~gone~~ label fallback")])
+        #expect(unclosedFence == [.codeBlock(language: "swift", code: "let value = 2")])
+    }
+
+    @Test("chat markdown renderer caches parsed blocks and evicts old entries")
+    func chatMarkdownRendererCachesParsedBlocksAndEvictsOldEntries() {
+        DesktopChatMarkdownRenderer.resetCacheForTesting(capacity: 2)
+
+        _ = DesktopChatMarkdownRenderer.blocks(from: "A")
+        let first = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+        _ = DesktopChatMarkdownRenderer.blocks(from: "A")
+        let second = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+        _ = DesktopChatMarkdownRenderer.blocks(from: "B")
+        _ = DesktopChatMarkdownRenderer.blocks(from: "C")
+        let third = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+        _ = DesktopChatMarkdownRenderer.blocks(from: "A")
+        let fourth = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+
+        #expect(first.parseMissCount == 1)
+        #expect(second.parseHitCount == 1)
+        #expect(third.evictionCount == 1)
+        #expect(fourth.parseMissCount == 4)
+        #expect(fourth.latestParseDurationMS >= 0)
+    }
+
+    @Test("chat markdown renderer caches inline attributed strings and evicts old entries")
+    func chatMarkdownRendererCachesInlineAttributedStringsAndEvictsOldEntries() {
+        DesktopChatMarkdownRenderer.resetCacheForTesting(capacity: 1)
+
+        _ = DesktopChatMarkdownInlineFormatter.attributedString(from: "**A**")
+        let first = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+        _ = DesktopChatMarkdownInlineFormatter.attributedString(from: "**A**")
+        let second = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+        _ = DesktopChatMarkdownInlineFormatter.attributedString(from: "**B**")
+        let third = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+
+        #expect(first.inlineMissCount == 1)
+        #expect(second.inlineHitCount == 1)
+        #expect(third.evictionCount == 1)
+
+        DesktopChatMarkdownRenderer.resetCacheForTesting()
     }
 
     @Test("chat session sidebar renders the empty state when no chat sessions exist")

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -4184,19 +4184,10 @@ struct DesktopFoundationViewTests {
 
         #expect(String(json.characters).contains(#""enabled""#))
         #expect(json.runs.contains { $0.foregroundColor != nil })
-        // Entire comment line is colored, not just the '#' delimiter.
-        let shellText = String(shell.characters)
-        let commentLineStart = shellText.range(of: "# comment line here").map { r in
-            shellText.distance(from: shellText.startIndex, to: r.lowerBound)
-        } ?? 0
-        let commentRun = shell.runs.first { run in
-            let runStart = shell.characters.distance(
-                from: shell.characters.startIndex,
-                to: run.range.lowerBound
-            )
-            return runStart >= commentLineStart && run.foregroundColor != nil
-        }
-        #expect(commentRun != nil, "Full comment line should be colored, not just the delimiter")
+        #expect(
+            attributedString(shell, hasColoredRunCovering: "# comment line here"),
+            "Full comment line should be colored, not just the delimiter"
+        )
         #expect(diff.runs.contains { $0.foregroundColor != nil })
         #expect(String(plain.characters).isEmpty)
     }
@@ -4245,6 +4236,46 @@ struct DesktopFoundationViewTests {
         // `func` is a Swift keyword and should be colored in Swift but not be
         // incorrectly used to color JS/Python (they have `function`/`def`).
         #expect(swift.runs.contains { $0.foregroundColor != nil })
+    }
+
+    @Test("chat markdown stable identities avoid positional render ids")
+    func chatMarkdownStableIdentitiesAvoidPositionalRenderIDs() {
+        let chunks = [
+            DesktopChatMarkdownRenderChunk(
+                source: "duplicate",
+                blocks: [.paragraph("repeat")],
+                isStable: true
+            ),
+            DesktopChatMarkdownRenderChunk(
+                source: "duplicate",
+                blocks: [.paragraph("repeat")],
+                isStable: true
+            ),
+        ]
+        let blocks: [DesktopChatMarkdownBlock] = [
+            .paragraph("repeat"),
+            .paragraph("repeat"),
+            .heading(level: 2, text: "Title"),
+            .unorderedList([
+                DesktopChatMarkdownListItem(text: "child"),
+            ]),
+        ]
+        let firstBlockIDs = DesktopChatMarkdownStableIdentity.identifiedBlocks(blocks).map(\.id)
+        let secondBlockIDs = DesktopChatMarkdownStableIdentity.identifiedBlocks(blocks).map(\.id)
+        let items = [
+            DesktopChatMarkdownListItem(text: "same"),
+            DesktopChatMarkdownListItem(text: "same"),
+            DesktopChatMarkdownListItem(text: "different"),
+        ]
+        let identifiedItems = DesktopChatMarkdownStableIdentity.identifiedListItems(items)
+        let chunkIDs = DesktopChatMarkdownStableIdentity.identifiedChunks(chunks).map(\.id)
+        let itemIDs = identifiedItems.map(\.id)
+
+        #expect(Set(chunkIDs).count == chunkIDs.count)
+        #expect(firstBlockIDs == secondBlockIDs)
+        #expect(Set(firstBlockIDs).count == firstBlockIDs.count)
+        #expect(Set(itemIDs).count == itemIDs.count)
+        #expect(identifiedItems.map(\.offset) == [0, 1, 2])
     }
 
     @Test("chat markdown table layout bounds wide content")
@@ -4309,6 +4340,31 @@ struct DesktopFoundationViewTests {
         #expect(secondPlan.chunks.count == firstPlan.chunks.count)
         #expect(secondStats.chunkHitCount > firstStats.chunkHitCount)
         #expect(secondStats.chunkMissCount - firstStats.chunkMissCount <= 1)
+
+        DesktopChatMarkdownRenderer.resetCacheForTesting()
+    }
+
+    @Test("chat markdown complete render plans cache the tail chunk")
+    func chatMarkdownCompleteRenderPlansCacheTheTailChunk() {
+        DesktopChatMarkdownRenderer.resetCacheForTesting(capacity: 64)
+        let source = chatMarkdownLongStreamingSample(sectionCount: 48) + "\n\nComplete tail"
+
+        _ = DesktopChatMarkdownRenderer.renderPlan(from: source, mode: .complete)
+        let firstCompleteStats = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+        _ = DesktopChatMarkdownRenderer.renderPlan(from: source, mode: .complete)
+        let secondCompleteStats = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+
+        #expect(secondCompleteStats.chunkHitCount > firstCompleteStats.chunkHitCount)
+        #expect(secondCompleteStats.chunkMissCount == firstCompleteStats.chunkMissCount)
+
+        DesktopChatMarkdownRenderer.resetCacheForTesting(capacity: 64)
+        _ = DesktopChatMarkdownRenderer.renderPlan(from: source, mode: .streaming)
+        let firstStreamingStats = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+        _ = DesktopChatMarkdownRenderer.renderPlan(from: source, mode: .streaming)
+        let secondStreamingStats = DesktopChatMarkdownRenderer.cacheStatsForTesting()
+
+        #expect(secondStreamingStats.chunkHitCount > firstStreamingStats.chunkHitCount)
+        #expect(secondStreamingStats.chunkMissCount > firstStreamingStats.chunkMissCount)
 
         DesktopChatMarkdownRenderer.resetCacheForTesting()
     }
@@ -7038,6 +7094,33 @@ private func chatMarkdownFixture(named name: String) throws -> String {
 private func chatMarkdownBlockSnapshot(_ blocks: [DesktopChatMarkdownBlock]) -> String {
     blocks.flatMap { chatMarkdownBlockSnapshotLines($0, indent: 0) }
         .joined(separator: "\n")
+}
+
+private func attributedString(
+    _ attributed: AttributedString,
+    hasColoredRunCovering substring: String
+) -> Bool {
+    let plainText = String(attributed.characters)
+    guard let range = plainText.range(of: substring) else {
+        return false
+    }
+    let substringStart = plainText.distance(from: plainText.startIndex, to: range.lowerBound)
+    let substringEnd = plainText.distance(from: plainText.startIndex, to: range.upperBound)
+
+    return attributed.runs.contains { run in
+        guard run.foregroundColor != nil else {
+            return false
+        }
+        let runStart = attributed.characters.distance(
+            from: attributed.characters.startIndex,
+            to: run.range.lowerBound
+        )
+        let runEnd = attributed.characters.distance(
+            from: attributed.characters.startIndex,
+            to: run.range.upperBound
+        )
+        return runStart <= substringStart && runEnd >= substringEnd
+    }
 }
 
 private func chatMarkdownLongStreamingSample(sectionCount: Int) -> String {

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -3901,7 +3901,7 @@ struct DesktopFoundationViewTests {
         """)
 
         #expect(blocks == [
-            .paragraph("Intro **bold** and _italic_ with `code`."),
+            .paragraph("Intro **bold** and _italic_ with `code`\\."),
             .unorderedList([
                 DesktopChatMarkdownListItem(text: "one"),
                 DesktopChatMarkdownListItem(text: "two"),
@@ -3977,9 +3977,72 @@ struct DesktopFoundationViewTests {
             .table(
                 header: ["Name", "Alignment", "Note"],
                 alignments: [.leading, .trailing, .center],
-                rows: [["Alpha | Beta", "Right", "Center"]]
+                rows: [["Alpha \\| Beta", "Right", "Center"]]
             ),
         ])
+    }
+
+    @Test("chat markdown list items preserve loose child order")
+    func chatMarkdownListItemsPreserveLooseChildOrder() {
+        let blocks = DesktopChatMarkdownRenderer.blocks(from: """
+        - intro
+
+          - nested
+
+          conclusion
+        """)
+
+        #expect(blocks == [
+            .unorderedList([
+                DesktopChatMarkdownListItem(
+                    text: "intro",
+                    children: [
+                        .unorderedList([
+                            DesktopChatMarkdownListItem(text: "nested"),
+                        ]),
+                        .paragraph("conclusion"),
+                    ]
+                ),
+            ]),
+        ])
+
+        let codeOnlyItem = DesktopChatMarkdownRenderer.blocks(from: """
+        -
+          ```swift
+          let value = 1
+          ```
+        """)
+
+        #expect(codeOnlyItem == [
+            .unorderedList([
+                DesktopChatMarkdownListItem(
+                    text: "",
+                    children: [
+                        .codeBlock(language: "swift", code: "let value = 1"),
+                    ]
+                ),
+            ]),
+        ])
+    }
+
+    @Test("chat markdown literal punctuation stays literal after inline parse")
+    func chatMarkdownLiteralPunctuationStaysLiteralAfterInlineParse() {
+        let blocks = DesktopChatMarkdownRenderer.blocks(from: "multiply: 2 * 3 or 4 * 5")
+
+        #expect(blocks == [.paragraph("multiply: 2 \\* 3 or 4 \\* 5")])
+
+        let text: String
+        if case .paragraph(let paragraphText) = blocks.first {
+            text = paragraphText
+        } else {
+            text = ""
+        }
+        let attributed = DesktopChatMarkdownInlineFormatter.attributedString(fromSanitized: text)
+        let inlineCodeWithBacktick = DesktopChatMarkdownRenderer.blocks(from: "``a ` b``")
+
+        #expect(String(attributed.characters) == "multiply: 2 * 3 or 4 * 5")
+        #expect(attributed.runs.allSatisfy { $0.inlinePresentationIntent == nil })
+        #expect(inlineCodeWithBacktick == [.paragraph("``a ` b``")])
     }
 
     @Test("chat markdown inline formatter removes markdown markers while preserving readable text")
@@ -4044,6 +4107,7 @@ struct DesktopFoundationViewTests {
         # Heading
         ## Subheading
         ### Minor
+        #### Body-sized
 
         > quoted
 
@@ -4191,6 +4255,55 @@ struct DesktopFoundationViewTests {
         DesktopChatMarkdownRenderer.resetCacheForTesting()
     }
 
+    @Test("chat markdown chunker keeps mismatched fence markers inside code")
+    func chatMarkdownChunkerKeepsMismatchedFenceMarkersInsideCode() {
+        DesktopChatMarkdownRenderer.resetCacheForTesting(capacity: 64)
+        let longCode = Array(repeating: "let value = 42", count: 180).joined(separator: "\n")
+        let source = """
+        ```swift
+        \(longCode)
+        ~~~not a closing fence~~~
+
+        \(longCode)
+        ```
+        """
+
+        let plan = DesktopChatMarkdownRenderer.renderPlan(from: source, mode: .complete)
+
+        #expect(plan.chunks.count == 1)
+        #expect(plan.blocks == [
+            .codeBlock(
+                language: "swift",
+                code: "\(longCode)\n~~~not a closing fence~~~\n\n\(longCode)"
+            ),
+        ])
+
+        let longerFenceSource = """
+        ````swift
+        \(longCode)
+        ```
+
+        \(longCode)
+        ````
+        """
+        let longerFencePlan = DesktopChatMarkdownRenderer.renderPlan(from: longerFenceSource, mode: .complete)
+
+        #expect(longerFencePlan.chunks.count == 1)
+        #expect(longerFencePlan.blocks == [
+            .codeBlock(language: "swift", code: "\(longCode)\n```\n\n\(longCode)"),
+        ])
+
+        let shortFenceMarkerSource = String(repeating: "plain text\n", count: 220) + "\n``\n\ntrailing"
+        let shortFenceMarkerPlan = DesktopChatMarkdownRenderer.renderPlan(
+            from: shortFenceMarkerSource,
+            mode: .complete
+        )
+
+        #expect(shortFenceMarkerPlan.blocks.isEmpty == false)
+
+        DesktopChatMarkdownRenderer.resetCacheForTesting()
+    }
+
     @Test("chat markdown renderer evicts old chunk cache entries")
     func chatMarkdownRendererEvictsOldChunkCacheEntries() {
         DesktopChatMarkdownRenderer.resetCacheForTesting(capacity: 1)
@@ -4296,11 +4409,13 @@ struct DesktopFoundationViewTests {
         ```swift
         let value = 2
         """)
+        let pureHTML = DesktopChatMarkdownRenderer.blocks(from: "<br />")
 
         #expect(softBreak == [.paragraph("soft break")])
         #expect(hardBreak == [.paragraph("hard\nbreak")])
         #expect(strikeLinkAndTitleImage == [.paragraph("~~gone~~ label fallback")])
         #expect(unclosedFence == [.codeBlock(language: "swift", code: "let value = 2")])
+        #expect(pureHTML == [])
     }
 
     @Test("chat markdown renderer caches parsed blocks and evicts old entries")
@@ -4320,6 +4435,7 @@ struct DesktopFoundationViewTests {
         #expect(first.parseMissCount == 1)
         #expect(second.parseHitCount == 1)
         #expect(third.evictionCount == 1)
+        // Misses are cumulative since reset: A, B, C, then A again after eviction.
         #expect(fourth.parseMissCount == 4)
         #expect(fourth.latestParseDurationMS >= 0)
     }
@@ -4327,15 +4443,17 @@ struct DesktopFoundationViewTests {
     @Test("chat markdown renderer caches inline attributed strings and evicts old entries")
     func chatMarkdownRendererCachesInlineAttributedStringsAndEvictsOldEntries() {
         DesktopChatMarkdownRenderer.resetCacheForTesting(capacity: 1)
+        let firstSource = String(repeating: "**A** ", count: 512)
 
-        _ = DesktopChatMarkdownInlineFormatter.attributedString(from: "**A**")
+        _ = DesktopChatMarkdownInlineFormatter.attributedString(from: firstSource)
         let first = DesktopChatMarkdownRenderer.cacheStatsForTesting()
-        _ = DesktopChatMarkdownInlineFormatter.attributedString(from: "**A**")
+        _ = DesktopChatMarkdownInlineFormatter.attributedString(from: firstSource)
         let second = DesktopChatMarkdownRenderer.cacheStatsForTesting()
         _ = DesktopChatMarkdownInlineFormatter.attributedString(from: "**B**")
         let third = DesktopChatMarkdownRenderer.cacheStatsForTesting()
 
         #expect(first.inlineMissCount == 1)
+        #expect(first.latestParseDurationMS > 0)
         #expect(second.inlineHitCount == 1)
         #expect(third.evictionCount == 1)
 

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -4465,7 +4465,7 @@ struct DesktopFoundationViewTests {
             }
             .joined(separator: ";")
         print(
-            "M16_CHAT_MARKDOWN_PERF=samples=[\(sampleMetrics)] eviction_count=\(stats.evictionCount) latest_parse_ms=\(String(format: "%.3f", stats.latestParseDurationMS))"
+            "M16_CHAT_MARKDOWN_PERF=samples=[\(sampleMetrics)] eviction_count=\(stats.evictionCount) latest_build_ms=\(String(format: "%.3f", stats.latestBuildDurationMS))"
         )
 
         DesktopChatMarkdownRenderer.resetCacheForTesting()
@@ -4553,7 +4553,7 @@ struct DesktopFoundationViewTests {
         #expect(third.evictionCount == 1)
         // Misses are cumulative since reset: A, B, C, then A again after eviction.
         #expect(fourth.parseMissCount == 4)
-        #expect(fourth.latestParseDurationMS >= 0)
+        #expect(fourth.latestBuildDurationMS >= 0)
     }
 
     @Test("chat markdown renderer caches inline attributed strings and evicts old entries")
@@ -4569,7 +4569,7 @@ struct DesktopFoundationViewTests {
         let third = DesktopChatMarkdownRenderer.cacheStatsForTesting()
 
         #expect(first.inlineMissCount == 1)
-        #expect(first.latestParseDurationMS > 0)
+        #expect(first.latestBuildDurationMS > 0)
         #expect(second.inlineHitCount == 1)
         #expect(third.evictionCount == 1)
 

--- a/apps/macos-menubar/Tests/MenuBarTests/Fixtures/chat-markdown-rich.md
+++ b/apps/macos-menubar/Tests/MenuBarTests/Fixtures/chat-markdown-rich.md
@@ -1,0 +1,26 @@
+# Release Notes
+
+> Stable renderer output for **assistant** rows.
+
+- Parse Markdown through the AST
+  - Keep nested list shape
+- Keep transcript storage raw
+
+2. Preserve ordered starts
+3. Keep numbering readable
+
+```swift
+let value = 42
+print(value)
+```
+
+| Metric | Value | Note |
+| :--- | ---: | :---: |
+| TTFT | 12 ms | cached |
+| TPS | 41 | steady |
+
+---
+
+![Diagram alt](https://example.com/diagram.png)
+
+[Unsafe label](javascript:alert(1))

--- a/apps/macos-menubar/Tests/MenuBarTests/Fixtures/chat-markdown-rich.snapshot.txt
+++ b/apps/macos-menubar/Tests/MenuBarTests/Fixtures/chat-markdown-rich.snapshot.txt
@@ -1,6 +1,6 @@
 heading1: Release Notes
 quote:
-  paragraph: Stable renderer output for **assistant** rows.
+  paragraph: Stable renderer output for **assistant** rows\.
 unordered:
   - Parse Markdown through the AST
     unordered:

--- a/apps/macos-menubar/Tests/MenuBarTests/Fixtures/chat-markdown-rich.snapshot.txt
+++ b/apps/macos-menubar/Tests/MenuBarTests/Fixtures/chat-markdown-rich.snapshot.txt
@@ -1,0 +1,19 @@
+heading1: Release Notes
+quote:
+  paragraph: Stable renderer output for **assistant** rows.
+unordered:
+  - Parse Markdown through the AST
+    unordered:
+      - Keep nested list shape
+  - Keep transcript storage raw
+ordered(2):
+  - Preserve ordered starts
+  - Keep numbering readable
+code[swift]:
+  let value = 42\nprint(value)
+table[leading,trailing,center]: Metric | Value | Note
+  row: TTFT | 12 ms | cached
+  row: TPS | 41 | steady
+thematic-break
+paragraph: Diagram alt
+paragraph: Unsafe label

--- a/docs/plans/2026-04-23-chat-waiting-indicator-and-markdown.md
+++ b/docs/plans/2026-04-23-chat-waiting-indicator-and-markdown.md
@@ -16,17 +16,39 @@ latest exchange in view without requiring manual scrolling.
 - The pending row is presentation state only: it is replaced by the first
   assistant token or final assistant text, and it is removed after failures or
   empty completions.
-- Assistant and reasoning rows render sanitized Markdown for inline emphasis,
-  inline code, lists, fenced code blocks, and simple pipe tables.
+- Assistant and reasoning rows render sanitized Markdown through an AST-backed
+  renderer. Supported blocks include paragraphs, headings, nested ordered and
+  unordered lists, block quotes, fenced and indented code blocks, tables with
+  column alignment, and thematic breaks. Supported inline constructs include
+  emphasis, strong emphasis, inline code, strikethrough, and readable link or
+  image labels.
 - The transcript auto-scrolls to the newest row when pending status, streamed
   content, or completed assistant output extends the conversation.
 - User, tool, and error rows remain literal plain text so prompts, logs, and
   diagnostics are not reformatted.
 
+## Rendering Architecture
+
+- Chat Markdown parsing uses the `swift-markdown` AST rather than a hand-written
+  line scanner. A block visitor converts parsed Markdown into small view models,
+  and a separate inline visitor builds safe `AttributedString` values for SwiftUI
+  text rendering.
+- The renderer keeps Markdown as presentation state only. The chat transcript,
+  persisted session history, exports, and runtime messages continue to store the
+  raw model output.
+- Parsed block output and inline attributed strings are cached after
+  sanitization. The cache is lock-protected, bounded, and reports internal hit,
+  miss, eviction, and latest parse-duration counters for tests and local metrics.
+- Code fence contents are preserved after sanitization, with the closing-fence
+  parser newline normalized to match the previous display behavior.
+
 ## Safety And Persistence
 
-- Rich output is sanitized with `RichOutputSanitizer` before Markdown parsing.
-- Unsafe links and active HTML are never rendered as rich content.
+- Rich output is sanitized with `RichOutputSanitizer` before Markdown parsing or
+  inline formatting.
+- Unsafe links and active HTML are never rendered as rich content. Links render
+  as readable label text without active navigation attributes, and images render
+  safe alternate text only; remote image loading is not performed.
 - Empty pending assistant rows are excluded from persisted chat session state.
 - Stored transcript text remains the raw model text; Markdown rendering is
   view-only.
@@ -35,7 +57,16 @@ latest exchange in view without requiring manual scrolling.
 
 - Runtime tests cover pending row creation, in-place final assistant replacement,
   stream failure cleanup, and empty completion cleanup.
-- View tests cover Markdown block parsing, inline Markdown formatting, row-kind
-  scoping, and sanitizer integration.
+- View tests cover Markdown block parsing, nested lists, block quotes, headings,
+  thematic breaks, aligned tables, escaped table pipes, image-alt fallback, safe
+  link-label rendering, row-kind scoping, sanitizer integration, and cache hit,
+  miss, eviction, and repeated-render behavior.
 - Manual UI verification should use the Chat surface with a delayed model
   response to confirm the pending indicator appears and then clears.
+
+## Metrics
+
+- Chat Markdown parse cache metrics: parse hit count, parse miss count, eviction
+  count, and latest parse duration in milliseconds.
+- Runtime hot-path metrics: N/A. The change is scoped to local UI rendering and
+  does not alter model execution or HTTP serving paths.

--- a/docs/plans/2026-04-23-chat-waiting-indicator-and-markdown.md
+++ b/docs/plans/2026-04-23-chat-waiting-indicator-and-markdown.md
@@ -22,6 +22,13 @@ latest exchange in view without requiring manual scrolling.
   column alignment, and thematic breaks. Supported inline constructs include
   emphasis, strong emphasis, inline code, strikethrough, and readable link or
   image labels.
+- Code blocks present a compact language badge, a copy control, and lightweight
+  syntax coloring for common local development snippets. The copy control writes
+  only the fenced code text and does not mutate transcript state.
+- Tables are horizontally scrollable when content is wider than the chat column.
+  Column sizing remains content-aware within bounded minimum and maximum widths,
+  and very long cell text is line-limited with tail truncation so one cell cannot
+  consume the whole transcript row.
 - The transcript auto-scrolls to the newest row when pending status, streamed
   content, or completed assistant output extends the conversation.
 - User, tool, and error rows remain literal plain text so prompts, logs, and
@@ -41,6 +48,15 @@ latest exchange in view without requiring manual scrolling.
   miss, eviction, and latest parse-duration counters for tests and local metrics.
 - Code fence contents are preserved after sanitization, with the closing-fence
   parser newline normalized to match the previous display behavior.
+- Streaming and long-response rendering use a chunked render plan. Stable
+  Markdown block chunks are parsed and cached independently, while the trailing
+  in-progress chunk is reparsed as tokens arrive. Very long transcripts render
+  chunks through a lazy stack so off-screen Markdown blocks do not require eager
+  view construction.
+- The renderer exposes local performance probes for 5 KB, 50 KB, and 200 KB
+  Markdown samples. The probes report first-parse duration, cached-parse
+  duration, block count, chunk count, cache hits, cache misses, and eviction
+  counts.
 
 ## Safety And Persistence
 
@@ -61,6 +77,12 @@ latest exchange in view without requiring manual scrolling.
   thematic breaks, aligned tables, escaped table pipes, image-alt fallback, safe
   link-label rendering, row-kind scoping, sanitizer integration, and cache hit,
   miss, eviction, and repeated-render behavior.
+- Fixture snapshot tests cover representative rich Markdown transcripts,
+  including code blocks, tables, nested lists, quotes, and unsafe content.
+- Focused tests cover code-block syntax highlighting, language badge
+  normalization, copy behavior, table column sizing and truncation policy,
+  streaming chunk reuse, lazy render-plan thresholds, and 5 KB / 50 KB / 200 KB
+  parse benchmark reporting.
 - Manual UI verification should use the Chat surface with a delayed model
   response to confirm the pending indicator appears and then clears.
 
@@ -68,5 +90,8 @@ latest exchange in view without requiring manual scrolling.
 
 - Chat Markdown parse cache metrics: parse hit count, parse miss count, eviction
   count, and latest parse duration in milliseconds.
+- Chat Markdown streaming metrics: chunk count, stable chunk reuse count, first
+  parse duration, cached parse duration, and per-sample parse durations for 5 KB,
+  50 KB, and 200 KB local benchmark samples.
 - Runtime hot-path metrics: N/A. The change is scoped to local UI rendering and
   does not alter model execution or HTTP serving paths.


### PR DESCRIPTION
## Summary
- Replace assistant and reasoning Markdown rendering with AST-backed block and inline rendering while keeping stored transcript text raw.
- Add code block language badges, copy behavior, and lightweight syntax coloring without enabling active HTML, clickable links, or remote image loading.
- Add horizontally scrollable tables with bounded content-aware columns, long-cell truncation policy, and refined heading, list, and quote hierarchy.
- Add chunked streaming render plans, lazy long-response rendering, cache stats, rich Markdown fixture snapshots, and local 5 KB / 50 KB / 200 KB performance probes.
- Address review feedback for language-specific code highlighting, full-line comment coloring, DEBUG-only performance probes, completed-message tail caching, and stable SwiftUI render identities.
- Address the two follow-up review notes by clarifying the table width estimate and renaming the shared cache build timing stat.
- Rebase the branch onto the latest `main` so the PR-scoped performance workflow can find the scope/report scripts.

## Plan or Spec
- `docs/plans/2026-04-23-chat-waiting-indicator-and-markdown.md`

## Commands Run
```text
git fetch origin - PASS
git rebase origin/main - PASS
TDD red check for renamed cache stat - EXPECTED FAIL before implementation, missing `latestBuildDurationMS`
xcrun swift test --package-path apps/macos-menubar --filter DesktopFoundationViewTests/chatMarkdownRendererCachesInlineAttributedStringsAndEvictsOldEntries - PASS, 1 test
xcrun swift test --package-path apps/macos-menubar --filter chat - PASS, 69 tests
xcrun swift test --package-path apps/macos-menubar --enable-code-coverage --filter chat - PASS, 69 tests
scripts/swift_changed_line_coverage.py --diff-from origin/main for touched menu-bar Swift source/test files - PASS, TOTAL 98.48% (1556/1580)
xcrun swift test --package-path apps/macos-menubar --filter DesktopPolishSmokeTests - PASS, 1 test
git diff --check - PASS
old cache-stat name scan - PASS, no matches
xcrun swift test --package-path apps/macos-menubar --filter DesktopFoundationViewTests - FAIL after latest-main rebase, 1 unrelated model registry empty-state test failed
xcrun swift test --package-path apps/macos-menubar --filter DesktopFoundationViewTests/modelRegistryRendersEmptyStateAndPlaceholderCard - FAIL, reproduces the same latest-main model registry empty-state issue
PR evidence validation - PASS
external-reference name scan - PASS, no matches
make swift-test - FAIL from earlier local run, blocked in services/mlx-text-worker-swift WorkerScaffoldTests/testFusedDecodeQuantizerRejectsUnsupportedInputs because the local MLX default metallib could not be loaded before the menu-bar package ran
GitHub review threads - PASS, replied and resolved 46/46
```

## Coverage and Metrics
- Latest changed-line coverage for touched menu-bar Swift source/test files: `TOTAL 98.48% (1556/1580)`.
- Renderer latest changed-line coverage: `97.75% (912/933)`.
- Chat row source latest changed-line coverage: `100.00% (6/6)`.
- Runtime view model latest changed-line coverage: `100.00% (5/5)`.
- Menu-bar foundation test latest changed-line coverage: `99.53% (633/636)`.
- Chat Markdown performance probe: `5KB first=7.404ms cached=1.457ms hits=3 misses=3 evictions=0 chunks=3`; `50KB first=16.704ms cached=11.680ms hits=25 misses=2 evictions=0 chunks=25`; `200KB first=47.704ms cached=45.430ms hits=98 misses=1 evictions=0 chunks=98`; `eviction_count=0`; `latest_build_ms=0.385`.
- Desktop polish smoke metric: `presentation_flush_count=9`, `presentation_lag_ms=210.609`, with persisted session restore and update/download signals present.
- Runtime hot-path metrics: `N/A`; this is SwiftUI presentation rendering only and does not add a runtime service hot path.

## Known Gaps
- After rebasing onto the latest `main`, the full `DesktopFoundationViewTests` filter fails in `modelRegistryRendersEmptyStateAndPlaceholderCard` on `view.subviews.isEmpty == false`. The failure reproduces standalone and this PR diff does not change model registry rendering or the test host helper; the chat-targeted tests and changed-line coverage pass.
- `make swift-test` failed in the earlier local run before reaching the menu-bar package because `services/mlx-text-worker-swift` could not load the local MLX default metallib in `WorkerScaffoldTests/testFusedDecodeQuantizerRejectsUnsupportedInputs`. The targeted menu-bar chat tests and changed-line coverage pass after the latest rebase.
- `make py-test` and `make integration-test` were not run; this change is limited to the macOS menu-bar Swift renderer, package dependency resolution, tests, and plan documentation.
- The package manifest dependency line is non-executable and is not included in Swift line coverage; source and test Swift changes are covered above.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
