### PR TITLE
perf: stream benchmark evaluation probe aggregation

### DIFF
--- a/docs/plans/2026-04-30-benchmark-evaluation-report-streaming-aggregation.md
+++ b/docs/plans/2026-04-30-benchmark-evaluation-report-streaming-aggregation.md
@@ -1,0 +1,31 @@
+# Benchmark Evaluation Report Streaming Aggregation Plan
+
+## Context
+
+This Linux-only optimization slice targets `services/mlx-worker-python` and avoids Swift or macOS-only surfaces.
+
+## Goal
+
+Reduce redundant memory use in `worker/productization/benchmark_evaluation_report.py` by replacing per-metric `list[float]` accumulation with running sum/count aggregation for benchmark probe metrics and evaluation sample probe metrics while preserving all output keys and values.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`
+- `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`
+
+## Constraints
+
+- Preserve report schema, metric names, numeric values, ordering, and warning semantics.
+- Keep the change locally verifiable on Linux with focused pytest and coverage.
+- Keep the slice small and avoid unrelated refactors.
+
+## Probe
+
+Create a self-contained Python measurement script that builds a large synthetic benchmark/evaluation bundle and compares the current `origin/main` implementation against the branch implementation for identical report output, elapsed time, and peak traced allocation.
+
+## Success Metrics
+
+- Focused pytest for `test_benchmark_evaluation_report.py` passes.
+- Changed executable scope coverage is at least 95%.
+- Performance probe shows reduced peak traced allocation for `build_benchmark_evaluation_report(...)` while preserving identical rows/summary output.
+- `git diff --check` passes.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -7,7 +7,9 @@ import pytest
 
 from worker.productization.benchmark_evaluation_report import (
     _aggregate_probe_values,
+    _finalize_numeric_aggregate,
     _markdown_cell,
+    _update_numeric_aggregate,
     build_benchmark_evaluation_report,
     build_sticky_comment_body,
     load_report_input,
@@ -230,6 +232,17 @@ def test_report_builder_includes_runtime_metadata_and_decode_probes() -> None:
     assert rows_by_metric[f"{label}.dflash_rollback_count_sum"]["status"] == "warning"
     assert rows_by_metric[f"{label}.dflash_enabled_rate"]["status"] == "not_comparable"
     assert report["summary"]["warning_count"] == 4
+
+
+def test_numeric_aggregate_helpers_track_running_totals() -> None:
+    aggregate = None
+    aggregate = _update_numeric_aggregate(aggregate, 3.0)
+    aggregate = _update_numeric_aggregate(aggregate, 5.0)
+
+    assert aggregate == (8.0, 2)
+    assert _finalize_numeric_aggregate("prefill_ms", aggregate) == ("mean", 4.0)
+    assert _finalize_numeric_aggregate("cache_hit", aggregate) == ("rate", 4.0)
+    assert _finalize_numeric_aggregate("speculative_fallback_count", aggregate) == ("sum", 8.0)
 
 
 def test_aggregate_probe_values_handles_empty_inputs() -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -61,6 +61,8 @@ _EVALUATION_SAMPLE_PROBE_KEYS = (
     "extracted_result_chars",
 )
 
+_NumericAggregate = tuple[float, int]
+
 
 def load_report_input(path: str | Path) -> dict[str, object]:
     input_path = Path(path)
@@ -383,15 +385,19 @@ def _collect_benchmark_probe_metrics(
     *,
     prefix: str,
 ) -> None:
-    values_by_label_and_key: dict[tuple[str, str], list[float]] = {}
+    aggregates_by_label_and_key: dict[tuple[str, str], _NumericAggregate] = {}
     for row in _dict_rows(rows):
         label = _benchmark_probe_label(row)
         for key in _REQUEST_PROBE_KEYS:
             value = _float_or_none(row.get(key))
             if value is not None:
-                values_by_label_and_key.setdefault((label, key), []).append(value)
-    for (label, key), values in values_by_label_and_key.items():
-        suffix, value = _aggregate_probe_values(key, values)
+                aggregate_key = (label, key)
+                aggregates_by_label_and_key[aggregate_key] = _update_numeric_aggregate(
+                    aggregates_by_label_and_key.get(aggregate_key),
+                    value,
+                )
+    for (label, key), aggregate in aggregates_by_label_and_key.items():
+        suffix, value = _finalize_numeric_aggregate(key, aggregate)
         metrics[f"{prefix}.{label}.{key}_{suffix}"] = value
 
 
@@ -399,38 +405,62 @@ def _collect_evaluation_sample_probe_metrics(
     metrics: dict[str, object],
     rows: object,
 ) -> None:
-    values_by_suite_and_key: dict[tuple[str, str], list[float]] = {}
+    aggregates_by_suite_and_key: dict[tuple[str, str], _NumericAggregate] = {}
     failure_stage_counts: dict[tuple[str, str], int] = {}
     for row in _dict_rows(rows):
         suite_id = str(row.get("suite_id", "")).strip() or "suite"
         for key in _EVALUATION_SAMPLE_PROBE_KEYS:
             value = _float_or_none(row.get(key))
             if value is not None:
-                values_by_suite_and_key.setdefault((suite_id, key), []).append(value)
+                aggregate_key = (suite_id, key)
+                aggregates_by_suite_and_key[aggregate_key] = _update_numeric_aggregate(
+                    aggregates_by_suite_and_key.get(aggregate_key),
+                    value,
+                )
         failure_stage = str(row.get("failure_stage", "")).strip()
         if failure_stage:
             failure_stage_counts[(suite_id, failure_stage)] = (
                 failure_stage_counts.get((suite_id, failure_stage), 0) + 1
             )
-    for (suite_id, key), values in values_by_suite_and_key.items():
-        if values:
-            metrics[f"eval.sample.{suite_id}.{key}_mean"] = sum(values) / len(values)
+    for (suite_id, key), aggregate in aggregates_by_suite_and_key.items():
+        _, value = _finalize_numeric_aggregate(key, aggregate)
+        metrics[f"eval.sample.{suite_id}.{key}_mean"] = value
     for (suite_id, failure_stage), count in failure_stage_counts.items():
         metrics[f"eval.sample.{suite_id}.failure_stage.{failure_stage}.failure_count"] = float(count)
 
 
-def _aggregate_probe_values(key: str, values: list[float]) -> tuple[str, float]:
-    if not values:
+def _update_numeric_aggregate(
+    aggregate: _NumericAggregate | None,
+    value: float,
+) -> _NumericAggregate:
+    if aggregate is None:
+        return (value, 1)
+    return (aggregate[0] + value, aggregate[1] + 1)
+
+
+def _finalize_numeric_aggregate(
+    key: str,
+    aggregate: _NumericAggregate | None,
+) -> tuple[str, float]:
+    if aggregate is None:
         if key in _RATE_PROBE_KEYS:
-            return "rate", 0.0
+            return ("rate", 0.0)
         if key in _COUNT_PROBE_KEYS:
-            return "sum", 0.0
-        return "mean", 0.0
+            return ("sum", 0.0)
+        return ("mean", 0.0)
+    total, count = aggregate
     if key in _COUNT_PROBE_KEYS:
-        return "sum", sum(values)
+        return ("sum", total)
     if key in _RATE_PROBE_KEYS:
-        return "rate", sum(values) / len(values)
-    return "mean", sum(values) / len(values)
+        return ("rate", total / count)
+    return ("mean", total / count)
+
+
+def _aggregate_probe_values(key: str, values: list[float]) -> tuple[str, float]:
+    aggregate: _NumericAggregate | None = None
+    for value in values:
+        aggregate = _update_numeric_aggregate(aggregate, value)
+    return _finalize_numeric_aggregate(key, aggregate)
 
 
 def _benchmark_probe_label(row: dict[str, object]) -> str:


### PR DESCRIPTION
## Summary
- replace per-metric `list[float]` accumulation in `worker/productization/benchmark_evaluation_report.py` with running sum/count aggregation for benchmark probe rows and evaluation sample probe rows
- preserve report keys, values, and warning behavior while reducing temporary allocations in large benchmark/evaluation report builds
- add focused regression coverage for the new numeric aggregation helpers and record the governing Linux-only optimization plan

## Plan or Spec
- `docs/plans/2026-04-30-benchmark-evaluation-report-streaming-aggregation.md`

## Commands Run
```text
PYTHONPATH=/tmp/melix-cron-20260430-043849:/tmp/melix-cron-20260430-043849/services/mlx-worker-python uv run --project /tmp/melix-cron-20260430-043849/services/mlx-worker-python pytest /tmp/melix-cron-20260430-043849/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py::test_numeric_aggregate_helpers_track_running_totals -v
# PASS (1 passed)

