### PR TITLE
perf: avoid deepcopy in chunked training messages

### DIFF
--- a/services/mlx-worker-python/tests/test_training_dataset_chunker.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_chunker.py
@@ -55,6 +55,13 @@ def _words(count: int) -> str:
     return " ".join(f"w{i}" for i in range(count))
 
 
+class _TrackingStr(str):
+    """String subclass that fails if the chunker deep-copies message payloads."""
+
+    def __deepcopy__(self, memo: dict[int, object]) -> "_TrackingStr":
+        raise AssertionError("message payload should not be deep-copied")
+
+
 def test_short_single_turn_sample_passes_through_unchanged() -> None:
     tokenizer = _FakeTokenizer()
     sample = {
@@ -204,6 +211,37 @@ def test_multi_turn_exceeding_chunk_size_splits_at_message_boundaries() -> None:
     # Ids are suffixed.
     assert chunked[0]["id"] == "multi-over#chunk-0"
     assert chunked[1]["id"] == "multi-over#chunk-1"
+
+
+
+def test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads() -> None:
+    tokenizer = _FakeTokenizer()
+    metadata = {"tags": ["chunked"]}
+    user_content = _TrackingStr(_words(200))
+    sample = {
+        "id": "chunked-copy-contract",
+        "metadata": metadata,
+        "messages": [
+            {"role": "user", "content": user_content},
+            {"role": "assistant", "content": _TrackingStr("ack")},
+        ],
+    }
+
+    chunked, stats = chunk_long_samples(
+        [sample], chunk_size=80, tokenizer=tokenizer
+    )
+
+    assert stats.chunk_count == len(chunked) >= 2
+    for idx, emitted in enumerate(chunked):
+        assert emitted["id"] == f"chunked-copy-contract#chunk-{idx}"
+        assert emitted["metadata"] is metadata
+        assert emitted["messages"] is not sample["messages"]
+        for message, source_message in zip(
+            emitted["messages"], sample["messages"], strict=False
+        ):
+            assert message is not source_message
+    chunked[0]["messages"][0]["content"] = "mutated"
+    assert sample["messages"][0]["content"] == user_content
 
 
 def test_multi_turn_single_pair_exceeds_chunk_size_falls_through_to_segmentation() -> None:

--- a/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
@@ -23,7 +23,6 @@ but cannot be made to fit raise ``ModelOperationError(code="chunk_size_too_small
 
 from __future__ import annotations
 
-import copy
 from dataclasses import dataclass
 from typing import Any, Iterable
 
@@ -268,6 +267,12 @@ def _chunk_single_turn(
     )
 
 
+def _copy_messages(messages: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Copy the message containers without deep-copying immutable string payloads."""
+
+    return [message.copy() for message in messages]
+
+
 def _passthrough_sample(sample: dict) -> dict:
     """Return a passthrough sample with independent messages but shared top-level fields.
 
@@ -277,7 +282,7 @@ def _passthrough_sample(sample: dict) -> dict:
     """
 
     out = {k: v for k, v in sample.items() if k != "messages"}
-    out["messages"] = copy.deepcopy(_extract_messages(sample))
+    out["messages"] = _copy_messages(_extract_messages(sample))
     return out
 
 
@@ -347,10 +352,11 @@ def _chunk_sample(
     chunks: list[dict] = []
     for idx, chunk in enumerate(chunked_messages):
         # Preserve any non-messages keys from the source sample (id, tools,
-        # metadata) via a shallow top-level copy, then deep-copy only the
-        # new messages so each chunk has an independent message list.
+        # metadata) via a shallow top-level copy, then copy only the message
+        # dict containers so each chunk has an independent message list
+        # without re-copying immutable string payloads.
         out = {k: v for k, v in sample.items() if k != "messages"}
-        out["messages"] = copy.deepcopy(chunk)
+        out["messages"] = _copy_messages(chunk)
         if sample_id:
             out["id"] = f"{sample_id}#chunk-{idx}"
         chunks.append(out)


### PR DESCRIPTION
## Summary
- Avoid deep-copying flat chunk message payloads in `training_dataset_chunker` by copying only message dict containers.
- Keep chunk outputs isolated from source samples while reducing redundant per-chunk copying work on long-context training paths.
- Add a regression test that fails if chunk emission deep-copies string payloads.

## Plan or Spec
- N/A: this is a small internal Python-worker performance optimization with no external behavior or protocol change, so there is no governing canonical plan/spec to update.

## Commands Run
```text
PYTHONPATH=. pytest -q tests/test_training_dataset_chunker.py -k chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads
- initial result before implementation: FAILED with AssertionError("message payload should not be deep-copied")
- result after implementation: 1 passed, 23 deselected

PYTHONPATH=. pytest -q tests/test_training_dataset_chunker.py
- 24 passed in 0.09s

PYTHONPATH=. python3 -m coverage erase && PYTHONPATH=. python3 -m coverage run --source=worker.model_ops.training_dataset_chunker -m pytest -q tests/test_training_dataset_chunker.py && python3 -m coverage report -m worker/model_ops/training_dataset_chunker.py
- 24 passed in 0.06s
- worker/model_ops/training_dataset_chunker.py: 97% coverage

python3 <inline benchmark comparing origin/main module vs working tree>
- baseline_seconds=0.120068 baseline_us_per_run=60.03 chunks_per_run=3.0
- current_seconds=0.079014 current_us_per_run=39.51 chunks_per_run=3.0
- improvement_seconds=0.041054 improvement_percent=34.19

git diff --check
- clean
```

## Coverage and Metrics
- Changed executable file: `services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py`
- Automated coverage: 97% (`123` statements, `4` misses)
- Performance probe: long-sample chunking microbenchmark improved from `60.03 µs/run` on `origin/main` to `39.51 µs/run` on this branch (`34.19%` faster) with the same `3.0` chunks/run output.

## Known Gaps
- Focused Linux verification only; I did not run the full repository Python/Swift/integration suites in this cron slice.
- Benchmark is a scoped microbenchmark for the chunker path, not an end-to-end LoRA training run.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
