### PR TITLE
perf(model-registry): reuse plain-local scan metadata

### DIFF
--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -25,6 +25,7 @@ from worker.model_registry.catalog import (
     _is_hf_cache_snapshot_dir,
     _load_json_dict_file,
     _local_model_id,
+    _metadata_payload_has_mlx_signal,
     _read_text_prefix,
     _text_lora_support_metadata,
 )
@@ -289,6 +290,12 @@ def test_has_mlx_signal_stops_after_first_matching_metadata_file(
 
     assert _has_mlx_signal(model_dir=model_dir, repo_id="google/bert-base") is True
     assert calls == ["README.md"]
+
+
+
+def test_metadata_payload_has_mlx_signal_returns_false_for_unserializable_payload() -> None:
+    assert _metadata_payload_has_mlx_signal({"tags": {"mlx"}}) is False
+
 
 
 def test_has_model_weight_files_uses_os_scandir_single_pass_without_path_glob_or_iterdir(
@@ -811,6 +818,85 @@ def test_registry_root_tree_detects_descriptors_during_single_scandir_pass(
 
 
 
+def test_registry_root_tree_records_plain_local_weight_presence_during_single_scandir_pass(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    config_dir = root / "plain-model"
+    _write_model_config(config_dir, {"model_type": "qwen3"})
+    _write_weights(config_dir)
+
+    manifest_paths, plain_scans, hf_cache_repo_dirs = WorkerModelCatalog._scan_registry_root_tree_with_hf_repos(root)
+
+    assert manifest_paths == ()
+    assert hf_cache_repo_dirs == ()
+    assert [(scan.model_dir, scan.has_model_weight_files) for scan in plain_scans] == [
+        (config_dir.resolve(), True)
+    ]
+
+
+
+def test_registry_snapshot_reuses_plain_local_tree_scan_and_config_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    model_dir = root / "plain-model"
+    config_path = model_dir / "config.json"
+    _write_model_config(
+        model_dir,
+        {
+            "model_type": "qwen3",
+            "architectures": ["Qwen3ForCausalLM"],
+            "library_name": "mlx",
+        },
+    )
+    _write_weights(model_dir)
+
+    original_scandir = os.scandir
+    scandir_calls: list[str] = []
+
+    def tracking_scandir(path: str):
+        scandir_calls.append(path)
+        return original_scandir(path)
+
+    original_read_text = Path.read_text
+    config_read_count = 0
+
+    def tracking_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        nonlocal config_read_count
+        if self.resolve() == config_path.resolve():
+            config_read_count += 1
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(os, "scandir", tracking_scandir)
+    monkeypatch.setattr(Path, "read_text", tracking_read_text)
+
+    catalog = WorkerModelCatalog(environment={"MELIX_MODEL_ROOTS": str(root), "HOME": str(tmp_path / "home")})
+    snapshot = catalog.registry_snapshot()
+
+    assert [model.model_id for model in snapshot.models] == ["plain-model"]
+    assert scandir_calls.count(os.fspath(model_dir.resolve())) == 1
+    assert config_read_count == 1
+
+
+
+def test_registry_snapshot_skips_plain_local_config_dirs_without_weights(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    model_dir = root / "plain-model"
+    _write_model_config(
+        model_dir,
+        {
+            "model_type": "qwen3",
+            "architectures": ["Qwen3ForCausalLM"],
+            "library_name": "mlx",
+        },
+    )
+
+    catalog = WorkerModelCatalog(environment={"MELIX_MODEL_ROOTS": str(root), "HOME": str(tmp_path / "home")})
+
+    assert catalog.registry_snapshot().models == ()
+
+
+
 def test_registry_root_tree_prunes_hf_cache_snapshot_and_refs_subtrees(tmp_path: Path) -> None:
     root = tmp_path / "root"
     snapshot_dir = root / "models--mlx-community--Tiny" / "snapshots" / "abc123"
@@ -1108,20 +1194,28 @@ def test_registry_snapshot_rescan_invalidates_cached_text_prefix_for_changed_hf_
     catalog = WorkerModelCatalog(environment={"HOME": str(home)})
     assert all(model.model_id != "google/bert-base" for model in catalog.registry_snapshot().models)
 
-    metadata_paths = {
+    metadata_open_counts = {
         snapshot_dir / "README.md": 0,
-        snapshot_dir / "config.json": 0,
         snapshot_dir / "model_index.json": 0,
     }
+    config_read_count = 0
     original_open = Path.open
+    original_read_text = Path.read_text
 
     def tracking_open(self: Path, *args: object, **kwargs: object):
         mode = args[0] if args else kwargs.get("mode", "r")
-        if self in metadata_paths and isinstance(mode, str) and mode.startswith("r"):
-            metadata_paths[self] += 1
+        if self in metadata_open_counts and isinstance(mode, str) and mode.startswith("r"):
+            metadata_open_counts[self] += 1
         return original_open(self, *args, **kwargs)
 
+    def tracking_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        nonlocal config_read_count
+        if self == snapshot_dir / "config.json":
+            config_read_count += 1
+        return original_read_text(self, *args, **kwargs)
+
     monkeypatch.setattr(Path, "open", tracking_open)
+    monkeypatch.setattr(Path, "read_text", tracking_read_text)
 
     (snapshot_dir / "README.md").write_text("---\nlibrary_name: mlx\n---\n", encoding="utf-8")
 
@@ -1130,9 +1224,9 @@ def test_registry_snapshot_rescan_invalidates_cached_text_prefix_for_changed_hf_
 
     assert discovered["google/bert-base"].model_path == str(snapshot_dir.resolve())
     assert discovered["google/bert-base"].ext["melix.source_kind"] == "hf_cache_snapshot"
-    assert metadata_paths[snapshot_dir / "README.md"] == 1
-    assert metadata_paths[snapshot_dir / "config.json"] == 1
-    assert metadata_paths[snapshot_dir / "model_index.json"] == 0
+    assert metadata_open_counts[snapshot_dir / "README.md"] == 1
+    assert config_read_count == 0
+    assert metadata_open_counts[snapshot_dir / "model_index.json"] == 0
 
 
 

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -72,6 +72,12 @@ class RegistrySnapshot:
     scanned_at_unix_ms: int
 
 
+@dataclass(frozen=True)
+class _PlainLocalModelScan:
+    model_dir: Path
+    has_model_weight_files: bool
+
+
 def _normalized(value: str | None) -> str:
     return (value or "").strip()
 
@@ -234,11 +240,20 @@ def _metadata_text_has_mlx_signal(metadata_text: str) -> bool:
     )
 
 
+def _metadata_payload_has_mlx_signal(metadata_payload: Mapping[str, object]) -> bool:
+    try:
+        metadata_text = json.dumps(metadata_payload, sort_keys=True).lower()
+    except (TypeError, ValueError):
+        return False
+    return _metadata_text_has_mlx_signal(metadata_text)
+
+
 def _has_mlx_signal(
     *,
     model_dir: Path,
     repo_id: str = "",
     text_prefix_cache: dict[Path, tuple[int, int, int, int, str]] | None = None,
+    config_payload: Mapping[str, object] | None = None,
 ) -> bool:
     lowered_repo_id = repo_id.lower()
     lowered_path = model_dir.name.lower()
@@ -246,6 +261,10 @@ def _has_mlx_signal(
         return True
 
     for metadata_filename in ("README.md", "config.json", "model_index.json"):
+        if metadata_filename == "config.json" and config_payload is not None:
+            if config_payload and _metadata_payload_has_mlx_signal(config_payload):
+                return True
+            continue
         metadata_text = _read_text_prefix(
             model_dir / metadata_filename,
             text_prefix_cache=text_prefix_cache,
@@ -1124,13 +1143,14 @@ class WorkerModelCatalog:
         root: Path,
         root_id: str,
         root_order: int,
-        plain_local_model_dirs: Iterable[Path],
+        plain_local_model_dirs: Iterable[_PlainLocalModelScan],
         discovered_models: dict[str, common_pb2.ModelSpec],
         accepted_model_ids: list[str],
         hf_cache_repo_dirs: Iterable[Path] | None = None,
     ) -> None:
         root_resolved = root.resolve()
         seen_paths: set[Path] = set()
+        json_cache = self._json_file_cache
         for model in self._scan_huggingface_cache_models(root=root, cache_repo_dirs=hf_cache_repo_dirs):
             resolved_path = Path(model.model_path)
             seen_paths.add(resolved_path)
@@ -1146,8 +1166,8 @@ class WorkerModelCatalog:
             discovered_models[model.model_id] = model
             accepted_model_ids.append(model.model_id)
 
-        for model_dir in plain_local_model_dirs:
-            resolved_path = model_dir
+        for plain_local_model in plain_local_model_dirs:
+            resolved_path = plain_local_model.model_dir
             if resolved_path in seen_paths or _is_hf_cache_snapshot_dir(root_resolved, resolved_path):
                 continue
             if (resolved_path / "manifest.json").is_file():
@@ -1155,10 +1175,14 @@ class WorkerModelCatalog:
             model_id = _local_model_id(root_resolved, resolved_path)
             if model_id in discovered_models or model_id in self._seed_models:
                 continue
-            if not _has_model_weight_files(resolved_path) or not _has_mlx_signal(
+            if not plain_local_model.has_model_weight_files:
+                continue
+            config_payload = _load_model_config_payload(resolved_path, json_cache=json_cache)
+            if not _has_mlx_signal(
                 model_dir=resolved_path,
                 repo_id=model_id,
                 text_prefix_cache=self._text_prefix_cache,
+                config_payload=config_payload,
             ):
                 continue
             model = self._raw_model_spec(
@@ -1184,6 +1208,10 @@ class WorkerModelCatalog:
         root: Path,
         cache_repo_dirs: Iterable[Path] | None = None,
     ) -> Iterable[common_pb2.ModelSpec]:
+        json_cache = getattr(self, "_json_file_cache", None)
+        if json_cache is None:
+            json_cache = {}
+            self._json_file_cache = json_cache
         resolved_cache_repo_dirs = (
             tuple(cache_repo_dirs)
             if cache_repo_dirs is not None
@@ -1204,10 +1232,12 @@ class WorkerModelCatalog:
             for snapshot_dir in snapshot_dirs:
                 if not (snapshot_dir / "config.json").is_file() or not _has_model_weight_files(snapshot_dir):
                     continue
+                config_payload = _load_model_config_payload(snapshot_dir, json_cache=json_cache)
                 if not _has_mlx_signal(
                     model_dir=snapshot_dir,
                     repo_id=repo_id,
                     text_prefix_cache=self._text_prefix_cache,
+                    config_payload=config_payload,
                 ):
                     continue
                 revision = _hf_cache_revision(cache_repo_dir, snapshot_dir.name, revision_map=revision_map)
@@ -1225,12 +1255,12 @@ class WorkerModelCatalog:
     @staticmethod
     def _scan_registry_root_tree(root: Path) -> tuple[tuple[Path, ...], tuple[Path, ...]]:
         manifest_paths, plain_local_model_dirs, _ = WorkerModelCatalog._scan_registry_root_tree_with_hf_repos(root)
-        return manifest_paths, plain_local_model_dirs
+        return manifest_paths, tuple(scan.model_dir for scan in plain_local_model_dirs)
 
     @staticmethod
-    def _scan_registry_root_tree_with_hf_repos(root: Path) -> tuple[tuple[Path, ...], tuple[Path, ...], tuple[Path, ...]]:
+    def _scan_registry_root_tree_with_hf_repos(root: Path) -> tuple[tuple[Path, ...], tuple[_PlainLocalModelScan, ...], tuple[Path, ...]]:
         manifest_paths: list[Path] = []
-        plain_local_model_dirs: list[Path] = []
+        plain_local_model_dirs: list[_PlainLocalModelScan] = []
         hf_cache_repo_dirs: list[Path] = []
         resolved_root = root.resolve()
         stack = [resolved_root]
@@ -1245,6 +1275,7 @@ class WorkerModelCatalog:
                     child_names: list[str] = []
                     has_manifest = False
                     has_config = False
+                    has_model_weight_files = False
                     for entry in entries:
                         try:
                             if entry.name == "manifest.json" and entry.is_file():
@@ -1252,6 +1283,12 @@ class WorkerModelCatalog:
                                 continue
                             if entry.name == "config.json" and entry.is_file():
                                 has_config = True
+                                continue
+                            if entry.name == "model.safetensors.index.json" and entry.is_file():
+                                has_model_weight_files = True
+                                continue
+                            if entry.name.endswith((".safetensors", ".npz")) and entry.is_file():
+                                has_model_weight_files = True
                                 continue
                             if entry.is_dir():
                                 child_path = current / entry.name
@@ -1268,7 +1305,12 @@ class WorkerModelCatalog:
                 manifest_paths.append(current / "manifest.json")
                 continue
             if has_config:
-                plain_local_model_dirs.append(current)
+                plain_local_model_dirs.append(
+                    _PlainLocalModelScan(
+                        model_dir=current,
+                        has_model_weight_files=has_model_weight_files,
+                    )
+                )
                 continue
             stack.extend(current / name for name in sorted(child_names, reverse=True))
         return tuple(manifest_paths), tuple(plain_local_model_dirs), tuple(sorted(hf_cache_repo_dirs))


### PR DESCRIPTION
## Summary
- Reuse plain-local scan metadata during model registry discovery so config-only directories without weights short-circuit before a second directory walk.
- Reuse parsed `config.json` payloads for MLX-signal detection so accepted local/HF models avoid an extra config-file read on discovery.
- Add focused tests covering cached config-signal detection, weight-presence capture, and config-only directories without weights.

## Plan or Spec
- N/A: this is a small Python-only performance optimization slice in `services/mlx-worker-python` and does not change a documented external contract or canonical spec.

## Commands Run
```text
pytest -q tests/test_model_registry_catalog.py
81 passed in 0.38s

python coverage runner for tests/test_model_registry_catalog.py
81 passed in 0.39s
changed_line_coverage=100.00%
measurable_changed_lines=[75,76,77,78,243,244,245,246,247,248,264,265,266,267,1153,1169,1170,1178,1179,1180,1181,1211,1212,1213,1214,1235,1258,1261,1263,1278,1287,1288,1289,1290,1291,1292,1308]
missed_changed_lines=[]

performance probe against origin/main baseline on 250 synthetic plain-local model dirs
baseline: elapsed_ms=86.71, model_scandir_calls=500, config_reads=250
current:  elapsed_ms=58.43, model_scandir_calls=250, config_reads=250

config-open probe against origin/main baseline on 250 synthetic plain-local model dirs
baseline: elapsed_ms=97.16, config_open_reads=500
current:  elapsed_ms=69.34, config_open_reads=250

git diff --check
clean
```

## Coverage and Metrics
- Changed-scope executable coverage for `services/mlx-worker-python/worker/model_registry/catalog.py`: **100.00%**.
- Performance probe on 250 synthetic plain-local model directories vs `origin/main`:
  - Directory scans on model dirs: **500 -> 250** (-50%).
  - `config.json` open reads: **500 -> 250** (-50%).
  - End-to-end registry snapshot wall time: **86.71 ms -> 58.43 ms** (~32.6% faster) in the scandir probe.
  - End-to-end registry snapshot wall time: **97.16 ms -> 69.34 ms** (~28.6% faster) in the config-open probe.

## Known Gaps
- None for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
