### PR TITLE
fix(benchmark): neutral metrics with no change are ok, not not_comparable

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -523,6 +523,48 @@ def test_neutral_direction_ok_when_equal_not_comparable_when_changed() -> None:
     assert report_changed["summary"]["not_comparable_count"] == 1
 
 
+def test_eval_sample_neutral_metrics_ok_when_equal_not_comparable_when_changed() -> None:
+    baseline = {
+        "evaluation_samples": [
+            {
+                "suite_id": "mmlu",
+                "inference_ms": 10.0,
+                "extraction_ms": 5.0,
+                "validation_ms": 2.0,
+                "scoring_ms": 1.0,
+                "raw_response_chars": 1,
+                "extracted_result_chars": 1,
+            }
+        ]
+    }
+    # Identical candidate — neutral eval-sample metrics should be ok
+    report_equal = build_benchmark_evaluation_report(baseline=baseline, candidate=baseline)
+    rows = {row["metric"]: row for row in report_equal["rows"]}
+    assert rows["eval.sample.mmlu.raw_response_chars_mean"]["status"] == "ok"
+    assert rows["eval.sample.mmlu.extracted_result_chars_mean"]["status"] == "ok"
+    assert report_equal["summary"]["not_comparable_count"] == 0
+
+    # Candidate with changed neutral metric — should be not_comparable
+    candidate_changed = {
+        "evaluation_samples": [
+            {
+                "suite_id": "mmlu",
+                "inference_ms": 10.0,
+                "extraction_ms": 5.0,
+                "validation_ms": 2.0,
+                "scoring_ms": 1.0,
+                "raw_response_chars": 3,
+                "extracted_result_chars": 1,
+            }
+        ]
+    }
+    report_changed = build_benchmark_evaluation_report(baseline=baseline, candidate=candidate_changed)
+    rows_changed = {row["metric"]: row for row in report_changed["rows"]}
+    assert rows_changed["eval.sample.mmlu.raw_response_chars_mean"]["status"] == "not_comparable"
+    assert rows_changed["eval.sample.mmlu.extracted_result_chars_mean"]["status"] == "ok"
+    assert report_changed["summary"]["not_comparable_count"] == 1
+
+
 def test_write_report_outputs_writes_json_and_markdown(tmp_path: Path) -> None:
     report = build_benchmark_evaluation_report(
         baseline=_bundle(ttft_ms=100.0, tokens_per_second=50.0, accuracy=0.8),

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -230,7 +230,7 @@ def test_report_builder_includes_runtime_metadata_and_decode_probes() -> None:
         "lower_is_better"
     )
     assert rows_by_metric[f"{label}.dflash_rollback_count_sum"]["status"] == "warning"
-    assert rows_by_metric[f"{label}.dflash_enabled_rate"]["status"] == "not_comparable"
+    assert rows_by_metric[f"{label}.dflash_enabled_rate"]["status"] == "ok"
     assert report["summary"]["warning_count"] == 4
 
 
@@ -463,6 +463,64 @@ def test_report_loader_accepts_export_bundle_directory_fallback(tmp_path: Path) 
     payload = load_report_input(bundle_dir)
 
     assert payload["export_schema_version"] == "melix.benchmark_export.v1"
