### PR TITLE
perf: stream closure audit milestone parsing

### DIFF
--- a/services/mlx-worker-python/tests/test_closure_audit.py
+++ b/services/mlx-worker-python/tests/test_closure_audit.py
@@ -148,6 +148,40 @@ def test_collect_probe_sources_stops_reading_after_all_probe_slots_are_filled(
         ]
 
 
+def test_load_milestone_statuses_streams_execution_index_without_read_text(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    execution_index = tmp_path / "execution-index.md"
+    execution_index.write_text(
+        "\n".join(
+            [
+                "# Execution Index",
+                "",
+                "- `M9.3` `docs/plans/m9.3.md`",
+                "  Status: completed. done.",
+                "- `M9.4` `docs/plans/m9.4.md`",
+                "  Status: pending. todo.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    original_read_text = Path.read_text
+
+    def fail_read_text(self: Path, *args, **kwargs) -> str:
+        if self == execution_index:
+            raise AssertionError("execution index parsing should not use Path.read_text")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+    assert closure_audit_module._load_milestone_statuses(execution_index) == {
+        "M9.3": "completed",
+        "M9.4": "pending",
+    }
+
+
 def test_closure_audit_helper_fallbacks_cover_policy_and_probe_edge_cases(tmp_path: Path) -> None:
     missing_index = tmp_path / "missing-execution-index.md"
     assert closure_audit_module._load_milestone_statuses(missing_index) == {}

--- a/services/mlx-worker-python/worker/productization/closure_audit.py
+++ b/services/mlx-worker-python/worker/productization/closure_audit.py
@@ -328,15 +328,16 @@ def _load_milestone_statuses(execution_index_path: Path) -> dict[str, str]:
         return statuses
 
     current_milestone = ""
-    for raw_line in execution_index_path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if line.startswith("- `M9."):
-            current_milestone = line.split("`", 2)[1]
-            continue
-        if current_milestone and line.startswith("Status:"):
-            status = line.split(":", 1)[1].strip().split(".", 1)[0].split()[0].lower()
-            statuses[current_milestone] = status
-            current_milestone = ""
+    with execution_index_path.open(encoding="utf-8") as execution_index_file:
+        for raw_line in execution_index_file:
+            line = raw_line.strip()
+            if line.startswith("- `M9."):
+                current_milestone = line.split("`", 2)[1]
+                continue
+            if current_milestone and line.startswith("Status:"):
+                status = line.split(":", 1)[1].strip().split(".", 1)[0].split()[0].lower()
+                statuses[current_milestone] = status
+                current_milestone = ""
     return statuses
 
 


### PR DESCRIPTION
## Summary
- Stream `closure_audit._load_milestone_statuses()` line by line instead of loading the entire execution-index file with `read_text().splitlines()`.
- Add a regression test that preserves parsing behavior while proving this path no longer relies on `Path.read_text`.
- Keep the slice Python-only, Linux-verifiable, and narrowly scoped to `services/mlx-worker-python`.

## Plan or Spec
- N/A: this is a small internal performance optimization slice for the Python worker with no canonical governing spec/plan and no externally visible behavior change.

## Commands Run
```text
git -C /root/.openclaw/workspace/melix fetch origin --prune
git -C /root/.openclaw/workspace/melix worktree add /tmp/melix-cron-python-opt-20260430-111851 -b akane/cron-python-opt-20260430-111851 origin/main
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-111851:/tmp/melix-cron-python-opt-20260430-111851/services/mlx-worker-python pytest services/mlx-worker-python/tests/test_closure_audit.py -k streams_execution_index_without_read_text  # failed first under TDD before the implementation
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-111851:/tmp/melix-cron-python-opt-20260430-111851/services/mlx-worker-python pytest services/mlx-worker-python/tests/test_closure_audit.py -k streams_execution_index_without_read_text  # passed after the implementation
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-111851:/tmp/melix-cron-python-opt-20260430-111851/services/mlx-worker-python pytest services/mlx-worker-python/tests/test_closure_audit.py  # 7 passed
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-111851:/tmp/melix-cron-python-opt-20260430-111851/services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_closure_audit.py  # 7 passed
coverage report -m services/mlx-worker-python/worker/productization/closure_audit.py  # 99% coverage (138 stmts, 1 miss)
python3 - <<'PY' ... synthetic execution-index benchmark comparing baseline read_text().splitlines() vs current streaming parser ... PY
git diff --check
```

## Coverage and Metrics
- Changed executable file coverage: `services/mlx-worker-python/worker/productization/closure_audit.py` = `99%` (`138` statements, `1` miss).
- Focused pytest: `services/mlx-worker-python/tests/test_closure_audit.py` = `7 passed`.
- Performance probe on a synthetic 50,000-milestone execution index (`3,977,799` bytes):
  - Baseline `read_text().splitlines()` parser mean: `52.63 ms`
  - Current streaming parser mean: `47.77 ms`
  - Mean wall-clock improvement: `9.23%`
  - Baseline peak traced memory: `16.67 MiB`
  - Current peak traced memory: `7.54 MiB`
  - Peak traced-memory reduction: `54.74%`

## Known Gaps
- None for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
