### PR TITLE
perf: reuse VLM prefill prompt metadata

### DIFF
--- a/services/mlx-worker-python/tests/test_vision_runtime.py
+++ b/services/mlx-worker-python/tests/test_vision_runtime.py
@@ -485,6 +485,101 @@ def test_vlm_runtime_load_model_exposes_family_capabilities() -> None:
     assert loaded_model["multimodal_adapter_hash"] == "vision-family-paligemma-v1"
 
 
+def test_vlm_render_prompt_reuses_prepared_prompt_metadata() -> None:
+    runtime = DeterministicVLMRuntime()
+    loaded_model = runtime.load_model(paligemma_vlm_model())
+    messages = [
+        common_pb2.ChatMessage(
+            role="user",
+            parts=[
+                common_pb2.MessagePart(text="Summarize the image."),
+                common_pb2.MessagePart(
+                    image_bytes=b"render prompt image",
+                    media=common_pb2.MediaMetadata(
+                        media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                        source_kind=common_pb2.MEDIA_SOURCE_INLINE_BYTES,
+                        mime_type="image/png",
+                        filename="render-prompt.png",
+                    ),
+                ),
+            ],
+        )
+    ]
+
+    prepared = runtime.render_prompt(messages, loaded_model=loaded_model)
+    snapshot = runtime.last_probe_snapshot()
+
+    assert prepared.prompt_text == "Summarize the image."
+    assert snapshot.cache_identity
+    assert snapshot.cache_scope_id
+    assert snapshot.cache_hit is False
+    assert loaded_model["_vision_family_config"].family_id == "paligemma-v1"
+
+
+def test_vlm_prefill_reuses_prompt_metadata_without_recomputing_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime = DeterministicVLMRuntime()
+    loaded_model = runtime.load_model(paligemma_vlm_model())
+    messages = [
+        common_pb2.ChatMessage(
+            role="user",
+            parts=[
+                common_pb2.MessagePart(text="Summarize the image."),
+                common_pb2.MessagePart(
+                    image_bytes=b"phase aware image",
+                    media=common_pb2.MediaMetadata(
+                        media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                        source_kind=common_pb2.MEDIA_SOURCE_INLINE_BYTES,
+                        mime_type="image/png",
+                        filename="phase-aware.png",
+                    ),
+                ),
+            ],
+        )
+    ]
+    call_counts = {
+        "family_config": 0,
+        "cache_identity": 0,
+        "prompt_token_count": 0,
+    }
+    original_family_config = runtime._family_config
+    original_cache_identity = runtime._cache_identity
+    original_prompt_token_count = runtime.prompt_token_count
+
+    def counted_family_config(model):
+        call_counts["family_config"] += 1
+        return original_family_config(model)
+
+    def counted_cache_identity(prepared_request, model, execution_ext=None):
+        call_counts["cache_identity"] += 1
+        return original_cache_identity(prepared_request, model, execution_ext=execution_ext)
+
+    def counted_prompt_token_count(prepared_request, loaded_model=None, family_config=None):
+        call_counts["prompt_token_count"] += 1
+        return original_prompt_token_count(
+            prepared_request,
+            loaded_model=loaded_model,
+            family_config=family_config,
+        )
+
+    monkeypatch.setattr(runtime, "_family_config", counted_family_config)
+    monkeypatch.setattr(runtime, "_cache_identity", counted_cache_identity)
+    monkeypatch.setattr(runtime, "prompt_token_count", counted_prompt_token_count)
+
+    session = runtime.prefill("prefill-reuse", loaded_model, messages)
+    events = list(runtime.decode_tokens(loaded_model, session.decode_handle, None, Event()))
+
+    assert session.cache_hit is False
+    assert session.prompt_tokens > 0
+    assert "_vision_family_config" in loaded_model
+    assert call_counts == {
+        "family_config": 2,
+        "cache_identity": 1,
+        "prompt_token_count": 1,
+    }
+    assert len(events) == 1
+    assert events[0].text == "Image content: phase aware image\nPrompt: Summarize the image."
+
+
 def test_resolve_vision_family_config_handles_invalid_family_overrides() -> None:
     with pytest.raises(ValueError, match="Unsupported vision family adapter"):
         resolve_vision_family_config({"vision_family_id": "unknown-family"})

