### PR TITLE
perf: reuse benchmark matrix row payloads

### DIFF
--- a/docs/plans/2026-04-29-benchmark-matrix-serialization-reuse.md
+++ b/docs/plans/2026-04-29-benchmark-matrix-serialization-reuse.md
@@ -1,0 +1,31 @@
+# Benchmark Matrix Serialization Reuse Plan
+
+## Context
+
+This Linux-only optimization slice targets `services/mlx-worker-python` and avoids Swift or macOS-only surfaces.
+
+## Goal
+
+Reduce redundant work in `worker/productization/benchmark_store.py` when persisting benchmark matrix artifacts by serializing each summary/request row exactly once per call and reusing the serialized payloads for both JSONL and CSV outputs.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/productization/benchmark_store.py`
+- `services/mlx-worker-python/tests/test_benchmark_store.py`
+
+## Constraints
+
+- Preserve all artifact names, paths, output ordering, and output content.
+- Keep the change locally verifiable on Linux with pytest and coverage.
+- Keep scope limited to one coherent optimization slice.
+
+## Probe
+
+Create a small Python measurement script that persists synthetic benchmark matrix rows through the current code path and prints wall-clock timings for repeated runs. Success means the optimized path reduces repeated serialization work while preserving output bytes.
+
+## Success Metrics
+
+- Focused pytest for `test_benchmark_store.py` passes.
+- Changed executable scope coverage is at least 95%.
+- Performance probe shows a measurable improvement in the benchmark matrix persistence path.
+- `git diff --check` passes.

--- a/services/mlx-worker-python/tests/test_benchmark_store.py
+++ b/services/mlx-worker-python/tests/test_benchmark_store.py
@@ -13,6 +13,16 @@ from worker.productization.benchmark_schemas import (
 from worker.productization.benchmark_store import BenchmarkStore
 
 
+class _CountingRow:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+        self.calls = 0
+
+    def to_dict(self) -> dict[str, object]:
+        self.calls += 1
+        return dict(self.payload)
+
+
 def test_persist_serving_benchmark_writes_expected_artifact_names_and_payloads(
     tmp_path: Path,
 ) -> None:
@@ -160,6 +170,88 @@ def test_persist_benchmark_matrix_writes_job_summary_request_and_csv_artifacts(
     assert "job_id,cell_id,task_kind,suite_id,context_length,generation_length" in persisted["requests_csv"].read_text(
         encoding="utf-8"
     )
+
+
+def test_persist_benchmark_matrix_serializes_each_row_once_per_persist(tmp_path: Path) -> None:
+    store = BenchmarkStore()
+    jobs_root = tmp_path / "bench" / "matrix-runs" / "bench-matrix-counts"
+    job = build_benchmark_matrix_job(
+        job_id="bench-matrix-counts",
+        model_id="melix-dev-text",
+        task_kind="text-generation",
+        source_repo="HuggingFaceH4/ultrachat_200k",
+        suite_ids=("smoke",),
+        status="completed",
+        output_dir=str(jobs_root),
+    )
+    summary_row = _CountingRow(
+        {
+            "job_id": "bench-matrix-counts",
+            "task_kind": "text-generation",
+            "source_repo": "HuggingFaceH4/ultrachat_200k",
+            "model_id": "melix-dev-text",
+            "suite_id": "smoke",
+            "context_length": 1024,
+            "generation_length": 128,
+            "batch_size": 2,
+            "cache_profile": "cold",
+            "reasoning_mode": "enabled",
+            "structured_output_mode": "plain_text",
+            "concurrency_level": 1,
+            "repeats": 3,
+            "requests": 24,
+            "duration_seconds": 0,
+            "ttft_mean_ms": 24.45,
+            "ttft_std_ms": 1.2,
+            "request_latency_mean_ms": 88.4,
+            "request_latency_std_ms": 3.1,
+            "prefill_tokens_per_second_mean": 1400.0,
+            "decode_tokens_per_second_mean": 58.2,
+            "throughput_requests_per_second": 3.8,
+            "throughput_tokens_per_second": 221.5,
+            "success_rate": 1.0,
+            "peak_memory_bytes_max": 2_147_483_648,
+            "queue_wait_mean_ms": 5.1,
+            "queue_wait_p95_ms": 9.2,
+            "created_at_unix_ms": 101,
+        }
+    )
+    request_row = _CountingRow(
+        {
+            "job_id": "bench-matrix-counts",
+            "cell_id": "cell-1",
+            "task_kind": "text-generation",
+            "suite_id": "smoke",
+            "context_length": 1024,
+            "generation_length": 128,
+            "batch_size": 2,
+            "cache_profile": "cold",
+            "reasoning_mode": "enabled",
+            "structured_output_mode": "plain_text",
+            "concurrency_level": 1,
+            "repeat_index": 0,
+            "request_index": 0,
+            "ttft_ms": 24.45,
+            "request_latency_ms": 88.4,
+            "prefill_tokens_per_second": 1400.0,
+            "decode_tokens_per_second": 58.2,
+            "queue_wait_ms": 5.1,
+            "peak_memory_bytes": 2_147_483_648,
+            "status": "completed",
+            "error_code": "",
+            "created_at_unix_ms": 101,
+        }
+    )
+
+    store.persist_benchmark_matrix(
+        jobs_root=jobs_root,
+        job=job,
+        summary_rows=(summary_row,),
+        request_rows=(request_row,),
+    )
+
+    assert summary_row.calls == 1
+    assert request_row.calls == 1
 
 
 def test_persist_benchmark_matrix_preserves_empty_jsonl_artifacts(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_store.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_store.py
@@ -60,16 +60,19 @@ class BenchmarkStore:
             encoding="utf-8",
         )
 
+        summary_payloads = tuple(row.to_dict() for row in summary_rows)
+        request_payloads = tuple(row.to_dict() for row in request_rows)
+
         summary_jsonl_path = jobs_root / "bench-matrix-summary.jsonl"
-        self._write_jsonl(summary_jsonl_path, (row.to_dict() for row in summary_rows))
+        self._write_jsonl(summary_jsonl_path, summary_payloads)
 
         requests_jsonl_path = jobs_root / "bench-matrix-requests.jsonl"
-        self._write_jsonl(requests_jsonl_path, (row.to_dict() for row in request_rows))
+        self._write_jsonl(requests_jsonl_path, request_payloads)
 
         summary_csv_path = jobs_root / "bench-matrix-summary.csv"
         summary_csv_path.write_text(
             build_benchmark_matrix_summary_csv(
-                {"benchmark_matrix_summary_rows": [row.to_dict() for row in summary_rows]}
+                {"benchmark_matrix_summary_rows": summary_payloads}
             ),
             encoding="utf-8",
         )
@@ -77,7 +80,7 @@ class BenchmarkStore:
         requests_csv_path = jobs_root / "bench-matrix-requests.csv"
         requests_csv_path.write_text(
             build_benchmark_matrix_requests_csv(
-                {"benchmark_matrix_request_rows": [row.to_dict() for row in request_rows]}
+                {"benchmark_matrix_request_rows": request_payloads}
             ),
             encoding="utf-8",
         )


### PR DESCRIPTION
## Summary
- Reuse serialized benchmark matrix summary/request payloads inside `BenchmarkStore.persist_benchmark_matrix()` instead of calling `to_dict()` separately for JSONL and CSV outputs.
- Add a regression test that proves each matrix row is serialized exactly once per persist call while preserving artifact semantics.
- Record the Linux-verifiable optimization slice in a small plan under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-04-29-benchmark-matrix-serialization-reuse.md`

