### PR TITLE
perf: reuse rerank query tokens across documents

### DIFF
--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -257,6 +257,41 @@ def test_score_documents_resolves_backend_and_family_from_loaded_model_metadata(
     assert scores[0] > 0.0
 
 
+def test_score_documents_tokenizes_the_query_once_for_multiple_documents() -> None:
+    class CountingBackend(DeterministicRerankBackend):
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def tokenize(self, text: str) -> list[str]:
+            self.calls.append(text)
+            return super().tokenize(text)
+
+    runtime = DeterministicRerankRuntime()
+    backend = CountingBackend()
+
+    scores = runtime.score_documents(
+        {
+            "rerank_backend": backend,
+            "rerank_family_adapter": JinaV3RerankFamilyAdapter(),
+        },
+        "swift runtime",
+        [
+            "swift runtime is available",
+            "runtime swift uses reversed order",
+            "python packaging release",
+        ],
+    )
+
+    assert len(scores) == 3
+    assert backend.calls.count("swift runtime") == 1
+    assert backend.calls == [
+        "swift runtime",
+        "swift runtime is available",
+        "runtime swift uses reversed order",
+        "python packaging release",
+    ]
+
+
 def test_rerank_rejects_missing_and_wrong_model_kinds() -> None:
     runtime_service, inference_service = build_services()
     text_handle = load_model(runtime_service, WorkerModelCatalog.dev_text_model())

--- a/services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py
@@ -30,4 +30,15 @@ class DeterministicRerankRuntime:
         family = loaded_model.get("rerank_family_adapter")
         if family is None:
             family = resolve_rerank_family(loaded_model.get("rerank_family_id", ""), backend)
-        return [family.score(backend, query, document) for document in documents]
+        query_tokens = backend.tokenize(query)
+        query_token_set = set(query_tokens)
+        return [
+            family.score(
+                backend,
+                query,
+                document,
+                query_tokens=query_tokens,
+                query_token_set=query_token_set,
+            )
+            for document in documents
+        ]

--- a/services/mlx-worker-python/worker/runtime/rerank_backends.py
+++ b/services/mlx-worker-python/worker/runtime/rerank_backends.py
@@ -54,7 +54,15 @@ class RerankFamilyAdapter:
             "rerank_family_adapter": self,
         }
 
-    def score(self, backend: DeterministicRerankBackend, query: str, document: str) -> float:
+    def score(
+        self,
+        backend: DeterministicRerankBackend,
+        query: str,
+        document: str,
+        *,
+        query_tokens: list[str] | None = None,
+        query_token_set: set[str] | None = None,
+    ) -> float:
         raise NotImplementedError
 
 
@@ -64,14 +72,25 @@ class BasicRerankFamilyAdapter(RerankFamilyAdapter):
         scoring_mode="set-overlap",
     )
 
-    def score(self, backend: DeterministicRerankBackend, query: str, document: str) -> float:
-        query_tokens = set(backend.tokenize(query))
+    def score(
+        self,
+        backend: DeterministicRerankBackend,
+        query: str,
+        document: str,
+        *,
+        query_tokens: list[str] | None = None,
+        query_token_set: set[str] | None = None,
+    ) -> float:
+        if query_tokens is None:
+            query_tokens = backend.tokenize(query)
+        if query_token_set is None:
+            query_token_set = set(query_tokens)
         document_tokens = set(backend.tokenize(document))
-        if not query_tokens and not document_tokens:
+        if not query_token_set and not document_tokens:
             overlap_score = 1.0
         else:
-            union = len(query_tokens | document_tokens) or 1
-            overlap_score = len(query_tokens & document_tokens) / union
+            union = len(query_token_set | document_tokens) or 1
+            overlap_score = len(query_token_set & document_tokens) / union
         return round(overlap_score + backend.tie_breaker(query, document), 6)
 
 
@@ -81,10 +100,20 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
         scoring_mode="order-aware-overlap",
     )
 
