### PR TITLE
perf: scan LoRA checkpoints without candidate list

### DIFF
--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -16,7 +16,12 @@ from worker.model_ops.adapter_activation_pipeline import AdapterActivationPipeli
 from worker.model_ops.lora_training_pipeline import (
     LoRATrainingPipeline,
     _latest_checkpoint_from_directory,
+    _load_manifest_payload,
+    _resolve_resume_context,
+    _resolve_resume_path_from_manifest,
+    _validated_resume_path,
 )
+from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.mlx_lm_runner import (
     ActivationMetrics,
     ActivationRequest,
@@ -28,6 +33,7 @@ from worker.model_ops.mlx_lm_runner import (
     TrainingResult,
     _checkpoint_order_key,
 )
+from worker.model_ops import lora_training_pipeline as lora_training_pipeline_module
 from worker.model_ops import training_config as training_config_module
 from worker.model_ops import training_dataset as training_dataset_module
 from worker.model_ops.training_dataset import (
@@ -64,6 +70,53 @@ def test_latest_checkpoint_from_directory_prefers_last_numeric_token(tmp_path: P
         checkpoint.write_bytes(b"weights")
 
     assert _latest_checkpoint_from_directory(tmp_path) == newer.resolve()
+
+
+def test_latest_checkpoint_from_directory_uses_scandir_stack(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    nested = tmp_path / "model-ops-001" / "adapter" / "checkpoint-3"
+    nested.mkdir(parents=True)
+    checkpoint = nested / "adapters.safetensors"
+    checkpoint.write_bytes(b"weights")
+
+    def fail_os_walk(path: Path):
+        raise AssertionError("expected explicit os.scandir stack, not os.walk")
+
+    monkeypatch.setattr(lora_training_pipeline_module.os, "walk", fail_os_walk)
+
+    assert _latest_checkpoint_from_directory(tmp_path) == checkpoint.resolve()
+
+
+def test_latest_checkpoint_from_directory_skips_non_weight_entries(tmp_path: Path) -> None:
+    (tmp_path / "checkpoint-99").mkdir()
+    (tmp_path / "checkpoint-99" / "adapter.txt").write_text("not weights", encoding="utf-8")
+
+    with pytest.raises(ModelOperationError, match="does not contain adapter weights"):
+        _latest_checkpoint_from_directory(tmp_path)
+
+
+def test_resume_helpers_reject_invalid_sources(tmp_path: Path) -> None:
+    missing_resume_path = tmp_path / "missing.safetensors"
+    with pytest.raises(ModelOperationError, match="Resume source does not exist"):
+        _resolve_resume_context({"resume_source_path": str(missing_resume_path)})
+
+    broken_manifest = tmp_path / "broken.json"
+    broken_manifest.write_text("not-json", encoding="utf-8")
+    with pytest.raises(ModelOperationError, match="Resume manifest is unreadable"):
+        _load_manifest_payload(broken_manifest)
+
+    with pytest.raises(ModelOperationError, match="does not expose a checkpoint"):
+        _resolve_resume_path_from_manifest(tmp_path / "manifest.json", {})
+
+    with pytest.raises(ModelOperationError, match="does not exist"):
+        _validated_resume_path(missing_resume_path, source_label="test")
+
+
+def test_validated_resume_path_selects_latest_checkpoint_from_directory(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "checkpoint-7" / "adapters.safetensors"
+    checkpoint.parent.mkdir(parents=True)
+    checkpoint.write_bytes(b"weights")
+
+    assert _validated_resume_path(tmp_path, source_label="test") == checkpoint.resolve()
 
 
 def _write_dataset_package(

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -353,23 +353,31 @@ def _resolve_resume_path_from_manifest(path: Path, manifest: dict[str, Any]) -> 
 
 
 def _latest_checkpoint_from_directory(path: Path) -> Path:
-    checkpoint_candidates: list[str] = []
-    for root, _, files in os.walk(path):
-        for filename in files:
-            if filename.endswith(".safetensors"):
-                checkpoint_candidates.append(os.path.join(root, filename))
+    pending: list[str] = [os.fspath(path)]
+    latest_checkpoint_path = ""
+    latest_checkpoint_key: tuple[int, str] | None = None
+    while pending:
+        current_dir = pending.pop()
+        with os.scandir(current_dir) as entries:
+            for entry in entries:
+                if entry.is_dir(follow_symlinks=False):
+                    pending.append(entry.path)
+                    continue
+                if not entry.name.endswith(".safetensors") or entry.is_dir(follow_symlinks=True):
+                    continue
+                numbers = _NUMERIC_TOKEN_RE.findall(entry.path)
+                checkpoint_key = (int(numbers[-1]) if numbers else -1, entry.path)
+                if latest_checkpoint_key is None or checkpoint_key > latest_checkpoint_key:
+                    latest_checkpoint_path = entry.path
+                    latest_checkpoint_key = checkpoint_key
 
-    if not checkpoint_candidates:
+    if latest_checkpoint_key is None:
         raise ModelOperationError(
             code="invalid_resume_source",
             message=f"Resume directory does not contain adapter weights: {path}",
         )
 
-    def order_key(candidate: str) -> tuple[int, str]:
-        numbers = _NUMERIC_TOKEN_RE.findall(candidate)
-        return (int(numbers[-1]) if numbers else -1, candidate)
-
-    return Path(max(checkpoint_candidates, key=order_key)).resolve()
+    return Path(latest_checkpoint_path).resolve()
 
 
 def _validated_resume_path(path: Path, *, source_label: str) -> Path:


### PR DESCRIPTION
## Summary
- Reworks LoRA resume checkpoint discovery to use an explicit `os.scandir` stack instead of `os.walk` plus a full candidate list.
- Tracks the current best `.safetensors` checkpoint during traversal to reduce allocations while preserving numeric-token ordering.
- Adds focused regression coverage for the scandir traversal and resume-helper error paths.

## Plan or Spec
- N/A: scoped Python performance slice for an existing LoRA resume checkpoint helper; no product behavior or public spec change.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_lora_model_ops.py::test_latest_checkpoint_from_directory_prefers_last_numeric_token -q
# exit 0: 1 passed in 0.49s

python .runtime/probes/benchmark_latest_checkpoint.py
# exit 0 baseline before edit: old_mean_ms=16.688, new_mean_ms=12.610, delta_ms=-4.077, speedup=1.323x

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_lora_model_ops.py::test_latest_checkpoint_from_directory_prefers_last_numeric_token services/mlx-worker-python/tests/test_lora_model_ops.py::test_latest_checkpoint_from_directory_uses_scandir_stack -q
# exit 0: 2 passed in 0.31s

python .runtime/probes/benchmark_latest_checkpoint.py
# exit 0 final probe: old_mean_ms=17.822, new_mean_ms=11.491, delta_ms=-6.331, speedup=1.551x

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_lora_model_ops.py -q
# exit 0: 40 passed in 0.42s

PYTHONPATH=services/mlx-worker-python:. uv run coverage run --source=worker.model_ops.lora_training_pipeline -m pytest services/mlx-worker-python/tests/test_lora_model_ops.py -q && uv run coverage report -m
# exit 0: 40 passed; lora_training_pipeline.py coverage 97%

git diff --check
# exit 0

make py-test
# exit 2: Linux-only environment failures unrelated to this slice: sandbox-exec unavailable, libmlx.so unavailable, device memory detection on Linux, and one dev_up chmod expectation. Focused LoRA tests above pass locally on Linux.
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py` 97% under focused coverage command.
- Performance probe: synthetic 400 checkpoint-directory tree with 8 files per directory, 7 iterations, comparing previous `os.walk`+candidate-list algorithm against the new scandir/best-candidate traversal in the same process.
- Final probe result: old_mean=17.822 ms, new_mean=11.491 ms, delta=-6.331 ms, speedup=1.551x.
- Linux validation scope only; broader macOS/MLX-dependent suite is not fully runnable in this environment.

## Known Gaps
- Full `make py-test` does not pass on this Linux host because several repository tests require macOS-only `sandbox-exec`, working MLX shared libraries, and host-specific platform behavior. No failures were observed in the focused LoRA resume tests.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated for this internal performance-only slice.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
