### PR TITLE
perf(python): stream training dataset JSONL writes

### DIFF
--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -601,6 +601,40 @@ def test_materialize_hf_training_dataset_rejects_empty_validation_split(tmp_path
     assert exc.value.code == "hf_dataset_fetch_failed"
 
 
+def test_materialize_hf_training_dataset_writes_validation_split_jsonl(tmp_path: Path) -> None:
+    reference = HFDatasetReference(
+        dataset_path="melix/demo-hf",
+        dataset_name="default",
+        dataset_revision="main",
+        train_split="train",
+        chat_feature="",
+        prompt_feature="p",
+        completion_feature="c",
+        text_feature="",
+        valid_split="validation",
+    )
+
+    def fetcher(endpoint: str, params: dict[str, str]) -> dict[str, object]:
+        if endpoint != "rows":
+            return {"splits": [{"split": "train", "config": "default"}]}
+        if params["split"] == "validation":
+            return {"rows": [{"row": {"p": "holdout", "c": "answer"}}]}
+        return {"rows": [{"row": {"p": "hello", "c": "world"}}]}
+
+    package = materialize_hf_training_dataset_package(
+        reference,
+        cache_root=tmp_path / "datasets",
+        fetch_json=fetcher,
+    )
+
+    assert (package.package_path / "samples.jsonl").read_text(encoding="utf-8") == (
+        '{"prompt": "hello", "completion": "world"}\n'
+    )
+    assert (package.package_path / "valid.jsonl").read_text(encoding="utf-8") == (
+        '{"prompt": "holdout", "completion": "answer"}\n'
+    )
+
+
 def test_hf_dataset_helpers_cover_paging_and_direct_chat_paths(tmp_path: Path) -> None:
     reference = HFDatasetReference(
         dataset_path="melix/demo-hf",

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -8,8 +8,10 @@ import pytest
 from worker.model_ops import training_dataset as training_dataset_module
 from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.training_dataset import (
+    TrainingDatasetPackage,
     build_training_dataset_artifact,
     load_training_dataset_package,
+    write_normalized_dataset_snapshot,
 )
 
 
@@ -20,6 +22,97 @@ def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> Path:
         encoding="utf-8",
     )
     return path
+
+
+def test_write_jsonl_rows_streams_each_row_without_joining_the_full_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output_path = tmp_path / "rows.jsonl"
+    writes: list[str] = []
+
+    class RecordingFile:
+        def __enter__(self) -> RecordingFile:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        def write(self, chunk: str) -> int:
+            writes.append(chunk)
+            return len(chunk)
+
+    def fake_open(self: Path, mode: str = "r", *args: object, **kwargs: object) -> RecordingFile:
+        assert self == output_path
+        assert mode == "w"
+        assert kwargs.get("encoding") == "utf-8"
+        return RecordingFile()
+
+    monkeypatch.setattr(Path, "open", fake_open)
+
+    training_dataset_module._write_jsonl_rows(
+        output_path,
+        [
+            {"text": "alpha"},
+            {"text": "beta"},
+        ],
+    )
+
+    assert writes == [
+        json.dumps({"text": "alpha"}) + "\n",
+        json.dumps({"text": "beta"}) + "\n",
+    ]
+
+
+def test_write_jsonl_rows_preserves_the_existing_blank_line_contract_for_empty_inputs(
+    tmp_path: Path,
+) -> None:
+    output_path = tmp_path / "empty.jsonl"
+
+    training_dataset_module._write_jsonl_rows(output_path, [])
+
+    assert output_path.read_text(encoding="utf-8") == "\n"
+
+
+def test_write_normalized_dataset_snapshot_writes_matching_train_and_samples_jsonl(
+    tmp_path: Path,
+) -> None:
+    package_path = tmp_path / "dataset-package"
+    package_path.mkdir(parents=True, exist_ok=True)
+    manifest_path = package_path / "manifest.json"
+    samples_path = package_path / "samples.jsonl"
+
+    dataset = TrainingDatasetPackage(
+        package_path=package_path,
+        manifest_path=manifest_path,
+        samples_path=samples_path,
+        schema_version="melix.training_dataset_package.v1",
+        dataset_id="melix-demo",
+        format="prompt_completion",
+        sample_count=2,
+        version="1",
+        normalized_samples=[
+            {"prompt": "alpha", "completion": "beta"},
+            {"prompt": "gamma", "completion": "delta"},
+        ],
+        normalized_validation_samples=[
+            {"prompt": "holdout", "completion": "answer"},
+        ],
+        validation_sample_count=1,
+        response_only_supported=False,
+    )
+
+    snapshot = write_normalized_dataset_snapshot(dataset, output_dir=tmp_path / "exports")
+
+    assert snapshot.samples_path.read_text(encoding="utf-8") == (
+        '{"prompt": "alpha", "completion": "beta"}\n'
+        '{"prompt": "gamma", "completion": "delta"}\n'
+    )
+    assert snapshot.train_path.read_text(encoding="utf-8") == snapshot.samples_path.read_text(encoding="utf-8")
+    assert snapshot.valid_path is not None
+    assert snapshot.valid_path.read_text(encoding="utf-8") == (
+        '{"prompt": "holdout", "completion": "answer"}\n'
+    )
 
 
 def test_build_training_dataset_artifact_converts_alpaca_rows_and_records_quality_signals(

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shutil
 from dataclasses import dataclass
 from dataclasses import replace
 import os
@@ -91,6 +92,16 @@ class BuiltTrainingDatasetArtifact:
     validation_sample_count: int
     format: str
     inspect_only: bool
+
+
+def _write_jsonl_rows(path: Path, rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        wrote_any = False
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+            wrote_any = True
+        if not wrote_any:
+            handle.write("\n")
 
 
 def load_training_dataset_package(
@@ -421,16 +432,10 @@ def build_training_dataset_artifact(
     manifest_payload["schema_version"] = "melix.training_dataset_package.v1"
     manifest_path = package_path / "manifest.json"
     samples_path = package_path / "samples.jsonl"
-    samples_path.write_text(
-        "\n".join(json.dumps(sample) for sample in train_samples) + "\n",
-        encoding="utf-8",
-    )
+    _write_jsonl_rows(samples_path, train_samples)
     valid_path = package_path / "valid.jsonl"
     if validation_samples:
-        valid_path.write_text(
-            "\n".join(json.dumps(sample) for sample in validation_samples) + "\n",
-            encoding="utf-8",
-        )
+        _write_jsonl_rows(valid_path, validation_samples)
     elif valid_path.exists():
         valid_path.unlink()
     manifest_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
@@ -472,18 +477,10 @@ def write_normalized_dataset_snapshot(
     }
     manifest_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
 
-    serialized_samples = [json.dumps(sample) for sample in dataset.normalized_samples]
-    samples_path.write_text("\n".join(serialized_samples) + "\n", encoding="utf-8")
-    train_path.write_text("\n".join(serialized_samples) + "\n", encoding="utf-8")
+    _write_jsonl_rows(samples_path, dataset.normalized_samples)
+    shutil.copyfile(samples_path, train_path)
     if dataset.normalized_validation_samples:
-        serialized_validation_samples = [
-            json.dumps(sample)
-            for sample in dataset.normalized_validation_samples
-        ]
-        valid_path.write_text(
-            "\n".join(serialized_validation_samples) + "\n",
-            encoding="utf-8",
-        )
+        _write_jsonl_rows(valid_path, dataset.normalized_validation_samples)
     else:
         valid_path = None
 
@@ -584,15 +581,9 @@ def materialize_hf_training_dataset_package(
         "text_feature": resolved_reference.text_feature,
     }
     manifest_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
-    samples_path.write_text(
-        "\n".join(json.dumps(sample) for sample in serialized_samples) + "\n",
-        encoding="utf-8",
-    )
+    _write_jsonl_rows(samples_path, serialized_samples)
     if serialized_validation_samples:
-        (package_path / "valid.jsonl").write_text(
-            "\n".join(json.dumps(sample) for sample in serialized_validation_samples) + "\n",
-            encoding="utf-8",
-        )
+        _write_jsonl_rows(package_path / "valid.jsonl", serialized_validation_samples)
     return MaterializedTrainingDatasetPackage(
         package_path=package_path,
         cache_key=cache_key,


### PR DESCRIPTION
## Summary
- Stream JSONL writes in `services/mlx-worker-python/worker/model_ops/training_dataset.py` instead of building full joined payload strings in memory.
- Reuse the streamed `samples.jsonl` snapshot when producing `train.jsonl` so the normalized snapshot path no longer materializes the same serialized dataset twice.
- Add focused regression tests for the streaming helper, normalized snapshot output parity, and Hugging Face validation split materialization.

## Plan or Spec
- N/A: this is a small internal Python-worker optimization slice with no governing canonical plan/spec and no external contract change.

## Commands Run
```text
# Scout / inspection
- delegated one read-only scout agent to inspect services/mlx-worker-python and rank safe Linux-verifiable optimization candidates

# TDD / focused verification
- pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py -k 'test_write_jsonl_rows_streams_each_row_without_joining_the_full_payload or test_write_normalized_dataset_snapshot_writes_matching_train_and_samples_jsonl'
  -> RED: 1 failed, 1 passed (missing _write_jsonl_rows helper)
- pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py
  -> GREEN: 7 passed
- python3 - <<'PY' ... Coverage()+pytest.main([... test_training_dataset_builder.py, test_lora_model_ops_unit.py ...]) ... PY
  -> 10 passed, 36 deselected
- git diff --check
  -> clean

# Performance probe
- python3 - <<'PY' ... benchmark old joined write vs _write_jsonl_rows across 25,000 rows with tracemalloc ... PY
  -> old mean 0.3612s / 23.10 MiB peak; new mean 0.3604s / 0.02 MiB peak

# Coverage confirmation
- python3 /tmp/melix-cron-python-opt-20260430-020557/.tmp_changed_scope_coverage.py
  -> changed_statement_coverage_pct=100.0
```

## Coverage and Metrics
- Changed-scope coverage for touched executable lines in `worker/model_ops/training_dataset.py`: `100.0%`.
- Focused pytest outcome: `10 passed, 36 deselected`.
- Performance probe on 25,000 JSONL rows:
  - old joined write mean: `0.3612s`
  - new streamed write mean: `0.3604s`
  - old peak traced memory: `23.10 MiB`
  - new peak traced memory: `0.02 MiB`
  - peak memory reduction: `99.9%`
  - runtime delta: `-0.2%` (roughly neutral)

## Known Gaps
- Focused Python-worker verification only. I did not run the repository-wide `make py-test`, `make swift-test`, or integration flows because this cron run is constrained to a Linux-verifiable Python-only slice.
- The changed-scope coverage helper was run from a temporary repo-local script during verification and then removed before commit.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
