### PR TITLE
perf: stream benchmark JSONL artifact writes

### DIFF
--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -3754,6 +3754,46 @@ def test_doctor_health_status_helpers_cover_healthy_and_unknown_states() -> None
     assert MaintenanceCore._doctor_health_status_label(maintenance_pb2.HEALTH_STATUS_UNSPECIFIED) == "unknown"
 
 
+def test_write_jsonl_rows_streams_each_row_without_joining_full_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output_path = tmp_path / "bench-rows.jsonl"
+    writes: list[str] = []
+
+    class RecordingFile:
+        def __enter__(self) -> RecordingFile:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        def write(self, chunk: str) -> int:
+            writes.append(chunk)
+            return len(chunk)
+
+    def fake_open(self: Path, mode: str = "r", *args: object, **kwargs: object) -> RecordingFile:
+        assert self == output_path
+        assert mode == "w"
+        assert kwargs.get("encoding") == "utf-8"
+        return RecordingFile()
+
+    monkeypatch.setattr(Path, "open", fake_open)
+
+    maintenance_core_module._write_jsonl_rows(
+        output_path,
+        [
+            {"suite": "smoke", "ttft_ms": 10.0},
+            {"suite": "latency", "ttft_ms": 20.0},
+        ],
+    )
+
+    assert writes == [
+        json.dumps({"suite": "smoke", "ttft_ms": 10.0}) + "\n",
+        json.dumps({"suite": "latency", "ttft_ms": 20.0}) + "\n",
+    ]
+
+
 def test_resolve_benchmark_loaded_model_reuses_existing_handle(tmp_path: Path) -> None:
     registry = WorkerRegistry(
         runtime=MLXTextRuntime(backend=DeterministicTextBackend()),

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -201,6 +201,12 @@ def _registry_roots_override(ext: dict[str, str]) -> list[str] | None:
     return None
 
 
+def _write_jsonl_rows(path: Path, rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
 class MaintenanceCore:
     def __init__(
         self,
@@ -1255,14 +1261,14 @@ class MaintenanceCore:
                 encoding="utf-8",
             )
             if text_context_rows:
-                (output_dir / "bench-context-rows.jsonl").write_text(
-                    "\n".join(json.dumps(row) for row in text_context_rows) + "\n",
-                    encoding="utf-8",
+                _write_jsonl_rows(
+                    output_dir / "bench-context-rows.jsonl",
+                    text_context_rows,
                 )
             if text_batch_rows:
-                (output_dir / "bench-batch-rows.jsonl").write_text(
-                    "\n".join(json.dumps(row) for row in text_batch_rows) + "\n",
-                    encoding="utf-8",
+                _write_jsonl_rows(
+                    output_dir / "bench-batch-rows.jsonl",
+                    text_batch_rows,
                 )
             self._job_registry.complete(job.job_id, str(report_path))
             self._benchmark_queue_store.transition(


### PR DESCRIPTION
## Summary
- Stream benchmark JSONL artifact writes in `MaintenanceCore` instead of building one giant joined string.
- Keep `bench-context-rows.jsonl` and `bench-batch-rows.jsonl` output byte-for-byte equivalent while reducing transient Python allocation pressure.
- Add a focused regression test that locks the per-row streaming write behavior.

## Plan or Spec
- N/A: this is a small internal performance optimization in the Python worker with no canonical spec or externally visible behavior change.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python python3 -m pytest services/mlx-worker-python/tests/test_maintenance_service.py -k 'test_write_jsonl_rows_streams_each_row_without_joining_full_payload or test_run_bench_persists_job_manifest_and_per_suite_results' -q
# 2 passed, 126 deselected

PYTHONPATH=services/mlx-worker-python python3 -m pytest services/mlx-worker-python/tests/test_benchmark_export.py -k collect_benchmark_artifacts_ignores_blank_and_non_object_jsonl_rows -q
# 1 passed, 29 deselected

PYTHONPATH=services/mlx-worker-python coverage erase
PYTHONPATH=services/mlx-worker-python coverage run -m pytest services/mlx-worker-python/tests/test_maintenance_service.py -k 'test_write_jsonl_rows_streams_each_row_without_joining_full_payload or test_run_bench_persists_job_manifest_and_per_suite_results' -q
PYTHONPATH=services/mlx-worker-python coverage json -o services/mlx-worker-python/coverage.json
# changed_line_coverage=100.00% for services/mlx-worker-python/worker/engine/maintenance_core.py

git diff --check
# clean

python3 - <<'PY'
# compared old join-based JSONL write vs _write_jsonl_rows on 50,000 rows
PY
# baseline_elapsed_s=2.206475 baseline_peak_bytes=42801714
# stream_elapsed_s=2.092762 stream_peak_bytes=23446
# peak_bytes_saved=42778268 peak_reduction_pct=99.95
```

## Coverage and Metrics
- Changed executable statement coverage for `services/mlx-worker-python/worker/engine/maintenance_core.py`: `100.00%`
  - measurable changed lines: `[204, 205, 206, 207, 1264, 1269]`
  - missed changed lines: `[]`
- Performance probe for 50,000 benchmark rows comparing baseline joined-string output vs streamed writes:
  - baseline: `2.206475s`, peak traced allocation `42,801,714` bytes
  - streamed: `2.092762s`, peak traced allocation `23,446` bytes
  - peak allocation reduction: `42,778,268` bytes (`99.95%`)
- Output bytes were verified equal between the baseline and streamed implementations.

## Known Gaps
- Did not run the full repository baseline (`make swift-test`, `make py-test`, `make integration-test`) because this cron run is constrained to a Linux-verifiable Python-only slice and the repository includes macOS/Swift surfaces that are not locally actionable here.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
