### PR TITLE
perf: reuse Hugging Face cache refs per repo scan

### DIFF
--- a/docs/plans/2026-04-29-hf-cache-ref-reuse-optimization.md
+++ b/docs/plans/2026-04-29-hf-cache-ref-reuse-optimization.md
@@ -1,0 +1,43 @@
+# Hugging Face Cache Ref Reuse Optimization Plan
+
+## Scope
+- Repository: `services/mlx-worker-python`
+- Touched executable path: `worker/model_registry/catalog.py`
+- Touched tests: `tests/test_model_registry_catalog.py`
+- Linux-only constraint: only Python code and pytest-verifiable behavior; no Swift/macOS validation.
+
+## Goal
+Reduce redundant filesystem work during Hugging Face cache scans by reusing parsed `refs/` data once per cache repo instead of rescanning `refs/` for every snapshot revision lookup.
+
+## Current Issue
+`WorkerModelCatalog._scan_huggingface_cache_models()` iterates each snapshot under a cache repo and calls `_hf_cache_revision(cache_repo_dir, snapshot_id)` for every snapshot. `_hf_cache_revision()` currently performs a fresh `refs_dir.rglob("*")` and file reads on every call, repeating the same work across snapshots in the same repo.
+
+## Proposed Change
+- Introduce a helper that materializes a `{snapshot_id: revision_path}` mapping from `refs/` once per cache repo.
+- Reuse that mapping while scanning all snapshots for the repo.
+- Preserve existing fallback behavior when refs are unreadable or absent.
+- Keep returned revision strings and model metadata unchanged.
+
+## Test Plan
+1. Add a focused failing test first for the reusable refs map behavior, including unreadable refs fallback.
+2. Run targeted pytest to confirm the new test fails before implementation.
+3. Implement the minimal catalog change.
+4. Re-run targeted pytest for `tests/test_model_registry_catalog.py`.
+5. Run coverage for the changed file and require at least 95% automated coverage.
+
+## Performance Probe
+Build a synthetic Hugging Face cache repo with many snapshots and refs, then compare old-vs-new revision resolution logic by timing repeated scans.
+
+### Measurement
+- wall-clock mean/median seconds across multiple scan iterations
+- synthetic repo shape: one `models--org--demo` cache repo, tens to hundreds of snapshots, several ref files
+
+### Success Metric
+- identical discovered model IDs and revisions
+- measurable reduction in scan time for the synthetic repeated-snapshot probe
+
+## Verification Commands
+- `PYTHONPATH=<repo>:<repo>/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py`
+- `PYTHONPATH=<repo>:<repo>/services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py`
+- `coverage report -m services/mlx-worker-python/worker/model_registry/catalog.py services/mlx-worker-python/tests/test_model_registry_catalog.py`
+- `git diff --check`

