### PR TITLE
perf: scan registry descriptors in one pass

### DIFF
--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -599,6 +599,32 @@ def test_registry_directory_iterators_use_os_scandir_and_preserve_sorted_depth_f
 
 
 
+def test_registry_root_tree_detects_descriptors_during_single_scandir_pass(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    manifest_dir = root / "manifest-model"
+    config_dir = root / "plain-model"
+    _write_registry_manifest(manifest_dir, model_id="manifest-model")
+    _write_model_config(config_dir, {"model_type": "qwen3"})
+
+    original_is_file = Path.is_file
+
+    def fail_descriptor_is_file(self: Path) -> bool:
+        if self.name in {"manifest.json", "config.json"}:
+            raise AssertionError("expected descriptor detection from os.scandir entries")
+        return original_is_file(self)
+
+    monkeypatch.setattr(Path, "is_file", fail_descriptor_is_file)
+
+    manifest_paths, plain_dirs = WorkerModelCatalog._scan_registry_root_tree(root)
+
+    assert manifest_paths == (manifest_dir.resolve() / "manifest.json",)
+    assert plain_dirs == (config_dir.resolve(),)
+
+
+
 def test_registry_root_tree_prunes_hf_cache_snapshot_and_refs_subtrees(tmp_path: Path) -> None:
     root = tmp_path / "root"
     snapshot_dir = root / "models--mlx-community--Tiny" / "snapshots" / "abc123"

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -1164,15 +1164,32 @@ class WorkerModelCatalog:
                 continue
             if _is_hf_cache_pruned_subtree(resolved_root, current):
                 continue
-            manifest_path = current / "manifest.json"
-            if manifest_path.is_file():
-                manifest_paths.append(manifest_path)
+            try:
+                with os.scandir(os.fspath(current)) as entries:
+                    child_names: list[str] = []
+                    has_manifest = False
+                    has_config = False
+                    for entry in entries:
+                        try:
+                            if entry.name == "manifest.json" and entry.is_file():
+                                has_manifest = True
+                                continue
+                            if entry.name == "config.json" and entry.is_file():
+                                has_config = True
+                                continue
+                            if entry.is_dir():
+                                child_names.append(entry.name)
+                        except OSError:
+                            continue
+            except OSError:
                 continue
-            if (current / "config.json").is_file():
+            if has_manifest:
+                manifest_paths.append(current / "manifest.json")
+                continue
+            if has_config:
                 plain_local_model_dirs.append(current)
                 continue
-            children = _sorted_child_directories(current)
-            stack.extend(reversed(children))
+            stack.extend(current / name for name in sorted(child_names, reverse=True))
         return tuple(manifest_paths), tuple(plain_local_model_dirs)
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Optimizes registry root traversal by detecting `manifest.json` and `config.json` from the same `os.scandir()` pass used to collect child directories.
- Adds a focused regression test that fails if descriptor detection falls back to separate `Path.is_file()` probes.

## Plan or Spec
- N/A: scoped Python performance-only slice for existing model registry traversal behavior; no product behavior or canonical spec change.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -q
# exit 0; 64 passed in 0.35s (baseline before edit)

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_root_tree_detects_descriptors_during_single_scandir_pass -q
# exit 0; 1 passed in 0.32s

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -q
# exit 0; 65 passed in 0.32s

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python python /tmp/melix_registry_scan_probe.py
# exit 0; candidate_count manifest=667 config=1333; old_mean=337.324 ms; new_mean=297.736 ms; delta=-39.588 ms; speedup=1.133x

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python coverage run --source=worker.model_registry.catalog -m pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -q
# exit 0; 65 passed in 0.46s

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python coverage report --include='*/worker/model_registry/catalog.py'
# exit 0; services/mlx-worker-python/worker/model_registry/catalog.py: 97% coverage

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/model_registry/catalog.py` 97% line coverage.
- Probe command: `PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python python /tmp/melix_registry_scan_probe.py`.
- Probe data set: synthetic Linux registry tree with 667 manifest descriptors and 1,333 config descriptors plus a pruned HF-cache-like subtree.
- Probe result: `old_mean=337.324 ms`, `new_mean=297.736 ms`, `delta_ms=-39.588`, `speedup=1.133x`.
- Validation scope: Linux-verifiable Python registry traversal only; macOS/Swift paths were not run in this environment.

## Known Gaps
- Full repository `make swift-test` / `make integration-test` were not run because this recurring task is limited to locally Linux-verifiable Python slices for a macOS-oriented project.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
