### PR TITLE
perf: stream benchmark export JSONL rows

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -5,7 +5,10 @@ import io
 import json
 from pathlib import Path
 
+import pytest
+
 from worker.productization.benchmark_export import (
+    _iter_jsonl_dict_rows,
     build_comparison_table,
     build_benchmark_batch_csv,
     build_benchmark_context_csv,
@@ -573,6 +576,23 @@ def test_collect_benchmark_artifacts_ignores_blank_and_non_object_jsonl_rows(tmp
     assert result["benchmark_batch_rows"] == [{"job_id": "bench-1", "row_kind": "batch"}]
     assert result["benchmark_matrix_summary_rows"] == [{"job_id": "bench-matrix-1", "row_kind": "summary"}]
     assert result["benchmark_matrix_request_rows"] == [{"job_id": "bench-matrix-1", "row_kind": "request"}]
+
+
+def test_iter_jsonl_dict_rows_streams_rows_lazily(tmp_path: Path) -> None:
+    path = tmp_path / "streamed.jsonl"
+    path.write_text(
+        "\n".join([
+            json.dumps({"job_id": "bench-1", "row_kind": "context"}),
+            "not-json",
+        ]) + "\n",
+        encoding="utf-8",
+    )
+
+    rows = _iter_jsonl_dict_rows(path)
+
+    assert next(rows) == {"job_id": "bench-1", "row_kind": "context"}
+    with pytest.raises(json.JSONDecodeError):
+        next(rows)
 
 
 def test_collect_evaluation_artifacts_ignores_blank_and_non_object_jsonl_rows(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -4,6 +4,7 @@ import csv
 import json
 import io
 import time
+from collections.abc import Iterator
 from pathlib import Path
 
 _EXPORT_SCHEMA_VERSION = "melix.benchmark_export.v1"
@@ -446,8 +447,7 @@ def _collect_benchmark_matrix_run(
         request_rows.extend(_iter_jsonl_dict_rows(requests_path))
 
 
-def _iter_jsonl_dict_rows(path: Path) -> list[dict[str, object]]:
-    rows: list[dict[str, object]] = []
+def _iter_jsonl_dict_rows(path: Path) -> Iterator[dict[str, object]]:
     with path.open("r", encoding="utf-8") as handle:
         for line in handle:
             stripped = line.strip()
@@ -455,8 +455,7 @@ def _iter_jsonl_dict_rows(path: Path) -> list[dict[str, object]]:
                 continue
             row = json.loads(stripped)
             if isinstance(row, dict):
-                rows.append(row)
-    return rows
+                yield row
 
 
 def _rows_to_csv(rows: list[dict[str, object]], fieldnames: list[str]) -> str:


### PR DESCRIPTION
## Summary
- Stream `worker.productization.benchmark_export._iter_jsonl_dict_rows()` instead of materializing an intermediate list for every JSONL artifact file.
- Add a focused regression test that proves rows are yielded lazily.
- Keep the change scoped to Linux-verifiable Python code in `services/mlx-worker-python`.

## Plan or Spec
- N/A: this is a small internal allocation/performance optimization for benchmark export helper code; it does not change the public product contract and no canonical spec currently governs this helper.

## Commands Run
```text
pytest red check:
- cd services/mlx-worker-python && pytest -q tests/test_benchmark_export.py -k streams_rows_lazily
- Result: FAILED with JSONDecodeError raised during helper construction, confirming eager materialization before the fix.

focused green checks:
- cd services/mlx-worker-python && pytest -q tests/test_benchmark_export.py -k streams_rows_lazily
- Result: 1 passed, 30 deselected
- cd services/mlx-worker-python && pytest -q tests/test_benchmark_export.py
- Result: 31 passed

coverage:
- cd services/mlx-worker-python && coverage erase
- cd services/mlx-worker-python && coverage run -m pytest -q tests/test_benchmark_export.py
- Result: 31 passed
- cd services/mlx-worker-python && coverage json -o coverage.json
- Result: JSON report written
- changed-scope coverage script over git diff hunks
- Result: changed_line_coverage=100.00% with no missed changed lines

performance probe:
- inline python probe comparing old list materialization vs new generator streaming over 200000 JSONL rows
- Result: old_list_materialization elapsed_s=2.283232 peak_bytes=156622851; new_generator_streaming elapsed_s=2.039391 peak_bytes=155024761

sanity:
- git diff --check
- Result: clean
```

## Coverage and Metrics
- Changed-scope coverage for `services/mlx-worker-python/worker/productization/benchmark_export.py`: `100.00%`
- Measurable changed lines: `7, 450, 458`
- Missed changed lines: `none`
- Performance probe on 200000 synthetic JSONL rows:
  - Wall-clock: `2.283232s` -> `2.039391s` (`10.68%` faster)
  - Peak traced allocations: `156622851` -> `155024761` bytes (`1598090` bytes / `1.02%` lower)

## Known Gaps
- None for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
