### PR TITLE
perf: stream local training dataset normalization

### DIFF
--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -374,6 +374,7 @@ def test_build_training_dataset_artifact_loads_existing_package_and_helper_branc
     assert built.manifest_payload["conversion_template"] == "existing_package"
     assert built.manifest_payload["preview_samples"] == [{"text": "alpha beta"}]
 
+
     with pytest.raises(ModelOperationError) as missing_uri:
         training_dataset_module._resolve_dataset_build_source(
             {},
@@ -602,3 +603,91 @@ def test_resolve_dataset_build_source_reuses_hf_package_sample_lists(
     assert resolved["samples"] is normalized_samples
     assert resolved["validation_samples"] is normalized_validation_samples
     assert resolved["hf_metadata"]["hf_valid_split"] == "validation"
+
+
+def test_build_training_dataset_artifact_streams_local_jsonl_without_bulk_row_helpers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset_path = _write_jsonl(
+        tmp_path / "alpaca-streamed.jsonl",
+        [
+            {
+                "instruction": "Translate to French.",
+                "input": "Hello world",
+                "output": "Bonjour le monde",
+            },
+            {
+                "instruction": "Summarize.",
+                "input": "A short article",
+                "output": "A concise summary",
+            },
+        ],
+    )
+
+    def fail_read_rows(path: Path, *, sample_limit: int) -> list[dict[str, object]]:
+        raise AssertionError(f"bulk row reader should not be used for {path} ({sample_limit=})")
+
+    def fail_convert_rows(rows: list[dict[str, object]], template: str) -> tuple[str, list[dict[str, object]]]:
+        raise AssertionError(f"bulk row converter should not be used for {template}")
+
+    monkeypatch.setattr(training_dataset_module, "_read_local_jsonl_rows", fail_read_rows)
+    monkeypatch.setattr(training_dataset_module, "_convert_local_rows", fail_convert_rows)
+
+    built = build_training_dataset_artifact(
+        {
+            "dataset_uri": str(dataset_path),
+            "template": "auto",
+            "preview_count": "1",
+        },
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "streamed-package",
+        source_model_id="melix-dev-text",
+    )
+
+    assert built.manifest_payload["source_kind"] == "local_path"
+    assert built.manifest_payload["conversion_template"] == "alpaca"
+    assert built.manifest_payload["sample_count"] == 2
+    assert built.manifest_payload["preview_samples"] == [
+        {
+            "prompt": "Translate to French.\n\nInput:\nHello world",
+            "completion": "Bonjour le monde",
+        }
+    ]
+    assert (built.package_path / "samples.jsonl").read_text(encoding="utf-8") == (
+        '{"prompt": "Translate to French.\\n\\nInput:\\nHello world", "completion": "Bonjour le monde"}\n'
+        '{"prompt": "Summarize.\\n\\nInput:\\nA short article", "completion": "A concise summary"}\n'
+    )
+
+
+def test_local_jsonl_helpers_cover_streaming_and_single_row_conversions(tmp_path: Path) -> None:
+    dataset_path = _write_jsonl(
+        tmp_path / "helpers.jsonl",
+        [
+            {"messages": [{"role": "user", "content": "Hi"}, {"role": "assistant", "content": "Hello"}]},
+            {"prompt": "Question", "completion": "Answer"},
+        ],
+    )
+
+    assert training_dataset_module._read_local_jsonl_rows(dataset_path, sample_limit=0) == [
+        {"messages": [{"role": "user", "content": "Hi"}, {"role": "assistant", "content": "Hello"}]},
+        {"prompt": "Question", "completion": "Answer"},
+    ]
+    assert training_dataset_module._convert_local_row(
+        {"messages": [{"role": "user", "content": "Hi"}]},
+        "chat_messages",
+    ) == {"messages": [{"role": "user", "content": "Hi"}]}
+    assert training_dataset_module._convert_local_row(
+        {"prompt": "Question", "completion": "Answer"},
+        "prompt_completion",
+    ) == {"prompt": "Question", "completion": "Answer"}
+
+    empty_jsonl = tmp_path / "empty-stream.jsonl"
+    empty_jsonl.write_text("\n", encoding="utf-8")
+    with pytest.raises(ModelOperationError) as empty_exc:
+        training_dataset_module._resolve_local_training_samples(
+            empty_jsonl,
+            template="auto",
+            sample_limit=0,
+        )
+    assert empty_exc.value.code == "invalid_dataset_source"

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1009,19 +1009,11 @@ def _resolve_dataset_build_source(
             details={"dataset_uri": dataset_uri},
         )
 
-    rows = _read_local_jsonl_rows(source_path, sample_limit=sample_limit)
-    resolved_template = _resolve_local_conversion_template(
-        request_ext.get("template", "").strip() or "auto",
-        rows[0],
+    normalized_samples, format_name, resolved_template = _resolve_local_training_samples(
+        source_path,
+        template=request_ext.get("template", "").strip() or "auto",
+        sample_limit=sample_limit,
     )
-    format_name, converted_rows = _convert_local_rows(
-        rows,
-        resolved_template,
-    )
-    normalized_samples = [
-        _normalize_sample(sample, format_name=format_name, max_characters_per_sample=0)
-        for sample in converted_rows
-    ]
     dataset_id = request_ext.get("dataset_id", "").strip() or source_path.stem
     return {
         "dataset_id": dataset_id,
@@ -1039,8 +1031,8 @@ def _resolve_dataset_build_source(
     }
 
 
-def _read_local_jsonl_rows(path: Path, *, sample_limit: int) -> list[dict[str, Any]]:
-    rows: list[dict[str, Any]] = []
+def _iter_local_jsonl_rows(path: Path, *, sample_limit: int) -> Iterable[dict[str, Any]]:
+    yielded = 0
     with path.open("r", encoding="utf-8") as handle:
         for line_number, raw_line in enumerate(handle, start=1):
             line = raw_line.strip()
@@ -1060,9 +1052,16 @@ def _read_local_jsonl_rows(path: Path, *, sample_limit: int) -> list[dict[str, A
                     message="Local dataset rows must be JSON objects.",
                     details={"line": str(line_number)},
                 )
-            rows.append(payload)
-            if sample_limit > 0 and len(rows) >= sample_limit:
+            yield payload
+            yielded += 1
+            if sample_limit > 0 and yielded >= sample_limit:
                 break
+
+
+def _read_local_jsonl_rows(path: Path, *, sample_limit: int) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for payload in _iter_local_jsonl_rows(path, sample_limit=sample_limit):
+        rows.append(payload)
     if not rows:
         raise ModelOperationError(
             code="invalid_dataset_source",
@@ -1103,35 +1102,41 @@ def _resolve_local_conversion_template(template: str, sample_row: dict[str, Any]
     )
 
 
-def _convert_local_rows(
-    rows: list[dict[str, Any]],
-    template: str,
-) -> tuple[str, list[dict[str, Any]]]:
-    if template == "chat_messages":
-        return "chat_messages", [{"messages": row.get("messages")} for row in rows]
-    if template == "prompt_completion":
-        return "prompt_completion", [
-            {
-                "prompt": row.get("prompt"),
-                "completion": row.get("completion"),
-            }
-            for row in rows
-        ]
+def _local_conversion_format(template: str) -> str:
+    if template == "chat_messages" or template == "sharegpt":
+        return "chat_messages"
+    if template == "prompt_completion" or template == "alpaca":
+        return "prompt_completion"
     if template == "text_completion":
-        return "text_completion", [{"text": row.get("text")} for row in rows]
+        return "text_completion"
+    raise ModelOperationError(
+        code="invalid_dataset_source",
+        message=f"Unsupported dataset conversion template: {template}",
+    )
+
+
+def _convert_local_row(
+    row: dict[str, Any],
+    template: str,
+) -> dict[str, Any]:
+    if template == "chat_messages":
+        return {"messages": row.get("messages")}
+    if template == "prompt_completion":
+        return {
+            "prompt": row.get("prompt"),
+            "completion": row.get("completion"),
+        }
+    if template == "text_completion":
+        return {"text": row.get("text")}
     if template == "alpaca":
-        converted: list[dict[str, Any]] = []
-        for row in rows:
-            instruction = str(row.get("instruction", "")).strip()
-            input_text = str(row.get("input", "")).strip()
-            completion = str(row.get("output", row.get("response", ""))).strip()
-            prompt = instruction
-            if input_text:
-                prompt = f"{instruction}\n\nInput:\n{input_text}"
-            converted.append({"prompt": prompt, "completion": completion})
-        return "prompt_completion", converted
+        instruction = str(row.get("instruction", "")).strip()
+        input_text = str(row.get("input", "")).strip()
+        completion = str(row.get("output", row.get("response", ""))).strip()
+        prompt = instruction
+        if input_text:
+            prompt = f"{instruction}\n\nInput:\n{input_text}"
+        return {"prompt": prompt, "completion": completion}
     if template == "sharegpt":
-        converted = []
         role_map = {
             "system": "system",
             "human": "user",
@@ -1140,36 +1145,69 @@ def _convert_local_rows(
             "assistant": "assistant",
             "tool": "tool",
         }
-        for row in rows:
-            raw_conversations = row.get("conversations", row.get("conversation"))
-            if not isinstance(raw_conversations, list):
+        raw_conversations = row.get("conversations", row.get("conversation"))
+        if not isinstance(raw_conversations, list):
+            raise ModelOperationError(
+                code="invalid_dataset_source",
+                message="sharegpt conversion requires a conversations array.",
+            )
+        messages: list[dict[str, str]] = []
+        for turn_index, turn in enumerate(raw_conversations):
+            if not isinstance(turn, dict):
                 raise ModelOperationError(
                     code="invalid_dataset_source",
-                    message="sharegpt conversion requires a conversations array.",
+                    message="sharegpt conversations must contain JSON object turns.",
+                    details={"message_index": str(turn_index)},
                 )
-            messages: list[dict[str, str]] = []
-            for turn_index, turn in enumerate(raw_conversations):
-                if not isinstance(turn, dict):
-                    raise ModelOperationError(
-                        code="invalid_dataset_source",
-                        message="sharegpt conversations must contain JSON object turns.",
-                        details={"message_index": str(turn_index)},
-                    )
-                raw_role = str(turn.get("from", turn.get("role", ""))).strip().lower()
-                role = role_map.get(raw_role, "")
-                if not role:
-                    raise ModelOperationError(
-                        code="invalid_dataset_source",
-                        message="sharegpt conversion encountered an unsupported role.",
-                        details={"role": raw_role or "unknown"},
-                    )
-                messages.append({"role": role, "content": turn.get("value", turn.get("content", ""))})
-            converted.append({"messages": messages})
-        return "chat_messages", converted
+            raw_role = str(turn.get("from", turn.get("role", ""))).strip().lower()
+            role = role_map.get(raw_role, "")
+            if not role:
+                raise ModelOperationError(
+                    code="invalid_dataset_source",
+                    message="sharegpt conversion encountered an unsupported role.",
+                    details={"role": raw_role or "unknown"},
+                )
+            messages.append({"role": role, "content": turn.get("value", turn.get("content", ""))})
+        return {"messages": messages}
     raise ModelOperationError(
         code="invalid_dataset_source",
         message=f"Unsupported dataset conversion template: {template}",
     )
+
+
+def _resolve_local_training_samples(
+    path: Path,
+    *,
+    template: str,
+    sample_limit: int,
+) -> tuple[list[dict[str, Any]], str, str]:
+    row_iterator = iter(_iter_local_jsonl_rows(path, sample_limit=sample_limit))
+    first_row = next(row_iterator, None)
+    if first_row is None:
+        raise ModelOperationError(
+            code="invalid_dataset_source",
+            message="Local dataset source did not contain any usable rows.",
+            details={"dataset_uri": str(path)},
+        )
+    resolved_template = _resolve_local_conversion_template(template, first_row)
+    format_name = _local_conversion_format(resolved_template)
+    normalized_samples = [
+        _normalize_sample(
+            _convert_local_row(row, resolved_template),
+            format_name=format_name,
+            max_characters_per_sample=0,
+        )
+        for row in chain((first_row,), row_iterator)
+    ]
+    return normalized_samples, format_name, resolved_template
+
+
+def _convert_local_rows(
+    rows: list[dict[str, Any]],
+    template: str,
+) -> tuple[str, list[dict[str, Any]]]:
+    format_name = _local_conversion_format(template)
+    return format_name, [_convert_local_row(row, template) for row in rows]
 
 
 def _deterministic_validation_split(


### PR DESCRIPTION
## Summary
- stream local `services/mlx-worker-python/worker/model_ops/training_dataset.py` JSONL normalization so local-path dataset builds stop materializing separate raw-row and converted-row bulk lists
- keep the existing dataset output contract while inferring the conversion template from the first parsed row and normalizing the rest in one pass
- add focused regression tests for the streaming path and direct helper coverage for the new single-row conversion helpers

## Plan or Spec
- N/A: this is a small internal performance optimization slice for the Python worker with no canonical feature plan and no user-visible behavior change

## Commands Run
```text
uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_training_dataset_builder.py -q
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-133646/services/mlx-worker-python uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_training_dataset_builder.py -q
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-133646/services/mlx-worker-python uv run --project services/mlx-worker-python coverage erase
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-133646/services/mlx-worker-python uv run --project services/mlx-worker-python coverage run -m pytest services/mlx-worker-python/tests/test_training_dataset_builder.py -q
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-133646/services/mlx-worker-python uv run --project services/mlx-worker-python coverage json -o /tmp/melix-cron-python-opt-20260430-133646/coverage.json
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-133646/services/mlx-worker-python uv run --project services/mlx-worker-python coverage report --include='services/mlx-worker-python/worker/model_ops/training_dataset.py'
python3 <changed-line coverage script against git diff + coverage.json>
python3 <performance probe comparing old bulk local-path flow vs new streaming flow on 20k Alpaca rows>
git diff --check
```

## Coverage and Metrics
- changed executable-line coverage for `services/mlx-worker-python/worker/model_ops/training_dataset.py`: `100.00%` (`missed_changed_lines=[]` from the git-diff + coverage.json statement-aware check)
- whole-file coverage for `services/mlx-worker-python/worker/model_ops/training_dataset.py` under the focused test file: `83%`
- performance probe on synthetic 20,000-row Alpaca JSONL:
  - old path: `0.5304s`, `27.88 MiB` peak traced memory
  - new path: `0.3559s`, `10.09 MiB` peak traced memory
  - delta: `1.49x` faster, `17.79 MiB` lower peak traced memory

## Known Gaps
- full repository Python/macOS/Swift suites were not run in this Linux cron slice
- the focused coverage gate is changed-scope coverage, not full-file coverage for `training_dataset.py`
- no docs were updated because this change is internal-only and does not alter the external dataset package contract

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
