### PR TITLE
ci: add PR-scoped performance workflow

### DIFF
--- a/.github/workflows/pr-scoped-performance.yml
+++ b/.github/workflows/pr-scoped-performance.yml
@@ -1,0 +1,238 @@
+name: pr-scoped-performance
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-scoped-performance-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  scope:
+    runs-on: ubuntu-latest
+    outputs:
+      selected_count: ${{ steps.scope_outputs.outputs.selected_count }}
+      matrix: ${{ steps.scope_outputs.outputs.matrix }}
+    steps:
+      - name: Checkout head
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Capture changed files
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            fs.mkdirSync('artifacts/scope', { recursive: true });
+            fs.writeFileSync(
+              'artifacts/scope/changed-files.json',
+              JSON.stringify(files.map((file) => file.filename), null, 2),
+            );
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Resolve selected probes
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/scope
+          python scripts/pr_scoped_performance_scope.py \
+            --registry infra/perf/pr_scoped_probes.json \
+            --changed-files-json artifacts/scope/changed-files.json \
+            --output artifacts/scope/scope.json > artifacts/scope/scope.stdout.json
+
+      - name: Export scope outputs
+        id: scope_outputs
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          scope = json.loads(Path('artifacts/scope/scope.json').read_text(encoding='utf-8'))
+          matrix = [
+              {
+                  'id': probe['id'],
+                  'name': probe['name'],
+                  'runner': probe.get('runner', 'ubuntu-latest'),
+              }
+              for probe in scope.get('selected_probes', [])
+          ]
+          with Path(os.environ['GITHUB_OUTPUT']).open('a', encoding='utf-8') as output_file:
+              output_file.write(f"selected_count={scope.get('selected_count', 0)}\n")
+              output_file.write(f"matrix={json.dumps(matrix)}\n")
+          PY
+
+      - name: Upload scope artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-scoped-performance-scope
+          path: artifacts/scope
+
+  probes:
+    needs:
+      - scope
+    if: needs.scope.outputs.selected_count != '0'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.scope.outputs.matrix) }}
+    steps:
+      - name: Checkout base
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.base.repo.full_name }}
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Checkout head
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Run scoped performance probe
+        id: run_probe
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/probes
+          python head/scripts/pr_scoped_performance_run.py \
+            --registry head/infra/perf/pr_scoped_probes.json \
+            --probe-id "${{ matrix.id }}" \
+            --base-repo "$GITHUB_WORKSPACE/base" \
+            --head-repo "$GITHUB_WORKSPACE/head" \
+            --output "artifacts/probes/${{ matrix.id }}.json"
+
+      - name: Upload probe artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-scoped-performance-probe-${{ matrix.id }}
+          path: artifacts/probes/${{ matrix.id }}.json
+
+  report:
+    needs:
+      - scope
+      - probes
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout head
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Download scope artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: pr-scoped-performance-scope
+          path: artifacts/scope
+
+      - name: Download probe artifacts
+        if: needs.scope.outputs.selected_count != '0'
+        uses: actions/download-artifact@v5
+        with:
+          pattern: pr-scoped-performance-probe-*
+          path: artifacts/probes
+          merge-multiple: true
+
+      - name: Ensure probe artifact directory exists
+        run: mkdir -p artifacts/probes artifacts/report
+
+      - name: Build scoped performance report
+        run: |
+          set -euo pipefail
+          python head/scripts/pr_scoped_performance_report.py \
+            --scope artifacts/scope/scope.json \
+            --results-dir artifacts/probes \
+            --output-dir artifacts/report \
+            --format terminal | tee artifacts/report/report.txt
+          python head/scripts/pr_scoped_performance_report.py \
+            --scope artifacts/scope/scope.json \
+            --results-dir artifacts/probes \
+            --format markdown \
+            --sticky-comment > artifacts/report/pr-comment.md
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-scoped-performance-report
+          path: artifacts/report
+
+      - name: Update PR comment
+        if: github.event_name == 'pull_request' && (success() || failure())
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- melix-pr-scoped-performance-report -->';
+            let body;
+            try {
+              body = fs.readFileSync('artifacts/report/pr-comment.md', 'utf8');
+            } catch (error) {
+              body = [
+                marker,
+                '# Melix PR Scoped Performance Report',
+                '',
+                'Report generation did not complete. See the workflow logs and uploaded artifacts for the failing phase.',
+              ].join('\n');
+            }
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/docs/plans/2026-05-01-pr-scoped-performance-ci.md
+++ b/docs/plans/2026-05-01-pr-scoped-performance-ci.md
@@ -1,0 +1,104 @@
+# PR-Scoped Performance CI Plan
+
+## Summary
+
+Add a dedicated GitHub Actions workflow that runs only the performance probes affected by the pull request, runs only the targeted verification commands for those probes, compares base-vs-head metrics, and publishes a sticky PR comment with the scoped report.
+
+## Goals
+
+1. Avoid full-repository performance sweeps on every PR.
+2. Tie each performance probe to explicit code paths and focused verification commands.
+3. Compare each selected probe against the PR base commit and the PR head commit.
+4. Publish a stable sticky PR comment that updates in place on each PR sync.
+5. Make future scope expansion data-driven so adding a new probe definition automatically expands CI coverage.
+
+## Non-Goals
+
+- Replacing the existing benchmark/evaluation report workflow.
+- Inventing cross-repository performance baselines outside the PR base/head diff.
+- Claiming full performance coverage for code paths that do not yet have registered probes.
+
+## Proposed Design
+
+### Probe Registry
+
+Create a JSON registry under `infra/perf/` where each entry declares:
+
+- `id` and human-readable `name`
+- `watch_globs` that decide whether a PR affects the probe
+- `test_command` for focused verification
+- `coverage_command` and `coverage_targets` for changed-scope evidence when practical
+- `probe_command` that prints machine-readable JSON metrics
+- metric metadata (`key`, `unit`, `direction`)
+
+The workflow scope step selects probes whose `watch_globs` match the PR diff. If registry or workflow infrastructure files change, select all probes so CI revalidates the framework.
+
+### Scope Resolution
+
+Add a Python script that:
+
+1. Reads the registry.
+2. Computes changed files between the PR base and head SHAs.
+3. Emits the selected probe list as workflow-job JSON outputs.
+4. Produces a small markdown summary for the final PR comment.
+
+### Probe Execution
+
+Add a Python runner script that:
+
+1. Receives a repository checkout path plus a probe id.
+2. Runs the probe's focused test and coverage commands in that checkout.
+3. Runs the probe command and captures JSON metrics.
+4. Persists a normalized artifact JSON payload.
+
+The workflow will run the selected probe matrix for both `base` and `head` checkouts and upload the artifacts.
+
+### Report Rendering
+
+Add a report builder that:
+
+1. Loads the selected-probe scope metadata.
+2. Loads base/head probe artifacts.
+3. Computes per-metric deltas.
+4. Renders terminal + markdown output.
+5. Emits a sticky-comment body with a stable marker.
+
+When no probes match, the workflow should still update the sticky comment with an explicit “no registered performance probes were affected” result.
+
+## Initial Seed Probes
+
+Seed the registry with Linux-verifiable Python probes for existing hot paths so the workflow is immediately useful without requiring a full Melix stack boot.
+
+Planned initial entries:
+
+1. `benchmark-evaluation-report-running-aggregates`
+   - Watches `worker/productization/benchmark_evaluation_report.py` and its tests.
+   - Focused verification: `test_benchmark_evaluation_report.py`.
+   - Probe: synthetic large-bundle aggregation comparison.
+
+2. `closure-audit-probe-source-short-circuit`
+   - Watches `worker/productization/closure_audit.py` and its tests.
+   - Focused verification: `test_closure_audit.py`.
+   - Probe: synthetic many-file scan comparison.
+
+## Success Metrics
+
+- The workflow runs only selected probes, not the full performance suite.
+- Each selected probe reports base/head metrics and deltas in a sticky PR comment.
+- Adding a new registry entry is sufficient to extend CI scope.
+- Focused coverage for the changed executable scope remains measurable at >=95% for seeded probes.
+
+## Verification Plan
+
+- Unit tests for scope selection logic.
+- Unit tests for report rendering and delta computation.
+- Unit tests for probe runner command parsing / artifact normalization.
+- Local dry-run of the scope script against synthetic changed-file inputs.
+- Local execution of seeded probe runners on the current checkout.
+- Local YAML validation for the new workflow.
+
+## Known Constraints
+
+- Only code paths with registered probes participate in this CI.
+- PRs that touch unregistered paths will receive an explicit no-probe comment rather than a speculative result.
+- Seed probes should avoid requiring a live Apple Silicon runtime so the CI remains reliable and reasonably fast.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1,0 +1,55 @@
+[
+  {
+    "id": "benchmark-evaluation-report-running-aggregates",
+    "name": "Benchmark evaluation report running aggregates",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py",
+      "services/mlx-worker-python/tests/test_benchmark_evaluation_report.py",
+      "scripts/benchmark_evaluation_report.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py",
+    "probe_impl": "benchmark_evaluation_report",
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
+    "id": "closure-audit-probe-source-short-circuit",
+    "name": "Closure audit probe-source short circuit",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/closure_audit.py",
+      "services/mlx-worker-python/tests/test_closure_audit.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_closure_audit.py",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_closure_audit.py && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/closure_audit.py services/mlx-worker-python/tests/test_closure_audit.py",
+    "probe_impl": "closure_audit",
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "probe_file_reads_mean",
+        "unit": "reads",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  }
+]