+
+
+def test_neutral_direction_ok_when_equal_not_comparable_when_changed() -> None:
+    baseline = {
+        "benchmark_context_rows": [
+            {
+                "suite": "smoke",
+                "context_length": 2,
+                "generation_length": 8,
+                "batch_size": 1,
+                "tokens_in": 2,
+                "tokens_out": 1,
+                "first_token_index": 1,
+                "dflash_block_size": 0,
+                "dflash_enabled": False,
+                "dflash_target_hidden_layers": 0,
+                "speculative_draft_model_configured": False,
+                "speculative_num_draft_tokens": 0,
+            }
+        ]
+    }
+    # Candidate identical to baseline — every neutral metric should be ok
+    report_equal = build_benchmark_evaluation_report(baseline=baseline, candidate=baseline)
+    rows = {row["metric"]: row for row in report_equal["rows"]}
+    label = "bench.context.smoke.ctx2.gen8.b1"
+    assert rows[f"{label}.tokens_in_mean"]["status"] == "ok"
+    assert rows[f"{label}.tokens_out_mean"]["status"] == "ok"
+    assert rows[f"{label}.first_token_index_mean"]["status"] == "ok"
+    assert rows[f"{label}.dflash_block_size_mean"]["status"] == "ok"
+    assert rows[f"{label}.dflash_enabled_rate"]["status"] == "ok"
+    assert rows[f"{label}.dflash_target_hidden_layers_mean"]["status"] == "ok"
+    assert rows[f"{label}.speculative_draft_model_configured_rate"]["status"] == "ok"
+    assert rows[f"{label}.speculative_num_draft_tokens_mean"]["status"] == "ok"
+    assert report_equal["summary"]["not_comparable_count"] == 0
+
+    # Candidate with changed neutral metric — should be not_comparable
+    candidate_changed = {
+        "benchmark_context_rows": [
+            {
+                "suite": "smoke",
+                "context_length": 2,
+                "generation_length": 8,
+                "batch_size": 1,
+                "tokens_in": 4,
+                "tokens_out": 1,
+                "first_token_index": 1,
+                "dflash_block_size": 0,
+                "dflash_enabled": False,
+                "dflash_target_hidden_layers": 0,
+                "speculative_draft_model_configured": False,
+                "speculative_num_draft_tokens": 0,
+            }
+        ]
+    }
+    report_changed = build_benchmark_evaluation_report(baseline=baseline, candidate=candidate_changed)
+    rows_changed = {row["metric"]: row for row in report_changed["rows"]}
+    assert rows_changed[f"{label}.tokens_in_mean"]["status"] == "not_comparable"
+    assert report_changed["summary"]["not_comparable_count"] == 1
 
 
 def test_write_report_outputs_writes_json_and_markdown(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -296,7 +296,7 @@ def _build_metric_row(
     delta = candidate_number - baseline_number
     delta_pct = (delta / abs(baseline_number) * 100.0) if baseline_number != 0 else None
     if direction == "neutral":
-        status = "ok" if delta == 0 else "not_comparable"
+        status = "ok" if round(delta, 6) == 0 else "not_comparable"
     else:
         status = "ok"
     if direction == "lower_is_better" and (

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -295,7 +295,10 @@ def _build_metric_row(
         }
     delta = candidate_number - baseline_number
     delta_pct = (delta / abs(baseline_number) * 100.0) if baseline_number != 0 else None
-    status = "not_comparable" if direction == "neutral" else "ok"
+    if direction == "neutral":
+        status = "ok" if delta == 0 else "not_comparable"
+    else:
+        status = "ok"
     if direction == "lower_is_better" and (
         (delta_pct is not None and delta_pct > _WARNING_THRESHOLD_PCT)
         or (baseline_number == 0 and candidate_number > baseline_number)


### PR DESCRIPTION
## Summary

Fixes 26 spurious `not_comparable` entries seen in the [PR #99 benchmark report](https://github.com/Keith-CY/melix/pull/99#issuecomment-4350053761).

Root cause: `_build_metric_row` in `benchmark_evaluation_report.py` unconditionally set `status = "not_comparable"` for any metric with `direction == "neutral"`, even when baseline == candidate (delta = 0). Affected metrics include `tokens_in_mean`, `tokens_out_mean`, `first_token_index_mean`, `dflash_block_size_mean`, `dflash_enabled_rate`, `dflash_target_hidden_layers_mean`, `speculative_draft_model_configured_rate`, `speculative_num_draft_tokens_mean`, `raw_response_chars_mean`, `extracted_result_chars_mean`.

Fix: **neutral + delta=0 → `ok`**; neutral + delta≠0 → `not_comparable` (a change exists but we can't assess its direction). Metrics with a known direction (`lower_is_better` / `higher_is_better`) are unaffected.

## Plan or Spec

Identified in PR #99 benchmark report comment. The fix is a single conditional change in `_build_metric_row` (line 298 of `benchmark_evaluation_report.py`): replace the unconditional `not_comparable` for neutral-direction metrics with a delta-aware check. No architectural changes needed.

## Commands Run

- `PYTHONPATH=services/mlx-worker-python pytest services/mlx-worker-python/tests/test_benchmark_evaluation_report.py -v` → 18 passed (17 existing + 1 new)

## Coverage and Metrics

- Modified: `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py` (3 lines changed)
- Modified: `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py` (updated 1 assertion + added `test_neutral_direction_ok_when_equal_not_comparable_when_changed` covering both the zero-delta and non-zero-delta cases)
- All 18 tests pass; the new test explicitly exercises the previously broken path

## Known Gaps

- Metrics that are consistently neutral and change between runs will still show `not_comparable` (by design — no direction is known). If specific neutral metrics gain a known direction in the future, they should be added to `lower_fragments` or `higher_fragments` in `_metric_direction`.

https://claude.ai/code/session_019UV6Ema2Yjmayuz3WG4WtY