### PR TITLE
perf: reuse presplit user words in chunker

### DIFF
--- a/services/mlx-worker-python/tests/test_training_dataset_chunker.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_chunker.py
@@ -16,6 +16,7 @@ from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.training_dataset_chunker import (
     ChunkStats,
     _split_messages_into_turns,
+    _split_words_into_k,
     _split_user_content_into_k,
     chunk_long_samples,
 )
@@ -294,6 +295,60 @@ def test_impossible_single_turn_short_circuits_before_trying_many_segment_counts
 
     assert exc.value.code == "chunk_size_too_small"
     assert tokenizer.render_calls == 3
+
+
+class _NoSplitTokenizer:
+    """Tokenizer stub that avoids calling ``content.split()`` itself."""
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        add_generation_prompt: bool = False,
+        return_dict: bool = False,
+    ) -> list[int]:
+        total = 0
+        for msg in messages:
+            content = msg.get("content", "") or ""
+            total += 5 + len(content)
+        if add_generation_prompt:
+            total += 5
+        return list(range(total))
+
+
+class _CountingContent(str):
+    def __new__(cls, value: str) -> "_CountingContent":
+        instance = super().__new__(cls, value)
+        instance.split_calls = 0
+        return instance
+
+    def split(self, *args: Any, **kwargs: Any) -> list[str]:
+        self.split_calls += 1
+        return super().split(*args, **kwargs)
+
+
+def test_split_words_into_k_matches_string_helper_output() -> None:
+    content = "alpha beta gamma delta epsilon zeta"
+
+    assert _split_words_into_k(content.split(), 3) == _split_user_content_into_k(content, 3)
+
+
+def test_chunking_reuses_presplit_user_words_across_k_attempts() -> None:
+    tokenizer = _NoSplitTokenizer()
+    user_content = _CountingContent("alpha beta gamma delta epsilon zeta eta theta iota kappa")
+    sample = {
+        "id": "presplit-reuse",
+        "messages": [
+            {"role": "user", "content": user_content},
+            {"role": "assistant", "content": "reply"},
+        ],
+    }
+
+    chunked, stats = chunk_long_samples([sample], chunk_size=35, tokenizer=tokenizer)
+
+    assert stats.chunk_count == len(chunked) >= 2
+    assert user_content.split_calls == 1
 
 
 def test_non_assistant_terminated_sample_passes_through_unchanged() -> None:

