### PR TITLE
perf: index benchmark comparison metrics once

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -28,6 +28,16 @@ from worker.productization.benchmark_export import (
 )
 
 
+class _CountingMetricList(list[dict[str, float | str]]):
+    def __init__(self, items: list[dict[str, float | str]]) -> None:
+        super().__init__(items)
+        self.iteration_count = 0
+
+    def __iter__(self):
+        self.iteration_count += 1
+        return super().__iter__()
+
+
 def _write_bench_fixtures(root: Path) -> None:
     root.mkdir(parents=True, exist_ok=True)
     (root / "bench-summary.json").write_text(
@@ -972,6 +982,43 @@ def test_build_comparison_table_handles_single_run() -> None:
 
     assert "| Metric | melix-dev |" in table
     assert "| bench.smoke.ttft_ms | 24.45 |" in table
+
+
+def test_build_comparison_table_indexes_metrics_once_per_result() -> None:
+    metrics = _CountingMetricList([
+        {"name": "bench.smoke.ttft_ms", "value": 24.45},
+        {"name": "bench.smoke.tokens_per_second", "value": 47.08},
+    ])
+    run = {
+        "benchmark_jobs": [{"job_id": "bench-1", "model_id": "melix-dev"}],
+        "benchmark_results": [{"suite": "smoke", "metrics": metrics}],
+    }
+
+    table = build_comparison_table([run])
+
+    assert "| bench.smoke.ttft_ms | 24.45 |" in table
+    assert "| bench.smoke.tokens_per_second | 47.08 |" in table
+    assert metrics.iteration_count == 1
+
+
+def test_build_comparison_table_ignores_blank_and_duplicate_metric_names() -> None:
+    run = {
+        "benchmark_jobs": [{"job_id": "bench-1", "model_id": "melix-dev"}],
+        "benchmark_results": [{
+            "suite": "smoke",
+            "metrics": [
+                {"name": "", "value": 999.0},
+                {"name": "bench.smoke.ttft_ms", "value": 24.45},
+                {"name": "bench.smoke.ttft_ms", "value": 88.88},
+            ],
+        }],
+    }
+
+    table = build_comparison_table([run])
+
+    assert "|  |" not in table
+    assert "| bench.smoke.ttft_ms | 24.45 |" in table
+    assert "88.88" not in table
 
 
 def test_build_comparison_table_ignores_evaluation_metrics() -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -319,13 +319,14 @@ def build_comparison_table(runs: list[dict[str, object]]) -> str:
 
     all_metric_names: list[str] = []
     seen: set[str] = set()
+    metric_values_by_run: list[dict[str, float]] = []
     for run in runs:
-        for result in run.get("benchmark_results", []):
-            for metric in result.get("metrics", []):
-                name = metric.get("name", "")
-                if name and name not in seen:
-                    all_metric_names.append(name)
-                    seen.add(name)
+        metric_values = _collect_metric_values(run)
+        metric_values_by_run.append(metric_values)
+        for name in metric_values:
+            if name not in seen:
+                all_metric_names.append(name)
+                seen.add(name)
 
     if not all_metric_names:
         return ""
@@ -337,8 +338,8 @@ def build_comparison_table(runs: list[dict[str, object]]) -> str:
     rows: list[str] = []
     for metric_name in all_metric_names:
         cells: list[str] = []
-        for run in runs:
-            value = _find_metric_value(run, metric_name)
+        for metric_values in metric_values_by_run:
+            value = metric_values.get(metric_name)
             cells.append(f"{value:.2f}" if value is not None else "-")
         rows.append(f"| {metric_name} | " + " | ".join(cells) + " |")
 
@@ -358,15 +359,15 @@ def _run_label(run: dict[str, object], index: int) -> str:
     return f"run-{index}"
 
 
-def _find_metric_value(
-    run: dict[str, object],
-    metric_name: str,
-) -> float | None:
+def _collect_metric_values(run: dict[str, object]) -> dict[str, float]:
+    metric_values: dict[str, float] = {}
     for result in run.get("benchmark_results", []):
         for metric in result.get("metrics", []):
-            if metric.get("name") == metric_name:
-                return float(metric["value"])
-    return None
+            name = metric.get("name", "")
+            if not name or name in metric_values:
+                continue
+            metric_values[name] = float(metric["value"])
+    return metric_values
 
 
 def _resolve_artifact_root(


### PR DESCRIPTION
## Summary
- Pre-index benchmark metric values per run before rendering the comparison table.
- Remove repeated linear rescans of each run's metric list while preserving first-seen metric ordering and existing Markdown output.
- Add focused tests for the single-pass metric indexing path plus blank/duplicate metric handling.

## Plan or Spec
- N/A: this is a small internal Python-only optimization slice from the cron mission, with no externally visible behavior or protocol change.

## Commands Run
```text
python -m pytest tests/test_benchmark_export.py::test_build_comparison_table_indexes_metrics_once_per_result -q
-> failed before the refactor (metrics.iteration_count was 3, expected 1)

python -m pytest tests/test_benchmark_export.py::test_build_comparison_table_indexes_metrics_once_per_result -q
-> passed after the refactor

python -m pytest tests/test_benchmark_export.py -q
-> 36 passed

coverage erase && coverage run -m pytest tests/test_benchmark_export.py -q && coverage json -o coverage.json
-> 36 passed, coverage JSON generated

python changed-scope coverage probe
-> changed_line_coverage=100.00%

python performance probe comparing origin/main vs branch implementation
-> baseline_seconds=2.037572, optimized_seconds=0.178404, speedup_ratio=11.42x over 200 iterations on 8 synthetic runs x 250 metrics

git diff --check
-> passed
```

## Coverage and Metrics
- Changed executable scope: `services/mlx-worker-python/worker/productization/benchmark_export.py`
- Changed-scope coverage: `100.00%`
- Measurable changed lines: `[322, 324, 325, 326, 327, 328, 329, 341, 342, 362, 363, 366, 367, 368, 369, 370]`
- Performance probe: `build_comparison_table()` improved from `2.037572s` to `0.178404s` for 200 iterations on 8 synthetic runs with 250 metrics each (`11.42x` faster)

## Known Gaps
- Did not run repository-wide `make swift-test` or `make integration-test` because this cron run was constrained to a Linux-verifiable Python-only slice.
- Performance evidence uses a deterministic synthetic benchmark rather than a full production artifact tree.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
