### PR TITLE
perf(python): reuse embedding projection chunks

### DIFF
--- a/services/mlx-worker-python/tests/test_embedding_runtime.py
+++ b/services/mlx-worker-python/tests/test_embedding_runtime.py
@@ -1,3 +1,6 @@
+import hashlib
+import math
+
 import pytest
 
 from packages.protocol.python.worker.v1 import common_pb2, inference_pb2, runtime_pb2
@@ -6,6 +9,7 @@ from worker.grpc_server import WorkerInferenceService, WorkerRuntimeService
 from worker.model_registry.catalog import WorkerModelCatalog
 from worker.registry import WorkerRegistry
 from worker.runtime.deterministic_embedding_runtime import DeterministicEmbeddingRuntime
+from worker.runtime.embedding_backends import BERTEmbeddingBackend
 from worker.runtime.mlx_text_runtime import MLXTextRuntime
 
 
@@ -36,6 +40,34 @@ def load_model(runtime_service: WorkerRuntimeService, model: common_pb2.ModelSpe
     )
     assert response.ok is True
     return response.model_handle
+
+
+def _legacy_project_digest(seed_text: str, dimensions: int) -> list[float]:
+    digest = hashlib.sha256(seed_text.encode("utf-8")).digest()
+    values: list[float] = []
+
+    for index in range(dimensions):
+        start = (index * 4) % len(digest)
+        chunk = digest[start : start + 4]
+        if len(chunk) < 4:
+            chunk = chunk + digest[: 4 - len(chunk)]
+        raw = int.from_bytes(chunk, "little")
+        normalized = (raw / 0xFFFFFFFF) * 2.0 - 1.0
+        values.append(normalized)
+
+    l2_norm = math.sqrt(sum(value * value for value in values))
+    if l2_norm == 0.0:
+        return [0.0] * dimensions
+    return [round(value / l2_norm, 6) for value in values]
+
+
+def test_project_digest_preserves_legacy_projection_values() -> None:
+    backend = BERTEmbeddingBackend()
+
+    for dimensions in (0, 1, 8, 9, 17, 384):
+        actual = backend._project_digest("bert::projection parity", dimensions)
+        expected = _legacy_project_digest("bert::projection parity", dimensions)
+        assert actual == expected
 
 
 def test_embed_returns_stable_vectors_for_loaded_embedding_models() -> None:

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -42,16 +42,13 @@ class DeterministicEmbeddingBackend:
 
     def _project_digest(self, seed_text: str, dimensions: int) -> list[float]:
         digest = hashlib.sha256(seed_text.encode("utf-8")).digest()
-        values: list[float] = []
-
-        for index in range(dimensions):
-            start = (index * 4) % len(digest)
-            chunk = digest[start : start + 4]
-            if len(chunk) < 4:
-                chunk = chunk + digest[: 4 - len(chunk)]
-            raw = int.from_bytes(chunk, "little")
-            normalized = (raw / 0xFFFFFFFF) * 2.0 - 1.0
-            values.append(normalized)
+        base_values = [
+            (int.from_bytes(digest[start : start + 4], "little") / 0xFFFFFFFF) * 2.0
+            - 1.0
+            for start in range(0, len(digest), 4)
+        ]
+        full_repeats, remainder = divmod(dimensions, len(base_values))
+        values = base_values * full_repeats + base_values[:remainder]
 
         l2_norm = math.sqrt(sum(value * value for value in values))
         if l2_norm == 0.0:


### PR DESCRIPTION
## Summary
- Reuses the eight 4-byte SHA-256 projection chunks in deterministic embedding projection instead of re-slicing and re-decoding the same digest for every output dimension.
- Adds a parity test comparing the optimized projection against the legacy algorithm across boundary dimensions.

## Plan or Spec
- N/A: small internal Python worker performance slice; no externally visible behavior or protocol semantics changed.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_embedding_runtime.py -q
# exit 0; 12 passed in 0.21s

PYTHONPATH=services/mlx-worker-python:. uv run coverage erase
PYTHONPATH=services/mlx-worker-python:. uv run coverage run --source=worker.runtime.embedding_backends -m pytest services/mlx-worker-python/tests/test_embedding_runtime.py -q
# exit 0; 12 passed in 0.29s
PYTHONPATH=services/mlx-worker-python:. uv run coverage report -m services/mlx-worker-python/worker/runtime/embedding_backends.py
# exit 0; services/mlx-worker-python/worker/runtime/embedding_backends.py: 96% coverage

PYTHONPATH=services/mlx-worker-python:. uv run python /tmp/melix_embedding_probe.py
# baseline before change exit 0: mean_ms=149.30718328624997, median_ms=146.0397560003912, min_ms=144.5737889953307
# after change exit 0: mean_ms=84.11818171589402, median_ms=84.73742099886294, min_ms=81.89651199791115

git diff --check
# exit 0

make py-test
# exit 2 on this Linux worker: 42 failed, 1194 passed, 14 skipped. Failures are environment/platform-bound (sandbox-exec unavailable, libmlx.so unavailable, Linux/root filesystem permission behavior, device memory detection), not in the changed embedding projection tests.
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/runtime/embedding_backends.py` reported 96% line coverage with the focused embedding runtime suite.
- Probe: `/tmp/melix_embedding_probe.py` runs 7 measured iterations after warmup over 300 BERT + 300 XLM-R deterministic embeddings at 384 dimensions.
- Baseline mean: 149.307 ms; optimized mean: 84.118 ms; delta: -65.189 ms; speedup: 1.775x (~43.7% faster).
- Validation scope: Linux-local Python worker code only. Full Python suite is not green on this host for pre-existing macOS/MLX sandbox and native-library assumptions.

## Known Gaps
- Full `make py-test` remains blocked on this Linux environment by platform dependencies unrelated to this slice (`sandbox-exec`, `libmlx.so`, and host-specific permission/device probes).
- No macOS runtime validation was performed from this Linux cron worker.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. N/A: internal implementation-only optimization, behavior parity covered by tests.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
