### PR TITLE
perf: reuse sorted token lists for dataset stats

### DIFF
--- a/docs/plans/2026-05-01-training-dataset-token-percentiles-optimization.md
+++ b/docs/plans/2026-05-01-training-dataset-token-percentiles-optimization.md
@@ -1,0 +1,45 @@
+# Training Dataset Token Percentile Optimization Plan
+
+## Goal
+
+Reduce redundant sorting work in `services/mlx-worker-python/worker/model_ops/training_dataset.py` when building training-dataset token statistics, while preserving output values and Linux-local verification.
+
+## Constraints
+
+- Host verification is Linux-only.
+- Scope must stay inside Python worker and PR-scoped performance CI.
+- Changes must remain behavior-preserving for dataset inspection and manifest token statistics.
+- Automated coverage for touched executable Python files must be at least 95% before commit.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset.py`
+- `services/mlx-worker-python/tests/test_training_dataset_builder.py`
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Optimization Slice
+
+1. Replace repeated percentile sorting for prompt/completion/total token lists with one pre-sort per list.
+2. Keep `sample_count`, means, percentiles, and maxima identical.
+3. Register a PR-scoped performance probe for the touched path so GitHub can compare `origin/main` vs PR head.
+
+## Performance Probe
+
+- **Probe ID:** `training-dataset-token-percentiles-single-sort`
+- **Local measurement:** synthetic large-sample benchmark around `_build_quality_and_token_stats(...)` with fixed prompt/completion samples.
+- **PR-scoped CI measurement:** base-vs-head probe in `pr_scoped_performance.py` that records:
+  - `elapsed_ms_mean`
+  - `sample_count`
+- **Success metric:** identical token-stat outputs with lower `elapsed_ms_mean` on the synthetic probe.
+
+## Verification Commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-token-percentiles-single-sort --base-repo /root/.openclaw/workspace/melix --head-repo "$PWD" --output /tmp/melix-training-dataset-probe.json
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -51,5 +51,27 @@
         "warn_pct": 0.0
       }
     ]
+  },
+  {
+    "id": "training-dataset-token-percentiles-single-sort",
+    "name": "Training dataset token percentiles single sort",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/training_dataset.py",
+      "services/mlx-worker-python/tests/test_training_dataset_builder.py",
+      "services/mlx-worker-python/worker/productization/pr_scoped_performance.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_impl": "training_dataset_token_percentiles",
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
   }
 ]

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -9,6 +9,7 @@ import pytest
 
 from worker.productization.pr_scoped_performance import (
     _build_large_benchmark_bundle,
+    _build_large_training_dataset_samples,
     _build_metric_row,
     _build_probe_report_row,
     _build_probe_details,
@@ -25,6 +26,7 @@ from worker.productization.pr_scoped_performance import (
     _parse_coverage_percent,
     _probe_benchmark_evaluation_report,
     _probe_closure_audit,
+    _probe_training_dataset_token_percentiles,
     _run_command,
     _run_head_verification,
     _run_probe_impl,
@@ -65,6 +67,16 @@ def test_scope_report_selects_only_matching_probe() -> None:
     selected_probe = scope["selected_probes"][0]
     assert selected_probe["id"] == "closure-audit-probe-source-short-circuit"
     assert scope["force_all"] is False
+
+
+def test_scope_report_selects_training_dataset_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/model_ops/training_dataset.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "training-dataset-token-percentiles-single-sort"
 
 
 def test_scope_report_force_selects_all_on_infra_change() -> None:
@@ -117,6 +129,7 @@ def test_load_probe_registry_rejects_invalid_payloads(tmp_path: Path) -> None:
 def test_probe_smokes_return_metrics_against_current_repo() -> None:
     benchmark_metrics = _probe_benchmark_evaluation_report(REPO_ROOT)
     closure_metrics = _probe_closure_audit(REPO_ROOT)
+    training_dataset_metrics = _probe_training_dataset_token_percentiles(REPO_ROOT)
 
     assert benchmark_metrics["elapsed_ms_mean"] > 0
     assert benchmark_metrics["peak_bytes_mean"] > 0
@@ -124,6 +137,10 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     assert closure_metrics["elapsed_ms_mean"] > 0
     assert closure_metrics["probe_file_reads_mean"] > 0
     assert closure_metrics["finding_count"] > 0
+    assert training_dataset_metrics["elapsed_ms_mean"] > 0
+    assert training_dataset_metrics["sample_count"] == 20000.0
+    assert training_dataset_metrics["prompt_tokens_p95"] > 0
+    assert training_dataset_metrics["total_tokens_p95"] > 0
 
 
 def test_run_probe_job_executes_verification_and_probe_for_current_repo() -> None:
@@ -318,9 +335,12 @@ def test_dispatch_and_module_loading_helpers_cover_failure_paths(tmp_path: Path)
 
 def test_data_generation_and_formatting_helpers_cover_misc_branches(tmp_path: Path) -> None:
     bundle = _build_large_benchmark_bundle(base_value=42.0)
+    training_samples = _build_large_training_dataset_samples()
     assert len(bundle["benchmark_results"]) == 250
     assert len(bundle["benchmark_context_rows"]) == 900
     assert len(bundle["benchmark_matrix_request_rows"]) == 1200
+    assert len(training_samples) == 20000
+    assert all("prompt" in sample and "completion" in sample for sample in training_samples[:3])
 
     seeded_root = _seed_closure_audit_repo(tmp_path)
     assert (seeded_root / "docs/plans/2026-03-30-full-capability-roadmap-execution-index.md").is_file()

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -626,6 +626,38 @@ def test_build_training_dataset_artifact_loads_existing_package_and_helper_branc
     assert training_dataset_module._mean_value([]) == 0.0
     assert training_dataset_module._percentile_value([], 0.95) == 0
 
+
+def test_build_token_stats_reuses_single_sorted_pass_per_token_series(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_percentile_value(values: list[int], pct: float) -> int:
+        raise AssertionError(f"legacy percentile helper should not run for optimized token stats ({pct=}, {values=})")
+
+    monkeypatch.setattr(training_dataset_module, "_percentile_value", fail_percentile_value)
+
+    assert training_dataset_module._build_token_stats(
+        [
+            {"prompt": "a b c", "completion": "d e"},
+            {"prompt": "f", "completion": "g h i j"},
+            {"prompt": "k l", "completion": "m"},
+            {"prompt": "n o p q", "completion": "r s t"},
+        ],
+        "prompt_completion",
+    ) == {
+        "estimator": "whitespace_v1",
+        "sample_count": 4,
+        "prompt_tokens_mean": 2.5,
+        "prompt_tokens_p50": 2,
+        "prompt_tokens_p95": 3,
+        "prompt_tokens_max": 4,
+        "completion_tokens_mean": 2.5,
+        "completion_tokens_p50": 2,
+        "completion_tokens_p95": 3,
+        "completion_tokens_max": 4,
+        "total_tokens_mean": 5.0,
+        "total_tokens_p50": 5,
+        "total_tokens_p95": 5,
+        "total_tokens_max": 7,
+    }
+
     with pytest.raises(ModelOperationError) as int_parse_exc:
         training_dataset_module._int_ext_value(
             "bad",

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1314,6 +1314,10 @@ def _build_quality_and_token_stats(
         completion_tokens.append(completion_count)
         total_tokens.append(prompt_count + completion_count)
 
+    prompt_summary = _summarize_token_values(prompt_tokens)
+    completion_summary = _summarize_token_values(completion_tokens)
+    total_summary = _summarize_token_values(total_tokens)
+
     return (
         {
             "duplicate_count": len(duplicate_indices),
@@ -1324,18 +1328,18 @@ def _build_quality_and_token_stats(
         {
             "estimator": "whitespace_v1",
             "sample_count": sample_count,
-            "prompt_tokens_mean": _mean_value(prompt_tokens),
-            "prompt_tokens_p50": _percentile_value(prompt_tokens, 0.50),
-            "prompt_tokens_p95": _percentile_value(prompt_tokens, 0.95),
-            "prompt_tokens_max": max(prompt_tokens, default=0),
-            "completion_tokens_mean": _mean_value(completion_tokens),
-            "completion_tokens_p50": _percentile_value(completion_tokens, 0.50),
-            "completion_tokens_p95": _percentile_value(completion_tokens, 0.95),
-            "completion_tokens_max": max(completion_tokens, default=0),
-            "total_tokens_mean": _mean_value(total_tokens),
-            "total_tokens_p50": _percentile_value(total_tokens, 0.50),
-            "total_tokens_p95": _percentile_value(total_tokens, 0.95),
-            "total_tokens_max": max(total_tokens, default=0),
+            "prompt_tokens_mean": prompt_summary["mean"],
+            "prompt_tokens_p50": prompt_summary["p50"],
+            "prompt_tokens_p95": prompt_summary["p95"],
+            "prompt_tokens_max": prompt_summary["max"],
+            "completion_tokens_mean": completion_summary["mean"],
+            "completion_tokens_p50": completion_summary["p50"],
+            "completion_tokens_p95": completion_summary["p95"],
+            "completion_tokens_max": completion_summary["max"],
+            "total_tokens_mean": total_summary["mean"],
+            "total_tokens_p50": total_summary["p50"],
+            "total_tokens_p95": total_summary["p95"],
+            "total_tokens_max": total_summary["max"],
         },
     )
 
@@ -1434,12 +1438,25 @@ def _mean_value(values: list[int]) -> float:
     return round(sum(values) / len(values), 3)
 
 
-def _percentile_value(values: list[int], pct: float) -> int:
-    if not values:
-        return 0
+def _summarize_token_values(values: list[int]) -> dict[str, float | int]:
     ordered = sorted(values)
-    index = int((len(ordered) - 1) * pct)
-    return ordered[index]
+    return {
+        "mean": _mean_value(values),
+        "p50": _sorted_percentile_value(ordered, 0.50),
+        "p95": _sorted_percentile_value(ordered, 0.95),
+        "max": ordered[-1] if ordered else 0,
+    }
+
+
+def _sorted_percentile_value(ordered_values: list[int], pct: float) -> int:
+    if not ordered_values:
+        return 0
+    index = int((len(ordered_values) - 1) * pct)
+    return ordered_values[index]
+
+
+def _percentile_value(values: list[int], pct: float) -> int:
+    return _sorted_percentile_value(sorted(values), pct)
 
 
 def _truthy(raw_value: str) -> bool:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -349,6 +349,8 @@ def _dispatch_probe_impl(*, probe: ProbeDefinition, repo_root: Path) -> dict[str
         return _probe_benchmark_evaluation_report(repo_root)
     if probe.probe_impl == "closure_audit":
         return _probe_closure_audit(repo_root)
+    if probe.probe_impl == "training_dataset_token_percentiles":
+        return _probe_training_dataset_token_percentiles(repo_root)
     raise ValueError(f"unsupported probe implementation: {probe.probe_impl}")
 
 
@@ -413,6 +415,32 @@ def _probe_closure_audit(repo_root: Path) -> dict[str, float]:
         "elapsed_ms_mean": round(sum(elapsed_samples) / len(elapsed_samples), 3),
         "probe_file_reads_mean": round(sum(read_samples) / len(read_samples), 3),
         "finding_count": finding_count,
+    }
+
+
+def _probe_training_dataset_token_percentiles(repo_root: Path) -> dict[str, float]:
+    module = _load_repo_module(
+        repo_root / "services/mlx-worker-python/worker/model_ops/training_dataset.py",
+        unique_name="melix_probe_training_dataset_token_percentiles",
+    )
+    samples = _build_large_training_dataset_samples()
+    elapsed_samples: list[float] = []
+    prompt_p95 = 0.0
+    total_p95 = 0.0
+    sample_count = 0.0
+    for _ in range(3):
+        gc.collect()
+        started = time.perf_counter()
+        token_stats = module._build_token_stats(samples, "prompt_completion")
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        prompt_p95 = float(token_stats["prompt_tokens_p95"])
+        total_p95 = float(token_stats["total_tokens_p95"])
+        sample_count = float(token_stats["sample_count"])
+    return {
+        "elapsed_ms_mean": round(sum(elapsed_samples) / len(elapsed_samples), 3),
+        "sample_count": sample_count,
+        "prompt_tokens_p95": prompt_p95,
+        "total_tokens_p95": total_p95,
     }
 
 
@@ -524,6 +552,16 @@ def _build_large_benchmark_bundle(*, base_value: float) -> dict[str, object]:
         "evaluation_summary_rows": evaluation_summary_rows,
         "evaluation_sample_rows": evaluation_sample_rows,
     }
+
+
+def _build_large_training_dataset_samples() -> list[dict[str, str]]:
+    return [
+        {
+            "prompt": " ".join(f"prompt{index}_{token}" for token in range(1 + (index % 9))),
+            "completion": " ".join(f"completion{index}_{token}" for token in range(1 + ((index * 3) % 7))),
+        }
+        for index in range(20000)
+    ]
 
 
 def _seed_closure_audit_repo(root: Path) -> Path:


### PR DESCRIPTION
## Summary
- Reuse one sorted token list per prompt/completion/total series when building training-dataset token stats instead of sorting the same values repeatedly for each percentile lookup.
- Add a focused regression test that fails if the optimized token-stat path falls back to the legacy repeated-sort helper.
- Register a PR-scoped performance probe for this path so the PR gets a base-vs-head timing comparison on GitHub Actions.

## Plan or Spec
- `docs/plans/2026-05-01-training-dataset-token-percentiles-optimization.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 33 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage erase
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o /tmp/melix-coverage.json
# changed executable scope from git diff:
# - services/mlx-worker-python/worker/model_ops/training_dataset.py: 100.00% changed-line coverage
# - services/mlx-worker-python/worker/productization/pr_scoped_performance.py: 95.00% changed-line coverage

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-token-percentiles-single-sort --base-repo /tmp/melix-base-20260501-053402 --head-repo "$PWD" --output /tmp/melix-training-dataset-probe-origin-main.json
# base elapsed_ms_mean=273.489
# head elapsed_ms_mean=268.294
# prompt_tokens_p95 and total_tokens_p95 unchanged

git diff --check
# clean
```

## Coverage and Metrics
- Changed executable scope coverage:
  - `services/mlx-worker-python/worker/model_ops/training_dataset.py`: `100.00%` changed-line coverage (`12/12` measurable changed lines covered)
  - `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`: `95.00%` changed-line coverage (`19/20` measurable changed lines covered)
- Focused test suites: `33 passed`
- PR-scoped local probe (`training-dataset-token-percentiles-single-sort`):
  - base `elapsed_ms_mean=273.489`
  - head `elapsed_ms_mean=268.294`
  - delta `-5.195 ms` (`-1.90%`, lower is better)
  - `prompt_tokens_p95=9.0` on both base/head
  - `total_tokens_p95=14.0` on both base/head
- Full-file focused coverage report remains lower for `training_dataset.py` because the file is large and only a narrow executable slice changed; the changed executable scope above is the policy signal for this PR.

## Known Gaps
- Local verification covered the Python worker slice only; repository-wide `make swift-test` / `make integration-test` were not run on this Linux host.
- The new PR-scoped performance probe is intentionally narrow and validates only the touched token-stat path.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] No protocol changes were made, so regenerated generated artifacts were not needed.
- [x] No dependency changes were made, so lockfile updates were not needed.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
