### PR TITLE
perf: reuse freshly materialized HF dataset packages

### DIFF
--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -38,6 +38,8 @@ from worker.model_ops import training_config as training_config_module
 from worker.model_ops import training_dataset as training_dataset_module
 from worker.model_ops.training_dataset import (
     HFDatasetReference,
+    MaterializedTrainingDatasetPackage,
+    TrainingDatasetPackage,
     materialize_hf_training_dataset_package,
     resolve_training_dataset_package,
 )
@@ -1445,6 +1447,67 @@ def test_resolve_training_dataset_rejects_hf_valid_split_for_local_package(tmp_p
         )
 
     assert exc.value.code == "invalid_dataset_source"
+
+
+def test_resolve_training_dataset_package_reuses_materialized_hf_package_without_reloading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package_path = tmp_path / "datasets" / "cached-hf"
+    package = TrainingDatasetPackage(
+        package_path=package_path,
+        manifest_path=package_path / "manifest.json",
+        samples_path=package_path / "samples.jsonl",
+        schema_version="melix.training_dataset_package.v1",
+        dataset_id="melix/demo-hf:default:train@main",
+        format="text_completion",
+        sample_count=1,
+        version="main",
+        normalized_samples=[{"text": "hello world"}],
+        normalized_validation_samples=[],
+        validation_sample_count=0,
+        response_only_supported=False,
+    )
+    reference = HFDatasetReference(
+        dataset_path="melix/demo-hf",
+        dataset_name="default",
+        dataset_revision="main",
+        train_split="train",
+        valid_split="",
+        chat_feature="",
+        prompt_feature="",
+        completion_feature="",
+        text_feature="text",
+    )
+
+    monkeypatch.setattr(
+        training_dataset_module,
+        "materialize_hf_training_dataset_package",
+        lambda *args, **kwargs: MaterializedTrainingDatasetPackage(
+            package_path=package_path,
+            cache_key="cached-hf",
+            cache_hit=False,
+            dataset_uri="hf://melix/demo-hf",
+            reference=reference,
+            package=package,
+        ),
+    )
+
+    def fail_load(*args, **kwargs):
+        raise AssertionError("resolve_training_dataset_package should reuse the freshly materialized package")
+
+    monkeypatch.setattr(training_dataset_module, "load_training_dataset_package", fail_load)
+
+    resolved = resolve_training_dataset_package(
+        {"dataset_source_kind": "hf_dataset", "hf_dataset_path": "melix/demo-hf"},
+        jobs_root=tmp_path / "jobs",
+    )
+
+    assert resolved.package is package
+    assert resolved.cache_hit is False
+    assert resolved.materialized_package_path == package_path
+    assert resolved.dataset_uri == "hf://melix/demo-hf"
+
 
 
 def test_materialize_hf_training_dataset_rejects_empty_row_payload(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -156,6 +156,84 @@ def test_write_normalized_dataset_snapshot_clears_stale_valid_jsonl_when_no_vali
     assert stale_valid_path.exists() is False
 
 
+
+def test_load_training_dataset_package_respects_sample_limit_after_skipping_blank_lines(
+    tmp_path: Path,
+) -> None:
+    package_path = tmp_path / "limited-package"
+    package_path.mkdir(parents=True, exist_ok=True)
+    (package_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "limited-package",
+                "format": "text_completion",
+                "sample_count": 2,
+                "version": "1",
+                "validation_sample_count": 0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (package_path / "samples.jsonl").write_text(
+        "\n"
+        '{"text": "alpha"}\n'
+        "\n"
+        '{"text": "beta"}\n',
+        encoding="utf-8",
+    )
+
+    package = load_training_dataset_package(str(package_path), sample_limit=1)
+
+    assert package.sample_count == 1
+    assert package.normalized_samples == [{"text": "alpha"}]
+
+
+
+def test_load_training_dataset_package_rejects_invalid_manifest_json(
+    tmp_path: Path,
+) -> None:
+    package_path = tmp_path / "invalid-manifest"
+    package_path.mkdir(parents=True, exist_ok=True)
+    (package_path / "manifest.json").write_text("{not-json", encoding="utf-8")
+    (package_path / "samples.jsonl").write_text('{"text": "alpha"}\n', encoding="utf-8")
+
+    with pytest.raises(ModelOperationError) as exc:
+        load_training_dataset_package(str(package_path))
+
+    assert exc.value.code == "invalid_dataset_package"
+
+
+
+def test_load_training_dataset_package_rejects_invalid_sample_json(
+    tmp_path: Path,
+) -> None:
+    package_path = tmp_path / "invalid-sample"
+    package_path.mkdir(parents=True, exist_ok=True)
+    (package_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "invalid-sample",
+                "format": "text_completion",
+                "sample_count": 1,
+                "version": "1",
+                "validation_sample_count": 0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (package_path / "samples.jsonl").write_text("{not-json\n", encoding="utf-8")
+
+    with pytest.raises(ModelOperationError) as exc:
+        load_training_dataset_package(str(package_path))
+
+    assert exc.value.code == "invalid_dataset_package"
+
+
+
 def test_build_training_dataset_artifact_converts_alpaca_rows_and_records_quality_signals(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -70,6 +70,7 @@ class MaterializedTrainingDatasetPackage:
     cache_hit: bool
     dataset_uri: str
     reference: HFDatasetReference
+    package: TrainingDatasetPackage | None = None
 
 
 @dataclass(frozen=True)
@@ -113,32 +114,18 @@ def _write_duplicate_jsonl_rows(paths: tuple[Path, ...], rows: list[dict[str, An
                 handle.write("\n")
 
 
-def load_training_dataset_package(
-    dataset_uri: str,
+def _build_training_dataset_package(
     *,
+    dataset_uri: str,
+    package_path: Path,
+    manifest_path: Path,
+    samples_path: Path,
+    manifest: dict[str, Any],
+    serialized_samples: list[dict[str, Any]],
+    serialized_validation_samples: list[dict[str, Any]],
     sample_limit: int = 0,
     max_characters_per_sample: int = 0,
 ) -> TrainingDatasetPackage:
-    package_path = Path(dataset_uri).expanduser().resolve()
-    manifest_path = package_path / "manifest.json"
-    samples_path = package_path / "samples.jsonl"
-
-    if not manifest_path.is_file() or not samples_path.is_file():
-        raise ModelOperationError(
-            code="invalid_dataset_package",
-            message="Training dataset package must contain manifest.json and samples.jsonl.",
-            details={"dataset_uri": dataset_uri},
-        )
-
-    try:
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise ModelOperationError(
-            code="invalid_dataset_package",
-            message="Training dataset manifest is not valid JSON.",
-            details={"dataset_uri": dataset_uri},
-        ) from exc
-
     if not isinstance(manifest, dict):
         raise ModelOperationError(
             code="invalid_dataset_package",
@@ -167,28 +154,16 @@ def load_training_dataset_package(
         )
 
     normalized_samples: list[dict[str, Any]] = []
-    with samples_path.open("r", encoding="utf-8") as handle:
-        for line_number, raw_line in enumerate(handle, start=1):
-            line = raw_line.strip()
-            if not line:
-                continue
-            try:
-                sample = json.loads(line)
-            except json.JSONDecodeError as exc:
-                raise ModelOperationError(
-                    code="invalid_dataset_package",
-                    message="Training dataset sample is not valid JSON.",
-                    details={"line": str(line_number)},
-                ) from exc
-
-            normalized = _normalize_sample(
+    for sample in serialized_samples:
+        normalized_samples.append(
+            _normalize_sample(
                 sample,
                 format_name=format_name,
                 max_characters_per_sample=max_characters_per_sample,
             )
-            normalized_samples.append(normalized)
-            if sample_limit > 0 and len(normalized_samples) >= sample_limit:
-                break
+        )
+        if sample_limit > 0 and len(normalized_samples) >= sample_limit:
+            break
 
     if not normalized_samples:
         raise ModelOperationError(
@@ -208,29 +183,14 @@ def load_training_dataset_package(
             },
         )
 
-    validation_samples_path = package_path / "valid.jsonl"
-    normalized_validation_samples: list[dict[str, Any]] = []
-    if validation_samples_path.is_file():
-        with validation_samples_path.open("r", encoding="utf-8") as handle:
-            for line_number, raw_line in enumerate(handle, start=1):
-                line = raw_line.strip()
-                if not line:
-                    continue
-                try:
-                    sample = json.loads(line)
-                except json.JSONDecodeError as exc:
-                    raise ModelOperationError(
-                        code="invalid_dataset_package",
-                        message="Training dataset validation sample is not valid JSON.",
-                        details={"line": str(line_number)},
-                    ) from exc
-                normalized_validation_samples.append(
-                    _normalize_sample(
-                        sample,
-                        format_name=format_name,
-                        max_characters_per_sample=max_characters_per_sample,
-                    )
-                )
+    normalized_validation_samples = [
+        _normalize_sample(
+            sample,
+            format_name=format_name,
+            max_characters_per_sample=max_characters_per_sample,
+        )
+        for sample in serialized_validation_samples
+    ]
 
     return TrainingDatasetPackage(
         package_path=package_path,
@@ -245,6 +205,79 @@ def load_training_dataset_package(
         normalized_validation_samples=normalized_validation_samples,
         validation_sample_count=len(normalized_validation_samples),
         response_only_supported=format_name in {"chat_messages", "prompt_completion"},
+    )
+
+
+def load_training_dataset_package(
+    dataset_uri: str,
+    *,
+    sample_limit: int = 0,
+    max_characters_per_sample: int = 0,
+) -> TrainingDatasetPackage:
+    package_path = Path(dataset_uri).expanduser().resolve()
+    manifest_path = package_path / "manifest.json"
+    samples_path = package_path / "samples.jsonl"
+
+    if not manifest_path.is_file() or not samples_path.is_file():
+        raise ModelOperationError(
+            code="invalid_dataset_package",
+            message="Training dataset package must contain manifest.json and samples.jsonl.",
+            details={"dataset_uri": dataset_uri},
+        )
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ModelOperationError(
+            code="invalid_dataset_package",
+            message="Training dataset manifest is not valid JSON.",
+            details={"dataset_uri": dataset_uri},
+        ) from exc
+
+    serialized_samples: list[dict[str, Any]] = []
+    with samples_path.open("r", encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                sample = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ModelOperationError(
+                    code="invalid_dataset_package",
+                    message="Training dataset sample is not valid JSON.",
+                    details={"line": str(line_number)},
+                ) from exc
+            serialized_samples.append(sample)
+
+    validation_samples_path = package_path / "valid.jsonl"
+    serialized_validation_samples: list[dict[str, Any]] = []
+    if validation_samples_path.is_file():
+        with validation_samples_path.open("r", encoding="utf-8") as handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    sample = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise ModelOperationError(
+                        code="invalid_dataset_package",
+                        message="Training dataset validation sample is not valid JSON.",
+                        details={"line": str(line_number)},
+                    ) from exc
+                serialized_validation_samples.append(sample)
+
+    return _build_training_dataset_package(
+        dataset_uri=dataset_uri,
+        package_path=package_path,
+        manifest_path=manifest_path,
+        samples_path=samples_path,
+        manifest=manifest,
+        serialized_samples=serialized_samples,
+        serialized_validation_samples=serialized_validation_samples,
+        sample_limit=sample_limit,
+        max_characters_per_sample=max_characters_per_sample,
     )
 
 
@@ -309,11 +342,13 @@ def resolve_training_dataset_package(
         cache_root=jobs_root / "datasets",
         fetch_json=hf_dataset_fetcher,
     )
-    package = load_training_dataset_package(
-        str(materialized.package_path),
-        sample_limit=sample_limit,
-        max_characters_per_sample=max_characters_per_sample,
-    )
+    package = materialized.package
+    if package is None or materialized.cache_hit or sample_limit > 0 or max_characters_per_sample > 0:
+        package = load_training_dataset_package(
+            str(materialized.package_path),
+            sample_limit=sample_limit,
+            max_characters_per_sample=max_characters_per_sample,
+        )
     return ResolvedTrainingDatasetPackage(
         package=package,
         source_kind="hf_dataset",
@@ -604,6 +639,15 @@ def materialize_hf_training_dataset_package(
         cache_hit=False,
         dataset_uri=dataset_uri,
         reference=resolved_reference,
+        package=_build_training_dataset_package(
+            dataset_uri=dataset_uri,
+            package_path=package_path,
+            manifest_path=manifest_path,
+            samples_path=samples_path,
+            manifest=manifest_payload,
+            serialized_samples=serialized_samples,
+            serialized_validation_samples=serialized_validation_samples,
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- Reuse the in-memory `TrainingDatasetPackage` produced during Hugging Face dataset materialization so cache-miss resolution does not immediately reopen and reparse the freshly written package files.
- Factor shared package construction into `_build_training_dataset_package` so disk-backed loads and fresh materializations keep identical validation and normalization behavior.
- Add regression tests for the no-reload path plus focused loader edge cases that cover the new helper and changed-scope branches.

## Plan or Spec
- N/A: internal Python-worker performance optimization for `services/mlx-worker-python` with no product-facing behavior or protocol change.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_lora_model_ops.py::test_resolve_training_dataset_package_reuses_materialized_hf_package_without_reloading -q
1 passed in 0.26s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_training_dataset_builder.py::test_load_training_dataset_package_respects_sample_limit_after_skipping_blank_lines services/mlx-worker-python/tests/test_training_dataset_builder.py::test_load_training_dataset_package_rejects_invalid_manifest_json services/mlx-worker-python/tests/test_training_dataset_builder.py::test_load_training_dataset_package_rejects_invalid_sample_json services/mlx-worker-python/tests/test_lora_model_ops.py::test_resolve_training_dataset_package_reuses_materialized_hf_package_without_reloading -q
4 passed in 0.31s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_lora_model_ops.py -q
57 passed in 0.43s

$ uv run --project services/mlx-worker-python python - <<'PY' ... Coverage() + pytest(main) ... PY
57 passed in 0.91s
changed_line_coverage=100.00%

$ uv run --project services/mlx-worker-python python - <<'PY' ... performance probe ... PY
current_avg_ms=6.890
baseline_old_reload_avg_ms=11.610
avg_ms_saved_per_cache_miss=4.720
percent_faster=40.65

$ git diff --check
(no output)
```

## Coverage and Metrics
- Changed executable statement coverage for `services/mlx-worker-python/worker/model_ops/training_dataset.py`: **100.00%** (`missed_changed_lines=[]`).
- Cache-miss HF dataset resolution probe over 15 iterations with 2,000 rows per iteration:
  - current path: **6.890 ms avg**
  - baseline old reload path: **11.610 ms avg**
  - saved: **4.720 ms per cache miss**
  - improvement: **40.65% faster**

## Known Gaps
- Repository-wide `make py-test` / full-suite gates were not run in this cron slice; verification was intentionally limited to the touched Python scope on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
