### PR TITLE
perf: cache multimodal preprocessing fingerprints

### DIFF
--- a/services/mlx-worker-python/tests/test_multimodal_fast_paths.py
+++ b/services/mlx-worker-python/tests/test_multimodal_fast_paths.py
@@ -10,6 +10,7 @@ from worker.runtime.multimodal_fast_paths import (
     MULTIMODAL_LOAD_FALLBACK,
     MULTIMODAL_LOAD_NATIVE_QUANTIZED,
     MultimodalFastPathController,
+    _preprocessing_fingerprint,
 )
 from worker.runtime.multimodal_preprocessing import PreparedImageInput, PreparedVisionRequest
 
@@ -257,3 +258,23 @@ def test_fast_path_documents_within_request_eviction_when_request_exceeds_cache_
     assert decision.image_feature_cache_misses == 2
     assert repeat_first.image_feature_cache_hits == 0
     assert repeat_first.image_feature_cache_misses == 1
+
+
+def test_fast_path_reuses_cached_preprocessing_fingerprint_for_same_request_shape() -> None:
+    _preprocessing_fingerprint.cache_clear()
+    controller = MultimodalFastPathController()
+    loaded_model = _loaded_model()
+    first_image = _image(b"first-image", filename="first.jpg")
+    second_image = _image(b"second-image", filename="second.jpg")
+
+    try:
+        before = _preprocessing_fingerprint.cache_info()
+        decision = controller.plan(loaded_model, _request([first_image, second_image]))
+        after = _preprocessing_fingerprint.cache_info()
+
+        assert decision.image_feature_cache_hits == 0
+        assert decision.image_feature_cache_misses == 2
+        assert after.misses - before.misses == 1
+        assert after.hits - before.hits == 1
+    finally:
+        _preprocessing_fingerprint.cache_clear()

--- a/services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py
+++ b/services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 from collections import OrderedDict
 from dataclasses import dataclass
+from functools import lru_cache
 import logging
 from threading import Lock
 from typing import Any
@@ -178,20 +179,16 @@ class MultimodalFastPathController:
         quant_profile_id: str,
         metadata: dict[str, str],
     ) -> ImageFeatureCacheKey:
-        digest = hashlib.sha256()
-        for value in (
-            image.mime_type,
-            image.format,
-            metadata.get("vision_prompt_profile_id", ""),
-            metadata.get("vision_tokenization_mode", ""),
-            metadata.get("vision_max_images_per_prompt", ""),
-        ):
-            digest.update(str(value or "").encode("utf-8"))
-            digest.update(b"\0")
         return ImageFeatureCacheKey(
             family_id=family_id,
             adapter_hash=adapter_hash,
-            preprocessing_fingerprint=digest.hexdigest(),
+            preprocessing_fingerprint=_preprocessing_fingerprint(
+                image.mime_type,
+                image.format,
+                metadata.get("vision_prompt_profile_id", ""),
+                metadata.get("vision_tokenization_mode", ""),
+                metadata.get("vision_max_images_per_prompt", ""),
+            ),
             quant_profile_id=quant_profile_id,
             sha256_hex=image.sha256_hex,
         )
@@ -312,3 +309,24 @@ def _adapter_hash(metadata: dict[str, str]) -> str:
         or metadata.get("multimodal_adapter_hash", "").strip()
         or "adapter-unset"
     )
+
+
+@lru_cache(maxsize=256)
+def _preprocessing_fingerprint(
+    mime_type: str,
+    image_format: str,
+    vision_prompt_profile_id: str,
+    vision_tokenization_mode: str,
+    vision_max_images_per_prompt: str,
+) -> str:
+    digest = hashlib.sha256()
+    for value in (
+        mime_type,
+        image_format,
+        vision_prompt_profile_id,
+        vision_tokenization_mode,
+        vision_max_images_per_prompt,
+    ):
+        digest.update(str(value or "").encode("utf-8"))
+        digest.update(b"\0")
+    return digest.hexdigest()


### PR DESCRIPTION
## Summary
- Cache multimodal preprocessing fingerprints in `worker/runtime/multimodal_fast_paths.py` with a bounded `lru_cache`.
- Reuse the cached fingerprint from `_cache_key()` instead of re-hashing identical MIME/format/vision-metadata tuples for every image.
- Add a regression test that proves same-shape multi-image requests hit the fingerprint cache within one planning pass.

## Plan or Spec
- N/A: this is a small internal Python-runtime performance optimization slice for `services/mlx-worker-python`, not a user-visible behavior change governed by an existing canonical plan/spec.

## Commands Run
```text
$ python3 -m pytest services/mlx-worker-python/tests/test_multimodal_fast_paths.py -q
FAILED during collection before implementation: ImportError: cannot import name '_preprocessing_fingerprint'

$ PYTHONPATH=/tmp/melix-cron-python-opt-20260430-082131/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-082131 python3 -m pytest services/mlx-worker-python/tests/test_multimodal_fast_paths.py -q
14 passed in 0.04s

$ PYTHONPATH=/tmp/melix-cron-python-opt-20260430-082131/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-082131 coverage run --branch -m pytest services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_vision_runtime.py -q && coverage report -m services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py
53 passed in 0.49s
multimodal_fast_paths.py coverage: 97%

$ PYTHONPATH=/tmp/melix-cron-python-opt-20260430-082131/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-082131 python3 - <<'PY' ...
baseline_ms=335.232
cached_ms=24.158
speedup_x=13.88
cache_info=CacheInfo(hits=320000, misses=1, maxsize=256, currsize=1)

$ git diff --check
OK
```

## Coverage and Metrics
- Changed executable file: `services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py`
- Automated coverage for changed executable file: `97%`
- Performance probe workload: 16 repeated same-shape image tuples across 20,000 iterations
- Baseline repeated hashing: `335.232 ms`
- Cached fingerprint path: `24.158 ms`
- Measured speedup: `13.88x`

## Known Gaps
- None for this slice.
- I did not run the full repository baseline (`make swift-test`, `make integration-test`) because this cron run was constrained to a Linux-verifiable Python-only optimization in `services/mlx-worker-python`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
