### PR TITLE
perf: streamline HF cache ref scans

### DIFF
--- a/docs/plans/2026-04-30-cron-python-optimization-slice.md
+++ b/docs/plans/2026-04-30-cron-python-optimization-slice.md
@@ -9,28 +9,30 @@ and an explicit performance probe before commit.
 ## Scout Result Summary
 
 The scouting pass proposed these safe candidates:
-1. Stream model registry scans in `worker/model_registry/catalog.py`.
-2. Remove immediate manifest reread/parse/rewrite after normalized dataset snapshot creation.
-3. Avoid `reversed(stdout.splitlines())` for tail parsing of subprocess output.
+1. Stream Hugging Face cache ref traversal in `worker/model_registry/catalog.py`.
+2. Collapse repeated benchmark export directory scans in `worker/productization/benchmark_export.py`.
+3. Reduce repeated manifest glob passes in `worker/model_ops/job_registry.py`.
 
 ## Chosen Slice
 
-Optimize `services/mlx-worker-python/worker/model_registry/catalog.py` by reducing
-redundant eager list construction and repeated path normalization during local
-model registry scans while preserving discovery output and ordering.
+Optimize `services/mlx-worker-python/worker/model_registry/catalog.py` by
+replacing eager `Path.rglob()` ref enumeration in `_hf_cache_revision_map()`
+with a sorted `os.scandir()` tree walk that avoids materializing the full refs
+path list while preserving revision mapping and ref-name ordering.
 
 ## Why This Slice
 
 - Pure Python and Linux-verifiable.
-- Reduces redundant work and allocation on a path that scales with model count.
+- Reduces redundant allocation and directory traversal overhead on a path that
+  scales with Hugging Face cache ref count.
 - Already has strong local tests in `tests/test_model_registry_catalog.py`.
-- Easy to benchmark with a synthetic large temporary registry tree.
+- Easy to benchmark with a synthetic large temporary refs tree.
 
 ## Task
 
-1. Add or update tests first to lock behavior and ordering.
-2. Refactor catalog scan helpers to avoid unnecessary full-list materialization
-   and repeated path resolution where possible.
+1. Add or update tests first to lock behavior, ordering, and single-pass scan behavior.
+2. Refactor `_hf_cache_revision_map()` to use deterministic `os.scandir()` recursion
+   instead of `Path.rglob()` list materialization.
 3. Run focused pytest for the touched scope.
 4. Measure touched-file coverage and require at least 95% coverage for the
    changed executable file before commit.
@@ -40,6 +42,6 @@ model registry scans while preserving discovery output and ordering.
 ## Success Metrics
 
 - Behavior and ordering unchanged in focused tests.
-- `worker/model_registry/catalog.py` coverage >= 95%.
-- Performance probe shows improved wall-clock time for the chosen synthetic scan.
+- `worker/model_registry/catalog.py` changed-scope coverage >= 95%.
+- Performance probe shows improved wall-clock time for the synthetic refs scan.
 - No whitespace or conflict issues from `git diff --check`.

