### PR TITLE
perf: stream evaluation jsonl writes

### DIFF
--- a/services/mlx-worker-python/tests/test_evaluation_store.py
+++ b/services/mlx-worker-python/tests/test_evaluation_store.py
@@ -22,6 +22,39 @@ from worker.productization.benchmark_export import (
 from worker.productization.evaluation_store import EvaluationStore
 
 
+def test_write_jsonl_streams_rows_without_building_one_giant_payload(monkeypatch) -> None:
+    writes: list[str] = []
+
+    class FakeFile:
+        def write(self, chunk: str) -> int:
+            writes.append(chunk)
+            return len(chunk)
+
+        def __enter__(self) -> FakeFile:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+            return None
+
+    target_path = Path("/tmp/evaluation-samples.jsonl")
+
+    def fake_open(self: Path, mode: str = "r", encoding: str | None = None) -> FakeFile:
+        assert self == target_path
+        assert mode == "w"
+        assert encoding == "utf-8"
+        return FakeFile()
+
+    monkeypatch.setattr(Path, "open", fake_open)
+
+    rows = ({"sample_id": "sample-1"}, {"sample_id": "sample-2"})
+
+    EvaluationStore._write_jsonl(target_path, rows)
+
+    expected_payload = "".join(json.dumps(row) + "\n" for row in rows)
+    assert "".join(writes) == expected_payload
+    assert writes == [json.dumps(rows[0]), "\n", json.dumps(rows[1]), "\n"]
+
+
 def test_persist_result_writes_expected_artifact_names_and_payloads(tmp_path: Path) -> None:
     store = EvaluationStore()
     jobs_root = tmp_path / "evaluation"
@@ -624,6 +657,7 @@ def test_compare_job_persists_adapter_target_lineage(tmp_path: Path) -> None:
     job_payload = json.loads(persisted["job"].read_text(encoding="utf-8"))
     assert "target_lineage" in job_payload
     assert len(job_payload["target_lineage"]) == 2
+    assert persisted["samples_jsonl"].read_text(encoding="utf-8") == ""
     registered, ephemeral = job_payload["target_lineage"]
     assert registered["materialization_kind"] == "registered"
     assert registered["adapter_manifest_path"] == ""

--- a/services/mlx-worker-python/worker/productization/evaluation_store.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 import json
 from pathlib import Path
 
@@ -58,10 +59,7 @@ class EvaluationStore:
         }
         if samples:
             jsonl_path = run_root / "evaluation-samples.jsonl"
-            jsonl_path.write_text(
-                "\n".join(json.dumps(sample.to_dict()) for sample in samples) + "\n",
-                encoding="utf-8",
-            )
+            self._write_jsonl(jsonl_path, (sample.to_dict() for sample in samples))
             csv_path = run_root / "evaluation-samples.csv"
             csv_path.write_text(
                 self._samples_csv(samples),
@@ -102,10 +100,7 @@ class EvaluationStore:
         )
 
         samples_jsonl_path = run_root / "evaluation-compare-samples.jsonl"
-        samples_jsonl_path.write_text(
-            "\n".join(json.dumps(sample.to_dict()) for sample in samples) + ("\n" if samples else ""),
-            encoding="utf-8",
-        )
+        self._write_jsonl(samples_jsonl_path, (sample.to_dict() for sample in samples))
 
         report_markdown_path = run_root / "evaluation-compare-report.md"
         report_markdown_path.write_text(
@@ -120,6 +115,13 @@ class EvaluationStore:
             "samples_jsonl": samples_jsonl_path,
             "report_markdown": report_markdown_path,
         }
+
+    @staticmethod
+    def _write_jsonl(path: Path, rows: Iterable[object]) -> None:
+        with path.open("w", encoding="utf-8") as handle:
+            for row in rows:
+                handle.write(json.dumps(row))
+                handle.write("\n")
 
     @staticmethod
     def _summary_payload(*, job: EvaluationJob, result: EvaluationResult) -> dict[str, object]:


### PR DESCRIPTION
## Summary
- Stream `EvaluationStore` JSONL artifact writes row-by-row instead of building one giant joined payload first.
- Cover the streaming helper directly and assert empty compare-sample outputs still materialize as an empty file.
- Reduce peak memory pressure for large evaluation runs without changing artifact contents.

## Plan or Spec
- N/A: this is a small Python-only optimization slice from the cron mission, not a behavior change governed by an existing canonical plan or spec.

## Commands Run
```text
python -m pytest -q tests/test_evaluation_store.py::test_write_jsonl_streams_rows_without_building_one_giant_payload
# FAIL before implementation: AttributeError: type object 'EvaluationStore' has no attribute '_write_jsonl'

python -m pytest -q tests/test_evaluation_store.py::test_write_jsonl_streams_rows_without_building_one_giant_payload
# PASS (1 passed)

python -m pytest -q tests/test_evaluation_store.py
# PASS (9 passed)

coverage erase
coverage run -m pytest -q tests/test_evaluation_store.py
coverage json -o coverage.json
python - <<'PY' ... changed-scope coverage parser ...
# PASS: changed_line_coverage=100.00%

python - <<'PY' ... baseline vs current performance probe for 20,000 samples ...
# baseline_elapsed_s=3.2641 baseline_peak_mb=35.35 current_elapsed_s=3.0779 current_peak_mb=7.96

git diff --check
# PASS
```

## Coverage and Metrics
- Changed-scope coverage for `worker/productization/evaluation_store.py`: **100.00%**
  - measurable changed lines: `[3, 62, 103, 119, 120, 121, 122, 123, 124]`
  - missed changed lines: `[]`
- Performance probe (`persist_result`, 20,000 evaluation samples):
  - baseline (`origin/main`): `3.2641s`, peak `35.35 MiB`, JSONL size `17.13 MiB`
  - optimized branch: `3.0779s`, peak `7.96 MiB`, JSONL size `17.13 MiB`
  - delta: `-27.39 MiB` peak memory (`-77.48%`), `-0.1862s` elapsed in this probe

## Known Gaps
- Did not run the repo-wide `make py-test` / integration suite in this Linux cron slice; verification stayed focused on `services/mlx-worker-python/tests/test_evaluation_store.py` because the change is isolated to `EvaluationStore` JSONL persistence.
- Performance numbers are from a synthetic local probe and may vary by host, but they demonstrate the intended reduction in redundant in-memory payload construction.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