--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -17,6 +17,7 @@ from worker.model_registry.catalog import (
     _has_mlx_signal,
     _hf_cache_repo_id,
     _hf_cache_revision,
+    _hf_cache_revision_map,
     _infer_embedding_identity,
     _is_hf_cache_snapshot_dir,
     _local_model_id,
@@ -140,11 +141,56 @@ def test_registry_catalog_helper_fallback_paths(tmp_path: Path) -> None:
     monkeypatch = pytest.MonkeyPatch()
     try:
         monkeypatch.setattr(Path, "read_text", fake_read_text)
+        assert _hf_cache_revision_map(refs_dir.parent) == {}
         assert _hf_cache_revision(refs_dir.parent, "abc123") == "abc123"
     finally:
         monkeypatch.undo()
     assert _is_hf_cache_snapshot_dir(tmp_path / "other-root", refs_dir) is False
     assert _local_model_id(tmp_path / "other-root", refs_dir) == refs_dir.name
+
+
+def test_hf_cache_revision_map_reads_refs_once_and_preserves_nested_ref_names(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cache_repo_dir = tmp_path / "models--org--demo"
+    refs_dir = cache_repo_dir / "refs"
+    nested_ref = refs_dir / "heads" / "main"
+    nested_ref.parent.mkdir(parents=True, exist_ok=True)
+    nested_ref.write_text("abc123\n", encoding="utf-8")
+    stable_ref = refs_dir / "tags" / "stable"
+    stable_ref.parent.mkdir(parents=True, exist_ok=True)
+    stable_ref.write_text("def456\n", encoding="utf-8")
+
+    original_read_text = Path.read_text
+    read_paths: list[Path] = []
+
+    def tracking_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        read_paths.append(self)
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", tracking_read_text)
+
+    revision_map = _hf_cache_revision_map(cache_repo_dir)
+
+    assert revision_map == {"abc123": "heads/main", "def456": "tags/stable"}
+    assert read_paths == [nested_ref, stable_ref]
+    assert _hf_cache_revision(cache_repo_dir, "abc123", revision_map=revision_map) == "heads/main"
+    assert _hf_cache_revision(cache_repo_dir, "missing", revision_map=revision_map) == "missing"
+
+
+def test_hf_cache_revision_map_returns_empty_mapping_when_ref_enumeration_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cache_repo_dir = tmp_path / "models--org--demo"
+    refs_dir = cache_repo_dir / "refs"
+    refs_dir.mkdir(parents=True, exist_ok=True)
+
+    original_rglob = Path.rglob
+
+    def fake_rglob(self: Path, pattern: str):
+        if self == refs_dir:
+            raise OSError("boom")
+        return original_rglob(self, pattern)
+
+    monkeypatch.setattr(Path, "rglob", fake_rglob)
+
+    assert _hf_cache_revision_map(cache_repo_dir) == {}
 
 
 
@@ -287,6 +333,37 @@ def test_registry_snapshot_discovers_mlx_models_from_default_huggingface_cache(t
     assert model.ext["melix.hf_revision"] == "main"
     assert model.ext["melix.model_path"] == str(snapshot_dir.resolve())
     assert "melix.registry_descriptor_path" not in model.ext
+
+
+def test_scan_huggingface_cache_models_reads_ref_files_once_per_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    cache_repo_dir = root / "models--mlx-community--Tiny"
+    refs_dir = cache_repo_dir / "refs" / "heads"
+    refs_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_ids = ("abc123", "def456")
+    for snapshot_id in snapshot_ids:
+        snapshot_dir = cache_repo_dir / "snapshots" / snapshot_id
+        _write_model_config(snapshot_dir, {"model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]})
+        _write_weights(snapshot_dir)
+        (snapshot_dir / "README.md").write_text("---\nlibrary_name: mlx\ntags:\n- mlx\n---\n", encoding="utf-8")
+        (refs_dir / snapshot_id).write_text(snapshot_id + "\n", encoding="utf-8")
+
+    from worker.model_registry import catalog as catalog_module
+
+    original_revision_map = catalog_module._hf_cache_revision_map
+    revision_map_calls: list[Path] = []
+
+    def tracking_revision_map(cache_repo_path: Path) -> dict[str, str]:
+        revision_map_calls.append(cache_repo_path)
+        return original_revision_map(cache_repo_path)
+
+    monkeypatch.setattr(catalog_module, "_hf_cache_revision_map", tracking_revision_map)
+
+    catalog = WorkerModelCatalog.__new__(WorkerModelCatalog)
+    models = catalog._scan_huggingface_cache_models(root=root)
+
+    assert [model.revision for model in models] == ["heads/abc123", "heads/def456"]
+    assert revision_map_calls == [cache_repo_dir]
 
 
 def test_registry_snapshot_drops_huggingface_cache_model_after_snapshot_deletion(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -189,16 +189,33 @@ def _hf_cache_repo_id(cache_repo_dir: Path) -> str | None:
     return f"{parts[0]}/{parts[1]}"
 
 
-def _hf_cache_revision(cache_repo_dir: Path, snapshot_id: str) -> str:
+def _hf_cache_revision_map(cache_repo_dir: Path) -> dict[str, str]:
     refs_dir = cache_repo_dir / "refs"
+    revisions: dict[str, str] = {}
     if refs_dir.is_dir():
-        for ref_path in sorted(path for path in refs_dir.rglob("*") if path.is_file()):
+        try:
+            ref_paths = sorted(path for path in refs_dir.rglob("*") if path.is_file())
+        except OSError:
+            return revisions
+        for ref_path in ref_paths:
             try:
-                if ref_path.read_text(encoding="utf-8").strip() == snapshot_id:
-                    return os.fspath(ref_path.relative_to(refs_dir))
+                snapshot_id = ref_path.read_text(encoding="utf-8").strip()
             except OSError:
                 continue
-    return snapshot_id
+            if not snapshot_id:
+                continue
+            revisions.setdefault(snapshot_id, os.fspath(ref_path.relative_to(refs_dir)))
+    return revisions
+
+
+def _hf_cache_revision(
+    cache_repo_dir: Path,
+    snapshot_id: str,
+    *,
+    revision_map: Mapping[str, str] | None = None,
+) -> str:
+    revisions = revision_map if revision_map is not None else _hf_cache_revision_map(cache_repo_dir)
+    return revisions.get(snapshot_id, snapshot_id)
 
 
 def _is_hf_cache_snapshot_dir(root: Path, model_dir: Path) -> bool:
@@ -1005,12 +1022,13 @@ class WorkerModelCatalog:
             snapshots_dir = cache_repo_dir / "snapshots"
             if not snapshots_dir.is_dir():
                 continue
+            revision_map = _hf_cache_revision_map(cache_repo_dir)
             for snapshot_dir in sorted(path for path in snapshots_dir.iterdir() if path.is_dir()):
                 if not (snapshot_dir / "config.json").is_file() or not _has_model_weight_files(snapshot_dir):
                     continue
                 if not _has_mlx_signal(model_dir=snapshot_dir, repo_id=repo_id):
                     continue
-                revision = _hf_cache_revision(cache_repo_dir, snapshot_dir.name)
+                revision = _hf_cache_revision(cache_repo_dir, snapshot_dir.name, revision_map=revision_map)
                 models.append(
                     self._raw_model_spec(
                         model_id=repo_id,


### PR DESCRIPTION
## Summary
- Reuse parsed Hugging Face cache `refs/` once per cache repo during Python worker registry scans instead of rescanning `refs/` for every snapshot revision lookup.
- Preserve existing revision fallback behavior when `refs/` files are missing or unreadable.
- Add focused tests for helper behavior, unreadable-ref fallback, and the scan path's one-map-per-repo reuse.

## Plan or Spec
- `docs/plans/2026-04-29-hf-cache-ref-reuse-optimization.md`
- Linux-only constraint: this PR intentionally limits verification to Python worker code under `services/mlx-worker-python`.

## Commands Run
```text
# TDD red step
PYTHONPATH=/tmp/melix-20260429-223822:/tmp/melix-20260429-223822/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py -k 'hf_cache_revision_map or helper_fallback_paths'
-> failed during collection before implementation because _hf_cache_revision_map did not exist

# TDD red step for robustness follow-up
PYTHONPATH=/tmp/melix-20260429-223822:/tmp/melix-20260429-223822/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py -k 'ref_enumeration_fails or reads_ref_files_once_per_repo'
-> 2 failed before the final fixes

# Focused verification
PYTHONPATH=/tmp/melix-20260429-223822:/tmp/melix-20260429-223822/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py
-> 49 passed in 0.15s

# Changed-scope coverage
PYTHONPATH=/tmp/melix-20260429-223822:/tmp/melix-20260429-223822/services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py
coverage report -m services/mlx-worker-python/worker/model_registry/catalog.py services/mlx-worker-python/tests/test_model_registry_catalog.py
-> catalog.py 98% coverage, test_model_registry_catalog.py 99% coverage

# Performance probe
python /tmp/hf_cache_ref_probe.py
-> baseline_mean_s=0.454652, current_mean_s=0.036459, improvement_pct=91.98, speedup=12.47x

# Diff hygiene
git diff --check
-> clean
```

## Coverage and Metrics
- Changed executable file: `services/mlx-worker-python/worker/model_registry/catalog.py`
- Automated coverage: `98%` for `catalog.py` (`722` statements, `14` missed)
- Probe setup: synthetic Hugging Face cache repo with `180` snapshots and matching refs, comparing `origin/main` vs this branch for repeated `_scan_huggingface_cache_models()` runs
- Probe results:
  - baseline mean: `0.454652s`
  - current mean: `0.036459s`
  - baseline median: `0.454131s`
  - current median: `0.035783s`
  - improvement: `91.98%`
  - speedup: `12.47x`
- Behavioral check: probe confirmed identical discovered model IDs/revisions between baseline and optimized implementations

## Known Gaps
- Swift/macOS-specific verification was not run on this Linux host.
- This PR verifies the touched Python registry path only; it does not claim full-repo validation.
- `services/mlx-worker-python/worker/model_registry/catalog.py` still contains a pre-existing malformed `_GENERATION_CONFIG_MAX_TOKENS_KEY` constant unrelated to this optimization and left untouched to keep the slice focused.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
