### PR TITLE
perf: fast-path prompt completion token stats

### DIFF
--- a/docs/plans/2026-05-01-training-token-stats-prompt-completion-fast-path.md
+++ b/docs/plans/2026-05-01-training-token-stats-prompt-completion-fast-path.md
@@ -1,0 +1,28 @@
+# Training Token Stats Prompt/Completion Fast Path
+
+## Goal
+
+Reduce per-sample overhead in the Python training dataset token-statistics path while preserving the existing whitespace token estimator, percentile semantics, and manifest/report payload shape.
+
+## Scope
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset.py`
+- `services/mlx-worker-python/tests/test_training_dataset_builder.py`
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `training-dataset-token-percentiles-single-sort` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and measures `elapsed_ms_mean` for `_build_token_stats()` over 20,000 prompt/completion samples.
+
+## Implementation plan
+
+1. Keep token count collection behavior unchanged.
+2. Add a direct `prompt_completion` branch in `_collect_token_stats()` so the common training-dataset path avoids dispatching through the generic format helper for every sample.
+3. Preserve the generic helper path for chat and text-completion formats.
+4. Add focused regression coverage that fails if the prompt/completion path falls back to the generic helper.
+5. Validate with the focused training dataset tests, changed-scope coverage, and the registered PR-scoped performance probe on Linux.
+
+## Success criteria
+
+- Focused training dataset tests pass.
+- Changed-scope coverage for the touched Python worker files is at least 95%.
+- The registered probe reports a stable `elapsed_ms_mean` improvement or a clearly non-regressive result.

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -631,7 +631,11 @@ def test_build_token_stats_reuses_single_sorted_pass_per_token_series(monkeypatc
     def fail_percentile_value(values: list[int], pct: float) -> int:
         raise AssertionError(f"legacy percentile helper should not run for optimized token stats ({pct=}, {values=})")
 
+    def fail_generic_token_counter(sample: dict[str, object], format_name: str) -> tuple[int, int]:
+        raise AssertionError(f"prompt_completion token stats should use the direct fast path ({format_name=})")
+
     monkeypatch.setattr(training_dataset_module, "_percentile_value", fail_percentile_value)
+    monkeypatch.setattr(training_dataset_module, "_sample_token_counts", fail_generic_token_counter)
 
     assert training_dataset_module._build_token_stats(
         [
@@ -658,6 +662,29 @@ def test_build_token_stats_reuses_single_sorted_pass_per_token_series(monkeypatc
         "total_tokens_max": 7,
     }
 
+    monkeypatch.undo()
+    assert training_dataset_module._build_token_stats(
+        [
+            {"text": "alpha beta gamma"},
+            {"text": "delta"},
+        ],
+        "text_completion",
+    ) == {
+        "estimator": "whitespace_v1",
+        "sample_count": 2,
+        "prompt_tokens_mean": 0.0,
+        "prompt_tokens_p50": 0,
+        "prompt_tokens_p95": 0,
+        "prompt_tokens_max": 0,
+        "completion_tokens_mean": 2.0,
+        "completion_tokens_p50": 1,
+        "completion_tokens_p95": 1,
+        "completion_tokens_max": 3,
+        "total_tokens_mean": 2.0,
+        "total_tokens_p50": 1,
+        "total_tokens_p95": 1,
+        "total_tokens_max": 3,
+    }
 
     with pytest.raises(ModelOperationError) as int_parse_exc:
         training_dataset_module._int_ext_value(

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1353,12 +1353,22 @@ def _collect_token_stats(samples: Iterable[dict[str, Any]], format_name: str) ->
     completion_tokens: list[int] = []
     total_tokens: list[int] = []
     sample_count = 0
-    for sample in samples:
-        sample_count += 1
-        prompt_count, completion_count = _sample_token_counts(sample, format_name)
-        prompt_tokens.append(prompt_count)
-        completion_tokens.append(completion_count)
-        total_tokens.append(prompt_count + completion_count)
+    if format_name == "prompt_completion":
+        count_tokens = _whitespace_token_count
+        for sample in samples:
+            sample_count += 1
+            prompt_count = count_tokens(str(sample.get("prompt", "")))
+            completion_count = count_tokens(str(sample.get("completion", "")))
+            prompt_tokens.append(prompt_count)
+            completion_tokens.append(completion_count)
+            total_tokens.append(prompt_count + completion_count)
+    else:
+        for sample in samples:
+            sample_count += 1
+            prompt_count, completion_count = _sample_token_counts(sample, format_name)
+            prompt_tokens.append(prompt_count)
+            completion_tokens.append(completion_count)
+            total_tokens.append(prompt_count + completion_count)
 
     prompt_summary = _summarize_token_values(prompt_tokens)
     completion_summary = _summarize_token_values(completion_tokens)


### PR DESCRIPTION
## Summary
- Adds a direct prompt/completion fast path in `_collect_token_stats()` to avoid dispatching through the generic token-count helper for every sample in the common training dataset format.
- Keeps chat/text-completion formats on the existing generic path.
- Adds regression coverage for the fast path and documents the slice plan.

## Plan or Spec
- `docs/plans/2026-05-01-training-token-stats-prompt-completion-fast-path.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 41 passed in 7.02s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/tests/test_training_dataset_builder.py
# focused suite: 41 passed in 31.40s
# changed-scope coverage: TOTAL 20 1 95%

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-token-percentiles-single-sort --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-training-token-20260501101741 --head-repo . --output /tmp/training-token-probe-final.json
# base elapsed_ms_mean=16.517, head elapsed_ms_mean=15.290

git diff --check
# passed
```

## Coverage and Metrics
- Registered probe: `training-dataset-token-percentiles-single-sort`.
- Local Linux registered probe result: `elapsed_ms_mean` improved from `16.517 ms` to `15.290 ms` (`delta=-1.227 ms`, `-7.43%`).
- Probe invariants stayed unchanged: `sample_count=20000`, `prompt_tokens_p95=9`, `total_tokens_p95=14`.
- Changed-scope coverage: `95%` aggregate (`20` measurable changed lines, `1` missed changed test-helper line). The registry coverage command reports overall focused-command coverage at `92%`, matching the existing focused scope behavior.

## Known Gaps
- Full repository `make` gates were not run locally; this slice was limited to the registered Python training-dataset probe and focused tests on Linux.
- GitHub Actions PR-scoped performance validation is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
