### PR TITLE
perf(productization): scan lora train runs with os.scandir

### DIFF
--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+import os
 from pathlib import Path
 from typing import Any
 
@@ -49,9 +50,14 @@ class LoraExperimentStore:
         train_root = jobs_root / "train_lora"
         runs_by_id: dict[str, dict[str, Any]] = {}
         if train_root.exists():
-            for run_dir in sorted(train_root.glob("model-ops-*")):
-                if run_dir.is_dir() is False:
+            for entry in sorted((entry for entry in os.scandir(train_root) if entry.name.startswith("model-ops-")), key=lambda entry: entry.name):
+                try:
+                    is_dir = entry.is_dir()
+                except OSError:
                     continue
+                if is_dir is False:
+                    continue
+                run_dir = Path(entry.path)
                 run_path = run_dir / self.run_record_name
                 payload = self._read_payload(run_path)
                 run_id = str(payload.get("run_id", "")).strip()


### PR DESCRIPTION
## Summary
- `services/mlx-worker-python/worker/productization/lora_experiment_store.py`
  - Replace `train_root.glob("model-ops-*")` with an `os.scandir(...)`-based enumeration in `LoraExperimentStore.rebuild_index`.
  - Added local `os` import and preserved current filtering (`model-ops-*` prefix + directory check) and sorting order.
  - Kept behavior parity with the previous glob-based discovery (skip non-directory entries, keep invalid payload handling unchanged).

## Tests
- `PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_lora_experiment_store.py -q`
  - Result: `10 passed`

## Probe
- `candidates=5000`
- `old_mean=0.045799s`
- `new_mean=0.006169s`
- `speedup=7.42x`
- `delta_ms=-39.6295`
