### PR TITLE
perf(scripts): short-circuit built Swift product lookup

### DIFF
--- a/scripts/dev_up.py
+++ b/scripts/dev_up.py
@@ -92,10 +92,24 @@ def optional_parent_environment_exports(names: tuple[str, ...]) -> dict[str, str
 
 def resolve_built_swift_product_binary(repo_root: Path, *, package_path: str, product_name: str) -> Path:
     build_root = repo_root / package_path / ".build"
-    candidates = [build_root / "debug" / product_name]
-    candidates.extend(sorted(build_root.glob(f"*/debug/{product_name}")))
+    direct_candidate = build_root / "debug" / product_name
+    if direct_candidate.is_file() and os.access(direct_candidate, os.X_OK):
+        return direct_candidate
 
-    for candidate in candidates:
+    child_names: list[str] = []
+    try:
+        with os.scandir(os.fspath(build_root)) as entries:
+            for entry in entries:
+                try:
+                    if entry.is_dir():
+                        child_names.append(entry.name)
+                except OSError:
+                    continue
+    except OSError:
+        child_names = []
+
+    for child_name in sorted(child_names):
+        candidate = build_root / child_name / "debug" / product_name
         if candidate.is_file() and os.access(candidate, os.X_OK):
             return candidate
 

--- a/services/mlx-worker-python/tests/test_dev_up_script.py
+++ b/services/mlx-worker-python/tests/test_dev_up_script.py
@@ -117,6 +117,68 @@ def test_build_swift_launch_command_prefers_built_binary_when_requested(tmp_path
     ) == [str(binary_path)]
 
 
+def test_build_swift_launch_command_uses_direct_debug_binary_without_glob(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dev_up = load_dev_up_module()
+    binary_path = tmp_path / "services/mlx-text-worker-swift/.build/debug/melix-text-worker-swift"
+    make_executable(binary_path)
+
+    def fail_glob(self: Path, pattern: str):
+        raise AssertionError("resolve_built_swift_product_binary() should not glob when .build/debug has the product")
+
+    monkeypatch.setattr(dev_up.Path, "glob", fail_glob)
+
+    assert dev_up.build_swift_launch_command(
+        tmp_path,
+        package_path="services/mlx-text-worker-swift",
+        product_name="melix-text-worker-swift",
+        prefer_built=True,
+    ) == [str(binary_path)]
+
+
+def test_resolve_built_swift_product_binary_skips_broken_scandir_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dev_up = load_dev_up_module()
+    build_root = tmp_path / "services/mlx-text-worker-swift/.build"
+    binary_path = build_root / "arm64-apple-macosx/debug/melix-text-worker-swift"
+    make_executable(binary_path)
+
+    class BrokenEntry:
+        name = "stale"
+
+        def is_dir(self) -> bool:
+            raise OSError("stale dirent")
+
+    class GoodEntry:
+        name = "arm64-apple-macosx"
+
+        def is_dir(self) -> bool:
+            return True
+
+    class FakeScandir:
+        def __enter__(self):
+            return iter((BrokenEntry(), GoodEntry()))
+
+        def __exit__(self, exc_type, exc, traceback) -> None:
+            return None
+
+    def fake_scandir(path: str):
+        assert path == os.fspath(build_root)
+        return FakeScandir()
+
+    monkeypatch.setattr(dev_up.os, "scandir", fake_scandir)
+
+    assert dev_up.resolve_built_swift_product_binary(
+        tmp_path,
+        package_path="services/mlx-text-worker-swift",
+        product_name="melix-text-worker-swift",
+    ) == binary_path
+
+
 def test_build_swift_launch_command_reports_missing_built_binary(tmp_path: Path) -> None:
     dev_up = load_dev_up_module()
 


### PR DESCRIPTION
## Summary
- Short-circuit `scripts/dev_up.py` built Swift product lookup when `.build/debug/<product>` already exists.
- Replace the fallback wildcard `Path.glob("*/debug/<product>")` allocation with a one-level `os.scandir()` pass that skips stale entries.
- Add focused regression coverage for the direct-debug no-glob path and broken dirent handling.

## Plan or Spec
- N/A: localized Python startup helper performance slice; no behavior or protocol contract changes.

## Commands Run
```text
PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_dev_up_script.py -q
  exit 1: pre-existing Linux/root baseline failure in test_spawn_background_process_recreates_stale_unwritable_log_file (readonly chmod still appendable as root); 33 passed, 1 failed.

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_dev_up_script.py -k 'build_swift_launch_command' -q
  exit 0: 4 passed, 31 deselected.

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_dev_up_script.py -k 'build_swift_launch_command or parse_args_prefers_built or dev_up_shell_wrapper_delegates_help_to_python_entrypoint' -q
  exit 0: 6 passed, 29 deselected.

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_dev_up_script.py -k 'build_swift_launch_command or resolve_built_swift_product_binary' -q
  exit 0: 5 passed, 31 deselected.

PYTHONPATH=services/mlx-worker-python:. uv run coverage erase && PYTHONPATH=services/mlx-worker-python:. uv run coverage run -m pytest services/mlx-worker-python/tests/test_dev_up_script.py -k 'build_swift_launch_command or resolve_built_swift_product_binary' -q && PYTHONPATH=services/mlx-worker-python:. uv run coverage json -o /tmp/dev_up_coverage.json && PYTHONPATH=services/mlx-worker-python:. uv run python scripts/python_changed_line_coverage.py --coverage-json /tmp/dev_up_coverage.json --diff-from origin/main scripts/dev_up.py
  exit 0: 5 passed, changed-line coverage scripts/dev_up.py 100.00% (16/16).

PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_dev_up_script.py -k 'not spawn_background_process_recreates_stale_unwritable_log_file' -q
  exit 0: 35 passed, 1 deselected.

PYTHONPATH=services/mlx-worker-python:. uv run python /tmp/probe_dev_up_product_resolution.py
  exit 0: candidate_dirs=5000 loops=200 iterations=5; old_mean_ms=17438.755; new_mean_ms=3.481; delta_ms=17435.274; speedup=5009.94x.

git diff --check
  exit 0.
```

## Coverage and Metrics
- Changed-line coverage: `scripts/dev_up.py` 100.00% (16/16) from the focused coverage command above.
- Performance probe (Linux synthetic SwiftPM `.build` layout, direct `.build/debug` binary present, 5,000 sibling build directories, 200 lookups x 5 iterations): old_mean_ms=17438.755, new_mean_ms=3.481, delta_ms=17435.274, speedup=5009.94x.
- Validation scope: Linux-verifiable Python helper behavior only; macOS Swift binaries were represented by executable fixture files.

## Known Gaps
- Full `test_dev_up_script.py` still has a pre-existing Linux/root-only failure in `test_spawn_background_process_recreates_stale_unwritable_log_file`; this slice did not modify that code path.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or not required because behavior is unchanged.
- [x] Protocol changes include regenerated generated artifacts, or not applicable.
- [x] Dependency changes include updated lockfiles, or not applicable.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
