### PR TITLE
perf(python): avoid deep-copying passthrough chunk metadata

### DIFF
--- a/services/mlx-worker-python/tests/test_training_dataset_chunker.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_chunker.py
@@ -15,6 +15,8 @@ import pytest
 from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.training_dataset_chunker import (
     ChunkStats,
+    _split_messages_into_turns,
+    _split_user_content_into_k,
     chunk_long_samples,
 )
 
@@ -73,6 +75,50 @@ def test_short_single_turn_sample_passes_through_unchanged() -> None:
     assert stats == ChunkStats(
         enabled=True, chunk_size=200, chunk_count=1, source_sample_count=1
     )
+
+
+def test_short_single_turn_passthrough_reuses_top_level_metadata_but_copies_messages() -> None:
+    tokenizer = _FakeTokenizer()
+    metadata = {"tags": ["short"]}
+    tools = [{"type": "function", "function": {"name": "lookup"}}]
+    sample = {
+        "id": "short-copy-contract",
+        "metadata": metadata,
+        "tools": tools,
+        "messages": [
+            {"role": "user", "content": _words(5)},
+            {"role": "assistant", "content": "ok"},
+        ],
+    }
+
+    chunked, _ = chunk_long_samples([sample], chunk_size=200, tokenizer=tokenizer)
+
+    emitted = chunked[0]
+    assert emitted["metadata"] is metadata
+    assert emitted["tools"] is tools
+    assert emitted["messages"] == sample["messages"]
+    assert emitted["messages"] is not sample["messages"]
+    assert emitted["messages"][0] is not sample["messages"][0]
+
+
+def test_passthrough_without_extractable_pairs_reuses_top_level_metadata_but_copies_messages() -> None:
+    tokenizer = _FakeTokenizer()
+    metadata = {"tags": ["malformed"]}
+    sample = {
+        "id": "no-pairs-copy-contract",
+        "metadata": metadata,
+        "messages": [
+            {"role": "assistant", "content": "leading assistant"},
+        ],
+    }
+
+    chunked, _ = chunk_long_samples([sample], chunk_size=1, tokenizer=tokenizer)
+
+    emitted = chunked[0]
+    assert emitted["metadata"] is metadata
+    assert emitted["messages"] == sample["messages"]
+    assert emitted["messages"] is not sample["messages"]
+    assert emitted["messages"][0] is not sample["messages"][0]
 
 
 def test_long_single_turn_splits_into_multiple_chunks() -> None:
@@ -382,3 +428,90 @@ def test_chunk_size_too_small_message_distinguishes_word_shortage() -> None:
 
     assert exc.value.code == "chunk_size_too_small"
     assert "few-words" in (exc.value.message or "")
+
+
+def test_invalid_messages_list_raises_invalid_dataset_package() -> None:
+    tokenizer = _FakeTokenizer()
+
+    with pytest.raises(ModelOperationError) as exc:
+        chunk_long_samples([{"id": "bad-messages", "messages": None}], chunk_size=10, tokenizer=tokenizer)
+
+    assert exc.value.code == "invalid_dataset_package"
+    assert "non-empty 'messages' list" in (exc.value.message or "")
+
+
+def test_invalid_tools_type_raises_invalid_dataset_package() -> None:
+    tokenizer = _FakeTokenizer()
+    sample = {
+        "id": "bad-tools",
+        "tools": {"name": "lookup"},
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "ok"},
+        ],
+    }
+
+    with pytest.raises(ModelOperationError) as exc:
+        chunk_long_samples([sample], chunk_size=10, tokenizer=tokenizer)
+
+    assert exc.value.code == "invalid_dataset_package"
+    assert "'tools' to be a list" in (exc.value.message or "")
+
+
+def test_non_string_user_content_raises_invalid_dataset_package() -> None:
+    class _ConstantLengthTokenizer(_FakeTokenizer):
+        def apply_chat_template(
+            self,
+            messages: list[dict[str, str]],
+            *,
+            tools: list[dict[str, Any]] | None = None,
+            add_generation_prompt: bool = False,
+            return_dict: bool = False,
+        ) -> list[int]:
+            return list(range(50))
+
+    tokenizer = _ConstantLengthTokenizer()
+    sample = {
+        "id": "bad-user-content",
+        "messages": [
+            {"role": "user", "content": ["not", "a", "string"]},
+            {"role": "assistant", "content": "ok"},
+        ],
+    }
+
+    with pytest.raises(ModelOperationError) as exc:
+        chunk_long_samples([sample], chunk_size=20, tokenizer=tokenizer)
+
+    assert exc.value.code == "invalid_dataset_package"
+    assert "bad-user-content" in (exc.value.message or "")
+    assert "list" in (exc.value.message or "")
+
+
+def test_chunk_size_must_be_positive() -> None:
+    tokenizer = _FakeTokenizer()
+
+    with pytest.raises(ModelOperationError) as exc:
+        chunk_long_samples([], chunk_size=0, tokenizer=tokenizer)
+
+    assert exc.value.code == "invalid_argument"
+    assert "chunk_size must be >= 1" in (exc.value.message or "")
+
+
+def test_malformed_multi_turn_stops_pair_extraction_at_first_non_user_assistant_pair() -> None:
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": _words(20)},
+        {"role": "assistant", "content": "a1"},
+        {"role": "tool", "content": "unexpected"},
+        {"role": "assistant", "content": "a2"},
+    ]
+
+    system_prefix, pairs = _split_messages_into_turns(messages)
+
+    assert system_prefix == [messages[0]]
+    assert pairs == [(messages[1], messages[2])]
+
+
+def test_split_user_content_into_k_handles_trivial_and_word_shortage_cases() -> None:
+    assert _split_user_content_into_k("alpha beta", 1) == ["alpha beta"]
+    assert _split_user_content_into_k("alpha beta", 3) == ["alpha", "beta"]

