### PR TITLE
perf: short-circuit mlx metadata signal scan

### DIFF
--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from packages.protocol.python.worker.v1 import common_pb2
+from worker.model_registry import catalog as catalog_module
 from worker.model_registry.catalog import (
     WorkerModelCatalog,
     _apply_registry_identity_metadata,
@@ -231,6 +232,31 @@ def test_has_mlx_signal_detects_metadata_signal_from_readme(tmp_path: Path) -> N
 
     assert _has_mlx_signal(model_dir=model_dir, repo_id="google/bert-base") is True
 
+
+
+def test_has_mlx_signal_stops_after_first_matching_metadata_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "plain-transformers-model"
+    model_dir.mkdir()
+    calls: list[str] = []
+
+    def fake_read_text_prefix(
+        path: Path,
+        *,
+        max_chars: int = 16_384,
+        text_prefix_cache: dict[Path, tuple[int, int, int, int, str]] | None = None,
+    ) -> str:
+        calls.append(path.name)
+        if path.name == "README.md":
+            return "---\nlibrary_name: mlx\n---\n"
+        raise AssertionError("metadata scan should short-circuit after README.md")
+
+    monkeypatch.setattr(catalog_module, "_read_text_prefix", fake_read_text_prefix)
+
+    assert _has_mlx_signal(model_dir=model_dir, repo_id="google/bert-base") is True
+    assert calls == ["README.md"]
 
 
 def test_has_model_weight_files_uses_os_scandir_single_pass_without_path_glob_or_iterdir(

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -218,6 +218,16 @@ def _read_text_prefix(
     return payload
 
 
+def _metadata_text_has_mlx_signal(metadata_text: str) -> bool:
+    return (
+        "library_name: mlx" in metadata_text
+        or '"library_name": "mlx"' in metadata_text
+        or "\n- mlx" in metadata_text
+        or "\n  - mlx" in metadata_text
+        or '"mlx"' in metadata_text and '"tags"' in metadata_text
+    )
+
+
 def _has_mlx_signal(
     *,
     model_dir: Path,
@@ -229,25 +239,14 @@ def _has_mlx_signal(
     if repo_id.startswith("mlx-community/") or "mlx" in lowered_repo_id or "mlx" in lowered_path:
         return True
 
-    metadata_text = "\n".join(
-        filter(
-            None,
-            (
-                _read_text_prefix(model_dir / "README.md", text_prefix_cache=text_prefix_cache),
-                _read_text_prefix(model_dir / "config.json", text_prefix_cache=text_prefix_cache),
-                _read_text_prefix(model_dir / "model_index.json", text_prefix_cache=text_prefix_cache),
-            ),
-        )
-    ).lower()
-    if not metadata_text:
-        return False
-    return (
-        "library_name: mlx" in metadata_text
-        or '"library_name": "mlx"' in metadata_text
-        or "\n- mlx" in metadata_text
-        or "\n  - mlx" in metadata_text
-        or '"mlx"' in metadata_text and '"tags"' in metadata_text
-    )
+    for metadata_filename in ("README.md", "config.json", "model_index.json"):
+        metadata_text = _read_text_prefix(
+            model_dir / metadata_filename,
+            text_prefix_cache=text_prefix_cache,
+        ).lower()
+        if metadata_text and _metadata_text_has_mlx_signal(metadata_text):
+            return True
+    return False
 
 
 def _hf_cache_repo_id(cache_repo_dir: Path) -> str | None:


### PR DESCRIPTION
## Summary
- Short-circuit `_has_mlx_signal` metadata probing after the first file that proves an MLX signal.
- Keep the same README/config/model_index signal rules while avoiding unnecessary metadata prefix reads for README-positive local model directories.
- Add a focused regression test proving `config.json` and `model_index.json` are not read after `README.md` matches.

## Plan or Spec
- N/A: this is a small Linux-validated Python performance slice that preserves existing model registry behavior and does not change a governed product spec.

## Commands Run
```text
# baseline focused test
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -q
exit 0: 74 passed in 0.41s

# baseline candidate probe before implementation
PYTHONPATH=services/mlx-worker-python:. uv run --package melix-mlx-worker python - <<'PY'
# compared current _has_mlx_signal with a local short-circuit candidate on 400 README-positive dirs, 7 iterations
PY
exit 0: old_mean=58.324ms, new_mean=19.100ms, delta_ms=-39.224ms, speedup=3.054x

# focused verification after implementation
PYTHONPATH=services/mlx-worker-python:. uv run --package melix-mlx-worker pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -q
exit 0: 75 passed in 0.47s

# accepted implementation probe
PYTHONPATH=services/mlx-worker-python:. uv run --package melix-mlx-worker python - <<'PY'
# compared inlined old implementation with new _has_mlx_signal on 400 README-positive dirs, 7 iterations
PY
exit 0: old_mean=56.760ms, new_mean=19.975ms, delta_ms=-36.785ms, speedup=2.842x

# changed-scope coverage
PYTHONPATH=services/mlx-worker-python:. uv run --package melix-mlx-worker coverage run --source=worker.model_registry.catalog -m pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -q
PYTHONPATH=services/mlx-worker-python:. uv run --package melix-mlx-worker coverage report services/mlx-worker-python/worker/model_registry/catalog.py
exit 0: 75 passed in 0.45s; catalog.py coverage 97%

# whitespace check
git diff --check
exit 0

# broader Linux Python suite (known Linux/macOS tooling gaps; not caused by this slice)
PYTHONPATH=services/mlx-worker-python:. uv run --package melix-mlx-worker pytest services/mlx-worker-python/tests -q
exit 1: 1264 passed, 14 skipped, 15 failed in 20.97s; failures require macOS sandbox-exec/ditto behavior or Linux host device/log-file assumptions.
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/model_registry/catalog.py` 97% via `coverage run --source=worker.model_registry.catalog -m pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -q`.
- Probe: `has_mlx_signal_readme_short_circuit`, 400 synthetic README-positive model directories, 7 iterations, fresh text prefix cache per call.
- Result: old_mean=56.760ms, new_mean=19.975ms, speedup=2.842x, delta_ms=-36.785ms.
- Validation scope: Linux-local Python only; repository remains Apple/macOS-oriented, so macOS-only runtime/tooling paths were not validated locally.

## Known Gaps
- Full Python suite is not green on this Linux worker because existing tests expect macOS-only `sandbox-exec`/`ditto` behavior and host-specific device/log-file semantics. Focused model registry tests and coverage passed.
- No protocol, dependency, generated artifact, or formal behavior-spec changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
