### PR TITLE
perf(python): converge manifest bytes before one write

### DIFF
--- a/docs/plans/2026-04-30-manifest-write-convergence-optimization.md
+++ b/docs/plans/2026-04-30-manifest-write-convergence-optimization.md
@@ -1,0 +1,62 @@
+# 2026-04-30 Manifest Write Convergence Optimization
+
+## Context
+
+This cron run is restricted to Linux-verifiable changes in `services/mlx-worker-python`.
+The slice must stay small, locally testable with Python-only tooling, and include
+focused coverage plus an explicit performance probe before commit.
+
+## Scout Result Summary
+
+The single scouting pass proposed these safe candidates:
+1. Converge `manifest_bytes` in memory before a single manifest write across
+   conversion, quantization, and upload receipt pipelines.
+2. Eliminate redundant post-write artifact directory scans in conversion and
+   quantization pipelines.
+3. Avoid building full registry snapshots when only active derived-model
+   manifests are needed.
+
+## Chosen Slice
+
+Optimize manifest serialization in:
+- `services/mlx-worker-python/worker/model_ops/conversion_pipeline.py`
+- `services/mlx-worker-python/worker/model_ops/quantization_pipeline.py`
+- `services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py`
+
+The change will compute the fixed-point `manifest_bytes` value in memory first
+and then write the converged manifest payload to disk once, instead of rewriting
+`manifest.json` or the upload receipt multiple times until the embedded byte count
+stabilizes.
+
+## Why This Slice
+
+- It reduces redundant JSON serialization and file writes without changing the
+  manifest schema or payload semantics.
+- It is pure Python and locally verifiable on Linux.
+- The affected paths already have focused tests in
+  `tests/test_quantization_pipeline.py`, `tests/test_maintenance_service.py`, and
+  related model-ops coverage.
+- The optimization effect can be measured with a synthetic repeated manifest
+  write probe using temporary directories.
+
+## Task
+
+1. Add or update focused tests first to lock the converged single-write behavior
+   and the persisted `manifest_bytes` value.
+2. Refactor the three pipeline helpers so fixed-point byte convergence happens in
+   memory and only the final payload is written.
+3. Run focused pytest for the touched scope.
+4. Measure changed-scope coverage for the touched executable files and require at
+   least 95% automated coverage before commit.
+5. Run an explicit performance probe comparing the legacy multi-write loop with
+   the new single-write flow and record concrete numbers.
+6. Run `git diff --check`, then commit, push, and open a PR.
+
+## Success Metrics
+
+- Persisted manifest payloads remain unchanged except for implementation detail
+  improvements behind the same schema.
+- Focused tests pass for conversion, quantization, and upload receipt flows.
+- Changed-scope coverage for touched executable lines is at least 95%.
+- The performance probe shows fewer manifest writes and improved wall-clock time.
+- `git diff --check` reports no whitespace or merge-marker issues.

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -16,6 +16,7 @@ import pytest
 from packages.protocol.python.worker.v1 import common_pb2, maintenance_pb2
 
 from worker.grpc_server import WorkerMaintenanceService
+from worker.model_ops.conversion_pipeline import ModelConversionPipeline
 from worker.model_ops.adapter_activation_pipeline import AdapterActivationPipeline
 from worker.model_ops.job_registry import (
     ModelOpsJob,
@@ -614,6 +615,40 @@ def test_convert_model_supports_convert_and_quantize_jobs(tmp_path: Path) -> Non
     assert quantize_payload["kv_quant"] == "q8"
 
 
+def test_convert_model_writes_manifest_once_after_in_memory_byte_convergence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = build_service(tmp_path)
+    write_calls = 0
+    original_write_manifest = ModelConversionPipeline._write_manifest
+
+    def counting_write_manifest(path: Path, payload: dict[str, object]) -> int:
+        nonlocal write_calls
+        write_calls += 1
+        return original_write_manifest(path, payload)
+
+    monkeypatch.setattr(ModelConversionPipeline, "_write_manifest", staticmethod(counting_write_manifest))
+
+    convert_events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "convert"),
+                generate_manifest=True,
+            ),
+            context=None,
+        )
+    )
+    convert_manifest = next(event.manifest for event in convert_events if event.HasField("manifest"))
+    convert_payload = json.loads(convert_manifest.manifest_json)
+    manifest_path = Path(convert_events[-1].completed.output_path) / "manifest.json"
+
+    assert write_calls == 1
+    assert convert_payload["manifest_bytes"] == manifest_path.stat().st_size
+    assert json.loads(manifest_path.read_text(encoding="utf-8")) == convert_payload
+
+
 def test_convert_model_supports_download_and_upload_jobs(tmp_path: Path) -> None:
     service = build_service(tmp_path)
     artifact_path = tmp_path / "artifact"
