### PR TITLE
perf(event-extraction): reuse normalized action alignment values

### DIFF
--- a/services/mlx-worker-python/tests/test_event_extraction.py
+++ b/services/mlx-worker-python/tests/test_event_extraction.py
@@ -1653,6 +1653,27 @@ def test_event_alignment_uses_global_optimum_not_greedy() -> None:
     assert matches == [(0, 1, 0.80), (1, 0, 0.80)]
 
 
+def test_event_alignment_reuses_normalized_action_values(monkeypatch) -> None:
+    calls = 0
+    original = event_extraction_module._normalize_event_field
+
+    def counted_normalize(value: object) -> list[str]:
+        nonlocal calls
+        calls += 1
+        return original(value)
+
+    monkeypatch.setattr(event_extraction_module, "_normalize_event_field", counted_normalize)
+
+    alignment = event_extraction_module._event_alignment(
+        {"actor": ["A"], "time": ["Monday"], "location": ["Office"], "action": ["meet"]},
+        {"actor": ["A"], "time": ["Monday"], "location": ["Office"], "action": ["call"]},
+    )
+
+    assert calls == len(event_extraction_module.FIELD_NAMES) * 2
+    assert alignment["fields"]["action"] < event_extraction_module.EVENT_ALIGNMENT_ACTION_THRESHOLD
+    assert alignment["accepted"] is False
+
+
 def test_write_event_prediction_rows_preserves_input_order_and_records_failures(tmp_path: Path) -> None:
     output = tmp_path / "predictions.jsonl"
     failures = tmp_path / "failures.jsonl"

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2038,9 +2038,14 @@ def _event_alignment(gold_event: dict[str, object], pred_event: dict[str, object
     field_scores: dict[str, float] = {}
     active_weight = 0.0
     weighted_score = 0.0
+    gold_actions: list[str] = []
+    pred_actions: list[str] = []
     for field_name in FIELD_NAMES:
         gold_values = _normalize_event_field(gold_event.get(field_name))
         pred_values = _normalize_event_field(pred_event.get(field_name))
+        if field_name == "action":
+            gold_actions = gold_values
+            pred_actions = pred_values
         field_score = _soft_field_f1(gold_values, pred_values)
         field_scores[field_name] = _round_metric(field_score)
         if gold_values or pred_values:
@@ -2048,8 +2053,6 @@ def _event_alignment(gold_event: dict[str, object], pred_event: dict[str, object
             active_weight += weight
             weighted_score += weight * field_score
     score = weighted_score / active_weight if active_weight else 0.0
-    gold_actions = _normalize_event_field(gold_event.get("action"))
-    pred_actions = _normalize_event_field(pred_event.get("action"))
     action_score = field_scores["action"]
     accepted = score >= EVENT_ALIGNMENT_SCORE_THRESHOLD
     if gold_actions and pred_actions and action_score < EVENT_ALIGNMENT_ACTION_THRESHOLD:


### PR DESCRIPTION
## Summary
- Reuses the already-normalized action field values inside event alignment instead of normalizing the action field a second time.
- Adds a focused regression/performance guard that counts normalization calls for `_event_alignment`.

## Plan or Spec
- N/A: Small Linux-validated Python performance slice for the event extraction evaluator hot path; no behavior or public contract change.

## Commands Run
```text
# Baseline focused tests before editing
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_event_extraction.py -q
exit 0: 53 passed in 0.43s

# Baseline probe before editing, 8,100 _event_alignment calls per sample
PYTHONPATH=services/mlx-worker-python:. uv run python - <<'PY'
# inline benchmark over synthetic event pairs
PY
exit 0: baseline_mean_ms=614.989 baseline_min_ms=599.823 calls_per_iter=8100

# Focused tests after editing
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_event_extraction.py -q
exit 0: 54 passed in 0.36s

# Same-process old-vs-new probe after editing, 8,100 _event_alignment calls per sample
PYTHONPATH=services/mlx-worker-python:. uv run python - <<'PY'
# inline benchmark comparing reconstructed old implementation to new implementation
PY
exit 0: old_mean_ms=629.370 old_min_ms=611.417; new_mean_ms=619.024 new_min_ms=600.926; delta_ms=-10.345; speedup=1.0167x; calls_per_iter=8100

# Changed-scope coverage
PYTHONPATH=services/mlx-worker-python:. uv run coverage run --source=worker.productization.event_extraction -m pytest services/mlx-worker-python/tests/test_event_extraction.py -q
PYTHONPATH=services/mlx-worker-python:. uv run coverage report --include='*/worker/productization/event_extraction.py'
exit 0: 54 passed in 0.29s; event_extraction.py coverage 97%

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/productization/event_extraction.py` 97% under the focused event extraction test file.
- Probe: same-process old-vs-new synthetic alignment benchmark, 7 samples, 8,100 `_event_alignment` calls per sample.
  - old_mean_ms=629.370
  - new_mean_ms=619.024
  - delta_ms=-10.345
  - speedup=1.0167x
- Scope: Linux-only Python validation; macOS/Apple Silicon runtime paths were not exercised.

## Known Gaps
- Full repository gates (`make swift-test`, `make integration-test`) were not run because this cron slice is limited to Python code that can be locally validated on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or no behavior change is declared.
- [x] Protocol changes include regenerated generated artifacts, or no protocol changes were made.
- [x] Dependency changes include updated lockfiles, or no dependency changes were made.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
