### PR TITLE
perf: speed up benchmark dimension dedupe

### DIFF
--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -4469,6 +4469,10 @@ def test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs(tmp_path: Pa
     ) == (4, 8)
     assert core._benchmark_context_lengths(
         suite=suite,
+        parameters={"context_lengths": "8, 4, 8, 4"},
+    ) == (4, 8)
+    assert core._benchmark_context_lengths(
+        suite=suite,
         parameters={"context_lengths": "8, , 4"},
     ) == (4, 8)
     assert core._benchmark_context_lengths(
@@ -4476,6 +4480,7 @@ def test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs(tmp_path: Pa
         parameters={"context_length": "oops"},
     ) == (32,)
     assert core._benchmark_batch_sizes({"batch_sizes": "1, bad, 2"}) == (1, 2)
+    assert core._benchmark_batch_sizes({"batch_sizes": "2, 1, 2, 1"}) == (1, 2)
     assert core._benchmark_batch_sizes({"batch_sizes": "1, , 2"}) == (1, 2)
     assert core._benchmark_batch_sizes({"batch_size": "oops"}) == (1,)
     assert core._shape_benchmark_prompt("", context_length=3) == "benchmark benchmark benchmark"

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -3307,7 +3307,7 @@ class MaintenanceCore:
             else:
                 default_prompt = suite.prompt_batches[0] if suite.prompt_batches else suite.title
                 values.append(max(1, len(default_prompt.split())))
-        return tuple(dict.fromkeys(sorted(values)))
+        return tuple(sorted(set(values)))
 
     @staticmethod
     def _benchmark_batch_sizes(parameters: dict[str, str]) -> tuple[int, ...]:
@@ -3331,7 +3331,7 @@ class MaintenanceCore:
                     values.append(1)
             else:
                 values.append(1)
-        return tuple(dict.fromkeys(sorted(values)))
+        return tuple(sorted(set(values)))
 
     def _suite_prompt_for_context(self, suite: ResolvedBenchmarkSuite, *, context_length: int) -> str:
         prompt = suite.prompt_batches[0] if suite.prompt_batches else suite.title


### PR DESCRIPTION
## Summary
- Replace benchmark dimension normalization from `dict.fromkeys(sorted(values))` to `sorted(set(values))` for parsed context-length and batch-size lists.
- Add focused coverage for duplicate benchmark dimension inputs so behavior remains sorted and deduplicated.

## Plan or Spec
- N/A: Small Python worker performance slice for benchmark parameter parsing; no product behavior or protocol surface changes.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run python /tmp/melix_benchmark_dimensions_probe.py
exit 0
old_samples_s=1.164326,1.240221,1.143012,1.138964,1.260758
old_mean_s=1.189456
new_samples_s=0.246824,0.236282,0.304551,0.252739,0.250996
new_mean_s=0.258279

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs -q
exit 0
1 passed in 0.27s

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_maintenance_service.py -q -k 'benchmark_helper_parsers_cover_invalid_and_boundary_inputs or not run_evaluation_uses_checked_in_code_fixture_when_dataset_root_is_omitted'
exit 0
138 passed, 2 deselected in 1.14s

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_benchmark_schemas.py services/mlx-worker-python/tests/test_benchmark_export.py -q
exit 0
47 passed in 0.24s

git diff --check
exit 0

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_maintenance_service.py -q
exit 1
138 passed, 2 failed in 1.30s
Failure was limited to existing Linux code-evaluation fixture tests that returned no results:
- test_run_evaluation_uses_checked_in_code_fixture_when_dataset_root_is_omitted[humaneval-...]
- test_run_evaluation_uses_checked_in_code_fixture_when_dataset_root_is_omitted[mbpp-...]
```

## Coverage and Metrics
- Probe: old_mean=1.189456s, new_mean=0.258279s over 5 samples of 1,000 normalizations of a 15k-value duplicate-heavy dimension list; speedup=4.61x, delta=-0.931177s.
- Focused behavior coverage added for duplicate `context_lengths` and `batch_sizes` parsing.
- Changed-scope line coverage was not separately reported because this slice reuses the existing focused pytest coverage path; Linux validation scope only.

## Known Gaps
- Full `test_maintenance_service.py` has two pre-existing/ambient Linux fixture failures in checked-in code-evaluation tests unrelated to benchmark dimension parsing; the affected benchmark tests pass when those two tests are deselected.
- Linux-only validation; macOS/Apple Silicon runtime behavior was not exercised.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
