### PR TITLE
perf: short-circuit oversized chunk candidates

### DIFF
--- a/services/mlx-worker-python/tests/test_training_dataset_chunker.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_chunker.py
@@ -158,6 +158,27 @@ def test_long_single_turn_splits_into_multiple_chunks() -> None:
         assert chunk["id"] == f"long#chunk-{idx}"
 
 
+def test_single_turn_search_stops_candidate_rendering_after_first_oversized_segment() -> None:
+    tokenizer = _CountingTokenizer()
+    sample = {
+        "id": "early-exit",
+        "messages": [
+            {"role": "user", "content": _words(200)},
+            {"role": "assistant", "content": _words(50)},
+        ],
+    }
+
+    chunked, stats = chunk_long_samples([sample], chunk_size=80, tokenizer=tokenizer)
+
+    assert stats.chunk_count == len(chunked) == 10
+    assert tokenizer.render_calls <= 18
+    for idx, chunk in enumerate(chunked):
+        rendered = tokenizer.apply_chat_template(
+            chunk["messages"], add_generation_prompt=False, return_dict=False
+        )
+        assert len(rendered) <= 80, f"chunk {idx} over budget: {len(rendered)}"
+
+
 def test_multi_turn_within_chunk_size_passes_through_unchanged() -> None:
     tokenizer = _FakeTokenizer()
     sample = {

--- a/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
@@ -249,14 +249,13 @@ def _chunk_single_turn(
             # smaller K. In practice this only fires when k > word_count,
             # which the guard above already rejects.
             continue
-        chunks = [
-            system_prefix + [{"role": "user", "content": seg}, assistant]
-            for seg in segments
-        ]
-        if all(
-            _render_len(chunk, tokenizer, tools=tools) <= chunk_size
-            for chunk in chunks
-        ):
+        chunks: list[list[dict[str, str]]] = []
+        for segment in segments:
+            chunk = system_prefix + [{"role": "user", "content": segment}, assistant]
+            if _render_len(chunk, tokenizer, tools=tools) > chunk_size:
+                break
+            chunks.append(chunk)
+        else:
             return chunks
 
     raise ModelOperationError(


### PR DESCRIPTION
## Summary
- Short-circuit single-turn chunk-size candidate evaluation after the first oversized segment.
- Avoid building/rendering the rest of a candidate split that already cannot fit, while preserving the emitted smallest valid chunk count.
- Add focused coverage proving the search stops early and all emitted chunks remain within budget.

## Plan or Spec
- N/A: Linux-verifiable Python performance slice for the training dataset chunker; no external behavior or canonical spec changes.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_training_dataset_chunker.py -q
# exit 0; 27 passed in 0.10s

PYTHONPATH=services/mlx-worker-python:. uv run python .runtime/probe_chunker.py
# baseline before change: mean_ms=2106.417, p95_ms=2143.453 over 9 runs x 80 calls
# after change: mean_ms=2038.230, p95_ms=2049.819 over 9 runs x 80 calls

PYTHONPATH=services/mlx-worker-python:. uv run coverage erase && PYTHONPATH=services/mlx-worker-python:. uv run coverage run --source=worker.model_ops.training_dataset_chunker -m pytest services/mlx-worker-python/tests/test_training_dataset_chunker.py -q && PYTHONPATH=services/mlx-worker-python:. uv run coverage report -m
# exit 0; 27 passed; training_dataset_chunker.py coverage 97%

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_training_dataset_builder.py -q
# exit 0; 13 passed in 0.11s

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py` 97% line coverage.
- Probe command: `PYTHONPATH=services/mlx-worker-python:. uv run python .runtime/probe_chunker.py`.
- Probe result: old_mean=2106.417 ms, new_mean=2038.230 ms, delta=-68.187 ms, speedup=1.033x (~3.2% faster), old_p95=2143.453 ms, new_p95=2049.819 ms.
- Validation scope: Linux-only Python worker unit tests and synthetic chunker probe; macOS/Apple Silicon runtime surfaces were not exercised.

## Known Gaps
- Full repository gates (`make swift-test`, `make integration-test`) were not run because this Linux cron environment is not a good fit for the macOS/Apple Silicon project runtime.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
