### PR TITLE
perf(quantization): scan quantize artifact with os.scandir

### DIFF
--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -91,11 +92,13 @@ class OQQuantizationPipeline:
         if request.run_smoke_test:
             smoke_test_passed = self._run_structural_smoke_test(bundle_path)
 
-        artifact_bytes = sum(
-            path.stat().st_size
-            for path in bundle_path.iterdir()
-            if path.is_file() and path.name != "manifest.json"
-        )
+        artifact_bytes = 0
+        for entry in os.scandir(bundle_path):
+            if entry.name == "manifest.json":
+                continue
+            if entry.is_file():
+                artifact_bytes += entry.stat().st_size
+
         manifest_path = bundle_path / "manifest.json"
         manifest_payload = self._manifest_payload(
             request=request,


### PR DESCRIPTION
## Summary
- In `services/mlx-worker-python/worker/model_ops/quantization_pipeline.py`, replace one directory scan from `Path.iterdir()` to `os.scandir()` when computing bundle artifact bytes.
- Keep behavior identical: only file entries are counted and `manifest.json` is excluded.

## Validation
- `PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_quantization_pipeline.py -q`
  - Result: `14 passed in 0.42s`
- Probe script: `/tmp/probe_quantization_pipeline.py`
  - `candidates=5000`
  - `old_mean=0.026976`
  - `new_mean=0.008392`
  - `speedup=3.21x`
  - `delta_ms=-18.5840`

Closes #
