### PR TITLE
perf: reuse checkpoint numeric token regex

### DIFF
--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -13,7 +13,10 @@ from packages.protocol.python.worker.v1 import common_pb2, maintenance_pb2
 from worker.grpc_server import WorkerMaintenanceService
 from worker.engine.maintenance_core import MaintenanceCore
 from worker.model_ops.adapter_activation_pipeline import AdapterActivationPipeline
-from worker.model_ops.lora_training_pipeline import LoRATrainingPipeline
+from worker.model_ops.lora_training_pipeline import (
+    LoRATrainingPipeline,
+    _latest_checkpoint_from_directory,
+)
 from worker.model_ops.mlx_lm_runner import (
     ActivationMetrics,
     ActivationRequest,
@@ -23,6 +26,7 @@ from worker.model_ops.mlx_lm_runner import (
     TrainingMetrics,
     TrainingRequest,
     TrainingResult,
+    _checkpoint_order_key,
 )
 from worker.model_ops import training_config as training_config_module
 from worker.model_ops import training_dataset as training_dataset_module
@@ -35,6 +39,31 @@ from worker.model_registry.catalog import WorkerModelCatalog
 from worker.registry import WorkerRegistry
 from worker.runtime.deterministic_backend import DeterministicTextBackend
 from worker.runtime.mlx_text_runtime import MLXTextRuntime
+
+
+def test_checkpoint_order_key_uses_last_numeric_token() -> None:
+    older = Path("/tmp/model-ops-999/adapter/checkpoint-2/adapters.safetensors")
+    newer = Path("/tmp/model-ops-001/adapter/checkpoint-10/adapters.safetensors")
+
+    assert max((older, newer), key=_checkpoint_order_key) == newer
+    assert _checkpoint_order_key(Path("/tmp/melix/no-number/adapters.safetensors")) == (
+        -1,
+        "/tmp/melix/no-number/adapters.safetensors",
+    )
+
+
+def test_latest_checkpoint_from_directory_prefers_last_numeric_token(tmp_path: Path) -> None:
+    older = (
+        tmp_path / "model-ops-999" / "adapter" / "checkpoint-2" / "adapters.safetensors"
+    )
+    newer = (
+        tmp_path / "model-ops-001" / "adapter" / "checkpoint-10" / "adapters.safetensors"
+    )
+    for checkpoint in (older, newer):
+        checkpoint.parent.mkdir(parents=True, exist_ok=True)
+        checkpoint.write_bytes(b"weights")
+
+    assert _latest_checkpoint_from_directory(tmp_path) == newer.resolve()
 
 
 def _write_dataset_package(

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -23,6 +23,9 @@ from worker.model_ops.training_dataset import (
 from worker.productization.lora_experiment_store import LoraExperimentStore
 
 
+_NUMERIC_TOKEN_RE = re.compile(r"\d+")
+
+
 @dataclass(frozen=True)
 class LoRATrainingPipelineResult:
     manifest: dict[str, Any]
@@ -363,8 +366,8 @@ def _latest_checkpoint_from_directory(path: Path) -> Path:
         )
 
     def order_key(candidate: str) -> tuple[int, str]:
-        numbers = [int(value) for value in re.findall(r"\d+", candidate)]
-        return (numbers[-1] if numbers else -1, candidate)
+        numbers = _NUMERIC_TOKEN_RE.findall(candidate)
+        return (int(numbers[-1]) if numbers else -1, candidate)
 
     return Path(max(checkpoint_candidates, key=order_key)).resolve()
 

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -26,6 +26,7 @@ from worker.model_ops.training_dataset_chunker import (
 )
 
 _RESULT_PREFIX = "__MELIX_MLX_RESULT__="
+_NUMERIC_TOKEN_RE = re.compile(r"\d+")
 
 
 @dataclass(frozen=True)
@@ -618,8 +619,9 @@ def _checkpoint_summary(adapter_output_dir: Path) -> tuple[int, str]:
 
 
 def _checkpoint_order_key(path: Path) -> tuple[int, str]:
-    numeric_tokens = [int(token) for token in re.findall(r"\d+", str(path))]
-    return (numeric_tokens[-1] if numeric_tokens else -1, str(path))
+    path_text = str(path)
+    numeric_tokens = _NUMERIC_TOKEN_RE.findall(path_text)
+    return (int(numeric_tokens[-1]) if numeric_tokens else -1, path_text)
 
 
 def _serialize_activation_request(request: ActivationRequest) -> dict:


### PR DESCRIPTION
## Summary
- Reuse compiled numeric-token regexes in LoRA checkpoint ordering helpers.
- Avoid building an intermediate `list[int]` for every checkpoint candidate during latest-checkpoint selection.
- Add focused regression coverage for last-numeric-token ordering semantics.

## Plan or Spec
- N/A: small Python worker performance slice for existing LoRA checkpoint discovery behavior; no public behavior or protocol contract changes.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python python .tmp_checkpoint_order_probe.py
# exit 0; candidate_count=30000 repetitions_per_sample=8 samples=8; old_mean_ms=483.832; new_mean_ms=347.301; delta_ms=-136.531; speedup=1.393x

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_lora_model_ops.py -q
# exit 0; 36 passed in 0.52s

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_long_context_baseline.py services/mlx-worker-python/tests/test_lora_long_context_chunked.py -q
# exit 0; 36 passed, 4 skipped in 0.44s

git diff --check
# exit 0

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests -q
# exit 1; 1229 passed, 14 skipped, 15 failed due Linux host limitations/unrelated environment gaps: sandbox-exec unavailable, /usr/bin/ditto unavailable, Linux device memory detection returned 0.0, and one root-only stale-log permission expectation.
```

## Coverage and Metrics
- Focused behavior coverage added in `test_lora_model_ops.py` for `_checkpoint_order_key` and `_latest_checkpoint_from_directory` last-numeric-token ordering.
- Performance probe (Linux, synthetic 30k checkpoint-like paths, 8 samples x 8 repetitions): old_mean=483.832 ms, new_mean=347.301 ms, delta=-136.531 ms, speedup=1.393x.
- Validation scope: Python-only checkpoint ordering helpers validated locally on Linux. macOS-only/system-dependent full-suite failures are documented above and were not caused by this slice.

## Known Gaps
- Full Python suite does not pass on this Linux worker because several existing tests require macOS tooling/sandbox behavior or host-specific device memory behavior.
- No protocol, dependency, or generated artifact changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. (N/A: no public behavior change.)
- [x] Protocol changes include regenerated generated artifacts. (N/A)
- [x] Dependency changes include updated lockfiles. (N/A)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
