### PR TITLE
perf: reuse parsed video URI metadata

### DIFF
--- a/docs/plans/2026-04-29-video-uri-parse-reuse.md
+++ b/docs/plans/2026-04-29-video-uri-parse-reuse.md
@@ -1,0 +1,52 @@
+# Video URI Parse Reuse Optimization Plan
+
+## Goal
+
+Reduce redundant URI parsing work in the Python video preprocessing path under `services/mlx-worker-python` without changing accepted input contracts or output fields.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/video_preprocessing.py`
+- `services/mlx-worker-python/tests/test_video_preprocessing.py`
+
+## Linux-Only Constraint
+
+This slice must stay Python-only and locally verifiable on Linux. No Swift or macOS-only behavior is in scope.
+
+## Proposed Change
+
+Introduce a small internal parsed-reference helper so `prepare_video_input()` can parse and decode a URI reference once, then reuse that normalized result for:
+
+- URI scheme validation
+- format inference from path suffix
+- filename inference from path name
+
+## Safety Constraints
+
+- Preserve supported schemes exactly.
+- Preserve format inference and filename inference behavior exactly.
+- Preserve URI identity hashing inputs exactly.
+- Keep the change small and reviewable.
+
+## Tests
+
+Add focused tests covering:
+
+- encoded remote URI filename/format inference
+- encoded `file://` URI filename/format inference
+- existing invalid-contract behavior remains unchanged
+
+## Performance Probe
+
+Run a micro-benchmark that compares repeated baseline-style URI parsing against the helper-based single-parse path over a representative encoded HTTP URI.
+
+Example probe target:
+- URI: `https://example.com/media/demo%20clip.mov?token=abc`
+- Loop count: large enough to measure stable timings
+
+## Success Metrics
+
+- Targeted pytest for touched scope passes.
+- Changed executable file coverage is at least 95%.
+- Performance probe shows lower wall-clock time for the parse-heavy loop.
+- `git diff --check` passes.

--- a/services/mlx-worker-python/tests/test_video_preprocessing.py
+++ b/services/mlx-worker-python/tests/test_video_preprocessing.py
@@ -7,6 +7,7 @@ from worker.runtime.video_preprocessing import (
     MAX_VIDEO_FRAME_BUDGET,
     PreparedVideoInput,
     VideoPreprocessError,
+    _parse_video_reference,
     prepare_video_input,
 )
 
@@ -107,6 +108,21 @@ def test_prepare_video_input_infers_format_from_plain_local_path() -> None:
     assert prepared.format == "m4v"
     assert prepared.filename == "local-demo.m4v"
     assert len(prepared.sha256_hex) == 64