--- a/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
@@ -245,6 +245,20 @@ def _chunk_single_turn(
     )
 
 
+def _passthrough_sample(sample: dict) -> dict:
+    """Return a passthrough sample with independent messages but shared top-level fields.
+
+    The chunker must not mutate the caller's messages list or nested message dicts,
+    but it also avoids deep-copying immutable-by-convention top-level payloads like
+    metadata or tool schemas on unchanged outputs.
+    """
+
+    out = {k: v for k, v in sample.items() if k != "messages"}
+    out["messages"] = copy.deepcopy(_extract_messages(sample))
+    return out
+
+
+
 def _chunk_sample(
     sample: dict,
     *,
@@ -268,13 +282,13 @@ def _chunk_sample(
     tools = _extract_tools(sample)
     messages = _extract_messages(sample)
     if _render_len(messages, tokenizer, tools=tools) <= chunk_size:
-        return [copy.deepcopy(sample)]
+        return [_passthrough_sample(sample)]
 
     sample_id = str(sample.get("id", ""))
     system_prefix, pairs = _split_messages_into_turns(messages)
 
     if not pairs:
-        return [copy.deepcopy(sample)]
+        return [_passthrough_sample(sample)]
 
     # Multi-turn: emit each (user, assistant) pair as its own chunk first.
     # If any chunk still overflows, fall through to single-turn segmentation
@@ -329,9 +343,11 @@ def chunk_long_samples(
     """Chunk every sample in ``samples`` that exceeds ``chunk_size`` tokens.
 
     Returns ``(chunked_samples, stats)``. Samples that already fit pass
-    through as one chunk each (deep-copied so downstream mutations can't leak
-    back to the caller). Iterates ``samples`` exactly once so the caller can
-    pass a generator over a large JSONL file without materializing it.
+    through as one chunk each with a copied ``messages`` payload but shared
+    top-level immutable-by-convention fields, so downstream message mutations
+    can't leak back to the caller without deep-copying large metadata blobs.
+    Iterates ``samples`` exactly once so the caller can pass a generator over
+    a large JSONL file without materializing it.
     """
 
     if chunk_size < 1:


### PR DESCRIPTION
## Summary
- Avoid deep-copying large top-level metadata and tool payloads when `training_dataset_chunker` passes samples through unchanged.
- Keep `messages` isolated via deep copy so downstream mutations still cannot leak back to the caller.
- Add focused tests for passthrough copy semantics, validation errors, malformed pair extraction, and helper edge cases.

## Plan or Spec
- N/A: this is a small Python-only optimization slice in `services/mlx-worker-python` with no governing canonical plan/spec for the chunker copy contract. The implementation docstrings were updated to reflect the new passthrough behavior.

## Commands Run
```text
python -m pytest -q tests/test_training_dataset_chunker.py::test_short_single_turn_passthrough_reuses_top_level_metadata_but_copies_messages tests/test_training_dataset_chunker.py::test_passthrough_without_extractable_pairs_reuses_top_level_metadata_but_copies_messages
  -> 2 passed
python -m pytest -q tests/test_training_dataset_chunker.py
  -> 20 passed
coverage run --source=worker.model_ops.training_dataset_chunker -m pytest -q tests/test_training_dataset_chunker.py && coverage report -m worker/model_ops/training_dataset_chunker.py
  -> 20 passed, worker/model_ops/training_dataset_chunker.py coverage 99%
python <inline performance probe comparing origin/main vs branch>
  -> baseline 0.2220s / 6.87 MiB peak, optimized 0.0218s / 0.46 MiB peak on 600 passthrough samples
git diff --check
  -> clean
```

## Coverage and Metrics
- Changed executable scope: `worker/model_ops/training_dataset_chunker.py`
- Automated coverage: 99% (`114/115` statements; only defensive `continue` branch at line 227 remains uncovered)
- Performance probe on 600 synthetic passthrough samples with large `metadata`/`tools` payloads:
  - `origin/main`: `0.2220s`, `6.87 MiB` peak traced allocations
  - this branch: `0.0218s`, `0.46 MiB` peak traced allocations
  - improvement: ~`10.2x` faster, ~`14.8x` lower peak traced allocations

## Known Gaps
- Probe is synthetic and targets the unchanged-sample fast path specifically; it is not an end-to-end training benchmark.
- Repository-wide Python/macOS/Swift suites were not run in this Linux cron slice; verification stayed intentionally focused on the touched Python worker scope.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
