### PR TITLE
perf: cache lora experiment payload reads

### DIFF
--- a/services/mlx-worker-python/tests/test_lora_experiment_store.py
+++ b/services/mlx-worker-python/tests/test_lora_experiment_store.py
@@ -206,6 +206,77 @@ def test_rebuild_index_skips_manifest_parse_when_run_record_exists(tmp_path: Pat
 
 
 
+def test_rebuild_index_reuses_cached_run_and_manifest_payloads(tmp_path: Path, monkeypatch) -> None:
+    jobs_root = tmp_path / "model-ops"
+    store = LoraExperimentStore()
+    _write_run_record(
+        jobs_root,
+        run_id="model-ops-0001",
+        group_id="nightly-qwen",
+        manifest_path="/tmp/model-ops-0001/from-run-record.json",
+        updated_at_unix_ms=1_000,
+    )
+    manifest_path = _write_manifest(
+        jobs_root,
+        run_id="model-ops-0002",
+        adapter_name="manifest-only-adapter",
+        updated_at_unix_ms=2_000,
+    )
+
+    first_payload = store.rebuild_index(jobs_root)
+    run_path = jobs_root / "train_lora" / "model-ops-0001" / LoraExperimentStore.run_record_name
+    original_read_payload = LoraExperimentStore._read_payload
+
+    def _read_payload(path: Path) -> dict[str, object]:
+        if path in {run_path, manifest_path}:
+            raise AssertionError("rebuild_index should reuse cached unchanged payloads")
+        return original_read_payload(path)
+
+    monkeypatch.setattr(LoraExperimentStore, "_read_payload", staticmethod(_read_payload))
+
+    second_payload = store.rebuild_index(jobs_root)
+
+    assert second_payload == first_payload
+
+
+
+def test_rebuild_index_invalidates_cached_payload_when_run_record_changes(tmp_path: Path) -> None:
+    jobs_root = tmp_path / "model-ops"
+    store = LoraExperimentStore()
+    _write_run_record(
+        jobs_root,
+        run_id="model-ops-0001",
+        group_id="nightly-qwen",
+        manifest_path="/tmp/model-ops-0001/train_lora.adapter.json",
+        updated_at_unix_ms=1_000,
+        checkpoint_count=1,
+    )
+
+    original_payload = store.rebuild_index(jobs_root)
+    run_path = jobs_root / "train_lora" / "model-ops-0001" / LoraExperimentStore.run_record_name
+    original_stat = run_path.stat()
+    run_record = json.loads(run_path.read_text(encoding="utf-8"))
+    run_record["checkpoint_count"] = 7
+    run_path.write_text(json.dumps(run_record, indent=2) + "\n", encoding="utf-8")
+    os.utime(run_path, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns + 1_000_000))
+
+    refreshed_payload = store.rebuild_index(jobs_root)
+
+    assert original_payload["runs"][0]["checkpoint_count"] == 1
+    assert refreshed_payload["runs"][0]["checkpoint_count"] == 7
+
+
+
+def test_cache_payload_drops_entries_for_missing_paths(tmp_path: Path) -> None:
+    store = LoraExperimentStore()
+    missing_path = tmp_path / "missing.json"
+
+    store._cache_payload(path=missing_path, payload={"run_id": "missing"})
+
+    assert missing_path not in store._cached_payloads
+
+
+
 def test_rebuild_index_falls_back_to_manifest_when_run_record_is_invalid(tmp_path: Path) -> None:
     jobs_root = tmp_path / "model-ops"
     manifest_path = _write_manifest(

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -38,6 +38,7 @@ class LoraExperimentStore:
         self._cached_index_path: Path | None = None
         self._cached_index_signature: tuple[int, int] | None = None
         self._cached_index_payload: dict[str, Any] | None = None
+        self._cached_payloads: dict[Path, tuple[tuple[int, int], dict[str, Any]]] = {}
 
     def persist_training_run(
         self,
@@ -49,6 +50,7 @@ class LoraExperimentStore:
         run_payload = self._build_run_payload(manifest=manifest, manifest_path=manifest_path)
         run_path = manifest_path.parent / self.run_record_name
         run_path.write_text(json.dumps(_json_safe(run_payload), indent=2, allow_nan=False) + "\n", encoding="utf-8")
+        self._cache_payload(path=run_path, payload=run_payload)
         index_path = self._index_path(jobs_root)
         self.rebuild_index(jobs_root)
         return {"run": run_path, "index": index_path}
@@ -56,10 +58,10 @@ class LoraExperimentStore:
     def load_index(self, jobs_root: Path) -> dict[str, Any]:
         index_path = self._index_path(jobs_root)
         if self._cached_index_path == index_path:
-            signature = self._index_signature(index_path)
+            signature = self._path_signature(index_path)
             if signature is not None and signature == self._cached_index_signature and self._cached_index_payload is not None:
                 return self._cached_index_payload
-        payload = self._read_payload(index_path)
+        payload = self._load_payload(index_path)
         if payload:
             self._cache_index(index_path=index_path, payload=payload)
             return payload
@@ -70,14 +72,14 @@ class LoraExperimentStore:
         runs_by_id: dict[str, dict[str, Any]] = {}
         for run_dir in _iter_lora_run_dirs(train_root):
             run_path = run_dir / self.run_record_name
-            payload = self._read_payload(run_path)
+            payload = self._load_payload(run_path)
             run_id = str(payload.get("run_id", "")).strip()
             if run_id:
                 runs_by_id[run_id] = payload
                 continue
 
             manifest_path = run_dir / "train_lora.adapter.json"
-            payload = self._read_payload(manifest_path)
+            payload = self._load_payload(manifest_path)
             run_id = str(payload.get("job_id", "")).strip() or manifest_path.parent.name
             if run_id in runs_by_id:
                 continue
@@ -256,11 +258,27 @@ class LoraExperimentStore:
             return {}
         return payload if isinstance(payload, dict) else {}
 
+    def _load_payload(self, path: Path) -> dict[str, Any]:
+        signature = self._path_signature(path)
+        if signature is None:
+            self._cached_payloads.pop(path, None)
+            return {}
+
+        cached_payload = self._cached_payloads.get(path)
+        if cached_payload is not None:
+            cached_signature, payload = cached_payload
+            if cached_signature == signature:
+                return payload
+
+        payload = self._read_payload(path)
+        self._cached_payloads[path] = (signature, payload)
+        return payload
+
     def _index_path(self, jobs_root: Path) -> Path:
         return jobs_root / "train_lora" / self.index_record_name
 
     @staticmethod
-    def _index_signature(path: Path) -> tuple[int, int] | None:
+    def _path_signature(path: Path) -> tuple[int, int] | None:
         try:
             stat_result = path.stat()
         except OSError:
@@ -269,8 +287,15 @@ class LoraExperimentStore:
 
     def _cache_index(self, *, index_path: Path, payload: dict[str, Any]) -> None:
         self._cached_index_path = index_path
-        self._cached_index_signature = self._index_signature(index_path)
+        self._cached_index_signature = self._path_signature(index_path)
         self._cached_index_payload = payload
+
+    def _cache_payload(self, *, path: Path, payload: dict[str, Any]) -> None:
+        signature = self._path_signature(path)
+        if signature is None:
+            self._cached_payloads.pop(path, None)
+            return
+        self._cached_payloads[path] = (signature, payload)
 
 
 


### PR DESCRIPTION
## Summary
- Cache unchanged LoRA run-record and manifest payloads inside `LoraExperimentStore` using `(st_mtime_ns, st_size)` file signatures.
- Reuse the freshly written run payload during `persist_training_run()` so the immediate index rebuild does not reparse the same JSON file.
- Add focused regression tests for cache reuse, cache invalidation after file updates, and missing-path cache eviction.

## Plan or Spec
- N/A: this is a small cron-driven internal Python optimization slice for `services/mlx-worker-python`, not a behavior change governed by an existing canonical spec or plan.

## Commands Run
```text
python3 -m pytest -q tests/test_lora_experiment_store.py
15 passed in 0.06s

python3 -m coverage run -m pytest -q tests/test_lora_experiment_store.py
15 passed in 0.07s
python3 -m coverage json -o coverage.json
Wrote JSON report to coverage.json

python3 changed-scope coverage probe
changed_line_coverage=100.00%
measurable_changed_lines=[41, 53, 61, 64, 75, 82, 261, 262, 263, 264, 265, 267, 268, 269, 270, 271, 273, 274, 275, 281, 290, 293, 294, 295, 296, 297, 298]
missed_changed_lines=[]

python3 synthetic perf probe for repeated rebuild_index() scans
cold_rebuild_ms=38.168
warm_rebuild_ms=23.259
cold_json_reads=500
warm_json_reads=0
wall_time_reduction_percent=39.06

git diff --check
(exit 0)
```

## Coverage and Metrics
- Changed executable-line coverage for `worker/productization/lora_experiment_store.py`: `27/27 = 100.00%`.
- Synthetic repeated-scan perf probe on 250 run-record dirs + 250 manifest-only dirs:
  - `cold_rebuild_ms=38.168`
  - `warm_rebuild_ms=23.259`
  - `cold_json_reads=500`
  - `warm_json_reads=0`
  - `wall_time_reduction_percent=39.06`
- Optimization effect: repeated unchanged rebuilds stop reparsing JSON payloads and complete faster while preserving current index output semantics.

## Known Gaps
- Did not run repository-wide `make py-test`, `make swift-test`, or integration/macOS verification because this cron slice is intentionally Linux-local and scoped to `services/mlx-worker-python`.
- Perf evidence is a synthetic focused probe for repeated index rebuilds, not an end-to-end MLX workload benchmark.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or no doc update is required for this internal cache-only optimization.
- [x] Protocol changes include regenerated generated artifacts, or no protocol changes were made.
- [x] Dependency changes include updated lockfiles, or no dependency changes were made.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
