### PR TITLE
perf(python): scan LoRA checkpoints with scandir

### DIFF
--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import sys
 import types
@@ -73,6 +74,37 @@ def _text_model(*, model_path: str = "models/plain-llama", quant_profile_id: str
         model.ext["text_family_id"] = family_id
     model.ext["text_layer_count"] = "2"
     return model
+
+
+def test_checkpoint_summary_uses_scandir_stack_without_os_walk(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    adapter_dir = tmp_path / "adapter"
+    checkpoint_one = adapter_dir / "checkpoint-1"
+    checkpoint_two = adapter_dir / "checkpoint-2"
+    checkpoint_one.mkdir(parents=True)
+    checkpoint_two.mkdir(parents=True)
+    (adapter_dir / "adapters.safetensors").write_text("root", encoding="utf-8")
+    (checkpoint_one / "adapters.safetensors").write_text("one", encoding="utf-8")
+    latest_path = checkpoint_two / "adapters.safetensors"
+    latest_path.write_text("two", encoding="utf-8")
+
+    def fail_os_walk(path: str):
+        raise AssertionError("expected explicit os.scandir stack, not os.walk")
+
+    monkeypatch.setattr(os, "walk", fail_os_walk)
+
+    assert mlx_lm_runner_module._checkpoint_summary(adapter_dir) == (2, str(latest_path))
+
+
+def test_checkpoint_summary_handles_empty_or_missing_directories(tmp_path: Path) -> None:
+    adapter_dir = tmp_path / "adapter"
+    adapter_dir.mkdir()
+    (adapter_dir / "README.txt").write_text("no checkpoints", encoding="utf-8")
+
+    assert mlx_lm_runner_module._checkpoint_summary(adapter_dir) == (0, "")
+    assert mlx_lm_runner_module._checkpoint_summary(tmp_path / "missing") == (0, "")
 
 
 class _UnexpectedActivationRunner(MLXLMRunner):

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -594,19 +594,29 @@ def _mlx_peak_memory_gb() -> float:
 
 def _checkpoint_summary(adapter_output_dir: Path) -> tuple[int, str]:
     checkpoint_candidates: dict[str, Path] = {}
-    root_weights_path = adapter_output_dir / "adapters.safetensors"
-    for root, _directories, filenames in os.walk(os.fspath(adapter_output_dir)):
-        for filename in filenames:
-            if not filename.endswith(".safetensors"):
-                continue
-            file_path = Path(root) / filename
-            if file_path == root_weights_path:
-                continue
-            relative_path = file_path.relative_to(adapter_output_dir)
-            if len(relative_path.parts) > 1:
-                checkpoint_candidates.setdefault(relative_path.parts[0], file_path)
-                continue
-            checkpoint_candidates.setdefault(file_path.stem, file_path)
+    root_path = os.fspath(adapter_output_dir)
+    root_weights_path = os.path.join(root_path, "adapters.safetensors")
+    stack = [root_path]
+    while stack:
+        current_root = stack.pop()
+        try:
+            with os.scandir(current_root) as entries:
+                for entry in entries:
+                    if entry.is_dir(follow_symlinks=False):
+                        stack.append(entry.path)
+                        continue
+                    if not entry.name.endswith(".safetensors"):
+                        continue
+                    if entry.path == root_weights_path:
+                        continue
+                    relative_path = os.path.relpath(entry.path, root_path)
+                    first_part = relative_path.split(os.sep, 1)[0]
+                    if first_part != relative_path:
+                        checkpoint_candidates.setdefault(first_part, Path(entry.path))
+                        continue
+                    checkpoint_candidates.setdefault(os.path.splitext(entry.name)[0], Path(entry.path))
+        except FileNotFoundError:
+            continue
 
     if not checkpoint_candidates:
         return 0, ""


### PR DESCRIPTION
## Summary
- Replaces LoRA checkpoint summary traversal with an explicit `os.scandir()` stack.
- Keeps checkpoint counting/latest selection behavior unchanged while avoiding `os.walk()` tuple/list allocation overhead.
- Adds focused regression coverage for scandir traversal and empty/missing checkpoint directories.

## Plan or Spec
- N/A: scoped Python worker performance slice for existing LoRA checkpoint summary behavior; no user-facing behavior or canonical spec change.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_lora_model_ops_unit.py -q
# exit 0; 46 passed in 0.39s

PYTHONPATH=services/mlx-worker-python:. uv run coverage run --include='*/worker/model_ops/mlx_lm_runner.py' -m pytest services/mlx-worker-python/tests/test_lora_model_ops_unit.py -q
# exit 0; 46 passed in 0.39s

PYTHONPATH=services/mlx-worker-python:. uv run coverage report -m services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
# exit 0; file coverage 58%; changed _checkpoint_summary statement lines have no missing coverage lines in coverage JSON.

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_lora_model_ops.py -q
# exit 0; 36 passed in 0.38s

PYTHONPATH=.:../.. uv run python /tmp/probe_checkpoint_summary.py
# exit 0; baseline old mean 65.982 ms / median 63.489 ms; new mean 18.432 ms / median 18.320 ms on the same synthetic 800-checkpoint fixture.

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed function coverage: `coverage json` reported no missing statement lines in the changed `_checkpoint_summary` range after focused tests.
- Probe command: `PYTHONPATH=.:../.. uv run python /tmp/probe_checkpoint_summary.py` from `services/mlx-worker-python`.
- Baseline (origin/main): mean 65.982 ms, median 63.489 ms.
- New implementation: mean 18.432 ms, median 18.320 ms.
- Delta: -47.550 ms mean; ~3.58x faster on the synthetic Linux fixture.
- Validation scope: Linux-local Python worker code only; macOS/MLX hardware paths were not exercised.

## Known Gaps
- Full repository gates (`make swift-test`, `make integration-test`) were not run because this recurring slice is limited to Linux-verifiable Python worker changes in a macOS-focused project.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is explained above.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
