### PR TITLE
perf(python): bound local eval dataset parsing

### DIFF
--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -385,6 +385,77 @@ def test_plan_evaluation_samples_preserves_order_without_shuffle() -> None:
     ]
 
 
+def test_run_local_suite_only_loads_needed_prefix_without_shuffle(tmp_path: Path) -> None:
+    dataset_root = _write_dataset_package(
+        tmp_path=tmp_path,
+        dataset_id="mmlu-dev-prefix",
+        suite_id="mmlu",
+        samples=(
+            {"id": "1", "prompt": "2+2?", "expected": "4"},
+            {"id": "2", "prompt": "3+3?", "expected": "6"},
+            {"id": "3", "prompt": "4+4?", "expected": "8"},
+        ),
+    )
+    (dataset_root / "samples.jsonl").write_text(
+        '{"id": "1", "input": {"text": "2+2?"}, "target": "4"}\n'
+        '{"id": "2", "input": {"text": "3+3?"}, "target": "6"}\n'
+        '{"id": "3", "input": {"text": "4+4?"}, "target": "8"\n',
+        encoding="utf-8",
+    )
+
+    backend = ScriptedEvaluationBackend(("Answer: 6",))
+    runtime = MLXTextRuntime(backend=backend)
+    registry = FakeEvaluationRegistry(runtime=runtime, model_id="persisted-eval-model")
+    runner = EvaluationCore(jobs_root=tmp_path / "runs" / "mmlu", registry=registry)
+
+    run = runner.run_local_suite(
+        model_id="persisted-eval-model",
+        model_handle=registry.handle,
+        suite_id="mmlu",
+        dataset_root=dataset_root,
+        sample_size=1,
+        few_shot=1,
+        seed=0,
+        scoring_mode="multiple_choice_accuracy",
+        code_exec_policy="disabled",
+    )
+
+    assert [sample.input_text for sample in run.samples] == ["3+3?"]
+    assert [sample.extracted_result for sample in run.samples] == ["6"]
+
+
+def test_run_local_suite_skips_dataset_parsing_for_zero_sample_request(tmp_path: Path) -> None:
+    dataset_root = _write_dataset_package(
+        tmp_path=tmp_path,
+        dataset_id="mmlu-dev-zero",
+        suite_id="mmlu",
+        samples=(({"id": "1", "prompt": "2+2?", "expected": "4"}),),
+    )
+    (dataset_root / "samples.jsonl").write_text(
+        '{"id": "1", "input": {"text": "2+2?"}, "target": "4"\n',
+        encoding="utf-8",
+    )
+
+    backend = ScriptedEvaluationBackend(())
+    runtime = MLXTextRuntime(backend=backend)
+    registry = FakeEvaluationRegistry(runtime=runtime, model_id="persisted-eval-model")
+    runner = EvaluationCore(jobs_root=tmp_path / "runs" / "mmlu", registry=registry)
+
+    run = runner.run_local_suite(
+        model_id="persisted-eval-model",
+        model_handle=registry.handle,
+        suite_id="mmlu",
+        dataset_root=dataset_root,
+        sample_size=0,
+        few_shot=0,
+        seed=7,
+        scoring_mode="multiple_choice_accuracy",
+        code_exec_policy="disabled",
+    )
+
+    assert run.samples == ()
+
+
 def test_run_local_suite_reuses_combined_sample_list_for_validators(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -118,7 +118,13 @@ class EvaluationCore:
         self._registry = registry
 
     @staticmethod
-    def _load_dataset_samples(samples_path: Path) -> list[dict[str, Any]]:
+    def _load_dataset_samples(
+        samples_path: Path,
+        *,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        if limit is not None and limit <= 0:
+            return []
         samples: list[dict[str, Any]] = []
         with samples_path.open("r", encoding="utf-8") as handle:
             for raw_line in handle:
@@ -126,6 +132,8 @@ class EvaluationCore:
                 if not line:
                     continue
                 samples.append(json.loads(line))
+                if limit is not None and len(samples) >= limit:
+                    break
         return samples
 
     def run_local_suite(
@@ -149,7 +157,6 @@ class EvaluationCore:
                 f"Dataset suite mismatch: expected {suite_id}, found {manifest['suite_id']}"
             )
 
-        samples = EvaluationCore._load_dataset_samples(dataset_root / "samples.jsonl")
         score_name, default_scoring_mode = _SUITE_SCORE_MODES.get(
             suite_id,
             ("typed_score_mean", str(manifest.get("scoring_mode") or "normalized_exact_match")),
@@ -196,6 +203,15 @@ class EvaluationCore:
             explicit_value=seed,
             parameters=parameters,
             key="seed",
+        )
+        prefix_sample_limit = self._dataset_sample_load_limit(
+            sample_size=sample_size,
+            few_shot=resolved_few_shot,
+            seed=resolved_seed,
+        )
+        samples = EvaluationCore._load_dataset_samples(
+            dataset_root / "samples.jsonl",
+            limit=prefix_sample_limit,
         )
         requested_scoring_mode = (
             scoring_mode
@@ -989,6 +1005,17 @@ class EvaluationCore:
         if normalized and normalized not in _CODE_EXEC_DISABLED_POLICIES:
             raise ValueError(f"Unsupported code_exec_policy '{normalized}' for suite {suite_id}")
         return normalized or "disabled"
+
+    @staticmethod
+    def _dataset_sample_load_limit(*, sample_size: int, few_shot: int, seed: int) -> int | None:
+        bounded_sample_size = max(sample_size, 0)
+        bounded_few_shot = max(few_shot, 0)
+        total_requested = bounded_sample_size + bounded_few_shot
+        if total_requested == 0:
+            return 0
+        if seed <= 0:
+            return total_requested
+        return None
 
     @staticmethod
     def _plan_evaluation_samples(


### PR DESCRIPTION
## Summary
- bound `EvaluationCore` dataset parsing to the deterministic prefix needed for non-shuffled local evaluation runs
- skip JSONL parsing entirely for zero-sample local evaluation requests
- add regression coverage for deterministic prefix loading and zero-sample malformed-JSONL handling

## Plan or Spec
- N/A: this is a small Python-only performance optimization slice from the autonomous cron mission, not a repository-governed canonical spec or plan update

## Commands Run
```text
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-153446:/tmp/melix-cron-python-opt-20260430-153446/services/mlx-worker-python python -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py -k only_loads_needed_prefix_without_shuffle
PASS (1 passed, 54 deselected)

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-153446:/tmp/melix-cron-python-opt-20260430-153446/services/mlx-worker-python python -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py -k 'load_dataset_samples or plan_evaluation_samples or only_loads_needed_prefix_without_shuffle or skips_dataset_parsing_for_zero_sample_request or run_local_suite_streams_samples_jsonl_without_read_text or run_local_suite_reuses_combined_sample_list_for_validators'
PASS (6 passed, 50 deselected)

coverage run /tmp/coverage_runner_melix_eval_opt.py
PASS (6 passed, 50 deselected)

coverage json -o coverage.json
PASS

python changed-scope coverage probe over services/mlx-worker-python/worker/engine/evaluation_core.py
PASS (100.00% changed executable line coverage; no missed changed lines)

python performance probe comparing EvaluationCore._load_dataset_samples(limit=None) vs limit=2 on a 50,000-row JSONL
PASS

git diff --check
PASS
```

## Coverage and Metrics
- changed executable scope: `services/mlx-worker-python/worker/engine/evaluation_core.py`
- changed-scope automated coverage: `100.00%`
- covered changed executable lines: `[121, 126, 127, 135, 136, 207, 212, 1009, 1010, 1011, 1012, 1013, 1014, 1015, 1016, 1017, 1018]`
- missed changed executable lines: `[]`
- performance probe on synthetic 50,000-row `samples.jsonl`:
  - full parse (`limit=None`): mean `0.5698s`, mean peak memory `36.49 MiB`, rows loaded `50000`
  - bounded prefix (`limit=2`): mean `0.000080s`, mean peak memory `0.0206 MiB`, rows loaded `2`

## Known Gaps
- targeted Linux-verifiable pytest coverage was run for the touched evaluation-core scope; the full repository suite was not run in this cron slice
- no canonical docs/spec files were updated because this is an internal performance optimization with no intended external contract change

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
