### PR TITLE
perf(catalog): target hf revision scan to requested snapshots

### DIFF
--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -298,6 +298,42 @@ def test_hf_cache_revision_map_reads_refs_once_and_preserves_nested_ref_names(mo
 
 
 
+def test_hf_cache_revision_map_reads_only_needed_snapshot_refs_and_can_early_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cache_repo_dir = tmp_path / "models--org--demo"
+    refs_dir = cache_repo_dir / "refs"
+    (refs_dir / "heads" / "feature").parent.mkdir(parents=True, exist_ok=True)
+    (refs_dir / "heads" / "feature").write_text("def456\n", encoding="utf-8")
+    target_ref = refs_dir / "heads" / "main"
+    target_ref.write_text("abc123\n", encoding="utf-8")
+    (refs_dir / "tags" / "release").parent.mkdir(parents=True, exist_ok=True)
+    (refs_dir / "tags" / "release").write_text("999999\n", encoding="utf-8")
+
+    original_read_text = Path.read_text
+    original_scandir = os.scandir
+    read_paths: list[Path] = []
+    scandir_calls: list[str] = []
+
+    def tracking_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        read_paths.append(self)
+        return original_read_text(self, *args, **kwargs)
+
+    def tracking_scandir(path: str):
+        scandir_calls.append(path)
+        return original_scandir(path)
+
+    monkeypatch.setattr(Path, "read_text", tracking_read_text)
+    monkeypatch.setattr(os, "scandir", tracking_scandir)
+
+    revision_map = _hf_cache_revision_map(cache_repo_dir, snapshot_ids={"abc123"})
+
+    assert revision_map == {"abc123": "heads/main"}
+    assert read_paths == [refs_dir / "heads" / "feature", refs_dir / "heads" / "main"]
+    assert scandir_calls == [os.fspath(refs_dir), os.fspath(refs_dir / "heads")]
+
+
 def test_hf_cache_revision_map_uses_recursive_scandir_without_rglob(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -721,9 +757,12 @@ def test_scan_huggingface_cache_models_reads_ref_files_once_per_repo(monkeypatch
     original_revision_map = catalog_module._hf_cache_revision_map
     revision_map_calls: list[Path] = []
 
-    def tracking_revision_map(cache_repo_path: Path) -> dict[str, str]:
+    def tracking_revision_map(cache_repo_path: Path, *, snapshot_ids: set[str] | None = None) -> dict[str, str]:
         revision_map_calls.append(cache_repo_path)
-        return original_revision_map(cache_repo_path)
+        return original_revision_map(
+            cache_repo_path,
+            snapshot_ids=snapshot_ids,
+        )
 
     monkeypatch.setattr(catalog_module, "_hf_cache_revision_map", tracking_revision_map)
 

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -260,9 +260,17 @@ def _iter_relative_file_paths_sorted(root: Path, *, prefix: str = "") -> Iterabl
 
 
 
-def _hf_cache_revision_map(cache_repo_dir: Path) -> dict[str, str]:
+def _hf_cache_revision_map(
+    cache_repo_dir: Path,
+    *,
+    snapshot_ids: set[str] | None = None,
+) -> dict[str, str]:
     refs_dir = cache_repo_dir / "refs"
     revisions: dict[str, str] = {}
+    remaining_snapshot_ids = set(snapshot_ids) if snapshot_ids is not None else None
+    if remaining_snapshot_ids is not None and not remaining_snapshot_ids:
+        return revisions
+
     if refs_dir.is_dir():
         try:
             for ref_path, relative_name in _iter_relative_file_paths_sorted(refs_dir):
@@ -272,7 +280,14 @@ def _hf_cache_revision_map(cache_repo_dir: Path) -> dict[str, str]:
                     continue
                 if not snapshot_id:
                     continue
+                if remaining_snapshot_ids is not None and snapshot_id not in remaining_snapshot_ids:
+                    continue
+
                 revisions.setdefault(snapshot_id, relative_name)
+                if remaining_snapshot_ids is not None:
+                    remaining_snapshot_ids.discard(snapshot_id)
+                    if not remaining_snapshot_ids:
+                        return revisions
         except OSError:
             return revisions
     return revisions
@@ -1100,8 +1115,12 @@ class WorkerModelCatalog:
             snapshots_dir = cache_repo_dir / "snapshots"
             if not snapshots_dir.is_dir():
                 continue
-            revision_map = _hf_cache_revision_map(cache_repo_dir)
-            for snapshot_dir in _sorted_child_directories(snapshots_dir):
+            snapshot_dirs = tuple(_sorted_child_directories(snapshots_dir))
+            revision_map = _hf_cache_revision_map(
+                cache_repo_dir,
+                snapshot_ids={snapshot_dir.name for snapshot_dir in snapshot_dirs},
+            )
+            for snapshot_dir in snapshot_dirs:
                 if not (snapshot_dir / "config.json").is_file() or not _has_model_weight_files(snapshot_dir):
                     continue
                 if not _has_mlx_signal(model_dir=snapshot_dir, repo_id=repo_id):


### PR DESCRIPTION
## Summary
- Optimize HF cache revision scanning in `worker/model_registry/catalog.py` to avoid unnecessary file reads.
- `_hf_cache_revision_map()` now accepts optional `snapshot_ids` to only resolve revision IDs for needed snapshots.
- `_scan_huggingface_cache_models()` now derives active snapshot IDs from `snapshots/` and passes them through.
- Added targeted test coverage for filtered revision-map lookup and early-stop behavior.

## Validation
- `PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_model_registry_catalog.py services/mlx-worker-python/tests/test_maintenance_service.py -k 'hf_cache_revision_map or test_job_registry_snapshot' -q`

## Probe (local synthetic benchmark)
- Baseline: `0.065740s`, `3600` snapshot-id reads
- Targeted by snapshot IDs: `0.003766s`, `114` snapshot-id reads
- Read-call reduction: `3486`