## Commands Run
```text
PYTHONPATH=/tmp/melix-20260429-202225:/tmp/melix-20260429-202225/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_store.py::test_persist_benchmark_matrix_serializes_each_row_once_per_persist
# 1 passed

PYTHONPATH=/tmp/melix-20260429-202225:/tmp/melix-20260429-202225/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_store.py
# 4 passed

PYTHONPATH=/tmp/melix-20260429-202225:/tmp/melix-20260429-202225/services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_store.py && PYTHONPATH=/tmp/melix-20260429-202225:/tmp/melix-20260429-202225/services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_store.py services/mlx-worker-python/tests/test_benchmark_store.py
# benchmark_store.py 100%, test_benchmark_store.py 100%

python3 <inline probe from PR branch worktree>
# rows_per_kind=800, rounds=8, old_mean_s=0.055070, new_mean_s=0.052120, improvement_pct=5.36

git diff --check
# clean
```

## Coverage and Metrics
- Changed-scope coverage:
  - `services/mlx-worker-python/worker/productization/benchmark_store.py`: `100%`
  - `services/mlx-worker-python/tests/test_benchmark_store.py`: `100%`
- Performance probe (synthetic benchmark matrix persistence, `800` summary rows + `800` request rows, `8` rounds):
  - old mean: `0.055070s`
  - new mean: `0.052120s`
  - delta: `0.002951s`
  - improvement: `5.36%`
- Probe also verified byte-for-byte equality of the old/new persisted artifacts for each round.

## Known Gaps
- Linux-only verification for the Python worker slice. I did not run Swift or macOS-specific checks because this cron host is Linux and the change is confined to `services/mlx-worker-python`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
