### PR TITLE
perf: reuse one registry tree walk per root

### DIFF
--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -598,6 +598,41 @@ def test_registry_directory_iterators_use_os_scandir_and_preserve_sorted_depth_f
 
 
 
+def test_registry_snapshot_reuses_single_plain_and_manifest_tree_walk_per_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    manifest_dir = root / "alpha-provider" / "AlphaModel" / "q4"
+    _write_registry_manifest(manifest_dir, model_id="alpha-provider/AlphaModel/q4")
+    plain_model_dir = root / "beta-local-a"
+    _write_model_config(plain_model_dir, {"model_type": "qwen3"})
+    _write_weights(plain_model_dir)
+    (plain_model_dir / "README.md").write_text("library_name: mlx\n", encoding="utf-8")
+
+    original_scandir = os.scandir
+    scandir_calls: list[str] = []
+
+    def tracking_scandir(path: str):
+        scandir_calls.append(path)
+        return original_scandir(path)
+
+    monkeypatch.setattr(os, "scandir", tracking_scandir)
+
+    catalog = WorkerModelCatalog(environment={"MELIX_MODEL_ROOTS": os.fspath(root)})
+
+    snapshot = catalog.registry_snapshot()
+
+    discovered_ids = [model.model_id for model in snapshot.models]
+    resolved_root = os.fspath(root.resolve())
+    provider_dir = os.fspath((root / "alpha-provider").resolve())
+
+    assert discovered_ids == ["alpha-provider/AlphaModel/q4", "beta-local-a"]
+    assert scandir_calls.count(resolved_root) == 2
+    assert scandir_calls.count(provider_dir) == 1
+
+
+
 def test_dev_models_honor_configured_text_embedding_and_rerank_overrides() -> None:
     text_model = WorkerModelCatalog.dev_text_model(
         {

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -962,7 +962,8 @@ class WorkerModelCatalog:
                 continue
 
             accepted_model_ids: list[str] = []
-            for manifest_path in self._iter_registry_manifest_paths(root):
+            manifest_paths, plain_local_model_dirs = self._scan_registry_root_tree(root)
+            for manifest_path in manifest_paths:
                 parsed = self._parse_registry_manifest(manifest_path)
                 if parsed is None:
                     continue
@@ -987,6 +988,7 @@ class WorkerModelCatalog:
                 root=root,
                 root_id=root_id,
                 root_order=index,
+                plain_local_model_dirs=plain_local_model_dirs,
                 discovered_models=discovered_models,
                 accepted_model_ids=accepted_model_ids,
             )
@@ -1059,6 +1061,7 @@ class WorkerModelCatalog:
         root: Path,
         root_id: str,
         root_order: int,
+        plain_local_model_dirs: Iterable[Path],
         discovered_models: dict[str, common_pb2.ModelSpec],
         accepted_model_ids: list[str],
     ) -> None:
@@ -1079,7 +1082,7 @@ class WorkerModelCatalog:
             discovered_models[model.model_id] = model
             accepted_model_ids.append(model.model_id)
 
-        for model_dir in self._iter_plain_local_model_dirs(root):
+        for model_dir in plain_local_model_dirs:
             resolved_path = model_dir
             if resolved_path in seen_paths or _is_hf_cache_snapshot_dir(root_resolved, resolved_path):
                 continue
@@ -1138,20 +1141,9 @@ class WorkerModelCatalog:
                 )
 
     @staticmethod
-    def _iter_plain_local_model_dirs(root: Path) -> Iterable[Path]:
-        stack = [root.resolve()]
-        while stack:
-            current = stack.pop()
-            if current.name in {"blobs", ".git", "__pycache__"}:
-                continue
-            if (current / "config.json").is_file():
-                yield current
-                continue
-            children = _sorted_child_directories(current)
-            stack.extend(reversed(children))
-
-    @staticmethod
-    def _iter_registry_manifest_paths(root: Path) -> Iterable[Path]:
+    def _scan_registry_root_tree(root: Path) -> tuple[tuple[Path, ...], tuple[Path, ...]]:
+        manifest_paths: list[Path] = []
+        plain_local_model_dirs: list[Path] = []
         stack = [root.resolve()]
         while stack:
             current = stack.pop()
@@ -1159,10 +1151,24 @@ class WorkerModelCatalog:
                 continue
             manifest_path = current / "manifest.json"
             if manifest_path.is_file():
-                yield manifest_path
+                manifest_paths.append(manifest_path)
+                continue
+            if (current / "config.json").is_file():
+                plain_local_model_dirs.append(current)
                 continue
             children = _sorted_child_directories(current)
             stack.extend(reversed(children))
+        return tuple(manifest_paths), tuple(plain_local_model_dirs)
+
+    @staticmethod
+    def _iter_plain_local_model_dirs(root: Path) -> Iterable[Path]:
+        _, plain_local_model_dirs = WorkerModelCatalog._scan_registry_root_tree(root)
+        yield from plain_local_model_dirs
+
+    @staticmethod
+    def _iter_registry_manifest_paths(root: Path) -> Iterable[Path]:
+        manifest_paths, _ = WorkerModelCatalog._scan_registry_root_tree(root)
+        yield from manifest_paths
 
     @staticmethod
     def _apply_root_metadata(


### PR DESCRIPTION
## Summary
- Reuse a single registry-root tree walk when discovering both manifest-backed models and plain local MLX directories.
- Keep the existing depth-first traversal behavior while avoiding redundant filesystem scans in `WorkerModelCatalog`.
- Add a regression test that proves `registry_snapshot()` now shares one tree walk for manifest/plain discovery per root.

## Plan or Spec
- N/A: behavior-neutral Python optimization slice from the scheduled Linux cron mission; no canonical Melix spec governs this internal traversal detail.

## Commands Run
```text
# RED
pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_reuses_single_plain_and_manifest_tree_walk_per_root
- FAIL (expected): root scandir count was 3 instead of 2 before the optimization.

# GREEN + focused scope
pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_reuses_single_plain_and_manifest_tree_walk_per_root
- PASS
pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py
- PASS (61 passed)

# changed-scope coverage
coverage erase
coverage run -m pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py
coverage json -o coverage.json
python <changed-line coverage script>
- PASS: changed_line_coverage=100.00% for services/mlx-worker-python/worker/model_registry/catalog.py

# perf probe
python <synthetic registry-root benchmark comparing old double walk vs new shared walk>
- PASS: per_run_old_ms=67.272, per_run_new_ms=37.461, speedup_pct=44.31

# hygiene
git diff --check
- PASS
git diff --stat
- PASS
```

## Coverage and Metrics
- Changed executable scope: `services/mlx-worker-python/worker/model_registry/catalog.py`
- Changed-scope coverage: `100.00%`
- Covered changed lines: `[965, 966, 1085, 1144, 1145, 1146, 1152, 1153, 1154, 1155, 1157, 1161, 1163, 1164, 1165, 1166, 1170, 1171]`
- Missed changed lines: `[]`
- Perf probe: synthetic registry root with 400 manifest directories + 800 plain local model directories over 40 runs
  - `old_double_walk_total_s=2.690887`
  - `new_shared_walk_total_s=1.498446`
  - `delta_s=1.192440`
  - `speedup_pct=44.31`
  - `per_run_old_ms=67.272`
  - `per_run_new_ms=37.461`

## Known Gaps
- Did not run the full repository baseline gates (`make proto`, `make swift-test`, `make py-test`, `make integration-test`) because this cron run is constrained to a Linux-verifiable Python-only slice in `services/mlx-worker-python`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
