### PR TITLE
perf(scripts): scan mlx metallib candidates with scandir

### DIFF
--- a/scripts/dev_up.py
+++ b/scripts/dev_up.py
@@ -251,6 +251,24 @@ def read_mlx_metal_dist_info_version(metallib_path: Path) -> str | None:
     return None
 
 
+def iter_mlx_metallib_candidates(root: Path):
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            stack.append(Path(entry.path))
+                        elif entry.name == "mlx.metallib" and entry.is_file(follow_symlinks=False):
+                            yield Path(entry.path)
+                    except OSError:
+                        continue
+        except OSError:
+            continue
+
+
 def resolve_local_mlx_metallib(repo_root: Path, *, uv_cache_dir: Path | None = None) -> Path | None:
     expected_mlx_metal_version = resolve_swift_mlx_package_version(repo_root)
     candidate_search_roots: list[Path] = []
@@ -271,17 +289,16 @@ def resolve_local_mlx_metallib(repo_root: Path, *, uv_cache_dir: Path | None = N
         if resolved_root in seen or not resolved_root.exists():
             continue
         seen.add(resolved_root)
-        for candidate in resolved_root.rglob("mlx.metallib"):
-            if candidate.is_file():
-                resolved_candidate = candidate.resolve()
-                if expected_mlx_metal_version is None:
-                    return resolved_candidate
+        for candidate in iter_mlx_metallib_candidates(resolved_root):
+            resolved_candidate = candidate.resolve()
+            if expected_mlx_metal_version is None:
+                return resolved_candidate
 
-                candidate_version = read_mlx_metal_dist_info_version(resolved_candidate)
-                if candidate_version == expected_mlx_metal_version:
-                    return resolved_candidate
+            candidate_version = read_mlx_metal_dist_info_version(resolved_candidate)
+            if candidate_version == expected_mlx_metal_version:
+                return resolved_candidate
 
-                rejected_versions.setdefault(candidate_version or "unknown", []).append(resolved_candidate)
+            rejected_versions.setdefault(candidate_version or "unknown", []).append(resolved_candidate)
 
     if expected_mlx_metal_version is not None and rejected_versions:
         observed = ", ".join(

--- a/services/mlx-worker-python/tests/test_dev_up_script.py
+++ b/services/mlx-worker-python/tests/test_dev_up_script.py
@@ -312,6 +312,63 @@ def test_prepare_swift_worker_launch_cwd_symlinks_runtime_local_default_metallib
     assert default_metallib.resolve() == metallib_path.resolve()
 
 
+def test_resolve_local_mlx_metallib_uses_scandir_stack_without_path_rglob(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dev_up = load_dev_up_module()
+    layout = make_layout(dev_up, tmp_path)
+    metallib_path = tmp_path / ".venv/lib/python3.13/site-packages/mlx/lib/mlx.metallib"
+    metallib_path.parent.mkdir(parents=True, exist_ok=True)
+    metallib_path.write_text("mlx", encoding="utf-8")
+
+    def fail_rglob(self: Path, pattern: str):
+        raise AssertionError("resolve_local_mlx_metallib() should not allocate a Path.rglob() tree")
+
+    monkeypatch.setattr(dev_up.Path, "rglob", fail_rglob)
+
+    assert dev_up.resolve_local_mlx_metallib(tmp_path, uv_cache_dir=layout.uv_cache_dir) == metallib_path.resolve()
+
+
+def test_iter_mlx_metallib_candidates_skips_scandir_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dev_up = load_dev_up_module()
+
+    def fail_scandir(path: Path):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(dev_up.os, "scandir", fail_scandir)
+
+    assert list(dev_up.iter_mlx_metallib_candidates(tmp_path)) == []
+
+
+def test_iter_mlx_metallib_candidates_skips_entry_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dev_up = load_dev_up_module()
+
+    class BrokenEntry:
+        name = "mlx.metallib"
+        path = os.fspath(tmp_path / "mlx.metallib")
+
+        def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+            raise OSError("stale dirent")
+
+    class FakeScandir:
+        def __enter__(self):
+            return iter((BrokenEntry(),))
+
+        def __exit__(self, exc_type, exc, traceback) -> None:
+            return None
+
+    monkeypatch.setattr(dev_up.os, "scandir", lambda path: FakeScandir())
+
+    assert list(dev_up.iter_mlx_metallib_candidates(tmp_path)) == []
+
+
 def test_prepare_swift_worker_launch_cwd_uses_configured_uv_cache_dir_for_metallib(tmp_path: Path) -> None:
     dev_up = load_dev_up_module()
     layout = replace(make_layout(dev_up, tmp_path), uv_cache_dir=tmp_path / "custom-uv-cache")


### PR DESCRIPTION
## Summary
- Replace `Path.rglob("mlx.metallib")` in the dev stack metallib autodiscovery path with an explicit `os.scandir` stack.
- Keep symlink avoidance and OSError skipping behavior local to the scanner.
- Add focused regression coverage proving the resolver no longer depends on `Path.rglob` and keeps error-tolerant traversal behavior.

## Plan or Spec
- AGENTS.md: small, verifiable Python performance slice with defined probe metrics.
- Linux-only validation scope: this optimizes a Python dev-stack helper and was validated locally on Linux; macOS Swift runtime startup was not exercised in this environment.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_dev_up_script.py -q -k 'metallib or swift_mlx'
# exit 0; 9 passed, 23 deselected (baseline before edit)

PYTHONPATH=services/mlx-worker-python:. uv run coverage run --source=scripts -m pytest services/mlx-worker-python/tests/test_dev_up_script.py -q -k 'metallib or swift_mlx'
PYTHONPATH=services/mlx-worker-python:. uv run coverage json -o /tmp/melix-dev-up-coverage.json
PYTHONPATH=services/mlx-worker-python:. uv run python scripts/python_changed_line_coverage.py --coverage-json /tmp/melix-dev-up-coverage.json --diff-from origin/main scripts/dev_up.py services/mlx-worker-python/tests/test_dev_up_script.py
# exit 0; 11 passed, 23 deselected; changed-line coverage TOTAL 100.00% (24/24)

PYTHONPATH=services/mlx-worker-python:. uv run python - <<'PY'
# inline synthetic uv-cache metallib discovery benchmark; compares old Path.rglob scanner vs new os.scandir stack over 160 package trees, 4 candidates, 9 iterations
PY
# exit 0; old_mean_ms=41.742, new_mean_ms=33.981, delta_ms=-7.761, speedup=1.228x

git diff --check
# exit 0

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_dev_up_script.py -q
# exit 1; 33 passed, 1 failed. Existing Linux/root-sensitive failure: test_spawn_background_process_recreates_stale_unwritable_log_file preserves stale content because root can append to the chmod-readonly log file.
```

## Coverage and Metrics
- Changed-line coverage: 100.00% (24/24) for `scripts/dev_up.py` changed lines.
- Performance probe: synthetic uv-cache metallib discovery benchmark found 4 candidates across 160 package trees, 9 iterations.
  - old_mean_ms=41.742
  - new_mean_ms=33.981
  - delta_ms=-7.761
  - speedup=1.228x
- Behavior parity: focused metallib tests pass and assert no `Path.rglob` allocation path remains for local metallib resolution.

## Known Gaps
- Full `test_dev_up_script.py` remains red on this Linux root runner due a pre-existing chmod/read-only log-file expectation unrelated to this slice; focused metallib coverage passes.
- macOS Swift worker startup was not executed because this scheduled agent runs on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or not required because this is an internal performance implementation slice.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
