### PR TITLE
perf: streamline benchmark queue record scanning

### DIFF
--- a/docs/plans/2026-04-29-benchmark-queue-scan-optimization.md
+++ b/docs/plans/2026-04-29-benchmark-queue-scan-optimization.md
@@ -1,0 +1,47 @@
+# 2026-04-29 Benchmark Queue Scan Optimization
+
+## Summary
+
+Optimize the Linux-verifiable Python benchmark queue scan path by removing unnecessary glob pattern work and centralizing queue record loading in `services/mlx-worker-python/worker/productization/benchmark_queue.py`.
+
+## Scope
+
+- `services/mlx-worker-python/worker/productization/benchmark_queue.py`
+- `services/mlx-worker-python/tests/test_benchmark_queue.py`
+
+## Constraints
+
+- Linux host only; no Swift or macOS-only validation.
+- Keep the change to one small optimization slice.
+- Preserve queue record ordering and on-disk JSON format.
+
+## Optimization Goal
+
+Reduce repeated directory-scan overhead in `BenchmarkQueueStore.list_records()` and remove duplicate file->JSON->record parsing logic shared with `transition()`.
+
+## Planned Change
+
+1. Add a shared helper that loads a queue record from a JSON file path.
+2. Replace `queue_root.glob("*.json")` with direct `queue_root.iterdir()` filtering for `*.json` files.
+3. Keep behavior identical for missing directories, non-file entries, sorting, and transitions.
+4. Add a regression test proving non-JSON files and JSON-named directories are ignored.
+
+## Performance Probe
+
+Use a synthetic queue directory with thousands of JSON queue item files plus noise files. Measure elapsed time for:
+
+- current `glob("*.json")` scan strategy
+- optimized `iterdir()` + suffix filter strategy
+
+Success metric: optimized probe is measurably faster while returning the same record count.
+
+## Verification Commands
+
+```bash
+cd services/mlx-worker-python
+PYTHONPATH=/tmp/melix-cron-python-opt-20260429-192455:/tmp/melix-cron-python-opt-20260429-192455/services/mlx-worker-python pytest -q tests/test_benchmark_queue.py
+PYTHONPATH=/tmp/melix-cron-python-opt-20260429-192455:/tmp/melix-cron-python-opt-20260429-192455/services/mlx-worker-python coverage run -m pytest -q tests/test_benchmark_queue.py
+PYTHONPATH=/tmp/melix-cron-python-opt-20260429-192455:/tmp/melix-cron-python-opt-20260429-192455/services/mlx-worker-python coverage report -m worker/productization/benchmark_queue.py tests/test_benchmark_queue.py
+python3 <probe script>
+git diff --check
+```

--- a/services/mlx-worker-python/tests/test_benchmark_queue.py
+++ b/services/mlx-worker-python/tests/test_benchmark_queue.py
@@ -83,6 +83,32 @@ def test_list_records_is_stable_by_created_time_then_id(tmp_path: Path) -> None:
     assert [record.queue_item_id for record in records] == ["queue-a", "queue-b", "queue-c"]
 
 
+def test_list_records_ignores_non_json_entries_and_json_named_directories(tmp_path: Path) -> None:
+    store = BenchmarkQueueStore()
+    queue_root = tmp_path / "queue"
+    queue_root.mkdir()
+    (queue_root / "notes.txt").write_text("ignore me", encoding="utf-8")
+    (queue_root / "nested-record.json").mkdir()
+
+    store.enqueue(
+        queue_root=queue_root,
+        record=BenchmarkQueueRecord(
+            queue_item_id="queue-valid",
+            job_kind="benchmark",
+            model_id="melix-dev-text",
+            suite_ids=("smoke",),
+            parameters={},
+            status="queued",
+            created_at_unix_ms=100,
+            updated_at_unix_ms=100,
+        ),
+    )
+
+    records = store.list_records(queue_root=queue_root)
+
+    assert [record.queue_item_id for record in records] == ["queue-valid"]
+
+
 def test_queue_snapshot_returns_counts_and_records_by_status(tmp_path: Path) -> None:
     store = BenchmarkQueueStore()
     queue_root = tmp_path / "queue"
