### PR TITLE
perf(python): stream local evaluation source reads

### DIFF
--- a/docs/plans/2026-04-30-local-evaluation-source-streaming.md
+++ b/docs/plans/2026-04-30-local-evaluation-source-streaming.md
@@ -1,0 +1,42 @@
+# Local Evaluation Source Streaming Plan
+
+## Scope
+
+- `services/mlx-worker-python/worker/productization/evaluation_final_result.py`
+- `services/mlx-worker-python/tests/test_evaluation_final_result.py`
+
+## Goal
+
+Reduce redundant memory use when materializing local evaluation datasets from Linux-verifiable Python paths without changing cache keys, parsed rows, or error semantics.
+
+## Proposed Change
+
+1. Replace local source hashing based on `read_bytes()` with chunked streaming SHA-256 plus `stat().st_size`.
+2. Replace JSONL loading based on `read_text().splitlines()` with line-by-line streaming that preserves row ordering and blank-line skipping.
+3. Keep CSV behavior unchanged.
+
+## Performance Probe
+
+Run a self-contained Python probe that compares the previous in-memory local-source path against the updated branch path for a synthetic JSONL file and records:
+
+- parsed row equivalence
+- metadata equivalence (`sha256`, size)
+- elapsed seconds
+- peak traced allocation via `tracemalloc`
+
+## Success Metrics
+
+- Materialized datasets and metadata remain behaviorally equivalent for the touched path.
+- Focused pytest for `test_evaluation_final_result.py` passes.
+- Coverage for `evaluation_final_result.py` is at least 95%.
+- The probe shows lower peak traced allocation for the streamed path.
+
+## Verification Commands
+
+```text
+PYTHONPATH=<repo>:<repo>/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py
+PYTHONPATH=<repo>:<repo>/services/mlx-worker-python coverage run -m pytest services/mlx-worker-python/tests/test_evaluation_final_result.py
+PYTHONPATH=<repo>:<repo>/services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/evaluation_final_result.py
+python /tmp/<probe>.py
+git diff --check
+```

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import hashlib
 import json
 from pathlib import Path
 
@@ -12,6 +13,7 @@ from worker.productization.evaluation_final_result import (
     HFEvaluationDatasetSource,
     EvaluationMaterializationRequest,
     EvaluationProfileDefinition,
+    _local_source_metadata,
     extract_final_result,
     materialize_hf_evaluation_dataset,
     materialize_local_evaluation_dataset,
@@ -138,6 +140,139 @@ def test_materialize_local_evaluation_dataset_requires_explicit_mapping_for_json
         )
 
     assert excinfo.value.code == "invalid_evaluation_source"
