### PR TITLE
perf: avoid duplicate lora experiment manifest scans

### DIFF
--- a/docs/plans/2026-04-29-lora-experiment-index-scan-optimization.md
+++ b/docs/plans/2026-04-29-lora-experiment-index-scan-optimization.md
@@ -1,0 +1,44 @@
+# LoRA Experiment Index Scan Optimization Plan
+
+## Scope
+- Repository: `services/mlx-worker-python`
+- Touched executable path: `worker/productization/lora_experiment_store.py`
+- Touched tests: `tests/test_lora_experiment_store.py`
+- Linux-only constraint: only Python code and pytest-verifiable behavior; no Swift/macOS validation.
+
+## Goal
+Reduce redundant filesystem scans and repeated JSON parsing during LoRA experiment index rebuilds by scanning each run directory once instead of globbing run records and manifests in separate passes.
+
+## Current Issue
+`LoraExperimentStore.rebuild_index()` currently walks `train_lora/model-ops-*` twice: once for `lora-experiment-run.json` and once for `train_lora.adapter.json`. When both files exist in the same run directory, the second pass still reparses many manifests even though the run record already wins for that run.
+
+## Proposed Change
+- Iterate the sorted `train_lora/model-ops-*` directories once.
+- Prefer an existing run record for each run directory.
+- Fall back to `train_lora.adapter.json` only when the run record is missing, unreadable, or lacks a usable `run_id`.
+- Preserve index ordering and payload shape.
+
+## Test Plan
+1. Add focused regression tests for run-record precedence and manifest fallback behavior.
+2. Run targeted pytest for `tests/test_lora_experiment_store.py`.
+3. Implement the minimal index rebuild change.
+4. Re-run targeted pytest.
+5. Run changed-scope coverage and require at least 95% automated coverage for `worker/productization/lora_experiment_store.py`.
+
+## Performance Probe
+Build a synthetic `train_lora/` tree with many run directories containing both a run record and a manifest, then compare a baseline double-scan implementation against the optimized one.
+
+### Measurement
+- wall-clock elapsed seconds across repeated rebuild runs
+- synthetic repo shape: hundreds of `model-ops-*` run directories with both files present
+- payload equivalence for discovered run IDs and ordering
+
+### Success Metric
+- identical index run IDs before and after
+- measurable reduction in elapsed time for repeated synthetic rebuilds
+
+## Verification Commands
+- `PYTHONPATH=<repo>:<repo>/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py`
+- `PYTHONPATH=<repo>:<repo>/services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py`
+- `coverage report -m services/mlx-worker-python/worker/productization/lora_experiment_store.py services/mlx-worker-python/tests/test_lora_experiment_store.py`
+- `git diff --check`

--- a/services/mlx-worker-python/tests/test_lora_experiment_store.py
+++ b/services/mlx-worker-python/tests/test_lora_experiment_store.py
@@ -48,6 +48,36 @@ def _write_run_record(
     )
 
 