-    def score(self, backend: DeterministicRerankBackend, query: str, document: str) -> float:
-        query_tokens = backend.tokenize(query)
+    def score(
+        self,
+        backend: DeterministicRerankBackend,
+        query: str,
+        document: str,
+        *,
+        query_tokens: list[str] | None = None,
+        query_token_set: set[str] | None = None,
+    ) -> float:
+        if query_tokens is None:
+            query_tokens = backend.tokenize(query)
         document_tokens = backend.tokenize(document)
-        query_token_set = set(query_tokens)
+        if query_token_set is None:
+            query_token_set = set(query_tokens)
         document_token_set = set(document_tokens)
 
         if not query_token_set and not document_token_set:
@@ -139,10 +168,20 @@ class CausalLMRerankFamilyAdapter(RerankFamilyAdapter):
         metadata["rerank_yes_no_labels"] = "yes,no"
         return metadata
 
-    def score(self, backend: DeterministicRerankBackend, query: str, document: str) -> float:
-        query_tokens = backend.tokenize(query)
+    def score(
+        self,
+        backend: DeterministicRerankBackend,
+        query: str,
+        document: str,
+        *,
+        query_tokens: list[str] | None = None,
+        query_token_set: set[str] | None = None,
+    ) -> float:
+        if query_tokens is None:
+            query_tokens = backend.tokenize(query)
         document_tokens = backend.tokenize(document)
-        query_token_set = set(query_tokens)
+        if query_token_set is None:
+            query_token_set = set(query_tokens)
         document_token_set = set(document_tokens)
         overlap = len(query_token_set & document_token_set) / (len(query_token_set) or 1)
         pair_bonus = JinaV3RerankFamilyAdapter._ordered_pair_bonus(query_tokens, document_tokens)


### PR DESCRIPTION
## Summary
- Reuse tokenized query state once per `score_documents` call instead of recomputing it for every document.
- Thread optional precomputed `query_tokens` and `query_token_set` through rerank family adapters without changing score outputs.
- Add a regression test that proves multi-document scoring tokenizes the query exactly once.

## Plan or Spec
- N/A: this is a small internal Python performance optimization slice for `services/mlx-worker-python`, with no canonical plan/spec governing this micro-optimization and no externally visible behavior change.

## Commands Run
```text
cd /tmp/melix-20260429-221231/services/mlx-worker-python
PYTHONPATH=/tmp/melix-20260429-221231:/tmp/melix-20260429-221231/services/mlx-worker-python pytest -q tests/test_rerank_runtime.py
# 15 passed in 0.34s

cd /tmp/melix-20260429-221231/services/mlx-worker-python
PYTHONPATH=/tmp/melix-20260429-221231:/tmp/melix-20260429-221231/services/mlx-worker-python coverage erase
PYTHONPATH=/tmp/melix-20260429-221231:/tmp/melix-20260429-221231/services/mlx-worker-python coverage run -m pytest -q tests/test_rerank_runtime.py
coverage report worker/runtime/deterministic_rerank_runtime.py worker/runtime/rerank_backends.py
# 15 passed in 0.29s
# deterministic_rerank_runtime.py: 100%
# rerank_backends.py: 98%
# total changed-scope coverage: 99%

cd /tmp/melix-20260429-221231/services/mlx-worker-python
PYTHONPATH=/tmp/melix-20260429-221231:/tmp/melix-20260429-221231/services/mlx-worker-python python - <<'PY'
# benchmark baseline family.score(...) vs runtime.score_documents(...)
PY
# baseline_avg_s=0.031990
# optimized_avg_s=0.028543
# speedup_pct=10.77

cd /tmp/melix-20260429-221231
git diff --check
# no output
```

## Coverage and Metrics
- Changed executable files:
  - `services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py`
  - `services/mlx-worker-python/worker/runtime/rerank_backends.py`
- Coverage:
  - `deterministic_rerank_runtime.py`: `100%`
  - `rerank_backends.py`: `98%`
  - changed-scope total: `99%`
- Performance probe (`4000` documents, `20` timed iterations, identical outputs asserted):
  - baseline average: `0.031990s`
  - optimized average: `0.028543s`
  - improvement: `10.77%` faster

## Known Gaps
- Did not run repository-wide `make swift-test` / macOS-specific validation because this cron run is constrained to Linux-verifiable Python-only work.
- No doc updates were needed because behavior and interfaces did not change.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