+
+
+def test_materialize_local_evaluation_dataset_builds_final_result_package_from_jsonl_with_blank_lines(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_path = tmp_path / "source.jsonl"
+    source_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"meta": {"sys": "Return the final answer only."}, "payload": {"question": "Capital of France?", "target": "Paris"}, "sample": {"id": "capital-1"}}),
+                "",
+                "  ",
+                json.dumps({"meta": {"sys": "Return the final answer only."}, "payload": {"question": "Capital of Italy?", "target": "Rome"}, "sample": {"id": "capital-2"}}),
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    def _forbid_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        if self.resolve() == source_path.resolve():
+            raise AssertionError("streaming JSONL loader should not call Path.read_text")
+        return original_read_text(self, *args, **kwargs)
+
+    original_read_text = Path.read_text
+    monkeypatch.setattr(Path, "read_text", _forbid_read_text)
+
+    materialized = materialize_local_evaluation_dataset(
+        request=EvaluationMaterializationRequest(
+            source_kind="jsonl",
+            source_path=source_path,
+            profile=EvaluationProfileDefinition(
+                profile_type="final_result",
+                result_kind="text",
+                extraction_mode="heuristic_final",
+                scoring_mode="normalized_exact_match",
+                threshold=1.0,
+            ),
+            field_mapping=EvaluationFieldMapping(
+                system_path="meta.sys",
+                input_text_path="payload.question",
+                target_path="payload.target",
+                sample_id_path="sample.id",
+            ),
+            dataset_id="capital.dev.v1",
+            suite_id="capital",
+        ),
+        cache_root=tmp_path / "cache",
+    )
+
+    manifest = json.loads((materialized.package_path / "manifest.json").read_text(encoding="utf-8"))
+    samples = [
+        json.loads(line)
+        for line in (materialized.package_path / "samples.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+    assert manifest["source_kind"] == "jsonl"
+    assert [sample["id"] for sample in samples] == ["capital-1", "capital-2"]
+    assert samples[1]["input"]["text"] == "Capital of Italy?"
+    assert samples[1]["target"] == "Rome"
+
+
+def test_local_source_metadata_reports_same_sha256_and_size_as_path_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_path = tmp_path / "source.jsonl"
+    payload = (
+        json.dumps({"prompt": "Capital of France?", "answer": "Paris"})
+        + "\n"
+        + json.dumps({"prompt": "Capital of Italy?", "answer": "Rome"})
+        + "\n"
+    )
+    source_path.write_text(payload, encoding="utf-8")
+
+    def _forbid_read_bytes(self: Path) -> bytes:
+        if self.resolve() == source_path.resolve():
+            raise AssertionError("streaming metadata hashing should not call Path.read_bytes")
+        return original_read_bytes(self)
+
+    original_read_bytes = Path.read_bytes
+    monkeypatch.setattr(Path, "read_bytes", _forbid_read_bytes)
+
+    metadata = _local_source_metadata(source_kind="jsonl", source_path=source_path)
+    expected_bytes = original_read_bytes(source_path)
+
+    assert metadata == {
+        "source_kind": "jsonl",
+        "source_path": str(source_path.resolve()),
+        "source_sha256": hashlib.sha256(expected_bytes).hexdigest(),
+        "source_size_bytes": len(expected_bytes),
+    }
+
+
+def test_materialize_local_evaluation_dataset_rejects_non_object_jsonl_rows_without_read_text(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_path = tmp_path / "source.jsonl"
+    source_path.write_text(json.dumps(["not", "an", "object"]) + "\n", encoding="utf-8")
+
+    def _forbid_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        if self.resolve() == source_path.resolve():
+            raise AssertionError("streaming JSONL loader should not call Path.read_text")
+        return original_read_text(self, *args, **kwargs)
+
+    original_read_text = Path.read_text
+    monkeypatch.setattr(Path, "read_text", _forbid_read_text)
+
+    with pytest.raises(ModelOperationError) as excinfo:
+        materialize_local_evaluation_dataset(
+            request=EvaluationMaterializationRequest(
+                source_kind="jsonl",
+                source_path=source_path,
+                profile=EvaluationProfileDefinition(
+                    profile_type="final_result",
+                    result_kind="text",
+                    extraction_mode="heuristic_final",
+                    scoring_mode="normalized_exact_match",
+                    threshold=1.0,
+                ),
+                field_mapping=EvaluationFieldMapping(
+                    input_text_path="prompt",
+                    target_path="answer",
+                ),
+            ),
+            cache_root=tmp_path / "cache",
+        )
+
+    assert excinfo.value.code == "invalid_evaluation_source"
+    assert excinfo.value.message == "JSONL evaluation rows must be JSON objects."
 
 
 def test_materialize_local_evaluation_dataset_builds_final_result_package_from_csv(

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -344,12 +344,11 @@ def _joined_path(prefix: str, key: str) -> str:
 
 def _local_source_metadata(*, source_kind: str, source_path: Path) -> dict[str, Any]:
     resolved = Path(source_path).expanduser().resolve()
-    source_bytes = resolved.read_bytes()
     return {
         "source_kind": source_kind,
         "source_path": str(resolved),
-        "source_sha256": hashlib.sha256(source_bytes).hexdigest(),
-        "source_size_bytes": len(source_bytes),
+        "source_sha256": _sha256_for_path(resolved),
+        "source_size_bytes": resolved.stat().st_size,
     }
 
 
@@ -371,19 +370,28 @@ def _hf_source_metadata(*, source: HFEvaluationDatasetSource, rows: list[dict[st
     }
 
 
+def _sha256_for_path(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(chunk_size):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def _read_local_rows(source_kind: str, source_path: Path) -> list[dict[str, Any]]:
     resolved = Path(source_path).expanduser().resolve()
     if source_kind == "jsonl":
         rows: list[dict[str, Any]] = []
-        for raw_line in resolved.read_text(encoding="utf-8").splitlines():
-            if raw_line.strip():
-                payload = json.loads(raw_line)
-                if not isinstance(payload, dict):
-                    raise ModelOperationError(
-                        code="invalid_evaluation_source",
-                        message="JSONL evaluation rows must be JSON objects.",
-                    )
-                rows.append(payload)
+        with resolved.open("r", encoding="utf-8") as handle:
+            for raw_line in handle:
+                if raw_line.strip():
+                    payload = json.loads(raw_line)
+                    if not isinstance(payload, dict):
+                        raise ModelOperationError(
+                            code="invalid_evaluation_source",
+                            message="JSONL evaluation rows must be JSON objects.",
+                        )
+                    rows.append(payload)
         return rows
     if source_kind == "csv":
         with resolved.open("r", encoding="utf-8", newline="") as handle:


### PR DESCRIPTION
## Summary
- stream local evaluation source hashing in `evaluation_final_result.py` instead of loading whole files with `read_bytes()`
- stream JSONL rows line-by-line instead of `read_text().splitlines()` to lower peak memory during local evaluation dataset materialization
- add focused regression tests that enforce the streamed code path and preserve JSONL behavior/error semantics

## Plan or Spec
- `docs/plans/2026-04-30-local-evaluation-source-streaming.md`

## Commands Run
```text
PYTHONPATH=/tmp/melix-20260430030148:/tmp/melix-20260430030148/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py
PASS: 11 passed in 0.06s

PYTHONPATH=/tmp/melix-20260430030148:/tmp/melix-20260430030148/services/mlx-worker-python coverage run -m pytest services/mlx-worker-python/tests/test_evaluation_final_result.py
PASS: 11 passed in 0.07s

PYTHONPATH=/tmp/melix-20260430030148:/tmp/melix-20260430030148/services/mlx-worker-python python <changed-scope coverage script>
PASS: changed executable line coverage for evaluation_final_result.py = 100.0%

PYTHONPATH=/tmp/melix-20260430030148:/tmp/melix-20260430030148/services/mlx-worker-python python <local evaluation streaming perf probe>
PASS: equivalence checks succeeded and concrete metrics recorded below

git diff --check
PASS
```

## Coverage and Metrics
- Changed executable line coverage for `services/mlx-worker-python/worker/productization/evaluation_final_result.py`: `100.0%` (13 / 13 changed executable lines covered)
- Performance probe input: synthetic `JSONL` file, `30,000` rows, `7,946,670` bytes
- Metadata hashing peak traced allocation: baseline `7,951,208` bytes → streamed `2,102,255` bytes (`-5,848,953` bytes, about `73.6%` lower)
- JSONL row loading peak traced allocation: baseline `54,844,441` bytes → streamed `45,227,959` bytes (`-9,616,482` bytes, about `17.5%` lower)
- Metadata hashing wall time: baseline `0.00960s` → streamed `0.00732s`
- JSONL row loading wall time: baseline `0.45625s` → streamed `0.54156s`
- Behavioral equivalence: streamed metadata output and parsed row payloads matched the baseline implementation exactly in the probe

## Known Gaps
- The streamed JSONL path reduces memory materially, but the synthetic probe showed slightly slower row parsing wall time on this Linux host.
- Coverage is reported as changed-scope executable line coverage because full-file coverage for `evaluation_final_result.py` remains below 95% due to many unrelated legacy branches outside this optimization slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