+def _write_manifest(
+    jobs_root: Path,
+    *,
+    run_id: str,
+    operation: str = "train_lora",
+    adapter_name: str = "demo-adapter",
+    group_id: str = "nightly-qwen",
+    updated_at_unix_ms: int = 0,
+    created_at_unix_ms: int | None = None,
+) -> Path:
+    manifest_dir = jobs_root / "train_lora" / run_id
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = manifest_dir / "train_lora.adapter.json"
+    payload = {
+        "job_id": run_id,
+        "operation": operation,
+        "adapter_name": adapter_name,
+        "source_model": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+        "experiment_group_id": group_id,
+        "updated_at_unix_ms": updated_at_unix_ms,
+    }
+    if created_at_unix_ms is not None:
+        payload["created_at_unix_ms"] = created_at_unix_ms
+    manifest_path.write_text(
+        json.dumps(payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
 def test_rebuild_index_prefers_runs_with_reported_loss_for_best_run(tmp_path: Path) -> None:
     jobs_root = tmp_path / "model-ops"
     _write_run_record(
@@ -84,6 +114,140 @@ def test_rebuild_index_prefers_runs_with_reported_loss_for_best_run(tmp_path: Pa
     assert payload["groups"][0]["checkpoint_lineage"][0]["run_id"] == "model-ops-0002"
     assert payload["groups"][0]["best_known_adapter"]["run_id"] == "model-ops-0001"
     assert payload["groups"][0]["best_known_adapter"]["latest_checkpoint_path"].endswith("checkpoint-1/adapters.safetensors")
+
+
+def test_rebuild_index_prefers_run_record_over_manifest_when_both_exist(tmp_path: Path) -> None:
+    jobs_root = tmp_path / "model-ops"
+    _write_manifest(
+        jobs_root,
+        run_id="model-ops-0001",
+        adapter_name="manifest-adapter",
+        updated_at_unix_ms=250,
+    )
+    _write_run_record(
+        jobs_root,
+        run_id="model-ops-0001",
+        group_id="nightly-qwen",
+        manifest_path="/tmp/model-ops-0001/from-run-record.json",
+        updated_at_unix_ms=1_000,
+        checkpoint_count=2,
+    )
+
+    payload = LoraExperimentStore().rebuild_index(jobs_root)
+
+    assert len(payload["runs"]) == 1
+    assert payload["runs"][0]["manifest_path"] == "/tmp/model-ops-0001/from-run-record.json"
+    assert payload["runs"][0]["checkpoint_count"] == 2
+    assert payload["runs"][0]["adapter_name"] == "demo-adapter"
+
+
+def test_rebuild_index_skips_manifest_parse_when_run_record_exists(tmp_path: Path, monkeypatch) -> None:
+    jobs_root = tmp_path / "model-ops"
+    manifest_path = _write_manifest(jobs_root, run_id="model-ops-0001")
+    _write_run_record(
+        jobs_root,
+        run_id="model-ops-0001",
+        group_id="nightly-qwen",
+        manifest_path="/tmp/model-ops-0001/from-run-record.json",
+        updated_at_unix_ms=1_000,
+    )
+
+    original_read_payload = LoraExperimentStore._read_payload
+
+    def _read_payload(path: Path) -> dict[str, object]:
+        if path == manifest_path:
+            raise AssertionError("manifest should not be reparsed when a run record already exists")
+        return original_read_payload(path)
+
+    monkeypatch.setattr(LoraExperimentStore, "_read_payload", staticmethod(_read_payload))
+
+    payload = LoraExperimentStore().rebuild_index(jobs_root)
+
+    assert [run["run_id"] for run in payload["runs"]] == ["model-ops-0001"]
+
+
+
+def test_rebuild_index_falls_back_to_manifest_when_run_record_is_invalid(tmp_path: Path) -> None:
+    jobs_root = tmp_path / "model-ops"
+    manifest_path = _write_manifest(
+        jobs_root,
+        run_id="model-ops-0001",
+        adapter_name="manifest-fallback-adapter",
+        updated_at_unix_ms=333,
+        created_at_unix_ms=222,
+    )
+    run_dir = jobs_root / "train_lora" / "model-ops-0001"
+    (run_dir / LoraExperimentStore.run_record_name).write_text("{not-json}\n", encoding="utf-8")
+
+    payload = LoraExperimentStore().rebuild_index(jobs_root)
+
+    assert len(payload["runs"]) == 1
+    assert payload["runs"][0]["run_id"] == "model-ops-0001"
+    assert payload["runs"][0]["manifest_path"] == str(manifest_path)
+    assert payload["runs"][0]["adapter_name"] == "manifest-fallback-adapter"
+    assert payload["runs"][0]["created_at_unix_ms"] == 222
+
+
+def test_load_index_uses_existing_index_and_rebuilds_when_missing(tmp_path: Path) -> None:
+    jobs_root = tmp_path / "model-ops"
+    store = LoraExperimentStore()
+    _write_run_record(
+        jobs_root,
+        run_id="model-ops-0001",
+        group_id="nightly-qwen",
+        manifest_path="/tmp/model-ops-0001/train_lora.adapter.json",
+        updated_at_unix_ms=1_000,
+    )
+
+    rebuilt = store.load_index(jobs_root)
+    cached = store.load_index(jobs_root)
+
+    assert rebuilt == cached
+    assert cached["runs"][0]["run_id"] == "model-ops-0001"
+
+
+
+def test_rebuild_index_skips_non_directories_duplicate_manifests_and_non_train_lora_entries(tmp_path: Path) -> None:
+    jobs_root = tmp_path / "model-ops"
+    train_root = jobs_root / "train_lora"
+    train_root.mkdir(parents=True, exist_ok=True)
+    (train_root / "model-ops-not-a-dir").write_text("placeholder\n", encoding="utf-8")
+
+    _write_run_record(
+        jobs_root,
+        run_id="model-ops-0001",
+        group_id="nightly-qwen",
+        manifest_path="/tmp/model-ops-0001/train_lora.adapter.json",
+        updated_at_unix_ms=1_000,
+    )
+    _write_manifest(
+        jobs_root,
+        run_id="model-ops-0002",
+        operation="evaluate",
+        updated_at_unix_ms=200,
+    )
+    _write_manifest(
+        jobs_root,
+        run_id="model-ops-0003",
+        updated_at_unix_ms=300,
+    )
+    duplicate_manifest = train_root / "model-ops-0003" / "train_lora.adapter.json"
+    duplicate_payload = json.loads(duplicate_manifest.read_text(encoding="utf-8"))
+    duplicate_payload["job_id"] = "model-ops-0001"
+    duplicate_manifest.write_text(json.dumps(duplicate_payload, indent=2) + "\n", encoding="utf-8")
+    _write_run_record(
+        jobs_root,
+        run_id="model-ops-0004",
+        group_id="",
+        manifest_path="/tmp/model-ops-0004/train_lora.adapter.json",
+        updated_at_unix_ms=1_100,
+    )
+
+    payload = LoraExperimentStore().rebuild_index(jobs_root)
+
+    assert [run["run_id"] for run in payload["runs"]] == ["model-ops-0004", "model-ops-0001"]
+    assert payload["groups"][0]["group_id"] == "nightly-qwen"
+    assert len(payload["groups"]) == 1
 
 
 def test_optional_finite_float_rejects_invalid_and_non_finite_values() -> None:

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -39,13 +39,17 @@ class LoraExperimentStore:
         train_root = jobs_root / "train_lora"
         runs_by_id: dict[str, dict[str, Any]] = {}
         if train_root.exists():
-            for run_path in sorted(train_root.glob(f"model-ops-*/{self.run_record_name}")):
+            for run_dir in sorted(train_root.glob("model-ops-*")):
+                if run_dir.is_dir() is False:
+                    continue
+                run_path = run_dir / self.run_record_name
                 payload = self._read_payload(run_path)
                 run_id = str(payload.get("run_id", "")).strip()
                 if run_id:
                     runs_by_id[run_id] = payload
+                    continue
 
-            for manifest_path in sorted(train_root.glob("model-ops-*/train_lora.adapter.json")):
+                manifest_path = run_dir / "train_lora.adapter.json"
                 payload = self._read_payload(manifest_path)
                 run_id = str(payload.get("job_id", "")).strip() or manifest_path.parent.name
                 if run_id in runs_by_id:


### PR DESCRIPTION
## Summary
- Avoid a second `train_lora/model-ops-*` manifest pass in `LoraExperimentStore.rebuild_index()` when a run record already exists for the same run directory.
- Preserve the existing fallback behavior for missing or unreadable run records.
- Add focused regression coverage for run-record precedence, manifest fallback, duplicate-manifest skipping, cached-index loading, and non-directory / non-`train_lora` filtering.

## Plan or Spec
- `docs/plans/2026-04-29-lora-experiment-index-scan-optimization.md`

## Commands Run
```text
PYTHONPATH=/tmp/melix-cron-20260429-231136:/tmp/melix-cron-20260429-231136/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py
  -> 8 passed in 0.04s

PYTHONPATH=/tmp/melix-cron-20260429-231136:/tmp/melix-cron-20260429-231136/services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py
  -> 8 passed in 0.06s

coverage report -m services/mlx-worker-python/worker/productization/lora_experiment_store.py services/mlx-worker-python/tests/test_lora_experiment_store.py
  -> worker/productization/lora_experiment_store.py: 100% (117/117)
  -> tests/test_lora_experiment_store.py: 98% (110/112)

python <synthetic rebuild_index probe comparing origin/main vs branch>
  -> baseline_mean_ms=100.685
  -> current_mean_ms=88.969
  -> improvement_pct=11.64
  -> speedup=1.13x
  -> payload_equivalent=True for 1500 synthetic runs

git diff --check
  -> clean
```

## Coverage and Metrics
- Changed executable scope coverage: `services/mlx-worker-python/worker/productization/lora_experiment_store.py` at `100%` (`117/117`).
- Focused test file coverage: `services/mlx-worker-python/tests/test_lora_experiment_store.py` at `98%` (`110/112`).
- Synthetic optimization probe on 1,500 run directories with both a run record and manifest:
  - baseline mean: `100.685 ms`
  - optimized mean: `88.969 ms`
  - improvement: `11.64%` (`1.13x`)
  - payload equivalence: `True`

## Known Gaps
- Linux-only verification for the Python worker path was run. No Swift/macOS validation was attempted in this cron run.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
