### PR TITLE
perf: short-circuit impossible chunk splits

### DIFF
--- a/services/mlx-worker-python/tests/test_training_dataset_chunker.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_chunker.py
@@ -257,6 +257,45 @@ def test_assistant_only_exceeding_chunk_size_raises_explicit_error() -> None:
     assert "giant-asst" in (exc.value.message or "")
 
 
+class _CountingTokenizer(_FakeTokenizer):
+    def __init__(self, *, overhead_per_message: int = 5) -> None:
+        super().__init__(overhead_per_message=overhead_per_message)
+        self.render_calls = 0
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        add_generation_prompt: bool = False,
+        return_dict: bool = False,
+    ) -> list[int]:
+        self.render_calls += 1
+        return super().apply_chat_template(
+            messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            return_dict=return_dict,
+        )
+
+
+def test_impossible_single_turn_short_circuits_before_trying_many_segment_counts() -> None:
+    tokenizer = _CountingTokenizer()
+    sample = {
+        "id": "impossible-short-circuit",
+        "messages": [
+            {"role": "user", "content": _words(100)},
+            {"role": "assistant", "content": _words(200)},
+        ],
+    }
+
+    with pytest.raises(ModelOperationError) as exc:
+        chunk_long_samples([sample], chunk_size=205, tokenizer=tokenizer)
+
+    assert exc.value.code == "chunk_size_too_small"
+    assert tokenizer.render_calls == 3
+
+
 def test_non_assistant_terminated_sample_passes_through_unchanged() -> None:
     """Chunker does not invent assistant messages.
 

--- a/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
@@ -207,6 +207,16 @@ def _chunk_single_turn(
     # than it has words. Above that, no K can possibly produce a non-empty
     # segment per bucket.
     word_count = len(user_content.split())
+    minimal_chunk = system_prefix + [{"role": "user", "content": ""}, assistant]
+    if _render_len(minimal_chunk, tokenizer, tools=tools) > chunk_size:
+        raise ModelOperationError(
+            code="chunk_size_too_small",
+            message=(
+                f"Cannot chunk sample {sample_id!r} within chunk_size={chunk_size}"
+                f" (full rendering is {full_len} tokens). The assistant message or"
+                " system prefix alone likely exceeds chunk_size."
+            ),
+        )
     k_floor = max(2, -(-full_len // chunk_size))
     if k_floor > word_count:
         raise ModelOperationError(


### PR DESCRIPTION
## Summary
- Short-circuit impossible long-context single-turn chunking when the system prefix plus assistant payload already exceeds `chunk_size`.
- Avoid probing every candidate segment count for cases that can never fit, while preserving the existing `chunk_size_too_small` operator message.
- Add a regression test that proves the failure path now stops after 3 render calls instead of probing 101 candidate renders.

## Plan or Spec
- N/A: this is a small internal Python-worker optimization slice with no governing canonical plan/spec document.

## Commands Run
```text
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-060923/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-060923 python -m pytest services/mlx-worker-python/tests/test_training_dataset_chunker.py -q
# 21 passed in 0.08s

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-060923/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-060923 coverage run -m pytest services/mlx-worker-python/tests/test_training_dataset_chunker.py -q
coverage json -o coverage.json
# 21 passed in 0.08s; JSON report written

python <changed-line-coverage script>
# training_dataset_chunker.py changed executable lines: [210, 211, 212]
# changed-line coverage: 100.0%

python <performance probe script>
# baseline avg: 2.9408 ms / 101 render calls
# optimized avg: 0.0336 ms / 3 render calls
# improvement: 98.86% lower avg latency, 97.03% fewer render calls

git diff --check
# clean
```

## Coverage and Metrics
- Changed executable line coverage for `services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py`: **100.0%** (lines 210-212).
- Performance probe on the impossible single-turn case (`chunk_size=205`, 100-word user + 200-word assistant, 50 repeats):
  - baseline: **2.9408 ms avg**, **101** render calls
  - optimized: **0.0336 ms avg**, **3** render calls
  - delta: **98.86% lower avg latency**, **97.03% fewer render calls**

## Known Gaps
- Targeted Linux-verifiable Python tests only; macOS/Swift repository baselines were intentionally not run for this cron slice.
- No canonical docs were updated because the change only optimizes an internal failure path without changing the external contract.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
