### PR TITLE
[codex] Align macOS colors with design system

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Branding/MelixDesignTokens.swift
+++ b/apps/macos-menubar/Sources/AppMain/Branding/MelixDesignTokens.swift
@@ -1,6 +1,33 @@
 import AppKit
 import SwiftUI
 
+private extension MelixDesignTokens.DesignColor.Components {
+    func nsColor(alpha: Double) -> NSColor {
+        NSColor(
+            srgbRed: CGFloat(red) / 255.0,
+            green: CGFloat(green) / 255.0,
+            blue: CGFloat(blue) / 255.0,
+            alpha: CGFloat(alpha)
+        )
+    }
+}
+
+private extension NSAppearance {
+    var isDarkMode: Bool {
+        let darkAppearances: Set<NSAppearance.Name> = [
+            .darkAqua,
+            .accessibilityHighContrastDarkAqua,
+        ]
+        let bestMatch = bestMatch(from: [
+            .aqua,
+            .darkAqua,
+            .accessibilityHighContrastAqua,
+            .accessibilityHighContrastDarkAqua,
+        ])
+        return bestMatch.map { darkAppearances.contains($0) } ?? false
+    }
+}
+
 /// Central design tokens for the Melix macOS operator app.
 ///
 /// Mirrors `docs/design-system/colors_and_type.css`. Refer to
