### PR TITLE
perf: reuse dataset source sample lists

### DIFF
--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -8,6 +8,8 @@ import pytest
 from worker.model_ops import training_dataset as training_dataset_module
 from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.training_dataset import (
+    HFDatasetReference,
+    ResolvedTrainingDatasetPackage,
     TrainingDatasetPackage,
     build_training_dataset_artifact,
     load_training_dataset_package,
@@ -497,3 +499,106 @@ def test_build_training_dataset_artifact_loads_existing_package_and_helper_branc
             field_name="validation_ratio",
         )
     assert float_range_exc.value.code == "invalid_dataset_source"
+
+
+def test_resolve_dataset_build_source_reuses_existing_package_sample_lists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    normalized_samples = [{"text": "alpha beta"}]
+    normalized_validation_samples = [{"text": "gamma delta"}]
+    package_path = tmp_path / "existing-package"
+    package_path.mkdir(parents=True, exist_ok=True)
+    package = TrainingDatasetPackage(
+        package_path=package_path,
+        manifest_path=package_path / "manifest.json",
+        samples_path=package_path / "samples.jsonl",
+        schema_version="melix.training_dataset_package.v1",
+        dataset_id="existing-package",
+        format="text_completion",
+        sample_count=1,
+        version="1",
+        normalized_samples=normalized_samples,
+        normalized_validation_samples=normalized_validation_samples,
+        validation_sample_count=1,
+        response_only_supported=False,
+    )
+
+    monkeypatch.setattr(
+        training_dataset_module,
+        "load_training_dataset_package",
+        lambda dataset_uri, sample_limit=0: package,
+    )
+
+    resolved = training_dataset_module._resolve_dataset_build_source(
+        {"dataset_uri": str(tmp_path / "existing-package"), "template": "existing_package"},
+        jobs_root=tmp_path / "jobs",
+        hf_dataset_fetcher=None,
+        sample_limit=0,
+    )
+
+    assert resolved["samples"] is normalized_samples
+    assert resolved["validation_samples"] is normalized_validation_samples
+
+
+def test_resolve_dataset_build_source_reuses_hf_package_sample_lists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    normalized_samples = [
+        {"messages": [{"role": "user", "content": "Hi"}, {"role": "assistant", "content": "Hello"}]}
+    ]
+    normalized_validation_samples = [
+        {"messages": [{"role": "user", "content": "Bye"}, {"role": "assistant", "content": "Goodbye"}]}
+    ]
+    package = TrainingDatasetPackage(
+        package_path=tmp_path / "hf-package",
+        manifest_path=tmp_path / "hf-package" / "manifest.json",
+        samples_path=tmp_path / "hf-package" / "samples.jsonl",
+        schema_version="melix.training_dataset_package.v1",
+        dataset_id="hf-package",
+        format="chat_messages",
+        sample_count=1,
+        version="1",
+        normalized_samples=normalized_samples,
+        normalized_validation_samples=normalized_validation_samples,
+        validation_sample_count=1,
+        response_only_supported=True,
+    )
+    reference = HFDatasetReference(
+        dataset_path="HuggingFaceH4/ultrachat_200k",
+        dataset_name="default",
+        dataset_revision="main",
+        train_split="train",
+        valid_split="validation",
+        chat_feature="messages",
+        prompt_feature="",
+        completion_feature="",
+        text_feature="",
+    )
+    resolved_package = ResolvedTrainingDatasetPackage(
+        package=package,
+        source_kind="hf_dataset",
+        dataset_uri="hf://HuggingFaceH4/ultrachat_200k",
+        materialized_package_path=package.package_path,
+        cache_key="demo-key",
+        cache_hit=True,
+        hf_reference=reference,
+    )
+
+    monkeypatch.setattr(
+        training_dataset_module,
+        "resolve_training_dataset_package",
+        lambda request_ext, jobs_root, hf_dataset_fetcher, sample_limit=0: resolved_package,
+    )
+
+    resolved = training_dataset_module._resolve_dataset_build_source(
+        {"hf_dataset_path": "HuggingFaceH4/ultrachat_200k", "template": "source_schema"},
+        jobs_root=tmp_path / "jobs",
+        hf_dataset_fetcher=None,
+        sample_limit=0,
+    )
+
+    assert resolved["samples"] is normalized_samples
+    assert resolved["validation_samples"] is normalized_validation_samples
+    assert resolved["hf_metadata"]["hf_valid_split"] == "validation"

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import hashlib
 import json
 import shutil
+from itertools import chain
 from contextlib import ExitStack
 from dataclasses import dataclass
 from dataclasses import replace
 import os
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Iterable
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
@@ -365,14 +366,16 @@ def build_training_dataset_artifact(
         sample_limit=sample_limit,
     )
 
-    train_samples = list(source["samples"])
-    validation_samples = list(source["validation_samples"])
-    combined_source_samples = train_samples + validation_samples
-    if not combined_source_samples:
+    source_train_samples = source["samples"]
+    source_validation_samples = source["validation_samples"]
+    if not source_train_samples and not source_validation_samples:
         raise ModelOperationError(
             code="invalid_dataset_source",
             message="Dataset builder did not resolve any usable training samples.",
         )
+
+    train_samples = source_train_samples
+    validation_samples = source_validation_samples
 
     if progress is not None:
         progress("inspect_samples", 0.45)
