### PR TITLE
perf(productization): filter lora run dirs before sorting

### DIFF
--- a/services/mlx-worker-python/tests/test_lora_experiment_store.py
+++ b/services/mlx-worker-python/tests/test_lora_experiment_store.py
@@ -297,6 +297,20 @@ def test_load_index_invalidates_cached_index_when_index_file_changes(tmp_path: P
     assert refreshed_payload["runs"][0]["run_id"] == "mutated-run-id"
 
 
+def test_iter_lora_run_dirs_filters_before_sorting(tmp_path: Path) -> None:
+    train_root = tmp_path / "train_lora"
+    train_root.mkdir()
+    (train_root / "model-ops-0002").mkdir()
+    (train_root / "model-ops-0001").mkdir()
+    (train_root / "notes").mkdir()
+    (train_root / "model-ops-not-a-dir").write_text("ignore\n", encoding="utf-8")
+
+    assert [path.name for path in lora_experiment_store_module._iter_lora_run_dirs(train_root)] == [
+        "model-ops-0001",
+        "model-ops-0002",
+    ]
+    assert lora_experiment_store_module._iter_lora_run_dirs(train_root / "missing") == ()
+
 
 def test_rebuild_index_skips_non_directories_duplicate_manifests_and_non_train_lora_entries(tmp_path: Path) -> None:
     jobs_root = tmp_path / "model-ops"

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -11,6 +11,25 @@ _RUN_SCHEMA_VERSION = "melix.lora_experiment_run.v1"
 _INDEX_SCHEMA_VERSION = "melix.lora_experiment_index.v1"
 
 
+def _iter_lora_run_dirs(train_root: Path) -> tuple[Path, ...]:
+    try:
+        with os.scandir(train_root) as entries:
+            run_dir_entries = []
+            for entry in entries:
+                if not entry.name.startswith("model-ops-"):
+                    continue
+                try:
+                    if not entry.is_dir():
+                        continue
+                except OSError:
+                    continue
+                run_dir_entries.append(entry)
+    except OSError:
+        return ()
+
+    return tuple(Path(entry.path) for entry in sorted(run_dir_entries, key=lambda entry: entry.name))
+
+
 class LoraExperimentStore:
     run_record_name = "lora-experiment-run.json"
     index_record_name = "lora-experiments.index.json"
@@ -49,30 +68,22 @@ class LoraExperimentStore:
     def rebuild_index(self, jobs_root: Path) -> dict[str, Any]:
         train_root = jobs_root / "train_lora"
         runs_by_id: dict[str, dict[str, Any]] = {}
-        if train_root.exists():
-            for entry in sorted((entry for entry in os.scandir(train_root) if entry.name.startswith("model-ops-")), key=lambda entry: entry.name):
-                try:
-                    is_dir = entry.is_dir()
-                except OSError:
-                    continue
-                if is_dir is False:
-                    continue
-                run_dir = Path(entry.path)
-                run_path = run_dir / self.run_record_name
-                payload = self._read_payload(run_path)
-                run_id = str(payload.get("run_id", "")).strip()
-                if run_id:
-                    runs_by_id[run_id] = payload
-                    continue
+        for run_dir in _iter_lora_run_dirs(train_root):
+            run_path = run_dir / self.run_record_name
+            payload = self._read_payload(run_path)
+            run_id = str(payload.get("run_id", "")).strip()
+            if run_id:
+                runs_by_id[run_id] = payload
+                continue
 
-                manifest_path = run_dir / "train_lora.adapter.json"
-                payload = self._read_payload(manifest_path)
-                run_id = str(payload.get("job_id", "")).strip() or manifest_path.parent.name
-                if run_id in runs_by_id:
-                    continue
-                if str(payload.get("operation", "train_lora")).strip() != "train_lora":
-                    continue
-                runs_by_id[run_id] = self._build_run_payload(manifest=payload, manifest_path=manifest_path)
+            manifest_path = run_dir / "train_lora.adapter.json"
+            payload = self._read_payload(manifest_path)
+            run_id = str(payload.get("job_id", "")).strip() or manifest_path.parent.name
+            if run_id in runs_by_id:
+                continue
+            if str(payload.get("operation", "train_lora")).strip() != "train_lora":
+                continue
+            runs_by_id[run_id] = self._build_run_payload(manifest=payload, manifest_path=manifest_path)
 
         runs = sorted(
             runs_by_id.values(),


### PR DESCRIPTION
## Summary
- Filter LoRA experiment run directories before sorting during index rebuilds.
- Keep the deterministic run-dir ordering while avoiding sorting non-directory `model-ops-*` entries.
- Add focused coverage for sorted directory filtering and missing `train_lora` roots.

## Plan or Spec
- N/A: small Linux-verifiable Python performance slice for the LoRA experiment index rebuild path; no behavior or protocol change.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_lora_experiment_store.py -q
# exit 0; 12 passed in 0.07s

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python coverage run --source=worker.productization.lora_experiment_store -m pytest services/mlx-worker-python/tests/test_lora_experiment_store.py -q
# exit 0; 12 passed in 0.12s

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python coverage report -m
# exit 0; lora_experiment_store.py 98% coverage

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/productization/lora_experiment_store.py` 98% line coverage.
- Linux-only local validation scope: Python unit tests/probe only; macOS app/runtime gates were not run on this Linux agent.
- Probe command: inline `uv run --project services/mlx-worker-python python` benchmark comparing the old run-dir iterator against the new filtered iterator on a synthetic `train_lora` tree with 120 run directories and 6000 non-directory `model-ops-*` entries, 9 iterations each.
- Probe result: `old_mean=12.919ms`, `new_mean=10.277ms`, `delta=-2.642ms`, `speedup=1.257x`; old p95 `17.016ms`, new p95 `10.714ms`.

## Known Gaps
- Full `make py-test`, Swift, integration, and macOS-specific gates were not run in this Linux cron environment.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
