### PR TITLE
perf(python): stream normalized snapshot writes

### DIFF
--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -115,6 +115,47 @@ def test_write_normalized_dataset_snapshot_writes_matching_train_and_samples_jso
     )
 
 
+def test_write_normalized_dataset_snapshot_streams_train_jsonl_without_copying(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package_path = tmp_path / "dataset-package"
+    package_path.mkdir(parents=True, exist_ok=True)
+
+    dataset = TrainingDatasetPackage(
+        package_path=package_path,
+        manifest_path=package_path / "manifest.json",
+        samples_path=package_path / "samples.jsonl",
+        schema_version="melix.training_dataset_package.v1",
+        dataset_id="melix-demo",
+        format="prompt_completion",
+        sample_count=2,
+        version="1",
+        normalized_samples=[
+            {"prompt": "alpha", "completion": "beta"},
+            {"prompt": "gamma", "completion": "delta"},
+        ],
+        normalized_validation_samples=[],
+        validation_sample_count=0,
+        response_only_supported=False,
+    )
+
+    def fail_copyfile(src: Path, dst: Path) -> None:
+        raise AssertionError(f"write_normalized_dataset_snapshot should not copy {src} to {dst}")
+
+    monkeypatch.setattr(training_dataset_module.shutil, "copyfile", fail_copyfile)
+
+    snapshot = write_normalized_dataset_snapshot(dataset, output_dir=tmp_path / "exports")
+
+    expected_payload = (
+        '{"prompt": "alpha", "completion": "beta"}\n'
+        '{"prompt": "gamma", "completion": "delta"}\n'
+    )
+    assert snapshot.samples_path.read_text(encoding="utf-8") == expected_payload
+    assert snapshot.train_path.read_text(encoding="utf-8") == expected_payload
+    assert snapshot.valid_path is None
+
+
 def test_build_training_dataset_artifact_converts_alpaca_rows_and_records_quality_signals(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import shutil
+from contextlib import ExitStack
 from dataclasses import dataclass
 from dataclasses import replace
 import os
@@ -95,13 +96,21 @@ class BuiltTrainingDatasetArtifact:
 
 
 def _write_jsonl_rows(path: Path, rows: list[dict[str, Any]]) -> None:
-    with path.open("w", encoding="utf-8") as handle:
+    _write_duplicate_jsonl_rows((path,), rows)
+
+
+def _write_duplicate_jsonl_rows(paths: tuple[Path, ...], rows: list[dict[str, Any]]) -> None:
+    with ExitStack() as stack:
+        handles = [stack.enter_context(path.open("w", encoding="utf-8")) for path in paths]
         wrote_any = False
         for row in rows:
-            handle.write(json.dumps(row) + "\n")
+            line = json.dumps(row) + "\n"
+            for handle in handles:
+                handle.write(line)
             wrote_any = True
         if not wrote_any:
-            handle.write("\n")
+            for handle in handles:
+                handle.write("\n")
 
 
 def load_training_dataset_package(
@@ -477,8 +486,7 @@ def write_normalized_dataset_snapshot(
     }
     manifest_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
 
-    _write_jsonl_rows(samples_path, dataset.normalized_samples)
-    shutil.copyfile(samples_path, train_path)
+    _write_duplicate_jsonl_rows((samples_path, train_path), dataset.normalized_samples)
     if dataset.normalized_validation_samples:
         _write_jsonl_rows(valid_path, dataset.normalized_validation_samples)
     else:


### PR DESCRIPTION
## Summary
- stream normalized dataset snapshot writes to `samples.jsonl` and `train.jsonl` in one pass instead of writing one file and copying it afterward
- keep the change scoped to `services/mlx-worker-python`
- add a regression test that fails if `write_normalized_dataset_snapshot()` falls back to `shutil.copyfile`

## Plan or Spec
- N/A: small internal Python-worker performance slice for cron maintenance; no existing canonical spec or plan governs this helper-level snapshot write path

## Commands Run
```text
python -m pytest tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_streams_train_jsonl_without_copying -q
# FAIL before implementation: write_normalized_dataset_snapshot should not copy samples.jsonl to train.jsonl

PYTHONPATH=/tmp/melix-20260430-023329 python -m pytest tests/test_training_dataset_builder.py -q
# PASS (8 passed)

PYTHONPATH=/tmp/melix-20260430-023329 python -m pytest tests/test_lora_model_ops.py::test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alias -q
# PASS (1 passed)

PYTHONPATH=/tmp/melix-20260430-023329 python -m coverage erase && PYTHONPATH=/tmp/melix-20260430-023329 python -m coverage run -m pytest tests/test_training_dataset_builder.py tests/test_lora_model_ops.py::test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alias -q && PYTHONPATH=/tmp/melix-20260430-023329 python -m coverage json -o coverage.json
# PASS (9 passed), coverage JSON generated for changed-line analysis

python changed-line coverage probe
# PASS: worker/model_ops/training_dataset.py changed-line coverage 100.0% (11/11 measured changed lines)

python strace performance probe
# baseline copyfile path: 0.004163s traced syscall time, 803 traced calls, includes 2 sendfile calls
# current dual-write path: 0.002481s traced syscall time, 1212 traced calls, removes sendfile copy path

git diff --check
# PASS
```

## Coverage and Metrics
- Changed executable file coverage: `worker/model_ops/training_dataset.py` changed-line coverage `100.0% (11/11)`
- Performance probe (`strace -c` on a 20k-row synthetic snapshot build):
  - baseline copyfile path: `0.004163s` traced syscall time, `803` traced file-I/O syscalls, `2` `sendfile` calls
  - current dual-write path: `0.002481s` traced syscall time, `1212` traced file-I/O syscalls, `0` `sendfile` calls
- Net effect: removes the extra file-copy phase and cut traced file-I/O time by about `40.4%` in the synthetic probe

## Known Gaps
- None for this slice.
- I did not run the full `make py-test` repository suite in this Linux cron run; I ran the focused Python-worker gates for the touched path instead.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
