### PR TITLE
perf(python): reduce upload publish file list overhead

### DIFF
--- a/services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py
@@ -59,6 +59,19 @@ _PROCESSOR_CONFIG_FILENAMES = frozenset({
 })
 
 
+def _collect_published_file_list(source_dir: Path) -> list[str]:
+    source_dir_str = os.fspath(source_dir)
+    published_files: list[str] = []
+    for root, _dirs, files in os.walk(source_dir_str):
+        files.sort()
+        relative_root = os.path.relpath(root, start=source_dir_str)
+        if relative_root == ".":
+            published_files.extend(files)
+        else:
+            published_files.extend(f"{relative_root}/{filename}" for filename in files)
+    return sorted(published_files)
+
+
 class HuggingFacePublishBackend:
     def publish(
         self,
@@ -114,7 +127,7 @@ class HuggingFacePublishBackend:
 
         if published_files is None:
             if resolved_source_path.is_dir():
-                published_files = self._collect_published_file_list(resolved_source_path)
+                published_files = _collect_published_file_list(resolved_source_path)
             else:
                 published_files = [resolved_source_path.name]
 
@@ -137,17 +150,7 @@ def _resolve_hf_cli_command() -> str:
 class UploadReceiptPipeline:
     @staticmethod
     def _collect_published_file_list(source_dir: Path) -> list[str]:
-        published_files: list[str] = []
-        for root, _dirs, files in os.walk(source_dir):
-            files.sort()
-            for filename in files:
-                published_files.append(
-                    os.path.relpath(
-                        os.path.join(root, filename),
-                        start=str(source_dir),
-                    )
-                )
-        return sorted(published_files)
+        return _collect_published_file_list(source_dir)
 
     def __init__(self, publisher: Any | None = None) -> None:
         self._publisher = publisher or HuggingFacePublishBackend()


### PR DESCRIPTION
## Summary
- Optimizes upload publish file-list collection by computing the relative root once per visited directory instead of calling `os.path.relpath(os.path.join(...))` for every file.
- Shares that optimized collector with the Hugging Face publish backend fallback path, which also restores the fallback directory-scan behavior covered by existing tests.

## Plan or Spec
- `docs/plans/2026-04-30-upload-receipt-publish-scan-reuse.md`

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_maintenance_service.py::test_hugging_face_publish_backend_adds_private_token_and_commit_message services/mlx-worker-python/tests/test_maintenance_service.py::test_hugging_face_publish_backend_falls_back_to_legacy_cli_when_hf_missing services/mlx-worker-python/tests/test_maintenance_service.py::test_upload_receipt_pipeline_collect_published_file_list_filters_and_sorts services/mlx-worker-python/tests/test_maintenance_service.py::test_prepare_publish_source_uses_collected_file_list_for_directory services/mlx-worker-python/tests/test_maintenance_service.py::test_hugging_face_publish_backend_uses_precomputed_published_files_without_rescanning services/mlx-worker-python/tests/test_maintenance_service.py::test_upload_job_publishes_fused_derived_model_as_merged_export services/mlx-worker-python/tests/test_maintenance_service.py::test_upload_job_publishes_merged_multimodal_model_with_processor_lineage -q
# exit 0; 7 passed in 0.30s

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_maintenance_service.py -q -k 'not test_run_evaluation_uses_checked_in_code_fixture_when_dataset_root_is_omitted'
# exit 0; 135 passed, 2 deselected in 1.19s

PYTHONPATH=services/mlx-worker-python:. uv run python <inline upload file-list probe>
# exit 0; files=9601 old_mean_ms=44.996 new_mean_ms=6.754 delta_ms=-38.241 speedup=6.662x

PYTHONPATH=services/mlx-worker-python:. uv run coverage run --branch -m pytest services/mlx-worker-python/tests/test_maintenance_service.py::test_upload_receipt_pipeline_collect_published_file_list_filters_and_sorts services/mlx-worker-python/tests/test_maintenance_service.py::test_prepare_publish_source_uses_collected_file_list_for_directory services/mlx-worker-python/tests/test_maintenance_service.py::test_hugging_face_publish_backend_uses_precomputed_published_files_without_rescanning -q
# exit 0; 3 passed in 0.52s

PYTHONPATH=services/mlx-worker-python:. uv run coverage report --include='services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py'
# exit 0; file-level targeted subset reported 31% (changed helper/wrapper exercised; broad file coverage not representative for this focused slice)

git diff --check
# exit 0
```

## Coverage and Metrics
- Probe: synthetic tree with 120 directories x 80 files plus one root file (`files=9601`), 9 repeated runs, old and new results asserted identical.
- Result: `old_mean_ms=44.996`, `new_mean_ms=6.754`, `delta_ms=-38.241`, `speedup=6.662x`.
- Linux-only validation scope: Python worker upload receipt code only; no Swift/macOS runtime validation performed.
- Coverage note: focused tests exercise the changed collector and publish paths, but file-level coverage over the large `upload_receipt_pipeline.py` module remains below 95% for the narrow targeted subset.

## Known Gaps
- Full `test_maintenance_service.py` is not fully green on this Linux host because the macOS `sandbox-exec`-dependent checked-in code fixture evaluation cases are not runnable here; the same file passes with those two cases deselected.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or no docs change is required for this internal Python performance slice.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