@@ -653,6 +688,44 @@ def test_convert_model_supports_download_and_upload_jobs(tmp_path: Path) -> None
     assert upload_payload["upload_backend"] == "huggingface_hub"
     assert upload_payload["published_url"] == "https://huggingface.co/melix/upload-target"
     assert upload_manifest.artifact.artifact_kind == "upload_receipt"
+
+
+def test_upload_job_writes_receipt_once_after_in_memory_byte_convergence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = build_service(tmp_path)
+    artifact_path = tmp_path / "artifact"
+    artifact_path.write_text("melix-upload", encoding="utf-8")
+    write_calls = 0
+    original_write_manifest = UploadReceiptPipeline._write_manifest
+
+    def counting_write_manifest(path: Path, payload: dict[str, object]) -> int:
+        nonlocal write_calls
+        write_calls += 1
+        return original_write_manifest(path, payload)
+
+    monkeypatch.setattr(UploadReceiptPipeline, "_write_manifest", staticmethod(counting_write_manifest))
+
+    upload_events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model=str(artifact_path),
+                output_dir=str(tmp_path / "upload"),
+                generate_manifest=True,
+                ext={"operation": "upload", "target_repo": "melix/upload-target"},
+            ),
+            context=None,
+        )
+    )
+    upload_manifest = next(event.manifest for event in upload_events if event.HasField("manifest"))
+    upload_payload = json.loads(upload_manifest.manifest_json)
+    receipt_path = Path(upload_events[-1].completed.output_path)
+
+    assert write_calls == 1
+    assert upload_payload["manifest_bytes"] == receipt_path.stat().st_size
+    assert upload_payload["artifact_bytes"] == receipt_path.stat().st_size
+    assert json.loads(receipt_path.read_text(encoding="utf-8")) == upload_payload
 
 
 def test_download_job_reports_managed_hub_snapshot_without_creating_descriptor(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_quantization_pipeline.py
+++ b/services/mlx-worker-python/tests/test_quantization_pipeline.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from packages.protocol.python.worker.v1 import common_pb2, maintenance_pb2
 
 from worker.grpc_server import WorkerMaintenanceService
+from worker.model_ops.quantization_pipeline import OQQuantizationPipeline
 from worker.model_ops.quantization_profiles import (
     normalize_quantization_profile,
     protected_scope_for_request,
@@ -118,6 +121,44 @@ def test_quantize_job_records_successful_smoke_validation(tmp_path: Path) -> Non
     assert manifest_event.artifact.smoke_test_passed is True
     assert completed_event.artifact.smoke_test_requested is True
     assert completed_event.artifact.smoke_test_passed is True
+
+
+def test_quantize_job_writes_manifest_once_after_in_memory_byte_convergence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = build_service(tmp_path)
+    write_calls = 0
+    original_write_manifest = OQQuantizationPipeline._write_manifest
+
+    def counting_write_manifest(path: Path, payload: dict[str, object]) -> int:
+        nonlocal write_calls
+        write_calls += 1
+        return original_write_manifest(path, payload)
+
+    monkeypatch.setattr(OQQuantizationPipeline, "_write_manifest", staticmethod(counting_write_manifest))
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                ext={"operation": "quantize"},
+            ),
+            context=None,
+        )
+    )
+
+    manifest_event = next(event.manifest for event in events if event.HasField("manifest"))
+    manifest_path = Path(events[-1].completed.output_path) / "manifest.json"
+    manifest_payload = json.loads(manifest_event.manifest_json)
+
+    assert write_calls == 1
+    assert manifest_payload["manifest_bytes"] == manifest_path.stat().st_size
+    assert json.loads(manifest_path.read_text(encoding="utf-8")) == manifest_payload
 
 
 def test_quantize_job_uses_typed_quant_profile_when_provided(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/model_ops/conversion_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/conversion_pipeline.py
@@ -107,10 +107,12 @@ class ModelConversionPipeline:
         manifest_bytes = 0
         while True:
             manifest_payload["manifest_bytes"] = manifest_bytes
-            next_manifest_bytes = self._write_manifest(manifest_path, manifest_payload)
+            next_manifest_bytes = self._manifest_size(manifest_payload)
             if next_manifest_bytes == manifest_bytes:
                 break
             manifest_bytes = next_manifest_bytes
+        manifest_payload["manifest_bytes"] = manifest_bytes
+        self._write_manifest(manifest_path, manifest_payload)
 
         return ConversionPipelineResult(
             bundle_path=bundle_path,
@@ -215,7 +217,15 @@ class ModelConversionPipeline:
         }
 
     @staticmethod
+    def _encode_manifest(payload: dict[str, Any]) -> bytes:
+        return json.dumps(payload, sort_keys=True, indent=2).encode("utf-8") + b"\n"
+
+    @staticmethod
+    def _manifest_size(payload: dict[str, Any]) -> int:
+        return len(ModelConversionPipeline._encode_manifest(payload))
+
+    @staticmethod
     def _write_manifest(path: Path, payload: dict[str, Any]) -> int:
-        encoded = json.dumps(payload, sort_keys=True, indent=2).encode("utf-8") + b"\n"
+        encoded = ModelConversionPipeline._encode_manifest(payload)
         path.write_bytes(encoded)
         return len(encoded)

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -119,10 +119,12 @@ class OQQuantizationPipeline:
         manifest_bytes = 0
         while True:
             manifest_payload["manifest_bytes"] = manifest_bytes
-            next_manifest_bytes = self._write_manifest(manifest_path, manifest_payload)
+            next_manifest_bytes = self._manifest_size(manifest_payload)
             if next_manifest_bytes == manifest_bytes:
                 break
             manifest_bytes = next_manifest_bytes
+        manifest_payload["manifest_bytes"] = manifest_bytes
+        self._write_manifest(manifest_path, manifest_payload)
 
         return QuantizationPipelineResult(
             bundle_path=bundle_path,
@@ -229,7 +231,15 @@ class OQQuantizationPipeline:
         return payload
 
     @staticmethod
+    def _encode_manifest(payload: dict[str, Any]) -> bytes:
+        return json.dumps(payload, sort_keys=True, indent=2).encode("utf-8") + b"\n"
+
+    @staticmethod
+    def _manifest_size(payload: dict[str, Any]) -> int:
+        return len(OQQuantizationPipeline._encode_manifest(payload))
+
+    @staticmethod
     def _write_manifest(path: Path, payload: dict[str, Any]) -> int:
-        encoded = json.dumps(payload, sort_keys=True, indent=2).encode("utf-8") + b"\n"
+        encoded = OQQuantizationPipeline._encode_manifest(payload)
         path.write_bytes(encoded)
         return len(encoded)

--- a/services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py
@@ -261,12 +261,15 @@ class UploadReceiptPipeline:
             manifest_payload["bundle_path"] = str(receipt_path)
             manifest_payload["manifest_bytes"] = manifest_bytes
             manifest_payload["artifact_bytes"] = artifact_bytes
-            next_manifest_bytes = self._write_manifest(receipt_path, manifest_payload)
+            next_manifest_bytes = self._manifest_size(manifest_payload)
             next_artifact_bytes = next_manifest_bytes
             if next_manifest_bytes == manifest_bytes and next_artifact_bytes == artifact_bytes:
                 break
             manifest_bytes = next_manifest_bytes
             artifact_bytes = next_artifact_bytes
+        manifest_payload["manifest_bytes"] = manifest_bytes
+        manifest_payload["artifact_bytes"] = artifact_bytes
+        self._write_manifest(receipt_path, manifest_payload)
 
         return UploadReceiptPipelineResult(
             receipt_path=receipt_path,
@@ -519,8 +522,16 @@ class UploadReceiptPipeline:
         return sorted(f for f in published_files if "/" not in f and f in _PROCESSOR_CONFIG_FILENAMES)
 
     @staticmethod
+    def _encode_manifest(payload: dict[str, Any]) -> bytes:
+        return json.dumps(payload, sort_keys=True, indent=2).encode("utf-8") + b"\n"
+
+    @staticmethod
+    def _manifest_size(payload: dict[str, Any]) -> int:
+        return len(UploadReceiptPipeline._encode_manifest(payload))
+
+    @staticmethod
     def _write_manifest(path: Path, payload: dict[str, Any]) -> int:
-        encoded = json.dumps(payload, sort_keys=True, indent=2).encode("utf-8") + b"\n"
+        encoded = UploadReceiptPipeline._encode_manifest(payload)
         path.write_bytes(encoded)
         return len(encoded)
 


### PR DESCRIPTION
## Summary
- converge manifest byte fixed-point calculation in memory before a single persisted write
- apply the same optimization to conversion, quantization, and upload receipt pipelines
- add focused regression tests that assert each path now performs exactly one manifest/receipt write while preserving persisted payload bytes

## Plan or Spec
- `docs/plans/2026-04-30-manifest-write-convergence-optimization.md`

## Commands Run
```text
pytest -q tests/test_quantization_pipeline.py -k 'writes_manifest_once_after_in_memory_byte_convergence' tests/test_maintenance_service.py -k 'writes_manifest_once_after_in_memory_byte_convergence or writes_receipt_once_after_in_memory_byte_convergence'
# 3 passed, 151 deselected

pytest -q tests/test_quantization_pipeline.py tests/test_maintenance_service.py -k 'test_convert_model_supports_convert_and_quantize_jobs or test_convert_model_writes_manifest_once_after_in_memory_byte_convergence or test_convert_model_supports_download_and_upload_jobs or test_upload_job_writes_receipt_once_after_in_memory_byte_convergence or test_upload_job_links_quantized_artifact_metadata or test_upload_job_links_converted_bundle_metadata'
# 6 passed, 148 deselected

python inline Coverage() runner over:
- tests/test_quantization_pipeline.py
- tests/test_maintenance_service.py -k 'test_convert_model_supports_convert_and_quantize_jobs or test_convert_model_writes_manifest_once_after_in_memory_byte_convergence or test_convert_model_supports_download_and_upload_jobs or test_upload_job_writes_receipt_once_after_in_memory_byte_convergence or test_upload_job_links_quantized_artifact_metadata or test_upload_job_links_converted_bundle_metadata'
# 15 passed + 6 passed, coverage.json emitted

python changed-scope coverage analyzer against git diff hunks
# conversion_pipeline.py changed lines: 100.00%
# quantization_pipeline.py changed lines: 100.00%
# upload_receipt_pipeline.py changed lines: 100.00%

python synthetic perf probe comparing legacy multi-write loop vs single-write flow over 2000 iterations each
# convert: legacy_writes=6000 new_writes=2000 legacy_s=1.180239 new_s=0.415447 speedup=64.80%
# quantize: legacy_writes=6000 new_writes=2000 legacy_s=1.167028 new_s=0.529695 speedup=54.61%
# upload_receipt: legacy_writes=6000 new_writes=2000 legacy_s=1.284508 new_s=0.359494 speedup=72.01%

git diff --check
# clean
```

## Coverage and Metrics
- changed-scope coverage:
  - `worker/model_ops/conversion_pipeline.py`: 100.00% (10/10 changed executable lines)
  - `worker/model_ops/quantization_pipeline.py`: 100.00% (10/10 changed executable lines)
  - `worker/model_ops/upload_receipt_pipeline.py`: 100.00% (11/11 changed executable lines)
- synthetic manifest-write probe over 2000 iterations per path:
  - convert: 6000 writes -> 2000 writes, `1.180239s -> 0.415447s` (`64.80%` faster)
  - quantize: 6000 writes -> 2000 writes, `1.167028s -> 0.529695s` (`54.61%` faster)
  - upload receipt: 6000 writes -> 2000 writes, `1.284508s -> 0.359494s` (`72.01%` faster)

## Known Gaps
- full repository `make` verification was not run in this Linux cron slice; this PR intentionally validates the touched Python worker scope only
- perf evidence is a focused synthetic serialization/write probe rather than an end-to-end MLX runtime benchmark

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (not applicable: no protocol changes)
- [x] Dependency changes include updated lockfiles. (not applicable: no dependency changes)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
