### PR TITLE
perf: stream benchmark matrix JSONL writes

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_store.py
+++ b/services/mlx-worker-python/tests/test_benchmark_store.py
@@ -147,14 +147,40 @@ def test_persist_benchmark_matrix_writes_job_summary_request_and_csv_artifacts(
         for line in persisted["summary_jsonl"].read_text(encoding="utf-8").splitlines()
         if line.strip()
     ] == [summary_rows[0].to_dict()]
+    assert persisted["summary_jsonl"].read_text(encoding="utf-8").endswith("\n")
     assert [
         json.loads(line)
         for line in persisted["requests_jsonl"].read_text(encoding="utf-8").splitlines()
         if line.strip()
     ] == [request_rows[0].to_dict()]
+    assert persisted["requests_jsonl"].read_text(encoding="utf-8").endswith("\n")
     assert "job_id,task_kind,source_repo,model_id,suite_id,context_length" in persisted["summary_csv"].read_text(
         encoding="utf-8"
     )
     assert "job_id,cell_id,task_kind,suite_id,context_length,generation_length" in persisted["requests_csv"].read_text(
         encoding="utf-8"
     )
+
+
+def test_persist_benchmark_matrix_preserves_empty_jsonl_artifacts(tmp_path: Path) -> None:
+    store = BenchmarkStore()
+    jobs_root = tmp_path / "bench" / "matrix-runs" / "bench-matrix-empty"
+    job = build_benchmark_matrix_job(
+        job_id="bench-matrix-empty",
+        model_id="melix-dev-text",
+        task_kind="text-generation",
+        source_repo="HuggingFaceH4/ultrachat_200k",
+        suite_ids=("smoke",),
+        status="completed",
+        output_dir=str(jobs_root),
+    )
+
+    persisted = store.persist_benchmark_matrix(
+        jobs_root=jobs_root,
+        job=job,
+        summary_rows=(),
+        request_rows=(),
+    )
+
+    assert persisted["summary_jsonl"].read_text(encoding="utf-8") == ""
+    assert persisted["requests_jsonl"].read_text(encoding="utf-8") == ""

--- a/services/mlx-worker-python/worker/productization/benchmark_store.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from pathlib import Path
 
 from worker.productization.benchmark_export import (
@@ -60,16 +61,10 @@ class BenchmarkStore:
         )
 
         summary_jsonl_path = jobs_root / "bench-matrix-summary.jsonl"
-        summary_jsonl_path.write_text(
-            "".join(json.dumps(row.to_dict()) + "\n" for row in summary_rows),
-            encoding="utf-8",
-        )
+        self._write_jsonl(summary_jsonl_path, (row.to_dict() for row in summary_rows))
 
         requests_jsonl_path = jobs_root / "bench-matrix-requests.jsonl"
-        requests_jsonl_path.write_text(
-            "".join(json.dumps(row.to_dict()) + "\n" for row in request_rows),
-            encoding="utf-8",
-        )
+        self._write_jsonl(requests_jsonl_path, (row.to_dict() for row in request_rows))
 
         summary_csv_path = jobs_root / "bench-matrix-summary.csv"
         summary_csv_path.write_text(
@@ -94,3 +89,10 @@ class BenchmarkStore:
             "requests_jsonl": requests_jsonl_path,
             "requests_csv": requests_csv_path,
         }
+
+    @staticmethod
+    def _write_jsonl(path: Path, rows: Iterable[dict[str, object]]) -> None:
+        with path.open("w", encoding="utf-8") as handle:
+            for row in rows:
+                handle.write(json.dumps(row))
+                handle.write("\n")


### PR DESCRIPTION
## Summary
- Stream benchmark matrix JSONL persistence in `services/mlx-worker-python/worker/productization/benchmark_store.py` instead of materializing one giant joined string before writing.
- Keep output bytes and newline semantics unchanged while reducing peak memory pressure for large benchmark matrices.
- Add focused tests covering trailing-newline preservation and empty-artifact behavior.

## Plan or Spec
- N/A: this is a small internal Python-only performance optimization in artifact persistence; it does not change an external behavior contract or require a canonical spec update.

## Commands Run
```text
PYTHONPATH=/tmp/melix-20260429-195806/services/mlx-worker-python python -m pytest -q tests/test_benchmark_store.py
# 3 passed in 0.05s

PYTHONPATH=/tmp/melix-20260429-195806/services/mlx-worker-python coverage run --source=worker.productization.benchmark_store -m pytest -q tests/test_benchmark_store.py && coverage report -m worker/productization/benchmark_store.py
# 3 passed in 0.07s
# worker/productization/benchmark_store.py  36 stmts, 0 miss, 100% cover

git diff --check
# exit 0

PYTHONPATH=/tmp/melix-20260429-195806/services/mlx-worker-python python - <<'PY'
# perf probe comparing old join-based JSONL writing vs new streaming helper
PY
# join:   seconds=5.6166 peak_mb=96.75 size_bytes=49566982
# stream: seconds=4.8371 peak_mb=0.02 size_bytes=49566982
```

## Coverage and Metrics
- Changed-scope automated coverage: `100%` for `worker/productization/benchmark_store.py`.
- Performance probe on 40,000 synthetic benchmark request rows writing a ~49.6 MB JSONL file:
  - old join-based writer: `5.6166s`, `96.75 MB` peak traced allocation
  - new streaming writer: `4.8371s`, `0.02 MB` peak traced allocation
- Result: same output size with ~`13.9%` faster runtime and ~`96.73 MB` lower peak traced allocation in the probe.

## Known Gaps
- Did not run the full repository Python or integration suites; this cron run intentionally stayed within the Linux-verifiable touched scope.
- Probe uses synthetic matrix rows rather than a production benchmark capture, but exercises the exact JSONL write path that changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
