### PR TITLE
perf: speed up python model registry scans

### DIFF
--- a/docs/plans/2026-04-30-cron-python-optimization-slice.md
+++ b/docs/plans/2026-04-30-cron-python-optimization-slice.md
@@ -1,0 +1,45 @@
+# 2026-04-30 Cron Python Optimization Slice
+
+## Context
+
+This cron run is limited to Linux-verifiable changes in `services/mlx-worker-python`.
+The goal is one small optimization slice with focused tests, measurable coverage,
+and an explicit performance probe before commit.
+
+## Scout Result Summary
+
+The scouting pass proposed these safe candidates:
+1. Stream model registry scans in `worker/model_registry/catalog.py`.
+2. Remove immediate manifest reread/parse/rewrite after normalized dataset snapshot creation.
+3. Avoid `reversed(stdout.splitlines())` for tail parsing of subprocess output.
+
+## Chosen Slice
+
+Optimize `services/mlx-worker-python/worker/model_registry/catalog.py` by reducing
+redundant eager list construction and repeated path normalization during local
+model registry scans while preserving discovery output and ordering.
+
+## Why This Slice
+
+- Pure Python and Linux-verifiable.
+- Reduces redundant work and allocation on a path that scales with model count.
+- Already has strong local tests in `tests/test_model_registry_catalog.py`.
+- Easy to benchmark with a synthetic large temporary registry tree.
+
+## Task
+
+1. Add or update tests first to lock behavior and ordering.
+2. Refactor catalog scan helpers to avoid unnecessary full-list materialization
+   and repeated path resolution where possible.
+3. Run focused pytest for the touched scope.
+4. Measure touched-file coverage and require at least 95% coverage for the
+   changed executable file before commit.
+5. Run an explicit synthetic performance probe and record concrete numbers.
+6. Run `git diff --check`, then commit, push, and open a PR.
+
+## Success Metrics
+
+- Behavior and ordering unchanged in focused tests.
+- `worker/model_registry/catalog.py` coverage >= 95%.
+- Performance probe shows improved wall-clock time for the chosen synthetic scan.
+- No whitespace or conflict issues from `git diff --check`.

--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -391,9 +391,89 @@ def test_catalog_scan_helpers_skip_invalid_huggingface_and_unreadable_directorie
     monkeypatch.setattr(Path, "iterdir", fake_iterdir)
 
     catalog = WorkerModelCatalog(environment={"MELIX_MODEL_ROOTS": str(root), "HOME": str(tmp_path / "home")})
-    assert catalog._scan_huggingface_cache_models(root=root) == []
+    assert list(catalog._scan_huggingface_cache_models(root=root)) == []
     assert unreadable_plain not in WorkerModelCatalog._iter_plain_local_model_dirs(root)