+
+
+def test_parse_video_reference_decodes_remote_and_file_uris_once() -> None:
+    remote = _parse_video_reference("https://example.com/media/demo%20clip.mov?token=abc")
+    local = _parse_video_reference("file:///tmp/local%20demo.webm")
+
+    assert remote.scheme == "https"
+    assert remote.decoded_path == "/media/demo clip.mov"
+    assert remote.path_name == "demo clip.mov"
+    assert remote.path_suffix == "mov"
+
+    assert local.scheme == "file"
+    assert local.decoded_path == "/tmp/local demo.webm"
+    assert local.path_name == "local demo.webm"
+    assert local.path_suffix == "webm"
 
 
 @pytest.mark.parametrize(

--- a/services/mlx-worker-python/worker/runtime/video_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/video_preprocessing.py
@@ -36,6 +36,15 @@ class PreparedVideoInput:
     sha256_hex: str
 
 
+@dataclass(frozen=True)
+class ParsedVideoReference:
+    raw: str
+    scheme: str
+    decoded_path: str
+    path_name: str
+    path_suffix: str
+
+
 def prepare_video_input(part) -> PreparedVideoInput:
     media = getattr(part, "media", None)
     mime_type = str(getattr(media, "mime_type", "") or "").strip().lower()
@@ -69,9 +78,12 @@ def prepare_video_input(part) -> PreparedVideoInput:
     uri = str(getattr(part, "video_uri", "") or "").strip()
     if not uri:
         raise VideoPreprocessError("No video input provided.")
-    _validate_video_uri(uri)
-    resolved_format = _resolve_video_format(format_name, mime_type, filename, uri)
-    resolved_filename = filename or _filename_from_reference(uri) or f"remote-video.{resolved_format}"
+    parsed_reference = _parse_video_reference(uri)
+    _validate_video_uri(parsed_reference)
+    resolved_format = _resolve_video_format(format_name, mime_type, filename, parsed_reference)
+    resolved_filename = (
+        filename or _filename_from_reference(parsed_reference) or f"remote-video.{resolved_format}"
+    )
     return PreparedVideoInput(
         source_kind="uri",
         reference=uri,
@@ -117,17 +129,36 @@ def _validate_bounds(duration_ms: int, frame_budget: int, start_ms: int, end_ms:
         raise VideoPreprocessError("end_ms must be less than or equal to duration_ms.")
 
 
-def _validate_video_uri(uri: str) -> None:
-    parsed = urlparse(uri)
-    if parsed.scheme in {"", "file", "http", "https"}:
+def _parse_video_reference(reference: str) -> ParsedVideoReference:
+    parsed = urlparse(reference)
+    if parsed.scheme in {"http", "https", "file"}:
+        decoded_path = unquote(parsed.path)
+        path = Path(decoded_path)
+    else:
+        decoded_path = reference
+        path = Path(reference)
+    return ParsedVideoReference(
+        raw=reference,
+        scheme=parsed.scheme,
+        decoded_path=decoded_path,
+        path_name=path.name,
+        path_suffix=path.suffix.lstrip(".").lower(),
+    )
+
+
+def _validate_video_uri(reference: str | ParsedVideoReference) -> None:
+    parsed_reference = (
+        reference if isinstance(reference, ParsedVideoReference) else _parse_video_reference(reference)
+    )
+    if parsed_reference.scheme in {"", "file", "http", "https"}:
         return
-    raise VideoPreprocessError(f"Unsupported video URI scheme: {parsed.scheme}.")
+    raise VideoPreprocessError(f"Unsupported video URI scheme: {parsed_reference.scheme}.")
 
 
 def _resolve_video_format(
     format_name: str,
     mime_type: str,
-    *candidates: str,
+    *candidates: str | ParsedVideoReference,
 ) -> str:
     if format_name:
         if format_name in SUPPORTED_VIDEO_FORMATS:
@@ -145,23 +176,21 @@ def _resolve_video_format(
     raise VideoPreprocessError("input_video.format or input_video.mime_type is required.")
 
 
-def _infer_format(candidate: str) -> str:
-    trimmed = candidate.strip()
-    if not trimmed:
+def _infer_format(candidate: str | ParsedVideoReference) -> str:
+    parsed_reference = (
+        candidate if isinstance(candidate, ParsedVideoReference) else _parse_video_reference(candidate.strip())
+    )
+    if not parsed_reference.raw:
         return ""
-    parsed = urlparse(trimmed)
-    if parsed.scheme in {"http", "https", "file"}:
-        suffix = Path(unquote(parsed.path)).suffix.lstrip(".").lower()
-    else:
-        suffix = Path(trimmed).suffix.lstrip(".").lower()
+    suffix = parsed_reference.path_suffix
     return suffix if suffix in SUPPORTED_VIDEO_FORMATS else ""
 
 
-def _filename_from_reference(reference: str) -> str:
-    parsed = urlparse(reference)
-    if parsed.scheme in {"http", "https", "file"}:
-        return Path(unquote(parsed.path)).name
-    return Path(reference).name
+def _filename_from_reference(reference: str | ParsedVideoReference) -> str:
+    parsed_reference = (
+        reference if isinstance(reference, ParsedVideoReference) else _parse_video_reference(reference)
+    )
+    return parsed_reference.path_name
 
 
 def _uri_identity_hash(


### PR DESCRIPTION
## Summary
- Reuse a parsed video-reference helper in `worker/runtime/video_preprocessing.py` so URI scheme validation, format inference, and filename inference do not reparsed the same URI repeatedly.
- Add a focused test for encoded remote and `file://` URI decoding semantics.
- Record the governing optimization plan for this Linux-verifiable Python-only slice.

## Plan or Spec
- `docs/plans/2026-04-29-video-uri-parse-reuse.md`

## Commands Run
```text
PYTHONPATH=/tmp/melix-cron-20260429-205038:/tmp/melix-cron-20260429-205038/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py::test_parse_video_reference_decodes_remote_and_file_uris_once
# 1 passed

PYTHONPATH=/tmp/melix-cron-20260429-205038:/tmp/melix-cron-20260429-205038/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_vision_runtime.py
# 51 passed

PYTHONPATH=/tmp/melix-cron-20260429-205038:/tmp/melix-cron-20260429-205038/services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_vision_runtime.py
coverage report -m services/mlx-worker-python/worker/runtime/video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_vision_runtime.py
# video_preprocessing.py: 96% coverage

PYTHONPATH=/tmp/melix-cron-20260429-205038:/tmp/melix-cron-20260429-205038/services/mlx-worker-python python <performance probe>
# baseline_seconds=3.045099
# optimized_seconds=2.129945
# speedup_percent=30.05

ruff check services/mlx-worker-python/worker/runtime/video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py
# All checks passed

git diff --check
# clean
```

## Coverage and Metrics
- Changed executable scope: `services/mlx-worker-python/worker/runtime/video_preprocessing.py`
- Automated coverage: `96%` (`113` statements, `4` misses)
- Probe: repeated encoded HTTP video URI parse/infer loop over `300000` iterations
  - Baseline: `3.045099s`
  - Optimized: `2.129945s`
  - Improvement: `0.915153s` faster (`30.05%`)

## Known Gaps
- Linux-only verification run. I did not run macOS/Swift checks (`make swift-test`) on this host.
- Probe is a micro-benchmark of the parse-heavy path, not an end-to-end runtime benchmark.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
