### PR TITLE
perf: skip chunker renders for no-pair passthrough samples

### DIFF
--- a/services/mlx-worker-python/tests/test_training_dataset_chunker.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_chunker.py
@@ -129,6 +129,22 @@ def test_passthrough_without_extractable_pairs_reuses_top_level_metadata_but_cop
     assert emitted["messages"][0] is not sample["messages"][0]
 
 
+def test_passthrough_without_extractable_pairs_skips_rendering() -> None:
+    tokenizer = _CountingTokenizer()
+    sample = {
+        "id": "no-pairs-no-render",
+        "messages": [
+            {"role": "assistant", "content": _words(200)},
+        ],
+    }
+
+    chunked, stats = chunk_long_samples([sample], chunk_size=1, tokenizer=tokenizer)
+
+    assert stats.chunk_count == len(chunked) == 1
+    assert chunked[0]["messages"] == sample["messages"]
+    assert tokenizer.render_calls == 0
+
+
 def test_long_single_turn_splits_into_multiple_chunks() -> None:
     tokenizer = _FakeTokenizer()  # 5 overhead/msg, 1 token/word
     # ~200 user words + 3-token assistant + overhead — full render ≈ 215 tokens.

--- a/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
@@ -310,14 +310,14 @@ def _chunk_sample(
 
     tools = _extract_tools(sample)
     messages = _extract_messages(sample)
-    full_len = _render_len(messages, tokenizer, tools=tools)
-    if full_len <= chunk_size:
-        return [_passthrough_sample(sample)]
-
     sample_id = str(sample.get("id", ""))
     system_prefix, pairs = _split_messages_into_turns(messages)
 
     if not pairs:
+        return [_passthrough_sample(sample)]
+
+    full_len = _render_len(messages, tokenizer, tools=tools)
+    if full_len <= chunk_size:
         return [_passthrough_sample(sample)]
 
     # Multi-turn: emit each (user, assistant) pair as its own chunk first.


### PR DESCRIPTION
## Summary
- Skip `training_dataset_chunker._render_len(...)` for malformed / non-extractable samples that have no `(user, assistant)` pairs.
- Keep passthrough behavior unchanged while avoiding redundant chat-template renders on a rejection-preserving fast path.
- Add a regression test that proves the no-pair passthrough path now performs zero tokenizer renders.

## Plan or Spec
- Governing plan: `docs/plans/2026-04-21-lora-long-context-chunked.md`
- This change is an internal optimization of the existing chunker path; no canonical docs needed updates because external behavior is unchanged.

## Commands Run
```text
python3 -m pytest -q tests/test_training_dataset_chunker.py
28 passed in 0.10s

python3 -m coverage run -m pytest -q tests/test_training_dataset_chunker.py
python3 -m coverage json -o coverage.json
changed_line_coverage=100.00%
measurable_changed_lines=[319, 320, 321]
missed_changed_lines=[]

python3 - <<'PY' ... benchmark old vs current no-pair passthrough path ...
baseline_seconds=0.081771
optimized_seconds=0.016643
baseline_render_calls=10000
optimized_render_calls=0
speedup_x=4.91

git diff --check
(exit 0)
```

## Coverage and Metrics
- Changed-scope coverage for `worker/model_ops/training_dataset_chunker.py`: **100.00%** on measurable changed lines `[319, 320, 321]`.
- Performance probe on 10,000 assistant-only passthrough samples:
  - Baseline (pre-change logic): `0.081771s`, `10000` render calls
  - Optimized (current logic): `0.016643s`, `0` render calls
  - Measured speedup: **4.91x**

## Known Gaps
- Did not run the full repository test matrix (`make py-test`, Swift tests, integration tests); this cron slice intentionally stayed within a Linux-verifiable Python-only optimization under `services/mlx-worker-python`.
- Performance probe is a targeted synthetic benchmark for the malformed no-pair passthrough path, not an end-to-end training benchmark.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs (N/A: no external behavior change).
- [x] Protocol changes include regenerated generated artifacts (N/A: none).
- [x] Dependency changes include updated lockfiles (N/A: none).
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
