### PR TITLE
perf: speed up upload published file collection

### DIFF
--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -1695,6 +1695,30 @@ def test_upload_receipt_pipeline_collect_published_file_list_filters_and_sorts(t
     ]
 
 
+def test_upload_receipt_pipeline_collect_published_file_list_preserves_symlink_rules(
+    tmp_path: Path,
+) -> None:
+    source_root = tmp_path / "model"
+    source_root.mkdir()
+    (source_root / "weights.bin").write_text("weights", encoding="utf-8")
+    target_file = source_root / "target.txt"
+    target_file.write_text("target", encoding="utf-8")
+    (source_root / "file-link.txt").symlink_to(target_file)
+    nested_root = source_root / "nested"
+    nested_root.mkdir()
+    (nested_root / "config.json").write_text("{}", encoding="utf-8")
+    (source_root / "dir-link").symlink_to(nested_root, target_is_directory=True)
+    (source_root / "broken-link").symlink_to(source_root / "missing.bin")
+
+    assert UploadReceiptPipeline._collect_published_file_list(source_root) == [
+        "broken-link",
+        "file-link.txt",
+        "nested/config.json",
+        "target.txt",
+        "weights.bin",
+    ]
+
+
 def test_prepare_publish_source_uses_collected_file_list_for_directory(tmp_path: Path) -> None:
     pipeline = UploadReceiptPipeline(publisher=FakePublishBackend())
     source_root = tmp_path / "source"

--- a/services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py
@@ -61,14 +61,19 @@ _PROCESSOR_CONFIG_FILENAMES = frozenset({
 
 def _collect_published_file_list(source_dir: Path) -> list[str]:
     source_dir_str = os.fspath(source_dir)
+    pending: list[tuple[str, str]] = [(source_dir_str, "")]
     published_files: list[str] = []
-    for root, _dirs, files in os.walk(source_dir_str):
-        files.sort()
-        relative_root = os.path.relpath(root, start=source_dir_str)
-        if relative_root == ".":
-            published_files.extend(files)
-        else:
-            published_files.extend(f"{relative_root}/{filename}" for filename in files)
+    while pending:
+        current_dir, relative_dir = pending.pop()
+        with os.scandir(current_dir) as entries:
+            for entry in entries:
+                relative_path = entry.name if not relative_dir else f"{relative_dir}/{entry.name}"
+                if entry.is_dir(follow_symlinks=False):
+                    pending.append((entry.path, relative_path))
+                elif entry.is_file(follow_symlinks=False):
+                    published_files.append(relative_path)
+                elif not entry.is_dir(follow_symlinks=True):
+                    published_files.append(relative_path)
     return sorted(published_files)
 
 


### PR DESCRIPTION
## Summary
- Replaced the upload receipt published-file directory walk with an explicit `os.scandir` stack.
- Avoids per-directory `os.path.relpath` work while preserving deterministic sorted output and non-followed directory symlink behavior.
- Added a Linux-valid focused regression test for file symlinks, directory symlinks, and broken symlinks.

## Plan or Spec
- N/A: recurring Python performance optimization slice; this is an internal helper optimization with no behavior/spec change.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_maintenance_service.py -k 'upload_receipt_pipeline_collect_published_file_list or prepare_publish_source_uses_collected_file_list_for_directory' -q
# exit 0: 3 passed, 137 deselected in 0.78s

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_maintenance_service.py -q
# exit 1: 138 passed, 2 failed; failures are existing evaluation fixture omissions in test_run_evaluation_uses_checked_in_code_fixture_when_dataset_root_is_omitted for humaneval/mbpp, unrelated to upload receipt file collection.

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_maintenance_service.py -q -k 'not run_evaluation_uses_checked_in_code_fixture_when_dataset_root_is_omitted'
# exit 0: 138 passed, 2 deselected in 1.14s

git diff --check
# exit 0

PYTHONPATH=services/mlx-worker-python:. python - <<'PY'
# inline probe comparing the previous os.walk implementation against the new os.scandir implementation on a synthetic 9,800-file model bundle
PY
# exit 0
```

## Coverage and Metrics
- Changed-scope behavior coverage: focused upload receipt tests passed on Linux.
- Performance probe: candidate_count=9800, old_mean=6.868ms, new_mean=6.113ms, delta_ms=-0.755ms, speedup=1.124x over 15 runs.
- Validation scope: Linux-only Python helper path; macOS runtime behavior was not exercised in this environment.

## Known Gaps
- Full `test_maintenance_service.py` currently has 2 unrelated failures in checked-in code evaluation fixture tests (`response.results` empty for humaneval/mbpp). The upload receipt focused tests and the rest of the file excluding those known failures pass.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is explained.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or N/A is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