-    assert WorkerModelCatalog._iter_registry_manifest_paths(root) == []
+    assert list(WorkerModelCatalog._iter_registry_manifest_paths(root)) == []
+
+
+def test_scan_huggingface_cache_models_uses_os_scandir_without_glob_or_iterdir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    cache_repo_dir = root / "models--mlx-community--Tiny"
+    snapshots_dir = cache_repo_dir / "snapshots"
+    refs_dir = cache_repo_dir / "refs"
+    snapshot_dir = snapshots_dir / "abc123"
+    _write_model_config(snapshot_dir, {"model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]})
+    _write_weights(snapshot_dir)
+    (snapshot_dir / "README.md").write_text("---\nlibrary_name: mlx\ntags:\n- mlx\n---\n", encoding="utf-8")
+    refs_dir.mkdir(parents=True, exist_ok=True)
+    (refs_dir / "main").write_text("abc123\n", encoding="utf-8")
+
+    original_scandir = os.scandir
+    scandir_calls: list[str] = []
+
+    def tracking_scandir(path: str):
+        scandir_calls.append(path)
+        return original_scandir(path)
+
+    def fail_glob(self: Path, pattern: str):
+        if self in {root, snapshots_dir}:
+            raise AssertionError("expected os.scandir-based Hugging Face cache traversal")
+        return []
+
+    def fail_iterdir(self: Path):
+        if self == snapshots_dir:
+            raise AssertionError("expected os.scandir-based Hugging Face cache traversal")
+        return iter(())
+
+    monkeypatch.setattr(os, "scandir", tracking_scandir)
+    monkeypatch.setattr(Path, "glob", fail_glob)
+    monkeypatch.setattr(Path, "iterdir", fail_iterdir)
+
+    catalog = WorkerModelCatalog.__new__(WorkerModelCatalog)
+
+    models = list(catalog._scan_huggingface_cache_models(root=root))
+
+    assert [model.model_id for model in models] == ["mlx-community/Tiny"]
+    assert os.fspath(root) in scandir_calls
+    assert os.fspath(snapshots_dir) in scandir_calls
+
+
+def test_registry_directory_iterators_use_os_scandir_and_preserve_sorted_depth_first_order(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    manifest_dir = root / "alpha-provider" / "AlphaModel" / "q4"
+    _write_registry_manifest(manifest_dir, model_id="alpha-provider/AlphaModel/q4")
+    plain_a = root / "beta-local-a"
+    plain_b = root / "beta-local-b"
+    _write_model_config(plain_a, {"model_type": "qwen3"})
+    _write_model_config(plain_b, {"model_type": "qwen3"})
+
+    original_scandir = os.scandir
+    scandir_calls: list[str] = []
+
+    def tracking_scandir(path: str):
+        scandir_calls.append(path)
+        return original_scandir(path)
+
+    def fail_iterdir(self: Path):
+        if self == root or self == root / "alpha-provider":
+            raise AssertionError("expected os.scandir-based directory traversal")
+        return iter(())
+
+    monkeypatch.setattr(os, "scandir", tracking_scandir)
+    monkeypatch.setattr(Path, "iterdir", fail_iterdir)
+
+    plain_dirs = list(WorkerModelCatalog._iter_plain_local_model_dirs(root))
+    manifest_paths = list(WorkerModelCatalog._iter_registry_manifest_paths(root))
+
+    assert plain_dirs == [plain_a.resolve(), plain_b.resolve()]
+    assert manifest_paths == [manifest_dir.resolve() / "manifest.json"]
+    assert os.fspath(root.resolve()) in scandir_calls
 
 
 

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -222,6 +222,24 @@ def _hf_cache_repo_id(cache_repo_dir: Path) -> str | None:
     return f"{parts[0]}/{parts[1]}"
 
 
+def _sorted_child_directories(root: Path, *, name_prefix: str | None = None) -> tuple[Path, ...]:
+    child_names: list[str] = []
+    try:
+        with os.scandir(os.fspath(root)) as entries:
+            for entry in entries:
+                if name_prefix is not None and not entry.name.startswith(name_prefix):
+                    continue
+                try:
+                    if not entry.is_dir():
+                        continue
+                except OSError:
+                    continue
+                child_names.append(entry.name)
+    except OSError:
+        return ()
+    return tuple(root / name for name in sorted(child_names))
+
+
 def _hf_cache_revision_map(cache_repo_dir: Path) -> dict[str, str]:
     refs_dir = cache_repo_dir / "refs"
     revisions: dict[str, str] = {}
@@ -1010,29 +1028,30 @@ class WorkerModelCatalog:
         discovered_models: dict[str, common_pb2.ModelSpec],
         accepted_model_ids: list[str],
     ) -> None:
+        root_resolved = root.resolve()
         seen_paths: set[Path] = set()
         for model in self._scan_huggingface_cache_models(root=root):
-            resolved_path = Path(model.model_path).resolve()
+            resolved_path = Path(model.model_path)
             seen_paths.add(resolved_path)
             if model.model_id in discovered_models or model.model_id in self._seed_models:
                 continue
             self._apply_root_metadata(
                 model,
-                root=root,
+                resolved_root=root_resolved,
                 root_id=root_id,
                 root_order=root_order,
-                relative_path=resolved_path.relative_to(root.resolve()),
+                relative_path=resolved_path.relative_to(root_resolved),
             )
             discovered_models[model.model_id] = model
             accepted_model_ids.append(model.model_id)
 
         for model_dir in self._iter_plain_local_model_dirs(root):
-            resolved_path = model_dir.resolve()
-            if resolved_path in seen_paths or _is_hf_cache_snapshot_dir(root.resolve(), resolved_path):
+            resolved_path = model_dir
+            if resolved_path in seen_paths or _is_hf_cache_snapshot_dir(root_resolved, resolved_path):
                 continue
             if (resolved_path / "manifest.json").is_file():
                 continue
-            model_id = _local_model_id(root.resolve(), resolved_path)
+            model_id = _local_model_id(root_resolved, resolved_path)
             if model_id in discovered_models or model_id in self._seed_models:
                 continue
             if not _has_model_weight_files(resolved_path) or not _has_mlx_signal(model_dir=resolved_path, repo_id=model_id):
@@ -1046,19 +1065,16 @@ class WorkerModelCatalog:
             )
             self._apply_root_metadata(
                 model,
-                root=root,
+                resolved_root=root_resolved,
                 root_id=root_id,
                 root_order=root_order,
-                relative_path=resolved_path.relative_to(root.resolve()),
+                relative_path=resolved_path.relative_to(root_resolved),
             )
             discovered_models[model_id] = model
             accepted_model_ids.append(model_id)
 
-    def _scan_huggingface_cache_models(self, *, root: Path) -> list[common_pb2.ModelSpec]:
-        models: list[common_pb2.ModelSpec] = []
-        for cache_repo_dir in sorted(root.glob("models--*")):
-            if not cache_repo_dir.is_dir():
-                continue
+    def _scan_huggingface_cache_models(self, *, root: Path) -> Iterable[common_pb2.ModelSpec]:
+        for cache_repo_dir in _sorted_child_directories(root, name_prefix="models--"):
             repo_id = _hf_cache_repo_id(cache_repo_dir)
             if repo_id is None:
                 continue
@@ -1066,47 +1082,38 @@ class WorkerModelCatalog:
             if not snapshots_dir.is_dir():
                 continue
             revision_map = _hf_cache_revision_map(cache_repo_dir)
-            for snapshot_dir in sorted(path for path in snapshots_dir.iterdir() if path.is_dir()):
+            for snapshot_dir in _sorted_child_directories(snapshots_dir):
                 if not (snapshot_dir / "config.json").is_file() or not _has_model_weight_files(snapshot_dir):
                     continue
                 if not _has_mlx_signal(model_dir=snapshot_dir, repo_id=repo_id):
                     continue
                 revision = _hf_cache_revision(cache_repo_dir, snapshot_dir.name, revision_map=revision_map)
-                models.append(
-                    self._raw_model_spec(
-                        model_id=repo_id,
-                        model_dir=snapshot_dir.resolve(),
-                        revision=revision,
-                        source_kind="hf_cache_snapshot",
-                        metadata={
-                            "melix.hf_repo_id": repo_id,
-                            "melix.hf_revision": revision,
-                        },
-                    )
+                yield self._raw_model_spec(
+                    model_id=repo_id,
+                    model_dir=snapshot_dir.resolve(),
+                    revision=revision,
+                    source_kind="hf_cache_snapshot",
+                    metadata={
+                        "melix.hf_repo_id": repo_id,
+                        "melix.hf_revision": revision,
+                    },
                 )
-        return models
 
     @staticmethod
-    def _iter_plain_local_model_dirs(root: Path) -> list[Path]:
-        model_dirs: list[Path] = []
+    def _iter_plain_local_model_dirs(root: Path) -> Iterable[Path]:
         stack = [root.resolve()]
         while stack:
             current = stack.pop()
             if current.name in {"blobs", ".git", "__pycache__"}:
                 continue
             if (current / "config.json").is_file():
-                model_dirs.append(current)
+                yield current
                 continue
-            try:
-                children = sorted(path for path in current.iterdir() if path.is_dir())
-            except OSError:
-                continue
+            children = _sorted_child_directories(current)
             stack.extend(reversed(children))
-        return model_dirs
 
     @staticmethod
-    def _iter_registry_manifest_paths(root: Path) -> list[Path]:
-        manifest_paths: list[Path] = []
+    def _iter_registry_manifest_paths(root: Path) -> Iterable[Path]:
         stack = [root.resolve()]
         while stack:
             current = stack.pop()
@@ -1114,26 +1121,22 @@ class WorkerModelCatalog:
                 continue
             manifest_path = current / "manifest.json"
             if manifest_path.is_file():
-                manifest_paths.append(manifest_path)
+                yield manifest_path
                 continue
-            try:
-                children = sorted(path for path in current.iterdir() if path.is_dir())
-            except OSError:
-                continue
+            children = _sorted_child_directories(current)
             stack.extend(reversed(children))
-        return sorted(manifest_paths)
 
     @staticmethod
     def _apply_root_metadata(
         model: common_pb2.ModelSpec,
         *,
-        root: Path,
+        resolved_root: Path,
         root_id: str,
         root_order: int,
         relative_path: Path,
     ) -> None:
         model.ext["melix.registry_root_id"] = root_id
-        model.ext["melix.registry_root_path"] = str(root.resolve())
+        model.ext["melix.registry_root_path"] = str(resolved_root)
         model.ext["melix.registry_root_order"] = str(root_order)
         model.ext["melix.registry_relative_path"] = os.fspath(relative_path)
 


### PR DESCRIPTION
## Summary
- Speed up `services/mlx-worker-python/worker/model_registry/catalog.py` registry scans by switching the hot traversal paths from eager `glob()` / `iterdir()` list building to `os.scandir()`-based sorted iteration.
- Reuse a single resolved root path during raw local model discovery instead of re-normalizing it per accepted model.
- Add focused regression tests that lock in `os.scandir()` traversal and preserved sorted depth-first ordering.

## Plan or Spec
- `docs/plans/2026-04-30-cron-python-optimization-slice.md`

## Commands Run
```text
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-101540 python -m pytest tests/test_model_registry_catalog.py -k 'uses_os_scandir or iterators_use_os_scandir or scan_helpers_skip_invalid_huggingface' -v
PASS (4 passed)

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-101540 python -m pytest tests/test_model_registry_catalog.py -k 'uses_os_scandir or iterators_use_os_scandir or raw_local_scan_skips_manifest_owned_directories or collects_models_from_ordered_roots' -v
PASS (5 passed)

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-101540 python -m pytest tests/test_model_registry_catalog.py -v
PASS (56 passed)

rm -f .coverage && PYTHONPATH=/tmp/melix-cron-python-opt-20260430-101540 python -m coverage run --source=worker.model_registry -m pytest tests/test_model_registry_catalog.py && python -m coverage report -m worker/model_registry/catalog.py
PASS (worker/model_registry/catalog.py coverage: 97%)

python - <<'PY' ... benchmark registry_snapshot(rescan=True) current branch vs origin/main on a 450-model synthetic fixture ... PY
PASS (mean improved from 173.45 ms to 130.70 ms, -42.75 ms / -24.65%)

git diff --check
PASS
```

## Coverage and Metrics
- Changed executable file coverage:
  - `worker/model_registry/catalog.py`: **97%** (`747` statements, `20` missed)
- Performance probe:
  - Synthetic fixture: `450` discovered models
  - `origin/main` mean `registry_snapshot(rescan=True)`: **173.45 ms**
  - optimized branch mean `registry_snapshot(rescan=True)`: **130.70 ms**
  - improvement: **42.75 ms faster** (**24.65%**)

## Known Gaps
- Linux-only validation in this cron run. I did not run repository-wide `make swift-test` or macOS-specific checks because this host cannot verify the Swift/macOS surfaces locally.
- `_sorted_child_directories()` edge handling is covered indirectly through the traversal tests rather than by a dedicated unit test for every helper branch.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
