### PR TITLE
perf: reduce benchmark report row rescans

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -7,8 +7,10 @@ import pytest
 
 from worker.productization.benchmark_evaluation_report import (
     _aggregate_probe_values,
+    _dict_rows,
     _finalize_numeric_aggregate,
     _markdown_cell,
+    _report_rows,
     _update_numeric_aggregate,
     build_benchmark_evaluation_report,
     build_sticky_comment_body,
@@ -249,6 +251,19 @@ def test_aggregate_probe_values_handles_empty_inputs() -> None:
     assert _aggregate_probe_values("prefill_ms", []) == ("mean", 0.0)
     assert _aggregate_probe_values("cache_hit", []) == ("rate", 0.0)
     assert _aggregate_probe_values("speculative_fallback_count", []) == ("sum", 0.0)
+
+
+def test_row_iterators_filter_invalid_entries_without_materializing_copies() -> None:
+    report = {"rows": [{"metric": "bench.smoke.ttft_ms"}, "skip", {"metric": "eval.mmlu.score"}]}
+    payload = [{"suite_id": "mmlu"}, None, {"suite_id": "gsm8k"}]
+
+    assert tuple(_report_rows(report)) == (
+        {"metric": "bench.smoke.ttft_ms"},
+        {"metric": "eval.mmlu.score"},
+    )
+    assert tuple(_dict_rows(payload)) == ({"suite_id": "mmlu"}, {"suite_id": "gsm8k"})
+    assert tuple(_report_rows({"rows": "not-a-list"})) == ()
+    assert tuple(_dict_rows("not-a-list")) == ()
 
 
 def test_report_builder_reports_missing_metrics_and_non_numeric_status() -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 import json
 from pathlib import Path
 from typing import Any
@@ -90,17 +91,24 @@ def build_benchmark_evaluation_report(
     baseline_metrics = _collect_metrics(baseline)
     candidate_metrics = _collect_metrics(candidate)
     metric_names = sorted(set(baseline_metrics) | set(candidate_metrics))
-    rows = [
-        _build_metric_row(
+    rows: list[dict[str, object]] = []
+    warning_count = 0
+    missing_count = 0
+    not_comparable_count = 0
+    for metric_name in metric_names:
+        row = _build_metric_row(
             metric_name=metric_name,
             baseline=baseline_metrics.get(metric_name),
             candidate=candidate_metrics.get(metric_name),
         )
-        for metric_name in metric_names
-    ]
-    warning_count = sum(1 for row in rows if row["status"] == "warning")
-    missing_count = sum(1 for row in rows if row["status"] == "missing")
-    not_comparable_count = sum(1 for row in rows if row["status"] == "not_comparable")
+        rows.append(row)
+        match row["status"]:
+            case "warning":
+                warning_count += 1
+            case "missing":
+                missing_count += 1
+            case "not_comparable":
+                not_comparable_count += 1
     status = "warning" if warning_count else "ok"
     if missing_count and status == "ok":
         status = "missing"
@@ -489,14 +497,21 @@ def _matrix_label(row: dict[str, object]) -> str:
     return ".".join(part.replace(" ", "_") for part in parts)
 
 
-def _report_rows(report: dict[str, object]) -> list[dict[str, object]]:
-    return [row for row in report.get("rows", []) if isinstance(row, dict)]
+def _report_rows(report: dict[str, object]) -> Iterator[dict[str, object]]:
+    rows = report.get("rows", [])
+    if not isinstance(rows, list):
+        return
+    for row in rows:
+        if isinstance(row, dict):
+            yield row
 
 
-def _dict_rows(value: object) -> list[dict[str, object]]:
+def _dict_rows(value: object) -> Iterator[dict[str, object]]:
     if not isinstance(value, list):
-        return []
-    return [row for row in value if isinstance(row, dict)]
+        return
+    for row in value:
+        if isinstance(row, dict):
+            yield row
 
 
 def _float_or_none(value: object) -> float | None:


### PR DESCRIPTION
## Summary
- reduce redundant rescans when building benchmark/evaluation report rows
- switch row-filter helpers to iterator-based filtering so collectors/renderers stop allocating throwaway filtered lists
- add focused tests for the iterator helpers while preserving existing report behavior

## Plan or Spec
- N/A: internal Python performance optimization slice for `services/mlx-worker-python` with no canonical behavior spec or external API/documentation change

## Commands Run
```text
cd /tmp/melix-cron-20260430-223644/services/mlx-worker-python
PYTHONPATH=/tmp/melix-cron-20260430-223644/services/mlx-worker-python pytest -q tests/test_benchmark_evaluation_report.py
# 20 passed in 0.08s

coverage erase
PYTHONPATH=/tmp/melix-cron-20260430-223644/services/mlx-worker-python coverage run -m pytest -q tests/test_benchmark_evaluation_report.py
coverage report -m worker/productization/benchmark_evaluation_report.py
# 253 stmts, 2 miss, 99% cover

coverage json -o coverage.json
python <changed-line-coverage probe>
# changed_line_coverage=100.00%

PYTHONPATH=/tmp/melix-cron-20260430-223644/services/mlx-worker-python python <benchmark probe>
# before: mean 1.158115s, min 0.996976s, peak mean 1552748 bytes
# after:  mean 1.006171s, min 0.904556s, peak mean 1552548 bytes

git diff --check
# clean
```

## Coverage and Metrics
- Automated coverage for `worker/productization/benchmark_evaluation_report.py`: 99% (253 statements, 2 misses)
- Changed executable line coverage for touched lines in `worker/productization/benchmark_evaluation_report.py`: 100.00%
- Performance probe (`build_benchmark_evaluation_report`, synthetic 50k `evaluation_samples` + 2k benchmark result rows, 5 runs):
  - mean wall time improved from `1.158115s` to `1.006171s` (`13.12%` faster)
  - best run improved from `0.996976s` to `0.904556s` (`9.27%` faster)
  - traced peak allocation changed from `1552748` to `1552548` bytes (`-200` bytes)
- Functional output summary remained stable in the probe: `metric_count=4009`, `warning_count=1`, `missing_count=0`, `not_comparable_count=1999`

## Known Gaps
- Focused Python verification only; repository-wide `make swift-test` / `make integration-test` were not run on this Linux host because this cron run is intentionally scoped to a locally verifiable Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
