### PR TITLE
perf: speed up HF cache weight detection scans

### DIFF
--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -15,6 +15,7 @@ from worker.model_registry.catalog import (
     _default_embedding_family_for_backend,
     _gemma4_index_has_vision_weights,
     _has_mlx_signal,
+    _has_model_weight_files,
     _hf_cache_repo_id,
     _hf_cache_revision,
     _hf_cache_revision_map,
@@ -120,6 +121,126 @@ def test_has_mlx_signal_returns_false_without_repo_hint_or_metadata(tmp_path: Pa
     model_dir = tmp_path / "plain-transformers-model"
     model_dir.mkdir()
     assert _has_mlx_signal(model_dir=model_dir, repo_id="google/bert-base") is False
+
+
+
+def test_has_model_weight_files_uses_os_scandir_single_pass_without_path_glob_or_iterdir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "hf-snapshot"
+    model_dir.mkdir()
+
+    class _FakeDirEntry:
+        def __init__(self, name: str, *, is_file_result: bool) -> None:
+            self.name = name
+            self._is_file_result = is_file_result
+
+        def is_file(self) -> bool:
+            return self._is_file_result
+
+    scandir_calls: list[str] = []
+
+    class _FakeScandir:
+        def __enter__(self) -> _FakeScandir:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        def __iter__(self):
+            return iter(
+                [
+                    _FakeDirEntry("config.json", is_file_result=True),
+                    _FakeDirEntry("model.safetensors", is_file_result=True),
+                ]
+            )
+
+    def fake_scandir(path: str):
+        scandir_calls.append(path)
+        assert path == os.fspath(model_dir)
+        return _FakeScandir()
+
+    def fail_iterdir(self: Path):
+        if self == model_dir:
+            raise AssertionError("expected os.scandir single-pass directory scan")
+        return iter(())
+
+    def fail_glob(self: Path, pattern: str):
+        if self == model_dir:
+            raise AssertionError("expected os.scandir single-pass directory scan")
+        return []
+
+    monkeypatch.setattr(os, "scandir", fake_scandir)
+    monkeypatch.setattr(Path, "iterdir", fail_iterdir)
+    monkeypatch.setattr(Path, "glob", fail_glob)
+
+    assert _has_model_weight_files(model_dir) is True
+    assert scandir_calls == [os.fspath(model_dir)]
+
+
+
+def test_has_model_weight_files_returns_false_when_scandir_raises_oserror(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    model_dir = tmp_path / "unreadable-model"
+    model_dir.mkdir()
+
+    original_scandir = os.scandir
+
+    def fake_scandir(path: str):
+        if path == os.fspath(model_dir):
+            raise OSError("boom")
+        return original_scandir(path)
+
+    monkeypatch.setattr(os, "scandir", fake_scandir)
+
+    assert _has_model_weight_files(model_dir) is False
+
+
+
+def test_has_model_weight_files_skips_unreadable_candidate_entries_and_finds_later_valid_weight(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "partially-unreadable-model"
+    model_dir.mkdir()
+    unreadable_weight = model_dir / "broken.safetensors"
+    unreadable_weight.write_bytes(b"broken")
+    valid_weight = model_dir / "model.npz"
+    valid_weight.write_bytes(b"weights")
+
+    class _FakeDirEntry:
+        def __init__(self, name: str, *, error: OSError | None = None, is_file_result: bool = False) -> None:
+            self.name = name
+            self._error = error
+            self._is_file_result = is_file_result
+
+        def is_file(self) -> bool:
+            if self._error is not None:
+                raise self._error
+            return self._is_file_result
+
+    class _FakeScandir:
+        def __enter__(self) -> _FakeScandir:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        def __iter__(self):
+            return iter(
+                [
+                    _FakeDirEntry(unreadable_weight.name, error=OSError("boom")),
+                    _FakeDirEntry(valid_weight.name, is_file_result=True),
+                ]
+            )
+
+    def fake_scandir(path: str):
+        assert path == os.fspath(model_dir)
+        return _FakeScandir()
+
+    monkeypatch.setattr(os, "scandir", fake_scandir)
+
+    assert _has_model_weight_files(model_dir) is True
 
 
 

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -160,9 +160,19 @@ def _load_model_config_payload(
 def _has_model_weight_files(model_dir: Path) -> bool:
     if (model_dir / "model.safetensors.index.json").is_file():
         return True
-    return any(path.is_file() for path in model_dir.glob("*.safetensors")) or any(
-        path.is_file() for path in model_dir.glob("*.npz")
-    )
+    try:
+        with os.scandir(os.fspath(model_dir)) as entries:
+            for entry in entries:
+                if not entry.name.endswith((".safetensors", ".npz")):
+                    continue
+                try:
+                    if entry.is_file():
+                        return True
+                except OSError:
+                    continue
+    except OSError:
+        return False
+    return False
 
 
 def _read_text_prefix(path: Path, *, max_chars: int = 16_384) -> str:


### PR DESCRIPTION
## Summary
- speed up `worker.model_registry.catalog._has_model_weight_files()` for Hugging Face cache snapshot scans
- replace repeated `Path.glob()` passes with one `os.scandir()` pass while preserving the existing `model.safetensors.index.json` fast path
- add focused regression tests for the scan path and unreadable-directory / unreadable-entry fallback behavior

## Plan or Spec
- N/A: internal Python-only micro-optimization slice with no governing committed Melix plan/spec; externally visible behavior is unchanged and the PR body records the verification and probe evidence.

## Commands Run
```text
python - <<'PY'
from __future__ import annotations
import sys
from pathlib import Path
repo = Path('/tmp/melix-cron-python-opt-20260430-074057')
sys.path.insert(0, str(repo))
sys.path.insert(0, str(repo / 'services/mlx-worker-python'))
import pytest
raise SystemExit(pytest.main(['-q', 'services/mlx-worker-python/tests/test_model_registry_catalog.py']))
PY
# outcome: 54 passed in 0.29s

python - <<'PY'
from __future__ import annotations
import sys
from pathlib import Path
import coverage
import pytest
repo = Path('/tmp/melix-cron-python-opt-20260430-074057')
sys.path.insert(0, str(repo))
sys.path.insert(0, str(repo / 'services/mlx-worker-python'))
cov = coverage.Coverage(include=['*/services/mlx-worker-python/worker/model_registry/catalog.py'])
cov.erase()
cov.start()
exit_code = pytest.main(['-q', 'services/mlx-worker-python/tests/test_model_registry_catalog.py'])
cov.stop()
cov.save()
print('PYTEST_EXIT', exit_code)
cov.report(show_missing=True)
raise SystemExit(exit_code)
PY
# outcome: 54 passed in 0.33s; catalog.py 98% coverage

git diff --check
# outcome: passed

python - <<'PY'
from __future__ import annotations
import sys
import tempfile
import time
from pathlib import Path
repo = Path('/tmp/melix-cron-python-opt-20260430-074057')
sys.path.insert(0, str(repo))
sys.path.insert(0, str(repo / 'services/mlx-worker-python'))
from worker.model_registry.catalog import _has_model_weight_files
ITERATIONS = 200
FILE_COUNT = 4000

def baseline_has_model_weight_files(model_dir: Path) -> bool:
    if (model_dir / 'model.safetensors.index.json').is_file():
        return True
    return any(path.is_file() for path in model_dir.glob('*.safetensors')) or any(
        path.is_file() for path in model_dir.glob('*.npz')
    )

with tempfile.TemporaryDirectory() as tmp:
    model_dir = Path(tmp) / 'snapshot'
    model_dir.mkdir()
    for idx in range(FILE_COUNT):
        (model_dir / f'noise-{idx:04d}.json').write_text('{}\n', encoding='utf-8')
    (model_dir / 'model.safetensors').write_bytes(b'weights')
    assert baseline_has_model_weight_files(model_dir) is True
    assert _has_model_weight_files(model_dir) is True
    start = time.perf_counter()
    for _ in range(ITERATIONS):
        baseline_has_model_weight_files(model_dir)
    baseline_s = time.perf_counter() - start
    start = time.perf_counter()
    for _ in range(ITERATIONS):
        _has_model_weight_files(model_dir)
    optimized_s = time.perf_counter() - start
    print('PERF_PROBE iterations=%d files=%d baseline_ms=%.3f optimized_ms=%.3f delta_ms=%.3f speedup_x=%.2f improvement_pct=%.2f' % (
        ITERATIONS,
        FILE_COUNT + 1,
        baseline_s * 1000,
        optimized_s * 1000,
        (baseline_s - optimized_s) * 1000,
        baseline_s / optimized_s if optimized_s else float('inf'),
        ((baseline_s - optimized_s) / baseline_s * 100.0) if baseline_s else 0.0,
    ))
PY
# outcome: PERF_PROBE iterations=200 files=4001 baseline_ms=341.909 optimized_ms=192.016 delta_ms=149.892 speedup_x=1.78 improvement_pct=43.84
```

## Coverage and Metrics
- changed executable file coverage: `services/mlx-worker-python/worker/model_registry/catalog.py` = `98%` (`744` statements, `17` missed)
- focused test scope: `services/mlx-worker-python/tests/test_model_registry_catalog.py` = `54 passed`
- performance probe: synthetic 4001-file snapshot directory, `200` helper calls
  - baseline: `341.909 ms`
  - optimized: `192.016 ms`
  - delta: `149.892 ms` faster
  - speedup: `1.78x`
  - improvement: `43.84%`

## Known Gaps
- did not run full-repo `make py-test`, `make swift-test`, or macOS/Swift validation; this Linux cron slice intentionally targeted only the touched Python registry path
- no committed Melix plan/spec file was added for this internal helper micro-optimization

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
