### PR TITLE
perf: reduce benchmark queue record normalization overhead

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_queue.py
+++ b/services/mlx-worker-python/tests/test_benchmark_queue.py
@@ -234,6 +234,51 @@ def test_list_records_returns_empty_when_queue_root_is_a_file(tmp_path: Path) ->
     assert records == []
 
 
+def test_list_records_skips_entries_when_is_file_raises_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store = BenchmarkQueueStore()
+    queue_root = tmp_path / "queue"
+    queue_root.mkdir()
+
+    class BrokenEntry:
+        name = "broken.json"
+
+        def is_file(self) -> bool:
+            raise OSError("transient stat failure")
+
+    class BrokenScandir:
+        def __enter__(self):
+            return iter([BrokenEntry()])
+
+        def __exit__(self, exc_type, exc, traceback) -> None:
+            return None
+
+    monkeypatch.setattr("worker.productization.benchmark_queue.os.scandir", lambda path: BrokenScandir())
+
+    records = store.list_records(queue_root=queue_root)
+
+    assert records == []
+
+
+def test_list_records_returns_empty_when_scandir_raises_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store = BenchmarkQueueStore()
+    queue_root = tmp_path / "queue"
+    queue_root.mkdir()
+    monkeypatch.setattr(
+        "worker.productization.benchmark_queue.os.scandir",
+        lambda path: (_ for _ in ()).throw(OSError("directory unavailable")),
+    )
+
+    records = store.list_records(queue_root=queue_root)
+
+    assert records == []
+
+
 def test_benchmark_queue_record_from_dict_uses_zero_for_missing_optional_timestamps() -> None:
     payload = {
         "queue_item_id": "q-minimal",

--- a/services/mlx-worker-python/worker/productization/benchmark_queue.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_queue.py
@@ -35,12 +35,19 @@ class BenchmarkQueueRecord:
 
     @staticmethod
     def from_dict(payload: dict[str, object]) -> BenchmarkQueueRecord:
+        raw_suite_ids = payload.get("suite_ids", ())
+        raw_parameters = payload.get("parameters", {})
+        parameter_items = (
+            raw_parameters.items()
+            if isinstance(raw_parameters, dict)
+            else dict(raw_parameters).items()
+        )
         return BenchmarkQueueRecord(
             queue_item_id=str(payload["queue_item_id"]),
             job_kind=str(payload["job_kind"]),
             model_id=str(payload["model_id"]),
-            suite_ids=tuple(str(item) for item in payload.get("suite_ids", [])),
-            parameters={str(key): str(value) for key, value in dict(payload.get("parameters", {})).items()},
+            suite_ids=tuple(map(str, raw_suite_ids)),
+            parameters={str(key): str(value) for key, value in parameter_items},
             status=str(payload["status"]),
             created_at_unix_ms=int(payload["created_at_unix_ms"]),
             updated_at_unix_ms=int(payload["updated_at_unix_ms"]),


### PR DESCRIPTION
## Summary
- Optimizes benchmark queue record normalization by avoiding an extra `dict(...)` copy for normal JSON object parameters.
- Uses `tuple(map(str, ...))` for suite ID normalization to reduce per-record conversion overhead.
- Adds focused OSError-path unit coverage for queue listing resilience.

## Plan or Spec
- N/A: this is a small Python worker performance slice for existing benchmark queue behavior; it does not change public behavior or protocol semantics.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_benchmark_queue.py -q
# exit 0; 14 passed in 0.05s

PYTHONPATH=services/mlx-worker-python:. uv run coverage erase
PYTHONPATH=services/mlx-worker-python:. uv run coverage run --source=worker.productization.benchmark_queue -m pytest services/mlx-worker-python/tests/test_benchmark_queue.py -q
# exit 0; 14 passed in 0.06s
PYTHONPATH=services/mlx-worker-python:. uv run coverage report --include='*/worker/productization/benchmark_queue.py'
# exit 0; benchmark_queue.py coverage 100% (72 statements, 0 missed)

PYTHONPATH=services/mlx-worker-python:. uv run python /tmp/melix_bq_fromdict_actual_probe.py
# exit 0; old_mean_ms=1041.755 new_mean_ms=982.940 delta_ms=-58.815 speedup=1.0598x over 9 rounds x 300,000 conversions

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_benchmark_export.py -q
# exit 0; 55 passed in 0.18s

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/productization/benchmark_queue.py` is 100% covered by the focused coverage command above.
- Performance probe (Linux-only local validation): `BenchmarkQueueRecord.from_dict` old vs new on a representative queue payload, 9 rounds x 300,000 conversions.
  - old_mean_ms=1041.755
  - new_mean_ms=982.940
  - delta_ms=-58.815
  - speedup=1.0598x

## Known Gaps
- Linux-only Python validation; macOS runtime surfaces were not exercised in this slice.
- Full repository gates (`make swift-test`, `make integration-test`) were not run because this slice only touches Linux-verifiable Python worker code.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is explained.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