@@ -9,50 +36,83 @@ import SwiftUI
 enum MelixDesignTokens {
 
     struct DesignColor: Equatable {
-        let red: Int
-        let green: Int
-        let blue: Int
+        struct Components: Equatable {
+            let red: UInt8
+            let green: UInt8
+            let blue: UInt8
+        }
+
+        let light: Components
+        let dark: Components
         let opacity: Double
 
-        init(red: Int, green: Int, blue: Int, opacity: Double = 1.0) {
-            self.red = red
-            self.green = green
-            self.blue = blue
+        init(red: UInt8, green: UInt8, blue: UInt8, opacity: Double = 1.0) {
+            let components = Components(red: red, green: green, blue: blue)
+            self.light = components
+            self.dark = components
+            self.opacity = opacity
+        }
+
+        init(light: Components, dark: Components, opacity: Double = 1.0) {
+            self.light = light
+            self.dark = dark
             self.opacity = opacity
         }
 
         var color: Color {
-            Color(
-                red: Double(red) / 255.0,
-                green: Double(green) / 255.0,
-                blue: Double(blue) / 255.0,
-                opacity: opacity
-            )
+            Color(nsColor: nsColor)
         }
 
         var nsColor: NSColor {
-            NSColor(
-                srgbRed: CGFloat(red) / 255.0,
-                green: CGFloat(green) / 255.0,
-                blue: CGFloat(blue) / 255.0,
-                alpha: CGFloat(opacity)
-            )
+            NSColor(name: nil) { appearance in
+                let components = appearance.isDarkMode ? dark : light
+                return components.nsColor(alpha: opacity)
+            }
         }
     }
+
+    private typealias Components = DesignColor.Components
 
     enum Palette {
         static let accent = DesignColor(red: 0x0F, green: 0x76, blue: 0x6E)
 
-        static let foregroundPrimary = DesignColor(red: 0x0A, green: 0x0A, blue: 0x0A)
-        static let foregroundSecondary = DesignColor(red: 0x3A, green: 0x3A, blue: 0x3A)
-        static let foregroundTertiary = DesignColor(red: 0x6B, green: 0x6B, blue: 0x6B)
-        static let foregroundQuaternary = DesignColor(red: 0x9A, green: 0x9A, blue: 0x9A)
-        static let foregroundInverse = DesignColor(red: 0xFD, green: 0xFD, blue: 0xFD)
+        static let foregroundPrimary = DesignColor(
+            light: Components(red: 0x0A, green: 0x0A, blue: 0x0A),
+            dark: Components(red: 0xFD, green: 0xFD, blue: 0xFD)
+        )
+        static let foregroundSecondary = DesignColor(
+            light: Components(red: 0x3A, green: 0x3A, blue: 0x3A),
+            dark: Components(red: 0xC8, green: 0xC8, blue: 0xC8)
+        )
+        static let foregroundTertiary = DesignColor(
+            light: Components(red: 0x6B, green: 0x6B, blue: 0x6B),
+            dark: Components(red: 0x8A, green: 0x8A, blue: 0x8A)
+        )
+        static let foregroundQuaternary = DesignColor(
+            light: Components(red: 0x9A, green: 0x9A, blue: 0x9A),
+            dark: Components(red: 0x5A, green: 0x5A, blue: 0x5A)
+        )
+        static let foregroundInverse = DesignColor(
+            light: Components(red: 0xFD, green: 0xFD, blue: 0xFD),
+            dark: Components(red: 0x0A, green: 0x0A, blue: 0x0A)
+        )
 
-        static let backgroundBaseLight = DesignColor(red: 0xFA, green: 0xFA, blue: 0xFA)
-        static let backgroundSurfaceLight = DesignColor(red: 0xFF, green: 0xFF, blue: 0xFF)
-        static let backgroundElevatedLight = DesignColor(red: 0xF5, green: 0xF5, blue: 0xF5)
-        static let backgroundSunkenLight = DesignColor(red: 0xF0, green: 0xF0, blue: 0xF0)
+        static let backgroundBase = DesignColor(
+            light: Components(red: 0xFA, green: 0xFA, blue: 0xFA),
+            dark: Components(red: 0x1A, green: 0x1A, blue: 0x1A)
+        )
+        static let backgroundSurface = DesignColor(
+            light: Components(red: 0xFF, green: 0xFF, blue: 0xFF),
+            dark: Components(red: 0x22, green: 0x22, blue: 0x22)
+        )
+        static let backgroundElevated = DesignColor(
+            light: Components(red: 0xF5, green: 0xF5, blue: 0xF5),
+            dark: Components(red: 0x2A, green: 0x2A, blue: 0x2A)
+        )
+        static let backgroundSunken = DesignColor(
+            light: Components(red: 0xF0, green: 0xF0, blue: 0xF0),
+            dark: Components(red: 0x16, green: 0x16, blue: 0x16)
+        )
 
         static let success = DesignColor(red: 0x14, green: 0xA0, blue: 0x5A)
         static let warning = DesignColor(red: 0xD9, green: 0x77, blue: 0x06)
@@ -67,9 +127,9 @@ enum MelixDesignTokens {
 
     // MARK: - Accent
 
-    /// Brand teal (`#0F766E`). Used for places where the Melix identity
-    /// must be fixed regardless of the user's system accent (app icon,
-    /// workspace badge, printed/exported artifacts).
+    /// Brand teal (`#0F766E`). Kept separate from `accent` so identity marks
+    /// and interactive affordances remain semantically distinct, even though
+    /// the design system intentionally maps both to CSS `--accent`.
     static let brandAccent = Palette.accent.color
 
     /// Design-system accent. Use for interaction signals: links, focus,
@@ -85,8 +145,6 @@ enum MelixDesignTokens {
         static let selected: Double = weak
         /// Capsule tab active fill.
         static let capsule: Double = weak
-        /// Stroke / border accent (focus ring, emphasis outline).
-        static let stroke: Double = medium
         /// Hover hint for interactive surfaces.
         static let faint: Double = 0.06
     }
@@ -117,7 +175,14 @@ enum MelixDesignTokens {
         static let success = Palette.success.color
         static let warning = Palette.warning.color
         static let error = Palette.error.color
+        /// CSS `--color-info` intentionally aliases `--accent`; informational
+        /// notices use ink color rather than introducing a separate blue.
         static let info = accent
+    }
+
+    enum StateOpacity {
+        /// Non-chat status background tint for rows and job states.
+        static let background: Double = 0.09
     }
 
     /// Base hues for chat transcript bubble backgrounds. Paired with

--- a/apps/macos-menubar/Sources/AppMain/Branding/MelixDesignTokens.swift
+++ b/apps/macos-menubar/Sources/AppMain/Branding/MelixDesignTokens.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Central design tokens for the Melix macOS operator app.
@@ -7,27 +8,85 @@ import SwiftUI
 /// typographic structure, whitespace as hierarchy, accent as ink.
 enum MelixDesignTokens {
 
+    struct DesignColor: Equatable {
+        let red: Int
+        let green: Int
+        let blue: Int
+        let opacity: Double
+
+        init(red: Int, green: Int, blue: Int, opacity: Double = 1.0) {
+            self.red = red
+            self.green = green
+            self.blue = blue
+            self.opacity = opacity
+        }
+
+        var color: Color {
+            Color(
+                red: Double(red) / 255.0,
+                green: Double(green) / 255.0,
+                blue: Double(blue) / 255.0,
+                opacity: opacity
+            )
+        }
+
+        var nsColor: NSColor {
+            NSColor(
+                srgbRed: CGFloat(red) / 255.0,
+                green: CGFloat(green) / 255.0,
+                blue: CGFloat(blue) / 255.0,
+                alpha: CGFloat(opacity)
+            )
+        }
+    }
+
+    enum Palette {
+        static let accent = DesignColor(red: 0x0F, green: 0x76, blue: 0x6E)
+
+        static let foregroundPrimary = DesignColor(red: 0x0A, green: 0x0A, blue: 0x0A)
+        static let foregroundSecondary = DesignColor(red: 0x3A, green: 0x3A, blue: 0x3A)
+        static let foregroundTertiary = DesignColor(red: 0x6B, green: 0x6B, blue: 0x6B)
+        static let foregroundQuaternary = DesignColor(red: 0x9A, green: 0x9A, blue: 0x9A)
+        static let foregroundInverse = DesignColor(red: 0xFD, green: 0xFD, blue: 0xFD)
+
+        static let backgroundBaseLight = DesignColor(red: 0xFA, green: 0xFA, blue: 0xFA)
+        static let backgroundSurfaceLight = DesignColor(red: 0xFF, green: 0xFF, blue: 0xFF)
+        static let backgroundElevatedLight = DesignColor(red: 0xF5, green: 0xF5, blue: 0xF5)
+        static let backgroundSunkenLight = DesignColor(red: 0xF0, green: 0xF0, blue: 0xF0)
+
+        static let success = DesignColor(red: 0x14, green: 0xA0, blue: 0x5A)
+        static let warning = DesignColor(red: 0xD9, green: 0x77, blue: 0x06)
+        static let error = DesignColor(red: 0xDC, green: 0x26, blue: 0x26)
+
+        static let userBubble = DesignColor(red: 0x00, green: 0x64, blue: 0xDC)
+        static let assistantBubble = DesignColor(red: 0x14, green: 0xA0, blue: 0x50)
+        static let reasoningBubble = DesignColor(red: 0xDC, green: 0x6E, blue: 0x14)
+        static let toolBubble = DesignColor(red: 0x78, green: 0x3C, blue: 0xC8)
+        static let errorBubble = DesignColor(red: 0xD2, green: 0x28, blue: 0x28)
+    }
+
     // MARK: - Accent
 
     /// Brand teal (`#0F766E`). Used for places where the Melix identity
     /// must be fixed regardless of the user's system accent (app icon,
     /// workspace badge, printed/exported artifacts).
-    static let brandAccent = Color(red: 0x0F / 255.0, green: 0x76 / 255.0, blue: 0x6E / 255.0)
+    static let brandAccent = Palette.accent.color
 
-    /// System accent. Prefer this for interaction signals (focus, selection,
-    /// active tab, one primary CTA per screen) so macOS users' accent
-    /// customization is honored.
-    static let accent = Color.accentColor
+    /// Design-system accent. Use for interaction signals: links, focus,
+    /// selection, active tabs, and one primary CTA per screen.
+    static let accent = Palette.accent.color
 
     enum AccentOpacity {
+        /// Medium accent wash (`--accent-medium` = 32%).
+        static let medium: Double = 0.32
         /// Selected row / bubble background (`--accent-weak` ≈ 12%).
         static let weak: Double = 0.12
-        /// Selection emphasis for chips and primary pills.
-        static let selected: Double = 0.14
+        /// Selection emphasis for rows, chips, and primary pills.
+        static let selected: Double = weak
         /// Capsule tab active fill.
-        static let capsule: Double = 0.18
+        static let capsule: Double = weak
         /// Stroke / border accent (focus ring, emphasis outline).
-        static let stroke: Double = 0.22
+        static let stroke: Double = medium
         /// Hover hint for interactive surfaces.
         static let faint: Double = 0.06
     }
@@ -54,27 +113,33 @@ enum MelixDesignTokens {
 
     // MARK: - Status tints
 
+    enum StatusColor {
+        static let success = Palette.success.color
+        static let warning = Palette.warning.color
+        static let error = Palette.error.color
+        static let info = accent
+    }
+
     /// Base hues for chat transcript bubble backgrounds. Paired with
     /// `BubbleOpacity` to stay consistent with the `AccentOpacity` pattern.
     /// These are intentionally flat `Color` values; transcript bubbles do not
     /// use gradients or materials in the Digital Broadsheet system.
     enum BubbleTint {
-        static let user = Color.blue
-        static let assistant = Color.green
-        static let reasoning = Color.orange
-        static let tool = Color.purple
-        static let error = Color.red
+        static let user = Palette.userBubble.color
+        static let assistant = Palette.assistantBubble.color
+        static let reasoning = Palette.reasoningBubble.color
+        static let tool = Palette.toolBubble.color
+        static let error = Palette.errorBubble.color
     }
 
-    /// Per-role opacities for chat bubble backgrounds. The user bubble sits
-    /// slightly stronger (0.14) because blue reads softer than the warm
-    /// tones on a near-white canvas; the rest match spec at 0.12.
+    /// Per-role opacities for chat bubble backgrounds, matching
+    /// `docs/design-system/colors_and_type.css`.
     enum BubbleOpacity {
-        static let user: Double = 0.14
-        static let assistant: Double = 0.12
-        static let reasoning: Double = 0.12
-        static let tool: Double = 0.12
-        static let error: Double = 0.12
+        static let user: Double = 0.10
+        static let assistant: Double = 0.09
+        static let reasoning: Double = 0.09
+        static let tool: Double = 0.09
+        static let error: Double = 0.09
     }
 
     // MARK: - Corner radii

--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
@@ -483,10 +483,10 @@ private struct DesktopChatCapabilityIconTile: View {
                 Image(systemName: capability.systemImageName)
                     .font(.system(size: 18, weight: .medium))
                     .frame(width: 34, height: 28)
-                    .foregroundStyle(capability.isReady ? Color.accentColor : Color.secondary)
+                    .foregroundStyle(capability.isReady ? MelixDesignTokens.accent : Color.secondary)
 
                 Circle()
-                    .fill(capability.isReady ? Color.green : Color.secondary.opacity(0.45))
+                    .fill(capability.isReady ? MelixDesignTokens.StatusColor.success : Color.secondary.opacity(0.45))
                     .frame(width: 7, height: 7)
                     .offset(x: 2, y: -1)
             }

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
@@ -149,8 +149,11 @@ struct DesktopModelsTabView: View {
                                     .font(.caption2)
                                     .padding(.horizontal, 7)
                                     .padding(.vertical, 3)
-                                    .background(Color.orange.opacity(0.16), in: Capsule())
-                                    .foregroundStyle(.orange)
+                                    .background(
+                                        MelixDesignTokens.StatusColor.warning.opacity(MelixDesignTokens.AccentOpacity.weak),
+                                        in: Capsule()
+                                    )
+                                    .foregroundStyle(MelixDesignTokens.StatusColor.warning)
                                     .accessibilityLabel(model.runtimeCacheStatusText)
                             }
                         }
@@ -160,7 +163,7 @@ struct DesktopModelsTabView: View {
                         if model.runtimeCacheMissing {
                             Text(model.runtimeCacheDetailText)
                                 .font(.caption2)
-                                .foregroundStyle(.orange)
+                                .foregroundStyle(MelixDesignTokens.StatusColor.warning)
                         }
                         if !model.typeOverrideText.isEmpty {
                             Text("type override: \(model.typeOverrideText)")
@@ -176,7 +179,7 @@ struct DesktopModelsTabView: View {
                         if !model.memoryAlertText.isEmpty {
                             Text(model.memoryAlertText)
                                 .font(.caption2)
-                                .foregroundStyle(.red)
+                                .foregroundStyle(MelixDesignTokens.StatusColor.error)
                         }
                         if model.adaptiveThinkingText != "Off" || model.toolParserFallbackText != "Off" {
                             Text("adaptive thinking: \(model.adaptiveThinkingText) • parser fallback: \(model.toolParserFallbackText)")
@@ -690,7 +693,7 @@ private struct DesktopRegistryRootRowView: View {
                     .font(.headline)
                 Text("#\(root.rootOrder) • \(root.statusText)")
                     .font(.caption)
-                    .foregroundStyle(root.accessible ? Color.secondary : Color.orange)
+                    .foregroundStyle(root.accessible ? Color.secondary : MelixDesignTokens.StatusColor.warning)
                 Text(root.detailText)
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
@@ -726,7 +729,7 @@ private struct DesktopResidencyRowsSection: View {
                             Spacer()
                             Text(model.stateText)
                                 .font(.caption)
-                                .foregroundStyle(model.memoryAlertText.isEmpty ? Color.secondary : Color.orange)
+                                .foregroundStyle(model.memoryAlertText.isEmpty ? Color.secondary : MelixDesignTokens.StatusColor.warning)
                         }
                         Text(model.residencyText)
                             .font(.caption)
@@ -737,7 +740,7 @@ private struct DesktopResidencyRowsSection: View {
                         if !model.memoryAlertText.isEmpty {
                             Text(model.memoryAlertText)
                                 .font(.caption2)
-                                .foregroundStyle(.red)
+                                .foregroundStyle(MelixDesignTokens.StatusColor.error)
                         }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -1300,7 +1303,7 @@ struct DesktopLogsTabView: View {
                     Spacer()
                     Text(entry.level.uppercased())
                         .font(.caption2)
-                        .foregroundStyle(entry.level == "error" ? .red : .secondary)
+                        .foregroundStyle(entry.level == "error" ? MelixDesignTokens.StatusColor.error : .secondary)
                 }
                 Text(entry.message)
                     .font(.body)

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -177,11 +177,11 @@ private struct DesktopShellBannerView: View {
     private var bannerSeverityColor: Color {
         switch banner.severity {
         case .info:
-            return Color.blue
+            return MelixDesignTokens.StatusColor.info
         case .warning:
-            return Color.orange
+            return MelixDesignTokens.StatusColor.warning
         case .critical:
-            return Color.red
+            return MelixDesignTokens.StatusColor.error
         }
     }
 }
@@ -213,11 +213,11 @@ struct DesktopInlineNoticeCardView: View {
     private var accentColor: Color {
         switch notice.severity {
         case .info:
-            return .blue
+            return MelixDesignTokens.StatusColor.info
         case .warning:
-            return .orange
+            return MelixDesignTokens.StatusColor.warning
         case .critical:
-            return .red
+            return MelixDesignTokens.StatusColor.error
         }
     }
 
@@ -371,7 +371,7 @@ struct DesktopCommandCenterView: View {
                     if let lastError = viewModel?.lastError {
                         GroupBox("Latest Error") {
                             Text(lastError)
-                                .foregroundStyle(.red)
+                                .foregroundStyle(MelixDesignTokens.StatusColor.error)
                                 .lineLimit(3)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
@@ -433,7 +433,7 @@ struct DesktopCommandCenterView: View {
                                     if !session.lastError.isEmpty {
                                         Text(session.lastError)
                                             .font(.caption)
-                                            .foregroundStyle(.red)
+                                            .foregroundStyle(MelixDesignTokens.StatusColor.error)
                                     }
                                 }
                             }
@@ -459,7 +459,7 @@ struct DesktopCommandCenterView: View {
                                     Spacer()
                                     Text(entry.level.uppercased())
                                         .font(.caption2)
-                                        .foregroundStyle(entry.level == "error" ? .red : .secondary)
+                                        .foregroundStyle(entry.level == "error" ? MelixDesignTokens.StatusColor.error : .secondary)
                                 }
                                 Text(entry.message)
                                     .font(.body)
@@ -643,7 +643,7 @@ private struct DesktopServerSessionSidebar: View {
                                         Spacer()
                                         Text(session.lifecycleSummaryText)
                                             .font(.caption)
-                                            .foregroundStyle(session.isInteractiveReady ? .green : .secondary)
+                                            .foregroundStyle(session.isInteractiveReady ? MelixDesignTokens.StatusColor.success : .secondary)
                                     }
                                     Text("\(session.modelID) • \(session.listenerLabel)")
                                         .font(.caption)
@@ -653,7 +653,7 @@ private struct DesktopServerSessionSidebar: View {
                                 .padding(12)
                                 .background(
                                     viewModel.selectedServerSession?.id == session.id
-                                    ? Color.accentColor.opacity(0.14)
+                                    ? MelixDesignTokens.accent.opacity(MelixDesignTokens.AccentOpacity.selected)
                                     : Color.secondary.opacity(0.06),
                                     in: RoundedRectangle(cornerRadius: 12)
                                 )
@@ -1080,7 +1080,7 @@ private struct DesktopServerSessionInspector: View {
                 if !session.lastError.isEmpty {
                     GroupBox("Error") {
                         Text(session.lastError)
-                            .foregroundStyle(.red)
+                            .foregroundStyle(MelixDesignTokens.StatusColor.error)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
@@ -1242,7 +1242,7 @@ struct DesktopToolsCategorySidebarView: View {
                                 .padding(.vertical, 10)
                                 .background(
                                     selectedToolSection == section
-                                    ? Color.accentColor.opacity(0.14)
+                                    ? MelixDesignTokens.accent.opacity(MelixDesignTokens.AccentOpacity.selected)
                                     : Color.secondary.opacity(0.06),
                                     in: RoundedRectangle(cornerRadius: 12)
                                 )
@@ -1323,7 +1323,7 @@ struct DesktopDownloadsToolSectionView: View {
                                             .font(.headline)
                                         Text(entry.statusText)
                                             .font(.caption.weight(.semibold))
-                                            .foregroundStyle(entry.resumeReady ? .orange : .secondary)
+                                            .foregroundStyle(entry.resumeReady ? MelixDesignTokens.StatusColor.warning : .secondary)
                                     }
                                     Spacer()
                                     if entry.resumeReady {
@@ -2222,9 +2222,9 @@ struct DesktopTrainingToolSectionView: View {
         case .running:
             return MelixDesignTokens.accent
         case .succeeded:
-            return .green
+            return MelixDesignTokens.StatusColor.success
         case .failed:
-            return .orange
+            return MelixDesignTokens.StatusColor.warning
         }
     }
 
@@ -2320,11 +2320,12 @@ enum DesktopTrainingWorkspaceDefaults {
 }
 
 enum DesktopLoRAVisualPolish {
-    static let pageBackgroundNSColor = NSColor.white
+    static let pageBackgroundColorSpec = MelixDesignTokens.Palette.backgroundBaseLight
+    static let pageBackgroundNSColor = pageBackgroundColorSpec.nsColor
     static let pageBackgroundColor = Color(nsColor: pageBackgroundNSColor)
     static let sectionSurfaceOpacity = 0.04
     static let metricSurfaceOpacity = 0.032
-    static let selectedHistorySurfaceOpacity = 0.14
+    static let selectedHistorySurfaceOpacity = MelixDesignTokens.AccentOpacity.selected
     static let chartFillOpacity = 0.24
 }
 
@@ -3136,7 +3137,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                             .font(.headline)
                                         Spacer()
                                         Image(systemName: viewModel.selectedBenchmarkSuiteIDs.contains(suite.id) ? "checkmark.circle.fill" : "circle")
-                                            .foregroundStyle(viewModel.selectedBenchmarkSuiteIDs.contains(suite.id) ? Color.accentColor : .secondary)
+                                            .foregroundStyle(viewModel.selectedBenchmarkSuiteIDs.contains(suite.id) ? MelixDesignTokens.accent : .secondary)
                                     }
                                     Text("config \(suite.datasetName) • \(suite.defaultsText)")
                                         .font(.caption.weight(.semibold))
@@ -4075,7 +4076,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                             .font(.headline)
                                         Spacer()
                                         Image(systemName: viewModel.selectedEvaluationSuiteIDs.contains(suite.id) ? "checkmark.circle.fill" : "circle")
-                                            .foregroundStyle(viewModel.selectedEvaluationSuiteIDs.contains(suite.id) ? Color.accentColor : .secondary)
+                                            .foregroundStyle(viewModel.selectedEvaluationSuiteIDs.contains(suite.id) ? MelixDesignTokens.accent : .secondary)
                                     }
                                     Text("\(suite.scoreLabel) • \(suite.defaultsText)")
                                         .font(.caption.weight(.semibold))
@@ -4138,7 +4139,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     } label: {
                                         HStack {
                                             Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                                                .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+                                                .foregroundStyle(isSelected ? MelixDesignTokens.accent : .secondary)
                                             Text(model.alias.isEmpty ? model.modelID : "\(model.alias) • \(model.modelID)")
                                                 .font(.caption)
                                                 .foregroundStyle(.primary)
@@ -5128,7 +5129,7 @@ struct DesktopAPIWorkspaceView: View {
                         .padding(.vertical, 10)
                         .background(
                             selectedSection == section
-                            ? Color.accentColor.opacity(0.14)
+                            ? MelixDesignTokens.accent.opacity(MelixDesignTokens.AccentOpacity.selected)
                             : Color.secondary.opacity(0.06),
                             in: RoundedRectangle(cornerRadius: 12)
                         )

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -2224,7 +2224,7 @@ struct DesktopTrainingToolSectionView: View {
         case .succeeded:
             return MelixDesignTokens.StatusColor.success
         case .failed:
-            return MelixDesignTokens.StatusColor.warning
+            return MelixDesignTokens.StatusColor.error
         }
     }
 
@@ -2320,7 +2320,7 @@ enum DesktopTrainingWorkspaceDefaults {
 }
 
 enum DesktopLoRAVisualPolish {
-    static let pageBackgroundColorSpec = MelixDesignTokens.Palette.backgroundBaseLight
+    static let pageBackgroundColorSpec = MelixDesignTokens.Palette.backgroundBase
     static let pageBackgroundNSColor = pageBackgroundColorSpec.nsColor
     static let pageBackgroundColor = Color(nsColor: pageBackgroundNSColor)
     static let sectionSurfaceOpacity = 0.04

--- a/apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift
@@ -578,15 +578,15 @@ private struct DesktopImageJobRowView: View {
 
     private var backgroundStyle: Color {
         if isSelected {
-            return .blue.opacity(0.16)
+            return MelixDesignTokens.accent.opacity(MelixDesignTokens.AccentOpacity.selected)
         }
         switch job.state {
         case .imageJobCompleted:
-            return .green.opacity(0.10)
+            return MelixDesignTokens.StatusColor.success.opacity(MelixDesignTokens.BubbleOpacity.assistant)
         case .imageJobFailed:
-            return .red.opacity(0.10)
+            return MelixDesignTokens.StatusColor.error.opacity(MelixDesignTokens.BubbleOpacity.error)
         case .imageJobRunning:
-            return .orange.opacity(0.10)
+            return MelixDesignTokens.StatusColor.warning.opacity(MelixDesignTokens.BubbleOpacity.reasoning)
         default:
             return .secondary.opacity(0.08)
         }

--- a/apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift
@@ -582,11 +582,11 @@ private struct DesktopImageJobRowView: View {
         }
         switch job.state {
         case .imageJobCompleted:
-            return MelixDesignTokens.StatusColor.success.opacity(MelixDesignTokens.BubbleOpacity.assistant)
+            return MelixDesignTokens.StatusColor.success.opacity(MelixDesignTokens.StateOpacity.background)
         case .imageJobFailed:
-            return MelixDesignTokens.StatusColor.error.opacity(MelixDesignTokens.BubbleOpacity.error)
+            return MelixDesignTokens.StatusColor.error.opacity(MelixDesignTokens.StateOpacity.background)
         case .imageJobRunning:
-            return MelixDesignTokens.StatusColor.warning.opacity(MelixDesignTokens.BubbleOpacity.reasoning)
+            return MelixDesignTokens.StatusColor.warning.opacity(MelixDesignTokens.StateOpacity.background)
         default:
             return .secondary.opacity(0.08)
         }

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -73,20 +73,24 @@ struct DesktopFoundationViewTests {
         #expect(MelixDesignTokens.BubbleOpacity.reasoning == 0.09)
         #expect(MelixDesignTokens.BubbleOpacity.tool == 0.09)
         #expect(MelixDesignTokens.BubbleOpacity.error == 0.09)
+        #expect(MelixDesignTokens.StateOpacity.background == 0.09)
     }
 
     @Test("design color palette matches the design system css tokens")
     func designColorPaletteMatchesDesignSystemCSSTokens() {
+        typealias DesignColor = MelixDesignTokens.DesignColor
+        typealias Components = DesignColor.Components
+
         #expect(MelixDesignTokens.Palette.accent == MelixDesignTokens.DesignColor(red: 0x0F, green: 0x76, blue: 0x6E))
-        #expect(MelixDesignTokens.Palette.foregroundPrimary == MelixDesignTokens.DesignColor(red: 0x0A, green: 0x0A, blue: 0x0A))
-        #expect(MelixDesignTokens.Palette.foregroundSecondary == MelixDesignTokens.DesignColor(red: 0x3A, green: 0x3A, blue: 0x3A))
-        #expect(MelixDesignTokens.Palette.foregroundTertiary == MelixDesignTokens.DesignColor(red: 0x6B, green: 0x6B, blue: 0x6B))
-        #expect(MelixDesignTokens.Palette.foregroundQuaternary == MelixDesignTokens.DesignColor(red: 0x9A, green: 0x9A, blue: 0x9A))
-        #expect(MelixDesignTokens.Palette.foregroundInverse == MelixDesignTokens.DesignColor(red: 0xFD, green: 0xFD, blue: 0xFD))
-        #expect(MelixDesignTokens.Palette.backgroundBaseLight == MelixDesignTokens.DesignColor(red: 0xFA, green: 0xFA, blue: 0xFA))
-        #expect(MelixDesignTokens.Palette.backgroundSurfaceLight == MelixDesignTokens.DesignColor(red: 0xFF, green: 0xFF, blue: 0xFF))
-        #expect(MelixDesignTokens.Palette.backgroundElevatedLight == MelixDesignTokens.DesignColor(red: 0xF5, green: 0xF5, blue: 0xF5))
-        #expect(MelixDesignTokens.Palette.backgroundSunkenLight == MelixDesignTokens.DesignColor(red: 0xF0, green: 0xF0, blue: 0xF0))
+        #expect(MelixDesignTokens.Palette.foregroundPrimary == DesignColor(light: Components(red: 0x0A, green: 0x0A, blue: 0x0A), dark: Components(red: 0xFD, green: 0xFD, blue: 0xFD)))
+        #expect(MelixDesignTokens.Palette.foregroundSecondary == DesignColor(light: Components(red: 0x3A, green: 0x3A, blue: 0x3A), dark: Components(red: 0xC8, green: 0xC8, blue: 0xC8)))
+        #expect(MelixDesignTokens.Palette.foregroundTertiary == DesignColor(light: Components(red: 0x6B, green: 0x6B, blue: 0x6B), dark: Components(red: 0x8A, green: 0x8A, blue: 0x8A)))
+        #expect(MelixDesignTokens.Palette.foregroundQuaternary == DesignColor(light: Components(red: 0x9A, green: 0x9A, blue: 0x9A), dark: Components(red: 0x5A, green: 0x5A, blue: 0x5A)))
+        #expect(MelixDesignTokens.Palette.foregroundInverse == DesignColor(light: Components(red: 0xFD, green: 0xFD, blue: 0xFD), dark: Components(red: 0x0A, green: 0x0A, blue: 0x0A)))
+        #expect(MelixDesignTokens.Palette.backgroundBase == DesignColor(light: Components(red: 0xFA, green: 0xFA, blue: 0xFA), dark: Components(red: 0x1A, green: 0x1A, blue: 0x1A)))
+        #expect(MelixDesignTokens.Palette.backgroundSurface == DesignColor(light: Components(red: 0xFF, green: 0xFF, blue: 0xFF), dark: Components(red: 0x22, green: 0x22, blue: 0x22)))
+        #expect(MelixDesignTokens.Palette.backgroundElevated == DesignColor(light: Components(red: 0xF5, green: 0xF5, blue: 0xF5), dark: Components(red: 0x2A, green: 0x2A, blue: 0x2A)))
+        #expect(MelixDesignTokens.Palette.backgroundSunken == DesignColor(light: Components(red: 0xF0, green: 0xF0, blue: 0xF0), dark: Components(red: 0x16, green: 0x16, blue: 0x16)))
         #expect(MelixDesignTokens.Palette.success == MelixDesignTokens.DesignColor(red: 0x14, green: 0xA0, blue: 0x5A))
         #expect(MelixDesignTokens.Palette.warning == MelixDesignTokens.DesignColor(red: 0xD9, green: 0x77, blue: 0x06))
         #expect(MelixDesignTokens.Palette.error == MelixDesignTokens.DesignColor(red: 0xDC, green: 0x26, blue: 0x26))
@@ -99,7 +103,7 @@ struct DesktopFoundationViewTests {
 
     @Test("lora visual polish tokens use the design system base background with clearer hierarchy")
     func loraVisualPolishTokensUseDesignSystemBaseBackground() {
-        #expect(DesktopLoRAVisualPolish.pageBackgroundColorSpec == MelixDesignTokens.Palette.backgroundBaseLight)
+        #expect(DesktopLoRAVisualPolish.pageBackgroundColorSpec == MelixDesignTokens.Palette.backgroundBase)
         #expect(DesktopLoRAVisualPolish.sectionSurfaceOpacity == 0.04)
         #expect(DesktopLoRAVisualPolish.metricSurfaceOpacity == 0.032)
         #expect(DesktopLoRAVisualPolish.selectedHistorySurfaceOpacity == MelixDesignTokens.AccentOpacity.selected)

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -63,18 +63,46 @@ struct DesktopFoundationViewTests {
 
         #expect(MelixDesignTokens.StrokeOpacity.hairline == MelixDesignTokens.SurfaceOpacity.card)
         #expect(MelixDesignTokens.StrokeOpacity.interactive == 0.08)
-        #expect(MelixDesignTokens.BubbleOpacity.user == 0.14)
-        #expect(MelixDesignTokens.BubbleOpacity.assistant == 0.12)
-        #expect(MelixDesignTokens.BubbleOpacity.reasoning == 0.12)
-        #expect(MelixDesignTokens.BubbleOpacity.tool == 0.12)
-        #expect(MelixDesignTokens.BubbleOpacity.error == 0.12)
+        #expect(MelixDesignTokens.AccentOpacity.medium == 0.32)
+        #expect(MelixDesignTokens.AccentOpacity.weak == 0.12)
+        #expect(MelixDesignTokens.AccentOpacity.selected == 0.12)
+        #expect(MelixDesignTokens.AccentOpacity.capsule == 0.12)
+        #expect(MelixDesignTokens.AccentOpacity.faint == 0.06)
+        #expect(MelixDesignTokens.BubbleOpacity.user == 0.10)
+        #expect(MelixDesignTokens.BubbleOpacity.assistant == 0.09)
+        #expect(MelixDesignTokens.BubbleOpacity.reasoning == 0.09)
+        #expect(MelixDesignTokens.BubbleOpacity.tool == 0.09)
+        #expect(MelixDesignTokens.BubbleOpacity.error == 0.09)
     }
 
-    @Test("lora visual polish tokens use a white marketing background with clearer hierarchy")
-    func loraVisualPolishTokensUseWhiteMarketingBackground() {
+    @Test("design color palette matches the design system css tokens")
+    func designColorPaletteMatchesDesignSystemCSSTokens() {
+        #expect(MelixDesignTokens.Palette.accent == MelixDesignTokens.DesignColor(red: 0x0F, green: 0x76, blue: 0x6E))
+        #expect(MelixDesignTokens.Palette.foregroundPrimary == MelixDesignTokens.DesignColor(red: 0x0A, green: 0x0A, blue: 0x0A))
+        #expect(MelixDesignTokens.Palette.foregroundSecondary == MelixDesignTokens.DesignColor(red: 0x3A, green: 0x3A, blue: 0x3A))
+        #expect(MelixDesignTokens.Palette.foregroundTertiary == MelixDesignTokens.DesignColor(red: 0x6B, green: 0x6B, blue: 0x6B))
+        #expect(MelixDesignTokens.Palette.foregroundQuaternary == MelixDesignTokens.DesignColor(red: 0x9A, green: 0x9A, blue: 0x9A))
+        #expect(MelixDesignTokens.Palette.foregroundInverse == MelixDesignTokens.DesignColor(red: 0xFD, green: 0xFD, blue: 0xFD))
+        #expect(MelixDesignTokens.Palette.backgroundBaseLight == MelixDesignTokens.DesignColor(red: 0xFA, green: 0xFA, blue: 0xFA))
+        #expect(MelixDesignTokens.Palette.backgroundSurfaceLight == MelixDesignTokens.DesignColor(red: 0xFF, green: 0xFF, blue: 0xFF))
+        #expect(MelixDesignTokens.Palette.backgroundElevatedLight == MelixDesignTokens.DesignColor(red: 0xF5, green: 0xF5, blue: 0xF5))
+        #expect(MelixDesignTokens.Palette.backgroundSunkenLight == MelixDesignTokens.DesignColor(red: 0xF0, green: 0xF0, blue: 0xF0))
+        #expect(MelixDesignTokens.Palette.success == MelixDesignTokens.DesignColor(red: 0x14, green: 0xA0, blue: 0x5A))
+        #expect(MelixDesignTokens.Palette.warning == MelixDesignTokens.DesignColor(red: 0xD9, green: 0x77, blue: 0x06))
+        #expect(MelixDesignTokens.Palette.error == MelixDesignTokens.DesignColor(red: 0xDC, green: 0x26, blue: 0x26))
+        #expect(MelixDesignTokens.Palette.userBubble == MelixDesignTokens.DesignColor(red: 0x00, green: 0x64, blue: 0xDC))
+        #expect(MelixDesignTokens.Palette.assistantBubble == MelixDesignTokens.DesignColor(red: 0x14, green: 0xA0, blue: 0x50))
+        #expect(MelixDesignTokens.Palette.reasoningBubble == MelixDesignTokens.DesignColor(red: 0xDC, green: 0x6E, blue: 0x14))
+        #expect(MelixDesignTokens.Palette.toolBubble == MelixDesignTokens.DesignColor(red: 0x78, green: 0x3C, blue: 0xC8))
+        #expect(MelixDesignTokens.Palette.errorBubble == MelixDesignTokens.DesignColor(red: 0xD2, green: 0x28, blue: 0x28))
+    }
+
+    @Test("lora visual polish tokens use the design system base background with clearer hierarchy")
+    func loraVisualPolishTokensUseDesignSystemBaseBackground() {
+        #expect(DesktopLoRAVisualPolish.pageBackgroundColorSpec == MelixDesignTokens.Palette.backgroundBaseLight)
         #expect(DesktopLoRAVisualPolish.sectionSurfaceOpacity == 0.04)
         #expect(DesktopLoRAVisualPolish.metricSurfaceOpacity == 0.032)
-        #expect(DesktopLoRAVisualPolish.selectedHistorySurfaceOpacity == 0.14)
+        #expect(DesktopLoRAVisualPolish.selectedHistorySurfaceOpacity == MelixDesignTokens.AccentOpacity.selected)
         #expect(DesktopLoRAVisualPolish.chartFillOpacity == 0.24)
     }
 

--- a/docs/plans/2026-04-28-macos-design-system-colors.md
+++ b/docs/plans/2026-04-28-macos-design-system-colors.md
@@ -16,6 +16,8 @@ and `docs/design-system/colors_and_type.css`.
 - Keep the change inside the macOS menu bar app surface.
 - Make the design-system teal `#0F766E` the fixed interaction accent in app
   code instead of the user-configurable macOS system accent color.
+- Preserve the design-system dark-mode foreground and background overrides in
+  the native token model.
 - Add explicit SwiftUI tokens for design-system status colors and chat bubble
   base hues.
 - Replace direct `Color.accentColor`, `.green`, `.orange`, `.red`, and `.blue`
@@ -33,8 +35,8 @@ and `docs/design-system/colors_and_type.css`.
    production code changes.
 3. Update
    `apps/macos-menubar/Sources/AppMain/Branding/MelixDesignTokens.swift` with
-   explicit sRGB color specs, fixed accent color, exact status colors, and
-   exact chat bubble opacities from `colors_and_type.css`.
+   explicit light/dark sRGB color specs, fixed accent color, exact status
+   colors, and exact chat bubble opacities from `colors_and_type.css`.
 4. Replace direct app accent and status color references in the macOS app
    sources with the new tokens.
 5. Run the targeted macOS tests, then the relevant repository command

--- a/docs/plans/2026-04-28-macos-design-system-colors.md
+++ b/docs/plans/2026-04-28-macos-design-system-colors.md
@@ -1,0 +1,49 @@
+# macOS Design System Colors Implementation Plan
+
+## Goal
+
+Align the native macOS operator app colors with `docs/design-system/README.md`
+and `docs/design-system/colors_and_type.css`.
+
+## Design Inputs
+
+- `docs/design-system/README.md`
+- `docs/design-system/colors_and_type.css`
+- `apps/macos-menubar/Sources/AppMain/Branding/MelixDesignTokens.swift`
+
+## Scope
+
+- Keep the change inside the macOS menu bar app surface.
+- Make the design-system teal `#0F766E` the fixed interaction accent in app
+  code instead of the user-configurable macOS system accent color.
+- Add explicit SwiftUI tokens for design-system status colors and chat bubble
+  base hues.
+- Replace direct `Color.accentColor`, `.green`, `.orange`, `.red`, and `.blue`
+  usages in the touched UI surfaces where they represent Melix design-system
+  semantics.
+- Keep layout, typography, behavior, and runtime code unchanged.
+
+## Implementation Steps
+
+1. Add failing tests in
+   `apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift`
+   that assert the design-system RGB values and opacities exposed by
+   `MelixDesignTokens`.
+2. Run the targeted macOS test suite and confirm the new test fails before
+   production code changes.
+3. Update
+   `apps/macos-menubar/Sources/AppMain/Branding/MelixDesignTokens.swift` with
+   explicit sRGB color specs, fixed accent color, exact status colors, and
+   exact chat bubble opacities from `colors_and_type.css`.
+4. Replace direct app accent and status color references in the macOS app
+   sources with the new tokens.
+5. Run the targeted macOS tests, then the relevant repository command
+   `make swift-test` if the targeted suite passes.
+
+## Metrics
+
+- Runtime performance probes: N/A. This change only adjusts static UI color
+  tokens and SwiftUI color references.
+- Automated coverage target: covered by macOS menu bar unit tests for the
+  changed token surface. Full changed-scope coverage measurement is N/A unless
+  the existing macOS coverage tooling is available in this worktree.


### PR DESCRIPTION
## Summary
- Added explicit macOS app design color tokens that mirror `docs/design-system/colors_and_type.css`, including the fixed `#0F766E` accent, status colors, chat bubble hues, and opacity roles.
- Replaced AppMain direct system accent/status color usage with `MelixDesignTokens` so the operator UI follows the Melix design system instead of macOS user accent colors.
- Added tests that lock the design-system RGB values and opacity semantics for the macOS menu bar app.

## Plan or Spec
- `docs/plans/2026-04-28-macos-design-system-colors.md`
- `docs/design-system/README.md`
- `docs/design-system/colors_and_type.css`

## Commands Run
```text
CLANG_MODULE_CACHE_PATH=/tmp/melix-clang-cache swift test --filter DesktopFoundationViewTests/designColorPaletteMatchesDesignSystemCSSTokens
Result: Passed after the production token implementation was added. The same test failed first, as expected, before `MelixDesignTokens.Palette` and related values existed.

CLANG_MODULE_CACHE_PATH=/tmp/melix-clang-cache swift test --filter DesktopFoundationViewTests
Result: Passed. Swift Testing reported 144 tests in 2 suites passed.

rg -n "Color\.accentColor|Color\.(blue|green|orange|purple|red)|foregroundStyle\(\.(blue|green|orange|purple|red)|return \.(blue|green|orange|purple|red)|NSColor\.white|opacity\(0\.14\)|opacity\(0\.16\)" apps/macos-menubar/Sources/AppMain -S
Result: Passed; no matches.

git diff --check
Result: Passed; no whitespace errors.

make swift-test
Result: Failed in `services/mlx-text-worker-swift` because the local Swift MLX runtime could not load the default metallib: `MLX error: Failed to load the default metallib`. The macOS AppMain targeted tests above passed before this broader environment-dependent failure.
```

## Coverage and Metrics
- Coverage: N/A. The repository does not currently provide a changed-scope coverage command for this macOS SwiftUI token surface in this worktree.
- Runtime performance metrics: N/A. This change only adjusts static UI color tokens and SwiftUI color references; no runtime or hot-path behavior changed.

## Known Gaps
- Full `make swift-test` remains blocked locally by missing Swift MLX metallib in `services/mlx-text-worker-swift`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
