### PR TITLE
perf: reuse safe job registry snapshots

### DIFF
--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 from typing import Any
 
@@ -89,3 +90,17 @@ def test_job_registry_restore_scans_manifest_directories_once(monkeypatch: pytes
     assert any(str(jobs_root / "activate_adapter") == call for call in scan_calls)
     assert any(str(jobs_root / "remove_derived_model") == call for call in scan_calls)
     assert len(scan_calls) <= 9
+
+
+def test_json_safe_reuses_clean_containers_and_copies_only_changed_branch() -> None:
+    clean = {"rows": [{"pct": 1.0, "label": "ready"}]}
+
+    assert ModelOpsJobRegistry._json_safe(clean) is clean
+
+    unsafe = {"rows": [{"pct": math.nan, "label": "bad"}], "other": {"pct": 1.0}}
+    safe = ModelOpsJobRegistry._json_safe(unsafe)
+
+    assert safe == {"rows": [{"pct": None, "label": "bad"}], "other": {"pct": 1.0}}
+    assert safe is not unsafe
+    assert safe["rows"] is not unsafe["rows"]
+    assert safe["other"] is unsafe["other"]

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -388,9 +388,25 @@ class ModelOpsJobRegistry:
     @classmethod
     def _json_safe(cls, value: Any) -> Any:
         if isinstance(value, dict):
-            return {key: cls._json_safe(item) for key, item in value.items()}
+            updated: dict[Any, Any] | None = None
+            for key, item in value.items():
+                safe_item = cls._json_safe(item)
+                if updated is not None:
+                    updated[key] = safe_item
+                elif safe_item is not item:
+                    updated = dict(value)
+                    updated[key] = safe_item
+            return value if updated is None else updated
         if isinstance(value, list):
-            return [cls._json_safe(item) for item in value]
+            updated_list: list[Any] | None = None
+            for index, item in enumerate(value):
+                safe_item = cls._json_safe(item)
+                if updated_list is not None:
+                    updated_list.append(safe_item)
+                elif safe_item is not item:
+                    updated_list = value[:index]
+                    updated_list.append(safe_item)
+            return value if updated_list is None else updated_list
         if isinstance(value, float) and math.isfinite(value) is False:
             return None
         return value


### PR DESCRIPTION
## Summary
- Optimizes `ModelOpsJobRegistry._json_safe` so clean snapshot containers are reused instead of eagerly rebuilding every dict/list.
- Keeps non-finite float sanitization behavior unchanged by copying only the branch that contains an unsafe value.
- Adds focused coverage for the copy-on-change behavior.

## Plan or Spec
- N/A: local Python performance-only slice for an internal job registry serialization helper; no external behavior or protocol contract changes.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_maintenance_service.py::test_job_registry_snapshot_records_merged_publish_lineage_for_derived_models -q
# exit 0; 4 passed in 0.33s

cd services/mlx-worker-python && PYTHONPATH=/tmp:.:../.. uv run python /tmp/melix_job_registry_snapshot_probe_large.py
# baseline origin/main exit 0: snapshot_large_ms mean=208.730 median=204.886 runs=252.509,182.443,204.886,205.539,198.275
# new branch exit 0: snapshot_large_ms mean=172.758 median=174.946 runs=178.668,163.780,174.946,181.599,164.799

git diff --check
# exit 0
```

## Coverage and Metrics
- Focused test coverage: `test_json_safe_reuses_clean_containers_and_copies_only_changed_branch` verifies clean container reuse and non-finite float sanitization parity.
- Changed-scope coverage command attempted with `coverage run --source=worker.model_ops.job_registry ...`; focused subset reported 72% for the whole large `job_registry.py` file because many unrelated registry paths are not exercised by this slice.
- Performance probe: old_mean=208.730 ms, new_mean=172.758 ms, delta=-35.972 ms, speedup=1.21x / 17.23% faster on a 7,600-job synthetic registry snapshot workload.
- Linux-only validation scope: Python unit tests and synthetic probes only; macOS/Apple Silicon runtime paths were not exercised.

## Known Gaps
- Full `test_maintenance_service.py` was attempted for broader coverage and had two pre-existing Linux fixture failures in code-evaluation tests (`response.results` empty for humaneval/mbpp fixture cases); the focused job-registry tests passed.
- The earlier attempted optimization to precompute removed-derived-target indexes was rejected and reverted because probe results regressed (`old_mean=217.520 ms`, attempted `new_mean=236.177 ms` on the large snapshot probe).

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
