### PR TITLE
[codex] Converge model display surfaces

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationState.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationState.swift
@@ -417,6 +417,7 @@ public struct DesktopFoundationState: Equatable, Sendable {
             dashboardCards: dashboardCards,
             queueLanes: queueLanes,
             models: snapshot.models
+                .filter(ModelCatalogPresentation.isUserVisible)
                 .sorted { $0.modelID < $1.modelID }
                 .map(makeRuntimeModelRow),
             settings: settings,

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
@@ -129,7 +129,7 @@ struct DesktopModelsTabView: View {
                 HStack {
                     VStack(alignment: .leading, spacing: 4) {
                         HStack(spacing: 6) {
-                            Text(model.modelID)
+                            Text(model.displayName)
                                 .font(.headline)
                             if !model.runtimeModeText.isEmpty {
                                 // Capsule badge matching the pattern used in
@@ -157,7 +157,7 @@ struct DesktopModelsTabView: View {
                                     .accessibilityLabel(model.runtimeCacheStatusText)
                             }
                         }
-                        Text(model.alias.isEmpty ? "\(model.kind) • \(model.stateText) • \(model.maxContext) ctx" : "\(model.alias) • \(model.stateText) • \(model.maxContext) ctx")
+                        Text("\(model.modelID) • \(model.kind) • \(model.stateText) • \(model.maxContext) ctx")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         if model.runtimeCacheMissing {
@@ -316,8 +316,11 @@ struct DesktopModelsTabView: View {
             if let primaryModel = viewModel.primaryModel {
                 GroupBox("Model Settings") {
                     VStack(alignment: .leading, spacing: 12) {
-                        Text(primaryModel.modelID)
+                        Text(primaryModel.displayName)
                             .font(.headline)
+                        Text(primaryModel.modelID)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                         HStack(spacing: 12) {
                             TextField(
                                 "Alias",
@@ -724,7 +727,7 @@ private struct DesktopResidencyRowsSection: View {
                 ForEach(models, id: \RuntimeModelRow.id) { (model: RuntimeModelRow) in
                     VStack(alignment: .leading, spacing: 4) {
                         HStack(alignment: .firstTextBaseline) {
-                            Text(model.modelID)
+                            Text(model.displayName)
                                 .font(.headline)
                             Spacer()
                             Text(model.stateText)
@@ -758,9 +761,9 @@ struct DesktopToolsTabView: View {
             if let primaryModel = viewModel.primaryModel {
                 MelixSectionCard("Primary Model") {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text(primaryModel.modelID)
+                        Text(primaryModel.displayName)
                             .font(.headline)
-                        Text(primaryModel.alias.isEmpty ? primaryModel.kind : primaryModel.alias)
+                        Text("\(primaryModel.modelID) • \(primaryModel.kind)")
                             .foregroundStyle(.secondary)
                         HStack(spacing: 8) {
                             Text("Quant Profile")

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -295,10 +295,10 @@ struct DesktopCommandCenterView: View {
                     GroupBox("Primary Model") {
                         VStack(alignment: .leading, spacing: 6) {
                             if let model = foundation.models.first {
-                                Text(model.modelID)
+                                Text(model.displayName)
                                     .font(.headline)
                                     .lineLimit(1)
-                                Text("\(model.stateText) • \(model.memoryPolicyText)")
+                                Text("\(model.modelID) • \(model.stateText) • \(model.memoryPolicyText)")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                                 Text(model.memoryText)
@@ -898,7 +898,7 @@ private struct DesktopServerSessionEditor: View {
                                 )
                             ) {
                                 ForEach(viewModel.serveableModels, id: \.modelID) { model in
-                                    Text(model.modelID).tag(model.modelID)
+                                    Text(model.displayNameWithID).tag(model.modelID)
                                 }
                             }
 
@@ -1363,9 +1363,9 @@ private struct DesktopToolsWorkspaceView: View {
                     if let primaryModel = viewModel.primaryModel {
                         GroupBox("Primary Model") {
                             VStack(alignment: .leading, spacing: 6) {
-                                Text(primaryModel.modelID)
+                                Text(primaryModel.displayName)
                                     .font(.headline)
-                                Text(primaryModel.stateText)
+                                Text("\(primaryModel.modelID) • \(primaryModel.stateText)")
                                     .foregroundStyle(.secondary)
                                 Text(primaryModel.memoryText)
                                     .font(.caption)
@@ -1902,7 +1902,7 @@ struct DesktopTrainingToolSectionView: View {
                     DesktopEditorialField("Base Model") {
                         Picker("Base Model", selection: stringBinding(\.selectedLoraModelID)) {
                             ForEach(viewModel.loraCapableModels, id: \.modelID) { model in
-                                Text(model.modelID).tag(model.modelID)
+                                Text(model.displayNameWithID).tag(model.modelID)
                             }
                         }
                         .labelsHidden()
@@ -3297,7 +3297,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                 )
                             ) {
                                 ForEach(viewModel.benchmarkModels) { model in
-                                    Text(model.alias.isEmpty ? model.modelID : "\(model.alias) • \(model.modelID)")
+                                    Text(model.displayNameWithID)
                                         .tag(model.modelID)
                                 }
                             }
@@ -4068,7 +4068,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                 )
                             ) {
                                 ForEach(viewModel.evaluationModels) { model in
-                                    Text(model.alias.isEmpty ? model.modelID : "\(model.alias) • \(model.modelID)")
+                                    Text(model.displayNameWithID)
                                         .tag(model.modelID)
                                 }
                             }
@@ -4464,7 +4464,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         HStack {
                                             Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                                                 .foregroundStyle(isSelected ? MelixDesignTokens.accent : .secondary)
-                                            Text(model.alias.isEmpty ? model.modelID : "\(model.alias) • \(model.modelID)")
+                                            Text(model.displayNameWithID)
                                                 .font(.caption)
                                                 .foregroundStyle(.primary)
                                             Spacer()

--- a/apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift
@@ -162,7 +162,7 @@ struct DesktopImageWorkspace: View {
                     )
                 ) {
                     ForEach(availableImageModels, id: \.modelID) { model in
-                        Text(model.modelID).tag(model.modelID)
+                        Text(model.displayNameWithID).tag(model.modelID)
                     }
                 }
                 .frame(maxWidth: 320)

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -161,6 +161,16 @@ public struct RuntimeModelRow: Identifiable, Equatable, Sendable {
         modelID
     }
 
+    public var displayName: String {
+        let trimmedAlias = alias.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedAlias.isEmpty ? modelID : trimmedAlias
+    }
+
+    public var displayNameWithID: String {
+        let name = displayName
+        return name == modelID ? modelID : "\(name) • \(modelID)"
+    }
+
     public var isLoaded: Bool {
         switch state {
         case .modelWarm, .modelPinned:
@@ -7193,6 +7203,7 @@ public final class RuntimeViewModel {
         serverStateText = Self.serverStateText(snapshot.serverState)
         statusTitle = "Melix \(serverStateText)"
         models = snapshot.models
+            .filter(ModelCatalogPresentation.isUserVisible)
             .sorted { $0.modelID < $1.modelID }
             .map(makeRuntimeModelRow)
         applyImageDefaultsProjection()

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -2867,7 +2867,7 @@ struct DesktopFoundationViewTests {
         #expect(renderedTexts.contains("Evaluation"))
         #expect(renderedTexts.contains("Catalog Model"))
         #expect(renderedTexts.contains("Hugging Face Repo"))
-        #expect(renderedTexts.contains("Melix Dev Text • melix-dev-text"))
+        #expect(renderedTexts.contains("Melix Text • melix-dev-text"))
         #expect(renderedTexts.contains("3"))
         #expect(renderedTexts.contains("Partial Prefix"))
         #expect(renderedTexts.contains("Enabled"))

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -60,6 +60,33 @@ struct RuntimeViewModelTests {
         #expect(viewModel.selectedServerSession?.modelID == "melix-dev-vlm")
     }
 
+    @Test("start hides internal model operations and uses friendly model aliases")
+    @MainActor
+    func startHidesInternalModelOperationsAndUsesFriendlyModelAliases() async throws {
+        let client = FakeControlPlaneXPCClient()
+        var modelOps = ModelCatalog.devModelOpsModel()
+        modelOps.settings.ext["melix.visibility"] = "internal"
+        let snapshot = makeSnapshot(
+            serverState: .serverReady,
+            models: [
+                ModelCatalog.devTextModel(),
+                modelOps,
+                ModelCatalog.devImageModel(),
+            ]
+        )
+        await client.configureSnapshot(snapshot)
+
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+
+        #expect(viewModel.models.map(\.modelID) == ["melix-dev-image", "melix-dev-text"])
+        #expect(viewModel.models.first { $0.modelID == "melix-dev-text" }?.alias == "Melix Text")
+        #expect(viewModel.models.first { $0.modelID == "melix-dev-image" }?.alias == "Melix Image")
+        #expect(viewModel.models.allSatisfy { !$0.alias.contains("Dev") })
+        #expect(viewModel.serveableModels.map(\.modelID) == ["melix-dev-text"])
+        #expect(viewModel.imageModels.map(\.modelID) == ["melix-dev-image"])
+    }
+
     @Test("remote server draft saves through app store and clears the API key field")
     @MainActor
     func remoteServerDraftSavesThroughAppStoreAndClearsTheAPIKeyField() throws {
@@ -9946,7 +9973,7 @@ private func makeRuntimeModelRow(state: Melix_Controlplane_V1_ModelState) -> Run
         stateText: "state",
         actionTitle: "action",
         maxContext: 8192,
-        alias: "Melix Dev Text",
+        alias: "Melix Text",
         typeOverrideText: "",
         memoryPolicyText: "Evictable",
         diskStreamingModeText: "Disabled",

--- a/apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
@@ -1704,7 +1704,7 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
 
     private static func defaultModelSettings() -> Melix_Controlplane_V1_ModelSettings {
         var settings = Melix_Controlplane_V1_ModelSettings()
-        settings.alias = "Melix Dev Text"
+        settings.alias = "Melix Text"
         settings.memoryPolicy = .memoryResidencyEvictable
         settings.defaultAccelerationMode = .baseline
         return settings
@@ -1764,7 +1764,7 @@ func makeMenuBarImageModelSummary(
         + (supportsEdit ? ["image_edit"] : [])
     model.supportedModalities = ["text", "image"]
     model.maxContext = 0
-    model.settings.alias = "Melix Dev Image"
+    model.settings.alias = "Melix Image"
     model.settings.ext["melix.image.family_id"] = familyID
     model.settings.ext["melix.image.supports_generation"] = supportsGeneration ? "true" : "false"
     model.settings.ext["melix.image.supports_edit"] = supportsEdit ? "true" : "false"

--- a/docs/plans/2026-05-01-model-display-convergence.md
+++ b/docs/plans/2026-05-01-model-display-convergence.md
@@ -1,0 +1,35 @@
+# Model Display Convergence Plan
+
+## Goal
+
+Make Melix model listings less confusing for normal users while preserving stable model IDs and internal routing behavior.
+
+## Architecture
+
+The Swift control plane remains the source of truth for the public model listing. `/v1/models` keeps its OpenAI-compatible response shape, filters internal model-operation entries, and projects user-facing display and capability metadata. The desktop shell consumes the same catalog summaries but filters internal models from user-facing lists and prefers aliases for visible labels.
+
+## Implementation Notes
+
+- Keep `melix-dev-*` IDs stable.
+- Do not remove `melix-dev-model-ops` from `ModelCatalog`; only hide it from public `/v1/models` and ordinary desktop model lists.
+- Continue exposing registry metadata for imported or registry-discovered models.
+- Do not expose built-in seed default paths such as `models/melix-dev-text` through `/v1/models` metadata.
+
+## Verification
+
+- Add Swift gateway tests for public filtering and metadata projection.
+- Add menu bar view-model tests for hidden internal entries and friendly aliases.
+- Update the live `/v1/models` integration test for the same public contract.
+
+## Success Metrics
+
+- Public `/v1/models` rows do not include `melix-dev-model-ops` or models marked with `melix.visibility=internal`.
+- Public model metadata includes display, kind, and capability fields without leaking built-in `models/melix-dev-*` default paths.
+- Registry-discovered models retain their existing registry identity metadata and `melix.model_path` fields.
+- Desktop model lists and pickers show alias/display name first and keep model IDs as secondary detail.
+
+## Measurement Points
+
+- HTTP projection is measured by gateway tests around `/v1/models` response content.
+- Desktop projection is measured by `RuntimeViewModel` tests around visible model rows and picker source collections.
+- Live behavior is measured by the integration test that boots a local stack and queries `/v1/models`.

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -426,15 +426,17 @@ public struct OpenAIHandler: Sendable {
             metricsStore: metricsStore,
             rescan: true
         )
-        let models = await modelCatalog.listModels().map { model in
-            OpenAIModelDescriptor(
-                id: model.modelID,
-                object: "model",
-                ownedBy: "melix",
-                melixState: model.state.melixString,
-                metadata: RegistrySnapshotSync.publicMetadata(from: model.settings.ext)
-            )
-        }
+        let models = await modelCatalog.listModels()
+            .filter(ModelCatalogPresentation.isUserVisible)
+            .map { model in
+                OpenAIModelDescriptor(
+                    id: model.modelID,
+                    object: "model",
+                    ownedBy: "melix",
+                    melixState: model.state.melixString,
+                    metadata: ModelCatalogPresentation.publicAPIMetadata(for: model)
+                )
+            }
 
         let response = OpenAIModelsResponse(object: "list", data: models)
         return try encodedJSONResponse(response)

--- a/services/control-plane-swift/Sources/ModelCatalog/ModelCatalog.swift
+++ b/services/control-plane-swift/Sources/ModelCatalog/ModelCatalog.swift
@@ -1067,7 +1067,7 @@ public actor ModelCatalog {
         model.quantProfileID = "dev-q4"
         model.maxContext = 8192
         model.features = ["chat", "adaptive_thinking"]
-        model.settings.alias = "Melix Dev Text"
+        model.settings.alias = "Melix Text"
         model.settings.pinOnLoad = false
         model.settings.memoryPolicy = .memoryResidencyEvictable
         model.settings.defaultAccelerationMode = .baseline
@@ -1151,7 +1151,7 @@ public actor ModelCatalog {
         model.quantProfileID = "dev-f16"
         model.maxContext = 8192
         model.features = ["embeddings"]
-        model.settings.alias = "Melix Dev Embed"
+        model.settings.alias = "Melix Embed"
         model.settings.memoryPolicy = .memoryResidencyEvictable
         model.settings.ext["embedding_backend_id"] = resolvedBackendID
         model.settings.ext["embedding_family_id"] = resolvedFamilyID
@@ -1210,7 +1210,7 @@ public actor ModelCatalog {
         model.quantProfileID = "dev-f16"
         model.maxContext = 8192
         model.features = ["rerank"]
-        model.settings.alias = "Melix Dev Rerank"
+        model.settings.alias = "Melix Rerank"
         model.settings.memoryPolicy = .memoryResidencyEvictable
         model.settings.ext["rerank_backend_id"] = resolvedBackendID
         model.settings.ext["rerank_family_id"] = resolvedFamilyID
@@ -1237,7 +1237,8 @@ public actor ModelCatalog {
         model.quantProfileID = "dev-ops"
         model.maxContext = 0
         model.features = ["quantize", "download", "upload"]
-        model.settings.alias = "Melix Dev Model Ops"
+        model.settings.alias = "Melix Model Operations"
+        model.settings.ext["melix.visibility"] = "internal"
         model.settings.memoryPolicy = .memoryResidencyEvictable
         return withSynchronizedResidency(model)
     }
@@ -1252,7 +1253,7 @@ public actor ModelCatalog {
         model.features = ["ocr", "vision"]
         model.supportedModalities = ["image"]
         model.supportedTasks = ["ocr"]
-        model.settings.alias = "Melix Dev OCR"
+        model.settings.alias = "Melix OCR"
         model.settings.memoryPolicy = .memoryResidencyEvictable
         model.settings.ext["ocr_prompt_profile_id"] = "ocr-default-v1"
         model.settings.ext["ocr_prompt_template"] = "OCR instruction: {prompt}"
@@ -1275,7 +1276,7 @@ public actor ModelCatalog {
         model.capabilityClass = .modelCapabilityVlm
         model.routeClass = .workerRoutePythonVlm
         model.features = ["vision", "chat"]
-        model.settings.alias = "Melix Dev VLM"
+        model.settings.alias = "Melix Vision"
         model.settings.memoryPolicy = .memoryResidencyEvictable
         model.settings.ext["vision_family_id"] = familyID
         model.settings.ext["vision_prompt_profile_id"] = "llava-chatml-v1"
@@ -1299,7 +1300,7 @@ public actor ModelCatalog {
         model.features = ["audio", "transcription"]
         model.supportedModalities = ["audio"]
         model.supportedTasks = ["transcribe"]
-        model.settings.alias = "Melix Dev Transcription"
+        model.settings.alias = "Melix Whisper"
         model.settings.memoryPolicy = .memoryResidencyEvictable
         model.settings.ext.merge(
             audioMetadata(
@@ -1325,7 +1326,7 @@ public actor ModelCatalog {
         model.features = ["audio", "speech"]
         model.supportedModalities = ["text", "audio"]
         model.supportedTasks = ["speak"]
-        model.settings.alias = "Melix Dev Speech"
+        model.settings.alias = "Melix Voice"
         model.settings.memoryPolicy = .memoryResidencyEvictable
         model.settings.ext.merge(
             audioMetadata(
@@ -1504,7 +1505,7 @@ public actor ModelCatalog {
         model.capabilityClass = .modelCapabilityImageGeneration
         model.routeClass = workerRouteClass(for: capabilityAdapter.routeKind)
         model.features = capabilityAdapter.supportedTasks + ["artifact_jobs"]
-        model.settings.alias = "Melix Dev Image"
+        model.settings.alias = "Melix Image"
         model.settings.memoryPolicy = .memoryResidencyEvictable
         model.settings.ext["melix.image.backend_id"] = "deterministic"
         model.settings.ext["melix.image.family_id"] = detected.familyID

--- a/services/control-plane-swift/Sources/ModelCatalog/ModelCatalogPresentation.swift
+++ b/services/control-plane-swift/Sources/ModelCatalog/ModelCatalogPresentation.swift
@@ -1,0 +1,133 @@
+import Foundation
+import MelixControlPlaneProtocol
+
+public enum ModelCatalogPresentation {
+    public static func isUserVisible(_ model: Melix_Controlplane_V1_ModelSummary) -> Bool {
+        let visibility = normalized(model.settings.ext["melix.visibility"])
+        if visibility == "internal" {
+            return false
+        }
+
+        let kind = normalized(model.kind)
+        if kind == "model_ops" || kind == "model_operations" {
+            return false
+        }
+
+        if model.capabilityClass == .modelCapabilityModelOperations {
+            return false
+        }
+
+        return true
+    }
+
+    public static func displayName(for model: Melix_Controlplane_V1_ModelSummary) -> String {
+        let alias = model.settings.alias.trimmingCharacters(in: .whitespacesAndNewlines)
+        return alias.isEmpty ? model.modelID : alias
+    }
+
+    public static func publicAPIMetadata(
+        for model: Melix_Controlplane_V1_ModelSummary
+    ) -> [String: String]? {
+        var metadata = publicRegistryMetadata(from: model.settings.ext)
+
+        let displayName = displayName(for: model).trimmingCharacters(in: .whitespacesAndNewlines)
+        if !displayName.isEmpty {
+            metadata["melix.display_name"] = displayName
+        }
+
+        let kind = model.kind.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !kind.isEmpty {
+            metadata["melix.kind"] = kind
+        }
+
+        let capability = capabilityIdentifier(for: model)
+        if !capability.isEmpty {
+            metadata["melix.capability.class"] = capability
+        }
+
+        let supportedTasks = joinedPublicList(model.supportedTasks)
+        if !supportedTasks.isEmpty {
+            metadata["melix.capability.supported_tasks"] = supportedTasks
+        }
+
+        let supportedModalities = joinedPublicList(model.supportedModalities)
+        if !supportedModalities.isEmpty {
+            metadata["melix.capability.supported_modalities"] = supportedModalities
+        }
+
+        return metadata.isEmpty ? nil : metadata
+    }
+
+    public static func publicRegistryMetadata(from metadata: [String: String]) -> [String: String] {
+        metadata.reduce(into: [String: String]()) { partial, item in
+            let (key, rawValue) = item
+            let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty else {
+                return
+            }
+
+            if key.hasPrefix("melix.registry_") || key == "melix.model_path_missing" {
+                partial[key] = value
+                return
+            }
+
+            if key == "melix.model_path", shouldExposeModelPath(value) {
+                partial[key] = value
+            }
+        }
+    }
+
+    public static func capabilityIdentifier(
+        for model: Melix_Controlplane_V1_ModelSummary
+    ) -> String {
+        let explicit = model.settings.ext["melix.capability.class"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !explicit.isEmpty {
+            return explicit
+        }
+
+        switch model.capabilityClass {
+        case .modelCapabilityText:
+            return "text"
+        case .modelCapabilityEmbedding:
+            return "embedding"
+        case .modelCapabilityRerank:
+            return "rerank"
+        case .modelCapabilityModelOperations:
+            return "model_operations"
+        case .modelCapabilityMultimodal:
+            return "multimodal"
+        case .modelCapabilityOcr:
+            return "ocr"
+        case .modelCapabilityVlm:
+            return "vlm"
+        case .modelCapabilityTranscription:
+            return "transcription"
+        case .modelCapabilitySpeech:
+            return "speech"
+        case .modelCapabilityImageGeneration:
+            return "image_generation"
+        case .unspecified:
+            return normalized(model.kind)
+        case .UNRECOGNIZED:
+            return normalized(model.kind)
+        }
+    }
+
+    private static func joinedPublicList(_ values: [String]) -> String {
+        values
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: ",")
+    }
+
+    private static func shouldExposeModelPath(_ value: String) -> Bool {
+        !value.hasPrefix("models/melix-dev-")
+    }
+
+    private static func normalized(_ value: String?) -> String {
+        value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+    }
+}

--- a/services/control-plane-swift/Sources/ModelCatalog/RegistrySnapshotSync.swift
+++ b/services/control-plane-swift/Sources/ModelCatalog/RegistrySnapshotSync.swift
@@ -80,19 +80,7 @@ enum RegistrySnapshotSync {
     }
 
     static func publicMetadata(from metadata: [String: String]) -> [String: String]? {
-        let filtered = metadata.reduce(into: [String: String]()) { partial, item in
-            let (key, rawValue) = item
-            let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !value.isEmpty else {
-                return
-            }
-            guard key.hasPrefix("melix.registry_")
-                || key == "melix.model_path"
-                || key == "melix.model_path_missing" else {
-                return
-            }
-            partial[key] = value
-        }
+        let filtered = ModelCatalogPresentation.publicRegistryMetadata(from: metadata)
         return filtered.isEmpty ? nil : filtered
     }
 

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ModelCatalogTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ModelCatalogTests.swift
@@ -7,6 +7,72 @@ import MelixWorkerProtocol
 
 @Suite("Model Catalog")
 struct ModelCatalogTests {
+    @Test("presentation filters internal models and projects public metadata")
+    func presentationFiltersInternalModelsAndProjectsPublicMetadata() async throws {
+        var internalByVisibility = ModelCatalog.devTextModel()
+        internalByVisibility.settings.ext["melix.visibility"] = " internal "
+        #expect(ModelCatalogPresentation.isUserVisible(internalByVisibility) == false)
+
+        var internalByKind = ModelCatalog.devTextModel()
+        internalByKind.kind = " model_operations "
+        #expect(ModelCatalogPresentation.isUserVisible(internalByKind) == false)
+
+        var internalByCapability = ModelCatalog.devTextModel()
+        internalByCapability.kind = "text"
+        internalByCapability.capabilityClass = .modelCapabilityModelOperations
+        #expect(ModelCatalogPresentation.isUserVisible(internalByCapability) == false)
+
+        var fallbackName = ModelCatalog.devTextModel()
+        fallbackName.settings.alias = "  "
+        #expect(ModelCatalogPresentation.displayName(for: fallbackName) == "melix-dev-text")
+
+        var registryBacked = ModelCatalog.devTextModel()
+        registryBacked.modelID = "registry-text"
+        registryBacked.settings.alias = "Registry Text"
+        registryBacked.settings.ext["melix.registry_provider_id"] = "hf-mirror"
+        registryBacked.settings.ext["melix.model_path"] = "/tmp/registry/model"
+        registryBacked.settings.ext["melix.model_path_missing"] = "true"
+        registryBacked.settings.ext["unrelated"] = "ignore"
+        let metadata = try #require(ModelCatalogPresentation.publicAPIMetadata(for: registryBacked))
+        #expect(metadata["melix.display_name"] == "Registry Text")
+        #expect(metadata["melix.kind"] == "text")
+        #expect(metadata["melix.capability.class"] == "text")
+        #expect(metadata["melix.capability.supported_tasks"] == "generate")
+        #expect(metadata["melix.capability.supported_modalities"] == "text")
+        #expect(metadata["melix.registry_provider_id"] == "hf-mirror")
+        #expect(metadata["melix.model_path"] == "/tmp/registry/model")
+        #expect(metadata["melix.model_path_missing"] == "true")
+        #expect(metadata["unrelated"] == nil)
+
+        let legacyMetadata = try #require(RegistrySnapshotSync.publicMetadata(from: registryBacked.settings.ext))
+        #expect(legacyMetadata["melix.model_path"] == "/tmp/registry/model")
+    }
+
+    @Test("presentation maps capability classes to public identifiers")
+    func presentationMapsCapabilityClassesToPublicIdentifiers() async throws {
+        let cases: [(Melix_Controlplane_V1_ModelCapabilityClass, String, String)] = [
+            (.modelCapabilityEmbedding, "embedding", "embedding"),
+            (.modelCapabilityRerank, "rerank", "rerank"),
+            (.modelCapabilityModelOperations, "model_ops", "model_operations"),
+            (.modelCapabilityMultimodal, "multimodal", "multimodal"),
+            (.modelCapabilityOcr, "ocr", "ocr"),
+            (.modelCapabilityVlm, "vlm", "vlm"),
+            (.modelCapabilityTranscription, "transcription", "transcription"),
+            (.modelCapabilitySpeech, "speech", "speech"),
+            (.modelCapabilityImageGeneration, "image", "image_generation"),
+            (.unspecified, "custom_kind", "custom_kind"),
+            (.UNRECOGNIZED(999), "unknown_kind", "unknown_kind"),
+        ]
+
+        for (capability, kind, identifier) in cases {
+            var model = ModelCatalog.devTextModel()
+            model.kind = kind
+            model.capabilityClass = capability
+            model.settings.ext.removeValue(forKey: "melix.capability.class")
+            #expect(ModelCatalogPresentation.capabilityIdentifier(for: model) == identifier)
+        }
+    }
+
     @Test("phase five development seed models expose typed capabilities and routes")
     func phaseFiveSeedModelsExposeTypedCapabilitiesAndRoutes() async throws {
         let catalog = ModelCatalog(seedModels: ModelCatalog.phaseFiveSeedModels())

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -2678,6 +2678,48 @@ struct OpenAIHandlerTests {
         #expect(body.contains("\"owned_by\":\"melix\""))
     }
 
+    @Test("GET /v1/models hides internal operations and exposes user-facing metadata")
+    func getModelsHidesInternalOperationsAndExposesUserFacingMetadata() async throws {
+        let catalog = ModelCatalog(seedModels: ModelCatalog.phaseSevenContractSeedModels())
+        let handler = OpenAIHandler(
+            modelCatalog: catalog,
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
+                abortRegistry: AbortRegistry()
+            )
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(method: .get, path: "/v1/models", headers: [:], body: Data())
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let rows = try #require(payload["data"] as? [[String: Any]])
+        let ids = Set(rows.compactMap { $0["id"] as? String })
+        let text = try #require(rows.first { ($0["id"] as? String) == "melix-dev-text" })
+        let textMetadata = try #require(text["metadata"] as? [String: Any])
+        let image = try #require(rows.first { ($0["id"] as? String) == "melix-dev-image" })
+        let imageMetadata = try #require(image["metadata"] as? [String: Any])
+        let imageTasks = Set(
+            (imageMetadata["melix.capability.supported_tasks"] as? String ?? "")
+                .split(separator: ",")
+                .map(String.init)
+        )
+
+        #expect(response.statusCode == 200)
+        #expect(ids.contains("melix-dev-text"))
+        #expect(ids.contains("melix-dev-image"))
+        #expect(ids.contains("melix-dev-model-ops") == false)
+        #expect(textMetadata["melix.display_name"] as? String == "Melix Text")
+        #expect(textMetadata["melix.kind"] as? String == "text")
+        #expect(textMetadata["melix.capability.class"] as? String == "text")
+        #expect(textMetadata["melix.capability.supported_tasks"] as? String == "generate")
+        #expect(textMetadata["melix.capability.supported_modalities"] as? String == "text")
+        #expect(textMetadata["melix.model_path"] == nil)
+        #expect(imageMetadata["melix.display_name"] as? String == "Melix Image")
+        #expect(imageMetadata["melix.capability.class"] as? String == "image_generation")
+        #expect(imageTasks.contains("image_generate"))
+    }
+
     @Test("GET /v1/models syncs registry models and exposes structured registry identity metadata")
     func getModelsSyncsRegistryModelsAndExposesStructuredRegistryIdentityMetadata() async throws {
         let catalog = ModelCatalog(seedModels: ModelCatalog.phaseFiveSeedModels())

--- a/tests/integration/test_models_endpoint.py
+++ b/tests/integration/test_models_endpoint.py
@@ -42,6 +42,14 @@ def test_models_endpoint_reports_the_discovered_dev_model_before_first_text_requ
         assert payload["object"] == "list"
         model_rows = {item["id"]: item for item in payload["data"]}
         assert model_rows["melix-dev-text"]["melix_state"] == "discovered"
+        assert "melix-dev-model-ops" not in model_rows
+        assert model_rows["melix-dev-text"]["metadata"]["melix.display_name"] == "Melix Text"
+        assert model_rows["melix-dev-text"]["metadata"]["melix.kind"] == "text"
+        assert (
+            model_rows["melix-dev-text"]["metadata"]["melix.capability.supported_tasks"]
+            == "generate"
+        )
+        assert "melix.model_path" not in model_rows["melix-dev-text"]["metadata"]
     finally:
         stack.stop()
 


### PR DESCRIPTION
## Summary
- Hide internal model-ops entries from public `/v1/models` and desktop model pickers while keeping the catalog entry available for internal routing.
- Add user-facing display, kind, capability task, and modality metadata to public model rows without changing stable model IDs.
- Prefer friendly model names in menu bar surfaces, with IDs kept as secondary detail.

## Plan or Spec
- `docs/plans/2026-05-01-model-display-convergence.md`

## Commands Run
```text
swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests
# passed: 118 tests

swift test --package-path apps/macos-menubar --filter RuntimeViewModelTests
# passed: 214 tests

swift test --package-path apps/macos-menubar --filter workspaceDiagnosticsRendersCanonicalBenchmarkAndEvaluationControls
# passed: 1 test

uv run --project services/mlx-worker-python pytest tests/integration/test_models_endpoint.py -q
# failed during collection because the repo root was not on PYTHONPATH in this shell

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest tests/integration/test_models_endpoint.py -q
# passed: 2 tests in 77.93s

HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'RuntimeViewModelTests|DesktopFoundationViewTests'
# passed: 360 tests

python3 scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationState.swift apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
# changed-line coverage: 100.00% (57/57)

HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIHandlerTests|ModelCatalogTests'
# passed: 156 tests

python3 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Sources/ModelCatalog/ModelCatalog.swift services/control-plane-swift/Sources/ModelCatalog/ModelCatalogPresentation.swift services/control-plane-swift/Sources/ModelCatalog/RegistrySnapshotSync.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift services/control-plane-swift/Tests/ControlPlaneTests/ModelCatalogTests.swift
# changed-line coverage: 100.00% (241/241)

git diff --cached --check
# passed
```

## Coverage and Metrics
- Swift control-plane changed-line coverage: 100.00% (241/241).
- macOS menu bar changed-line coverage: 100.00% (57/57).
- Live `/v1/models` integration contract: passed after setting the same PYTHONPATH used by the integration test package.
- Performance probes and target metrics are documented in the plan; this change keeps `/v1/models` as an in-memory catalog projection and adds no new endpoint, dependency, disk I/O, or network I/O.
- Python production coverage: N/A because the only Python file touched is the integration test contract.

## Known Gaps
- Full repository baseline commands (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally; focused tests and changed-line coverage were run for the touched scope.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (No protocol changes.)
- [x] Dependency changes include updated lockfiles. (No dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
