### PR TITLE
perf(download): avoid mirror list allocation

### DIFF
--- a/services/mlx-worker-python/tests/test_download_pipeline_unit.py
+++ b/services/mlx-worker-python/tests/test_download_pipeline_unit.py
@@ -15,6 +15,13 @@ def test_selected_mirror_uses_first_configured_mirror() -> None:
     )
 
 
+def test_selected_mirror_uses_default_when_configured_mirrors_are_blank() -> None:
+    assert (
+        DownloadPipeline._selected_mirror({"mirror_urls": " , , "})
+        == "https://huggingface.co"
+    )
+
+
 def test_load_model_config_payload_returns_empty_for_non_object_json(tmp_path: Path) -> None:
     model_dir = tmp_path / "model"
     model_dir.mkdir()

--- a/services/mlx-worker-python/worker/model_ops/download_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/download_pipeline.py
@@ -297,9 +297,10 @@ class DownloadPipeline:
         explicit = ext.get("mirror_url", "").strip()
         if explicit:
             return explicit
-        mirrors = [part.strip() for part in ext.get("mirror_urls", "").split(",") if part.strip()]
-        if mirrors:
-            return mirrors[0]
+        for mirror in ext.get("mirror_urls", "").split(","):
+            mirror = mirror.strip()
+            if mirror:
+                return mirror
         return "https://huggingface.co"
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Avoid building a temporary list when selecting the first configured download mirror.
- Add a focused blank mirror-list fallback test to preserve default mirror behavior.

## Plan or Spec
- N/A: this is a narrow Python download helper performance slice with no behavior change and no governing feature spec update required.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_download_pipeline_unit.py -q
# exit 0; 5 passed in 0.04s

PYTHONPATH=services/mlx-worker-python:. python3 - <<'PY'
# benchmark DownloadPipeline._selected_mirror over 20,000 calls x 7 runs using
# 1,000 blank entries before the first valid mirror and 1,000 trailing mirrors
PY
# baseline mean: 2125.441 ms; new mean: 1375.838 ms; speedup: 1.545x; delta: -749.603 ms (-35.27%)

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests -q
# exit 1 on Linux; 1271 passed, 14 skipped, 15 failed.
# Failures are pre-existing Linux/macOS host limitations: missing sandbox-exec,
# missing /usr/bin/ditto, platform memory detection, and one unwritable-log
# permission expectation under root.

PYTHONPATH=services/mlx-worker-python:. uv run coverage run --branch --source=worker.model_ops.download_pipeline -m pytest services/mlx-worker-python/tests/test_download_pipeline_unit.py -q
PYTHONPATH=services/mlx-worker-python:. uv run coverage report --include='*/worker/model_ops/download_pipeline.py'
# exit 0; 5 passed; file-level report 34% because the focused unit test file
# intentionally covers only the download helper slice in a large module.

git diff --check
# exit 0
```

## Coverage and Metrics
- Focused behavior coverage: selected mirror first-nonblank selection and blank-list fallback are covered by `test_download_pipeline_unit.py`.
- File-level coverage for `download_pipeline.py` from the focused command: 34% (large module; this slice only touches `_selected_mirror`).
- Performance probe: old_mean=2125.441 ms, new_mean=1375.838 ms, speedup=1.545x, delta_ms=-749.603 over 20,000 calls x 7 runs on Linux.
- Validation scope: Linux-verifiable Python helper/unit path only; macOS-only suite failures were not changed by this slice.

## Known Gaps
- Full Python suite is not green on this Linux host because the project includes macOS-only facilities (`sandbox-exec`, `/usr/bin/ditto`) and host-specific platform checks.
- No Swift/macOS tests were run in this Linux environment.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
