### PR TITLE
perf(scripts): scan model ops artifacts with scandir

### DIFF
--- a/scripts/phase5_model_ops_metrics.py
+++ b/scripts/phase5_model_ops_metrics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from statistics import mean
 from tempfile import TemporaryDirectory
 from time import perf_counter
@@ -19,11 +20,17 @@ def build_service(root: Path) -> WorkerMaintenanceService:
 
 def artifact_size(path: Path) -> int:
     if path.is_dir():
-        return sum(
-            child.stat().st_size
-            for child in path.rglob("*")
-            if child.is_file()
-        )
+        total = 0
+        stack = [os.fspath(path)]
+        while stack:
+            current = stack.pop()
+            with os.scandir(current) as entries:
+                for entry in entries:
+                    if entry.is_dir(follow_symlinks=False):
+                        stack.append(entry.path)
+                    elif entry.is_file():
+                        total += entry.stat().st_size
+        return total
     return path.stat().st_size
 
 

--- a/services/mlx-worker-python/tests/test_phase5_model_ops_metrics.py
+++ b/services/mlx-worker-python/tests/test_phase5_model_ops_metrics.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from scripts.phase5_model_ops_metrics import artifact_size
 
 
@@ -12,5 +14,29 @@ def test_artifact_size_sums_directory_contents(tmp_path: Path) -> None:
     nested = artifact_dir / "nested"
     nested.mkdir()
     (nested / "weights.safetensors").write_bytes(b"12345")
+
+    assert artifact_size(artifact_dir) == 7
+
+
+def test_artifact_size_returns_single_file_size(tmp_path: Path) -> None:
+    artifact_file = tmp_path / "download.artifact"
+    artifact_file.write_bytes(b"artifact-bytes")
+
+    assert artifact_size(artifact_file) == len(b"artifact-bytes")
+
+
+def test_artifact_size_uses_scandir_stack_without_rglob(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifact_dir = tmp_path / "download.artifact"
+    nested = artifact_dir / "nested"
+    nested.mkdir(parents=True)
+    (artifact_dir / "config.json").write_text("{}", encoding="utf-8")
+    (nested / "weights.safetensors").write_bytes(b"12345")
+
+    def fail_rglob(self: Path, pattern: str):
+        raise AssertionError("artifact_size() should not allocate a Path.rglob() tree")
+
+    monkeypatch.setattr(Path, "rglob", fail_rglob)
 
     assert artifact_size(artifact_dir) == 7


### PR DESCRIPTION
## Summary
- Replace `artifact_size()` directory sizing in the phase 5 model-ops metrics probe with an explicit `os.scandir()` stack.
- Avoid `Path.rglob()` Path allocation while preserving recursive file-size semantics for artifact directories.
- Add focused regression coverage for directory artifacts, single-file artifacts, and the no-`rglob` scan path.

## Plan or Spec
- N/A: this is a Linux-validated Python performance-only slice for an existing metrics helper and does not change product behavior or protocol/spec contracts.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_phase5_model_ops_metrics.py -q
# exit 0; 3 passed in 0.24s

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python coverage run --source=scripts.phase5_model_ops_metrics -m pytest services/mlx-worker-python/tests/test_phase5_model_ops_metrics.py -q
# exit 0; 3 passed in 0.46s

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python coverage report -m
# exit 0; scripts/phase5_model_ops_metrics.py 52% file coverage; changed artifact_size() lines covered by focused tests; unexecuted lines are build_service/main probe orchestration outside this slice.

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python python /tmp/melix_artifact_size_probe.py
# exit 0; old_mean=106.591 ms, new_mean=35.828 ms over a 12,800-file artifact tree; speedup=2.98x, delta=-70.764 ms, improvement=66.4%.

git diff --check
# exit 0
```

## Coverage and Metrics
- Focused tests cover the changed `artifact_size()` directory and file paths, including a monkeypatch guard that fails if `Path.rglob()` is used.
- File-level coverage for `scripts/phase5_model_ops_metrics.py` is 52% because this slice intentionally does not execute the script's `main()` model-ops orchestration in Linux CI; changed helper lines are covered.
- Probe command: `PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python python /tmp/melix_artifact_size_probe.py`
- Probe dataset: synthetic Linux artifact tree with 12,800 files and 6,603,040 bytes.
- Baseline: samples `[110.009, 104.841, 104.924]` ms, mean `106.591` ms.
- New implementation: samples `[37.053, 34.818, 35.613]` ms, mean `35.828` ms.
- Result: `2.98x` faster, `-70.764 ms` mean delta, `66.4%` improvement.

## Known Gaps
- Linux-only validation in this cron environment; the broader Melix product remains Apple Silicon/macOS-oriented and was not fully exercised here.
- Full repository `make py-test`, Swift, integration, and macOS packaging checks were not run for this small Python helper slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is justified.
- [x] Protocol changes include regenerated generated artifacts, or N/A (no protocol changes).
- [x] Dependency changes include updated lockfiles, or N/A (no dependency changes).
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
