### PR TITLE
perf: reuse registry tree scan for hf cache roots

### DIFF
--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -682,17 +682,20 @@ def test_is_hf_cache_pruned_subtree_returns_false_for_paths_outside_root(tmp_pat
     assert _is_hf_cache_pruned_subtree(root, outside_snapshot_dir) is False
 
 
-def test_registry_snapshot_reuses_single_plain_and_manifest_tree_walk_per_root(
+def test_registry_snapshot_reuses_single_tree_walk_for_plain_manifest_and_hf_cache_repos(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     root = tmp_path / "root"
     manifest_dir = root / "alpha-provider" / "AlphaModel" / "q4"
     _write_registry_manifest(manifest_dir, model_id="alpha-provider/AlphaModel/q4")
-    plain_model_dir = root / "beta-local-a"
-    _write_model_config(plain_model_dir, {"model_type": "qwen3"})
-    _write_weights(plain_model_dir)
-    (plain_model_dir / "README.md").write_text("library_name: mlx\n", encoding="utf-8")
+    hf_snapshot_dir = root / "models--mlx-community--Tiny" / "snapshots" / "abc123"
+    _write_model_config(hf_snapshot_dir, {"model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]})
+    _write_weights(hf_snapshot_dir)
+    (hf_snapshot_dir / "README.md").write_text("library_name: mlx\n", encoding="utf-8")
+    hf_refs_dir = hf_snapshot_dir.parent.parent / "refs"
+    hf_refs_dir.mkdir(parents=True, exist_ok=True)
+    (hf_refs_dir / "main").write_text("abc123\n", encoding="utf-8")
 
     original_scandir = os.scandir
     scandir_calls: list[str] = []
@@ -710,10 +713,14 @@ def test_registry_snapshot_reuses_single_plain_and_manifest_tree_walk_per_root(
     discovered_ids = [model.model_id for model in snapshot.models]
     resolved_root = os.fspath(root.resolve())
     provider_dir = os.fspath((root / "alpha-provider").resolve())
+    hf_cache_dir = os.fspath((root / "models--mlx-community--Tiny").resolve())
+    hf_snapshots_dir = os.fspath((root / "models--mlx-community--Tiny" / "snapshots").resolve())
 
-    assert discovered_ids == ["alpha-provider/AlphaModel/q4", "beta-local-a"]
-    assert scandir_calls.count(resolved_root) == 2
+    assert discovered_ids == ["alpha-provider/AlphaModel/q4", "mlx-community/Tiny"]
+    assert scandir_calls.count(resolved_root) == 1
     assert scandir_calls.count(provider_dir) == 1
+    assert hf_cache_dir not in scandir_calls
+    assert hf_snapshots_dir in scandir_calls
 
 
 

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -974,7 +974,7 @@ class WorkerModelCatalog:
                 continue
 
             accepted_model_ids: list[str] = []
-            manifest_paths, plain_local_model_dirs = self._scan_registry_root_tree(root)
+            manifest_paths, plain_local_model_dirs, hf_cache_repo_dirs = WorkerModelCatalog._scan_registry_root_tree_with_hf_repos(root)
             for manifest_path in manifest_paths:
                 parsed = self._parse_registry_manifest(manifest_path)
                 if parsed is None:
@@ -1001,6 +1001,7 @@ class WorkerModelCatalog:
                 root_id=root_id,
                 root_order=index,
                 plain_local_model_dirs=plain_local_model_dirs,
+                hf_cache_repo_dirs=hf_cache_repo_dirs,
                 discovered_models=discovered_models,
                 accepted_model_ids=accepted_model_ids,
             )
@@ -1076,10 +1077,11 @@ class WorkerModelCatalog:
         plain_local_model_dirs: Iterable[Path],
         discovered_models: dict[str, common_pb2.ModelSpec],
         accepted_model_ids: list[str],
+        hf_cache_repo_dirs: Iterable[Path] | None = None,
     ) -> None:
         root_resolved = root.resolve()
         seen_paths: set[Path] = set()
-        for model in self._scan_huggingface_cache_models(root=root):
+        for model in self._scan_huggingface_cache_models(root=root, cache_repo_dirs=hf_cache_repo_dirs):
             resolved_path = Path(model.model_path)
             seen_paths.add(resolved_path)
             if model.model_id in discovered_models or model.model_id in self._seed_models:
@@ -1122,8 +1124,18 @@ class WorkerModelCatalog:
             discovered_models[model_id] = model
             accepted_model_ids.append(model_id)
 
-    def _scan_huggingface_cache_models(self, *, root: Path) -> Iterable[common_pb2.ModelSpec]:
-        for cache_repo_dir in _sorted_child_directories(root, name_prefix="models--"):
+    def _scan_huggingface_cache_models(
+        self,
+        *,
+        root: Path,
+        cache_repo_dirs: Iterable[Path] | None = None,
+    ) -> Iterable[common_pb2.ModelSpec]:
+        resolved_cache_repo_dirs = (
+            tuple(cache_repo_dirs)
+            if cache_repo_dirs is not None
+            else _sorted_child_directories(root, name_prefix="models--")
+        )
+        for cache_repo_dir in resolved_cache_repo_dirs:
             repo_id = _hf_cache_repo_id(cache_repo_dir)
             if repo_id is None:
                 continue
@@ -1154,8 +1166,14 @@ class WorkerModelCatalog:
 
     @staticmethod
     def _scan_registry_root_tree(root: Path) -> tuple[tuple[Path, ...], tuple[Path, ...]]:
+        manifest_paths, plain_local_model_dirs, _ = WorkerModelCatalog._scan_registry_root_tree_with_hf_repos(root)
+        return manifest_paths, plain_local_model_dirs
+
+    @staticmethod
+    def _scan_registry_root_tree_with_hf_repos(root: Path) -> tuple[tuple[Path, ...], tuple[Path, ...], tuple[Path, ...]]:
         manifest_paths: list[Path] = []
         plain_local_model_dirs: list[Path] = []
+        hf_cache_repo_dirs: list[Path] = []
         resolved_root = root.resolve()
         stack = [resolved_root]
         while stack:
@@ -1178,6 +1196,11 @@ class WorkerModelCatalog:
                                 has_config = True
                                 continue
                             if entry.is_dir():
+                                child_path = current / entry.name
+                                if current == resolved_root and entry.name.startswith("models--"):
+                                    if _hf_cache_repo_id(child_path) is not None:
+                                        hf_cache_repo_dirs.append(child_path)
+                                        continue
                                 child_names.append(entry.name)
                         except OSError:
                             continue
@@ -1190,7 +1213,7 @@ class WorkerModelCatalog:
                 plain_local_model_dirs.append(current)
                 continue
             stack.extend(current / name for name in sorted(child_names, reverse=True))
-        return tuple(manifest_paths), tuple(plain_local_model_dirs)
+        return tuple(manifest_paths), tuple(plain_local_model_dirs), tuple(sorted(hf_cache_repo_dirs))
 
     @staticmethod
     def _iter_plain_local_model_dirs(root: Path) -> Iterable[Path]:


### PR DESCRIPTION
## Summary
- Reuses the registry root tree scan to identify valid Hugging Face cache repository directories.
- Avoids descending into valid `models--*` cache repository directories during the plain/manifest tree walk, leaving them to the dedicated Hugging Face cache scanner.
- Keeps invalid `models--*` directories on the local-model path so existing fallback behavior is preserved.

## Plan or Spec
- N/A: scoped Linux-validated Python performance slice for the model registry scanner; no user-visible behavior or canonical spec behavior changes.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -q
# exit 0; 65 passed in 0.27s

PYTHONPATH=services/mlx-worker-python:. uv run coverage run --source=worker.model_registry.catalog -m pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -q
# exit 0; 65 passed in 0.47s

PYTHONPATH=services/mlx-worker-python:. uv run coverage report --include='*/worker/model_registry/catalog.py'
# exit 0; catalog.py coverage: 97%

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_runtime_service.py services/mlx-worker-python/tests/test_generate_stream.py -q
# exit 0; 28 passed in 0.57s

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/model_registry/catalog.py` 97% line coverage.
- Probe scope: synthetic registry root with 300 plain local model dirs, 30 manifest model dirs, and 500 Hugging Face cache repos; old behavior emulated by monkeypatching the tree scanner to return no pre-collected HF cache repo dirs.
- Probe command: inline `PYTHONPATH=../..:. uv run python` benchmark from `services/mlx-worker-python` with 5 measured registry snapshots for old and new paths.
- Results: `old_mean=437.281ms`, `new_mean=373.438ms`, `speedup=1.171x`, `delta_ms=-63.843ms`; `old_scandir_mean=2663`, `new_scandir_mean=2162`, `scandir_delta=-501`.
- Linux-only validation: this slice only touches Python registry scanning and was validated locally on Linux; macOS runtime/app gates were not run in this environment.

## Known Gaps
- Full repository `make swift-test`, `make py-test`, and `make integration-test` were not run because this cron agent is Linux-only while Melix is Apple Silicon/macOS oriented.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
