### PR TITLE
perf(python): cache MLX metadata prefixes across rescans

### DIFF
--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -107,6 +107,7 @@ def test_read_text_prefix_reads_only_requested_prefix(monkeypatch: pytest.Monkey
 def test_read_text_prefix_returns_empty_string_on_open_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     target = tmp_path / "README.md"
     target.write_text("placeholder", encoding="utf-8")
+    text_prefix_cache: dict[Path, tuple[int, int, int, int, str]] = {}
 
     def fake_open(self: Path, mode: str = "r", *args: object, **kwargs: object) -> object:
         assert self == target
@@ -114,7 +115,105 @@ def test_read_text_prefix_returns_empty_string_on_open_error(monkeypatch: pytest
 
     monkeypatch.setattr(Path, "open", fake_open)
 
-    assert _read_text_prefix(target) == ""
+    assert _read_text_prefix(target, text_prefix_cache=text_prefix_cache) == ""
+    assert text_prefix_cache == {}
+
+
+
+def test_read_text_prefix_returns_empty_string_and_clears_cache_for_non_file_path(tmp_path: Path) -> None:
+    target = tmp_path / "README.d"
+    target.mkdir()
+    text_prefix_cache: dict[Path, tuple[int, int, int, int, str]] = {
+        target: (1, 2, 3, 4, "stale payload")
+    }
+
+    assert _read_text_prefix(target, text_prefix_cache=text_prefix_cache) == ""
+    assert text_prefix_cache == {}
+
+
+
+def test_read_text_prefix_does_not_cache_transient_open_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "README.md"
+    target.write_text("library_name: mlx\n", encoding="utf-8")
+    text_prefix_cache: dict[Path, tuple[int, int, int, int, str]] = {}
+    open_attempts: list[str] = []
+
+    class _Reader:
+        def __init__(self, payload: str) -> None:
+            self._payload = payload
+
+        def __enter__(self) -> _Reader:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        def read(self, size: int = -1) -> str:
+            return self._payload[:size]
+
+    def fake_open(self: Path, mode: str = "r", *args: object, **kwargs: object) -> _Reader:
+        assert self == target
+        open_attempts.append(mode)
+        if len(open_attempts) == 1:
+            raise OSError("transient boom")
+        return _Reader("library_name: mlx\n")
+
+    monkeypatch.setattr(Path, "open", fake_open)
+
+    assert _read_text_prefix(target, text_prefix_cache=text_prefix_cache) == ""
+    assert text_prefix_cache == {}
+
+    assert _read_text_prefix(target, text_prefix_cache=text_prefix_cache) == "library_name: mlx\n"
+    assert target in text_prefix_cache
+
+    assert _read_text_prefix(target, text_prefix_cache=text_prefix_cache) == "library_name: mlx\n"
+    assert open_attempts == ["r", "r"]
+
+
+
+def test_read_text_prefix_invalidates_cache_when_stat_mode_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "README.md"
+    target.write_text("library_name: mlx\n", encoding="utf-8")
+    text_prefix_cache: dict[Path, tuple[int, int, int, int, str]] = {}
+    open_attempts: list[str] = []
+    stat_modes = [0o100644, 0o100200]
+
+    class _Reader:
+        def __enter__(self) -> _Reader:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        def read(self, size: int = -1) -> str:
+            return "library_name: mlx\n"[:size]
+
+    original_stat = Path.stat
+
+    def fake_stat(self: Path, *args: object, **kwargs: object):
+        stat_result = original_stat(self, *args, **kwargs)
+        if self != target:
+            return stat_result
+        mode = stat_modes[min(len(open_attempts), len(stat_modes) - 1)]
+        return os.stat_result((mode, *stat_result[1:]))
+
+    def fake_open(self: Path, mode: str = "r", *args: object, **kwargs: object) -> _Reader:
+        assert self == target
+        open_attempts.append(mode)
+        return _Reader()
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    monkeypatch.setattr(Path, "open", fake_open)
+
+    assert _read_text_prefix(target, text_prefix_cache=text_prefix_cache) == "library_name: mlx\n"
+    assert _read_text_prefix(target, text_prefix_cache=text_prefix_cache) == "library_name: mlx\n"
+    assert open_attempts == ["r", "r"]
 
 
 
@@ -122,6 +221,15 @@ def test_has_mlx_signal_returns_false_without_repo_hint_or_metadata(tmp_path: Pa
     model_dir = tmp_path / "plain-transformers-model"
     model_dir.mkdir()
     assert _has_mlx_signal(model_dir=model_dir, repo_id="google/bert-base") is False
+
+
+
+def test_has_mlx_signal_detects_metadata_signal_from_readme(tmp_path: Path) -> None:
+    model_dir = tmp_path / "plain-transformers-model"
+    model_dir.mkdir()
+    (model_dir / "README.md").write_text("---\nlibrary_name: mlx\n---\n", encoding="utf-8")
+
+    assert _has_mlx_signal(model_dir=model_dir, repo_id="google/bert-base") is True
 
 
 
@@ -490,6 +598,25 @@ def test_catalog_overlay_registration_and_snapshot_payload(tmp_path: Path) -> No
 
 
 
+def test_catalog_rescan_prunes_text_prefix_cache_for_disappeared_metadata_path(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    model_dir = root / "plain-local"
+    _write_model_config(model_dir, {"model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]})
+    _write_weights(model_dir)
+    readme_path = model_dir / "README.md"
+    readme_path.write_text("---\nlibrary_name: mlx\n---\n", encoding="utf-8")
+
+    catalog = WorkerModelCatalog(environment={"MELIX_MODEL_ROOTS": str(root), "HOME": str(tmp_path / "home")})
+
+    assert readme_path.resolve() in catalog._text_prefix_cache
+
+    shutil.rmtree(model_dir)
+    catalog.registry_snapshot(rescan=True)
+
+    assert readme_path.resolve() not in catalog._text_prefix_cache
+
+
+
 def test_catalog_scan_helpers_skip_invalid_huggingface_and_unreadable_directories(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     root = tmp_path / "root"
     invalid_repo = root / "models--missing-snapshots"
@@ -555,6 +682,7 @@ def test_scan_huggingface_cache_models_uses_os_scandir_without_glob_or_iterdir(
     monkeypatch.setattr(Path, "iterdir", fail_iterdir)
 
     catalog = WorkerModelCatalog.__new__(WorkerModelCatalog)
+    catalog._text_prefix_cache = {}
 
     models = list(catalog._scan_huggingface_cache_models(root=root))
 
@@ -783,6 +911,173 @@ def test_registry_snapshot_discovers_mlx_models_from_default_huggingface_cache(t
     assert "melix.registry_descriptor_path" not in model.ext
 
 
+def test_registry_snapshot_rescan_reuses_cached_text_prefixes_for_unchanged_mlx_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    model_dir = root / "plain-qwen-model"
+    model_dir.mkdir(parents=True)
+    _write_weights(model_dir)
+    (model_dir / "README.md").write_text("---\nlibrary_name: mlx\n---\n", encoding="utf-8")
+    (model_dir / "config.json").write_text('{"architectures": ["Qwen3ForCausalLM"]}\n', encoding="utf-8")
+    (model_dir / "model_index.json").write_text('{"tags": ["mlx"]}\n', encoding="utf-8")
+
+    catalog = WorkerModelCatalog(environment={"MELIX_MODEL_ROOTS": str(root)})
+
+    metadata_paths = {
+        model_dir / "README.md": 0,
+        model_dir / "config.json": 0,
+        model_dir / "model_index.json": 0,
+    }
+    original_open = Path.open
+
+    def tracking_open(self: Path, *args: object, **kwargs: object):
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if self in metadata_paths and isinstance(mode, str) and mode.startswith("r"):
+            metadata_paths[self] += 1
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", tracking_open)
+
+    first_snapshot = catalog.registry_snapshot(rescan=True)
+    second_snapshot = catalog.registry_snapshot(rescan=True)
+
+    assert any(model.model_id == "plain-qwen-model" for model in first_snapshot.models)
+    assert any(model.model_id == "plain-qwen-model" for model in second_snapshot.models)
+    assert metadata_paths == {
+        model_dir / "README.md": 0,
+        model_dir / "config.json": 0,
+        model_dir / "model_index.json": 0,
+    }
+
+
+
+def test_registry_snapshot_rescan_invalidates_cached_text_prefix_when_metadata_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    model_dir = root / "plain-qwen-model"
+    model_dir.mkdir(parents=True)
+    _write_weights(model_dir)
+    (model_dir / "README.md").write_text("plain readme\n", encoding="utf-8")
+    (model_dir / "config.json").write_text('{"architectures": ["Qwen3ForCausalLM"]}\n', encoding="utf-8")
+    (model_dir / "model_index.json").write_text('{"scheduler": "ddim"}\n', encoding="utf-8")
+
+    catalog = WorkerModelCatalog(environment={"MELIX_MODEL_ROOTS": str(root)})
+    assert all(model.model_id != "plain-qwen-model" for model in catalog.registry_snapshot().models)
+
+    metadata_paths = {
+        model_dir / "README.md": 0,
+        model_dir / "config.json": 0,
+        model_dir / "model_index.json": 0,
+    }
+    original_open = Path.open
+
+    def tracking_open(self: Path, *args: object, **kwargs: object):
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if self in metadata_paths and isinstance(mode, str) and mode.startswith("r"):
+            metadata_paths[self] += 1
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", tracking_open)
+
+    (model_dir / "README.md").write_text("---\nlibrary_name: mlx\n---\n", encoding="utf-8")
+
+    snapshot = catalog.registry_snapshot(rescan=True)
+
+    assert any(model.model_id == "plain-qwen-model" for model in snapshot.models)
+    assert metadata_paths[model_dir / "README.md"] == 1
+    assert metadata_paths[model_dir / "model_index.json"] == 0
+
+
+
+def test_registry_snapshot_rescan_reuses_cached_text_prefixes_for_unchanged_hf_cache_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    hf_cache = home / ".cache" / "huggingface" / "hub"
+    snapshot_dir = hf_cache / "models--google--bert-base" / "snapshots" / "abc123"
+    _write_model_config(snapshot_dir, {"model_type": "bert"})
+    _write_weights(snapshot_dir)
+    (snapshot_dir / "README.md").write_text("---\nlibrary_name: mlx\n---\n", encoding="utf-8")
+    (snapshot_dir / "model_index.json").write_text('{"tags": ["mlx"]}\n', encoding="utf-8")
+
+    catalog = WorkerModelCatalog(environment={"HOME": str(home)})
+
+    metadata_paths = {
+        snapshot_dir / "README.md": 0,
+        snapshot_dir / "config.json": 0,
+        snapshot_dir / "model_index.json": 0,
+    }
+    original_open = Path.open
+
+    def tracking_open(self: Path, *args: object, **kwargs: object):
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if self in metadata_paths and isinstance(mode, str) and mode.startswith("r"):
+            metadata_paths[self] += 1
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", tracking_open)
+
+    first_snapshot = catalog.registry_snapshot(rescan=True)
+    second_snapshot = catalog.registry_snapshot(rescan=True)
+
+    assert any(model.model_id == "google/bert-base" for model in first_snapshot.models)
+    assert any(model.model_id == "google/bert-base" for model in second_snapshot.models)
+    assert metadata_paths == {
+        snapshot_dir / "README.md": 0,
+        snapshot_dir / "config.json": 0,
+        snapshot_dir / "model_index.json": 0,
+    }
+
+
+
+def test_registry_snapshot_rescan_invalidates_cached_text_prefix_for_changed_hf_cache_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    hf_cache = home / ".cache" / "huggingface" / "hub"
+    snapshot_dir = hf_cache / "models--google--bert-base" / "snapshots" / "abc123"
+    _write_model_config(snapshot_dir, {"model_type": "bert"})
+    _write_weights(snapshot_dir)
+    (snapshot_dir / "README.md").write_text("plain readme\n", encoding="utf-8")
+    (snapshot_dir / "model_index.json").write_text('{"scheduler": "ddim"}\n', encoding="utf-8")
+
+    catalog = WorkerModelCatalog(environment={"HOME": str(home)})
+    assert all(model.model_id != "google/bert-base" for model in catalog.registry_snapshot().models)
+
+    metadata_paths = {
+        snapshot_dir / "README.md": 0,
+        snapshot_dir / "config.json": 0,
+        snapshot_dir / "model_index.json": 0,
+    }
+    original_open = Path.open
+
+    def tracking_open(self: Path, *args: object, **kwargs: object):
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if self in metadata_paths and isinstance(mode, str) and mode.startswith("r"):
+            metadata_paths[self] += 1
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", tracking_open)
+
+    (snapshot_dir / "README.md").write_text("---\nlibrary_name: mlx\n---\n", encoding="utf-8")
+
+    snapshot = catalog.registry_snapshot(rescan=True)
+    discovered = {model.model_id: model for model in snapshot.models}
+
+    assert discovered["google/bert-base"].model_path == str(snapshot_dir.resolve())
+    assert discovered["google/bert-base"].ext["melix.source_kind"] == "hf_cache_snapshot"
+    assert metadata_paths[snapshot_dir / "README.md"] == 1
+    assert metadata_paths[snapshot_dir / "config.json"] == 1
+    assert metadata_paths[snapshot_dir / "model_index.json"] == 0
+
+
+
 def test_registry_snapshot_rescan_reuses_cached_json_payloads_for_unchanged_registry_files(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -893,6 +1188,7 @@ def test_scan_huggingface_cache_models_reads_ref_files_once_per_repo(monkeypatch
     monkeypatch.setattr(catalog_module, "_hf_cache_revision_map", tracking_revision_map)
 
     catalog = WorkerModelCatalog.__new__(WorkerModelCatalog)
+    catalog._text_prefix_cache = {}
     models = catalog._scan_huggingface_cache_models(root=root)
 
     assert [model.revision for model in models] == ["heads/abc123", "heads/def456"]

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -175,17 +175,55 @@ def _has_model_weight_files(model_dir: Path) -> bool:
     return False
 
 
-def _read_text_prefix(path: Path, *, max_chars: int = 16_384) -> str:
-    if not path.is_file():
+def _read_text_prefix(
+    path: Path,
+    *,
+    max_chars: int = 16_384,
+    text_prefix_cache: dict[Path, tuple[int, int, int, int, str]] | None = None,
+) -> str:
+    try:
+        stat_result = path.stat()
+    except OSError:
+        if text_prefix_cache is not None:
+            text_prefix_cache.pop(path, None)
         return ""
+
+    if not path.is_file():
+        if text_prefix_cache is not None:
+            text_prefix_cache.pop(path, None)
+        return ""
+
+    if text_prefix_cache is not None:
+        cached_entry = text_prefix_cache.get(path)
+        if cached_entry is not None:
+            cached_mtime_ns, cached_size, cached_mode, cached_max_chars, cached_payload = cached_entry
+            if (
+                cached_mtime_ns == stat_result.st_mtime_ns
+                and cached_size == stat_result.st_size
+                and cached_mode == stat_result.st_mode
+                and cached_max_chars >= max_chars
+            ):
+                return cached_payload[:max_chars]
+
     try:
         with path.open("r", encoding="utf-8", errors="ignore") as handle:
-            return handle.read(max_chars)
+            payload = handle.read(max_chars)
     except OSError:
+        if text_prefix_cache is not None:
+            text_prefix_cache.pop(path, None)
         return ""
 
+    if text_prefix_cache is not None:
+        text_prefix_cache[path] = (stat_result.st_mtime_ns, stat_result.st_size, stat_result.st_mode, max_chars, payload)
+    return payload
 
-def _has_mlx_signal(*, model_dir: Path, repo_id: str = "") -> bool:
+
+def _has_mlx_signal(
+    *,
+    model_dir: Path,
+    repo_id: str = "",
+    text_prefix_cache: dict[Path, tuple[int, int, int, int, str]] | None = None,
+) -> bool:
     lowered_repo_id = repo_id.lower()
     lowered_path = model_dir.name.lower()
     if repo_id.startswith("mlx-community/") or "mlx" in lowered_repo_id or "mlx" in lowered_path:
@@ -195,9 +233,9 @@ def _has_mlx_signal(*, model_dir: Path, repo_id: str = "") -> bool:
         filter(
             None,
             (
-                _read_text_prefix(model_dir / "README.md"),
-                _read_text_prefix(model_dir / "config.json"),
-                _read_text_prefix(model_dir / "model_index.json"),
+                _read_text_prefix(model_dir / "README.md", text_prefix_cache=text_prefix_cache),
+                _read_text_prefix(model_dir / "config.json", text_prefix_cache=text_prefix_cache),
+                _read_text_prefix(model_dir / "model_index.json", text_prefix_cache=text_prefix_cache),
             ),
         )
     ).lower()
@@ -850,6 +888,7 @@ class WorkerModelCatalog:
         self._overlay_models: dict[str, common_pb2.ModelSpec] = {}
         self._registry_lock = threading.RLock()
         self._json_file_cache: dict[Path, tuple[int, int, dict[str, object]]] = {}
+        self._text_prefix_cache: dict[Path, tuple[int, int, int, int, str]] = {}
         self._registry_snapshot_cache: dict[tuple[str, ...], RegistrySnapshot] = {}
         self._active_registry_roots = tuple(self._configured_registry_roots())
         self._last_registry_snapshot = self._refresh_registry_snapshot(self._active_registry_roots)
@@ -943,12 +982,18 @@ class WorkerModelCatalog:
         }
 
     def _refresh_registry_snapshot(self, registry_roots: tuple[str, ...]) -> RegistrySnapshot:
+        self._prune_text_prefix_cache()
         roots, discovered_models = self._scan_registry_roots(registry_roots)
         return RegistrySnapshot(
             roots=tuple(roots),
             models=tuple(discovered_models[model_id] for model_id in sorted(discovered_models)),
             scanned_at_unix_ms=int(time.time() * 1000),
         )
+
+    def _prune_text_prefix_cache(self) -> None:
+        for path in tuple(self._text_prefix_cache):
+            if not path.exists():
+                self._text_prefix_cache.pop(path, None)
 
     def _scan_registry_roots(
         self,
@@ -1105,7 +1150,11 @@ class WorkerModelCatalog:
             model_id = _local_model_id(root_resolved, resolved_path)
             if model_id in discovered_models or model_id in self._seed_models:
                 continue
-            if not _has_model_weight_files(resolved_path) or not _has_mlx_signal(model_dir=resolved_path, repo_id=model_id):
+            if not _has_model_weight_files(resolved_path) or not _has_mlx_signal(
+                model_dir=resolved_path,
+                repo_id=model_id,
+                text_prefix_cache=self._text_prefix_cache,
+            ):
                 continue
             model = self._raw_model_spec(
                 model_id=model_id,
@@ -1150,7 +1199,11 @@ class WorkerModelCatalog:
             for snapshot_dir in snapshot_dirs:
                 if not (snapshot_dir / "config.json").is_file() or not _has_model_weight_files(snapshot_dir):
                     continue
-                if not _has_mlx_signal(model_dir=snapshot_dir, repo_id=repo_id):
+                if not _has_mlx_signal(
+                    model_dir=snapshot_dir,
+                    repo_id=repo_id,
+                    text_prefix_cache=self._text_prefix_cache,
+                ):
                     continue
                 revision = _hf_cache_revision(cache_repo_dir, snapshot_dir.name, revision_map=revision_map)
                 yield self._raw_model_spec(


### PR DESCRIPTION
## Summary
- cache MLX metadata prefix reads across repeated registry rescans in `services/mlx-worker-python`
- reuse cached README/config/model_index prefixes for both plain-local and Hugging Face cache discovery paths
- add focused regressions for cache reuse, invalidation, transient read failures, mode changes, disappeared paths, and HF-cache behavior

## Plan or Spec
- N/A: internal Python-worker performance optimization slice for `services/mlx-worker-python`; no governing canonical spec or user-facing behavior document applies

## Commands Run
```text
python -m pytest tests/test_model_registry_catalog.py -k 'read_text_prefix'  # initial import-path failure: ModuleNotFoundError: packages
PYTHONPATH=/tmp/akane-cron-python-opt-20260501-001703:/tmp/akane-cron-python-opt-20260501-001703/services/mlx-worker-python python -m pytest tests/test_model_registry_catalog.py -k 'read_text_prefix'  # 5 passed
PYTHONPATH=/tmp/akane-cron-python-opt-20260501-001703:/tmp/akane-cron-python-opt-20260501-001703/services/mlx-worker-python pytest tests/test_model_registry_catalog.py -q  # 74 passed
python inline coverage runner for tests/test_model_registry_catalog.py  # 74 passed, changed-scope coverage 100.00%
python inline performance probe comparing origin/main baseline vs current branch on 200 local model dirs across two rescans  # baseline 101.08ms / 1200 opens; current 71.42ms / 0 opens
git diff --check  # pass
```

## Coverage and Metrics
- changed-scope coverage for `services/mlx-worker-python/worker/model_registry/catalog.py`: **100.00%**
- measurable changed lines: `178, 184-200, 206, 210, 212-218, 221, 891, 985, 993-996, 1153, 1202`
- missed changed lines: none
- performance probe on 200 plain-local model dirs across two rescans:
  - baseline (`origin/main`): `101.08ms`, `1200` metadata opens
  - current branch: `71.42ms`, `0` metadata opens

## Known Gaps
- Full repository gates (`make py-test`, `make swift-test`, `make integration-test`) were not run in this cron slice; verification stayed focused on the touched Python scope per the Linux-only constraint.
- No canonical docs were updated because this is an internal caching optimization with no user-facing behavior or protocol change.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
