### PR TITLE
perf(scripts): scan hf cache snapshots with os.scandir

### DIFF
--- a/scripts/real_model_support.py
+++ b/scripts/real_model_support.py
@@ -290,10 +290,15 @@ def _huggingface_cache_model_path(
     snapshots_root = repo_cache / "snapshots"
     if not snapshots_root.is_dir():
         return None
-    snapshots = sorted(path for path in snapshots_root.iterdir() if path.is_dir())
-    if not snapshots:
+    snapshot_names: list[str] = []
+    with os.scandir(snapshots_root) as entries:
+        for entry in entries:
+            if not entry.is_dir():
+                continue
+            snapshot_names.append(entry.name)
+    if not snapshot_names:
         return None
-    fallback = snapshots[-1].resolve()
+    fallback = (snapshots_root / sorted(snapshot_names)[-1]).resolve()
     return _HuggingFaceCacheModelPath(
         path=fallback,
         warnings=(


### PR DESCRIPTION
## Summary
- In `scripts/real_model_support.py`, replace snapshot directory enumeration
  from `Path.iterdir()` filtering to `os.scandir()` + name-sorted selection in
  `_huggingface_cache_model_path()`.
- Scope kept narrow: only the fallback path that resolves the last HF cache snapshot
  when `refs/main` is missing.
- Behavior preserved: returns lexicographically highest snapshot directory name as before.

## Verification
- `PYTHONPATH=services/mlx-worker-python:. uv run pytest tests/test_real_model_support.py -q`
  - Result: `19 passed`

## Probe
- Candidates: 5000
- `old_mean=0.040476s`
- `new_mean=0.011963s`
- `speedup=3.38x`
- `delta_ms=-28.5130`
