### PR TITLE
perf(evaluation): avoid answer prefix match list allocation

### DIFF
--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -1855,6 +1855,7 @@ def test_parse_prediction_prefers_answer_prefix_and_equation_results_for_numeric
         expected="9",
         raw_response=(
             "Thinking Process:\n"
+            "Answer: 8.\n"
             "6 + 3 = 9.\n"
             "Final Answer: 9.\n"
             "Constraint Checklist:\n"

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -2634,8 +2634,9 @@ class EvaluationCore:
         if not normalized_response:
             return "", "empty_prediction"
 
-        answer_matches = list(_ANSWER_PREFIX_PATTERN.finditer(normalized_response))
-        answer_match = answer_matches[-1] if answer_matches else None
+        answer_match = None
+        for match in _ANSWER_PREFIX_PATTERN.finditer(normalized_response):
+            answer_match = match
         if answer_match is not None:
             candidate = answer_match.group(1).strip()
             parsed = EvaluationCore._parse_candidate_for_expected(candidate=candidate, expected=expected)


### PR DESCRIPTION
## Summary
- Avoid materializing every regex answer-prefix match while parsing evaluation predictions.
- Keep the last-prefix-wins behavior by retaining only the latest match object during iteration.
- Extend the focused parser regression to cover multiple answer prefixes.

## Plan or Spec
- N/A: small Linux-validated Python performance slice in evaluation parsing; no behavior or protocol contract changes.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_evaluation_core.py::test_parse_prediction_prefers_answer_prefix_and_equation_results_for_numeric_answers services/mlx-worker-python/tests/test_evaluation_core.py::test_parse_prediction_covers_empty_numeric_option_and_default_paths -q
# exit 0; 2 passed in 0.64s

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python coverage run --source=worker.engine.evaluation_core -m pytest services/mlx-worker-python/tests/test_evaluation_core.py::test_parse_prediction_prefers_answer_prefix_and_equation_results_for_numeric_answers services/mlx-worker-python/tests/test_evaluation_core.py::test_parse_prediction_covers_empty_numeric_option_and_default_paths services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_helpers_cover_numeric_option_and_normalization_paths -q
# exit 0; 3 passed in 0.47s

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python coverage json -o /tmp/melix-eval-coverage.json
PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/melix-eval-coverage.json --diff-from origin/main services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py
# exit 0; TOTAL 100.00% 3/3 changed executable lines

PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_evaluation_core.py -q -k 'not test_run_local_suite_executes_code_candidates_for_mbpp and not test_run_local_suite_executes_candidate_code_for_humaneval_samples'
# exit 0; 54 passed, 2 deselected in 0.70s

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-line coverage: 100.00% (3/3 executable changed lines) via `scripts/python_changed_line_coverage.py`.
- Probe command: inline `uv run --project services/mlx-worker-python python` comparing old list materialization vs new last-match iteration on a 5,001 answer-prefix synthetic response, 200 loops x 7 repeats.
- Probe result: `old_mean=2.422584ms`, `new_mean=2.081213ms`, `delta_ms=-0.341370ms`, `speedup=1.1640x`.

## Known Gaps
- Linux-only validation scope. Full `test_evaluation_core.py` has two existing sandbox-exec-dependent tests that fail on Linux because `sandbox-exec` is unavailable, so the Linux-safe run deselected those two macOS-specific code execution tests.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is justified.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