--- a/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
@@ -129,6 +129,29 @@ def _split_messages_into_turns(
     return system_prefix, pairs
 
 
+def _split_words_into_k(words: list[str], k: int) -> list[str]:
+    """Split pre-tokenized ``words`` into ``k`` roughly equal segments.
+
+    Accepts a word list that has already been computed by the caller so the
+    chunk-search loop does not repeatedly re-split the same user content for
+    every candidate ``k``.
+    """
+
+    if k <= 1:
+        return [" ".join(words)]
+    if len(words) < k:
+        return words[:]  # caller detects len(segments) < k and retries
+    bucket_size = len(words) // k
+    extras = len(words) % k
+    segments: list[str] = []
+    start = 0
+    for bucket_idx in range(k):
+        length = bucket_size + (1 if bucket_idx < extras else 0)
+        segments.append(" ".join(words[start : start + length]))
+        start += length
+    return [s for s in segments if s]
+
+
 def _split_user_content_into_k(content: str, k: int) -> list[str]:
     """Split ``content`` into ``k`` roughly equal word-boundary segments.
 
@@ -147,18 +170,7 @@ def _split_user_content_into_k(content: str, k: int) -> list[str]:
 
     if k <= 1:
         return [content]
-    words = content.split()
-    if len(words) < k:
-        return words[:]  # caller detects len(segments) < k and retries
-    bucket_size = len(words) // k
-    extras = len(words) % k
-    segments: list[str] = []
-    start = 0
-    for bucket_idx in range(k):
-        length = bucket_size + (1 if bucket_idx < extras else 0)
-        segments.append(" ".join(words[start : start + length]))
-        start += length
-    return [s for s in segments if s]
+    return _split_words_into_k(content.split(), k)
 
 
 def _chunk_single_turn(
@@ -206,7 +218,8 @@ def _chunk_single_turn(
     # True ceiling: we can never split ``user_content`` into more segments
     # than it has words. Above that, no K can possibly produce a non-empty
     # segment per bucket.
-    word_count = len(user_content.split())
+    words = user_content.split()
+    word_count = len(words)
     minimal_chunk = system_prefix + [{"role": "user", "content": ""}, assistant]
     if _render_len(minimal_chunk, tokenizer, tools=tools) > chunk_size:
         raise ModelOperationError(
@@ -229,7 +242,7 @@ def _chunk_single_turn(
             ),
         )
     for k in range(k_floor, word_count + 1):
-        segments = _split_user_content_into_k(user_content, k)
+        segments = _split_words_into_k(words, k)
         if len(segments) < k:
             # User content has fewer words than buckets — caller must try a
             # smaller K. In practice this only fires when k > word_count,


### PR DESCRIPTION
## Summary
- Reuse a pre-split user word list across `training_dataset_chunker`'s candidate-`k` search instead of re-splitting the same prompt on every attempt.
- Keep the existing string-based helper for compatibility while routing the hot path through a new internal `_split_words_into_k` helper.
- Add focused regression tests covering helper equivalence and the single-split contract during chunk search.

## Plan or Spec
- N/A: this is an internal Python-only optimization slice in `services/mlx-worker-python` with no canonical governing plan or spec change and no user-visible behavior change.

## Commands Run
```text
cd /root/.openclaw/workspace/melix
git fetch origin --prune
git worktree add /tmp/melix-cron-python-opt-20260430-064117 -b akane/cron-python-opt-20260430-064117 origin/main
cd /tmp/melix-cron-python-opt-20260430-064117/services/mlx-worker-python
PYTHONPATH=. uv run pytest tests/test_training_dataset_chunker.py -q
PYTHONPATH=. uv run coverage run -m pytest tests/test_training_dataset_chunker.py -q
PYTHONPATH=. uv run coverage report -m worker/model_ops/training_dataset_chunker.py
PYTHONPATH=. uv run python - <<'PY'
from time import perf_counter
from worker.model_ops.training_dataset_chunker import _split_words_into_k
CONTENT = " ".join(f"word{i}" for i in range(4096))
WORDS = CONTENT.split()
K_VALUES = range(32, 257)
ITERATIONS = 200

def old_loop() -> int:
    total = 0
    for _ in range(ITERATIONS):
        for k in K_VALUES:
            segments = _split_words_into_k(CONTENT.split(), k)
            total += len(segments)
    return total

def new_loop() -> int:
    total = 0
    for _ in range(ITERATIONS):
        for k in K_VALUES:
            segments = _split_words_into_k(WORDS, k)
            total += len(segments)
    return total

start = perf_counter(); old_total = old_loop(); old_s = perf_counter() - start
start = perf_counter(); new_total = new_loop(); new_s = perf_counter() - start
assert old_total == new_total
print(old_s, new_s)
PY
git diff --check
git push -u origin HEAD
```

## Coverage and Metrics
- Focused pytest: `23 passed in 0.04s`
- Changed executable file coverage: `worker/model_ops/training_dataset_chunker.py` = `97%` (`122` statements, `4` missed)
- Perf probe (4,096-word prompt, candidate `k=32..256`, 200 iterations):
  - old repeated-split loop: `8.494409s`
  - new pre-split loop: `3.790348s`
  - improvement: `4.704061s` faster (`55.38%` reduction)

## Known Gaps
- No canonical doc/spec update was added because the change is an internal optimization with no user-visible behavior change.
- The perf probe is a scoped microbenchmark of the optimized splitting path rather than an end-to-end MLX training run.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. (N/A: no user-visible behavior change.)
- [x] Protocol changes include regenerated generated artifacts. (N/A: none.)
- [x] Dependency changes include updated lockfiles. (N/A: none.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
