### PR TITLE
Optimize benchmark export run directory scanning

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -9,6 +9,7 @@ import pytest
 
 from worker.productization.benchmark_export import (
     _iter_jsonl_dict_rows,
+    _iter_sorted_child_directories,
     _rows_to_csv,
     build_comparison_table,
     build_benchmark_batch_csv,
@@ -536,6 +537,21 @@ def test_collect_benchmark_artifacts_reads_matrix_run_history_from_matrix_runs_d
     assert [job["job_id"] for job in result["benchmark_matrix_jobs"]] == ["bench-matrix-1", "bench-matrix-2"]
     assert [row["job_id"] for row in result["benchmark_matrix_summary_rows"]] == ["bench-matrix-1", "bench-matrix-2"]
     assert [row["job_id"] for row in result["benchmark_matrix_request_rows"]] == ["bench-matrix-1", "bench-matrix-2"]
+
+
+def test_iter_sorted_child_directories_returns_sorted_directories(tmp_path: Path) -> None:
+    parent = tmp_path / "artifacts"
+    (parent / "b_dir").mkdir(parents=True)
+    (parent / "a_dir").mkdir(parents=True)
+    (parent / "c_file").write_text("x")
+    (parent / "a_file.txt").write_text("x")
+
+    # ensure non-directories are ignored and ordering is lexical
+    assert [path.name for path in _iter_sorted_child_directories(parent)] == ["a_dir", "b_dir"]
+
+
+def test_iter_sorted_child_directories_nonexistent_root_returns_empty() -> None:
+    assert _iter_sorted_child_directories(Path("/tmp/this-path-should-not-exist-12345")) == ()
 
 
 def test_collect_benchmark_artifacts_ignores_blank_and_non_object_jsonl_rows(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -5,6 +5,7 @@ import json
 import io
 import time
 from collections.abc import Iterable, Iterator
+import os
 from pathlib import Path
 
 _EXPORT_SCHEMA_VERSION = "melix.benchmark_export.v1"
@@ -44,25 +45,23 @@ def collect_benchmark_artifacts(jobs_root: Path) -> dict[str, object]:
             request_rows=matrix_request_rows,
         )
     runs_root = jobs_root / "runs"
-    if runs_root.is_dir():
-        for run_root in sorted(path for path in runs_root.iterdir() if path.is_dir()):
-            _collect_benchmark_run(
-                run_root,
-                summary_rows=summary_rows,
-                context_rows=context_rows,
-                batch_rows=batch_rows,
-                results=results,
-            )
+    for run_root in _iter_sorted_child_directories(runs_root):
+        _collect_benchmark_run(
+            run_root,
+            summary_rows=summary_rows,
+            context_rows=context_rows,
+            batch_rows=batch_rows,
+            results=results,
+        )
     for matrix_root in matrix_roots:
         matrix_runs_root = matrix_root / "matrix-runs"
-        if matrix_runs_root.is_dir():
-            for run_root in sorted(path for path in matrix_runs_root.iterdir() if path.is_dir()):
-                _collect_benchmark_matrix_run(
-                    run_root,
-                    jobs=matrix_jobs,
-                    summary_rows=matrix_summary_rows,
-                    request_rows=matrix_request_rows,
-                )
+        for run_root in _iter_sorted_child_directories(matrix_runs_root):
+            _collect_benchmark_matrix_run(
+                run_root,
+                jobs=matrix_jobs,
+                summary_rows=matrix_summary_rows,
+                request_rows=matrix_request_rows,
+            )
 
     return {
         "benchmark_jobs": summary_rows,
@@ -102,18 +101,17 @@ def collect_evaluation_artifacts(jobs_root: Path) -> dict[str, object]:
         compare_samples=compare_samples,
     )
     runs_root = jobs_root / "runs"
-    if runs_root.is_dir():
-        for run_root in sorted(path for path in runs_root.iterdir() if path.is_dir()):
-            _collect_evaluation_run(
-                run_root,
-                jobs=jobs,
-                results=results,
-                summaries=summaries,
-                samples=samples,
-                compare_jobs=compare_jobs,
-                compare_summary_rows=compare_summary_rows,
-                compare_samples=compare_samples,
-            )
+    for run_root in _iter_sorted_child_directories(runs_root):
+        _collect_evaluation_run(
+            run_root,
+            jobs=jobs,
+            results=results,
+            summaries=summaries,
+            samples=samples,
+            compare_jobs=compare_jobs,
+            compare_summary_rows=compare_summary_rows,
+            compare_samples=compare_samples,
+        )
 
     return {
         "evaluation_jobs": jobs,
@@ -404,6 +402,23 @@ def _resolve_artifact_root(
     ):
         return fallback_root
     return jobs_root
+
+
+
+def _iter_sorted_child_directories(parent: Path) -> tuple[Path, ...]:
+    try:
+        names: list[str] = []
+        with os.scandir(parent) as entries:
+            for entry in entries:
+                try:
+                    if not entry.is_dir():
+                        continue
+                except OSError:
+                    continue
+                names.append(entry.name)
+    except OSError:
+        return ()
+    return tuple(parent / name for name in sorted(names))
 
 
 def _collect_benchmark_run(


### PR DESCRIPTION
## Why
- Reduce per-run directory traversal overhead in benchmark/evaluation export collection by replacing sorted Path.iterdir() loops with a shared scandir-based child directory scanner.

## What changed
- Add _iter_sorted_child_directories() in services/mlx-worker-python/worker/productization/benchmark_export.py.
- Replace directory loops for:
  - collect_benchmark_artifacts runs
  - collect_benchmark_artifacts matrix-runs
  - collect_evaluation_artifacts runs
- Add tests for helper behavior in services/mlx-worker-python/tests/test_benchmark_export.py.

## Validation
- PYTHONPATH=. uv run pytest tests/test_benchmark_export.py (34 passed)
- Probe: synthetic workload with 2500 runs + 2500 matrix-runs averaged 360.8ms per collect over 3 iterations.
