### PR TITLE
perf(python): prune valid hf cache subtrees during registry scan

### DIFF
--- a/docs/plans/2026-04-30-hf-cache-tree-pruning-optimization.md
+++ b/docs/plans/2026-04-30-hf-cache-tree-pruning-optimization.md
@@ -1,0 +1,33 @@
+# Hugging Face Cache Tree Pruning Optimization
+
+## Goal
+
+Avoid redundant generic registry-tree traversal work for Hugging Face cache roots in `services/mlx-worker-python/worker/model_registry/catalog.py` while preserving current model discovery behavior.
+
+## Linux-Only Constraint
+
+This optimization is limited to the Python worker codepath and must be fully verifiable on Linux with targeted pytest, coverage, and a synthetic filesystem-scan performance probe.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/model_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_model_registry_catalog.py`
+
+## Planned Change
+
+- Teach the generic registry root walker to prune Hugging Face cache-specific subtrees (`models--*`, `snapshots`, `refs`) instead of feeding those directories into the plain local model directory scan.
+- Preserve dedicated Hugging Face cache discovery via `_scan_huggingface_cache_models()`.
+- Add regression coverage showing the generic walker skips the redundant Hugging Face subtree while `registry_snapshot()` still discovers the same Hugging Face cache model.
+
+## Performance Probe
+
+Build a synthetic Hugging Face cache root with many `models--*/snapshots/*` directories and compare repeated registry rescans against an `origin/main` baseline helper. Success means identical discovered model IDs with lower repeated-rescan wall time and/or fewer directory enumeration calls for the optimized branch.
+
+## Verification Commands
+
+- `PYTHONPATH=<repo>:<repo>/services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py`
+- `PYTHONPATH=<repo>:<repo>/services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py`
+- `coverage json -o coverage.json`
+- changed-scope coverage script against `worker/model_registry/catalog.py`
+- synthetic performance probe comparing `origin/main` logic to branch logic
+- `git diff --check`

--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -20,6 +20,7 @@ from worker.model_registry.catalog import (
     _hf_cache_revision,
     _hf_cache_revision_map,
     _infer_embedding_identity,
+    _is_hf_cache_pruned_subtree,
     _is_hf_cache_snapshot_dir,
     _local_model_id,
     _read_text_prefix,
@@ -596,6 +597,63 @@ def test_registry_directory_iterators_use_os_scandir_and_preserve_sorted_depth_f
     assert manifest_paths == [manifest_dir.resolve() / "manifest.json"]
     assert os.fspath(root.resolve()) in scandir_calls
 
+
+
+def test_registry_root_tree_prunes_hf_cache_snapshot_and_refs_subtrees(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    snapshot_dir = root / "models--mlx-community--Tiny" / "snapshots" / "abc123"
+    refs_dir = root / "models--mlx-community--Tiny" / "refs"
+    plain_model_dir = root / "plain-local"
+    _write_model_config(snapshot_dir, {"model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]})
+    _write_weights(snapshot_dir)
+    (snapshot_dir / "README.md").write_text("library_name: mlx\n", encoding="utf-8")
+    refs_dir.mkdir(parents=True, exist_ok=True)
+    (refs_dir / "main").write_text("abc123\n", encoding="utf-8")
+    _write_model_config(plain_model_dir, {"model_type": "qwen3"})
+
+    plain_dirs = list(WorkerModelCatalog._iter_plain_local_model_dirs(root))
+    manifest_paths = list(WorkerModelCatalog._iter_registry_manifest_paths(root))
+
+    assert plain_dirs == [plain_model_dir.resolve()]
+    assert snapshot_dir.resolve() not in plain_dirs
+    assert manifest_paths == []
+
+
+
+def test_registry_root_tree_does_not_prune_invalid_models_prefix_dirs(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    invalid_snapshot_dir = root / "models--custom" / "snapshots" / "v1"
+    invalid_refs_dir = root / "models--custom" / "refs"
+    _write_model_config(invalid_snapshot_dir, {"model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]})
+    _write_weights(invalid_snapshot_dir)
+    (invalid_snapshot_dir / "README.md").write_text("library_name: mlx\n", encoding="utf-8")
+    invalid_refs_dir.mkdir(parents=True, exist_ok=True)
+    (invalid_refs_dir / "main").write_text("v1\n", encoding="utf-8")
+
+    plain_dirs = list(WorkerModelCatalog._iter_plain_local_model_dirs(root))
+    manifest_paths = list(WorkerModelCatalog._iter_registry_manifest_paths(root))
+
+    assert _is_hf_cache_pruned_subtree(root.resolve(), (root / "models--custom" / "snapshots").resolve()) is False
+    assert _is_hf_cache_pruned_subtree(root.resolve(), invalid_refs_dir.resolve()) is False
+    assert _is_hf_cache_snapshot_dir(root.resolve(), invalid_snapshot_dir.resolve()) is False
+    assert invalid_snapshot_dir.resolve() in plain_dirs
+    assert manifest_paths == []
+
+    catalog = WorkerModelCatalog(environment={"MELIX_MODEL_ROOTS": os.fspath(root)})
+    snapshot = catalog.registry_snapshot()
+
+    assert [model.model_id for model in snapshot.models] == ["models--custom/snapshots/v1"]
+    model = snapshot.models[0]
+    assert model.model_path == str(invalid_snapshot_dir.resolve())
+    assert model.ext["melix.source_kind"] == "local_mlx_directory"
+    assert "melix.hf_repo_id" not in model.ext
+
+
+def test_is_hf_cache_pruned_subtree_returns_false_for_paths_outside_root(tmp_path: Path) -> None:
+    root = (tmp_path / "root").resolve()
+    outside_snapshot_dir = (tmp_path / "outside" / "models--mlx-community--Tiny" / "snapshots").resolve()
+
+    assert _is_hf_cache_pruned_subtree(root, outside_snapshot_dir) is False
 
 
 def test_registry_snapshot_reuses_single_plain_and_manifest_tree_walk_per_root(

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -308,7 +308,19 @@ def _is_hf_cache_snapshot_dir(root: Path, model_dir: Path) -> bool:
         relative_parts = model_dir.relative_to(root).parts
     except ValueError:
         return False
-    return len(relative_parts) >= 3 and relative_parts[0].startswith("models--") and relative_parts[1] == "snapshots"
+    if len(relative_parts) < 3 or relative_parts[1] != "snapshots":
+        return False
+    return _hf_cache_repo_id(root / relative_parts[0]) is not None
+
+
+def _is_hf_cache_pruned_subtree(root: Path, current: Path) -> bool:
+    try:
+        relative_parts = current.relative_to(root).parts
+    except ValueError:
+        return False
+    if len(relative_parts) < 2 or relative_parts[1] not in {"snapshots", "refs"}:
+        return False
+    return _hf_cache_repo_id(root / relative_parts[0]) is not None
 
 
 def _local_model_id(root: Path, model_dir: Path) -> str:
@@ -1144,10 +1156,13 @@ class WorkerModelCatalog:
     def _scan_registry_root_tree(root: Path) -> tuple[tuple[Path, ...], tuple[Path, ...]]:
         manifest_paths: list[Path] = []
         plain_local_model_dirs: list[Path] = []
-        stack = [root.resolve()]
+        resolved_root = root.resolve()
+        stack = [resolved_root]
         while stack:
             current = stack.pop()
             if current.name in {"blobs", ".git", "__pycache__"}:
+                continue
+            if _is_hf_cache_pruned_subtree(resolved_root, current):
                 continue
             manifest_path = current / "manifest.json"
             if manifest_path.is_file():


### PR DESCRIPTION
## Summary
- Prune valid Hugging Face cache `snapshots/` and `refs/` subtrees from the generic registry root walker in `services/mlx-worker-python/worker/model_registry/catalog.py`.
- Keep dedicated Hugging Face cache discovery in `_scan_huggingface_cache_models()` as the authoritative path.
- Add focused regression coverage for valid HF pruning, invalid `models--*` prefixes, and outside-root fallback behavior.

## Plan or Spec
- `docs/plans/2026-04-30-hf-cache-tree-pruning-optimization.md`

## Commands Run
```text
python - <<'PY'
import sys, pytest
repo = '/tmp/melix-cron-python-opt-20260430-190959'
sys.path.insert(0, repo)
sys.path.insert(0, repo + '/services/mlx-worker-python')
raise SystemExit(pytest.main(['-q', 'services/mlx-worker-python/tests/test_model_registry_catalog.py']))
PY
# Result: 64 passed in 0.18s

python - <<'PY'
import json, pathlib, re, subprocess, sys
from coverage import Coverage
import pytest
repo = pathlib.Path('/tmp/melix-cron-python-opt-20260430-190959')
sys.path.insert(0, str(repo))
sys.path.insert(0, str(repo / 'services/mlx-worker-python'))
cov = Coverage(); cov.erase(); cov.start()
exit_code = pytest.main(['-q', 'services/mlx-worker-python/tests/test_model_registry_catalog.py'])
cov.stop(); cov.save()
if exit_code != 0:
    raise SystemExit(exit_code)
coverage_json = repo / 'coverage.json'
cov.json_report(outfile=str(coverage_json))
data = json.loads(coverage_json.read_text())
file_key = 'services/mlx-worker-python/worker/model_registry/catalog.py'
entry = data['files'][file_key]
measured = set(entry['executed_lines']) | set(entry['missing_lines'])
proc = subprocess.run(['git', 'diff', '--unified=0', 'origin/main', '--', file_key], cwd=repo, text=True, capture_output=True, check=True)
changed = set(); new_line = None
for line in proc.stdout.splitlines():
    if line.startswith('@@'):
        m = re.search(r'\+(\d+)(?:,(\d+))?', line)
        new_line = int(m.group(1)); continue
    if new_line is None or line.startswith('+++') or line.startswith('---'):
        continue
    if line.startswith('+'):
        changed.add(new_line); new_line += 1
    elif not line.startswith('-'):
        new_line += 1
source_lines = (repo / file_key).read_text().splitlines()
measurable_changed = [n for n in sorted(changed) if n in measured and source_lines[n-1].strip() and not source_lines[n-1].strip().startswith('#')]
covered = [n for n in measurable_changed if n in entry['executed_lines']]
missed = [n for n in measurable_changed if n in entry['missing_lines']]
percent = 100.0 if not measurable_changed else len(covered) / len(measurable_changed) * 100
print(measurable_changed)
print(covered)
print(missed)
print(percent)
PY
# Result: changed_line_coverage=100.00%; file-level percent_covered=97.46%

python - <<'PY'
import json, statistics, subprocess, sys, tempfile, time, types
from pathlib import Path
repo = Path('/tmp/melix-cron-python-opt-20260430-190959')
sys.path.insert(0, str(repo))
sys.path.insert(0, str(repo / 'services/mlx-worker-python'))
from worker.model_registry.catalog import WorkerModelCatalog as CurrentCatalog
baseline_source = subprocess.run(['git', 'show', 'origin/main:services/mlx-worker-python/worker/model_registry/catalog.py'], cwd=repo, text=True, capture_output=True, check=True).stdout
module = types.ModuleType('baseline_catalog'); module.__file__ = 'baseline_catalog.py'; sys.modules[module.__name__] = module
exec(compile(baseline_source, module.__file__, 'exec'), module.__dict__)
BaselineCatalog = module.WorkerModelCatalog
with tempfile.TemporaryDirectory() as tmp:
    root = Path(tmp) / 'hf-root'
    for repo_idx in range(60):
        cache_repo = root / f'models--org{repo_idx}--demo-model'
        refs_dir = cache_repo / 'refs'; refs_dir.mkdir(parents=True, exist_ok=True)
        for snap_idx in range(4):
            snapshot_id = f's{snap_idx:02d}'
            snap = cache_repo / 'snapshots' / snapshot_id; snap.mkdir(parents=True, exist_ok=True)
            (snap / 'config.json').write_text('{"model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]}\n', encoding='utf-8')
            (snap / 'model.safetensors').write_bytes(b'weights')
            (snap / 'README.md').write_text('library_name: mlx\n', encoding='utf-8')
            (refs_dir / f'branch-{snap_idx}').write_text(snapshot_id + '\n', encoding='utf-8')
    for local_idx in range(8):
        local_dir = root / f'plain-local-{local_idx}'
        local_dir.mkdir(parents=True, exist_ok=True)
        (local_dir / 'config.json').write_text('{"model_type": "qwen3"}\n', encoding='utf-8')
        (local_dir / 'model.safetensors').write_bytes(b'weights')
        (local_dir / 'README.md').write_text('library_name: mlx\n', encoding='utf-8')
    def measure(catalog_cls):
        durations = []; counts = None
        for _ in range(30):
            start = time.perf_counter()
            manifests, plain_dirs = catalog_cls._scan_registry_root_tree(root)
            durations.append(time.perf_counter() - start)
            if counts is None:
                counts = (len(manifests), len(plain_dirs))
        return statistics.mean(durations) * 1000, counts
    base_ms, base_counts = measure(BaselineCatalog)
    cur_ms, cur_counts = measure(CurrentCatalog)
    print(base_ms, base_counts, cur_ms, cur_counts)
PY
# Result: baseline mean 7.372 ms / plain_dir_count 248; branch mean 2.980 ms / plain_dir_count 8 (~59.57% faster)

git diff --check
# Result: clean
```

## Coverage and Metrics
- Changed executable line coverage for `services/mlx-worker-python/worker/model_registry/catalog.py`: `100.00%`
- File-level coverage for `services/mlx-worker-python/worker/model_registry/catalog.py`: `97.46%` (`768/788` statements covered)
- Synthetic performance probe on `_scan_registry_root_tree()` with a 60-repo × 4-snapshot HF cache fixture plus 8 plain local models:
  - `origin/main` baseline: `7.372 ms` mean, `plain_dir_count=248`
  - branch: `2.980 ms` mean, `plain_dir_count=8`
  - improvement: `~59.57%` lower mean wall time while eliminating redundant HF snapshot candidates from the generic walker

## Known Gaps
- Verification for this PR is intentionally limited to the Linux-verifiable Python worker scope.
- I did not run macOS/Swift validation (`make swift-test`) on this Linux host.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
