### PR TITLE
perf: cache LoRA experiment index reads

### DIFF
--- a/services/mlx-worker-python/tests/test_lora_experiment_store.py
+++ b/services/mlx-worker-python/tests/test_lora_experiment_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 from worker.productization import lora_experiment_store as lora_experiment_store_module
@@ -204,6 +205,58 @@ def test_load_index_uses_existing_index_and_rebuilds_when_missing(tmp_path: Path
 
     assert rebuilt == cached
     assert cached["runs"][0]["run_id"] == "model-ops-0001"
+
+
+def test_load_index_reuses_cached_index_without_reparsing_unchanged_file(tmp_path: Path, monkeypatch) -> None:
+    jobs_root = tmp_path / "model-ops"
+    store = LoraExperimentStore()
+    _write_run_record(
+        jobs_root,
+        run_id="model-ops-0001",
+        group_id="nightly-qwen",
+        manifest_path="/tmp/model-ops-0001/train_lora.adapter.json",
+        updated_at_unix_ms=1_000,
+    )
+
+    first_payload = store.load_index(jobs_root)
+    original_read_payload = LoraExperimentStore._read_payload
+
+    def _read_payload(path: Path) -> dict[str, object]:
+        if path == jobs_root / "train_lora" / LoraExperimentStore.index_record_name:
+            raise AssertionError("load_index should reuse an unchanged cached index")
+        return original_read_payload(path)
+
+    monkeypatch.setattr(LoraExperimentStore, "_read_payload", staticmethod(_read_payload))
+
+    second_payload = store.load_index(jobs_root)
+
+    assert second_payload == first_payload
+
+
+def test_load_index_invalidates_cached_index_when_index_file_changes(tmp_path: Path) -> None:
+    jobs_root = tmp_path / "model-ops"
+    store = LoraExperimentStore()
+    _write_run_record(
+        jobs_root,
+        run_id="model-ops-0001",
+        group_id="nightly-qwen",
+        manifest_path="/tmp/model-ops-0001/train_lora.adapter.json",
+        updated_at_unix_ms=1_000,
+    )
+
+    cached_payload = store.load_index(jobs_root)
+    index_path = jobs_root / "train_lora" / LoraExperimentStore.index_record_name
+    original_stat = index_path.stat()
+    mutated_payload = {
+        **cached_payload,
+        "runs": [{**cached_payload["runs"][0], "run_id": "mutated-run-id"}],
+    }
+    index_path.write_text(json.dumps(mutated_payload, indent=2) + "\n", encoding="utf-8")
+    os.utime(index_path, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns + 1_000_000))
+
+    refreshed_payload = store.load_index(jobs_root)
+
+    assert refreshed_payload["runs"][0]["run_id"] == "mutated-run-id"
 
 
 

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -14,6 +14,11 @@ class LoraExperimentStore:
     run_record_name = "lora-experiment-run.json"
     index_record_name = "lora-experiments.index.json"
 
+    def __init__(self) -> None:
+        self._cached_index_path: Path | None = None
+        self._cached_index_signature: tuple[int, int] | None = None
+        self._cached_index_payload: dict[str, Any] | None = None
+
     def persist_training_run(
         self,
         *,
@@ -30,8 +35,13 @@ class LoraExperimentStore:
 
     def load_index(self, jobs_root: Path) -> dict[str, Any]:
         index_path = self._index_path(jobs_root)
+        if self._cached_index_path == index_path:
+            signature = self._index_signature(index_path)
+            if signature is not None and signature == self._cached_index_signature and self._cached_index_payload is not None:
+                return self._cached_index_payload
         payload = self._read_payload(index_path)
         if payload:
+            self._cache_index(index_path=index_path, payload=payload)
             return payload
         return self.rebuild_index(jobs_root)
 
@@ -72,6 +82,7 @@ class LoraExperimentStore:
         index_path = self._index_path(jobs_root)
         index_path.parent.mkdir(parents=True, exist_ok=True)
         index_path.write_text(json.dumps(_json_safe(payload), indent=2, allow_nan=False) + "\n", encoding="utf-8")
+        self._cache_index(index_path=index_path, payload=payload)
         return payload
 
     def _build_group_payloads(self, runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -216,6 +227,20 @@ class LoraExperimentStore:
 
     def _index_path(self, jobs_root: Path) -> Path:
         return jobs_root / "train_lora" / self.index_record_name
+
+    @staticmethod
+    def _index_signature(path: Path) -> tuple[int, int] | None:
+        try:
+            stat_result = path.stat()
+        except OSError:
+            return None
+        return (stat_result.st_mtime_ns, stat_result.st_size)
+
+    def _cache_index(self, *, index_path: Path, payload: dict[str, Any]) -> None:
+        self._cached_index_path = index_path
+        self._cached_index_signature = self._index_signature(index_path)
+        self._cached_index_payload = payload
+
 
 
 def _manifest_optional_float(manifest: dict[str, Any], *keys: str) -> float | None:


### PR DESCRIPTION
## Summary
- Cache `LoraExperimentStore.load_index()` results per store instance when the on-disk index file is unchanged.
- Invalidate the cache when the index file metadata changes, and refresh the cached payload after rebuilding the index.
- Add focused tests covering cache reuse and cache invalidation for externally updated index files.

## Plan or Spec
- N/A: this is an internal Python-only performance optimization slice for `services/mlx-worker-python` with no externally visible contract or workflow change.

## Commands Run
```text
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-114806/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-114806 pytest -q tests/test_lora_experiment_store.py::test_load_index_reuses_cached_index_without_reparsing_unchanged_file tests/test_lora_experiment_store.py::test_load_index_invalidates_cached_index_when_index_file_changes
# 2 passed in 0.03s

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-114806/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-114806 pytest -q tests/test_lora_experiment_store.py
# 10 passed in 0.04s

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-114806/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-114806 coverage run --branch -m pytest -q tests/test_lora_experiment_store.py
# 10 passed in 0.07s

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-114806/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-114806 coverage report -m worker/productization/lora_experiment_store.py
# 98% coverage for worker/productization/lora_experiment_store.py

python3 - <<'PY'
# temporary performance probe measuring repeated cold loads vs repeated cached loads
PY
# cold_total_ms=293.661, cached_total_ms=7.602, speedup_x=38.63 over 400 repeated loads of a 250-run index

git diff --check
# clean
```

## Coverage and Metrics
- Changed executable scope: `worker/productization/lora_experiment_store.py`
- Automated coverage: `98%` (`138` statements, `2` misses, `44` branches, `1` partial branch)
- Performance probe: 400 repeated loads of a generated 250-run index
  - cold total: `293.661 ms`
  - cached total: `7.602 ms`
  - cold mean: `0.7342 ms`
  - cached mean: `0.0190 ms`
  - observed speedup: `38.63x`

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