--- a/services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py
@@ -74,6 +74,15 @@ class VisionPrefillSession:
     block_table: common_pb2.BlockTable
 
 
+@dataclass(frozen=True)
+class PreparedVisionPrompt:
+    prepared_request: PreparedVisionRequest
+    family_config: object
+    prompt_tokens: int
+    cache_identity: str
+    scope_id: str
+
+
 class DeterministicVLMRuntime:
     runtime_name = "deterministic-vlm"
 
@@ -118,27 +127,28 @@ class DeterministicVLMRuntime:
         execution_ext: dict[str, str] | None = None,
     ) -> PreparedVisionRequest:
         _ = template_kwargs
-        prepared = self._family_config(loaded_model).shape_request(prepare_vision_request(messages))
-        cache_identity, scope_id = self._cache_identity(
-            prepared,
-            loaded_model,
+        prompt = self._prepare_prompt(
+            messages,
+            loaded_model=loaded_model,
             execution_ext=execution_ext,
         )
-        self._record_fast_path_probe(loaded_model, prepared)
+        self._record_fast_path_probe(loaded_model, prompt.prepared_request)
         self._last_probe = replace(
             self._last_probe,
-            cache_identity=cache_identity,
-            cache_scope_id=scope_id,
-            cache_hit=cache_identity in self._cache_entries,
+            cache_identity=prompt.cache_identity,
+            cache_scope_id=prompt.scope_id,
+            cache_hit=prompt.cache_identity in self._cache_entries,
         )
-        return prepared
+        return prompt.prepared_request
 
     def prompt_token_count(
         self,
         prepared_request: PreparedVisionRequest,
         loaded_model=None,
+        family_config: object | None = None,
     ) -> int:
-        return self._family_config(loaded_model).prompt_token_count(prepared_request)
+        config = family_config if family_config is not None else self._family_config(loaded_model)
+        return config.prompt_token_count(prepared_request)
 
     def prefill(
         self,
@@ -147,17 +157,15 @@ class DeterministicVLMRuntime:
         messages,
         execution_ext: dict[str, str] | None = None,
     ) -> VisionPrefillSession:
-        prepared_request = self.render_prompt(
+        prompt = self._prepare_prompt(
             messages,
             loaded_model=loaded_model,
             execution_ext=execution_ext,
         )
-        prompt_tokens = self.prompt_token_count(prepared_request, loaded_model=loaded_model)
-        cache_identity, scope_id = self._cache_identity(
-            prepared_request,
-            loaded_model,
-            execution_ext=execution_ext,
-        )
+        prepared_request = prompt.prepared_request
+        prompt_tokens = prompt.prompt_tokens
+        cache_identity = prompt.cache_identity
+        scope_id = prompt.scope_id
         self._ensure_fast_path_probe(loaded_model, prepared_request)
         self._cache_lookups += 1
         cache_hit = cache_identity in self._cache_entries
@@ -170,6 +178,7 @@ class DeterministicVLMRuntime:
                     prepared_request=prepared_request,
                     cache_identity=cache_identity,
                     scope_id=scope_id,
+                    token_length=prompt_tokens,
                     execution_ext=execution_ext,
                 )
             )
@@ -523,10 +532,11 @@ class DeterministicVLMRuntime:
         prepared_request: PreparedVisionRequest,
         cache_identity: str,
         scope_id: str,
+        token_length: int | None = None,
         execution_ext: dict[str, str] | None = None,
     ) -> VisionCacheEntry:
         prompt_bytes = len(prepared_request.prompt_text.encode("utf-8"))