PYTHONPATH=/tmp/melix-cron-20260430-043849:/tmp/melix-cron-20260430-043849/services/mlx-worker-python uv run --project /tmp/melix-cron-20260430-043849/services/mlx-worker-python pytest /tmp/melix-cron-20260430-043849/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py -q
# PASS (17 passed)

PYTHONPATH=/tmp/melix-cron-20260430-043849:/tmp/melix-cron-20260430-043849/services/mlx-worker-python uv run --project /tmp/melix-cron-20260430-043849/services/mlx-worker-python coverage run -m pytest /tmp/melix-cron-20260430-043849/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py -q
PYTHONPATH=/tmp/melix-cron-20260430-043849:/tmp/melix-cron-20260430-043849/services/mlx-worker-python uv run --project /tmp/melix-cron-20260430-043849/services/mlx-worker-python coverage report -m /tmp/melix-cron-20260430-043849/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py /tmp/melix-cron-20260430-043849/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# PASS (17 passed; changed executable scope 99% coverage)

python3 - <<'PY'
# compared origin/main vs branch implementation for build_benchmark_evaluation_report(...)
# on a large synthetic bundle, asserting identical report output before timing
PY
# PASS (identical output; metrics recorded below)

git diff --check
# PASS
```

## Coverage and Metrics
- `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`: `99%` coverage (`233` statements, `2` missed)
- `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`: `100%` coverage
- Synthetic performance probe comparing `origin/main` to this branch for `build_benchmark_evaluation_report(...)` on a large synthetic bundle:
  - baseline `origin/main`: `elapsed_mean_s=2.5524`, `peak_mean_bytes=2773981`
  - candidate branch: `elapsed_mean_s=2.6314`, `peak_mean_bytes=490169.8`
  - peak traced allocation improvement: `82.33%` lower (`~2.28 MB` fewer traced bytes)
  - elapsed time change: `-3.10%` slower mean wall time
- Interpretation: this slice intentionally trades a small CPU regression for a large reduction in temporary memory pressure while preserving identical report output.

## Known Gaps
- Linux-only verification for the Python worker path; no Swift/macOS checks were run on this host.
- The changed executable scope is covered and benchmarked, but no full-repo test suite was run for this small isolated slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs (plan added; no external behavior doc changes required for this internal optimization).
- [x] Protocol changes include regenerated generated artifacts (N/A: no protocol changes).
- [x] Dependency changes include updated lockfiles (N/A: no dependency changes).
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
