### PR TITLE
perf: stream benchmark suite cache row loading

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_suites.py
+++ b/services/mlx-worker-python/tests/test_benchmark_suites.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -94,6 +95,35 @@ def test_benchmark_suite_catalog_materializes_curated_hf_suite_and_reuses_cache(
     assert len(first.prompt_batches) == 2
     assert first.prompt_batches[0] == "Say hi.\n\nSay bye."
     assert first.metadata()["dataset_uri"].startswith("hf://HuggingFaceH4/ultrachat_200k")
+
+
+def test_load_materialized_rows_streams_without_read_text(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    rows_path = tmp_path / "rows.jsonl"
+    rows_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"prompt": "Say hi."}),
+                "",
+                json.dumps(["ignored", "list"]),
+                json.dumps({"prompt": "Say bye."}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    original_read_text = Path.read_text
+
+    def guarded_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        if self == rows_path:
+            raise AssertionError("rows loader should stream from disk instead of calling read_text")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
+
+    assert benchmark_suites._load_materialized_rows(rows_path) == [
+        {"prompt": "Say hi."},
+        {"prompt": "Say bye."},
+    ]
 
 
 def test_benchmark_suite_catalog_raises_typed_error_for_unknown_suite(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_suites.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_suites.py
@@ -553,13 +553,14 @@ def _resolve_dataset_name(
 
 def _load_materialized_rows(rows_path: Path) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
-    for raw_line in rows_path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        row = json.loads(line)
-        if isinstance(row, dict):
-            rows.append(row)
+    with rows_path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            if isinstance(row, dict):
+                rows.append(row)
     return rows
 
 


### PR DESCRIPTION
## Summary
- Stream cached benchmark-suite `rows.jsonl` parsing in `services/mlx-worker-python/worker/productization/benchmark_suites.py` with `Path.open(...)` instead of `Path.read_text(...).splitlines()`.
- Add a focused regression test that fails if the cached rows loader falls back to `Path.read_text()` for the JSONL file.
- Preserve blank-line skipping and non-dict row filtering semantics while lowering peak memory on large cache hits.

## Plan or Spec
- N/A: this is a small internal Python-only optimization slice for `services/mlx-worker-python` and does not change a documented external contract.
- Repository guidance followed: `AGENTS.md`, `docs/README.md`, `docs/engineering-standards.md`, `docs/contributing.md`, and `docs/templates/pr-evidence-checklist.md`.

## Commands Run
```text
Created isolated worktree/branch from origin/main:
- git fetch origin main --prune
- git worktree add /tmp/melix-cron-python-opt-20260430-000554 -b akane/cron-python-opt-20260430-000554 origin/main
- git config user.name "Akane"
- git config user.email "258593038+Akane-CN@users.noreply.github.com"

Focused RED test:
- PYTHONPATH=. uv run pytest tests/test_benchmark_suites.py::test_load_materialized_rows_streams_without_read_text -v
  -> failed before the code change because `_load_materialized_rows()` called `Path.read_text()`.

Focused GREEN test:
- PYTHONPATH=. uv run pytest tests/test_benchmark_suites.py::test_load_materialized_rows_streams_without_read_text -v
  -> 1 passed

Focused scope verification:
- PYTHONPATH=. uv run coverage run -m pytest tests/test_benchmark_suites.py
  -> 14 passed
- PYTHONPATH=. uv run coverage report --include='worker/productization/benchmark_suites.py'
  -> 98% coverage for the touched executable file
- git diff --check
  -> clean
```

## Coverage and Metrics
- Changed executable scope: `services/mlx-worker-python/worker/productization/benchmark_suites.py`
- Automated coverage: `98%` (`209` statements, `4` missed)
- Performance probe: synthetic `100000`-row cached `rows.jsonl`, `5` repeats, compared old full-buffer parser vs new streaming parser with `tracemalloc`
  - Baseline mean peak traced memory: `64,052,335.8` bytes
  - Optimized mean peak traced memory: `49,485,225.6` bytes
  - Peak memory delta: `-14,567,110.2` bytes (`-22.74%`)
  - Baseline mean wall time: `0.9451s`
  - Optimized mean wall time: `0.9724s`
  - Wall-time delta: `+0.0273s` (`+2.89%`)
- Interpretation: this slice intentionally trades a small amount of CPU time for materially lower peak memory on large cached benchmark-suite loads.

## Known Gaps
- Did not run macOS/Swift verification (`make swift-test`) because this cron host is Linux and the change is intentionally limited to `services/mlx-worker-python`.
- Did not run the full repository test matrix; only the touched Python scope was verified.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