-        token_length = self.prompt_token_count(prepared_request)
+        token_length = token_length if token_length is not None else self.prompt_token_count(prepared_request)
         bytes_used = max(
             64,
             prepared_request.preprocess_input_bytes + prompt_bytes + (token_length * 8),
@@ -669,9 +679,41 @@ class DeterministicVLMRuntime:
     def _family_config(self, loaded_model) -> object:
         metadata: dict[str, str] = {}
         if isinstance(loaded_model, dict):
+            cached_config = loaded_model.get("_vision_family_config")
+            if cached_config is not None:
+                return cached_config
             metadata = {
                 key: value
                 for key, value in loaded_model.items()
                 if isinstance(value, str) and value
             }
-        return resolve_vision_family_config(metadata)
+        config = resolve_vision_family_config(metadata)
+        if isinstance(loaded_model, dict):
+            loaded_model["_vision_family_config"] = config
+        return config
+
+    def _prepare_prompt(
+        self,
+        messages,
+        loaded_model=None,
+        execution_ext: dict[str, str] | None = None,
+    ) -> PreparedVisionPrompt:
+        family_config = self._family_config(loaded_model)
+        prepared_request = family_config.shape_request(prepare_vision_request(messages))
+        cache_identity, scope_id = self._cache_identity(
+            prepared_request,
+            loaded_model,
+            execution_ext=execution_ext,
+        )
+        prompt_tokens = self.prompt_token_count(
+            prepared_request,
+            loaded_model=loaded_model,
+            family_config=family_config,
+        )
+        return PreparedVisionPrompt(
+            prepared_request=prepared_request,
+            family_config=family_config,
+            prompt_tokens=prompt_tokens,
+            cache_identity=cache_identity,
+            scope_id=scope_id,
+        )


### PR DESCRIPTION
## Summary
- reduce redundant deterministic VLM prefill bookkeeping by preparing the shaped request, cache identity, and prompt token count once per prefill
- cache the resolved vision family config on the loaded model so repeated helper calls do not rebuild it
- add focused runtime tests that lock in the reduced helper-call pattern and render-prompt metadata behavior

## Plan or Spec
- N/A: this is a small internal Python runtime optimization slice from the scheduled Linux cron run, not a user-facing behavior change governed by an existing canonical spec or plan document

## Commands Run
```text
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-164748:/tmp/melix-cron-python-opt-20260430-164748/services/mlx-worker-python pytest -q tests/test_vision_runtime.py -k 'render_prompt_reuses_prepared_prompt_metadata or prefill_reuses_prompt_metadata_without_recomputing_helpers or vlm_prefill_and_decode_expose_explicit_runtime_lifecycle or vlm_runtime_render_prompt_accepts_chat_template_kwargs'
# 4 passed, 37 deselected in 0.32s

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-164748:/tmp/melix-cron-python-opt-20260430-164748/services/mlx-worker-python coverage erase
PYTHONPATH=/tmp/melix-cron-python-opt-20260430-164748:/tmp/melix-cron-python-opt-20260430-164748/services/mlx-worker-python coverage run -m pytest -q tests/test_vision_runtime.py
coverage json -o coverage.json
# 41 passed in 0.39s
# Wrote JSON report to coverage.json

PYTHONPATH=/tmp/melix-cron-python-opt-20260430-164748:/tmp/melix-cron-python-opt-20260430-164748/services/mlx-worker-python python3 <changed-scope coverage + perf probe script>
# changed_line_coverage=100.00%
# current_helper_counts={'family_config': 2, 'cache_identity': 1, 'prompt_token_count': 1}
# naive_helper_counts={'family_config': 4, 'cache_identity': 2, 'prompt_token_count': 2}
# reductions={'family_config': 2, 'cache_identity': 1, 'prompt_token_count': 1}

git diff --check
# clean
```

## Coverage and Metrics
- Changed executable statement coverage for `services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py`: **100.00%**
- Changed executable lines covered: `77-83, 130, 135, 142, 150-151, 160, 165-168, 539, 682-684, 690-695, 701-703, 708, 713`
- Perf probe on the optimized prefill path reduced helper work for one representative request from:
  - `_family_config`: **4 -> 2** calls
  - `_cache_identity`: **2 -> 1** calls
  - `prompt_token_count`: **2 -> 1** calls
- The scoped runtime behavior remains covered by `tests/test_vision_runtime.py` (**41 passed**)

## Known Gaps
- `make swift-test` and `make integration-test` were not run because this cron slice intentionally stayed inside the Linux-verifiable Python worker scope
- the perf evidence is helper-call reduction on the targeted prefill path rather than an end-to-end MLX/macOS benchmark

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
