### PR TITLE
perf: lazily scan closure audit probe files

### DIFF
--- a/services/mlx-worker-python/tests/test_closure_audit.py
+++ b/services/mlx-worker-python/tests/test_closure_audit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -149,6 +150,42 @@ def test_collect_probe_sources_stops_reading_after_all_probe_slots_are_filled(
         ]
 
 
+def test_collect_probe_sources_stops_discovering_files_after_probe_slots_are_filled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = _seed_repo(tmp_path)
+    docs_root = repo_root / "docs"
+    probe_names = [
+        probe_name
+        for probe_group in closure_audit_module._REQUIRED_PROBES.values()
+        for probe_name in probe_group
+    ]
+    repeated_probe_text = "\n".join(probe_names) + "\n"
+    for index in range(3):
+        (docs_root / f"a-probe-{index}.md").write_text(repeated_probe_text, encoding="utf-8")
+    services_root = repo_root / "services"
+    services_root.mkdir(exist_ok=True)
+    (services_root / "after-saturation.py").write_text("should not be scanned\n", encoding="utf-8")
+
+    original_scandir = os.scandir
+
+    def tracked_scandir(path: Path | str):
+        if Path(path) == services_root:
+            raise AssertionError("probe file discovery should stop before scanning later roots")
+        return original_scandir(path)
+
+    monkeypatch.setattr(closure_audit_module.os, "scandir", tracked_scandir)
+
+    probe_sources = closure_audit_module._collect_probe_sources(repo_root)
+
+    for probe_name in probe_names:
+        assert probe_sources[probe_name] == [
+            "docs/a-probe-0.md",
+            "docs/a-probe-1.md",
+            "docs/a-probe-2.md",
+        ]
+
+
 def test_collect_probe_sources_uses_iterator_order_without_resorting(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -229,7 +266,7 @@ def test_closure_audit_helper_fallbacks_cover_policy_and_probe_edge_cases(tmp_pa
     (services_dir / "ignored.bin").write_bytes(b"ignored")
     expected_text_file = services_dir / "kept.md"
     expected_text_file.write_text("kept\n", encoding="utf-8")
-    assert closure_audit_module._iter_probe_text_files(helper_root) == [expected_text_file]
+    assert list(closure_audit_module._iter_probe_text_files(helper_root)) == [expected_text_file]
 
     first_probe_name = next(iter(closure_audit_module._REQUIRED_PROBES.values()))[0]
     partial_sources = {probe_name: [] for probe_group in closure_audit_module._REQUIRED_PROBES.values() for probe_name in probe_group}

--- a/services/mlx-worker-python/worker/productization/closure_audit.py
+++ b/services/mlx-worker-python/worker/productization/closure_audit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -56,7 +57,7 @@ _REQUIRED_PROBES: dict[str, tuple[str, ...]] = {
     ),
 }
 _TEXT_SEARCH_ROOTS = ("docs", "scripts", "services", "tests", "README.md", "progress.md", "task_plan.md")
-_TEXT_FILE_SUFFIXES = {".md", ".py", ".swift", ".json", ".txt", ".yaml", ".yml"}
+_TEXT_FILE_SUFFIXES = (".md", ".py", ".swift", ".json", ".txt", ".yaml", ".yml")
 _FINDING_SEVERITY_PRIORITY = {
     "blocker": 0,
     "evidence_gap": 1,
@@ -386,21 +387,28 @@ def _probe_sources_complete(probe_sources: dict[str, list[str]]) -> bool:
     return all(len(matches) >= 3 for matches in probe_sources.values())
 
 
-def _iter_probe_text_files(root: Path) -> list[Path]:
-    files: list[Path] = []
+def _iter_probe_text_files(root: Path) -> Iterator[Path]:
     for entry in _TEXT_SEARCH_ROOTS:
         candidate = root / entry
         if candidate.is_file():
             if candidate.suffix in _TEXT_FILE_SUFFIXES:
-                files.append(candidate)
+                yield candidate
             continue
         if not candidate.exists():
             continue
-        for current_root, _, filenames in os.walk(candidate):
-            for name in filenames:
-                if name.endswith(tuple(_TEXT_FILE_SUFFIXES)):
-                    files.append(Path(current_root) / name)
-    return sorted(files)
+        yield from _iter_text_files_sorted(candidate)
+
+
+def _iter_text_files_sorted(root: Path) -> Iterator[Path]:
+    with os.scandir(root) as scandir_entries:
+        entries = sorted(scandir_entries, key=lambda entry: entry.name)
+    for entry in entries:
+        entry_path = Path(entry.path)
+        if entry.is_dir(follow_symlinks=False):
+            yield from _iter_text_files_sorted(entry_path)
+            continue
+        if entry.is_file(follow_symlinks=False) and entry.name.endswith(_TEXT_FILE_SUFFIXES):
+            yield entry_path
 
 
 


### PR DESCRIPTION
## Summary
- Lazily iterates closure-audit probe text files so `_collect_probe_sources` can stop file discovery once every required probe has three evidence sources.
- Replaces eager `os.walk` accumulation with a sorted `os.scandir` iterator that avoids scanning later roots after probe saturation while preserving deterministic per-directory order.
- Adds regression coverage proving both read-time and discovery-time short-circuiting.

## Plan or Spec
- N/A: scoped Python performance slice for an existing closure-audit helper; no behavior/spec change intended.

## Commands Run
```text
cd services/mlx-worker-python && PYTHONPATH=. uv run pytest tests/test_closure_audit.py -q
# exit 0; 9 passed in 0.06s

cd services/mlx-worker-python && PYTHONPATH=. uv run coverage run --source=worker.productization.closure_audit -m pytest tests/test_closure_audit.py -q && PYTHONPATH=. uv run coverage report --include='worker/productization/closure_audit.py'
# exit 0; 9 passed; closure_audit.py coverage 99%

cd services/mlx-worker-python && PYTHONPATH=. uv run pytest tests/test_phase8_runtime_probes.py -q
# exit 0; 34 passed in 0.29s

git diff --check
# exit 0

Synthetic probe command: PYTHONPATH=. uv run python <inline benchmark creating 6,006 candidate text files with all required probes in the first three docs files>
# old mean 68.606 ms over 7 runs; new mean 0.373 ms over 7 runs
```

## Coverage and Metrics
- Changed-scope coverage: `worker/productization/closure_audit.py` 99% line coverage from focused coverage command.
- Probe: synthetic Linux filesystem benchmark with 6,006 candidate text files and early probe saturation.
  - old_mean=68.606 ms
  - new_mean=0.373 ms
  - delta_ms=-68.233 ms
  - speedup≈184.1x
- Linux-only validation scope: this slice touches Python closure-audit filesystem scanning and was validated locally on Linux; macOS runtime/app surfaces were not exercised.

## Known Gaps
- Full repository gates (`make swift-test`, `make integration-test`) were not run because this environment is Linux and the project targets Apple Silicon/macOS for those surfaces.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated for no behavior/spec change.
- [x] Protocol changes include regenerated generated artifacts, or N/A because no protocol changes were made.
- [x] Dependency changes include updated lockfiles, or N/A because no dependency changes were made.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