--- a/scripts/pr_scoped_performance_report.py
+++ b/scripts/pr_scoped_performance_report.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "services/mlx-worker-python"))
+
+from worker.productization.pr_scoped_performance import (  # noqa: E402
+    build_performance_report,
+    build_sticky_comment_body,
+    render_markdown_report,
+    render_terminal_report,
+    write_report_outputs,
+)
+
+
+def _load_results(results_dir: Path) -> list[dict[str, object]]:
+    if not results_dir.exists():
+        return []
+    results: list[dict[str, object]] = []
+    for path in sorted(results_dir.glob("*.json")):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            results.append(payload)
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scope", required=True)
+    parser.add_argument("--results-dir", required=True)
+    parser.add_argument("--format", choices=("terminal", "markdown", "json"), default="terminal")
+    parser.add_argument("--output-dir", default="")
+    parser.add_argument("--sticky-comment", action="store_true")
+    args = parser.parse_args()
+
+    scope = json.loads(Path(args.scope).read_text(encoding="utf-8"))
+    if not isinstance(scope, dict):
+        raise ValueError("scope payload must be a JSON object")
+    report = build_performance_report(scope=scope, probe_results=_load_results(Path(args.results_dir)))
+    if args.output_dir:
+        write_report_outputs(report, args.output_dir)
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+    if args.format == "markdown":
+        markdown = render_markdown_report(report)
+        if args.sticky_comment:
+            markdown = build_sticky_comment_body(markdown)
+        print(markdown, end="" if markdown.endswith("\n") else "\n")
+        return 0
+    print(render_terminal_report(report), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pr_scoped_performance_run.py
+++ b/scripts/pr_scoped_performance_run.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "services/mlx-worker-python"))
+
+from worker.productization.pr_scoped_performance import run_probe_job  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--registry", required=True)
+    parser.add_argument("--probe-id", required=True)
+    parser.add_argument("--base-repo", required=True)
+    parser.add_argument("--head-repo", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    result, success = run_probe_job(
+        registry_path=args.registry,
+        probe_id=args.probe_id,
+        base_repo=args.base_repo,
+        head_repo=args.head_repo,
+    )
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pr_scoped_performance_scope.py
+++ b/scripts/pr_scoped_performance_scope.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "services/mlx-worker-python"))
+
+from worker.productization.pr_scoped_performance import build_scope_report  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--registry", required=True)
+    parser.add_argument("--changed-files-json", required=True)
+    parser.add_argument("--output", default="")
+    args = parser.parse_args()
+
+    changed_files = json.loads(Path(args.changed_files_json).read_text(encoding="utf-8"))
+    if not isinstance(changed_files, list):
+        raise ValueError("changed files payload must be a JSON list")
+    scope = build_scope_report(registry_path=args.registry, changed_files=[str(path) for path in changed_files])
+    rendered = json.dumps(scope, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import runpy
+import sys
+
+import pytest
+
+from worker.productization.pr_scoped_performance import (
+    _build_large_benchmark_bundle,
+    _build_metric_row,
+    _build_probe_report_row,
+    _build_probe_details,
+    _closure_index_text,
+    _dict_list,
+    _dispatch_probe_impl,
+    _float_or_none,
+    _format_delta,
+    _format_value,
+    _is_relative_to,
+    _load_repo_module,
+    _markdown_cell,
+    _matches_any_glob,
+    _parse_coverage_percent,
+    _probe_benchmark_evaluation_report,
+    _probe_closure_audit,
+    _run_command,
+    _run_head_verification,
+    _run_probe_impl,
+    _seed_closure_audit_repo,
+    _string_list,
+    _write,
+    MetricDefinition,
+    ProbeDefinition,
+    build_performance_report,
+    build_scope_report,
+    build_sticky_comment_body,
+    load_probe_registry,
+    render_markdown_report,
+    render_terminal_report,
+    run_probe_job,
+    write_report_outputs,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REGISTRY_PATH = REPO_ROOT / "infra/perf/pr_scoped_probes.json"
+
+
+@pytest.fixture()
+def benchmark_scope() -> dict[str, object]:
+    return build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py"],
+    )
+
+
+def test_scope_report_selects_only_matching_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/closure_audit.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    selected_probe = scope["selected_probes"][0]
+    assert selected_probe["id"] == "closure-audit-probe-source-short-circuit"
+    assert scope["force_all"] is False
+
+
+def test_scope_report_force_selects_all_on_infra_change() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["infra/perf/pr_scoped_probes.json"],
+    )
+
+    assert scope["force_all"] is True
+    assert scope["selected_count"] == len(load_probe_registry(REGISTRY_PATH))
+
+
+def test_scope_report_with_no_matching_probe_returns_empty_selection() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["README.md"],
+    )
+
+    assert scope["selected_count"] == 0
+    assert scope["selected_probes"] == []
+
+
+def test_load_probe_registry_rejects_invalid_payloads(tmp_path: Path) -> None:
+    invalid_root = tmp_path / "invalid-root.json"
+    invalid_root.write_text("{}\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="JSON list"):
+        load_probe_registry(invalid_root)
+
+    invalid_entry = tmp_path / "invalid-entry.json"
+    invalid_entry.write_text(json.dumps(["bad"]), encoding="utf-8")
+    with pytest.raises(ValueError, match="JSON objects"):
+        load_probe_registry(invalid_entry)
+
+    invalid_metrics = tmp_path / "invalid-metrics.json"
+    invalid_metrics.write_text(
+        json.dumps([
+            {
+                "id": "demo",
+                "name": "Demo",
+                "probe_impl": "benchmark_evaluation_report",
+                "metrics": [],
+            }
+        ]),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="non-empty list"):
+        load_probe_registry(invalid_metrics)
+
+
+def test_probe_smokes_return_metrics_against_current_repo() -> None:
+    benchmark_metrics = _probe_benchmark_evaluation_report(REPO_ROOT)
+    closure_metrics = _probe_closure_audit(REPO_ROOT)
+
+    assert benchmark_metrics["elapsed_ms_mean"] > 0
+    assert benchmark_metrics["peak_bytes_mean"] > 0
+    assert benchmark_metrics["row_count"] > 0
+    assert closure_metrics["elapsed_ms_mean"] > 0
+    assert closure_metrics["probe_file_reads_mean"] > 0
+    assert closure_metrics["finding_count"] > 0
+
+
+def test_run_probe_job_executes_verification_and_probe_for_current_repo() -> None:
+    result, success = run_probe_job(
+        registry_path=REGISTRY_PATH,
+        probe_id="benchmark-evaluation-report-running-aggregates",
+        base_repo=REPO_ROOT,
+        head_repo=REPO_ROOT,
+    )
+
+    assert success is True
+    assert result["head_verification"]["test"]["ok"] is True
+    assert result["head_verification"]["coverage"]["coverage_pct"] >= 95.0
+    assert result["base_probe"]["metrics"]["elapsed_ms_mean"] > 0
+
+
+def test_report_rendering_marks_regressions_and_builds_sticky_comment(
+    benchmark_scope: dict[str, object],
+) -> None:
+    result = {
+        "probe": benchmark_scope["selected_probes"][0],
+        "head_verification": {
+            "test": {"ok": True, "coverage_pct": None},
+            "coverage": {"ok": True, "coverage_pct": 97.0},
+        },
+        "base_probe": {
+            "ok": True,
+            "metrics": {
+                "elapsed_ms_mean": 10.0,
+                "peak_bytes_mean": 100.0,
+            },
+        },
+        "head_probe": {
+            "ok": True,
+            "metrics": {
+                "elapsed_ms_mean": 12.0,
+                "peak_bytes_mean": 120.0,
+            },
+        },
+    }
+
+    report = build_performance_report(scope=benchmark_scope, probe_results=[result])
+    markdown = render_markdown_report(report)
+    terminal = render_terminal_report(report)
+    sticky = build_sticky_comment_body(markdown)
+
+    assert report["summary"]["status"] == "regression"
+    assert report["summary"]["regression_count"] == 1
+    assert "Melix PR Scoped Performance Report" in markdown
+    assert "regression" in terminal
+    assert sticky.startswith("<!-- melix-pr-scoped-performance-report -->\n")
+    assert json.loads(json.dumps(report))["summary"]["selected_probe_count"] == 1
+
+
+def test_report_handles_missing_results_and_empty_probe_selection(tmp_path: Path) -> None:
+    scope = {
+        "changed_files": ["README.md"],
+        "force_all": False,
+        "selected_count": 1,
+        "selected_probes": [{"id": "missing", "name": "Missing probe", "metrics": []}],
+    }
+    report = build_performance_report(scope=scope, probe_results=[])
+    outputs = write_report_outputs(report, tmp_path / "report")
+
+    assert report["summary"]["status"] == "verification_failed"
+    assert outputs["json"].is_file()
+    assert outputs["markdown"].is_file()
+
+    empty_report = build_performance_report(
+        scope={"changed_files": [], "force_all": False, "selected_count": 0, "selected_probes": []},
+        probe_results=[],
+    )
+    assert "No registered performance probes were selected" in render_markdown_report(empty_report)
+    assert "No registered performance probes were selected" in render_terminal_report(empty_report)
+
+
+def test_metric_and_probe_helpers_cover_error_branches() -> None:
+    missing = _build_metric_row(
+        key="elapsed_ms_mean",
+        unit="ms",
+        direction="lower_is_better",
+        warn_pct=5.0,
+        base_metrics={},
+        head_metrics={},
+    )
+    higher_is_better = _build_metric_row(
+        key="score",
+        unit="ratio",
+        direction="higher_is_better",
+        warn_pct=5.0,
+        base_metrics={"score": 10.0},
+        head_metrics={"score": 8.0},
+    )
+    zero_baseline = _build_metric_row(
+        key="count",
+        unit="count",
+        direction="lower_is_better",
+        warn_pct=0.0,
+        base_metrics={"count": 0.0},
+        head_metrics={"count": 1.0},
+    )
+
+    assert missing["status"] == "missing"
+    assert higher_is_better["status"] == "regression"
+    assert zero_baseline["delta_pct"] is None
+
+    probe_result = {
+        "probe": {"id": "demo", "name": "Demo", "metrics": [{"key": "score", "unit": "ms", "direction": "lower_is_better", "warn_pct": 5.0}]},
+        "head_verification": {
+            "test": {"ok": False},
+            "coverage": {"ok": False, "coverage_pct": None},
+        },
+        "base_probe": {"ok": False, "error": "base boom", "metrics": {}},
+        "head_probe": {"ok": False, "error": "head boom", "metrics": {}},
+    }
+    row = _build_probe_report_row(probe_result)
+
+    assert row["status"] == "verification_failed"
+    assert "Targeted tests failed." in _build_probe_details(result=probe_result)
+    assert "Coverage command failed." in _build_probe_details(result=probe_result)
+    assert "base boom" in _build_probe_details(result=probe_result)
+    assert "head boom" in _build_probe_details(result=probe_result)
+
+
+def test_command_and_verification_helpers_cover_skip_and_failure_paths(tmp_path: Path) -> None:
+    coverage_stdout = "TOTAL  10  0  100%\n"
+    command_result = _run_command(
+        "python -c \"print('TOTAL  10  0  100%')\"",
+        cwd=tmp_path,
+    )
+    assert command_result["coverage_pct"] == 100.0
+    assert _parse_coverage_percent(coverage_stdout) == 100.0
+    assert _parse_coverage_percent("no total line\n") is None
+
+    probe = ProbeDefinition(
+        probe_id="demo",
+        name="Demo",
+        runner="ubuntu-latest",
+        watch_globs=("*.py",),
+        test_command="python -c \"raise SystemExit(1)\"",
+        coverage_command="python -c \"print('should not run')\"",
+        probe_impl="benchmark_evaluation_report",
+        metrics=(MetricDefinition(key="elapsed_ms_mean", unit="ms", direction="lower_is_better"),),
+    )
+    verification = _run_head_verification(probe=probe, repo_root=tmp_path)
+
+    assert verification["test"]["ok"] is False
+    assert verification["coverage"]["stderr"].startswith("Skipped because")
+
+
+def test_dispatch_and_module_loading_helpers_cover_failure_paths(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unsupported probe implementation"):
+        _dispatch_probe_impl(
+            probe=ProbeDefinition(
+                probe_id="bad",
+                name="Bad",
+                runner="ubuntu-latest",
+                watch_globs=(),
+                test_command="true",
+                coverage_command="true",
+                probe_impl="unsupported",
+                metrics=(MetricDefinition(key="x", unit="ms", direction="lower_is_better"),),
+            ),
+            repo_root=tmp_path,
+        )
+
+    broken = _run_probe_impl(
+        probe=ProbeDefinition(
+            probe_id="bad",
+            name="Bad",
+            runner="ubuntu-latest",
+            watch_globs=(),
+            test_command="true",
+            coverage_command="true",
+            probe_impl="unsupported",
+            metrics=(MetricDefinition(key="x", unit="ms", direction="lower_is_better"),),
+        ),
+        repo_root=tmp_path,
+        repo_label="head",
+    )
+    assert broken["ok"] is False
+
+    missing_module = tmp_path / "missing.py"
+    with pytest.raises(ValueError, match="could not load module"):
+        _load_repo_module(missing_module, unique_name="missing")
+
+    module_path = tmp_path / "demo_module.py"
+    module_path.write_text("VALUE = 7\n", encoding="utf-8")
+    module = _load_repo_module(module_path, unique_name="demo_module")
+    assert module.VALUE == 7
+
+
+def test_data_generation_and_formatting_helpers_cover_misc_branches(tmp_path: Path) -> None:
+    bundle = _build_large_benchmark_bundle(base_value=42.0)
+    assert len(bundle["benchmark_results"]) == 250
+    assert len(bundle["benchmark_context_rows"]) == 900
+    assert len(bundle["benchmark_matrix_request_rows"]) == 1200
+
+    seeded_root = _seed_closure_audit_repo(tmp_path)
+    assert (seeded_root / "docs/plans/2026-03-30-full-capability-roadmap-execution-index.md").is_file()
+    assert "M9.8" in _closure_index_text()
+
+    nested_path = tmp_path / "nested" / "file.txt"
+    _write(nested_path, "hello\n")
+    assert nested_path.read_text(encoding="utf-8") == "hello\n"
+
+    assert _format_value(1.25) == "1.250"
+    assert _format_value(3) == "3"
+    assert _format_value(None) == "-"
+    assert _format_delta({"delta": None, "delta_pct": None}) == "-"
+    assert _format_delta({"delta": 2.5, "delta_pct": None}) == "+2.500"
+    assert _format_delta({"delta": 2.5, "delta_pct": 10.0}) == "+2.500 (+10.00%)"
+    assert _markdown_cell("a|b") == "a\\|b"
+    assert _dict_list([{"ok": True}, 1]) == [{"ok": True}]
+    assert _dict_list("not-a-list") == []
+    assert _string_list([1, "two"]) == ["1", "two"]
+    assert _string_list("not-a-list") == []
+    assert _float_or_none(True) == 1.0
+    assert _float_or_none(False) == 0.0
+    assert _float_or_none("x") is None
+    assert _matches_any_glob("services/a.py", ("services/*.py",)) is True
+    assert _matches_any_glob("docs/a.md", ("services/*.py",)) is False
+    assert _is_relative_to(nested_path, tmp_path) is True
+    assert _is_relative_to(Path("/tmp/not-child"), tmp_path) is False
+
+
+def test_cli_scripts_smoke(tmp_path: Path, benchmark_scope: dict[str, object], monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    changed_files_path = tmp_path / "changed-files.json"
+    changed_files_path.write_text(json.dumps(["services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py"]), encoding="utf-8")
+    scope_output = tmp_path / "scope.json"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pr_scoped_performance_scope.py",
+            "--registry",
+            str(REGISTRY_PATH),
+            "--changed-files-json",
+            str(changed_files_path),
+            "--output",
+            str(scope_output),
+        ],
+    )
+    scope_script = runpy.run_path(str(REPO_ROOT / "scripts/pr_scoped_performance_scope.py"))
+    assert scope_script["main"]() == 0
+    assert json.loads(scope_output.read_text(encoding="utf-8"))["selected_count"] == 1
+    capsys.readouterr()
+
+    probe_output = tmp_path / "probe.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pr_scoped_performance_run.py",
+            "--registry",
+            str(REGISTRY_PATH),
+            "--probe-id",
+            "benchmark-evaluation-report-running-aggregates",
+            "--base-repo",
+            str(REPO_ROOT),
+            "--head-repo",
+            str(REPO_ROOT),
+            "--output",
+            str(probe_output),
+        ],
+    )
+    run_script = runpy.run_path(str(REPO_ROOT / "scripts/pr_scoped_performance_run.py"))
+    assert run_script["main"]() == 0
+    assert json.loads(probe_output.read_text(encoding="utf-8"))["probe"]["id"] == (
+        "benchmark-evaluation-report-running-aggregates"
+    )
+    capsys.readouterr()
+
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    (results_dir / "probe.json").write_text(probe_output.read_text(encoding="utf-8"), encoding="utf-8")
+    report_dir = tmp_path / "report"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pr_scoped_performance_report.py",
+            "--scope",
+            str(scope_output),
+            "--results-dir",
+            str(results_dir),
+            "--output-dir",
+            str(report_dir),
+            "--format",
+            "markdown",
+            "--sticky-comment",
+        ],
+    )
+    report_script = runpy.run_path(str(REPO_ROOT / "scripts/pr_scoped_performance_report.py"))
+    assert report_script["main"]() == 0
+    output = capsys.readouterr().out
+    assert output.startswith("<!-- melix-pr-scoped-performance-report -->\n")
+    assert (report_dir / "report.json").is_file()

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -1,0 +1,841 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import fnmatch
+import gc
+import importlib.util
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import tracemalloc
+from typing import Any
+
+_COMMENT_MARKER = "<!-- melix-pr-scoped-performance-report -->"
+_SCOPE_SCHEMA_VERSION = "melix.pr_scoped_performance_scope.v1"
+_PROBE_RESULT_SCHEMA_VERSION = "melix.pr_scoped_performance_probe_result.v1"
+_REPORT_SCHEMA_VERSION = "melix.pr_scoped_performance_report.v1"
+_FORCE_ALL_GLOBS = (
+    ".github/workflows/pr-scoped-performance.yml",
+    "infra/perf/pr_scoped_probes.json",
+    "scripts/pr_scoped_performance_*.py",
+    "services/mlx-worker-python/worker/productization/pr_scoped_performance.py",
+    "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+)
+_COVERAGE_PERCENT_RE = re.compile(r"TOTAL\s+\d+\s+\d+\s+(\d+)%")
+_TEXT_FILE_SUFFIXES = {".md", ".py", ".json", ".txt", ".yaml", ".yml"}
+
+
+@dataclass(frozen=True)
+class MetricDefinition:
+    key: str
+    unit: str
+    direction: str
+    warn_pct: float = 5.0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "key": self.key,
+            "unit": self.unit,
+            "direction": self.direction,
+            "warn_pct": self.warn_pct,
+        }
+
+
+@dataclass(frozen=True)
+class ProbeDefinition:
+    probe_id: str
+    name: str
+    runner: str
+    watch_globs: tuple[str, ...]
+    test_command: str
+    coverage_command: str
+    probe_impl: str
+    metrics: tuple[MetricDefinition, ...]
+
+    def to_scope_dict(self) -> dict[str, object]:
+        return {
+            "id": self.probe_id,
+            "name": self.name,
+            "runner": self.runner,
+            "watch_globs": list(self.watch_globs),
+            "metrics": [metric.to_dict() for metric in self.metrics],
+        }
+
+
+def load_probe_registry(path: str | Path) -> tuple[ProbeDefinition, ...]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("probe registry must be a JSON list")
+    probes: list[ProbeDefinition] = []
+    for raw_probe in payload:
+        if not isinstance(raw_probe, dict):
+            raise ValueError("probe registry entries must be JSON objects")
+        raw_metrics = raw_probe.get("metrics", [])
+        if not isinstance(raw_metrics, list) or not raw_metrics:
+            raise ValueError("probe registry metrics must be a non-empty list")
+        metrics = tuple(
+            MetricDefinition(
+                key=str(raw_metric["key"]),
+                unit=str(raw_metric.get("unit", "value")),
+                direction=str(raw_metric["direction"]),
+                warn_pct=float(raw_metric.get("warn_pct", 5.0)),
+            )
+            for raw_metric in raw_metrics
+            if isinstance(raw_metric, dict)
+        )
+        probes.append(
+            ProbeDefinition(
+                probe_id=str(raw_probe["id"]),
+                name=str(raw_probe["name"]),
+                runner=str(raw_probe.get("runner", "ubuntu-latest")),
+                watch_globs=tuple(str(glob) for glob in raw_probe.get("watch_globs", [])),
+                test_command=str(raw_probe.get("test_command", "")).strip(),
+                coverage_command=str(raw_probe.get("coverage_command", "")).strip(),
+                probe_impl=str(raw_probe["probe_impl"]),
+                metrics=metrics,
+            )
+        )
+    return tuple(probes)
+
+
+def build_scope_report(
+    *,
+    registry_path: str | Path,
+    changed_files: list[str],
+) -> dict[str, object]:
+    probes = load_probe_registry(registry_path)
+    changed_paths = tuple(sorted({path for path in changed_files if path}))
+    force_all = any(_matches_any_glob(path, _FORCE_ALL_GLOBS) for path in changed_paths)
+    if force_all:
+        selected = probes
+    else:
+        selected = tuple(
+            probe
+            for probe in probes
+            if any(_matches_any_glob(path, probe.watch_globs) for path in changed_paths)
+        )
+    return {
+        "schema_version": _SCOPE_SCHEMA_VERSION,
+        "changed_files": list(changed_paths),
+        "force_all": force_all,
+        "selected_probes": [probe.to_scope_dict() for probe in selected],
+        "selected_count": len(selected),
+    }
+
+
+def run_probe_job(
+    *,
+    registry_path: str | Path,
+    probe_id: str,
+    base_repo: str | Path,
+    head_repo: str | Path,
+) -> tuple[dict[str, object], bool]:
+    probes = {probe.probe_id: probe for probe in load_probe_registry(registry_path)}
+    probe = probes.get(probe_id)
+    if probe is None:
+        raise ValueError(f"unknown probe id: {probe_id}")
+
+    head_verification = _run_head_verification(probe=probe, repo_root=Path(head_repo))
+    base_probe = _run_probe_impl(probe=probe, repo_root=Path(base_repo), repo_label="base")
+    head_probe = _run_probe_impl(probe=probe, repo_root=Path(head_repo), repo_label="head")
+    success = (
+        head_verification["test"]["ok"]
+        and head_verification["coverage"]["ok"]
+        and base_probe["ok"]
+        and head_probe["ok"]
+    )
+    return (
+        {
+            "schema_version": _PROBE_RESULT_SCHEMA_VERSION,
+            "probe": probe.to_scope_dict(),
+            "head_verification": head_verification,
+            "base_probe": base_probe,
+            "head_probe": head_probe,
+        },
+        success,
+    )
+
+
+def build_performance_report(
+    *,
+    scope: dict[str, object],
+    probe_results: list[dict[str, object]],
+) -> dict[str, object]:
+    selected_probes = _dict_list(scope.get("selected_probes"))
+    probe_result_map = {
+        str(result.get("probe", {}).get("id", "")): result
+        for result in probe_results
+        if isinstance(result, dict)
+    }
+    rows: list[dict[str, object]] = []
+    regression_count = 0
+    verification_failure_count = 0
+    for probe_entry in selected_probes:
+        probe_id = str(probe_entry.get("id", "")).strip()
+        if not probe_id:
+            continue
+        result = probe_result_map.get(probe_id)
+        if result is None:
+            rows.append(
+                {
+                    "probe_id": probe_id,
+                    "name": str(probe_entry.get("name", probe_id)),
+                    "status": "missing_result",
+                    "metrics": [],
+                    "coverage_pct": None,
+                    "test_ok": False,
+                    "coverage_ok": False,
+                    "details": "Probe result artifact is missing.",
+                }
+            )
+            verification_failure_count += 1
+            continue
+        row = _build_probe_report_row(result)
+        rows.append(row)
+        if row["status"] == "regression":
+            regression_count += 1
+        if row["status"] in {"verification_failed", "probe_failed", "missing_result"}:
+            verification_failure_count += 1
+    status = "ok"
+    if verification_failure_count:
+        status = "verification_failed"
+    elif regression_count:
+        status = "regression"
+    return {
+        "schema_version": _REPORT_SCHEMA_VERSION,
+        "summary": {
+            "status": status,
+            "changed_file_count": len(_string_list(scope.get("changed_files"))),
+            "selected_probe_count": len(selected_probes),
+            "regression_count": regression_count,
+            "verification_failure_count": verification_failure_count,
+            "force_all": bool(scope.get("force_all", False)),
+        },
+        "changed_files": _string_list(scope.get("changed_files")),
+        "rows": rows,
+    }
+
+
+def render_terminal_report(report: dict[str, object]) -> str:
+    summary = report.get("summary", {})
+    lines = [
+        "Melix PR Scoped Performance Report",
+        f"Status: {summary.get('status', 'ok')}",
+        f"Changed files: {summary.get('changed_file_count', 0)}",
+        f"Selected probes: {summary.get('selected_probe_count', 0)}",
+        f"Regressions: {summary.get('regression_count', 0)}",
+        f"Verification failures: {summary.get('verification_failure_count', 0)}",
+        "",
+    ]
+    rows = _dict_list(report.get("rows"))
+    if not rows:
+        lines.append("No registered performance probes were selected for this change set.")
+        return "\n".join(lines) + "\n"
+    for row in rows:
+        lines.extend(_render_probe_terminal_block(row))
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_markdown_report(report: dict[str, object]) -> str:
+    summary = report.get("summary", {})
+    lines = [
+        "# Melix PR Scoped Performance Report",
+        "",
+        f"- Status: `{summary.get('status', 'ok')}`",
+        f"- Changed files: `{summary.get('changed_file_count', 0)}`",
+        f"- Selected probes: `{summary.get('selected_probe_count', 0)}`",
+        f"- Regressions: `{summary.get('regression_count', 0)}`",
+        f"- Verification failures: `{summary.get('verification_failure_count', 0)}`",
+        "",
+    ]
+    changed_files = _string_list(report.get("changed_files"))
+    if changed_files:
+        lines.append("## Changed Files")
+        lines.append("")
+        for path in changed_files[:20]:
+            lines.append(f"- `{path}`")
+        if len(changed_files) > 20:
+            lines.append(f"- `... (+{len(changed_files) - 20} more)`")
+        lines.append("")
+    rows = _dict_list(report.get("rows"))
+    if not rows:
+        lines.append("No registered performance probes were selected for this pull request.")
+        lines.append("")
+        return "\n".join(lines)
+    for row in rows:
+        lines.extend(_render_probe_markdown_block(row))
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_sticky_comment_body(markdown_report: str) -> str:
+    return f"{_COMMENT_MARKER}\n{markdown_report.rstrip()}\n"
+
+
+def write_report_outputs(report: dict[str, object], output_dir: str | Path) -> dict[str, Path]:
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    json_path = root / "report.json"
+    markdown_path = root / "report.md"
+    json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_markdown_report(report), encoding="utf-8")
+    return {"json": json_path, "markdown": markdown_path}
+
+
+def _run_head_verification(*, probe: ProbeDefinition, repo_root: Path) -> dict[str, object]:
+    test_result = _run_command(probe.test_command, cwd=repo_root)
+    coverage_result = (
+        _run_command(probe.coverage_command, cwd=repo_root)
+        if test_result["ok"]
+        else {
+            "command": probe.coverage_command,
+            "ok": False,
+            "returncode": None,
+            "stdout": "",
+            "stderr": "Skipped because the targeted test command failed.\n",
+            "coverage_pct": None,
+        }
+    )
+    return {"test": test_result, "coverage": coverage_result}
+
+
+def _run_command(command: str, *, cwd: Path) -> dict[str, object]:
+    completed = subprocess.run(
+        command,
+        shell=True,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
+    return {
+        "command": command,
+        "ok": completed.returncode == 0,
+        "returncode": completed.returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+        "coverage_pct": _parse_coverage_percent(stdout),
+    }
+
+
+def _run_probe_impl(*, probe: ProbeDefinition, repo_root: Path, repo_label: str) -> dict[str, object]:
+    started = time.perf_counter()
+    try:
+        metrics = _dispatch_probe_impl(probe=probe, repo_root=repo_root)
+        return {
+            "repo_label": repo_label,
+            "ok": True,
+            "elapsed_ms": round((time.perf_counter() - started) * 1000.0, 3),
+            "metrics": metrics,
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "repo_label": repo_label,
+            "ok": False,
+            "elapsed_ms": round((time.perf_counter() - started) * 1000.0, 3),
+            "error": f"{type(exc).__name__}: {exc}",
+            "metrics": {},
+        }
+
+
+def _dispatch_probe_impl(*, probe: ProbeDefinition, repo_root: Path) -> dict[str, float]:
+    if probe.probe_impl == "benchmark_evaluation_report":
+        return _probe_benchmark_evaluation_report(repo_root)
+    if probe.probe_impl == "closure_audit":
+        return _probe_closure_audit(repo_root)
+    raise ValueError(f"unsupported probe implementation: {probe.probe_impl}")
+
+
+def _probe_benchmark_evaluation_report(repo_root: Path) -> dict[str, float]:
+    module = _load_repo_module(
+        repo_root / "services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py",
+        unique_name="melix_probe_benchmark_evaluation_report",
+    )
+    baseline = _build_large_benchmark_bundle(base_value=100.0)
+    candidate = _build_large_benchmark_bundle(base_value=108.0)
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    row_count = 0.0
+    for _ in range(3):
+        gc.collect()
+        tracemalloc.start()
+        started = time.perf_counter()
+        report = module.build_benchmark_evaluation_report(baseline=baseline, candidate=candidate)
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        peak_samples.append(float(peak_bytes))
+        tracemalloc.stop()
+        row_count = float(len(report.get("rows", [])))
+    return {
+        "elapsed_ms_mean": round(sum(elapsed_samples) / len(elapsed_samples), 3),
+        "peak_bytes_mean": round(sum(peak_samples) / len(peak_samples), 1),
+        "row_count": row_count,
+    }
+
+
+def _probe_closure_audit(repo_root: Path) -> dict[str, float]:
+    module = _load_repo_module(
+        repo_root / "services/mlx-worker-python/worker/productization/closure_audit.py",
+        unique_name="melix_probe_closure_audit",
+    )
+    with tempfile.TemporaryDirectory(prefix="melix-pr-perf-closure-audit-") as temp_dir:
+        seeded_root = _seed_closure_audit_repo(Path(temp_dir))
+        elapsed_samples: list[float] = []
+        read_samples: list[float] = []
+        finding_count = 0.0
+        for _ in range(3):
+            gc.collect()
+            read_count = 0
+            original_read_text = Path.read_text
+
+            def tracked_read_text(path: Path, *args: object, **kwargs: object) -> str:
+                nonlocal read_count
+                if path.suffix in _TEXT_FILE_SUFFIXES and _is_relative_to(path, seeded_root):
+                    read_count += 1
+                return original_read_text(path, *args, **kwargs)
+
+            Path.read_text = tracked_read_text  # type: ignore[method-assign]
+            try:
+                started = time.perf_counter()
+                report = module.build_closure_audit(seeded_root, created_at_unix_ms=7)
+                elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+            finally:
+                Path.read_text = original_read_text  # type: ignore[method-assign]
+            read_samples.append(float(read_count))
+            finding_count = float(len(report.findings))
+    return {
+        "elapsed_ms_mean": round(sum(elapsed_samples) / len(elapsed_samples), 3),
+        "probe_file_reads_mean": round(sum(read_samples) / len(read_samples), 3),
+        "finding_count": finding_count,
+    }
+
+
+def _load_repo_module(path: Path, *, unique_name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(unique_name, path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"could not load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[unique_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except FileNotFoundError as exc:
+        raise ValueError(f"could not load module from {path}") from exc
+    return module
+
+
+def _build_large_benchmark_bundle(*, base_value: float) -> dict[str, object]:
+    benchmark_results = [
+        {
+            "job_id": f"bench-{index}",
+            "suite": "smoke",
+            "metrics": [
+                {"name": f"bench.smoke.metric_{index}.ttft_ms", "value": base_value + index},
+                {
+                    "name": f"bench.smoke.metric_{index}.tokens_per_second",
+                    "value": (base_value * 2.0) + index,
+                },
+            ],
+        }
+        for index in range(250)
+    ]
+    benchmark_context_rows = [
+        {
+            "suite": "smoke",
+            "context_length": 1024 + index,
+            "generation_length": 64,
+            "batch_size": 1,
+            "prefill_ms": base_value + (index % 7),
+            "decode_ms": (base_value / 2.0) + (index % 5),
+            "cache_hit": index % 3 == 0,
+        }
+        for index in range(900)
+    ]
+    benchmark_matrix_summary_rows = [
+        {
+            "suite_id": "smoke",
+            "context_length": 1024 + index,
+            "generation_length": 64,
+            "batch_size": 1,
+            "concurrency_level": 1,
+            "request_latency_mean_ms": base_value + index,
+            "request_latency_p95_ms": base_value + index + 3,
+            "ttft_mean_ms": base_value + index / 4.0,
+            "ttft_p95_ms": base_value + index / 3.0,
+            "throughput_tokens_per_second": 200.0 + index,
+            "success_rate": 1.0,
+            "failed_count": 0,
+        }
+        for index in range(180)
+    ]
+    benchmark_matrix_request_rows = [
+        {
+            "suite_id": "smoke",
+            "context_length": 1024 + (index % 180),
+            "generation_length": 64,
+            "batch_size": 1,
+            "concurrency_level": 1,
+            "prefill_ms": base_value + (index % 9),
+            "decode_ms": base_value + (index % 11),
+            "speculative_acceptance_rate": 0.7,
+            "speculative_rejected_tokens": index % 4,
+            "speculative_fallback_count": index % 2,
+            "dflash_enabled": True,
+            "dflash_rollback_count": index % 3,
+        }
+        for index in range(1200)
+    ]
+    evaluation_summary_rows = [
+        {
+            "suite_id": f"eval-{index}",
+            "dataset_id": "mmlu.dev.v1",
+            "primary_score_name": "typed_score_mean",
+            "primary_score_value": 0.7 + ((index % 5) / 100.0),
+            "sample_size": 8,
+            "failure_count": 0,
+            "duration_seconds": 5.0,
+        }
+        for index in range(90)
+    ]
+    evaluation_sample_rows = [
+        {
+            "suite_id": f"eval-{index % 90}",
+            "dataset_id": "mmlu.dev.v1",
+            "sample_render_ms": base_value + (index % 6),
+            "inference_ms": base_value + (index % 8),
+            "extraction_ms": base_value / 3.0,
+            "validation_ms": base_value / 4.0,
+            "scoring_ms": base_value / 5.0,
+            "raw_response_chars": 120 + index,
+            "extracted_result_chars": 80 + index,
+        }
+        for index in range(600)
+    ]
+    return {
+        "benchmark_results": benchmark_results,
+        "benchmark_context_rows": benchmark_context_rows,
+        "benchmark_matrix_summary_rows": benchmark_matrix_summary_rows,
+        "benchmark_matrix_request_rows": benchmark_matrix_request_rows,
+        "evaluation_summary_rows": evaluation_summary_rows,
+        "evaluation_sample_rows": evaluation_sample_rows,
+    }
+
+
+def _seed_closure_audit_repo(root: Path) -> Path:
+    repo_root = root / "repo"
+    _write(repo_root / "docs/plans/2026-03-30-full-capability-roadmap-execution-index.md", _closure_index_text())
+    _write(
+        repo_root / "docs/plans/2026-03-30-m9-7-security-and-stability-closure-audit.md",
+        "# M9.7\n\n- repository-owned evidence only\n",
+    )
+    _write(
+        repo_root / "infra/release/phase8-release-gate-policy.json",
+        json.dumps(
+            {
+                "install": {},
+                "benchmarks": {},
+                "training": {},
+                "recovery": {},
+                "audio": {},
+                "runtime_core": {},
+                "evaluation": {},
+                "quantization": {},
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+    )
+    _write(repo_root / "scripts/phase8_metrics_report.py", "print('phase8 metrics report')\n")
+    _write(repo_root / "docs/runbooks/phase-8-release-gates.md", "# Phase 8 Release Gates\n")
+    for relative_path in (
+        "docs/runbooks/shared-access.md",
+        "docs/runbooks/persistent-sessions.md",
+        "docs/runbooks/rich-output-sanitization.md",
+        "docs/runbooks/connection-lifecycle.md",
+    ):
+        _write(repo_root / relative_path, f"# {relative_path}\n")
+    probe_text = "\n".join(
+        [
+            "gateway.accepted_api_key_count",
+            "shared_access.accepted_client_count",
+            "shared_access.rejected_request_count",
+            "persistent_session.restore_success_rate",
+            "persistent_session.sign_out_latency_ms",
+            "sanitized_output.enforcement_count",
+            "sanitized_output.blocked_html_fragment_count",
+            "sanitized_output.unsafe_uri_rejection_count",
+            "disconnect.keepalive_gap_ms",
+            "disconnect.recovery_latency_ms",
+            "disconnect.resume_success_rate",
+            "disconnect.terminal_failure_count",
+        ]
+    )
+    docs_root = repo_root / "docs"
+    for index in range(3):
+        _write(docs_root / f"a-probe-{index}.md", probe_text + "\n")
+    for index in range(250):
+        _write(docs_root / f"z-noise-{index:03d}.md", f"noise file {index}\n")
+    services_root = repo_root / "services"
+    for index in range(150):
+        _write(services_root / f"module-{index:03d}.py", f"# module {index}\n")
+    return repo_root
+
+
+def _closure_index_text() -> str:
+    return "\n".join(
+        [
+            "# Melix Full Capability Roadmap Execution Index",
+            "",
+            "- `M9.3` `docs/plans/m9.3-placeholder.md`",
+            "  Status: completed. placeholder.",
+            "- `M9.4` `docs/plans/m9.4-placeholder.md`",
+            "  Status: completed. placeholder.",
+            "- `M9.5` `docs/plans/m9.5-placeholder.md`",
+            "  Status: completed. placeholder.",
+            "- `M9.6` `docs/plans/m9.6-placeholder.md`",
+            "  Status: completed. placeholder.",
+            "- `M9.7` `docs/plans/m9.7-placeholder.md`",
+            "  Status: pending. placeholder.",
+            "- `M9.8` `docs/plans/m9.8-placeholder.md`",
+            "  Status: pending. placeholder.",
+            "",
+        ]
+    )
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _build_probe_report_row(result: dict[str, object]) -> dict[str, object]:
+    probe = result.get("probe", {}) if isinstance(result.get("probe"), dict) else {}
+    metrics = []
+    regression_count = 0
+    for metric_definition in _dict_list(probe.get("metrics")):
+        key = str(metric_definition.get("key", "")).strip()
+        if not key:
+            continue
+        metric_row = _build_metric_row(
+            key=key,
+            unit=str(metric_definition.get("unit", "value")),
+            direction=str(metric_definition.get("direction", "lower_is_better")),
+            warn_pct=float(metric_definition.get("warn_pct", 5.0)),
+            base_metrics=result.get("base_probe", {}).get("metrics", {}),
+            head_metrics=result.get("head_probe", {}).get("metrics", {}),
+        )
+        metrics.append(metric_row)
+        if metric_row["status"] == "regression":
+            regression_count += 1
+    test_ok = bool(result.get("head_verification", {}).get("test", {}).get("ok", False))
+    coverage_ok = bool(result.get("head_verification", {}).get("coverage", {}).get("ok", False))
+    base_ok = bool(result.get("base_probe", {}).get("ok", False))
+    head_ok = bool(result.get("head_probe", {}).get("ok", False))
+    coverage_pct = result.get("head_verification", {}).get("coverage", {}).get("coverage_pct")
+    status = "ok"
+    if not test_ok or not coverage_ok:
+        status = "verification_failed"
+    elif not base_ok or not head_ok:
+        status = "probe_failed"
+    elif regression_count:
+        status = "regression"
+    return {
+        "probe_id": str(probe.get("id", "")),
+        "name": str(probe.get("name", probe.get("id", "probe"))),
+        "status": status,
+        "metrics": metrics,
+        "coverage_pct": coverage_pct,
+        "test_ok": test_ok,
+        "coverage_ok": coverage_ok,
+        "base_ok": base_ok,
+        "head_ok": head_ok,
+        "details": _build_probe_details(result=result),
+    }
+
+
+def _build_metric_row(
+    *,
+    key: str,
+    unit: str,
+    direction: str,
+    warn_pct: float,
+    base_metrics: object,
+    head_metrics: object,
+) -> dict[str, object]:
+    base_value = _float_or_none(base_metrics.get(key) if isinstance(base_metrics, dict) else None)
+    head_value = _float_or_none(head_metrics.get(key) if isinstance(head_metrics, dict) else None)
+    if base_value is None or head_value is None:
+        return {
+            "key": key,
+            "unit": unit,
+            "direction": direction,
+            "warn_pct": warn_pct,
+            "base": base_value,
+            "head": head_value,
+            "delta": None,
+            "delta_pct": None,
+            "status": "missing",
+        }
+    delta = head_value - base_value
+    delta_pct = None if base_value == 0 else (delta / base_value) * 100.0
+    status = "neutral"
+    threshold = abs(base_value) * (warn_pct / 100.0)
+    if direction == "lower_is_better":
+        if head_value > base_value + threshold:
+            status = "regression"
+        elif head_value < base_value - threshold:
+            status = "improvement"
+    else:
+        if head_value < base_value - threshold:
+            status = "regression"
+        elif head_value > base_value + threshold:
+            status = "improvement"
+    return {
+        "key": key,
+        "unit": unit,
+        "direction": direction,
+        "warn_pct": warn_pct,
+        "base": base_value,
+        "head": head_value,
+        "delta": delta,
+        "delta_pct": delta_pct,
+        "status": status,
+    }
+
+
+def _build_probe_details(*, result: dict[str, object]) -> str:
+    fragments: list[str] = []
+    if not result.get("head_verification", {}).get("test", {}).get("ok", False):
+        fragments.append("Targeted tests failed.")
+    if not result.get("head_verification", {}).get("coverage", {}).get("ok", False):
+        fragments.append("Coverage command failed.")
+    if not result.get("base_probe", {}).get("ok", False):
+        fragments.append(str(result.get("base_probe", {}).get("error", "Base probe failed.")))
+    if not result.get("head_probe", {}).get("ok", False):
+        fragments.append(str(result.get("head_probe", {}).get("error", "Head probe failed.")))
+    return " ".join(fragment for fragment in fragments if fragment).strip()
+
+
+def _render_probe_terminal_block(row: dict[str, object]) -> list[str]:
+    lines = [
+        f"Probe: {row['name']}",
+        f"  Status: {row['status']}",
+        f"  Targeted tests: {'pass' if row['test_ok'] else 'fail'}",
+        f"  Coverage: {'pass' if row['coverage_ok'] else 'fail'}"
+        + (f" ({row['coverage_pct']}%)" if row.get('coverage_pct') is not None else ""),
+    ]
+    if row.get("details"):
+        lines.append(f"  Details: {row['details']}")
+    metrics = _dict_list(row.get("metrics"))
+    for metric in metrics:
+        lines.append(
+            "  - "
+            + f"{metric['key']}: base={_format_value(metric.get('base'))} "
+            + f"head={_format_value(metric.get('head'))} "
+            + f"delta={_format_delta(metric)} status={metric['status']}"
+        )
+    return lines
+
+
+def _render_probe_markdown_block(row: dict[str, object]) -> list[str]:
+    lines = [
+        f"## {row['name']}",
+        "",
+        f"- Status: `{row['status']}`",
+        f"- Targeted tests: `{'pass' if row['test_ok'] else 'fail'}`",
+        f"- Coverage: `{'pass' if row['coverage_ok'] else 'fail'}`"
+        + (f" (`{row['coverage_pct']}%`)" if row.get('coverage_pct') is not None else ""),
+    ]
+    if row.get("details"):
+        lines.append(f"- Details: {row['details']}")
+    lines.extend(
+        [
+            "",
+            "| Metric | Base | Head | Delta | Status |",
+            "| --- | ---: | ---: | ---: | --- |",
+        ]
+    )
+    for metric in _dict_list(row.get("metrics")):
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _markdown_cell(metric.get("key")),
+                    _markdown_cell(_format_value(metric.get("base"))),
+                    _markdown_cell(_format_value(metric.get("head"))),
+                    _markdown_cell(_format_delta(metric)),
+                    _markdown_cell(metric.get("status")),
+                ]
+            )
+            + " |"
+        )
+    return lines
+
+
+def _parse_coverage_percent(output: str) -> float | None:
+    match = _COVERAGE_PERCENT_RE.search(output)
+    if match is None:
+        return None
+    return float(match.group(1))
+
+
+def _format_value(value: object) -> str:
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    if isinstance(value, int):
+        return str(value)
+    if value is None:
+        return "-"
+    return str(value)
+
+
+def _format_delta(metric: dict[str, object]) -> str:
+    delta = _float_or_none(metric.get("delta"))
+    delta_pct = _float_or_none(metric.get("delta_pct"))
+    if delta is None:
+        return "-"
+    if delta_pct is None:
+        return f"{delta:+.3f}"
+    return f"{delta:+.3f} ({delta_pct:+.2f}%)"
+
+
+def _markdown_cell(value: object) -> str:
+    return str(value).replace("|", "\\|")
+
+
+def _dict_list(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _float_or_none(value: object) -> float | None:
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, (float, int)):
+        return float(value)
+    return None
+
+
+def _matches_any_glob(path: str, globs: tuple[str, ...]) -> bool:
+    return any(fnmatch.fnmatch(path, glob) for glob in globs)
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False


### PR DESCRIPTION
## Summary
- add a dedicated `pr-scoped-performance` workflow that selects only the registered performance probes affected by the PR diff
- compare scoped base-vs-head probe results, run targeted verification/coverage on the head checkout, and publish a sticky PR comment
- seed the registry with Python-safe probes for `benchmark_evaluation_report` and `closure_audit`, plus scripts/tests for scope resolution, probe execution, and report rendering

## Plan or Spec
- `docs/plans/2026-05-01-pr-scoped-performance-ci.md`

## Commands Run
```text
python -m py_compile scripts/pr_scoped_performance_scope.py scripts/pr_scoped_performance_run.py scripts/pr_scoped_performance_report.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/pr_scoped_performance_scope.py scripts/pr_scoped_performance_run.py scripts/pr_scoped_performance_report.py
python - <<'PY'
import yaml, pathlib
path = pathlib.Path('.github/workflows/pr-scoped-performance.yml')
yaml.safe_load(path.read_text())
print('yaml ok')
PY
python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json <(python - <<'PY'
import json
print(json.dumps(['services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py']))
PY
)
python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-evaluation-report-running-aggregates --base-repo "$PWD" --head-repo "$PWD" --output /tmp/benchmark-probe.json
python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id closure-audit-probe-source-short-circuit --base-repo "$PWD" --head-repo "$PWD" --output /tmp/closure-probe.json
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 96%`
- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`: `96%`
- `scripts/pr_scoped_performance_run.py`: `96%`
- `scripts/pr_scoped_performance_scope.py`: `92%`
- `scripts/pr_scoped_performance_report.py`: `84%`
- Local scoped probe smoke results:
  - `benchmark-evaluation-report-running-aggregates`: targeted tests `22 passed`, coverage `99%`, local base/head smoke probe emitted `elapsed_ms_mean` and `peak_bytes_mean`
  - `closure-audit-probe-source-short-circuit`: targeted tests `8 passed`, coverage `98%`, local base/head smoke probe emitted `elapsed_ms_mean` and `probe_file_reads_mean`
- Example combined terminal report on local same-repo base/head smoke run:
  - overall status `ok`
  - benchmark probe delta `elapsed_ms_mean -4.30%`
  - closure-audit probe delta `elapsed_ms_mean -5.22%`

## Known Gaps
- Only code paths with registered probes participate in this CI; unregistered paths will report that no scoped probe matched instead of inventing coverage.
- The seeded probes are Linux-safe Python probes, so this initial workflow does not yet cover macOS/Swift-only performance surfaces.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
