### PR TITLE
perf(python): optimize stream assembler partial tag checks

### DIFF
--- a/docs/plans/2026-05-01-stream-assembler-suffix-check-optimization.md
+++ b/docs/plans/2026-05-01-stream-assembler-suffix-check-optimization.md
@@ -1,0 +1,66 @@
+# Task Plan
+
+## Title
+
+`stream-assembler suffix check optimization`
+
+## Goal
+
+Reduce hot-path overhead in `services/mlx-worker-python/worker/runtime/stream_assembler.py` by replacing the generator-based structural-tag suffix scan with an equivalent tuple-based `str.endswith(...)` check, and prove the change with focused tests, coverage, and a local performance probe.
+
+## Non-Goals
+
+- Do not refactor unrelated parser logic.
+- Do not change Swift or macOS-specific code.
+- Do not broaden the optimization slice beyond one coherent change.
+
+## Context
+
+- Relevant specs: N/A for a micro-optimization slice; repository verification and PR evidence rules in `AGENTS.md` apply.
+- Relevant code paths:
+  - `services/mlx-worker-python/worker/runtime/stream_assembler.py`
+  - `services/mlx-worker-python/tests/test_stream_assembler.py`
+- Current constraints:
+  - Linux host only.
+  - Must stay locally verifiable with pytest.
+  - Touched executable Python scope must have at least 95% automated changed-scope coverage.
+  - Must include concrete performance numbers before commit.
+
+## Assumptions
+
+- `str.endswith(tuple[str, ...])` is semantics-equivalent to iterating over the same suffix set with `any(...)`.
+- Existing stream assembler tests cover the relevant partial-tag behavior, and one additional direct regression test can lock the equivalence down.
+
+## Work Plan
+
+1. Add a failing test that directly exercises `_has_partial_structural_tag_suffix()` for both think-only and tool-enabled parser modes.
+2. Replace the generator-based suffix scan with tuple-based `str.endswith(...)` and rerun the focused test scope.
+3. Measure changed-scope coverage and run a dedicated micro-benchmark / profile probe to capture before-or-after optimization evidence.
+4. Validate formatting and git diff hygiene, then prepare a small PR with the required evidence sections.
+
+## Verification
+
+```bash
+cd services/mlx-worker-python
+PYTHONPATH=. pytest -q tests/test_stream_assembler.py
+PYTHONPATH=. coverage erase
+PYTHONPATH=. coverage run -m pytest -q tests/test_stream_assembler.py
+PYTHONPATH=. coverage json -o coverage.json
+python scripts/changed_scope_coverage.py  # equivalent inline script if helper absent
+python scripts/perf_probe.py              # equivalent inline probe for stream assembler
+git diff --check
+```
+
+Record the expected evidence for each command.
+
+## Acceptance Criteria
+
+- Focused stream assembler tests pass.
+- Changed executable lines in `worker/runtime/stream_assembler.py` reach at least 95% automated coverage.
+- Performance probe shows improved time for the targeted suffix-check-heavy workload.
+- Diff stays small and limited to the planned optimization slice and its tests.
+
+## Rollback or Safe Exit
+
+- If the optimization changes behavior, revert the code and keep the branch unpushed.
+- If no measurable improvement appears, stop without opening a PR.

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -44,6 +44,28 @@ def test_next_structural_tag_prefers_the_earliest_tool_tag() -> None:
     assert assembler._next_structural_tag() == (RequestStreamAssembler._TOOL_OPEN, 0)
 
 
+def test_partial_structural_tag_suffix_checks_all_prefixes_in_one_endswith_call() -> None:
+    class RecordingBuffer:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, ...]] = []
+
+        def endswith(self, suffix: tuple[str, ...]) -> bool:
+            self.calls.append(suffix)
+            return "<thi" in suffix
+
+    assembler = RequestStreamAssembler(
+        request_id="req-partial-suffix-fast-path",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+    buffer = RecordingBuffer()
+    assembler._buffer = buffer  # type: ignore[assignment]
+
+    assert assembler._has_partial_structural_tag_suffix() is True
+    assert buffer.calls == [assembler._structural_tag_prefixes]
+
+
 def test_stream_assembler_instances_do_not_share_request_state() -> None:
     assemblers = [
         RequestStreamAssembler(

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -223,7 +223,7 @@ class RequestStreamAssembler:
         return (self._TOOL_OPEN, tool_index)
 
     def _has_partial_structural_tag_suffix(self) -> bool:
-        return any(self._buffer.endswith(prefix) for prefix in self._structural_tag_prefixes)
+        return self._buffer.endswith(self._structural_tag_prefixes)
 
     def _content_delta(self, content: str) -> AssemblyDelta:
         self._assistant_parts.append(content)


### PR DESCRIPTION
## Summary
- Replace the hot-path generator-based structural-tag suffix scan in `worker/runtime/stream_assembler.py` with tuple-based `str.endswith(...)` matching.
- Add a focused regression test that proves the suffix check forwards the full prefix tuple in a single `endswith` call.
- Record a small implementation plan for this Linux-verifiable optimization slice.

## Plan or Spec
- `docs/plans/2026-05-01-stream-assembler-suffix-check-optimization.md`

## Commands Run
```text
cd services/mlx-worker-python
PYTHONPATH=. pytest -q tests/test_stream_assembler.py::test_partial_structural_tag_suffix_checks_all_prefixes_in_one_endswith_call
# before code change: FAILED (expected RED)
# after code change: 1 passed

PYTHONPATH=. pytest -q tests/test_stream_assembler.py
# 20 passed in 0.04s

PYTHONPATH=. coverage erase
PYTHONPATH=. coverage run -m pytest -q tests/test_stream_assembler.py
PYTHONPATH=. coverage json -o coverage.json
python <inline changed-scope coverage script>
# overall_changed_scope_coverage=100.00% (13/13)

git diff --check
# clean

python <inline perf probe>
# old_seconds=1.584421
# new_seconds=0.242354
# improvement_percent=84.70
```

## Coverage and Metrics
- Changed-scope coverage:
  - `worker/runtime/stream_assembler.py`: `100.00%` (`1/1` measurable changed executable lines covered)
  - `tests/test_stream_assembler.py`: `100.00%` (`12/12` measurable changed executable lines covered)
  - Overall changed scope: `100.00%` (`13/13`)
- Performance probe for `_has_partial_structural_tag_suffix()` equivalent workload:
  - old generator-based implementation: `1.584421s`
  - new tuple-based `endswith(...)`: `0.242354s`
  - measured improvement: `84.70%`
- Domain check: both implementations returned identical hit counts (`1280000`).

## Known Gaps
- None for the touched slice.
- I did not run repository-wide `make proto`, `make swift-test`, or `make integration-test` because this cron run intentionally targeted a Linux-verifiable Python-only optimization in `services/mlx-worker-python`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