@@ -194,6 +220,16 @@ def test_list_records_returns_empty_when_queue_root_does_not_exist(tmp_path: Pat
     store = BenchmarkQueueStore()
 
     records = store.list_records(queue_root=tmp_path / "missing-queue-dir")
+
+    assert records == []
+
+
+def test_list_records_returns_empty_when_queue_root_is_a_file(tmp_path: Path) -> None:
+    store = BenchmarkQueueStore()
+    queue_root = tmp_path / "queue-file"
+    queue_root.write_text("not a directory", encoding="utf-8")
+
+    records = store.list_records(queue_root=queue_root)
 
     assert records == []
 

--- a/services/mlx-worker-python/worker/productization/benchmark_queue.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_queue.py
@@ -59,13 +59,13 @@ class BenchmarkQueueStore:
         return record
 
     def list_records(self, *, queue_root: Path) -> list[BenchmarkQueueRecord]:
-        if not queue_root.exists():
+        if not queue_root.is_dir():
             return []
 
         records = [
-            BenchmarkQueueRecord.from_dict(json.loads(path.read_text(encoding="utf-8")))
-            for path in queue_root.glob("*.json")
-            if path.is_file()
+            self._load_record(path)
+            for path in queue_root.iterdir()
+            if path.suffix == ".json" and path.is_file()
         ]
         return sorted(records, key=lambda record: (record.created_at_unix_ms, record.queue_item_id))
 
@@ -78,8 +78,7 @@ class BenchmarkQueueStore:
         updated_at_unix_ms: int,
     ) -> BenchmarkQueueRecord:
         path = self._record_path(queue_root=queue_root, queue_item_id=queue_item_id)
-        payload = json.loads(path.read_text(encoding="utf-8"))
-        record = BenchmarkQueueRecord.from_dict(payload)
+        record = self._load_record(path)
         started_at_unix_ms = record.started_at_unix_ms
         if status == "running" and started_at_unix_ms == 0:
             started_at_unix_ms = updated_at_unix_ms
@@ -105,6 +104,10 @@ class BenchmarkQueueStore:
             json.dumps(record.to_dict(), indent=2) + "\n",
             encoding="utf-8",
         )
+
+    @staticmethod
+    def _load_record(path: Path) -> BenchmarkQueueRecord:
+        return BenchmarkQueueRecord.from_dict(json.loads(path.read_text(encoding="utf-8")))
 
     def queue_snapshot(self, *, queue_root: Path) -> dict[str, object]:
         records = self.list_records(queue_root=queue_root)


### PR DESCRIPTION
## Summary
- optimize `BenchmarkQueueStore.list_records()` in `services/mlx-worker-python` by iterating the queue directory directly instead of using `glob("*.json")`
- centralize queue record loading in `_load_record()` so `list_records()` and `transition()` share the same JSON-to-record path
- add regression coverage for non-JSON entries, `.json`-named directories, and queue roots that exist as regular files

## Plan or Spec
- `docs/plans/2026-04-29-benchmark-queue-scan-optimization.md`
- `docs/engineering-standards.md`
- `docs/contributing.md`

## Commands Run
- `git fetch origin --prune`
- `git worktree add /tmp/melix-cron-python-opt-20260429-192455 -b akane/cron-python-opt-20260429-192455 origin/main`
- `PYTHONPATH=/tmp/melix-cron-python-opt-20260429-192455:/tmp/melix-cron-python-opt-20260429-192455/services/mlx-worker-python pytest -q tests/test_benchmark_queue.py`
- `PYTHONPATH=/tmp/melix-cron-python-opt-20260429-192455:/tmp/melix-cron-python-opt-20260429-192455/services/mlx-worker-python coverage run -m pytest -q tests/test_benchmark_queue.py`
- `PYTHONPATH=/tmp/melix-cron-python-opt-20260429-192455:/tmp/melix-cron-python-opt-20260429-192455/services/mlx-worker-python coverage report -m worker/productization/benchmark_queue.py tests/test_benchmark_queue.py`
- `python3 <synthetic queue scan probe>`
- `git diff --check`

## Coverage and Metrics
- targeted pytest: `12 passed in 0.03s`
- changed-scope coverage:
  - `worker/productization/benchmark_queue.py`: `100%` (55/55 statements)
  - `tests/test_benchmark_queue.py`: `100%` (105/105 statements)
- synthetic performance probe on 5,000 queue JSON files plus noise entries:
  - `glob_scan`: `0.150372s`
  - `iterdir_scan`: `0.112036s`
  - improvement: `0.038336s` faster, about `25.5%` lower elapsed time
- Linux-only verification note: no Swift or macOS-specific checks were run for this Python-only slice

## Known Gaps
- performance evidence comes from a synthetic filesystem probe rather than a production benchmark workload
- broader repository suites (`make py-test`, Swift/macOS flows) were not run because this cron task intentionally targeted a small Linux-verifiable Python slice

## Evidence Checklist
- [x] Relevant plan/spec identified
- [x] Behavior change covered by targeted tests
- [x] Changed executable scope measured at >=95% coverage
- [x] Performance probe defined and run with concrete numbers
- [x] Verification commands recorded with outcomes
- [x] Known gaps stated explicitly
