### PR TITLE
perf: reuse multimodal cache key state per request

### DIFF
--- a/services/mlx-worker-python/tests/test_multimodal_fast_paths.py
+++ b/services/mlx-worker-python/tests/test_multimodal_fast_paths.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 from worker.runtime.multimodal_fast_paths import (
+    ImageFeatureCacheKey,
     MULTIMODAL_DECODE_BASELINE,
     MULTIMODAL_DECODE_FALLBACK,
     MULTIMODAL_DECODE_IMAGE_CACHE_REUSE,
@@ -287,7 +288,7 @@ def test_fast_path_documents_within_request_eviction_when_request_exceeds_cache_
     assert repeat_first.image_feature_cache_misses == 1
 
 
-def test_fast_path_reuses_cached_preprocessing_fingerprint_for_same_request_shape() -> None:
+def test_fast_path_avoids_repeating_preprocessing_fingerprint_lookups_for_same_request_shape() -> None:
     _preprocessing_fingerprint.cache_clear()
     controller = MultimodalFastPathController()
     loaded_model = _loaded_model()
@@ -302,9 +303,102 @@ def test_fast_path_reuses_cached_preprocessing_fingerprint_for_same_request_shap
         assert decision.image_feature_cache_hits == 0
         assert decision.image_feature_cache_misses == 2
         assert after.misses - before.misses == 1
-        assert after.hits - before.hits == 1
+        assert after.hits - before.hits == 0
     finally:
         _preprocessing_fingerprint.cache_clear()
+
+
+def test_fast_path_builds_request_scoped_cache_keys_with_one_fingerprint_per_media_shape(monkeypatch) -> None:
+    controller = MultimodalFastPathController()
+    loaded_model = _loaded_model()
+    metadata = loaded_model["metadata"]
+    assert isinstance(metadata, dict)
+    first_image = _image(b"first-image", filename="first.jpg")
+    second_image = _image(b"second-image", filename="second.jpg")
+    fingerprint_calls: list[tuple[str, str, str, str, str]] = []
+
+    def fake_fingerprint(
+        mime_type: str,
+        image_format: str,
+        vision_prompt_profile_id: str,
+        vision_tokenization_mode: str,
+        vision_max_images_per_prompt: str,
+    ) -> str:
+        fingerprint_calls.append(
+            (
+                mime_type,
+                image_format,
+                vision_prompt_profile_id,
+                vision_tokenization_mode,
+                vision_max_images_per_prompt,
+            )
+        )
+        return "fake-fingerprint"
+
+    monkeypatch.setattr("worker.runtime.multimodal_fast_paths._preprocessing_fingerprint", fake_fingerprint)
+
+    factory = controller._cache_key_factory(
+        family_id="gemma4-v1",
+        adapter_hash="adapter-a",
+        quant_profile_id="none",
+        metadata=metadata,
+    )
+
+    first_key = factory(first_image)
+    second_key = factory(second_image)
+
+    assert first_key == ImageFeatureCacheKey(
+        family_id="gemma4-v1",
+        adapter_hash="adapter-a",
+        preprocessing_fingerprint="fake-fingerprint",
+        quant_profile_id="none",
+        sha256_hex=first_image.sha256_hex,
+    )
+    assert second_key == ImageFeatureCacheKey(
+        family_id="gemma4-v1",
+        adapter_hash="adapter-a",
+        preprocessing_fingerprint="fake-fingerprint",
+        quant_profile_id="none",
+        sha256_hex=second_image.sha256_hex,
+    )
+    assert fingerprint_calls == [
+        (
+            "image/jpeg",
+            "jpg",
+            "gemma4-chatml-v1",
+            "interleaved",
+            "",
+        )
+    ]
+
+
+def test_fast_path_cache_key_wrapper_preserves_existing_key_shape() -> None:
+    loaded_model = _loaded_model()
+    metadata = loaded_model["metadata"]
+    assert isinstance(metadata, dict)
+    image = _image(b"first-image", filename="first.jpg")
+
+    key = MultimodalFastPathController._cache_key(
+        image=image,
+        family_id="gemma4-v1",
+        adapter_hash="adapter-a",
+        quant_profile_id="none",
+        metadata=metadata,
+    )
+
+    assert key == ImageFeatureCacheKey(
+        family_id="gemma4-v1",
+        adapter_hash="adapter-a",
+        preprocessing_fingerprint=_preprocessing_fingerprint(
+            "image/jpeg",
+            "jpg",
+            "gemma4-chatml-v1",
+            "interleaved",
+            "",
+        ),
+        quant_profile_id="none",
+        sha256_hex=image.sha256_hex,
+    )
 
 
 def test_fast_path_falls_back_for_video_only_requests() -> None:

--- a/services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py
+++ b/services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 import logging
 from threading import Lock
-from typing import Any
+from typing import Any, Callable
 
 from worker.runtime.multimodal_preprocessing import PreparedImageInput, PreparedVisionRequest
 
@@ -131,18 +131,18 @@ class MultimodalFastPathController:
         hits = 0
         misses = 0
         adapter_hash = _adapter_hash(metadata)
+        cache_key_factory = self._cache_key_factory(
+            family_id=family_id,
+            adapter_hash=adapter_hash,
+            quant_profile_id=quant_profile_id,
+            metadata=metadata,
+        )
         with self._image_feature_cache_lock:
             for image in prepared_request.images:
                 if not image.sha256_hex:
                     misses += 1
                     continue
-                key = self._cache_key(
-                    image=image,
-                    family_id=family_id,
-                    adapter_hash=adapter_hash,
-                    quant_profile_id=quant_profile_id,
-                    metadata=metadata,
-                )
+                key = cache_key_factory(image)
                 if key in self._image_feature_cache:
                     hits += 1
                     self._image_feature_cache.move_to_end(key)
@@ -172,6 +172,41 @@ class MultimodalFastPathController:
         )
 
     @staticmethod
