### PR TITLE
perf: streamline benchmark export artifact parsing

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -10,6 +10,8 @@ import pytest
 from worker.productization.benchmark_export import (
     _iter_jsonl_dict_rows,
     _iter_sorted_child_directories,
+    _iter_sorted_matching_files,
+    _load_json_object,
     _rows_to_csv,
     build_comparison_table,
     build_benchmark_batch_csv,
@@ -564,6 +566,65 @@ def test_iter_sorted_child_directories_nonexistent_root_returns_empty() -> None:
     assert _iter_sorted_child_directories(Path("/tmp/this-path-should-not-exist-12345")) == ()
 
 
+def test_iter_sorted_matching_files_returns_lexically_sorted_matching_files(tmp_path: Path) -> None:
+    parent = tmp_path / "artifacts"
+    parent.mkdir(parents=True)
+    (parent / "bench-result-b.json").write_text("{}\n")
+    (parent / "bench-result-a.json").write_text("{}\n")
+    (parent / "bench-result-z.json").mkdir()
+    (parent / "other.json").write_text("{}\n")
+
+    assert [path.name for path in _iter_sorted_matching_files(parent, prefix="bench-result-", suffix=".json")] == [
+        "bench-result-a.json",
+        "bench-result-b.json",
+    ]
+
+
+def test_load_json_object_reads_json_without_read_text_round_trip(tmp_path: Path) -> None:
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text(json.dumps({"job_id": "bench-1", "status": "completed"}) + "\n")
+
+    assert _load_json_object(payload_path) == {"job_id": "bench-1", "status": "completed"}
+
+
+def test_load_json_object_rejects_non_object_payload(tmp_path: Path) -> None:
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text(json.dumps(["not", "an", "object"]) + "\n")
+
+    with pytest.raises(TypeError, match="expected JSON object"):
+        _load_json_object(payload_path)
+
+
+def test_iter_sorted_matching_files_skips_entries_with_stat_failures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    parent = tmp_path / "artifacts"
+    parent.mkdir(parents=True)
+
+    class _BrokenEntry:
+        name = "bench-result-broken.json"
+
+        def is_file(self) -> bool:
+            raise OSError("stat failed")
+
+    class _GoodEntry:
+        name = "bench-result-ok.json"
+
+        def is_file(self) -> bool:
+            return True
+
+    class _Scandir:
+        def __enter__(self):
+            return iter((_BrokenEntry(), _GoodEntry()))
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    monkeypatch.setattr("worker.productization.benchmark_export.os.scandir", lambda path: _Scandir())
+
+    assert [path.name for path in _iter_sorted_matching_files(parent, prefix="bench-result-", suffix=".json")] == [
+        "bench-result-ok.json",
+    ]
+
+
 def test_collect_benchmark_artifacts_ignores_blank_and_non_object_jsonl_rows(tmp_path: Path) -> None:
     _write_bench_fixtures(tmp_path)
     (tmp_path / "bench-context-rows.jsonl").write_text(
@@ -670,6 +731,29 @@ def test_collect_evaluation_artifacts_finds_persisted_eval_files(tmp_path: Path)
     assert result["evaluation_results"][0]["suite_id"] == "mmlu"
     assert len(result["evaluation_samples"]) == 1
     assert result["evaluation_samples"][0]["sample_id"] == "1"
+
+
+def test_collect_evaluation_artifacts_prefers_persisted_summary_json_when_present(tmp_path: Path) -> None:
+    _write_eval_fixtures(tmp_path)
+    (tmp_path / "evaluation-summary.json").write_text(
+        json.dumps({
+            "job_id": "eval-1",
+            "model_id": "summary-model",
+            "primary_score_name": "typed_score_mean",
+            "primary_score_value": 0.99,
+        }) + "\n"
+    )
+
+    result = collect_evaluation_artifacts(tmp_path)
+
+    assert result["evaluation_summary_rows"] == [
+        {
+            "job_id": "eval-1",
+            "model_id": "summary-model",
+            "primary_score_name": "typed_score_mean",
+            "primary_score_value": 0.99,
+        }
+    ]
 
 
 def test_collect_evaluation_artifacts_reads_per_run_history_from_runs_directory(

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -422,6 +422,33 @@ def _iter_sorted_child_directories(parent: Path) -> tuple[Path, ...]:
     return tuple(parent / name for name in sorted(names))
 
 
+def _iter_sorted_matching_files(parent: Path, *, prefix: str, suffix: str) -> tuple[Path, ...]:
+    try:
+        names: list[str] = []
+        with os.scandir(parent) as entries:
+            for entry in entries:
+                name = entry.name
+                if not name.startswith(prefix) or not name.endswith(suffix):
+                    continue
+                try:
+                    if not entry.is_file():
+                        continue
+                except OSError:
+                    continue
+                names.append(name)
+    except OSError:
+        return ()
+    return tuple(parent / name for name in sorted(names))
+
+
+def _load_json_object(path: Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise TypeError(f"expected JSON object in {path}")
+    return payload
+
+
 def _collect_benchmark_run(
     run_root: Path,
     *,
@@ -433,9 +460,9 @@ def _collect_benchmark_run(
     summary_path = run_root / "bench-summary.json"
     job_path = run_root / "bench-job.json"
     if summary_path.is_file():
-        summary_rows.append(json.loads(summary_path.read_text(encoding="utf-8")))
+        summary_rows.append(_load_json_object(summary_path))
     elif job_path.is_file():
-        summary_rows.append(json.loads(job_path.read_text(encoding="utf-8")))
+        summary_rows.append(_load_json_object(job_path))
 
     context_path = run_root / "bench-context-rows.jsonl"
     if context_path.is_file():
@@ -445,9 +472,8 @@ def _collect_benchmark_run(
     if batch_path.is_file():
         batch_rows.extend(_iter_jsonl_dict_rows(batch_path))
 
-    for result_path in sorted(run_root.glob("bench-result-*.json")):
-        if result_path.is_file():
-            results.append(json.loads(result_path.read_text(encoding="utf-8")))
+    for result_path in _iter_sorted_matching_files(run_root, prefix="bench-result-", suffix=".json"):
+        results.append(_load_json_object(result_path))
 
 
 def _collect_benchmark_matrix_run(
@@ -459,7 +485,7 @@ def _collect_benchmark_matrix_run(
 ) -> None:
     job_path = run_root / "bench-matrix-job.json"
     if job_path.is_file():
-        jobs.append(json.loads(job_path.read_text(encoding="utf-8")))
+        jobs.append(_load_json_object(job_path))
 
     summary_path = run_root / "bench-matrix-summary.jsonl"
     if summary_path.is_file():
@@ -739,16 +765,16 @@ def _collect_evaluation_run(
 ) -> None:
     job_path = run_root / "evaluation-job.json"
     if job_path.is_file():
-        jobs.append(json.loads(job_path.read_text(encoding="utf-8")))
+        jobs.append(_load_json_object(job_path))
 
     result_path = run_root / "evaluation-result.json"
     if result_path.is_file():
-        result = json.loads(result_path.read_text(encoding="utf-8"))
+        result = _load_json_object(result_path)
         results.append(result)
 
     summary_path = run_root / "evaluation-summary.json"
     if summary_path.is_file():
-        summaries.append(json.loads(summary_path.read_text(encoding="utf-8")))
+        summaries.append(_load_json_object(summary_path))
     elif job_path.is_file() and result_path.is_file():
         summaries.append(_build_evaluation_summary_row(jobs[-1], results[-1]))
 
@@ -760,13 +786,13 @@ def _collect_evaluation_run(
     if not compare_job_path.is_file():
         return
 
-    compare_job = json.loads(compare_job_path.read_text(encoding="utf-8"))
+    compare_job = _load_json_object(compare_job_path)
     compare_jobs.append(compare_job)
     jobs.append(_normalize_evaluation_compare_job(compare_job))
 
     compare_summary_path = run_root / "evaluation-compare-summary.json"
     if compare_summary_path.is_file():
-        compare_summary_payload = json.loads(compare_summary_path.read_text(encoding="utf-8"))
+        compare_summary_payload = _load_json_object(compare_summary_path)
         for summary in _compare_target_summaries(compare_summary_payload):
             results.append(_normalize_evaluation_compare_result(summary))
             summaries.append(_normalize_evaluation_compare_summary_row(compare_job, summary))


### PR DESCRIPTION
## Summary
- streamline `services/mlx-worker-python/worker/productization/benchmark_export.py` artifact parsing by replacing repeated `read_text()` + `json.loads()` round trips with a shared file-handle JSON loader
- replace `sorted(run_root.glob("bench-result-*.json"))` with an `os.scandir`-backed sorted matcher to reduce extra `Path.glob()` work while preserving lexical ordering
- add focused regression tests for the new helpers, persisted evaluation summaries, and error-handling branches used by the optimized path

## Plan or Spec
- N/A: this is a small internal Python-only optimization slice for benchmark/evaluation export parsing and is not governed by an existing canonical plan or spec

## Commands Run
```text
PYTHONPATH=. pytest -q tests/test_benchmark_export.py::test_iter_sorted_matching_files_returns_lexically_sorted_matching_files tests/test_benchmark_export.py::test_load_json_object_reads_json_without_read_text_round_trip
- PASS (2 passed)

PYTHONPATH=. pytest -q tests/test_benchmark_export.py
- PASS (41 passed)

coverage erase
PYTHONPATH=. coverage run -m pytest -q tests/test_benchmark_export.py
coverage json -o coverage.json
python <changed-scope coverage script>
- PASS; changed_line_coverage=100.00% with missed_changed_lines=[]

python <benchmark export perf probe comparing origin/main vs HEAD>
- PASS; baseline_seconds=12.9793, current_seconds=11.5557, improvement_percent=10.97, baseline_peak_mb=35.88, current_peak_mb=35.99

git diff --check
- PASS
```

## Coverage and Metrics
- Changed-scope coverage for `worker/productization/benchmark_export.py`: **100.00%**
- Measurable changed lines: `[425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 444, 445, 446, 447, 448, 449, 463, 465, 475, 476, 488, 768, 772, 777, 789, 795]`
- Missed changed lines: `[]`
- Performance probe (`collect_benchmark_artifacts` on 1,800 synthetic runs x 12 loops):
  - baseline: `12.9793s`
  - optimized: `11.5557s`
  - wall-clock improvement: `10.97%`
  - baseline peak memory: `35.88 MiB`
  - optimized peak memory: `35.99 MiB`
  - result count parity: `43200` vs `43200`

## Known Gaps
- Did not run repository-wide `make swift-test` / `make integration-test` gates because this cron run is constrained to Linux-verifiable Python-only work.
- The perf probe uses a synthetic filesystem-heavy benchmark workload rather than a captured production artifact bundle.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