@@ -385,8 +388,11 @@ def build_training_dataset_artifact(
         )
         validation_strategy = "deterministic_ratio"
 
-    quality = _build_quality_report(combined_source_samples)
-    token_stats = _build_token_stats(combined_source_samples, source["format"])
+    quality = _build_quality_report(chain(source_train_samples, source_validation_samples))
+    token_stats = _build_token_stats(
+        chain(source_train_samples, source_validation_samples),
+        source["format"],
+    )
 
     manifest_payload: dict[str, Any] = {
         "dataset_id": source["dataset_id"],
@@ -954,8 +960,8 @@ def _resolve_dataset_build_source(
             "source_uri": resolved.dataset_uri,
             "source_manifest_path": str(resolved.package.manifest_path),
             "source_samples_path": str(resolved.package.samples_path),
-            "samples": list(resolved.package.normalized_samples),
-            "validation_samples": list(resolved.package.normalized_validation_samples),
+            "samples": resolved.package.normalized_samples,
+            "validation_samples": resolved.package.normalized_validation_samples,
             "response_only_supported": resolved.package.response_only_supported,
             "conversion_template": template,
             "hf_metadata": {
@@ -989,8 +995,8 @@ def _resolve_dataset_build_source(
             "source_uri": str(source_path),
             "source_manifest_path": str(package.manifest_path),
             "source_samples_path": str(package.samples_path),
-            "samples": list(package.normalized_samples),
-            "validation_samples": list(package.normalized_validation_samples),
+            "samples": package.normalized_samples,
+            "validation_samples": package.normalized_validation_samples,
             "response_only_supported": package.response_only_supported,
             "conversion_template": template,
             "hf_metadata": {},
@@ -1191,7 +1197,7 @@ def _deterministic_validation_split(
     return train_samples, validation_samples
 
 
-def _build_quality_report(samples: list[dict[str, Any]]) -> dict[str, Any]:
+def _build_quality_report(samples: Iterable[dict[str, Any]]) -> dict[str, Any]:
     seen: set[bytes] = set()
     duplicate_indices: list[int] = []
     dirty_samples: list[dict[str, Any]] = []
@@ -1212,11 +1218,13 @@ def _build_quality_report(samples: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _build_token_stats(samples: list[dict[str, Any]], format_name: str) -> dict[str, Any]:
+def _build_token_stats(samples: Iterable[dict[str, Any]], format_name: str) -> dict[str, Any]:
     prompt_tokens: list[int] = []
     completion_tokens: list[int] = []
     total_tokens: list[int] = []
+    sample_count = 0
     for sample in samples:
+        sample_count += 1
         prompt_count, completion_count = _sample_token_counts(sample, format_name)
         prompt_tokens.append(prompt_count)
         completion_tokens.append(completion_count)
@@ -1224,7 +1232,7 @@ def _build_token_stats(samples: list[dict[str, Any]], format_name: str) -> dict[
 
     return {
         "estimator": "whitespace_v1",
-        "sample_count": len(samples),
+        "sample_count": sample_count,
         "prompt_tokens_mean": _mean_value(prompt_tokens),
         "prompt_tokens_p50": _percentile_value(prompt_tokens, 0.50),
         "prompt_tokens_p95": _percentile_value(prompt_tokens, 0.95),


### PR DESCRIPTION
## Summary
- Reuse existing normalized sample lists when rebuilding from local or Hugging Face dataset packages instead of copying them again.
- Replace the temporary combined sample list in `build_training_dataset_artifact()` with iterator-based aggregation for quality and token statistics.
- Add regression tests that lock in list reuse for local-package and HF-package source resolution.

## Plan or Spec
- N/A: this is a small internal Python-only optimization slice for `services/mlx-worker-python`; no canonical Melix plan or spec currently governs redundant list copying inside `worker/model_ops/training_dataset.py`.

## Commands Run
```text
PASS python -m pytest -q tests/test_training_dataset_builder.py
PASS coverage erase && coverage run -m pytest -q tests/test_training_dataset_builder.py && coverage json -o coverage.json >/dev/null && python - <<'PY' ... changed_line_coverage=100.00%
PASS python - <<'PY' ... synthetic perf probe for baseline vs optimized dataset inspection path
PASS git diff --check
PASS git push -u origin HEAD
```

## Coverage and Metrics
- Changed-scope coverage for `worker/model_ops/training_dataset.py`: 100.00% of measurable changed executable lines.
- Measurable changed lines: `6, 12, 369, 370, 371, 377, 378, 391, 392, 1200, 1221, 1225, 1227`
- Perf probe on synthetic `prompt_completion` data (`120000` train + `30000` validation samples):
  - Baseline avg wall time: `4.8475s`
  - Optimized avg wall time: `4.6602s` (`3.86%` faster)
  - Baseline avg traced peak memory: `15.59 MiB`
  - Optimized avg traced peak memory: `13.30 MiB` (`2.29 MiB`, `14.68%` lower)

## Known Gaps
- Did not run `make swift-test` or other macOS/Swift-only verification because this cron host is Linux and the change is scoped to the Python worker.
- Full-file coverage for `worker/model_ops/training_dataset.py` remains below 95%; the enforced gate here is changed executable scope coverage, which is 100.00% for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
