### PR TITLE
perf: stream evaluation final-result sample writes

### DIFF
--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from worker.model_ops.errors import ModelOperationError
+from worker.productization import evaluation_final_result as evaluation_final_result_module
 from worker.productization.evaluation_final_result import (
     EvaluationFieldMapping,
     HFEvaluationDatasetSource,
@@ -19,6 +20,56 @@ from worker.productization.evaluation_final_result import (
     materialize_local_evaluation_dataset,
     score_final_result,
 )
+
+
+def test_write_jsonl_rows_streams_each_row_without_joining_the_full_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output_path = tmp_path / "streamed.jsonl"
+    writes: list[str] = []
+
+    class _Writer:
+        def write(self, chunk: str) -> int:
+            writes.append(chunk)
+            return len(chunk)
+
+        def __enter__(self) -> _Writer:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    def fake_open(self: Path, mode: str = "r", *args: object, **kwargs: object) -> _Writer:
+        assert self == output_path
+        assert mode == "w"
+        assert kwargs.get("encoding") == "utf-8"
+        return _Writer()
+
+    monkeypatch.setattr(Path, "open", fake_open)
+
+    evaluation_final_result_module._write_jsonl_rows(
+        output_path,
+        [
+            {"id": "sample-1", "target": "Paris"},
+            {"id": "sample-2", "target": "Rome"},
+        ],
+    )
+
+    assert writes == [
+        '{"id": "sample-1", "target": "Paris"}',
+        "\n",
+        '{"id": "sample-2", "target": "Rome"}',
+        "\n",
+    ]
+
+
+def test_write_jsonl_rows_preserves_blank_line_contract_for_empty_inputs(tmp_path: Path) -> None:
+    output_path = tmp_path / "empty.jsonl"
+
+    evaluation_final_result_module._write_jsonl_rows(output_path, [])
+
+    assert output_path.read_text(encoding="utf-8") == "\n"
 
 
 def test_extract_final_result_prefers_last_fenced_json_block() -> None:

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -543,11 +543,19 @@ def _materialize_evaluation_rows(
         **source_metadata,
     }
     manifest_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
-    samples_path.write_text(
-        "\n".join(json.dumps(sample) for sample in serialized_samples) + "\n",
-        encoding="utf-8",
-    )
+    _write_jsonl_rows(samples_path, serialized_samples)
     return MaterializedEvaluationDataset(package_path=package_path, cache_key=cache_key, cache_hit=False)
+
+
+def _write_jsonl_rows(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        if not rows:
+            handle.write("\n")
+            return
+        for row in rows:
+            handle.write(json.dumps(row))
+            handle.write("\n")
 
 
 def _validate_field_mapping(field_mapping: EvaluationFieldMapping) -> None:


### PR DESCRIPTION
## Summary
- Stream `samples.jsonl` writes in `worker/productization/evaluation_final_result.py` instead of building one large joined string in memory.
- Add focused helper tests that lock in per-row streaming and the existing empty-file newline contract.

## Plan or Spec
- N/A: this is a small internal Python memory-pressure optimization in `services/mlx-worker-python` and does not change user-visible behavior or any canonical spec/documented contract beyond the tested file-output contract.

## Commands Run
```text
PYTHONPATH=. uv run pytest tests/test_evaluation_final_result.py -q
13 passed in 0.08s

PYTHONPATH=. uv run coverage erase
PYTHONPATH=. uv run coverage run --include='*/worker/productization/evaluation_final_result.py' -m pytest tests/test_evaluation_final_result.py -q
13 passed in 0.12s
PYTHONPATH=. uv run coverage report -m
worker/productization/evaluation_final_result.py 369 stmts, 124 miss, 66% file coverage
python changed-scope coverage script
changed_line_coverage=100.00%

python performance probe (20,000 rows, 5 loops)
old_join: mean_time_s=0.405916 peak_bytes_mean=6266600 output_bytes=2566670
new_stream: mean_time_s=0.410642 peak_bytes_mean=26245 output_bytes=2566670
time_ratio_old_over_new=0.988
peak_memory_reduction=99.58%
byte_identical=True

git diff --check
(clean)
```

## Coverage and Metrics
- Changed executable-line coverage for `worker/productization/evaluation_final_result.py`: `100.00%` (`missed_changed_lines=[]`).
- Full-file coverage for the touched module under the focused test file: `66%`; changed-scope gate is satisfied because only the edited executable lines were measured and all were covered.
- Performance probe on synthetic 20,000-row sample output:
  - Peak traced Python memory: `6,266,600 -> 26,245` bytes (`99.58%` reduction).
  - Output bytes: identical at `2,566,670` bytes.
  - Mean wall time: `0.405916s -> 0.410642s` (`~1.2%` slower in this microbenchmark, effectively time-neutral for this slice while substantially reducing transient allocation pressure).

## Known Gaps
- Did not run the full repository verification matrix (`make py-test`, `make integration-test`, Swift/macOS checks) in this Linux cron slice.
- The performance probe demonstrates lower transient Python allocation pressure, not end-to-end RSS under production workloads.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. (N/A: no user-visible behavior change; helper/file-output contract covered by tests.)
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
