### PR TITLE
perf: tail-read startup log excerpts

### DIFF
--- a/docs/plans/2026-04-29-startup-log-tail-optimization.md
+++ b/docs/plans/2026-04-29-startup-log-tail-optimization.md
@@ -1,0 +1,42 @@
+# Startup Log Tail Optimization For Linux-Verified Python Worker Slice
+
+## Summary
+
+Optimize Melix startup failure classification in `services/mlx-worker-python/worker/productization/startup_signals.py` so it extracts only the final log line needed for diagnostics instead of materializing entire log files in memory.
+
+## Scope
+
+- Touched code:
+  - `services/mlx-worker-python/worker/productization/startup_signals.py`
+- Touched tests:
+  - `services/mlx-worker-python/tests/test_startup_signals.py`
+- Linux-only verification path:
+  - targeted `pytest`
+  - changed-scope `coverage`
+  - explicit synthetic performance probe against large log files
+
+## Why This Slice
+
+`classify_startup_failure()` only needs the most recent line from each configured log file. The current `_log_excerpt()` helper reads each whole file, strips it, then keeps only `splitlines()[-1]`. That creates avoidable I/O and memory pressure when startup logs are large.
+
+## Implementation Plan
+
+1. Add a focused failing test that proves `_log_excerpt()` / `classify_startup_failure()` still returns the last non-empty line from a log with trailing blank lines.
+2. Replace full-file `read_text()` usage with a bounded tail reader that seeks from the end of the file and decodes only the bytes needed to recover the last line.
+3. Keep missing-file and empty-file behavior unchanged.
+4. Re-run the targeted startup-signals tests and measure changed-scope coverage.
+5. Run a synthetic probe that compares current behavior metrics for startup failure classification on a large generated log file and record wall-clock plus peak-memory numbers.
+
+## Success Metrics
+
+- Functional output remains identical for the startup failure classification cases covered by tests.
+- Changed executable file coverage is at least 95%.
+- Synthetic probe shows materially lower peak memory for large-log classification.
+
+## Verification Commands
+
+- `PYTHONPATH=<repo>:<repo>/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py`
+- `PYTHONPATH=<repo>:<repo>/services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py`
+- `PYTHONPATH=<repo>:<repo>/services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py`
+- synthetic Python performance probe under `/tmp` for large log excerpts
+- `git diff --check`

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -5,11 +5,14 @@ import socket
 from pathlib import Path
 
 from worker.productization.startup_signals import (
+    _read_last_nonempty_line,
     check_for_updates,
     classify_startup_failure,
     compare_versions,
+    default_update_channel_path,
     normalized_version_parts,
     port_is_available,
+    read_product_version,
     resolve_http_port,
 )
 
@@ -35,10 +38,60 @@ def test_check_for_updates_reports_newer_available_version(tmp_path: Path) -> No
     assert result.summary == "Update available: 0.2.0"
 
 
