### PR TITLE
perf: stream benchmark export CSV rows

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -9,6 +9,7 @@ import pytest
 
 from worker.productization.benchmark_export import (
     _iter_jsonl_dict_rows,
+    _rows_to_csv,
     build_comparison_table,
     build_benchmark_batch_csv,
     build_benchmark_context_csv,
@@ -1109,6 +1110,21 @@ def test_evaluation_samples_csv_builder_maps_sample_id_and_preserves_modalities(
     assert rows[0]["extraction_status"] == "extracted"
     assert rows[0]["validation_status"] == "validated"
     assert rows[0]["input_modalities"] == "text"
+
+
+def test_rows_to_csv_accepts_generators_without_materializing_lists() -> None:
+    rows = (
+        {"job_id": f"eval-{index}", "typed_score": index / 10}
+        for index in range(3)
+    )
+
+    csv_text = _rows_to_csv(rows, ["job_id", "typed_score"])
+
+    assert list(csv.DictReader(io.StringIO(csv_text))) == [
+        {"job_id": "eval-0", "typed_score": "0.0"},
+        {"job_id": "eval-1", "typed_score": "0.1"},
+        {"job_id": "eval-2", "typed_score": "0.2"},
+    ]
 
 
 def test_evaluation_compare_csv_builders_emit_compare_rows() -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -4,7 +4,7 @@ import csv
 import json
 import io
 import time
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 
 _EXPORT_SCHEMA_VERSION = "melix.benchmark_export.v1"
@@ -138,9 +138,8 @@ def build_export_bundle(jobs_root: Path) -> dict[str, object]:
 
 
 def build_evaluation_summary_csv(bundle: dict[str, object]) -> str:
-    rows = [row for row in bundle.get("evaluation_summary_rows", []) if isinstance(row, dict)]
     return _rows_to_csv(
-        rows,
+        (row for row in bundle.get("evaluation_summary_rows", []) if isinstance(row, dict)),
         [
             "job_id",
             "model_id",
@@ -168,17 +167,19 @@ def build_evaluation_summary_csv(bundle: dict[str, object]) -> str:
 
 
 def build_evaluation_samples_csv(bundle: dict[str, object]) -> str:
-    rows = [row for row in bundle.get("evaluation_samples", []) if isinstance(row, dict)]
     return _rows_to_csv(
-        [_normalized_evaluation_sample_row(row) for row in rows],
+        (
+            _normalized_evaluation_sample_row(row)
+            for row in bundle.get("evaluation_samples", [])
+            if isinstance(row, dict)
+        ),
         _canonical_evaluation_sample_columns(),
     )
 
 
 def build_evaluation_compare_summary_csv(bundle: dict[str, object]) -> str:
-    rows = [row for row in bundle.get("evaluation_compare_summary_rows", []) if isinstance(row, dict)]
     return _rows_to_csv(
-        rows,
+        (row for row in bundle.get("evaluation_compare_summary_rows", []) if isinstance(row, dict)),
         [
             "job_id",
             "base_model_id",
@@ -199,9 +200,8 @@ def build_evaluation_compare_summary_csv(bundle: dict[str, object]) -> str:
 
 
 def build_evaluation_compare_samples_csv(bundle: dict[str, object]) -> str:
-    rows = [row for row in bundle.get("evaluation_compare_samples", []) if isinstance(row, dict)]
     return _rows_to_csv(
-        rows,
+        (row for row in bundle.get("evaluation_compare_samples", []) if isinstance(row, dict)),
         [
             "job_id",
             "suite_id",
@@ -251,9 +251,8 @@ def build_evaluation_compare_samples_csv(bundle: dict[str, object]) -> str:
 
 
 def build_benchmark_summary_csv(bundle: dict[str, object]) -> str:
-    rows = [row for row in bundle.get("benchmark_summary_rows", []) if isinstance(row, dict)]
     return _rows_to_csv(
-        rows,
+        (row for row in bundle.get("benchmark_summary_rows", []) if isinstance(row, dict)),
         [
             "job_id",
             "model_id",
@@ -278,23 +277,31 @@ def build_benchmark_summary_csv(bundle: dict[str, object]) -> str:
 
 
 def build_benchmark_context_csv(bundle: dict[str, object]) -> str:
-    rows = [row for row in bundle.get("benchmark_context_rows", []) if isinstance(row, dict)]
-    return _rows_to_csv(rows, _canonical_benchmark_row_columns())
+    return _rows_to_csv(
+        (row for row in bundle.get("benchmark_context_rows", []) if isinstance(row, dict)),
+        _canonical_benchmark_row_columns(),
+    )
 
 
 def build_benchmark_batch_csv(bundle: dict[str, object]) -> str:
-    rows = [row for row in bundle.get("benchmark_batch_rows", []) if isinstance(row, dict)]
-    return _rows_to_csv(rows, _canonical_benchmark_row_columns())
+    return _rows_to_csv(
+        (row for row in bundle.get("benchmark_batch_rows", []) if isinstance(row, dict)),
+        _canonical_benchmark_row_columns(),
+    )
 
 
 def build_benchmark_matrix_summary_csv(bundle: dict[str, object]) -> str:
-    rows = [row for row in bundle.get("benchmark_matrix_summary_rows", []) if isinstance(row, dict)]
-    return _rows_to_csv(rows, _canonical_benchmark_matrix_summary_columns())
+    return _rows_to_csv(
+        (row for row in bundle.get("benchmark_matrix_summary_rows", []) if isinstance(row, dict)),
+        _canonical_benchmark_matrix_summary_columns(),
+    )
 
 
 def build_benchmark_matrix_requests_csv(bundle: dict[str, object]) -> str:
-    rows = [row for row in bundle.get("benchmark_matrix_request_rows", []) if isinstance(row, dict)]
-    return _rows_to_csv(rows, _canonical_benchmark_matrix_request_columns())
+    return _rows_to_csv(
+        (row for row in bundle.get("benchmark_matrix_request_rows", []) if isinstance(row, dict)),
+        _canonical_benchmark_matrix_request_columns(),
+    )
 
 
 def write_export_bundle(jobs_root: Path, output_path: Path) -> Path:
@@ -458,7 +465,7 @@ def _iter_jsonl_dict_rows(path: Path) -> Iterator[dict[str, object]]:
                 yield row
 
 
-def _rows_to_csv(rows: list[dict[str, object]], fieldnames: list[str]) -> str:
+def _rows_to_csv(rows: Iterable[dict[str, object]], fieldnames: list[str]) -> str:
     buffer = io.StringIO()
     writer = csv.DictWriter(buffer, fieldnames=fieldnames, extrasaction="ignore")
     writer.writeheader()


### PR DESCRIPTION
## Summary
- Stream CSV export row filtering/normalization in `services/mlx-worker-python/worker/productization/benchmark_export.py` so the export helpers stop materializing intermediate row lists before writing.
- Keep CSV output unchanged while reducing memory pressure on large evaluation sample exports.
- Add a focused regression test that `_rows_to_csv()` accepts generator inputs.

## Plan or Spec
- N/A: this is a small Python-only performance optimization slice with no canonical plan/spec for the internal implementation detail, and it does not change the external export schema or product behavior.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python python -m pytest services/mlx-worker-python/tests/test_benchmark_export.py -q
# 32 passed in 0.13s

python - <<'PY'
# compared origin/main vs current branch for build_evaluation_samples_csv on 50,000 rows
PY
# baseline mean time: 2.166s, baseline peak mean: 59.867 MB
# current mean time: 2.112s, current peak mean: 19.347 MB
# time delta: -2.52%, peak memory delta: -67.68% (-40.52 MB)

coverage erase
PYTHONPATH=services/mlx-worker-python coverage run -m pytest services/mlx-worker-python/tests/test_benchmark_export.py -q
coverage json -o coverage.json
python - <<'PY'
# changed-scope coverage from git diff for benchmark_export.py
PY
# changed_line_coverage=100.00%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage for `services/mlx-worker-python/worker/productization/benchmark_export.py`: `100.00%` (`missed_changed_lines=[]`).
- Performance probe for `build_evaluation_samples_csv()` with 50,000 synthetic rows:
  - baseline (`origin/main`) mean time: `2.166s`
  - current branch mean time: `2.112s`
  - mean wall-clock delta: `-2.52%`
  - baseline peak traced memory: `59.867 MB`
  - current branch peak traced memory: `19.347 MB`
  - peak memory delta: `-67.68%` (`-40.52 MB`)
- Output length stayed identical at `8,629,449` bytes.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
