### PR TITLE
perf(python): stream event extraction jsonl writes

### DIFF
--- a/services/mlx-worker-python/tests/test_event_extraction.py
+++ b/services/mlx-worker-python/tests/test_event_extraction.py
@@ -2140,6 +2140,50 @@ def test_evaluation_core_event_extraction_records_rate_limit_sleep_in_dialogue_t
     assert fake_clock.sleeps
 
 
+def test_evaluation_core_write_jsonl_rows_streams_each_row_via_path_open(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    output_path = tmp_path / "rows.jsonl"
+    writes: list[str] = []
+
+    class RecordingFile:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def write(self, chunk: str) -> int:
+            writes.append(chunk)
+            return len(chunk)
+
+    def fake_open(self: Path, mode: str = "r", *args: object, **kwargs: object) -> RecordingFile:
+        assert self == output_path
+        assert mode == "w"
+        assert kwargs.get("encoding") == "utf-8"
+        return RecordingFile()
+
+    def fail_write_text(self: Path, data: str, encoding: str | None = None) -> int:
+        raise AssertionError("_write_jsonl_rows should not use Path.write_text")
+
+    monkeypatch.setattr(Path, "open", fake_open)
+    monkeypatch.setattr(Path, "write_text", fail_write_text)
+
+    EvaluationCore._write_jsonl_rows(
+        output_path,
+        [
+            {"dialogue_id": "dlg-1", "events": []},
+            {"dialogue_id": "dlg-2", "events": [{"actor": ["A"]}]},
+        ],
+    )
+
+    assert writes == [
+        json.dumps({"dialogue_id": "dlg-1", "events": []}, ensure_ascii=False) + "\n",
+        json.dumps({"dialogue_id": "dlg-2", "events": [{"actor": ["A"]}]}, ensure_ascii=False) + "\n",
+    ]
+
+
 def test_evaluation_core_event_extraction_aborts_on_provider_rate_limit_and_writes_error_log(
     tmp_path: Path,
     monkeypatch,
@@ -2186,7 +2230,15 @@ def test_evaluation_core_event_extraction_aborts_on_provider_rate_limit_and_writ
         captured["client"] = client
         return client
 
+    observed_paths: list[Path] = []
+    original_write_jsonl_rows = EvaluationCore._write_jsonl_rows
+
+    def recording_write_jsonl_rows(path: Path, rows: list[dict[str, object]]) -> None:
+        observed_paths.append(path)
+        original_write_jsonl_rows(path, rows)
+
     monkeypatch.setattr(evaluation_core, "make_event_extraction_client", fake_client_factory)
+    monkeypatch.setattr(EvaluationCore, "_write_jsonl_rows", staticmethod(recording_write_jsonl_rows))
 
     try:
         EvaluationCore(jobs_root=tmp_path / "evals").run_local_suite(
@@ -2227,6 +2279,9 @@ def test_evaluation_core_event_extraction_aborts_on_provider_rate_limit_and_writ
     assert failures[0]["reason"] == 'remote provider HTTP 429: {"error":"rate"}'
     assert failures[0]["code"] == "remote_provider_rate_limited"
     assert prediction_log.read_text(encoding="utf-8") == ""
+    assert output_dir / "gold_subset.jsonl" in observed_paths
+    assert prediction_log in observed_paths
+    assert failure_log in observed_paths
     trace_log = output_dir / "reports" / "remote_model" / "event_eval_dialogue_traces.jsonl"
     traces = [json.loads(line) for line in trace_log.read_text(encoding="utf-8").splitlines()]
     assert len(traces) == 1
@@ -2235,6 +2290,105 @@ def test_evaluation_core_event_extraction_aborts_on_provider_rate_limit_and_writ
     assert traces[0]["error_code"] == "remote_provider_rate_limited"
     assert traces[0]["failure_reason"] == 'remote provider HTTP 429: {"error":"rate"}'
     assert "sk-secret" not in json.dumps(traces, ensure_ascii=False)
+
+
+def test_evaluation_core_event_extraction_routes_jsonl_outputs_through_write_jsonl_rows(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source = tmp_path / "top200_final.jsonl"
+    source_rows = [
+        {
+            "dialogue_id": "dlg-1",
+            "dialogue": ["speaker_1: 明天见面"],
+            "events": [
+                {
+                    "actor": ["speaker_1"],
+                    "time": ["明天"],
+                    "location": None,
+                    "action": ["见面"],
+                    "digest": "",
+                }
+            ],
+        }
+    ]
+    _write_jsonl(source, source_rows)
+
+    class FakeClient:
+        def extract_events(self, dialogue, dialogue_id=""):
+            assert dialogue == ["speaker_1: 明天见面"]
+            assert dialogue_id == "dlg-1"
+            return EventExtractionClientResult(
+                events=[
+                    {
+                        "actor": ["speaker_1"],
+                        "time": ["明天"],
+                        "location": None,
+                        "action": ["见面"],
+                    }
+                ],
+                raw_response='{"events":[]}',
+            )
+
+    class FakeTarget:
+        provider_kind = "openai-compatible"
+        base_url = "https://sub2api.example/v1"
+        api_key = "sk-secret"
+        model_id = "remote-model"
+        timeout_seconds = 30
+        rate_limit_per_minute = 0
+
+    observed_paths: list[Path] = []
+    original_write_jsonl_rows = EvaluationCore._write_jsonl_rows
+
+    def recording_write_jsonl_rows(path: Path, rows: list[dict[str, object]]) -> None:
+        observed_paths.append(path)
+        original_write_jsonl_rows(path, rows)
+
+    monkeypatch.setattr(evaluation_core, "make_event_extraction_client", lambda target, prompt_spec=None: FakeClient())
+    monkeypatch.setattr(EvaluationCore, "_write_jsonl_rows", staticmethod(recording_write_jsonl_rows))
+
+    run = EvaluationCore(jobs_root=tmp_path / "evals").run_local_suite(
+        model_id="remote-model",
+        suite_id="event_extraction",
+        dataset_root=tmp_path,
+        sample_size=1,
+        scoring_mode="event_extraction_weighted_f1",
+        parameters={"event_source_jsonl": str(source)},
+        remote_target=FakeTarget(),
+    )
+
+    output_dir = Path(run.job.output_dir)
+    gold_subset_path = output_dir / "gold_subset.jsonl"
+    prediction_path = output_dir / "predictions" / "remote-model.jsonl"
+    failure_path = output_dir / "predictions" / "remote-model.failures.jsonl"
+    expected_gold_subset = json.dumps(source_rows[0], ensure_ascii=False) + "\n"
+    expected_prediction = (
+        json.dumps(
+            {
+                "dialogue_id": "dlg-1",
+                "dialogue": ["speaker_1: 明天见面"],
+                "events": [
+                    {
+                        "actor": ["speaker_1"],
+                        "time": ["明天"],
+                        "location": None,
+                        "action": ["见面"],
+                        "digest": "speaker_1明天见面",
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        )
+        + "\n"
+    )
+
+    assert gold_subset_path.read_text(encoding="utf-8") == expected_gold_subset
+    assert prediction_path.read_text(encoding="utf-8") == expected_prediction
+    assert failure_path.read_text(encoding="utf-8") == ""
+    assert gold_subset_path in observed_paths
+    assert prediction_path in observed_paths
+    assert failure_path in observed_paths
 
 
 def test_evaluation_core_reserves_unique_job_ids_for_concurrent_runs(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -581,10 +581,7 @@ class EvaluationCore:
         prompt_snapshot_path = output_root / "prompt_snapshot.json"
 
         rows = self._read_event_extraction_rows(Path(source_jsonl), sample_size=sample_size)
-        gold_subset_path.write_text(
-            "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows),
-            encoding="utf-8",
-        )
+        self._write_jsonl_rows(gold_subset_path, rows)
         prompt_spec = self._event_extraction_prompt_spec(parameters)
         overlapping_examples = sorted(
             set(prompt_example_dialogue_ids(prompt_spec))
@@ -682,14 +679,8 @@ class EvaluationCore:
                     )
                 )
                 if should_abort:
-                    prediction_path.write_text(
-                        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in prediction_rows),
-                        encoding="utf-8",
-                    )
-                    failure_path.write_text(
-                        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in failures),
-                        encoding="utf-8",
-                    )
+                    self._write_jsonl_rows(prediction_path, prediction_rows)
+                    self._write_jsonl_rows(failure_path, failures)
                     self._write_jsonl_rows(trace_path, dialogue_traces)
                     error_payload = self._event_extraction_error_payload(
                         exc=exc,
@@ -765,14 +756,8 @@ class EvaluationCore:
             )
 
         self._write_jsonl_rows(trace_path, dialogue_traces)
-        prediction_path.write_text(
-            "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in prediction_rows),
-            encoding="utf-8",
-        )
-        failure_path.write_text(
-            "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in failures),
-            encoding="utf-8",
-        )
+        self._write_jsonl_rows(prediction_path, prediction_rows)
+        self._write_jsonl_rows(failure_path, failures)
         summary = evaluate_event_extraction(
             gold_jsonl=gold_subset_path,
             pred_jsonl=prediction_path,
@@ -950,10 +935,9 @@ class EvaluationCore:
 
     @staticmethod
     def _write_jsonl_rows(path: Path, rows: list[dict[str, object]]) -> None:
-        path.write_text(
-            "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows),
-            encoding="utf-8",
-        )
+        with path.open("w", encoding="utf-8") as handle:
+            for row in rows:
+                handle.write(json.dumps(row, ensure_ascii=False) + "\n")
 
     @staticmethod
     def _round_ms(value: float) -> float:


### PR DESCRIPTION
## Summary
- Stream event-extraction JSONL artifact writes through `EvaluationCore._write_jsonl_rows` instead of building one giant joined string in memory first.
- Route `gold_subset.jsonl`, prediction JSONL, and failure JSONL through the shared streaming helper in both the normal and abort paths.
- Add focused tests that prove the helper uses `Path.open(...).write(...)` and that event-extraction outputs keep the same JSONL content.

## Plan or Spec
- N/A: this is a small internal Python performance optimization that preserves the existing event-extraction JSONL artifact contract; no canonical spec or plan needed updates for externally visible behavior.

## Commands Run
```text
python3 - <<'PY'
import pathlib, sys, pytest
repo = pathlib.Path('/tmp/melix-cron-python-opt-20260430-233805')
svc = repo / 'services' / 'mlx-worker-python'
sys.path.insert(0, str(repo))
sys.path.insert(0, str(svc))
raise SystemExit(pytest.main([str(svc / 'tests' / 'test_event_extraction.py')]))
PY
# outcome: 53 passed in 0.19s

python3 - <<'PY'
import json, pathlib, re, subprocess, sys
from coverage import Coverage
import pytest
repo = pathlib.Path('/tmp/melix-cron-python-opt-20260430-233805')
svc = repo / 'services' / 'mlx-worker-python'
source_file = svc / 'worker' / 'engine' / 'evaluation_core.py'
coverage_json = repo / 'coverage-event-extraction.json'
sys.path.insert(0, str(repo))
sys.path.insert(0, str(svc))
cov = Coverage(data_file=str(repo / '.coverage-event-extraction'))
cov.erase(); cov.start()
exit_code = pytest.main([str(svc / 'tests' / 'test_event_extraction.py')])
cov.stop(); cov.save()
if exit_code != 0:
    raise SystemExit(exit_code)
cov.json_report(outfile=str(coverage_json))
# changed-line coverage parsing omitted here for brevity in the PR body; see metrics section
PY
# outcome: 53 passed under coverage; changed executable lines in evaluation_core.py covered 8/8 = 100.00%

python3 - <<'PY'
import json, pathlib, statistics, tempfile, time, tracemalloc, sys
repo = pathlib.Path('/tmp/melix-cron-python-opt-20260430-233805')
svc = repo / 'services' / 'mlx-worker-python'
sys.path.insert(0, str(repo))
sys.path.insert(0, str(svc))
from worker.engine.evaluation_core import EvaluationCore
rows = [{
    'dialogue_id': f'dlg-{i:05d}',
    'dialogue': [f'speaker_1: line {i}', f'speaker_2: response {i}'],
    'events': [{'actor': ['speaker_1'], 'time': ['明天'], 'location': None, 'action': ['见面', f'步骤{i % 7}'], 'digest': f'speaker_1明天见面步骤{i % 7}'}],
} for i in range(25000)]
def baseline_join(path, payload):
    path.write_text(''.join(json.dumps(row, ensure_ascii=False) + '\n' for row in payload), encoding='utf-8')
def streaming(path, payload):
    EvaluationCore._write_jsonl_rows(path, payload)
def measure(fn, label):
    durations, peaks = [], []
    with tempfile.TemporaryDirectory() as tmpdir:
        path = pathlib.Path(tmpdir) / f'{label}.jsonl'
        for _ in range(5):
            tracemalloc.start(); start = time.perf_counter(); fn(path, rows)
            duration = time.perf_counter() - start
            _, peak = tracemalloc.get_traced_memory(); tracemalloc.stop()
            durations.append(duration); peaks.append(peak); path.unlink()
    return {'avg_ms': statistics.mean(durations) * 1000.0, 'min_ms': min(durations) * 1000.0, 'peak_mb': statistics.mean(peaks) / (1024 * 1024)}
print('baseline', measure(baseline_join, 'baseline'))
print('streaming', measure(streaming, 'streaming'))
PY
# outcome: baseline avg 974.25 ms / peak 26.60 MB; streaming avg 968.48 ms / peak 0.02 MB

git diff --check
# outcome: pass
```

## Coverage and Metrics
- Changed executable file: `services/mlx-worker-python/worker/engine/evaluation_core.py`
- Changed executable lines: `584, 682, 683, 759, 760, 938, 939, 940`
- Changed-scope coverage: `8/8` measurable changed lines covered = `100.00%`
- Performance probe (`25000` synthetic event-extraction rows, 5 runs each):
  - Baseline join/write: `avg 974.25 ms`, `min 906.45 ms`, `avg peak traced memory 26.60 MB`
  - Streaming helper: `avg 968.48 ms`, `min 943.96 ms`, `avg peak traced memory 0.02 MB`
  - Delta: `-5.77 ms` average wall time, `-26.58 MB` average peak traced memory

## Known Gaps
- Did not run repository-wide `make swift-test` or full `make integration-test`; this cron run was intentionally constrained to a Linux-verifiable Python-only slice under `services/mlx-worker-python`.
- The performance probe is synthetic and file-write focused; it demonstrates the allocation reduction of the helper itself rather than an end-to-end remote provider benchmark.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. (No external contract change; docs unchanged.)
- [x] Protocol changes include regenerated generated artifacts. (No protocol changes.)
- [x] Dependency changes include updated lockfiles. (No dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
