### PR TITLE
fix: split owner mode sentinels and publish PR app link

### DIFF
--- a/.github/workflows/package-self-contained-app.yml
+++ b/.github/workflows/package-self-contained-app.yml
@@ -28,6 +28,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: package-self-contained-app-${{ github.ref }}
@@ -88,11 +89,67 @@ jobs:
             --json
 
       - name: Upload app artifact
+        id: upload-app-artifact
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.compute-build-metadata.outputs.artifact_name }}
           path: ${{ runner.temp }}/${{ steps.compute-build-metadata.outputs.artifact_name }}.zip
           if-no-files-found: error
+
+      - name: Update PR artifact comment
+        if: github.event_name == 'pull_request' && success()
+        uses: actions/github-script@v9
+        env:
+          ARTIFACT_NAME: ${{ steps.compute-build-metadata.outputs.artifact_name }}
+        with:
+          script: |
+            const marker = '<!-- melix-packaged-app-artifact -->';
+            const artifactName = process.env.ARTIFACT_NAME || 'melix-app';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { owner, repo } = context.repo;
+            const artifactResponse = await github.rest.actions.listWorkflowRunArtifacts({
+              owner,
+              repo,
+              run_id: context.runId,
+              per_page: 100,
+            });
+            const artifact = artifactResponse.data.artifacts.find((entry) => entry.name === artifactName);
+            const artifactUrl = artifact
+              ? `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/artifacts/${artifact.id}`
+              : runUrl;
+            const body = [
+              marker,
+              '## Download packaged Melix.app',
+              '',
+              `- Artifact: **${artifactName}.zip**`,
+              `- Download: ${artifactUrl}`,
+              `- Workflow run: ${runUrl}`,
+              '',
+              '> GitHub authentication may be required to download workflow artifacts.',
+            ].join('\n');
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
 
   attach-release-artifact:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/docs/architecture-spec.md
+++ b/docs/architecture-spec.md
@@ -145,7 +145,8 @@ through `RuntimeStats.generation_stream_owner_mode`,
 `RuntimeStats.worker_thread_init_latency_ms`, and
 `RuntimeStats.stream_sync_fallback_count`. Control-plane observability should
 project those fields into `python_worker.*` metrics whenever worker runtime
-stats are refreshed.
+stats are refreshed, and it must reserve distinct numeric sentinel codes for
+missing owner-mode state versus unrecognized future owner-mode strings.
 
 Python workers also own ordered multi-root on-disk registry scanning. Registry sources are user-configured model roots first, followed by the default Hugging Face cache at `~/.cache/huggingface/hub` when it exists. Root order is significant, the first root wins on duplicate `model_id`, and invalid roots must not poison discovery from valid roots. Scanning recognizes Hugging Face cache snapshots at `models--<org>--<repo>/snapshots/<snapshot-id>` and plain local MLX model directories that contain `config.json` plus model weights. The scanner must skip Hugging Face `blobs` payloads and must not load the MLX runtime during discovery.
 

--- a/docs/plans/2026-04-29-issue-71-owner-mode-sentinel-and-pr-app-artifact-link.md
+++ b/docs/plans/2026-04-29-issue-71-owner-mode-sentinel-and-pr-app-artifact-link.md
@@ -1,0 +1,40 @@
+# Issue 71 Owner-Mode Sentinel And PR App Artifact Link Plan
+
+## Goal
+
+Make Python worker stream-ownership observability unambiguous on the Swift side and expose a stable downloadable Melix app artifact link on pull requests.
+
+## Architecture
+
+Keep the existing `python_worker.generation_stream_owner_mode_code` metric but split missing/uninitialized values from future unknown values with distinct sentinel codes. The Swift control plane remains the projection layer from worker runtime stats into numeric observability metrics.
+
+For CI, extend the existing `package-self-contained-app` workflow so PR runs publish a sticky comment containing the uploaded app artifact link from the workflow run.
+
+## Scope
+
+- Add explicit constants or mapping behavior for:
+  - missing or empty owner mode values
+  - known executor-owned modes
+  - unrecognized future owner mode strings
+- Update Swift tests that currently collapse empty and unknown values into the same metric code.
+- Keep worker protobuf/runtime payloads unchanged; this is a Swift observability contract change only.
+- Extend `.github/workflows/package-self-contained-app.yml` so pull requests receive a sticky comment with the packaged app artifact name and download URL.
+
+## Tests
+
+- Request coordinator metric mapping tests prove empty values and unrecognized future values produce different sentinel codes.
+- Existing runtime metric propagation tests still pass for known executor-owned modes.
+- Workflow YAML parses successfully after the CI change.
+
+## Verification
+
+- `swift test --package-path services/control-plane-swift --filter RequestCoordinatorTests`
+- `swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests`
+- `python3 - <<'PY'` YAML parse for `.github/workflows/package-self-contained-app.yml`
+- `git diff --check`
+
+## Metrics
+
+- Observability correctness metric: empty/missing owner-mode strings and unrecognized future strings are distinguishable in `python_worker.generation_stream_owner_mode_code`.
+- PR delivery metric: packaged-app PR runs emit one sticky comment containing a downloadable artifact link.
+- Performance metric: N/A for runtime throughput; this slice changes observability mapping and CI artifact discoverability only.

