### PR TITLE
perf(model-registry): avoid dflash metadata mapping copies

### DIFF
--- a/services/mlx-worker-python/tests/test_dflash_metadata.py
+++ b/services/mlx-worker-python/tests/test_dflash_metadata.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from worker.model_registry.dflash_metadata import (
+    DFLASH_BLOCK_SIZE_KEY,
+    DFLASH_TARGET_LAYER_IDS_KEY,
+    DRAFT_ARCHITECTURE_KEY,
+    DRAFT_RUNTIME_KIND_KEY,
+    dflash_draft_metadata,
+    is_dflash_draft_config,
+)
+
+
+def test_dflash_draft_metadata_uses_mapping_without_copying() -> None:
+    payload = {
+        "architectures": ["DFlashDraftModel"],
+        "block_size": 8,
+        "dflash_config": {"target_layer_ids": [1, "skip", 3]},
+    }
+
+    assert dflash_draft_metadata(payload) == {
+        DRAFT_RUNTIME_KIND_KEY: "dflash",
+        DRAFT_ARCHITECTURE_KEY: "DFlashDraftModel",
+        DFLASH_BLOCK_SIZE_KEY: "8",
+        DFLASH_TARGET_LAYER_IDS_KEY: "1,3",
+    }
+
+
+def test_is_dflash_draft_config_detects_auto_map_and_nested_config() -> None:
+    assert is_dflash_draft_config({"auto_map": {"AutoModel": "pkg.DFlashDraftModel"}}) is True
+    assert is_dflash_draft_config({"dflash_config": {"target_layer_ids": []}}) is True
+
+
+def test_dflash_draft_metadata_ignores_empty_and_non_dflash_configs() -> None:
+    assert is_dflash_draft_config(None) is False
+    assert dflash_draft_metadata(None) == {}
+    assert dflash_draft_metadata({"architectures": ["OtherModel"]}) == {}

--- a/services/mlx-worker-python/worker/model_registry/dflash_metadata.py
+++ b/services/mlx-worker-python/worker/model_registry/dflash_metadata.py
@@ -9,8 +9,7 @@ DFLASH_TARGET_LAYER_IDS_KEY = "melix.dflash.target_layer_ids"
 
 
 def dflash_draft_metadata(config_payload: Mapping[str, object] | None) -> dict[str, str]:
-    payload = dict(config_payload or {})
-    if not is_dflash_draft_config(payload):
+    if config_payload is None or not is_dflash_draft_config(config_payload):
         return {}
 
     metadata = {
@@ -18,11 +17,11 @@ def dflash_draft_metadata(config_payload: Mapping[str, object] | None) -> dict[s
         DRAFT_ARCHITECTURE_KEY: "DFlashDraftModel",
     }
 
-    block_size = payload.get("block_size")
+    block_size = config_payload.get("block_size")
     if isinstance(block_size, int) and block_size > 0:
         metadata[DFLASH_BLOCK_SIZE_KEY] = str(block_size)
 
-    dflash_config = payload.get("dflash_config")
+    dflash_config = config_payload.get("dflash_config")
     if isinstance(dflash_config, Mapping):
         target_layer_ids = dflash_config.get("target_layer_ids")
         if isinstance(target_layer_ids, list):
@@ -34,18 +33,19 @@ def dflash_draft_metadata(config_payload: Mapping[str, object] | None) -> dict[s
 
 
 def is_dflash_draft_config(config_payload: Mapping[str, object] | None) -> bool:
-    payload = dict(config_payload or {})
-    architectures = payload.get("architectures")
+    if config_payload is None:
+        return False
+    architectures = config_payload.get("architectures")
     if isinstance(architectures, list):
         if any(_normalized(item) == "dflashdraftmodel" for item in architectures):
             return True
 
-    auto_map = payload.get("auto_map")
+    auto_map = config_payload.get("auto_map")
     if isinstance(auto_map, Mapping):
         if any("dflashdraftmodel" in _normalized(value) for value in auto_map.values()):
             return True
 
-    return isinstance(payload.get("dflash_config"), Mapping)
+    return isinstance(config_payload.get("dflash_config"), Mapping)
 
 
 def _normalized(value: object) -> str:


### PR DESCRIPTION
## Summary
- Avoids copying DFlash config mappings while detecting draft metadata in the Python worker model registry.
- Adds direct unit coverage for DFlash metadata detection paths.

## Plan or Spec
- N/A: scoped internal Python worker performance slice with no behavior or protocol change.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_code_eval_runner.py -q -k 'extract_candidate_code or count_tests or load_payload_file or read_limited_text or timeout_failure_detail or output_limit_failure_detail or sandbox_python_executable or sandbox_executable_paths or sandbox_allow_path_variants or policy_supported or summarize_stdio'
# 10 passed, 13 deselected; exit 0

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_marks_dflash_draft_metadata_from_local_config -q
# 1 passed; exit 0

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_dflash_metadata.py services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_marks_dflash_draft_metadata_from_local_config services/mlx-worker-python/tests/test_maintenance_service.py::test_download_job_marks_managed_dflash_draft_metadata -q
# 5 passed; exit 0

PYTHONPATH=services/mlx-worker-python:. uv run coverage run --source=worker.model_registry.dflash_metadata -m pytest services/mlx-worker-python/tests/test_dflash_metadata.py services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_marks_dflash_draft_metadata_from_local_config services/mlx-worker-python/tests/test_maintenance_service.py::test_download_job_marks_managed_dflash_draft_metadata -q
PYTHONPATH=services/mlx-worker-python:. uv run coverage report -m services/mlx-worker-python/worker/model_registry/dflash_metadata.py
# 5 passed; dflash_metadata.py 100% coverage; exits 0/0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/model_registry/dflash_metadata.py` 35/35 statements, 100%.
- Linux-only validation scope: Python worker unit tests and micro-probe only; macOS-only runtime paths were not exercised.
- Probe command: inline `uv run python` benchmark over `dflash_draft_metadata` and `is_dflash_draft_config`, 7 samples per case.
- Probe results:
  - `metadata_positive` (50,000 loops): old_mean=270.700ms, new_mean=219.585ms, delta=-51.115ms, speedup=1.23x.
  - `metadata_negative` (50,000 loops): old_mean=121.107ms, new_mean=77.356ms, delta=-43.751ms, speedup=1.57x.
  - `detect_positive` (100,000 loops): old_mean=94.905ms, new_mean=57.772ms, delta=-37.133ms, speedup=1.64x.
  - `detect_negative` (100,000 loops): old_mean=194.141ms, new_mean=147.956ms, delta=-46.185ms, speedup=1.31x.

## Known Gaps
- Full `test_code_eval_runner.py` still has Linux-host failures because `sandbox-exec` is unavailable; only Linux-valid focused tests were run.
- Full repository gates were not run because this cron worker is Linux-only while Melix has macOS/Apple Silicon-specific gates.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
