### PR TITLE
perf: streamline stream assembler structural tag scans

### DIFF
--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -5,6 +5,45 @@ import logging
 from worker.runtime.stream_assembler import RequestStreamAssembler, StreamFragment
 
 
+def test_structural_tag_prefixes_are_cached_per_parser_mode() -> None:
+    think_prefixes = tuple(
+        RequestStreamAssembler._THINK_OPEN[:index]
+        for index in range(1, len(RequestStreamAssembler._THINK_OPEN))
+    )
+    tool_prefixes = tuple(
+        RequestStreamAssembler._TOOL_OPEN[:index]
+        for index in range(1, len(RequestStreamAssembler._TOOL_OPEN))
+    )
+
+    tool_enabled = RequestStreamAssembler(
+        request_id="req-prefixes-tools",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+    tool_disabled = RequestStreamAssembler(
+        request_id="req-prefixes-think-only",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="",
+    )
+
+    assert tool_enabled._structural_tag_prefixes == think_prefixes + tool_prefixes
+    assert tool_disabled._structural_tag_prefixes == think_prefixes
+
+
+def test_next_structural_tag_prefers_the_earliest_tool_tag() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-tool-first",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+    assembler._buffer = '<tool_call>{"name":"search","arguments":{}}</tool_call><think>later</think>'
+
+    assert assembler._next_structural_tag() == (RequestStreamAssembler._TOOL_OPEN, 0)
+
+
 def test_stream_assembler_instances_do_not_share_request_state() -> None:
     assemblers = [
         RequestStreamAssembler(
@@ -198,6 +237,26 @@ def test_split_structural_tag_prefix_longer_than_one_character_is_not_public_con
     assert [delta.reasoning_text for delta in deltas if delta.reasoning_text] == ["hidden"]
 
 
+def test_split_tool_tag_prefix_longer_than_one_character_is_not_public_content() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-split-tool-tag-prefix",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+
+    assert assembler.accept(StreamFragment(raw_text="alpha<tool_ca")) == []
+    deltas = assembler.accept(
+        StreamFragment(
+            raw_text='alpha<tool_call>{"name":"search","arguments":{"q":"alpha"}}</tool_call>'
+        )
+    )
+
+    assert [delta.content_text for delta in deltas if delta.content_text] == ["alpha"]
+    calls = [delta.tool_call for delta in deltas if delta.tool_call]
+    assert [call.tool_name for call in calls] == ["search"]
+
+
 def test_truncated_reasoning_is_recoverable_and_not_public_content() -> None:
     assembler = RequestStreamAssembler(
         request_id="req-truncated-reasoning",
@@ -301,3 +360,14 @@ def test_repeated_tool_calls_with_distinct_call_ids_are_emitted() -> None:
     assert [call.call_id for call in calls] == ["call-1", "call-2"]
     assert [call.tool_name for call in calls] == ["search", "search"]
     assert assembler.completed().metrics["duplicate_tool_delta_count"] == 0
+
+
+def test_first_json_delimiter_prefers_array_when_it_appears_first() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-array-first",
+        reasoning_enabled=False,
+        structured_output_mode="json_schema",
+        tool_parser_mode="",
+    )
+
+    assert assembler._first_json_delimiter("prefix [1, 2]{\"later\": true}") == 7

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -44,6 +44,8 @@ class RequestStreamAssembler:
     _THINK_CLOSE = "</think>"
     _TOOL_OPEN = "<tool_call>"
     _TOOL_CLOSE = "</tool_call>"
+    _THINK_PREFIXES = tuple("<think>"[:index] for index in range(1, len("<think>")))
+    _TOOL_PREFIXES = tuple("<tool_call>"[:index] for index in range(1, len("<tool_call>")))
 
     def __init__(
         self,
@@ -109,6 +111,12 @@ class RequestStreamAssembler:
     @property
     def _tool_parsing_enabled(self) -> bool:
         return bool(self._tool_parser_mode) and not self._is_json_structured_output
+
+    @property
+    def _structural_tag_prefixes(self) -> tuple[str, ...]:
+        if self._tool_parsing_enabled:
+            return self._THINK_PREFIXES + self._TOOL_PREFIXES
+        return self._THINK_PREFIXES
 
     def _unseen_delta(self, raw: str) -> str:
         if raw.startswith(self._raw_seen):
@@ -203,27 +211,19 @@ class RequestStreamAssembler:
         return deltas
 
     def _next_structural_tag(self) -> tuple[str, int] | None:
-        candidates: list[tuple[str, int]] = []
         think_index = self._buffer.find(self._THINK_OPEN)
-        if think_index >= 0:
-            candidates.append((self._THINK_OPEN, think_index))
-        if self._tool_parsing_enabled:
-            tool_index = self._buffer.find(self._TOOL_OPEN)
-            if tool_index >= 0:
-                candidates.append((self._TOOL_OPEN, tool_index))
-        if not candidates:
-            return None
-        return min(candidates, key=lambda item: item[1])
+        if not self._tool_parsing_enabled:
+            return None if think_index < 0 else (self._THINK_OPEN, think_index)
+
+        tool_index = self._buffer.find(self._TOOL_OPEN)
+        if think_index < 0:
+            return None if tool_index < 0 else (self._TOOL_OPEN, tool_index)
+        if tool_index < 0 or think_index <= tool_index:
+            return (self._THINK_OPEN, think_index)
+        return (self._TOOL_OPEN, tool_index)
 
     def _has_partial_structural_tag_suffix(self) -> bool:
-        tags = [self._THINK_OPEN]
-        if self._tool_parsing_enabled:
-            tags.append(self._TOOL_OPEN)
-        return any(
-            self._buffer.endswith(tag[:prefix_length])
-            for tag in tags
-            for prefix_length in range(1, len(tag))
-        )
+        return any(self._buffer.endswith(prefix) for prefix in self._structural_tag_prefixes)
 
     def _content_delta(self, content: str) -> AssemblyDelta:
         self._assistant_parts.append(content)
@@ -266,7 +266,10 @@ class RequestStreamAssembler:
         )
 
     def _first_json_delimiter(self, text: str) -> int | None:
-        indexes = [index for index in (text.find("{"), text.find("[")) if index >= 0]
-        if not indexes:
-            return None
-        return min(indexes)
+        object_index = text.find("{")
+        array_index = text.find("[")
+        if object_index < 0:
+            return None if array_index < 0 else array_index
+        if array_index < 0 or object_index <= array_index:
+            return object_index
+        return array_index


### PR DESCRIPTION
## Summary
- Cache structural tag prefixes in the Python stream assembler instead of rebuilding partial-tag candidates on every buffer drain.
- Replace list-building/min scans in `_next_structural_tag` and `_first_json_delimiter` with direct comparisons to cut temporary allocations on hot parsing paths.
- Add focused stream assembler tests covering cached prefixes, tool-first tag selection, split tool-tag recovery, and array-first JSON delimiter handling.

## Plan or Spec
- N/A: this is a small internal Python-only performance slice in `services/mlx-worker-python` with no governing repo plan/spec and no external behavior contract change.

## Commands Run
```text
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-150249/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-150249 python3 -m pytest tests/test_stream_assembler.py -q -k 'structural_tag_prefixes_are_cached_per_parser_mode or split_tool_tag_prefix_longer_than_one_character'
# 2 passed, 15 deselected

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-150249/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-150249 python3 -m pytest tests/test_stream_assembler.py -q
# 19 passed

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-150249/services/mlx-worker-python:/tmp/melix-cron-python-opt-20260430-150249 coverage run -m pytest tests/test_stream_assembler.py -q
coverage json -o coverage.json
python3 <changed-scope coverage script for worker/runtime/stream_assembler.py>
# changed_line_coverage=100.00%

python3 <baseline-vs-branch microbenchmark for stream_assembler helpers>
# partial_tool_suffix: baseline=1.4105s current=0.9643s delta=0.4461s speedup=31.63% loops=500000
# next_structural_tag_tool_first: baseline=0.4902s current=0.2377s delta=0.2525s speedup=51.51% loops=500000
# first_json_delimiter_array_first: baseline=0.2310s current=0.1025s delta=0.1285s speedup=55.62% loops=500000

git diff --check
```

## Coverage and Metrics
- Changed-scope coverage for `worker/runtime/stream_assembler.py`: `100.00%`
- Measurable changed lines: `[47, 48, 115, 116, 117, 118, 119, 215, 216, 218, 219, 220, 221, 222, 223, 226, 269, 270, 271, 272, 273, 274, 275]`
- Microbenchmark vs `origin/main` on this Linux host:
  - `partial_tool_suffix`: `1.4105s -> 0.9643s` (`31.63%` faster, 500000 loops)
  - `next_structural_tag_tool_first`: `0.4902s -> 0.2377s` (`51.51%` faster, 500000 loops)
  - `first_json_delimiter_array_first`: `0.2310s -> 0.1025s` (`55.62%` faster, 500000 loops)

## Known Gaps
- Focused Linux verification only; no macOS/Swift verification was run for this cron slice.
- Performance evidence is microbenchmark-based on helper hot paths rather than a full end-to-end runtime trace.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
