### PR TITLE
perf: cache VLM cache stats snapshot

### DIFF
--- a/services/mlx-worker-python/tests/test_vision_runtime.py
+++ b/services/mlx-worker-python/tests/test_vision_runtime.py
@@ -1405,6 +1405,46 @@ def test_vlm_runtime_reuses_cache_for_identical_multimodal_requests() -> None:
     assert cache_stats.snapshot.hot_prefixes[0].scope.model_id == "melix-dev-vlm"
 
 
+def test_vlm_runtime_reuses_cached_snapshot_between_stats_reads(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime = DeterministicVLMRuntime()
+    loaded_model = runtime.load_model(WorkerModelCatalog.dev_vlm_model())
+    messages = [
+        common_pb2.ChatMessage(
+            role="user",
+            parts=[
+                common_pb2.MessagePart(text="Describe the image."),
+                common_pb2.MessagePart(
+                    image_bytes=b"cache snapshot reuse payload",
+                    media=common_pb2.MediaMetadata(
+                        media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                        source_kind=common_pb2.MEDIA_SOURCE_INLINE_BYTES,
+                    ),
+                ),
+            ],
+        )
+    ]
+
+    prepared = runtime.render_prompt(messages, loaded_model=loaded_model)
+    list(runtime.generate_tokens(loaded_model, prepared, None, Event()))
+
+    prefix_ref_calls = 0
+    original_prefix_ref = common_pb2.PrefixRef
+
+    def counting_prefix_ref(*args, **kwargs):
+        nonlocal prefix_ref_calls
+        prefix_ref_calls += 1
+        return original_prefix_ref(*args, **kwargs)
+
+    monkeypatch.setattr("worker.runtime.deterministic_vlm_runtime.common_pb2.PrefixRef", counting_prefix_ref)
+
+    first_stats = runtime.cache_stats_response()
+    second_stats = runtime.cache_stats_response()
+
+    assert prefix_ref_calls == 1
+    assert first_stats == second_stats
+    assert second_stats.snapshot.hot_prefixes[0].scope.model_id == "melix-dev-vlm"
+
+
 def test_vlm_runtime_plans_fast_path_when_generate_is_called_directly() -> None:
     runtime = DeterministicVLMRuntime()
     loaded_model = runtime.load_model(WorkerModelCatalog.dev_vlm_model())

--- a/services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py
@@ -89,6 +89,8 @@ class DeterministicVLMRuntime:
         self._decode_sessions: dict[str, VisionPrefillSession] = {}
         self._cache_lookups = 0
         self._cache_hits = 0
+        self._cache_l1_bytes = 0
+        self._cache_snapshot: cache_pb2.CacheSnapshot | None = None
         self._fast_path_controller = MultimodalFastPathController()
         self._last_fast_path_signature: tuple[str, ...] | None = None
 
@@ -162,12 +164,14 @@ class DeterministicVLMRuntime:
         if cache_hit:
             self._cache_hits += 1
         else:
-            self._cache_entries[cache_identity] = self._cache_entry(
-                loaded_model=loaded_model,
-                prepared_request=prepared_request,
-                cache_identity=cache_identity,
-                scope_id=scope_id,
-                execution_ext=execution_ext,
+            self._record_cache_entry(
+                self._cache_entry(
+                    loaded_model=loaded_model,
+                    prepared_request=prepared_request,
+                    cache_identity=cache_identity,
+                    scope_id=scope_id,
+                    execution_ext=execution_ext,
+                )
             )
         block_table_id = f"vlm-block:{cache_identity[:16]}"
         block_table = self._block_table_for(
@@ -276,14 +280,15 @@ class DeterministicVLMRuntime:
         if cache_hit:
             self._cache_hits += 1
         else:
-            entry = self._cache_entry(
-                loaded_model=loaded_model,
-                prepared_request=prepared_request,
-                cache_identity=cache_identity,
-                scope_id=scope_id,
-                execution_ext=execution_ext,
+            self._record_cache_entry(
+                self._cache_entry(
+                    loaded_model=loaded_model,
+                    prepared_request=prepared_request,
+                    cache_identity=cache_identity,
+                    scope_id=scope_id,
+                    execution_ext=execution_ext,
+                )
             )
-            self._cache_entries[cache_identity] = entry
         self._last_probe = replace(
             self._last_probe,
             preprocess_latency_ms=prepared_request.preprocess_latency_ms,
@@ -383,16 +388,30 @@ class DeterministicVLMRuntime:
 
     def cache_stats_response(self) -> cache_pb2.GetCacheStatsResponse:
         response = cache_pb2.GetCacheStatsResponse()
-        total_l1_bytes = sum(entry.bytes_used for entry in self._cache_entries.values())
-        total_block_count = len(self._cache_entries)
         lookup_count = max(1, self._cache_lookups)
-        response.stats.l1_bytes = total_l1_bytes
-        response.stats.block_count = total_block_count
+        response.stats.l1_bytes = self._cache_l1_bytes
+        response.stats.block_count = len(self._cache_entries)
         response.stats.l1_hit_rate = self._cache_hits / lookup_count
-        response.stats.dedup_ratio = 1.0 - (total_block_count / lookup_count)
+        response.stats.dedup_ratio = 1.0 - (response.stats.block_count / lookup_count)
         response.stats.active_mode = common_pb2.CACHE_MODE_TIERED
         response.snapshot.stats.CopyFrom(response.stats)
+        snapshot = self._cache_snapshot_message()
+        response.snapshot.hot_prefixes.extend(snapshot.hot_prefixes)
+        response.snapshot.scopes.extend(snapshot.scopes)
+        return response
 
+    def _record_cache_entry(self, entry: VisionCacheEntry) -> None:
+        self._cache_entries[entry.cache_identity] = entry
+        self._cache_l1_bytes += entry.bytes_used
+        self._cache_snapshot = None
+
+    def _cache_snapshot_message(self) -> cache_pb2.CacheSnapshot:
+        if self._cache_snapshot is None:
+            self._cache_snapshot = self._build_cache_snapshot()
+        return self._cache_snapshot
+
+    def _build_cache_snapshot(self) -> cache_pb2.CacheSnapshot:
+        snapshot = cache_pb2.CacheSnapshot()
         scopes: dict[str, cache_pb2.CacheScopeSummary] = {}
         for entry in self._cache_entries.values():
             prefix = common_pb2.PrefixRef()
@@ -410,7 +429,7 @@ class DeterministicVLMRuntime:
             prefix.scope.reasoning_mode = entry.reasoning_mode
             prefix.scope.multimodal_adapter_hash = entry.multimodal_adapter_hash
             prefix.scope.scope_id = entry.scope_id
-            response.snapshot.hot_prefixes.append(prefix)
+            snapshot.hot_prefixes.append(prefix)
 
             if entry.scope_id not in scopes:
                 scope_summary = cache_pb2.CacheScopeSummary()
@@ -435,8 +454,8 @@ class DeterministicVLMRuntime:
             )
             scopes[entry.scope_id].hot_blocks.append(block)
 
-        response.snapshot.scopes.extend(scopes.values())
-        return response
+        snapshot.scopes.extend(scopes.values())
+        return snapshot
 
     def has_decode_session(self, decode_handle: str) -> bool:
         return decode_handle in self._decode_sessions


### PR DESCRIPTION
## Summary
- Cache the deterministic VLM cache-stats snapshot so repeated stats reads stop rebuilding identical hot-prefix and scope protobuf payloads.
- Keep runtime stats dynamic by recomputing hit-rate and dedup fields per call while reusing cached snapshot structure.
- Add a regression test that proves repeated `cache_stats_response()` calls reuse the cached snapshot path.

## Plan or Spec
- N/A: this is a small internal Python-worker optimization slice with no governing canonical plan/spec for this exact cache-stats implementation detail.

## Commands Run
```text
PYTHONPATH="/tmp/melix-cron-python-opt-20260430-053713:/tmp/melix-cron-python-opt-20260430-053713/services/mlx-worker-python" UV_CACHE_DIR="/tmp/melix-cron-python-opt-20260430-053713/.uv-cache" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_runtime_reuses_cached_snapshot_between_stats_reads -v
  -> PASS (1 passed)

PYTHONPATH="/tmp/melix-cron-python-opt-20260430-053713:/tmp/melix-cron-python-opt-20260430-053713/services/mlx-worker-python" UV_CACHE_DIR="/tmp/melix-cron-python-opt-20260430-053713/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_runtime_edges.py -q
  -> PASS (70 passed)

PYTHONPATH="/tmp/melix-cron-python-opt-20260430-053713:/tmp/melix-cron-python-opt-20260430-053713/services/mlx-worker-python" UV_CACHE_DIR="/tmp/melix-cron-python-opt-20260430-053713/.uv-cache" uv run --project services/mlx-worker-python coverage report --include='services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py'
  -> PASS (98% coverage for touched executable file)

python3 performance probe comparing origin/main vs branch implementation of deterministic_vlm_runtime cache stats
  -> PASS (baseline 35.63 ms/call vs optimized 6.57 ms/call over 50 repeated calls with 5,000 cache entries)

git diff --check
  -> PASS
```

## Coverage and Metrics
- Changed executable file coverage: `services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py` = `98%` (309 statements, 7 missed).
- Performance probe: repeated `cache_stats_response()` calls on a synthetic 5,000-entry cache dropped from `1.7813s / 50 calls` (`35.63 ms/call`) on `origin/main` to `0.3286s / 50 calls` (`6.57 ms/call`) on this branch.
- Relative improvement: about `5.4x` faster for repeated cache-stats reads in the measured probe.

## Known Gaps
- Did not run the full repository baseline (`make proto`, `make swift-test`, `make py-test`, `make integration-test`) because this Linux cron run intentionally targeted a Python-only slice in a repo whose broader verification includes macOS/Swift paths that are not locally reliable here.
- No canonical spec or runbook update was needed because the change is an internal cache-stats implementation optimization with unchanged external behavior.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
