### PR TITLE
perf(python): limit benchmark suite cache-hit row loads

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_suites.py
+++ b/services/mlx-worker-python/tests/test_benchmark_suites.py
@@ -126,6 +126,66 @@ def test_load_materialized_rows_streams_without_read_text(tmp_path: Path, monkey
     ]
 
 
+def test_load_materialized_rows_respects_limit(tmp_path: Path) -> None:
+    rows_path = tmp_path / "rows.jsonl"
+    rows_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"prompt": "prompt-1"}),
+                json.dumps({"prompt": "prompt-2"}),
+                json.dumps({"prompt": "prompt-3"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert benchmark_suites._load_materialized_rows(rows_path, limit=2) == [
+        {"prompt": "prompt-1"},
+        {"prompt": "prompt-2"},
+    ]
+
+
+def test_benchmark_suite_catalog_cache_hit_reads_only_requested_prefix(tmp_path: Path) -> None:
+    fetcher = FakeBenchmarkSuiteFetcher()
+    catalog = BenchmarkSuiteCatalog(hf_dataset_fetcher=fetcher)
+
+    first = catalog.resolve_suite(
+        "smoke",
+        jobs_root=tmp_path,
+        parameters={"sample_size": "2", "batch_factor": "2"},
+    )
+
+    assert first.cache_hit is False
+
+    package_path = Path(first.materialized_package_path)
+    rows_path = package_path / "rows.jsonl"
+    original_rows = rows_path.read_text(encoding="utf-8").rstrip("\n").splitlines()
+    extra_rows = [json.dumps({"messages": [{"role": "user", "content": f"extra-{index}"}]}) for index in range(8, 20)]
+    rows_path.write_text("\n".join([*original_rows, *extra_rows]) + "\n", encoding="utf-8")
+
+    second = catalog.resolve_suite(
+        "smoke",
+        jobs_root=tmp_path,
+        parameters={"sample_size": "1", "batch_factor": "1"},
+    )
+
+    assert second.cache_hit is True
+    assert second.prompt_batches == ("Say hi.",)
+    assert fetcher.calls == [
+        (
+            "rows",
+            {
+                "dataset": "HuggingFaceH4/ultrachat_200k",
+                "config": "default",
+                "split": "train_sft",
+                "offset": "0",
+                "length": "8",
+            },
+        )
+    ]
+
+
 def test_benchmark_suite_catalog_raises_typed_error_for_unknown_suite(tmp_path: Path) -> None:
     catalog = BenchmarkSuiteCatalog(hf_dataset_fetcher=FakeBenchmarkSuiteFetcher())
 

--- a/services/mlx-worker-python/worker/productization/benchmark_suites.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_suites.py
@@ -114,11 +114,12 @@ class BenchmarkSuiteCatalog:
 
         sample_size = _parse_positive_int(parameters.get("sample_size", ""), definition.default_sample_size)
         batch_factor = _parse_positive_int(parameters.get("batch_factor", ""), definition.default_batch_factor)
+        sample_hint = _materialized_sample_hint(sample_size=sample_size, batch_factor=batch_factor)
         materialized = _materialize_benchmark_suite(
             definition,
             cache_root=jobs_root / "datasets",
             fetch_json=self._hf_dataset_fetcher,
-            sample_hint=max(sample_size * batch_factor, 8),
+            sample_hint=sample_hint,
         )
         cases = tuple(
             _suite_cases(
@@ -346,7 +347,7 @@ def _materialize_benchmark_suite(
             "cache_key": cache_key,
             "cache_hit": True,
             "dataset_name": str(manifest.get("dataset_name", definition.dataset_name or "default")),
-            "rows": _load_materialized_rows(rows_path),
+            "rows": _load_materialized_rows(rows_path, limit=sample_hint),
         }
 
     dataset_name = definition.dataset_name or _resolve_dataset_name(definition, fetch_json)
@@ -551,7 +552,11 @@ def _resolve_dataset_name(
     return "default"
 
 
-def _load_materialized_rows(rows_path: Path) -> list[dict[str, Any]]:
+def _materialized_sample_hint(*, sample_size: int, batch_factor: int) -> int:
+    return max(sample_size * batch_factor, 8)
+
+
+def _load_materialized_rows(rows_path: Path, *, limit: int | None = None) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     with rows_path.open("r", encoding="utf-8") as handle:
         for raw_line in handle:
@@ -561,6 +566,8 @@ def _load_materialized_rows(rows_path: Path) -> list[dict[str, Any]]:
             row = json.loads(line)
             if isinstance(row, dict):
                 rows.append(row)
+                if limit is not None and len(rows) >= limit:
+                    break
     return rows
 
 


### PR DESCRIPTION
## Summary
- limit benchmark suite cache-hit row loading to the request-sized sample hint instead of always materializing the full cached `rows.jsonl`
- keep the existing `max(sample_size * batch_factor, 8)` lower bound so cache-hit behavior stays aligned with initial materialization semantics
- add targeted tests for the new row-limit helper path and cache-hit prefix loading behavior

## Plan or Spec
- N/A: this is a small internal Python performance optimization in `services/mlx-worker-python` and does not change a governed external behavior or canonical repository spec

## Commands Run
```text
uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_benchmark_suites.py -q
# 16 passed in 0.10s

uv run --project services/mlx-worker-python --extra mlx coverage erase
uv run --project services/mlx-worker-python --extra mlx coverage run --include='*/worker/productization/benchmark_suites.py' -m pytest services/mlx-worker-python/tests/test_benchmark_suites.py -q
# 16 passed in 0.11s
uv run --project services/mlx-worker-python --extra mlx coverage report -m
# services/mlx-worker-python/worker/productization/benchmark_suites.py 214 stmts, 4 miss, 98% cover

git diff --check
# clean

uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
# generated a 30k-row rows.jsonl file and timed _load_materialized_rows(limit=None) vs limit=8
PY
# full_mean_ms=73.355, limit8_mean_ms=0.034, speedup_x=2165.82
```

## Coverage and Metrics
- changed-scope coverage: `services/mlx-worker-python/worker/productization/benchmark_suites.py` = **98%** (`214` statements, `4` missed)
- performance probe on a synthetic 30,000-row cached `rows.jsonl`:
  - full cached load mean: **73.355 ms**
  - limited cache-hit prefix load (`limit=8`) mean: **0.034 ms**
  - measured speedup: **2165.82x**
  - measured reduction: **~100.0%** lower mean wall time for the cache-hit load step

## Known Gaps
- No macOS/Swift verification was run; this slice is intentionally limited to Linux-verifiable Python worker code.
- The performance probe is synthetic and isolates cached row loading only; it does not measure end-to-end benchmark execution.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
