### PR TITLE
perf: avoid redundant registry file-type checks

### DIFF
--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -23,6 +23,7 @@ from worker.model_registry.catalog import (
     _infer_embedding_identity,
     _is_hf_cache_pruned_subtree,
     _is_hf_cache_snapshot_dir,
+    _load_json_dict_file,
     _local_model_id,
     _read_text_prefix,
     _text_lora_support_metadata,
@@ -130,6 +131,37 @@ def test_read_text_prefix_returns_empty_string_and_clears_cache_for_non_file_pat
 
     assert _read_text_prefix(target, text_prefix_cache=text_prefix_cache) == ""
     assert text_prefix_cache == {}
+
+
+
+def test_read_text_prefix_uses_stat_result_without_path_is_file_call(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "README.md"
+    target.write_text("library_name: mlx\n", encoding="utf-8")
+    original_is_file = Path.is_file
+
+    def fail_is_file(self: Path) -> bool:
+        if self == target:
+            raise AssertionError("expected file-type detection from stat_result")
+        return original_is_file(self)
+
+    monkeypatch.setattr(Path, "is_file", fail_is_file)
+
+    assert _read_text_prefix(target) == "library_name: mlx\n"
+
+
+
+def test_load_json_dict_file_returns_empty_and_clears_cache_for_non_file_path(tmp_path: Path) -> None:
+    target = tmp_path / "config.json"
+    target.mkdir()
+    json_cache: dict[Path, tuple[int, int, dict[str, object]]] = {
+        target: (1, 2, {"stale": True})
+    }
+
+    assert _load_json_dict_file(target, json_cache=json_cache) == {}
+    assert json_cache == {}
 
 
 

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import stat
 import threading
 import time
 from typing import Iterable, Mapping
@@ -94,6 +95,11 @@ def _load_json_dict_file(
     try:
         stat_result = path.stat()
     except OSError:
+        if json_cache is not None:
+            json_cache.pop(path, None)
+        return {}
+
+    if not stat.S_ISREG(stat_result.st_mode):
         if json_cache is not None:
             json_cache.pop(path, None)
         return {}
@@ -188,7 +194,7 @@ def _read_text_prefix(
             text_prefix_cache.pop(path, None)
         return ""
 
-    if not path.is_file():
+    if not stat.S_ISREG(stat_result.st_mode):
         if text_prefix_cache is not None:
             text_prefix_cache.pop(path, None)
         return ""


### PR DESCRIPTION
## Summary
- Avoid redundant file-type syscalls during Python registry rescans in `worker/model_registry/catalog.py`.
- Reuse `path.stat()` results for `_read_text_prefix()` and short-circuit `_load_json_dict_file()` for non-regular paths.
- Add focused regression tests for the stat-based fast path and non-file JSON cache pruning.

## Plan or Spec
- N/A: small internal Python optimization slice for Linux-verifiable registry scanning; no governing canonical plan/spec currently covers this micro-optimization.

## Commands Run
```text
python3 /tmp/melix_pytest_runner_catalog.py
- 77 passed in 0.23s

python3 -m coverage erase && python3 -m coverage run --include='*/worker/model_registry/catalog.py' /tmp/melix_pytest_runner_catalog.py && python3 -m coverage json -o coverage.json && python3 -m coverage report -m
- 77 passed in 0.36s
- worker/model_registry/catalog.py: 97% file coverage

python3 - <<'PY' ... changed-scope coverage script ... PY
- measurable_changed_lines=[8, 102, 103, 104, 105, 197]
- missed_changed_lines=[]
- changed_line_coverage=100.00%

python3 /tmp/melix_catalog_perf_probe.py
- baseline: 1.6371436759945937s, 30000 Path.is_file() calls
- optimized: 1.541161735993228s, 20000 Path.is_file() calls
- speedup_x: 1.062278953441255
- path_is_file_reduction_percent: 33.333333333333336

git diff --check
- clean
```

## Coverage and Metrics
- Changed executable line coverage for `worker/model_registry/catalog.py`: **100.00%** (`6/6` measurable changed lines covered).
- File coverage for `worker/model_registry/catalog.py`: **97%** (`849` statements, `25` missed).
- Perf probe on synthetic plain-local registry rescans (`500` models x `20` rescans):
  - Wall time: **1.6371s -> 1.5412s** (`~6.23%` faster, `1.062x`).
  - `Path.is_file()` calls: **30000 -> 20000** (`33.33%` fewer).
  - Discovered model counts were unchanged across all runs (`500` each rescan).

## Known Gaps
- Did not run repository-wide `make swift-test` / `make integration-test`; this cron slice was intentionally limited to Linux-verifiable Python worker scope.
- No canonical doc/spec update was needed because this change preserves behavior and only trims redundant filesystem work.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
