### PR TITLE
perf: stream lora adapter hashing

### DIFF
--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 import json
 from pathlib import Path
 import pytest
@@ -387,6 +388,61 @@ def test_train_lora_produces_adapter_package_and_expanded_modules(tmp_path: Path
         "model.layers.0.mlp.gate_proj",
         "model.layers.1.mlp.gate_proj",
     ]
+
+
+def test_train_lora_persists_response_only_boundary_metrics_when_present(tmp_path: Path) -> None:
+    class ResponseOnlyMetricsRunner(SuccessfulRunner):
+        def train_native(self, request: TrainingRequest) -> TrainingResult:
+            base = super().train_native(request)
+            return replace(
+                base,
+                metrics=replace(
+                    base.metrics,
+                    response_only_boundary_sample_count=2,
+                    response_only_boundary_min=4,
+                    response_only_boundary_max=9,
+                    response_only_boundary_mean=6.5,
+                ),
+            )
+
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset-response-only-boundary",
+        samples=[
+            {
+                "messages": [
+                    {"role": "user", "content": "Question?"},
+                    {"role": "assistant", "content": "Answer."},
+                ]
+            }
+        ],
+    )
+    service = _build_service(tmp_path, ResponseOnlyMetricsRunner())
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "train-response-only-boundary"),
+                generate_manifest=True,
+                ext={
+                    "operation": "train_lora",
+                    "adapter_name": "melix-boundary-adapter",
+                    "dataset_uri": str(dataset_dir),
+                    "response_only": "true",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+
+    assert payload["response_only"] is True
+    assert payload["response_only_boundary_sample_count"] == 2
+    assert payload["response_only_boundary_min"] == 4
+    assert payload["response_only_boundary_max"] == 9
+    assert payload["response_only_boundary_mean"] == 6.5
+
 
 
 def test_train_lora_records_resume_manifest_metadata_and_reuses_checkpoint_path(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -15,7 +15,15 @@ from worker.model_ops import mlx_lm_runner as mlx_lm_runner_module
 from worker.model_ops import training_config as training_config_module
 from worker.model_ops import training_dataset as training_dataset_module
 from worker.model_ops.adapter_activation_pipeline import AdapterActivationPipeline
-from worker.model_ops.lora_training_pipeline import _int_ext
+from worker.model_ops.lora_training_pipeline import (
+    _content_hash,
+    _int_ext,
+    _latest_checkpoint_from_directory,
+    _load_manifest_payload,
+    _resolve_resume_context,
+    _resolve_resume_path_from_manifest,
+    _validated_resume_path,
+)
 from worker.model_ops.mlx_lm_runner import MLXLMRunner
 from worker.model_ops.training_dataset import HFDatasetReference, load_training_dataset_package, materialize_hf_training_dataset_package
 
@@ -70,6 +78,104 @@ def _text_model(*, model_path: str = "models/plain-llama", quant_profile_id: str
 class _UnexpectedActivationRunner(MLXLMRunner):
     def activate(self, request):  # noqa: ANN001
         raise AssertionError("adapter_backed_runtime should not invoke fused activation")
+
+
+
+def test_content_hash_streams_file_chunks_without_read_bytes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    first = tmp_path / "weights-a.bin"
+    second = tmp_path / "weights-b.bin"
+    first.write_bytes(b"a" * (1024 * 1024 + 17))
+    second.write_bytes(b"b" * (512 * 1024 + 9))
+
+    expected = __import__("hashlib").sha256(first.read_bytes() + second.read_bytes()).hexdigest()[:16]
+
+    def forbid_read_bytes(self: Path) -> bytes:  # pragma: no cover - exercised via monkeypatch
+        raise AssertionError("_content_hash should stream via open(), not read_bytes()")
+
+    monkeypatch.setattr(Path, "read_bytes", forbid_read_bytes)
+
+    assert _content_hash(first, second) == expected
+
+
+
+def test_load_manifest_payload_rejects_unreadable_and_non_object_json(tmp_path: Path) -> None:
+    broken = tmp_path / "broken.json"
+    broken.write_text("{not-json}\n", encoding="utf-8")
+    with pytest.raises(ModelOperationError, match="Resume manifest is unreadable"):
+        _load_manifest_payload(broken)
+
+    non_object = tmp_path / "array.json"
+    non_object.write_text("[]\n", encoding="utf-8")
+    with pytest.raises(ModelOperationError, match="Resume manifest must be a JSON object"):
+        _load_manifest_payload(non_object)
+
+
+
+def test_latest_checkpoint_helpers_pick_latest_numeric_file_and_validate_errors(tmp_path: Path) -> None:
+    checkpoints = tmp_path / "checkpoints"
+    (checkpoints / "checkpoint-2").mkdir(parents=True)
+    (checkpoints / "checkpoint-10").mkdir(parents=True)
+    older = checkpoints / "checkpoint-2" / "adapters.safetensors"
+    newer = checkpoints / "checkpoint-10" / "adapters.safetensors"
+    older.write_bytes(b"older")
+    newer.write_bytes(b"newer")
+
+    assert _latest_checkpoint_from_directory(checkpoints) == newer.resolve()
+    assert _validated_resume_path(checkpoints, source_label="unit-test") == newer.resolve()
+
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    with pytest.raises(ModelOperationError, match="Resume directory does not contain adapter weights"):
+        _latest_checkpoint_from_directory(empty_dir)
+
+    with pytest.raises(ModelOperationError, match="Resume source from unit-test does not exist"):
+        _validated_resume_path(tmp_path / "missing.safetensors", source_label="unit-test")
+
+
+
+def test_resolve_resume_path_from_manifest_prefers_checkpoint_and_requires_weight_entries(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "resume.json"
+    checkpoint = tmp_path / "checkpoint-7" / "adapters.safetensors"
+    checkpoint.parent.mkdir(parents=True)
+    checkpoint.write_bytes(b"checkpoint")
+
+    resolved = _resolve_resume_path_from_manifest(
+        manifest_path,
+        {"latest_checkpoint_path": str(checkpoint), "weights_path": str(tmp_path / "ignored.safetensors")},
+    )
+    assert resolved == checkpoint.resolve()
+
+    with pytest.raises(ModelOperationError, match="Resume manifest does not expose a checkpoint or weights path"):
+        _resolve_resume_path_from_manifest(manifest_path, {})
+
+
+
+def test_resolve_resume_context_handles_manifest_directory_and_missing_sources(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "run-42" / "checkpoint-3" / "adapters.safetensors"
+    checkpoint.parent.mkdir(parents=True)
+    checkpoint.write_bytes(b"checkpoint")
+    manifest = tmp_path / "resume.json"
+    manifest.write_text(
+        json.dumps({"job_id": "run-42", "latest_checkpoint_path": str(checkpoint)}) + "\n",
+        encoding="utf-8",
+    )
+
+    manifest_context = _resolve_resume_context({"resume_manifest_path": str(manifest)})
+    assert manifest_context == {
+        "resume_source_path": checkpoint.resolve(),
+        "resume_manifest_path": manifest.resolve(),
+        "resume_source_job_id": "run-42",
+    }
+
+    directory_context = _resolve_resume_context({"resume_source_path": str(checkpoint.parent.parent)})
+    assert directory_context == {
+        "resume_source_path": checkpoint.resolve(),
+        "resume_manifest_path": None,
+        "resume_source_job_id": "",
+    }
+
+    with pytest.raises(ModelOperationError, match="Resume source does not exist"):
+        _resolve_resume_context({"resume_source_path": str(tmp_path / "missing")})
 
 
 

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -261,10 +261,16 @@ def _int_ext(ext: dict[str, str], key: str) -> int:
     return int(raw_value)
 
 
+_CONTENT_HASH_CHUNK_SIZE = 1024 * 1024
+
+
+
 def _content_hash(*paths: Path) -> str:
     digest = hashlib.sha256()
     for path in paths:
-        digest.update(path.read_bytes())
+        with path.open("rb") as handle:
+            while chunk := handle.read(_CONTENT_HASH_CHUNK_SIZE):
+                digest.update(chunk)
     return digest.hexdigest()[:16]
 
 


### PR DESCRIPTION
## Summary
- stream LoRA adapter hash inputs in 1 MiB chunks instead of loading each file into memory with `read_bytes()`
- add regression coverage for streaming hash behavior plus uncovered resume/helper branches in `lora_training_pipeline`
- add a response-only boundary manifest test so the touched Python pipeline file stays fully covered

## Plan or Spec
- N/A: this is a small internal Python-worker optimization slice for `services/mlx-worker-python` and does not change the external product contract or an existing canonical plan/spec

## Commands Run
```text
git fetch origin --prune
git worktree prune
git worktree add /tmp/melix-cron-python-opt-20260430-092056 -b akane/cron-python-opt-20260430-092056 origin/main
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-092056/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-092056 pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k content_hash_streams_file_chunks_without_read_bytes
# before fix: 1 failed
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-092056/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-092056 pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k content_hash_streams_file_chunks_without_read_bytes
# after fix: 1 passed
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-092056/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-092056 pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py
# 78 passed
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-092056/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-092056 coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py && coverage report -m services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
# 78 passed, touched executable file coverage 100%
python3 - <<'PY'
# performance probe comparing old read_bytes baseline vs current streaming _content_hash
PY
# peak traced memory: 50,336,389 -> 2,102,102 bytes; elapsed time: 0.0914s -> 0.0631s
git diff --check
```

## Coverage and Metrics
- Changed executable file coverage: `services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py` = `100%` (`132/132` statements)
- Performance probe on two synthetic adapter artifacts (`50,331,771 B` and `33,554,753 B`):
  - old `read_bytes()` baseline peak traced memory: `50,336,389 B`
  - new streaming implementation peak traced memory: `2,102,102 B`
  - peak memory reduction: `48,234,287 B` (`95.82%`)
  - old elapsed time: `0.0914 s`
  - new elapsed time: `0.0631 s`
  - elapsed delta: `-0.0283 s` (streaming was faster in this probe)

## Known Gaps
- None for the touched Python scope.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
