### PR TITLE
perf: memoize resolved benchmark suites

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_suites.py
+++ b/services/mlx-worker-python/tests/test_benchmark_suites.py
@@ -146,6 +146,36 @@ def test_load_materialized_rows_respects_limit(tmp_path: Path) -> None:
     ]
 
 
+def test_benchmark_suite_catalog_reuses_in_memory_resolved_suite_for_identical_requests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetcher = FakeBenchmarkSuiteFetcher()
+    catalog = BenchmarkSuiteCatalog(hf_dataset_fetcher=fetcher)
+
+    first = catalog.resolve_suite(
+        "smoke",
+        jobs_root=tmp_path,
+        parameters={"sample_size": "2", "batch_factor": "2"},
+    )
+
+    def fail_materialization(*args: object, **kwargs: object) -> dict[str, object]:
+        raise AssertionError("identical suite resolution should reuse the in-memory result")
+
+    monkeypatch.setattr(benchmark_suites, "_materialize_benchmark_suite", fail_materialization)
+
+    second = catalog.resolve_suite(
+        "smoke",
+        jobs_root=tmp_path,
+        parameters={"sample_size": "2", "batch_factor": "2"},
+    )
+
+    assert first.cache_hit is False
+    assert second.cache_hit is True
+    assert second.prompt_batches == first.prompt_batches
+    assert second.cases == first.cases
+
+
 def test_benchmark_suite_catalog_cache_hit_reads_only_requested_prefix(tmp_path: Path) -> None:
     fetcher = FakeBenchmarkSuiteFetcher()
     catalog = BenchmarkSuiteCatalog(hf_dataset_fetcher=fetcher)

--- a/services/mlx-worker-python/worker/productization/benchmark_suites.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_suites.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
@@ -92,6 +92,10 @@ class BenchmarkSuiteCatalog:
             for definition in resolved_definitions
         }
         self._hf_dataset_fetcher = hf_dataset_fetcher or _fetch_hf_dataset_server_json
+        self._resolved_suite_cache: dict[
+            tuple[str, str, Path, int, int],
+            ResolvedBenchmarkSuite,
+        ] = {}
 
     def list_definitions(self) -> tuple[BenchmarkSuiteDefinition, ...]:
         return tuple(self._definitions.values())
@@ -114,6 +118,11 @@ class BenchmarkSuiteCatalog:
 
         sample_size = _parse_positive_int(parameters.get("sample_size", ""), definition.default_sample_size)
         batch_factor = _parse_positive_int(parameters.get("batch_factor", ""), definition.default_batch_factor)
+        cache_key = (definition.task_kind, definition.suite_id, jobs_root, sample_size, batch_factor)
+        cached_suite = self._resolved_suite_cache.get(cache_key)
+        if cached_suite is not None:
+            return cached_suite
+
         sample_hint = _materialized_sample_hint(sample_size=sample_size, batch_factor=batch_factor)
         materialized = _materialize_benchmark_suite(
             definition,
@@ -129,7 +138,7 @@ class BenchmarkSuiteCatalog:
                 batch_factor=batch_factor,
             )
         )
-        return ResolvedBenchmarkSuite(
+        resolved_suite = ResolvedBenchmarkSuite(
             task_kind=definition.task_kind,
             suite_id=definition.suite_id,
             title=definition.title,
@@ -151,6 +160,8 @@ class BenchmarkSuiteCatalog:
             prompt_batches=tuple(case.prompt for case in cases),
             cases=cases,
         )
+        self._resolved_suite_cache[cache_key] = replace(resolved_suite, cache_hit=True)
+        return resolved_suite
 
 
 def default_benchmark_suite_definitions() -> tuple[BenchmarkSuiteDefinition, ...]:


### PR DESCRIPTION
## Summary
- Memoize identical `BenchmarkSuiteCatalog.resolve_suite(...)` requests within a catalog instance.
- Avoid repeated in-process re-materialization, manifest reloads, and row parsing for the same `task_kind`/`suite_id`/`jobs_root`/`sample_size`/`batch_factor` tuple.
- Add a focused regression test that proves identical requests reuse the in-memory result.

## Plan or Spec
- N/A: small internal Python optimization slice executed under the cron optimization workflow; no canonical product/spec doc governs this memoization detail.

## Commands Run
```text
- read .github/pull_request_template.md, docs/contributing.md, docs/templates/pr-evidence-checklist.md
- pytest RED: services/mlx-worker-python/tests/test_benchmark_suites.py::test_benchmark_suite_catalog_reuses_in_memory_resolved_suite_for_identical_requests -> FAILED before implementation
- pytest targeted subset after implementation -> 3 passed
- pytest services/mlx-worker-python/tests/test_benchmark_suites.py -> 17 passed
- coverage(include=benchmark_suites.py) + pytest services/mlx-worker-python/tests/test_benchmark_suites.py -> 98.19% (217/221 statements)
- explicit perf probe comparing origin/main vs branch -> completed
- git diff --check -> clean
- independent spec review -> PASS
- independent quality review -> APPROVED
```

## Coverage and Metrics
- Changed executable file: `services/mlx-worker-python/worker/productization/benchmark_suites.py`
- Automated coverage: 98.19% statement coverage (217/221 statements) for the touched executable file.
- Perf probe for 5,000 repeated identical resolves after first materialization:
  - before (`origin/main`): 484.89 ms, `materialize_calls=5001`, `rows_load_calls=5000`
  - after (this branch): 4.39 ms, `materialize_calls=1`, `rows_load_calls=0`
  - improvement: 480.50 ms faster, 110.45x speedup in the hot path probe

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs (no canonical doc update required for this internal memoization slice).
- [x] Protocol changes include regenerated generated artifacts. (not applicable)
- [x] Dependency changes include updated lockfiles. (not applicable)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