--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -297,22 +297,107 @@ def test_hf_cache_revision_map_reads_refs_once_and_preserves_nested_ref_names(mo
     assert _hf_cache_revision(cache_repo_dir, "missing", revision_map=revision_map) == "missing"
 
 
+
+def test_hf_cache_revision_map_uses_recursive_scandir_without_rglob(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cache_repo_dir = tmp_path / "models--org--demo"
+    refs_dir = cache_repo_dir / "refs"
+    nested_ref = refs_dir / "heads" / "main"
+    nested_ref.parent.mkdir(parents=True, exist_ok=True)
+    nested_ref.write_text("abc123\n", encoding="utf-8")
+    stable_ref = refs_dir / "tags" / "stable"
+    stable_ref.parent.mkdir(parents=True, exist_ok=True)
+    stable_ref.write_text("def456\n", encoding="utf-8")
+
+    original_scandir = os.scandir
+    scandir_calls: list[str] = []
+
+    def tracking_scandir(path: str):
+        scandir_calls.append(path)
+        return original_scandir(path)
+
+    def fail_rglob(self: Path, pattern: str):
+        raise AssertionError("expected os.scandir-based recursive scan")
+
+    monkeypatch.setattr(os, "scandir", tracking_scandir)
+    monkeypatch.setattr(Path, "rglob", fail_rglob)
+
+    assert _hf_cache_revision_map(cache_repo_dir) == {"abc123": "heads/main", "def456": "tags/stable"}
+    assert scandir_calls == [os.fspath(refs_dir), os.fspath(refs_dir / "heads"), os.fspath(refs_dir / "tags")]
+
+
+
 def test_hf_cache_revision_map_returns_empty_mapping_when_ref_enumeration_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     cache_repo_dir = tmp_path / "models--org--demo"
     refs_dir = cache_repo_dir / "refs"
     refs_dir.mkdir(parents=True, exist_ok=True)
 
-    original_rglob = Path.rglob
+    original_scandir = os.scandir
 
-    def fake_rglob(self: Path, pattern: str):
-        if self == refs_dir:
+    def fake_scandir(path: str):
+        if path == os.fspath(refs_dir):
             raise OSError("boom")
-        return original_rglob(self, pattern)
+        return original_scandir(path)
 
-    monkeypatch.setattr(Path, "rglob", fake_rglob)
+    monkeypatch.setattr(os, "scandir", fake_scandir)
 
     assert _hf_cache_revision_map(cache_repo_dir) == {}
 
+
+
+def test_hf_cache_revision_map_returns_empty_mapping_when_entry_type_probe_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cache_repo_dir = tmp_path / "models--org--demo"
+    refs_dir = cache_repo_dir / "refs"
+    refs_dir.mkdir(parents=True, exist_ok=True)
+
+    class _BrokenDirEntry:
+        name = "broken"
+
+        def is_dir(self) -> bool:
+            raise OSError("boom")
+
+        def is_file(self) -> bool:
+            raise AssertionError("is_file should not be reached after is_dir failure")
+
+    class _FakeScandir:
+        def __enter__(self) -> _FakeScandir:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        def __iter__(self):
+            return iter([_BrokenDirEntry()])
+
+    original_scandir = os.scandir
+
+    def fake_scandir(path: str):
+        if path == os.fspath(refs_dir):
+            return _FakeScandir()
+        return original_scandir(path)
+
+    monkeypatch.setattr(os, "scandir", fake_scandir)
+
+    assert _hf_cache_revision_map(cache_repo_dir) == {}
+
+
+
+def test_hf_cache_revision_map_skips_blank_snapshot_ids(tmp_path: Path) -> None:
+    cache_repo_dir = tmp_path / "models--org--demo"
+    refs_dir = cache_repo_dir / "refs"
+    blank_ref = refs_dir / "heads" / "blank"
+    blank_ref.parent.mkdir(parents=True, exist_ok=True)
+    blank_ref.write_text("\n", encoding="utf-8")
+    valid_ref = refs_dir / "tags" / "stable"
+    valid_ref.parent.mkdir(parents=True, exist_ok=True)
+    valid_ref.write_text("def456\n", encoding="utf-8")
+
+    assert _hf_cache_revision_map(cache_repo_dir) == {"def456": "tags/stable"}
 
 
 def test_apply_registry_identity_metadata_rejects_missing_required_parts() -> None:

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -240,22 +240,41 @@ def _sorted_child_directories(root: Path, *, name_prefix: str | None = None) -> 
     return tuple(root / name for name in sorted(child_names))
 
 
+def _iter_relative_file_paths_sorted(root: Path, *, prefix: str = "") -> Iterable[tuple[Path, str]]:
+    try:
+        with os.scandir(os.fspath(root)) as entries:
+            child_entries = sorted(entries, key=lambda entry: entry.name)
+    except OSError as exc:
+        raise OSError(str(exc)) from exc
+
+    for entry in child_entries:
+        try:
+            if entry.is_dir():
+                child_prefix = f"{prefix}{entry.name}/"
+                yield from _iter_relative_file_paths_sorted(root / entry.name, prefix=child_prefix)
+                continue
+            if entry.is_file():
+                yield root / entry.name, f"{prefix}{entry.name}"
+        except OSError as exc:
+            raise OSError(str(exc)) from exc
+
+
+
 def _hf_cache_revision_map(cache_repo_dir: Path) -> dict[str, str]:
     refs_dir = cache_repo_dir / "refs"
     revisions: dict[str, str] = {}
     if refs_dir.is_dir():
         try:
-            ref_paths = sorted(path for path in refs_dir.rglob("*") if path.is_file())
+            for ref_path, relative_name in _iter_relative_file_paths_sorted(refs_dir):
+                try:
+                    snapshot_id = ref_path.read_text(encoding="utf-8").strip()
+                except OSError:
+                    continue
+                if not snapshot_id:
+                    continue
+                revisions.setdefault(snapshot_id, relative_name)
         except OSError:
             return revisions
-        for ref_path in ref_paths:
-            try:
-                snapshot_id = ref_path.read_text(encoding="utf-8").strip()
-            except OSError:
-                continue
-            if not snapshot_id:
-                continue
-            revisions.setdefault(snapshot_id, os.fspath(ref_path.relative_to(refs_dir)))
     return revisions
 
 


### PR DESCRIPTION
## Summary
- replace `_hf_cache_revision_map()`'s eager `Path.rglob()` materialization with a deterministic `os.scandir()` tree walk
- preserve nested ref-name ordering while avoiding a full in-memory list of ref paths before parsing
- add focused regression tests for scandir traversal, traversal failure fallback, and blank ref payload handling

## Plan or Spec
- `docs/plans/2026-04-30-cron-python-optimization-slice.md`

## Commands Run
```text
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-124239/services/mlx-worker-python python3 -m pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py -k 'hf_cache_revision_map_uses_recursive_scandir_without_rglob or hf_cache_revision_map_returns_empty_mapping_when_ref_enumeration_fails'
# pre-change: 1 failed, 1 passed

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-124239/services/mlx-worker-python python3 -m pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py -k 'hf_cache_revision_map'
# post-change: 5 passed

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-124239/services/mlx-worker-python python3 -m pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py
# 59 passed

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-124239/services/mlx-worker-python python3 -m coverage erase
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-124239/services/mlx-worker-python python3 -m coverage run -m pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py
python3 -m coverage json -o coverage.json
python3 -m coverage report --include='services/mlx-worker-python/worker/model_registry/catalog.py'
# catalog.py full-file coverage: 98%
# changed-scope coverage: 100.00%

git diff --check
# clean

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-124239/services/mlx-worker-python python3 - <<'PY'
# synthetic 10,000-ref benchmark comparing baseline Path.rglob() logic vs current scandir walk
PY
# baseline mean: 247.507 ms
# optimized mean: 145.403 ms
# mean improvement: 41.25%
```

## Coverage and Metrics
- Changed executable file: `services/mlx-worker-python/worker/model_registry/catalog.py`
- Full-file coverage for `catalog.py`: `98%` (`762` statements, `19` missed)
- Changed-scope coverage: `100.00%`
- Changed measurable lines: `243,244,245,246,247,248,250,251,252,253,254,255,256,257,258,259,268,269,270,271,272,273,274,275`
- Synthetic performance probe (`10,000` refs, `7` iterations):
  - baseline `Path.rglob()` mean: `247.507 ms`
  - optimized `os.scandir()` mean: `145.403 ms`
  - improvement: `41.25%` faster mean wall-clock time

## Known Gaps
- CI has not run yet on this branch.
- The performance probe is synthetic and Linux-local; it does not measure macOS filesystem behavior directly.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
