### PR TITLE
perf: cache benchmark report direction fragments

### DIFF
--- a/docs/plans/2026-05-01-pr-scoped-performance-ci.md
+++ b/docs/plans/2026-05-01-pr-scoped-performance-ci.md
@@ -97,6 +97,15 @@ Planned initial entries:
 - Local execution of seeded probe runners on the current checkout.
 - Local YAML validation for the new workflow.
 
+## Iterative Optimization Slices
+
+### Benchmark evaluation metric-direction constants
+
+- Scope: `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`.
+- Probe: `benchmark-evaluation-report-running-aggregates` remains the registered CI and local probe for this path.
+- Slice boundary: hoist the metric-direction fragment tables out of `_metric_direction` and use direct loops so the large synthetic report path does not rebuild identical tuples or allocate generator objects once per metric row.
+- Verification target: focused benchmark-evaluation report tests, changed-scope coverage, and the registered PR-scoped performance probe.
+
 ## Known Constraints
 
 - Only code paths with registered probes participate in this CI.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -66,6 +66,7 @@
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
     "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c \"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_training_dataset_token_percentiles as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))\"",
     "probe_impl": "training_dataset_token_percentiles",
     "metrics": [
       {

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -10,6 +10,7 @@
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py",
     "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c \"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_benchmark_evaluation_report as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))\"",
     "probe_impl": "benchmark_evaluation_report",
     "metrics": [
       {
@@ -36,6 +37,7 @@
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_closure_audit.py",
     "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_closure_audit.py && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/closure_audit.py services/mlx-worker-python/tests/test_closure_audit.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c \"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_closure_audit as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))\"",
     "probe_impl": "closure_audit",
     "metrics": [
       {

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -90,6 +90,13 @@ def test_scope_report_force_selects_all_on_infra_change() -> None:
     assert scope["selected_count"] == len(load_probe_registry(REGISTRY_PATH))
 
 
+def test_registered_probes_expose_focused_commands() -> None:
+    for probe in load_probe_registry(REGISTRY_PATH):
+        assert probe.test_command
+        assert probe.coverage_command
+        assert probe.probe_command
+
+
 def test_scope_report_with_no_matching_probe_returns_empty_selection() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -63,6 +63,39 @@ _EVALUATION_SAMPLE_PROBE_KEYS = (
     "extracted_result_chars",
 )
 _EVALUATION_SAMPLE_PROBE_KEY_SET = frozenset(_EVALUATION_SAMPLE_PROBE_KEYS)
+_LOWER_IS_BETTER_METRIC_FRAGMENTS = (
+    "latency",
+    "ttft",
+    "_ms",
+    "duration_seconds",
+    "memory",
+    "bytes",
+    "failure_count",
+    "failed_count",
+    "queue_wait",
+    "warmup",
+    "prefill_ms",
+    "decode_ms",
+    "rollback_rate",
+    "rejected_tokens",
+    "fallback_count",
+    "draft_propose_ms",
+    "target_verify_ms",
+    "dflash_rollback_count",
+)
+_HIGHER_IS_BETTER_METRIC_FRAGMENTS = (
+    "tokens_per_second",
+    "throughput",
+    "success_rate",
+    "accuracy",
+    "typed_score",
+    "pass_rate",
+    "win_count",
+    "acceptance_rate",
+    "accepted_tokens",
+    "speedup",
+    "cache_hit",
+)
 
 _NumericAggregate = tuple[float, int]
 
@@ -332,43 +365,12 @@ def _build_metric_row(
 
 def _metric_direction(metric_name: str) -> str:
     metric_key = metric_name.rsplit(".", maxsplit=1)[-1]
-    lower_fragments = (
-        "latency",
-        "ttft",
-        "_ms",
-        "duration_seconds",
-        "memory",
-        "bytes",
-        "failure_count",
-        "failed_count",
-        "queue_wait",
-        "warmup",
-        "prefill_ms",
-        "decode_ms",
-        "rollback_rate",
-        "rejected_tokens",
-        "fallback_count",
-        "draft_propose_ms",
-        "target_verify_ms",
-        "dflash_rollback_count",
-    )
-    higher_fragments = (
-        "tokens_per_second",
-        "throughput",
-        "success_rate",
-        "accuracy",
-        "typed_score",
-        "pass_rate",
-        "win_count",
-        "acceptance_rate",
-        "accepted_tokens",
-        "speedup",
-        "cache_hit",
-    )
-    if any(fragment in metric_key for fragment in lower_fragments):
-        return "lower_is_better"
-    if any(fragment in metric_key for fragment in higher_fragments):
-        return "higher_is_better"
+    for fragment in _LOWER_IS_BETTER_METRIC_FRAGMENTS:
+        if fragment in metric_key:
+            return "lower_is_better"
+    for fragment in _HIGHER_IS_BETTER_METRIC_FRAGMENTS:
+        if fragment in metric_key:
+            return "higher_is_better"
     return "neutral"
 
 

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -63,6 +63,9 @@ class ProbeDefinition:
             "name": self.name,
             "runner": self.runner,
             "watch_globs": list(self.watch_globs),
+            "test_command": self.test_command,
+            "coverage_command": self.coverage_command,
+            "probe_command": self.probe_command,
             "metrics": [metric.to_dict() for metric in self.metrics],
         }
 


### PR DESCRIPTION
## Summary
- Hoist benchmark/evaluation metric-direction fragment tables to module constants and replace per-row generator checks with direct loops.
- Add explicit `probe_command` metadata to the PR-scoped probe registry and expose it through the scope model.
- Document the benchmark report metric-direction optimization slice in the PR-scoped performance CI plan.

## Plan or Spec
- `docs/plans/2026-05-01-pr-scoped-performance-ci.md` — adds the benchmark evaluation metric-direction constants slice under iterative optimization slices.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; 36 passed in 5.83s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; 36 passed in 29.60s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; TOTAL 98%; benchmark_evaluation_report.py 99%; pr_scoped_performance.py 96%; test_benchmark_evaluation_report.py 99%; test_pr_scoped_performance.py 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-evaluation-report-running-aggregates --base-repo /tmp/melix-base-20260501054845 --head-repo "$PWD" --output /tmp/benchmark-evaluation-report-running-aggregates.json
# exit 0; base elapsed_ms_mean=193.225 ms, head elapsed_ms_mean=180.741 ms

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id closure-audit-probe-source-short-circuit --base-repo /tmp/melix-base-20260501054845 --head-repo "$PWD" --output /tmp/closure-audit-probe-source-short-circuit.json
# exit 0; registry-change force-all smoke ran locally; closure behavior metrics unchanged for finding_count=2.0 and probe_file_reads_mean=4.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: TOTAL 98%; `benchmark_evaluation_report.py` 99%; `pr_scoped_performance.py` 96%; `test_benchmark_evaluation_report.py` 99%; `test_pr_scoped_performance.py` 100%.
- Registered benchmark probe (`benchmark-evaluation-report-running-aggregates`, local Linux): `elapsed_ms_mean` improved from 193.225 ms to 180.741 ms (delta -12.484 ms, -6.46%); `peak_bytes_mean` changed from 3,785,276 bytes to 3,785,244 bytes (delta -32 bytes); `row_count` stayed 5,990.
- The registry now includes focused `test_command`, `coverage_command`, and `probe_command` entries for seeded probes. CI is still required for the canonical registered probe report before merge.

## Known Gaps
- Swift runtime effects are not touched in this slice.
- Local Linux metrics are synthetic; the PR-scoped performance workflow is the merge gate for the registered probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