--- a/services/control-plane-swift/Sources/Metrics/PythonWorkerRuntimeObservability.swift
+++ b/services/control-plane-swift/Sources/Metrics/PythonWorkerRuntimeObservability.swift
@@ -1,5 +1,8 @@
 import MelixWorkerProtocol
 
+private let pythonWorkerGenerationStreamOwnerModeMissingCode = 0.0
+private let pythonWorkerGenerationStreamOwnerModeUnknownCode = -2.0
+
 func recordPythonWorkerStreamOwnershipMetrics(
     from stats: Melix_Worker_V1_RuntimeStats,
     metricsStore: MetricsStore
@@ -19,7 +22,11 @@ func recordPythonWorkerStreamOwnershipMetrics(
 }
 
 func pythonWorkerGenerationStreamOwnerModeCode(_ mode: String) -> Double {
-    switch mode {
+    let normalizedMode = mode.trimmingCharacters(in: .whitespacesAndNewlines)
+    if normalizedMode.isEmpty || normalizedMode == "uninitialized" {
+        return pythonWorkerGenerationStreamOwnerModeMissingCode
+    }
+    switch normalizedMode {
     case "executor_owned":
         return 1
     case "executor_owned_no_stream":
@@ -27,6 +34,6 @@ func pythonWorkerGenerationStreamOwnerModeCode(_ mode: String) -> Double {
     case "executor_owned_stream_init_failed":
         return 3
     default:
-        return -1
+        return pythonWorkerGenerationStreamOwnerModeUnknownCode
     }
 }

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -7,10 +7,11 @@ import MelixWorkerProtocol
 
 @Suite("Request Coordinator", .serialized)
 struct RequestCoordinatorTests {
-    @Test("python worker stream owner mode uses sentinel for unknown values")
-    func pythonWorkerStreamOwnerModeUsesSentinelForUnknownValues() {
-        #expect(pythonWorkerGenerationStreamOwnerModeCode("") == -1)
-        #expect(pythonWorkerGenerationStreamOwnerModeCode("future_mode") == -1)
+    @Test("python worker stream owner mode uses distinct sentinels for missing and unknown values")
+    func pythonWorkerStreamOwnerModeUsesDistinctSentinelsForMissingAndUnknownValues() {
+        #expect(pythonWorkerGenerationStreamOwnerModeCode("") == 0)
+        #expect(pythonWorkerGenerationStreamOwnerModeCode("uninitialized") == 0)
+        #expect(pythonWorkerGenerationStreamOwnerModeCode("future_mode") == -2)
         #expect(pythonWorkerGenerationStreamOwnerModeCode("executor_owned") == 1)
     }
 


### PR DESCRIPTION
## Summary
- split Python worker stream-owner observability into distinct Swift sentinel codes for missing/uninitialized versus future unknown values
- document the owner-mode sentinel contract in the architecture spec and add an execution plan for this slice
- extend the packaged-app workflow so PR runs post a sticky comment with a downloadable Melix app artifact link

## Plan or Spec
- `docs/plans/2026-04-29-issue-71-owner-mode-sentinel-and-pr-app-artifact-link.md`
- `docs/architecture-spec.md`
- Closes #71

## Commands Run
```text
python3 - <<'PY'
import pathlib
import yaml
path = pathlib.Path('/tmp/melix-issue71/.github/workflows/package-self-contained-app.yml')
obj = yaml.safe_load(path.read_text())
print(obj['name'])
print(sorted(obj['permissions'].keys()))
print(obj['jobs']['package-app']['steps'][8]['name'])
PY
# passed

swift test --package-path services/control-plane-swift --filter RequestCoordinatorTests/pythonWorkerStreamOwnerModeUsesDistinctSentinelsForMissingAndUnknownValues
# not run: swift toolchain unavailable on this Linux host (`swift: command not found`)

git diff --check
# passed before commit
```

## Coverage and Metrics
- Coverage: N/A on this host because the Swift toolchain is unavailable, so changed-scope Swift coverage could not be measured locally.
- Observability metric contract:
  - missing/uninitialized `generation_stream_owner_mode` -> `0`
  - unrecognized future `generation_stream_owner_mode` -> `-2`
  - known executor-owned modes remain `1..3`
- PR delivery metric: packaged-app pull request runs now publish one sticky comment with the uploaded Melix app artifact link when packaging succeeds.

## Known Gaps
- Swift tests were not runnable in this environment because this host does not have `swift`/`xcrun` installed.
- The PR artifact comment behavior is validated by workflow structure and YAML parsing here; it still needs live GitHub Actions confirmation on the PR run.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
