### PR TITLE
perf: stream benchmark suite JSONL writes

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_suites.py
+++ b/services/mlx-worker-python/tests/test_benchmark_suites.py
@@ -10,6 +10,7 @@ import worker.productization.benchmark_suites as benchmark_suites
 from worker.productization.benchmark_suites import (
     BenchmarkSuiteCatalog,
     BenchmarkSuiteDefinition,
+    _write_jsonl_rows,
 )
 
 
@@ -71,6 +72,21 @@ class FakeBenchmarkSuiteFetcher:
         raise AssertionError(f"Unexpected benchmark fetch: endpoint={endpoint} dataset={dataset}")
 
 
+class _RecordingWriter:
+    def __init__(self) -> None:
+        self.writes: list[str] = []
+
+    def write(self, chunk: str) -> int:
+        self.writes.append(chunk)
+        return len(chunk)
+
+    def __enter__(self) -> "_RecordingWriter":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
 def test_benchmark_suite_catalog_materializes_curated_hf_suite_and_reuses_cache(
     tmp_path: Path,
 ) -> None:
@@ -123,6 +139,28 @@ def test_load_materialized_rows_streams_without_read_text(tmp_path: Path, monkey
     assert benchmark_suites._load_materialized_rows(rows_path) == [
         {"prompt": "Say hi."},
         {"prompt": "Say bye."},
+    ]
+
+
+def test_write_jsonl_rows_streams_one_row_at_a_time(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    rows_path = tmp_path / "rows.jsonl"
+    recorder = _RecordingWriter()
+
+    def fake_open(self: Path, mode: str = "r", encoding: str | None = None):
+        assert self == rows_path
+        assert mode == "w"
+        assert encoding == "utf-8"
+        return recorder
+
+    monkeypatch.setattr(Path, "open", fake_open)
+
+    _write_jsonl_rows(rows_path, [{"prompt": "Say hi."}, {"prompt": "Say bye."}])
+
+    assert recorder.writes == [
+        '{"prompt": "Say hi."}',
+        "\n",
+        '{"prompt": "Say bye."}',
+        "\n",
     ]
 
 

--- a/services/mlx-worker-python/worker/productization/benchmark_suites.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_suites.py
@@ -401,10 +401,7 @@ def _materialize_benchmark_suite(
         "default_prompt": definition.default_prompt,
     }
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
-    rows_path.write_text(
-        "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n",
-        encoding="utf-8",
-    )
+    _write_jsonl_rows(rows_path, rows)
     return {
         "package_path": package_path,
         "cache_key": cache_key,
@@ -565,6 +562,16 @@ def _resolve_dataset_name(
 
 def _materialized_sample_hint(*, sample_size: int, batch_factor: int) -> int:
     return max(sample_size * batch_factor, 8)
+
+
+def _write_jsonl_rows(path: Path, rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        if not rows:
+            handle.write("\n")
+            return
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True))
+            handle.write("\n")
 
 
 def _load_materialized_rows(rows_path: Path, *, limit: int | None = None) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
- stream benchmark suite `rows.jsonl` materialization row-by-row instead of building one large joined string first
- keep JSONL bytes unchanged by preserving `json.dumps(..., sort_keys=True)` and trailing newline behavior
- add a focused regression test that proves incremental writes and exact newline emission

## Plan or Spec
- N/A: this is a small internal Python optimization slice in `services/mlx-worker-python` and is not governed by a dedicated canonical plan or spec document
- Followed repository guidance from `AGENTS.md`, `docs/contributing.md`, and `docs/templates/pr-evidence-checklist.md`

## Commands Run
- `git fetch origin main`
- `git worktree add /tmp/akane-cron-python-opt-20260430-230825 -b akane/cron-python-opt-20260430-230825 origin/main`
- `PYTHONPATH=. uv run pytest tests/test_benchmark_suites.py -q`
- `PYTHONPATH=. uv run coverage erase`
- `PYTHONPATH=. uv run coverage run --include='*/worker/productization/benchmark_suites.py' -m pytest tests/test_benchmark_suites.py -q`
- `PYTHONPATH=. uv run coverage report -m`
- `PYTHONPATH=. uv run coverage json -o coverage.json`
- `python3` perf probe comparing old joined write vs new streamed write on 20,000 rows
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `18 passed`
- Coverage for `worker/productization/benchmark_suites.py`: `97%` (`229` statements, `6` missed)
- Perf probe dataset: `20,000` rows, byte-identical output (`3,636,670` bytes)
- Mean wall time: `0.825532s -> 0.780236s` (`5.49%` faster)
- Mean peak traced memory: `8,406,728 -> 25,059` bytes (`99.70%` lower)

## Known Gaps
- The performance probe uses `tracemalloc` and a synthetic local dataset, so the memory result is a Python allocation metric rather than end-to-end RSS
- `.github/pull_request_template.md` is not present in this repository checkout, so this body uses the required evidence headings directly

## Evidence Checklist
- [x] Relevant plan or spec is identified (`N/A` with reason for this internal optimization slice)
- [x] Behavior changes do not require canonical doc updates
- [x] Protocol changes: none
- [x] Dependency changes: none
- [x] Relevant tests were run
- [x] Performance probe and metrics are included
- [x] Coverage for the touched executable file is >=95%
- [x] Command outcomes are recorded
- [x] Known gaps are stated explicitly