+def test_check_for_updates_reports_up_to_date_version(tmp_path: Path) -> None:
+    channel_path = tmp_path / "stable.json"
+    channel_path.write_text(
+        json.dumps({"channel": "stable", "latest_version": "0.2.0"}),
+        encoding="utf-8",
+    )
+
+    result = check_for_updates("0.2.0", channel_path)
+
+    assert result.checked is True
+    assert result.update_available is False
+    assert result.summary == "Update: up to date"
+
+
+def test_check_for_updates_reports_missing_latest_version(tmp_path: Path) -> None:
+    channel_path = tmp_path / "stable.json"
+    channel_path.write_text(json.dumps({"channel": "beta"}), encoding="utf-8")
+
+    result = check_for_updates("0.1.0", channel_path)
+
+    assert result.checked is False
+    assert result.latest_version == ""
+    assert result.channel == "beta"
+    assert "does not declare latest_version" in result.detail
+
+
+def test_read_product_version_reads_project_version(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "melix"\nversion = "1.2.3"\n', encoding="utf-8")
+
+    assert read_product_version(tmp_path) == "1.2.3"
+
+
+def test_read_product_version_raises_when_version_is_missing(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "melix"\n', encoding="utf-8")
+
+    try:
+        read_product_version(tmp_path)
+    except ValueError as exc:
+        assert "Unable to read version" in str(exc)
+    else:
+        raise AssertionError("expected read_product_version to raise ValueError")
+
+
+def test_default_update_channel_path_uses_stable_channel_json(tmp_path: Path) -> None:
+    expected = tmp_path.resolve() / "infra/packaging/update-channels/stable.json"
+
+    assert default_update_channel_path(tmp_path) == expected
+
+
 def test_compare_versions_ignores_build_metadata_suffix() -> None:
     assert normalized_version_parts("v1.2.3+abcdef1") == [1, 2, 3]
     assert compare_versions("1.2.3", "1.2.3+abcdef1") == 0
     assert compare_versions("1.2.4", "1.2.3+abcdef1") == 1
+    assert compare_versions("1.2.2", "1.2.3") == -1
 
 
 def test_resolve_http_port_can_pick_an_available_port_when_requested_is_busy() -> None:
@@ -56,6 +109,36 @@ def test_resolve_http_port_can_pick_an_available_port_when_requested_is_busy() -
 
     assert selected_port != occupied_port
     assert selected_port > occupied_port
+
+
+def test_resolve_http_port_returns_requested_port_when_preference_is_disabled() -> None:
+    assert resolve_http_port(11434, prefer_available_http_port=False) == 11434
+
+
+def test_resolve_http_port_raises_when_no_candidate_is_available() -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as first_listener, socket.socket(
+        socket.AF_INET,
+        socket.SOCK_STREAM,
+    ) as second_listener:
+        first_listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        first_listener.bind(("127.0.0.1", 0))
+        occupied_port = int(first_listener.getsockname()[1])
+        first_listener.listen(1)
+
+        second_listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        second_listener.bind(("127.0.0.1", occupied_port + 1))
+        second_listener.listen(1)
+
+        try:
+            resolve_http_port(
+                occupied_port,
+                prefer_available_http_port=True,
+                search_limit=2,
+            )
+        except RuntimeError as exc:
+            assert str(occupied_port) in str(exc)
+        else:
+            raise AssertionError("expected resolve_http_port to raise RuntimeError")
 
 
 def test_classify_startup_failure_reports_host_port_conflict(tmp_path: Path) -> None:
@@ -88,6 +171,45 @@ def test_classify_startup_failure_reports_worker_crash(tmp_path: Path) -> None:
     assert report.classification == "worker_crash"
     assert "worker" in report.summary.lower()
     assert "Traceback" in report.log_excerpt
+
+
+def test_classify_startup_failure_reports_control_plane_crash(tmp_path: Path) -> None:
+    control_plane_stderr = tmp_path / "control-plane.stderr.log"
+    control_plane_stderr.write_text("fatal error: crashed\n", encoding="utf-8")
+
+    report = classify_startup_failure(
+        {
+            "http_port": 11434,
+            "ready_probe_url": "http://127.0.0.1:11434/v1/models",
+            "control_plane_stderr_path": str(control_plane_stderr),
+        },
+        error_text="handshake failed",
+    )
+
+    assert report.classification == "control_plane_crash"
+    assert "Control plane crashed" in report.summary
+    assert report.to_dict()["classification"] == "control_plane_crash"
+
+
+def test_read_last_nonempty_line_ignores_trailing_blank_lines(tmp_path: Path) -> None:
+    log_path = tmp_path / "control-plane.stderr.log"
+    log_path.write_text("booting\nready\n\n", encoding="utf-8")
+
+    assert _read_last_nonempty_line(log_path) == "ready"
+
+
+def test_read_last_nonempty_line_returns_empty_string_for_whitespace_only_file(tmp_path: Path) -> None:
+    log_path = tmp_path / "control-plane.stderr.log"
+    log_path.write_text("\n\t  \r\n", encoding="utf-8")
+
+    assert _read_last_nonempty_line(log_path) == ""
+
+
+def test_read_last_nonempty_line_decodes_invalid_utf8_with_replacement(tmp_path: Path) -> None:
+    log_path = tmp_path / "python-worker.stderr.log"
+    log_path.write_bytes(b"booting\nlast line \xff\n")
+
+    assert _read_last_nonempty_line(log_path) == "last line �"
 
 
 def test_classify_startup_failure_falls_back_to_hang_when_logs_are_empty() -> None:

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -218,7 +218,49 @@ def _log_excerpt(*paths: object) -> str:
         resolved = Path(str(path)).expanduser()
         if resolved.exists() is False:
             continue
-        payload = resolved.read_text(encoding="utf-8", errors="replace").strip()
-        if payload:
-            excerpts.append(payload.splitlines()[-1])
+        excerpt = _read_last_nonempty_line(resolved)
+        if excerpt:
+            excerpts.append(excerpt)
     return " | ".join(excerpts)
+
+
+def _read_last_nonempty_line(path: Path, *, chunk_size: int = 8192) -> str:
+    with path.open("rb") as handle:
+        handle.seek(0, 2)
+        payload_end = _seek_non_whitespace_end(handle, chunk_size=chunk_size)
+        if payload_end == 0:
+            return ""
+        line_start = _seek_last_line_start(handle, payload_end=payload_end, chunk_size=chunk_size)
+        handle.seek(line_start)
+        payload = handle.read(payload_end - line_start)
+    return payload.decode("utf-8", errors="replace").rstrip()
+
+
+def _seek_non_whitespace_end(handle: Any, *, chunk_size: int) -> int:
+    position = handle.tell()
+    while position > 0:
+        read_size = min(chunk_size, position)
+        start = position - read_size
+        handle.seek(start)
+        chunk = handle.read(read_size)
+        index = read_size - 1
+        while index >= 0 and chr(chunk[index]).isspace():
+            index -= 1
+        if index >= 0:
+            return start + index + 1
+        position = start
+    return 0
+
+
+def _seek_last_line_start(handle: Any, *, payload_end: int, chunk_size: int) -> int:
+    position = payload_end
+    while position > 0:
+        read_size = min(chunk_size, position)
+        start = position - read_size
+        handle.seek(start)
+        chunk = handle.read(read_size)
+        newline_index = max(chunk.rfind(b"\n"), chunk.rfind(b"\r"))
+        if newline_index >= 0:
+            return start + newline_index + 1
+        position = start
+    return 0


### PR DESCRIPTION
## Summary
- tail-read startup log excerpts in `services/mlx-worker-python/worker/productization/startup_signals.py` instead of materializing full log files
- preserve the existing failure-classification behavior while cutting large-log diagnostic I/O and memory pressure
- add focused regression coverage for startup signal helpers and related startup-signals branches

## Plan or Spec
- `docs/plans/2026-04-29-startup-log-tail-optimization.md`
- repository verification and PR evidence rules from `AGENTS.md`, `docs/contributing.md`, and `docs/templates/pr-evidence-checklist.md`

## Commands Run
- `PYTHONPATH=/tmp/melix-cron-python-opt-20260429-185651:/tmp/melix-cron-python-opt-20260429-185651/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_read_last_nonempty_line_ignores_trailing_blank_lines`
- `PYTHONPATH=/tmp/melix-cron-python-opt-20260429-185651:/tmp/melix-cron-python-opt-20260429-185651/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py`
- `PYTHONPATH=/tmp/melix-cron-python-opt-20260429-185651:/tmp/melix-cron-python-opt-20260429-185651/services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py`
- `PYTHONPATH=/tmp/melix-cron-python-opt-20260429-185651:/tmp/melix-cron-python-opt-20260429-185651/services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py`
- `PYTHONPATH=/tmp/melix-cron-python-opt-20260429-185651:/tmp/melix-cron-python-opt-20260429-185651/services/mlx-worker-python python /tmp/startup_signals_perf_probe.py`
- `git diff --check`

## Coverage and Metrics
- changed executable file coverage: `services/mlx-worker-python/worker/productization/startup_signals.py` = `99%` (`166 statements, 1 miss`)
- targeted test file coverage: `services/mlx-worker-python/tests/test_startup_signals.py` = `98%`
- synthetic large-log probe (`51,200,022` byte log, 3 runs):
  - old full-read path: `0.794597s`, `108.36 MB` peak
  - new tail-read path: `0.000496s`, `0.01 MB` peak
- excerpt correctness preserved in the probe: both paths returned `final startup signal`

## Known Gaps
- verification in this cron run was intentionally limited to the Linux-verifiable Python worker slice; no Swift/macOS-only checks were run on this host
- the performance probe compares the old helper logic to the new helper logic on a synthetic large log rather than a full app startup session

## Evidence Checklist
- [x] Relevant plan/spec identified
- [x] Behavior change covered with focused automated tests
- [x] Changed executable scope measured at >=95% automated coverage
- [x] Explicit performance probe run with concrete numbers
- [x] `git diff --check` passed
- [x] Known Linux/macOS verification boundary stated explicitly
