### PR TITLE
refactor(job_registry): single-pass restore manifest collection

### DIFF
--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from worker.model_ops.job_registry import ModelOpsJobRegistry
+
+
+def test_collect_restore_manifest_paths_scans_expected_operations_once(tmp_path: Path) -> None:
+    jobs_root = tmp_path / "jobs"
+    (jobs_root / "train_lora" / "model-ops-0002").mkdir(parents=True)
+    (jobs_root / "train_lora" / "model-ops-abc").mkdir(parents=True)
+    (jobs_root / "activate_adapter" / "model-ops-0001" / "one").mkdir(parents=True)
+    (jobs_root / "activate_adapter" / "model-ops-0001" / "two").mkdir(parents=True)
+    (jobs_root / "remove_derived_model" / "model-ops-0003").mkdir(parents=True)
+    (jobs_root / "other" / "ignored").mkdir(parents=True)
+
+    train_manifest = jobs_root / "train_lora" / "model-ops-0002" / "train_lora.adapter.json"
+    activate_manifest = (
+        jobs_root / "activate_adapter" / "model-ops-0001" / "one" / "manifest.json"
+    )
+    remove_manifest = jobs_root / "remove_derived_model" / "model-ops-0003" / "remove_derived_model.lifecycle.json"
+
+    train_manifest.write_text(json.dumps({"operation": "train_lora"}), encoding="utf-8")
+    activate_manifest.write_text(json.dumps({"operation": "activate_adapter"}), encoding="utf-8")
+    remove_manifest.write_text(json.dumps({"operation": "remove_derived_model"}), encoding="utf-8")
+
+    paths = ModelOpsJobRegistry._collect_restore_manifest_paths(jobs_root)
+
+    assert paths["train_lora"] == [train_manifest]
+    assert paths["activate_adapter"] == [activate_manifest]
+    assert paths["remove_derived_model"] == [remove_manifest]
+
+
+def test_job_registry_restore_scans_manifest_directories_once(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    jobs_root = tmp_path / "jobs"
+    (jobs_root / "train_lora" / "model-ops-0001").mkdir(parents=True)
+    (jobs_root / "activate_adapter" / "model-ops-0002" / "one").mkdir(parents=True)
+    (jobs_root / "remove_derived_model" / "model-ops-0003").mkdir(parents=True)
+
+    (jobs_root / "train_lora" / "model-ops-0001" / "train_lora.adapter.json").write_text(
+        json.dumps(
+            {
+                "job_id": "model-ops-0001",
+                "operation": "train_lora",
+                "source_model": "src-1",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (jobs_root / "activate_adapter" / "model-ops-0002" / "one" / "manifest.json").write_text(
+        json.dumps(
+            {
+                "job_id": "model-ops-0002",
+                "operation": "activate_adapter",
+                "source_model": "src-2",
+                "derived_model_id": "derived-2",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (jobs_root / "remove_derived_model" / "model-ops-0003" / "remove_derived_model.lifecycle.json").write_text(
+        json.dumps(
+            {
+                "job_id": "model-ops-0003",
+                "operation": "remove_derived_model",
+                "source_model": "src-3",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    scan_calls: list[str] = []
+    original_scandir = __import__("os").scandir
+
+    def tracked_scandir(path: str | bytes | Path) -> Any:
+        scan_calls.append(str(path))
+        return original_scandir(path)
+
+    monkeypatch.setattr(__import__("os"), "scandir", tracked_scandir)
+
+    registry = ModelOpsJobRegistry(jobs_root=jobs_root)
+
+    assert set(registry._jobs) == {"model-ops-0003", "model-ops-0002", "model-ops-0001"}
+    assert any(str(jobs_root / "train_lora") == call for call in scan_calls)
+    assert any(str(jobs_root / "activate_adapter") == call for call in scan_calls)
+    assert any(str(jobs_root / "remove_derived_model") == call for call in scan_calls)
+    assert len(scan_calls) <= 9

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass, field
 import math
 from pathlib import Path
@@ -118,24 +119,123 @@ class ModelOpsJobRegistry:
         if self._jobs_root is None or self._jobs_root.exists() is False:
             return
 
+        manifest_paths = self._collect_restore_manifest_paths(self._jobs_root)
         self._restore_manifest_jobs(
             operation="train_lora",
-            manifest_paths=self._jobs_root.glob("train_lora/model-ops-*/train_lora.adapter.json"),
+            manifest_paths=manifest_paths["train_lora"],
             pct=0.97,
         )
         self._restore_manifest_jobs(
             operation="activate_adapter",
-            manifest_paths=self._jobs_root.glob("activate_adapter/model-ops-*/*/manifest.json"),
+            manifest_paths=manifest_paths["activate_adapter"],
             pct=0.95,
         )
         self._restore_manifest_jobs(
             operation="remove_derived_model",
-            manifest_paths=self._jobs_root.glob(
-                "remove_derived_model/model-ops-*/remove_derived_model.lifecycle.json"
-            ),
+            manifest_paths=manifest_paths["remove_derived_model"],
             pct=0.95,
         )
         self._next_id = max(self._next_id, self._max_numeric_job_id() + 1)
+
+    @staticmethod
+    def _collect_restore_manifest_paths(
+        jobs_root: Path,
+    ) -> dict[str, list[Path]]:
+        manifest_paths: dict[str, list[Path]] = {
+            "train_lora": [],
+            "activate_adapter": [],
+            "remove_derived_model": [],
+        }
+
+        try:
+            with os.scandir(os.fspath(jobs_root)) as op_entries:
+                for op_entry in op_entries:
+                    if not op_entry.is_dir(follow_symlinks=False):
+                        continue
+                    if op_entry.name == "train_lora":
+                        manifest_paths["train_lora"].extend(
+                            ModelOpsJobRegistry._collect_train_lora_restore_manifests(Path(op_entry.path))
+                        )
+                    elif op_entry.name == "activate_adapter":
+                        manifest_paths["activate_adapter"].extend(
+                            ModelOpsJobRegistry._collect_activate_adapter_restore_manifests(
+                                Path(op_entry.path)
+                            )
+                        )
+                    elif op_entry.name == "remove_derived_model":
+                        manifest_paths["remove_derived_model"].extend(
+                            ModelOpsJobRegistry._collect_remove_derived_model_restore_manifests(
+                                Path(op_entry.path)
+                            )
+                        )
+        except OSError:
+            return manifest_paths
+
+        manifest_paths["train_lora"].sort()
+        manifest_paths["activate_adapter"].sort()
+        manifest_paths["remove_derived_model"].sort()
+        return manifest_paths
+
+    @staticmethod
+    def _collect_train_lora_restore_manifests(manifest_root: Path) -> list[Path]:
+        manifests: list[Path] = []
+        try:
+            with os.scandir(os.fspath(manifest_root)) as job_id_entries:
+                for job_id_entry in job_id_entries:
+                    if (
+                        not job_id_entry.is_dir(follow_symlinks=False)
+                        or not job_id_entry.name.startswith("model-ops-")
+                    ):
+                        continue
+                    manifest_path = Path(job_id_entry.path) / "train_lora.adapter.json"
+                    if manifest_path.is_file():
+                        manifests.append(manifest_path)
+        except OSError:
+            return manifests
+        return manifests
+
+    @staticmethod
+    def _collect_activate_adapter_restore_manifests(manifest_root: Path) -> list[Path]:
+        manifests: list[Path] = []
+        try:
+            with os.scandir(os.fspath(manifest_root)) as job_id_entries:
+                for job_id_entry in job_id_entries:
+                    if (
+                        not job_id_entry.is_dir(follow_symlinks=False)
+                        or not job_id_entry.name.startswith("model-ops-")
+                    ):
+                        continue
+                    try:
+                        with os.scandir(os.fspath(job_id_entry.path)) as manifest_entry_parent_entries:
+                            for manifest_entry in manifest_entry_parent_entries:
+                                if not manifest_entry.is_dir(follow_symlinks=False):
+                                    continue
+                                manifest_path = Path(manifest_entry.path) / "manifest.json"
+                                if manifest_path.is_file():
+                                    manifests.append(manifest_path)
+                    except OSError:
+                        continue
+        except OSError:
+            return manifests
+        return manifests
+
+    @staticmethod
+    def _collect_remove_derived_model_restore_manifests(manifest_root: Path) -> list[Path]:
+        manifests: list[Path] = []
+        try:
+            with os.scandir(os.fspath(manifest_root)) as job_id_entries:
+                for job_id_entry in job_id_entries:
+                    if (
+                        not job_id_entry.is_dir(follow_symlinks=False)
+                        or not job_id_entry.name.startswith("model-ops-")
+                    ):
+                        continue
+                    manifest_path = Path(job_id_entry.path) / "remove_derived_model.lifecycle.json"
+                    if manifest_path.is_file():
+                        manifests.append(manifest_path)
+        except OSError:
+            return manifests
+        return manifests
 
     def _restore_manifest_jobs(
         self,


### PR DESCRIPTION
## Summary
- Refactor JobRegistry restore collection to avoid repeated directory traversals.
- Collect restore manifest paths in one pass through `jobs_root` and group by operation type.
- Keep restore behavior unchanged and add focused regression tests.

## Validation
- Added: `services/mlx-worker-python/tests/test_model_ops_job_registry.py`
- `PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_maintenance_service.py -k 'test_job_registry_snapshot or test_model_ops_job_registry' -q`

No functional behavior changes; tests pass.
