### PR TITLE
perf(lora): reduce experiment group aggregation passes

### DIFF
--- a/services/mlx-worker-python/tests/test_lora_experiment_store.py
+++ b/services/mlx-worker-python/tests/test_lora_experiment_store.py
@@ -117,6 +117,44 @@ def test_rebuild_index_prefers_runs_with_reported_loss_for_best_run(tmp_path: Pa
     assert payload["groups"][0]["best_known_adapter"]["latest_checkpoint_path"].endswith("checkpoint-1/adapters.safetensors")
 
 
+def test_build_group_payloads_evaluates_best_loss_once_per_run(monkeypatch) -> None:
+    runs = [
+        {
+            "run_id": "model-ops-0001",
+            "group_id": "nightly-qwen",
+            "updated_at_unix_ms": 1_000,
+            "loss_best": 0.42,
+        },
+        {
+            "run_id": "model-ops-0002",
+            "group_id": "nightly-qwen",
+            "updated_at_unix_ms": 2_000,
+            "loss_best": 0.37,
+        },
+        {
+            "run_id": "model-ops-0003",
+            "group_id": "nightly-qwen",
+            "updated_at_unix_ms": 3_000,
+        },
+    ]
+    call_count = 0
+    original_best_loss = lora_experiment_store_module._best_loss_value
+
+    def tracked_best_loss(item: dict[str, object]) -> float | None:
+        nonlocal call_count
+        call_count += 1
+        return original_best_loss(item)
+
+    monkeypatch.setattr(lora_experiment_store_module, "_best_loss_value", tracked_best_loss)
+
+    groups = LoraExperimentStore()._build_group_payloads(runs)
+
+    assert call_count == len(runs)
+    assert groups[0]["latest_run_id"] == "model-ops-0003"
+    assert groups[0]["best_run_id"] == "model-ops-0002"
+    assert groups[0]["best_loss"] == 0.37
+
+
 def test_rebuild_index_prefers_run_record_over_manifest_when_both_exist(tmp_path: Path) -> None:
     jobs_root = tmp_path / "model-ops"
     _write_manifest(

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -101,18 +101,32 @@ class LoraExperimentStore:
 
         groups: list[dict[str, Any]] = []
         for group_id, group_runs in grouped_runs.items():
-            latest_run = max(
-                group_runs,
-                key=lambda item: (int(item.get("updated_at_unix_ms", 0)), str(item.get("run_id", ""))),
+            latest_run = group_runs[0]
+            latest_key = (
+                int(latest_run.get("updated_at_unix_ms", 0)),
+                str(latest_run.get("run_id", "")),
             )
-            best_run = min(
-                group_runs,
-                key=lambda item: (
-                    _best_loss_value(item) if _best_loss_value(item) is not None else float("inf"),
-                    -int(item.get("updated_at_unix_ms", 0)),
-                ),
-            )
+            best_run = latest_run
             best_loss = _best_loss_value(best_run)
+            best_key = (
+                best_loss if best_loss is not None else float("inf"),
+                -latest_key[0],
+            )
+            for run in group_runs[1:]:
+                run_updated_at = int(run.get("updated_at_unix_ms", 0))
+                run_key_latest = (run_updated_at, str(run.get("run_id", "")))
+                if run_key_latest > latest_key:
+                    latest_run = run
+                    latest_key = run_key_latest
+                run_loss = _best_loss_value(run)
+                run_key = (
+                    run_loss if run_loss is not None else float("inf"),
+                    -run_updated_at,
+                )
+                if run_key < best_key:
+                    best_run = run
+                    best_loss = run_loss
+                    best_key = run_key
             groups.append(
                 {
                     "group_id": group_id,


### PR DESCRIPTION
## Summary
- Reduce LoRA experiment group aggregation from separate latest/best passes to one pass per group.
- Add focused coverage proving best-loss selection is evaluated once per run while preserving latest/best run behavior.

## Plan or Spec
- N/A: scoped internal Python performance optimization for the LoRA experiment index aggregation path; no product behavior or canonical spec changes.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_lora_experiment_store.py -q
# exit 0; 11 passed in 0.05s before coverage run / 0.07s during coverage run

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_lora_experiment_store.py services/mlx-worker-python/tests/test_maintenance_service.py::test_job_registry_snapshot_reuses_cached_manifest_after_restore services/mlx-worker-python/tests/test_model_ops_job_registry.py -q
# exit 0; 14 passed in 0.27s

PYTHONPATH=services/mlx-worker-python:. uv run coverage erase && PYTHONPATH=services/mlx-worker-python:. uv run coverage run --source=worker.productization.lora_experiment_store -m pytest services/mlx-worker-python/tests/test_lora_experiment_store.py -q && PYTHONPATH=services/mlx-worker-python:. uv run coverage report --show-missing
# exit 0; lora_experiment_store.py coverage 97%

git diff --check
# exit 0

PYTHONPATH=services/mlx-worker-python:. uv run python .tmp_lora_probe.py
# baseline before change: mean_ms=6.249344, median_ms=5.973762, run_count=3200, group_count=80
# after change: mean_ms=5.416091, median_ms=4.808103, run_count=3200, group_count=80
# delta_ms=-0.833253, speedup=1.1538x, improvement=13.33%
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/productization/lora_experiment_store.py` 97% line coverage via `coverage report --show-missing`.
- Probe: synthetic 3,200-run / 80-group `_build_group_payloads` workload, 8 iterations on Linux.
  - old_mean=6.249344 ms
  - new_mean=5.416091 ms
  - delta_ms=-0.833253 ms
  - speedup=1.1538x
  - improvement=13.33%
- Validation scope: Linux-local Python unit tests/probe only; macOS/Apple Silicon runtime paths were not exercised.

## Known Gaps
- Full `make py-test`, Swift tests, and integration tests were not run because this recurring slice is constrained to Linux-verifiable Python changes.
- One initial broadened pytest selector used a stale test name and exited 4 with no tests run; reran with the existing targeted test successfully.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
