### PR TITLE
perf: skip quality work for training token stats

### DIFF
--- a/docs/plans/2026-05-01-training-dataset-token-stats-single-pass-plan.md
+++ b/docs/plans/2026-05-01-training-dataset-token-stats-single-pass-plan.md
@@ -1,0 +1,52 @@
+# Training Dataset Token Stats Single-Pass Optimization Plan
+
+## Goal
+
+Reduce redundant work in `services/mlx-worker-python/worker/model_ops/training_dataset.py` by separating token-stat collection from quality-report collection when callers only need token statistics.
+
+## Constraints
+
+- Work is being performed from a Linux host.
+- The slice must remain Python-only and locally verifiable.
+- Behavior and output schema must remain unchanged.
+- The existing PR-scoped performance probe must continue to validate the path.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset.py`
+- `services/mlx-worker-python/tests/test_training_dataset_builder.py`
+- `infra/perf/pr_scoped_probes.json` only if the existing probe coverage needs adjustment
+
+## Problem Statement
+
+`_build_token_stats()` currently delegates to `_build_quality_and_token_stats()`, which also computes duplicate digests and dirty-sample reasons. That extra quality work is unnecessary for token-stat-only callers and adds avoidable hot-path cost.
+
+## Implementation Approach
+
+1. Keep `_build_quality_and_token_stats()` for callers that need both quality and token statistics in one pass.
+2. Introduce a token-stats-only helper that only computes sample count plus prompt/completion/total token summaries.
+3. Route `_build_token_stats()` through the token-stats-only helper.
+4. Add or update focused regression tests to prove `_build_token_stats()` no longer performs duplicate-digest or dirty-sample work while preserving output.
+
+## Performance Probe
+
+- Existing scoped probe: `training-dataset-token-percentiles-single-sort`
+- Probe implementation: `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- Success metric: lower `elapsed_ms_mean` with unchanged `sample_count`, `prompt_tokens_p95`, and `total_tokens_p95`
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-token-percentiles-single-sort --base-repo . --head-repo . --output /tmp/melix-training-dataset-probe-head.json
+git diff --check
+```
+
+## Success Criteria
+
+- Focused tests pass.
+- Automated coverage for the changed executable scope is at least 95%.
+- The scoped performance probe reports improved `elapsed_ms_mean` with unchanged token-stat outputs.
+- The change remains small and reviewable.

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -658,6 +658,7 @@ def test_build_token_stats_reuses_single_sorted_pass_per_token_series(monkeypatc
         "total_tokens_max": 7,
     }
 
+
     with pytest.raises(ModelOperationError) as int_parse_exc:
         training_dataset_module._int_ext_value(
             "bad",
@@ -693,6 +694,40 @@ def test_build_token_stats_reuses_single_sorted_pass_per_token_series(monkeypatc
             field_name="validation_ratio",
         )
     assert float_range_exc.value.code == "invalid_dataset_source"
+
+
+def test_build_token_stats_skips_quality_only_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_canonical_sample_digest(sample: dict[str, object]) -> bytes:
+        raise AssertionError(f"token stats should not compute canonical digests ({sample=})")
+
+    def fail_dirty_sample_reasons(sample: dict[str, object]) -> list[str]:
+        raise AssertionError(f"token stats should not inspect dirty-sample reasons ({sample=})")
+
+    monkeypatch.setattr(training_dataset_module, "_canonical_sample_digest", fail_canonical_sample_digest)
+    monkeypatch.setattr(training_dataset_module, "_dirty_sample_reasons", fail_dirty_sample_reasons)
+
+    assert training_dataset_module._build_token_stats(
+        [
+            {"prompt": "alpha beta", "completion": "gamma delta"},
+            {"prompt": "epsilon", "completion": "zeta eta theta"},
+        ],
+        "prompt_completion",
+    ) == {
+        "estimator": "whitespace_v1",
+        "sample_count": 2,
+        "prompt_tokens_mean": 1.5,
+        "prompt_tokens_p50": 1,
+        "prompt_tokens_p95": 1,
+        "prompt_tokens_max": 2,
+        "completion_tokens_mean": 2.5,
+        "completion_tokens_p50": 2,
+        "completion_tokens_p95": 2,
+        "completion_tokens_max": 3,
+        "total_tokens_mean": 4.0,
+        "total_tokens_p50": 4,
+        "total_tokens_p95": 4,
+        "total_tokens_max": 4,
+    }
 
 
 def test_resolve_dataset_build_source_reuses_existing_package_sample_lists(

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1345,8 +1345,41 @@ def _build_quality_and_token_stats(
 
 
 def _build_token_stats(samples: Iterable[dict[str, Any]], format_name: str) -> dict[str, Any]:
-    _, token_stats = _build_quality_and_token_stats(samples, format_name)
-    return token_stats
+    return _collect_token_stats(samples, format_name)
+
+
+def _collect_token_stats(samples: Iterable[dict[str, Any]], format_name: str) -> dict[str, Any]:
+    prompt_tokens: list[int] = []
+    completion_tokens: list[int] = []
+    total_tokens: list[int] = []
+    sample_count = 0
+    for sample in samples:
+        sample_count += 1
+        prompt_count, completion_count = _sample_token_counts(sample, format_name)
+        prompt_tokens.append(prompt_count)
+        completion_tokens.append(completion_count)
+        total_tokens.append(prompt_count + completion_count)
+
+    prompt_summary = _summarize_token_values(prompt_tokens)
+    completion_summary = _summarize_token_values(completion_tokens)
+    total_summary = _summarize_token_values(total_tokens)
+
+    return {
+        "estimator": "whitespace_v1",
+        "sample_count": sample_count,
+        "prompt_tokens_mean": prompt_summary["mean"],
+        "prompt_tokens_p50": prompt_summary["p50"],
+        "prompt_tokens_p95": prompt_summary["p95"],
+        "prompt_tokens_max": prompt_summary["max"],
+        "completion_tokens_mean": completion_summary["mean"],
+        "completion_tokens_p50": completion_summary["p50"],
+        "completion_tokens_p95": completion_summary["p95"],
+        "completion_tokens_max": completion_summary["max"],
+        "total_tokens_mean": total_summary["mean"],
+        "total_tokens_p50": total_summary["p50"],
+        "total_tokens_p95": total_summary["p95"],
+        "total_tokens_max": total_summary["max"],
+    }
 
 
 def _sample_token_counts(sample: dict[str, Any], format_name: str) -> tuple[int, int]:


### PR DESCRIPTION
## Summary
- Split training-dataset token-stat collection away from duplicate-digest and dirty-sample quality inspection when callers only need token metrics.
- Keep `_build_quality_and_token_stats()` unchanged for the combined one-pass quality+token path used by dataset artifact inspection.
- Add a focused regression test proving `_build_token_stats()` no longer touches quality-only helpers.
- Add a lightweight execution plan documenting the Linux-safe verification path for this slice.

## Plan or Spec
- `docs/plans/2026-05-01-training-dataset-token-stats-single-pass-plan.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
- PASS (36 passed in 7.19s)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage erase
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
- PASS (36 passed in 32.74s)
- training_dataset.py full-file coverage: 85%
- test_training_dataset_builder.py coverage: 98%
- test_pr_scoped_performance.py coverage: 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o /tmp/melix-training-coverage.json
python3 <changed-line coverage script against git diff>
- PASS (changed executable lines: [1348, 1351, 1352, 1353, 1354, 1355, 1356, 1357, 1358, 1359, 1360, 1361, 1363, 1364, 1365, 1367])
- covered changed lines: [1348, 1351, 1352, 1353, 1354, 1355, 1356, 1357, 1358, 1359, 1360, 1361, 1363, 1364, 1365, 1367]
- missed changed lines: []
- changed executable line coverage: 100.00%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-token-percentiles-single-sort --base-repo /tmp/melix-base-20260501-073432 --head-repo /tmp/melix-20260501-073432 --output /tmp/melix-training-probe.json
- PASS
- base elapsed_ms_mean: 293.014
- head elapsed_ms_mean: 16.058
- sample_count/base=head: 20000
- prompt_tokens_p95/base=head: 9
- total_tokens_p95/base=head: 14

git diff --check
- PASS
```

## Coverage and Metrics
- Changed executable coverage for `services/mlx-worker-python/worker/model_ops/training_dataset.py`: **100.00%** (`16/16` measurable changed lines covered).
- Full-file coverage for `services/mlx-worker-python/worker/model_ops/training_dataset.py`: `85%`; the file is large, so the gating metric for this narrow optimization slice is changed executable coverage.
- Registered scoped CI probe already covering this path: `training-dataset-token-percentiles-single-sort` in `infra/perf/pr_scoped_probes.json`.
- Local probe comparison:
  - `elapsed_ms_mean`: `293.014` → `16.058` (~94.52% lower, ~18.25x faster)
  - `sample_count`: `20000` → `20000` (unchanged)
  - `prompt_tokens_p95`: `9` → `9` (unchanged)
  - `total_tokens_p95`: `14` → `14` (unchanged)

## Known Gaps
- This cron run verified only the Linux-safe Python slice.
- Repository-wide `make swift-test` and `make integration-test` were not run because this host cannot validate the broader macOS/Swift surfaces locally.
- Auto-merge should only be enabled after the PR-scoped performance CI and required GitHub checks complete successfully.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
