### PR TITLE
perf: cache parsed job registry manifests

### DIFF
--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -17,7 +17,11 @@ from packages.protocol.python.worker.v1 import common_pb2, maintenance_pb2
 
 from worker.grpc_server import WorkerMaintenanceService
 from worker.model_ops.adapter_activation_pipeline import AdapterActivationPipeline
-from worker.model_ops.job_registry import ModelOpsJob, ModelOpsJobRegistry
+from worker.model_ops.job_registry import (
+    ModelOpsJob,
+    ModelOpsJobRegistry,
+    _runtime_mode_from_activation,
+)
 from worker.model_ops.hub_catalog import (
     HubCatalogError,
     HubModelCardRecord,
@@ -2237,6 +2241,87 @@ def test_job_registry_snapshot_handles_invalid_manifests_and_non_numeric_ids() -
     assert custom_job["pct"] == 0.0
     assert custom_job["manifest"] == {}
     assert payload["adapters"][0]["status"] == "completed"
+
+
+def test_job_registry_snapshot_reuses_cached_manifest_after_attach(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = ModelOpsJobRegistry()
+    completed = registry.start("train_lora", "melix-dev-text", "/tmp/train")
+    manifest = json.dumps({"adapter_name": "adapter-a", "adapter_set_hash": "hash-a"})
+    registry.attach_manifest(completed.job_id, manifest)
+    registry.complete(completed.job_id, "/tmp/train/train_lora.adapter.json")
+
+    def fail_manifest_decode(manifest_json: str) -> dict[str, object]:
+        raise AssertionError(f"snapshot should not reparse cached manifest: {manifest_json}")
+
+    monkeypatch.setattr(ModelOpsJobRegistry, "_decode_manifest_json", staticmethod(fail_manifest_decode))
+
+    payload = registry.snapshot()
+
+    assert payload["jobs"][0]["manifest"] == {"adapter_name": "adapter-a", "adapter_set_hash": "hash-a"}
+    assert payload["adapters"][0]["adapter_name"] == "adapter-a"
+
+
+def test_job_registry_snapshot_reuses_cached_manifest_after_restore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    jobs_root = tmp_path / "jobs"
+    manifest_path = jobs_root / "train_lora" / "model-ops-0007" / "train_lora.adapter.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "job_id": "model-ops-0007",
+                "operation": "train_lora",
+                "source_model": "melix-dev-text",
+                "adapter_name": "adapter-restored",
+                "adapter_set_hash": "hash-restored",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    registry = ModelOpsJobRegistry(jobs_root=jobs_root)
+
+    def fail_manifest_decode(manifest_json: str) -> dict[str, object]:
+        raise AssertionError(f"snapshot should not reparse restored manifest: {manifest_json}")
+
+    monkeypatch.setattr(ModelOpsJobRegistry, "_decode_manifest_json", staticmethod(fail_manifest_decode))
+
+    payload = registry.snapshot()
+
+    assert payload["jobs"][0]["manifest"] == {
+        "job_id": "model-ops-0007",
+        "operation": "train_lora",
+        "source_model": "melix-dev-text",
+        "adapter_name": "adapter-restored",
+        "adapter_set_hash": "hash-restored",
+    }
+    assert payload["adapters"][0]["adapter_name"] == "adapter-restored"
+
+
+def test_job_registry_helper_paths_cover_restore_and_runtime_edges(tmp_path: Path) -> None:
+    missing_manifest = tmp_path / "missing.json"
+    list_manifest = tmp_path / "list.json"
+    list_manifest.write_text("[]\n", encoding="utf-8")
+
+    assert ModelOpsJobRegistry._decode_manifest_json("[]") == {}
+    assert ModelOpsJobRegistry._read_manifest_dict(missing_manifest) == {}
+    assert ModelOpsJobRegistry._read_manifest_dict(list_manifest) == {}
+    assert ModelOpsJobRegistry._resolved_job_id(
+        Path("/tmp/train_lora/model-ops-0042/train_lora.adapter.json"), {}
+    ) == "model-ops-0042"
+    assert ModelOpsJobRegistry._resolved_job_id(Path("/tmp/train_lora/no-job-id/manifest.json"), {}) == ""
+    assert ModelOpsJobRegistry().resolve_derived_model_target() is None
+    assert ModelOpsJobRegistry._job_sort_key(
+        ModelOpsJob(
+            job_id="custom-job",
+            operation="train_lora",
+            source_model="melix-dev-text",
+            output_dir="/tmp/custom",
+        )
+    ) == 0
+    assert common_pb2.RuntimeMode.Name(_runtime_mode_from_activation(" adapter_backed_runtime ")) == "RUNTIME_MODE_ADAPTER_BACKED"
 
 
 def test_job_registry_snapshot_exposes_download_rows_with_machine_readable_status(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -36,6 +36,8 @@ class ModelOpsJob:
     output_dir: str
     stage_history: list[tuple[str, float]] = field(default_factory=list)
     manifest_json: str = ""
+    manifest: dict[str, Any] = field(default_factory=dict)
+    manifest_cached: bool = False
     output_path: str = ""
     status: str = "running"
     error_code: str = ""
@@ -75,7 +77,10 @@ class ModelOpsJobRegistry:
 
     def attach_manifest(self, job_id: str, manifest_json: str) -> None:
         with self._lock:
-            self._jobs[job_id].manifest_json = manifest_json
+            job = self._jobs[job_id]
+            job.manifest_json = manifest_json
+            job.manifest = self._decode_manifest_json(manifest_json)
+            job.manifest_cached = True
 
     def complete(self, job_id: str, output_path: str) -> None:
         with self._lock:
@@ -156,9 +161,19 @@ class ModelOpsJobRegistry:
                 output_dir=str(output_dir),
                 stage_history=[("write_manifest", pct)],
                 manifest_json=json.dumps(payload, sort_keys=True),
+                manifest=payload,
+                manifest_cached=True,
                 output_path=str(manifest_path),
                 status="completed",
             )
+
+    @staticmethod
+    def _decode_manifest_json(manifest_json: str) -> dict[str, Any]:
+        try:
+            decoded = json.loads(manifest_json)
+        except json.JSONDecodeError:
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
 
     @staticmethod
     def _read_manifest_dict(path: Path) -> dict[str, Any]:
@@ -295,12 +310,10 @@ class ModelOpsJobRegistry:
 
         manifest: dict[str, Any] = {}
         if job.operation != "registry_snapshot" and job.manifest_json:
-            try:
-                decoded = json.loads(job.manifest_json)
-            except json.JSONDecodeError:
-                decoded = {}
-            if isinstance(decoded, dict):
-                manifest = decoded
+            if job.manifest_cached:
+                manifest = job.manifest
+            else:
+                manifest = ModelOpsJobRegistry._decode_manifest_json(job.manifest_json)
 
         return {
             "job_id": job.job_id,


### PR DESCRIPTION
## Summary
- Cache parsed `manifest_json` payloads inside `ModelOpsJobRegistry` so repeated `snapshot()` calls reuse decoded manifests instead of reparsing every job payload.
- Preserve restore behavior by seeding the cache when rebuilding jobs from `jobs_root`.
- Add focused regression tests for cached manifests and helper edge cases so the optimization stays covered on Linux.

## Plan or Spec
- N/A: this is a small Python-only internal performance optimization in `services/mlx-worker-python` with no external behavior or protocol change. Repository guidance still required changed-scope tests, coverage, and metrics, which are included below.

## Commands Run
```text
# red: new cache-focused tests fail before the implementation
PYTHONPATH=/tmp/melix-cron-python-opt-20260429-211712:/tmp/melix-cron-python-opt-20260429-211712/services/mlx-worker-python python -m pytest tests/test_maintenance_service.py -q -k 'reuses_cached_manifest_after_attach or reuses_cached_manifest_after_restore'
=> 2 failed

# green: new tests pass after the implementation
PYTHONPATH=/tmp/melix-cron-python-opt-20260429-211712:/tmp/melix-cron-python-opt-20260429-211712/services/mlx-worker-python python -m pytest tests/test_maintenance_service.py -q -k 'reuses_cached_manifest_after_attach or reuses_cached_manifest_after_restore or helper_paths_cover_restore_and_runtime_edges'
=> 3 passed

# focused scope validation
PYTHONPATH=/tmp/melix-cron-python-opt-20260429-211712:/tmp/melix-cron-python-opt-20260429-211712/services/mlx-worker-python python -m pytest tests/test_maintenance_service.py -q -k 'job_registry or derived_model or active_derived_model_manifests'
=> 21 passed

# final focused verification + diff sanity
cd services/mlx-worker-python && git diff --check && PYTHONPATH=/tmp/melix-cron-python-opt-20260429-211712:/tmp/melix-cron-python-opt-20260429-211712/services/mlx-worker-python python -m pytest tests/test_maintenance_service.py -q -k 'job_registry or derived_model or active_derived_model_manifests or helper_paths_cover_restore_and_runtime_edges'
=> diff check passed, 22 passed

# changed-scope coverage
python - <<'PY'
# coverage harness over test_maintenance_service.py + test_lora_model_ops.py
PY
=> worker/model_ops/job_registry.py coverage 96.66% (32 passed, 121 deselected)

# explicit performance probe against origin/main vs current branch
python - <<'PY'
# synthetic 1,500-job snapshot benchmark using origin/main file via git show
PY
=> baseline mean 54.81 ms, current mean 49.05 ms, improvement 10.52%, speedup 1.12x
```

## Coverage and Metrics
- Changed executable scope: `services/mlx-worker-python/worker/model_ops/job_registry.py`
- Automated coverage: `96.66%` (`32 passed, 121 deselected` across focused registry tests)
- Performance probe: synthetic `ModelOpsJobRegistry.snapshot()` benchmark with 1,500 completed jobs
  - `origin/main` mean: `54.81 ms`
  - branch mean: `49.05 ms`
  - median: `54.15 ms -> 48.03 ms`
  - improvement: `10.52%`
  - speedup: `1.12x`

## Known Gaps
- This probe is synthetic and CPU-only; it demonstrates reduced repeated JSON parsing in the registry path, but it is not an end-to-end production trace.
- I did not run the full repository `make py-test` suite in this cron slice because the mission required a small, Linux-verifiable optimization with focused validation in `services/mlx-worker-python`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
