### PR TITLE
perf(scripts): scan real model weight files with os.scandir

### DIFF
--- a/scripts/real_model_support.py
+++ b/scripts/real_model_support.py
@@ -327,11 +327,15 @@ def _is_deterministic_development_model(model_id: str) -> bool:
 def _has_recognized_model_weight_files(path: Path) -> bool:
     if not path.is_dir():
         return False
-    for child in path.iterdir():
-        if not child.is_file():
-            continue
-        if child.name in _REAL_MODEL_WEIGHT_FILENAMES:
-            return True
-        if child.suffix.lower() in _REAL_MODEL_WEIGHT_SUFFIXES:
-            return True
+    with os.scandir(path) as entries:
+        for entry in entries:
+            try:
+                if not entry.is_file():
+                    continue
+            except OSError:
+                continue
+            if entry.name in _REAL_MODEL_WEIGHT_FILENAMES:
+                return True
+            if entry.name.lower().endswith(_REAL_MODEL_WEIGHT_SUFFIXES):
+                return True
     return False

--- a/tests/test_real_model_support.py
+++ b/tests/test_real_model_support.py
@@ -8,11 +8,11 @@ from scripts.real_model_support import (
     REAL_SMALL_TEXT_MODEL_ID,
     REAL_SMALL_TEXT_MODEL_PATH_ENV,
     _descriptor_runtime_model_path,
+    _has_recognized_model_weight_files,
     build_runtime_model_preflight,
     resolve_real_small_text_model_path,
     resolve_real_small_text_model_source,
 )
-
 
 def test_phase2_default_draft_model_is_small_mlx_qwen() -> None:
     assert PHASE2_DEFAULT_DRAFT_TEXT_MODEL_ID == "mlx-community/Qwen3-0.6B-4bit"
@@ -347,3 +347,26 @@ def test_runtime_model_preflight_accepts_index_weight_files(tmp_path: Path) -> N
     )
 
     assert preflight.runtime_model_class == "real_local_model"
+
+
+def test_has_recognized_model_weight_files_skips_path_iterdir(monkeypatch, tmp_path: Path) -> None:
+    model_dir = tmp_path / "weights"
+    model_dir.mkdir()
+    (model_dir / "model.safetensors").write_text("{}", encoding="utf-8")
+
+    def fail_iterdir(_: Path):
+        raise AssertionError("path.iterdir should not be called in _has_recognized_model_weight_files")
+
+    monkeypatch.setattr(Path, "iterdir", fail_iterdir)
+
+    assert _has_recognized_model_weight_files(model_dir) is True
+
+
+def test_has_recognized_model_weight_files_does_not_recurse_into_subdirectories(tmp_path: Path) -> None:
+    model_dir = tmp_path / "weights"
+    model_dir.mkdir()
+    nested = model_dir / "nested"
+    nested.mkdir()
+    (nested / "model.safetensors").write_text("{}", encoding="utf-8")
+
+    assert _has_recognized_model_weight_files(model_dir) is False


### PR DESCRIPTION
### Why
Optimize one more directory traversal hotspot in local model support to avoid `Path.iterdir()` overhead and reduce object allocations in repeated runtime checks.

### Scope
- File: `scripts/real_model_support.py`
- Slice: `_has_recognized_model_weight_files`
- Change: replace `path.iterdir()` loop with `os.scandir(path)` and avoid `Path`-based suffix extraction.
- Added tests in `tests/test_real_model_support.py`:
  - `test_has_recognized_model_weight_files_skips_path_iterdir`
  - `test_has_recognized_model_weight_files_does_not_recurse_into_subdirectories`

### Validation
- Regression test:
  - `PYTHONPATH=services/mlx-worker-python:. uv run pytest tests/test_real_model_support.py -q`
  - Result: `21 passed in 0.08s`
- Probe (CANDIDATES=5000):
  - command: `PYTHONPATH=services/mlx-worker-python:. python /tmp/probe_real_model_support_scan_weights.py`
  - old_mean=24.308345 ms
  - new_mean=3.144539 ms
  - speedup=7.73x
  - delta_ms=-21.163806

### Notes
Single-purpose optimization slice only; no behavior changes beyond scan mechanism.
