### PR TITLE
perf: scan download snapshots with scandir stack

### DIFF
--- a/services/mlx-worker-python/tests/test_download_pipeline_unit.py
+++ b/services/mlx-worker-python/tests/test_download_pipeline_unit.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from worker.model_ops.download_pipeline import DownloadPipeline
+
+
+def test_selected_mirror_uses_first_configured_mirror() -> None:
+    assert (
+        DownloadPipeline._selected_mirror({"mirror_urls": " , https://first.example, https://second.example"})
+        == "https://first.example"
+    )
+
+
+def test_load_model_config_payload_returns_empty_for_non_object_json(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text("[]", encoding="utf-8")
+
+    assert DownloadPipeline._load_model_config_payload(model_dir) == {}
+
+
+def test_huggingface_hub_failure_detects_hub_exception_module() -> None:
+    HubError = type("HubError", (Exception,), {"__module__": "huggingface_hub.errors"})
+
+    assert DownloadPipeline._is_huggingface_hub_failure(HubError("boom")) is True
+
+
+def test_directory_size_uses_scandir_stack_without_os_walk(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "managed-snapshot"
+    nested_dir = model_dir / "nested"
+    nested_dir.mkdir(parents=True)
+    (model_dir / "config.json").write_bytes(b"{}")
+    (nested_dir / "weights.safetensors").write_bytes(b"weights")
+
+    def fail_os_walk(path: str):
+        raise AssertionError("expected explicit os.scandir stack, not os.walk")
+
+    monkeypatch.setattr(os, "walk", fail_os_walk)
+
+    assert DownloadPipeline._directory_size(model_dir) == len(b"{}") + len(b"weights")

--- a/services/mlx-worker-python/worker/model_ops/download_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/download_pipeline.py
@@ -451,10 +451,15 @@ class DownloadPipeline:
     @staticmethod
     def _directory_size(path: Path) -> int:
         total_bytes = 0
-        for root, _dirs, filenames in os.walk(os.fspath(path)):
-            for filename in filenames:
-                file_path = os.path.join(root, filename)
-                total_bytes += os.path.getsize(file_path)
+        stack = [os.fspath(path)]
+        while stack:
+            current = stack.pop()
+            with os.scandir(current) as entries:
+                for entry in entries:
+                    if entry.is_dir(follow_symlinks=False):
+                        stack.append(entry.path)
+                    elif entry.is_file():
+                        total_bytes += entry.stat().st_size
         return total_bytes
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Replaced the managed hub import directory-size walk with an explicit `os.scandir` stack.
- Added focused unit coverage proving the size helper no longer depends on `os.walk` and preserving helper behavior used by the download manifest path.

## Plan or Spec
- N/A: small Linux-validatable Python performance slice for the managed hub download manifest byte-count path; no canonical behavior change or protocol/documentation update required.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_download_pipeline_unit.py services/mlx-worker-python/tests/test_maintenance_service.py -k 'managed_hub or download or directory_size' -q
# exit 0: 14 passed, 129 deselected in 0.35s

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python coverage erase
PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python coverage run --source=worker.model_ops.download_pipeline -m pytest services/mlx-worker-python/tests/test_download_pipeline_unit.py services/mlx-worker-python/tests/test_maintenance_service.py -k 'managed_hub or download or directory_size' -q
# exit 0: 14 passed, 129 deselected in 0.64s
PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python coverage report --include='services/mlx-worker-python/worker/model_ops/download_pipeline.py' -m
# exit 0: services/mlx-worker-python/worker/model_ops/download_pipeline.py 95% coverage

git diff --check
# exit 0

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python python <inline directory-size probe>
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `download_pipeline.py` 95% (235 statements, 12 missed).
- Linux-only performance probe scope: synthetic managed hub snapshot tree with 10,000 files (80 directories x 125 files), comparing old `os.walk` + `os.path.getsize` logic against the new `DownloadPipeline._directory_size` implementation in the same run.
- Probe result: `old_mean=33.084 ms`, `new_mean=23.443 ms`, `delta_ms=-9.641`, `speedup=1.411x`.

## Known Gaps
- Full repository gates were not run in this Linux cron environment; Melix remains primarily Apple Silicon/macOS-oriented.
- A broader `test_maintenance_service.py` run was attempted and hit two pre-existing Linux fixture failures in evaluation code paths unrelated to this download directory-size slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. N/A: implementation-only performance slice with unchanged manifest semantics.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