+    def _cache_key_factory(
+        *,
+        family_id: str,
+        adapter_hash: str,
+        quant_profile_id: str,
+        metadata: dict[str, str],
+    ) -> Callable[[PreparedImageInput], ImageFeatureCacheKey]:
+        vision_prompt_profile_id = metadata.get("vision_prompt_profile_id", "")
+        vision_tokenization_mode = metadata.get("vision_tokenization_mode", "")
+        vision_max_images_per_prompt = metadata.get("vision_max_images_per_prompt", "")
+        preprocessing_fingerprints: dict[tuple[str, str], str] = {}
+
+        def build(image: PreparedImageInput) -> ImageFeatureCacheKey:
+            shape = (image.mime_type, image.format)
+            preprocessing_fingerprint = preprocessing_fingerprints.get(shape)
+            if preprocessing_fingerprint is None:
+                preprocessing_fingerprint = _preprocessing_fingerprint(
+                    image.mime_type,
+                    image.format,
+                    vision_prompt_profile_id,
+                    vision_tokenization_mode,
+                    vision_max_images_per_prompt,
+                )
+                preprocessing_fingerprints[shape] = preprocessing_fingerprint
+            return ImageFeatureCacheKey(
+                family_id=family_id,
+                adapter_hash=adapter_hash,
+                preprocessing_fingerprint=preprocessing_fingerprint,
+                quant_profile_id=quant_profile_id,
+                sha256_hex=image.sha256_hex,
+            )
+
+        return build
+
+    @staticmethod
     def _cache_key(
         *,
         image: PreparedImageInput,
@@ -180,19 +215,12 @@ class MultimodalFastPathController:
         quant_profile_id: str,
         metadata: dict[str, str],
     ) -> ImageFeatureCacheKey:
-        return ImageFeatureCacheKey(
+        return MultimodalFastPathController._cache_key_factory(
             family_id=family_id,
             adapter_hash=adapter_hash,
-            preprocessing_fingerprint=_preprocessing_fingerprint(
-                image.mime_type,
-                image.format,
-                metadata.get("vision_prompt_profile_id", ""),
-                metadata.get("vision_tokenization_mode", ""),
-                metadata.get("vision_max_images_per_prompt", ""),
-            ),
             quant_profile_id=quant_profile_id,
-            sha256_hex=image.sha256_hex,
-        )
+            metadata=metadata,
+        )(image)
 
     @staticmethod
     def _fallback_decision(


### PR DESCRIPTION
## Summary
- Hoist multimodal image-feature cache key invariants out of the per-image `plan()` loop in `worker/runtime/multimodal_fast_paths.py`.
- Reuse a request-scoped cache-key factory so repeated images of the same media shape do not recompute metadata lookups or preprocessing fingerprints.
- Add focused regression tests for the new request-scoped key builder and the legacy `_cache_key()` wrapper.

## Plan or Spec
- N/A: small internal Python worker optimization slice with no dedicated canonical plan. Governed by `AGENTS.md`, `docs/contributing.md`, and `docs/engineering-standards.md` requirements for small verifiable slices plus explicit coverage/metrics evidence.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. pytest services/mlx-worker-python/tests/test_multimodal_fast_paths.py::test_fast_path_builds_request_scoped_cache_keys_with_one_fingerprint_per_media_shape -q
# PASS (after implementation); initially failed with AttributeError for missing _cache_key_factory

PYTHONPATH=services/mlx-worker-python:. pytest services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py -q
# PASS (39 passed)

PYTHONPATH=services/mlx-worker-python:. coverage run -m pytest services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py -q
coverage json -o coverage.json
python <changed-scope coverage parser>
# PASS; changed_line_coverage=100.00%

python <performance probe comparing origin/main vs branch implementation>
# old_seconds=0.636206
# new_seconds=0.566532
# delta_seconds=0.069674
# improvement_percent=10.95

git diff --check
# PASS
```

## Coverage and Metrics
- Changed-scope coverage for `services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py`: **100.00%**
- Measurable changed lines: `[9, 134, 145, 174, 175, 182, 183, 184, 185, 187, 188, 189, 190, 191, 198, 199, 207, 218]`
- Missed changed lines: `[]`
- Performance probe on a synthetic 64-image request over 5,000 `plan()` calls:
  - `origin/main`: `0.636206s`
  - branch: `0.566532s`
  - improvement: `10.95%` faster (`0.069674s` absolute reduction)

## Known Gaps
- Did not run repository-wide `make swift-test` or `make integration-test`; this cron run intentionally stayed within the Linux-verifiable Python worker scope.
- Performance numbers are synthetic microbenchmark evidence for the touched hot path, not an end-to-end runtime benchmark.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
