### PR TITLE
perf: reuse single-turn chunk render length

### DIFF
--- a/services/mlx-worker-python/tests/test_training_dataset_chunker.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_chunker.py
@@ -332,7 +332,54 @@ def test_impossible_single_turn_short_circuits_before_trying_many_segment_counts
         chunk_long_samples([sample], chunk_size=205, tokenizer=tokenizer)
 
     assert exc.value.code == "chunk_size_too_small"
-    assert tokenizer.render_calls == 3
+    assert tokenizer.render_calls == 2
+
+
+def test_single_turn_chunking_reuses_full_render_length() -> None:
+    tokenizer = _CountingTokenizer()
+    sample = {
+        "id": "single-turn-render-reuse",
+        "messages": [
+            {"role": "user", "content": _words(200)},
+            {"role": "assistant", "content": "ack ack ack"},
+        ],
+    }
+
+    chunked, stats = chunk_long_samples([sample], chunk_size=80, tokenizer=tokenizer)
+
+    assert stats.chunk_count == len(chunked) >= 3
+    assert tokenizer.render_calls == 5
+
+
+def test_single_pair_with_trailing_malformed_messages_uses_pair_local_render_length() -> None:
+    tokenizer = _FakeTokenizer()
+    clean_sample = {
+        "id": "clean-single-pair",
+        "messages": [
+            {"role": "user", "content": _words(150)},
+            {"role": "assistant", "content": "ack ack ack"},
+        ],
+    }
+    malformed_sample = {
+        "id": "trailing-malformed-extra",
+        "messages": [
+            *clean_sample["messages"],
+            {"role": "tool", "content": _words(100)},
+        ],
+    }
+
+    clean_chunked, clean_stats = chunk_long_samples(
+        [clean_sample], chunk_size=80, tokenizer=tokenizer
+    )
+    malformed_chunked, malformed_stats = chunk_long_samples(
+        [malformed_sample], chunk_size=80, tokenizer=tokenizer
+    )
+
+    assert clean_stats.chunk_count == len(clean_chunked) == 3
+    assert malformed_stats.chunk_count == len(malformed_chunked) == 3
+    assert [chunk["messages"] for chunk in malformed_chunked] == [
+        chunk["messages"] for chunk in clean_chunked
+    ]
 
 
 class _NoSplitTokenizer:

--- a/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
@@ -181,6 +181,7 @@ def _chunk_single_turn(
     tokenizer: _ChatTemplateTokenizer,
     tools: list[dict[str, Any]] | None,
     sample_id: str,
+    full_len: int | None = None,
 ) -> list[list[dict[str, str]]]:
     """Segment a single (user, assistant) pair so each chunk fits chunk_size.
 
@@ -200,7 +201,8 @@ def _chunk_single_turn(
     """
 
     full = system_prefix + [user, assistant]
-    full_len = _render_len(full, tokenizer, tools=tools)
+    if full_len is None:
+        full_len = _render_len(full, tokenizer, tools=tools)
     if full_len <= chunk_size:
         return [full]
 
@@ -309,7 +311,8 @@ def _chunk_sample(
 
     tools = _extract_tools(sample)
     messages = _extract_messages(sample)
-    if _render_len(messages, tokenizer, tools=tools) <= chunk_size:
+    full_len = _render_len(messages, tokenizer, tools=tools)
+    if full_len <= chunk_size:
         return [_passthrough_sample(sample)]
 
     sample_id = str(sample.get("id", ""))
@@ -337,6 +340,9 @@ def _chunk_sample(
             )
     else:
         user, assistant = pairs[0]
+        single_turn_full_len = (
+            full_len if len(messages) == len(system_prefix) + 2 else None
+        )
         chunked_messages.extend(
             _chunk_single_turn(
                 system_prefix,
@@ -346,6 +352,7 @@ def _chunk_sample(
                 tokenizer=tokenizer,
                 tools=tools,
                 sample_id=sample_id,
+                full_len=single_turn_full_len,
             )
         )
 


### PR DESCRIPTION
## Summary
- reduce one redundant chat-template render when chunking exact single-turn training samples in `services/mlx-worker-python`
- reuse the already-computed sample render length only for true single-turn shapes
- add focused regression tests for the optimized path and for malformed trailing-message fallback behavior

## Plan or Spec
- N/A: this is a small internal Python-only performance optimization slice that preserves existing behavior and is not governed by a dedicated canonical plan/spec document

## Commands Run
```text
- scout subagent inspected services/mlx-worker-python and proposed optimization candidates; selected training_dataset_chunker single-turn render reuse as the highest confidence-to-effort slice
- pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py
  -> 26 passed in 0.08s
- coverage run -m pytest -q tests/test_training_dataset_chunker.py
  -> 26 passed in 0.08s
- coverage json -o coverage.json
  -> wrote coverage report
- changed-scope coverage script over git diff hunks
  -> worker/model_ops/training_dataset_chunker.py changed-line coverage 100.00%
  -> tests/test_training_dataset_chunker.py changed-line coverage 100.00%
- python performance probe comparing optimized path vs baseline without full_len reuse
  -> optimized mean 102.57 ms, 5.00 render calls/iteration
  -> baseline mean 119.94 ms, 6.00 render calls/iteration
- git diff --check
  -> clean
```

## Coverage and Metrics
- changed-scope coverage:
  - `worker/model_ops/training_dataset_chunker.py`: 100.00% (`[204, 205, 314, 315, 343]`, no missed changed lines)
  - `tests/test_training_dataset_chunker.py`: 100.00% (`[335, 338, 339, 340, 348, 350, 351, 354, 355, 356, 363, 371, 374, 378, 379, 380]`, no missed changed lines)
- performance probe for a long exact single-turn sample (`chunk_size=80`, 3000 iterations/repeat, 5 repeats):
  - optimized: mean `102.57 ms`, `5.00` chat-template renders per iteration
  - baseline without `full_len` reuse: mean `119.94 ms`, `6.00` chat-template renders per iteration
  - effect: about `14.5%` lower mean wall time and one fewer render per iteration with unchanged `chunk_count=3`

## Known Gaps
- did not run repository-wide `make swift-test` / `make integration-test`; this cron run was intentionally constrained to a Linux-verifiable Python-only slice under `services/mlx-worker-python`
- pre-existing whitespace-normalizing user-content splitting behavior remains unchanged by this PR

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
