### PR TITLE
perf(python): avoid fixed-key probe scans in report builder

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -21,6 +21,17 @@ from worker.productization.benchmark_evaluation_report import (
 )
 
 
+class _SparseProbeRow(dict[str, object]):
+    def __init__(self, *args: object, forbidden_keys: set[str], **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self._forbidden_keys = forbidden_keys
+
+    def get(self, key: str, default: object = None) -> object:
+        if key in self._forbidden_keys:
+            raise AssertionError(f"unexpected fixed-key scan for {key}")
+        return super().get(key, default)
+
+
 def _bundle(*, ttft_ms: float, tokens_per_second: float, accuracy: float) -> dict[str, object]:
     return {
         "export_schema_version": "melix.benchmark_export.v1",
@@ -413,6 +424,67 @@ def test_report_builder_aggregates_evaluation_sample_probes() -> None:
     assert rows_by_metric["eval.sample.mmlu.failure_stage.scoring.failure_count"]["status"] == (
         "warning"
     )
+
+
+def test_report_builder_uses_sparse_benchmark_probe_rows_without_fixed_key_scans() -> None:
+    sparse_row = _SparseProbeRow(
+        {
+            "suite": "smoke",
+            "context_length": 128,
+            "generation_length": 32,
+            "batch_size": 1,
+            "prefill_ms": 7.0,
+            "ignored": 999,
+            "prefill_ms_extra": 123,
+        },
+        forbidden_keys={"prefill_ms", "decode_ms", "tokens_in", "dflash_enabled"},
+    )
+
+    report = build_benchmark_evaluation_report(
+        baseline={"benchmark_context_rows": [sparse_row]},
+        candidate={"benchmark_context_rows": [dict(sparse_row)]},
+    )
+
+    rows_by_metric = {row["metric"]: row for row in report["rows"]}
+
+    assert set(rows_by_metric) == {"bench.context.smoke.ctx128.gen32.b1.prefill_ms_mean"}
+    assert rows_by_metric["bench.context.smoke.ctx128.gen32.b1.prefill_ms_mean"]["baseline"] == (
+        pytest.approx(7.0)
+    )
+    assert rows_by_metric["bench.context.smoke.ctx128.gen32.b1.prefill_ms_mean"]["status"] == "ok"
+
+
+def test_report_builder_uses_sparse_evaluation_sample_rows_without_fixed_key_scans() -> None:
+    sparse_row = _SparseProbeRow(
+        {
+            "suite_id": "mmlu",
+            "sample_render_ms": 5.0,
+            "failure_stage": "validation",
+            "ignored": 42,
+            "sample_render_ms_extra": 77,
+        },
+        forbidden_keys={
+            "sample_render_ms",
+            "inference_ms",
+            "raw_response_chars",
+            "extracted_result_chars",
+        },
+    )
+
+    report = build_benchmark_evaluation_report(
+        baseline={"evaluation_samples": [sparse_row]},
+        candidate={"evaluation_samples": [dict(sparse_row)]},
+    )
+
+    rows_by_metric = {row["metric"]: row for row in report["rows"]}
+
+    assert set(rows_by_metric) == {
+        "eval.sample.mmlu.failure_stage.validation.failure_count",
+        "eval.sample.mmlu.sample_render_ms_mean",
+    }
+    assert rows_by_metric["eval.sample.mmlu.sample_render_ms_mean"]["candidate"] == pytest.approx(5.0)
+    assert rows_by_metric["eval.sample.mmlu.sample_render_ms_mean"]["status"] == "ok"
+    assert rows_by_metric["eval.sample.mmlu.failure_stage.validation.failure_count"]["status"] == "ok"
 
 
 def test_report_renderers_are_stable_and_sticky_comment_is_marked() -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -41,6 +41,7 @@ _REQUEST_PROBE_KEYS = (
     "dflash_rollback_count",
     "dflash_target_hidden_layers",
 )
+_REQUEST_PROBE_KEY_SET = frozenset(_REQUEST_PROBE_KEYS)
 _COUNT_PROBE_KEYS = {
     "speculative_accepted_tokens",
     "speculative_rejected_tokens",
@@ -61,6 +62,7 @@ _EVALUATION_SAMPLE_PROBE_KEYS = (
     "raw_response_chars",
     "extracted_result_chars",
 )
+_EVALUATION_SAMPLE_PROBE_KEY_SET = frozenset(_EVALUATION_SAMPLE_PROBE_KEYS)
 
 _NumericAggregate = tuple[float, int]
 
@@ -399,8 +401,10 @@ def _collect_benchmark_probe_metrics(
     aggregates_by_label_and_key: dict[tuple[str, str], _NumericAggregate] = {}
     for row in _dict_rows(rows):
         label = _benchmark_probe_label(row)
-        for key in _REQUEST_PROBE_KEYS:
-            value = _float_or_none(row.get(key))
+        for key, raw_value in row.items():
+            if key not in _REQUEST_PROBE_KEY_SET:
+                continue
+            value = _float_or_none(raw_value)
             if value is not None:
                 aggregate_key = (label, key)
                 aggregates_by_label_and_key[aggregate_key] = _update_numeric_aggregate(
@@ -420,8 +424,10 @@ def _collect_evaluation_sample_probe_metrics(
     failure_stage_counts: dict[tuple[str, str], int] = {}
     for row in _dict_rows(rows):
         suite_id = str(row.get("suite_id", "")).strip() or "suite"
-        for key in _EVALUATION_SAMPLE_PROBE_KEYS:
-            value = _float_or_none(row.get(key))
+        for key, raw_value in row.items():
+            if key not in _EVALUATION_SAMPLE_PROBE_KEY_SET:
+                continue
+            value = _float_or_none(raw_value)
             if value is not None:
                 aggregate_key = (suite_id, key)
                 aggregates_by_suite_and_key[aggregate_key] = _update_numeric_aggregate(


### PR DESCRIPTION
## Summary
- optimize `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py` to aggregate sparse probe rows by iterating actual `row.items()` instead of scanning every allowed probe key with repeated `row.get(...)`
- preserve existing metric names and aggregation semantics for benchmark probe rows and evaluation sample probe rows
- add focused sparse-row regression tests that fail if the implementation falls back to fixed-key scans

## Plan or Spec
- N/A: this is a small internal Python performance optimization slice with no user-visible behavior change and no governing canonical spec/plan file for this helper-level implementation detail

## Commands Run
```text
cd /tmp/cron-python-opt-20260501-034150/services/mlx-worker-python
python -m pytest tests/test_benchmark_evaluation_report.py -q
# 22 passed in 0.04s

coverage erase
coverage run -m pytest tests/test_benchmark_evaluation_report.py -q
coverage json -o coverage.json
python <changed-line coverage script>
# changed_line_coverage=100.00%
coverage report -m worker/productization/benchmark_evaluation_report.py
# 99% file coverage for the touched executable file

python <performance probe comparing old fixed-key loops vs new row.items() filtering>
# benchmark_probe_old_s=1.289673
# benchmark_probe_new_s=0.518257
# benchmark_probe_speedup=2.49x
# eval_probe_old_s=0.420236
# eval_probe_new_s=0.240293
# eval_probe_speedup=1.75x

cd /tmp/cron-python-opt-20260501-034150
git diff --check
```

## Coverage and Metrics
- changed executable-line coverage for `worker/productization/benchmark_evaluation_report.py`: `100.00%` (`10/10` measurable changed lines covered; no missed changed lines)
- focused file coverage for `worker/productization/benchmark_evaluation_report.py`: `99%`
- synthetic sparse benchmark probe aggregation microbenchmark: `1.289673s -> 0.518257s` over the same workload (`2.49x` faster)
- synthetic sparse evaluation sample aggregation microbenchmark: `0.420236s -> 0.240293s` over the same workload (`1.75x` faster)
- semantic parity check in the performance probe asserted old-vs-new metric outputs were identical before timing

## Known Gaps
- None

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
