### PR TITLE
perf(event-extraction): fast-path fenced JSON parsing

### DIFF
--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2711,12 +2711,16 @@ def _coerce_string_list(value: object) -> list[str]:
 def _parse_response_json(response_text: str) -> dict[str, object]:
     stripped = response_text.strip()
     if stripped.startswith("```"):
-        lines = stripped.splitlines()
-        if lines and lines[0].startswith("```"):
-            lines = lines[1:]
-        if lines and lines[-1].strip() == "```":
-            lines = lines[:-1]
-        stripped = "\n".join(lines).strip()
+        newline_index = stripped.find("\n")
+        if newline_index >= 0 and stripped.endswith("```"):
+            stripped = stripped[newline_index + 1 : -3].strip()
+        else:
+            lines = stripped.splitlines()
+            if lines and lines[0].startswith("```"):
+                lines = lines[1:]
+            if lines and lines[-1].strip() == "```":
+                lines = lines[:-1]
+            stripped = "\n".join(lines).strip()
     parsed = json.loads(stripped)
     if not isinstance(parsed, dict):
         raise ValueError("LLM response must be a JSON object")


### PR DESCRIPTION
## Summary
- Fast-path common fenced JSON model responses in event extraction by slicing out the fence body directly.
- Keep the existing splitlines fallback for unusual fenced payloads so validation behavior remains unchanged.

## Plan or Spec
- N/A: small Linux-validated Python performance slice for existing event response parsing; no user-facing behavior or protocol semantics changed.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_event_extraction.py::test_response_parsing_and_normalization_validation_errors -q
# exit 0; 1 passed in 0.09s

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_event_extraction.py -q
# exit 0; 53 passed in 0.18s

PYTHONPATH=services/mlx-worker-python:. uv run coverage run --source=worker.productization.event_extraction -m pytest services/mlx-worker-python/tests/test_event_extraction.py -q
PYTHONPATH=services/mlx-worker-python:. uv run coverage report -m services/mlx-worker-python/worker/productization/event_extraction.py
# exit 0; 53 passed in 0.29s; event_extraction.py coverage 97%

PYTHONPATH=services/mlx-worker-python:. uv run python - <<'PY'
# inline old-vs-new fenced JSON parser probe; 50,000 parses/sample, 7 samples
PY
# exit 0; old_mean=1426.601ms; new_mean=1341.899ms; delta=-84.702ms; speedup=1.0631x

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/productization/event_extraction.py` 97% via coverage command above.
- Probe: fenced JSON parsing path over 50,000 parses/sample, 7 samples. `old_mean=1426.601ms`, `new_mean=1341.899ms`, `delta=-84.702ms`, `speedup=1.0631x`.
- Validation scope: Linux-only Python unit tests/probe. The broader Melix product is Apple Silicon/macOS-oriented and was not exercised here.

## Known Gaps
- Full repository gates (`make swift-test`, `make integration-test`) were not run because this recurring slice is limited to Linux-verifiable Python code.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
