### PR TITLE
perf: fast-path benchmark report probe rows

### DIFF
--- a/docs/plans/2026-04-30-benchmark-evaluation-report-streaming-aggregation.md
+++ b/docs/plans/2026-04-30-benchmark-evaluation-report-streaming-aggregation.md
@@ -6,7 +6,7 @@ This Linux-only optimization slice targets `services/mlx-worker-python` and avoi
 
 ## Goal
 
-Reduce redundant memory use in `worker/productization/benchmark_evaluation_report.py` by replacing per-metric `list[float]` accumulation with running sum/count aggregation for benchmark probe metrics and evaluation sample probe metrics while preserving all output keys and values.
+Reduce redundant memory use and per-row overhead in `worker/productization/benchmark_evaluation_report.py` by replacing per-metric `list[float]` accumulation with running sum/count aggregation, then fast-pathing numeric probe rows and label formatting before falling back to generic handling, while preserving all output keys and values.
 
 ## Touched Files
 
@@ -27,5 +27,5 @@ Create a self-contained Python measurement script that builds a large synthetic 
 
 - Focused pytest for `test_benchmark_evaluation_report.py` passes.
 - Changed executable scope coverage is at least 95%.
-- Performance probe shows reduced peak traced allocation for `build_benchmark_evaluation_report(...)` while preserving identical rows/summary output.
+- Performance probe shows reduced elapsed time and/or peak traced allocation for `build_benchmark_evaluation_report(...)` while preserving identical rows/summary output.
 - `git diff --check` passes.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -453,6 +453,66 @@ def test_metric_direction_fast_path_covers_report_probe_keys() -> None:
         assert _metric_direction(f"bench.synthetic.{metric_key}") == direction
 
 
+def test_report_builder_aggregates_numeric_probe_values_without_normalizing_all_values() -> None:
+    report = build_benchmark_evaluation_report(
+        baseline={
+            "benchmark_context_rows": [
+                {
+                    "suite": "mixed",
+                    "context_length": 128,
+                    "generation_length": 32,
+                    "batch_size": 1,
+                    "prefill_ms": 7,
+                    "cache_hit": True,
+                },
+                {
+                    "suite": "mixed",
+                    "context_length": 128,
+                    "generation_length": 32,
+                    "batch_size": 1,
+                    "prefill_ms": "9.0",
+                    "cache_hit": False,
+                },
+            ]
+        },
+        candidate={
+            "benchmark_context_rows": [
+                {
+                    "suite": "mixed",
+                    "context_length": 128,
+                    "generation_length": 32,
+                    "batch_size": 1,
+                    "prefill_ms": 8.0,
+                    "cache_hit": True,
+                },
+                {
+                    "suite": "mixed",
+                    "context_length": 128,
+                    "generation_length": 32,
+                    "batch_size": 1,
+                    "prefill_ms": "10.0",
+                    "cache_hit": True,
+                },
+            ]
+        },
+    )
+
+    rows_by_metric = {row["metric"]: row for row in report["rows"]}
+
+    assert rows_by_metric["bench.context.mixed.ctx128.gen32.b1.prefill_ms_mean"]["baseline"] == (
+        pytest.approx(8.0)
+    )
+    assert rows_by_metric["bench.context.mixed.ctx128.gen32.b1.prefill_ms_mean"]["candidate"] == (
+        pytest.approx(9.0)
+    )
+    assert rows_by_metric["bench.context.mixed.ctx128.gen32.b1.cache_hit_rate"]["baseline"] == (
+        pytest.approx(0.5)
+    )
+    assert rows_by_metric["bench.context.mixed.ctx128.gen32.b1.cache_hit_rate"]["candidate"] == (
+        pytest.approx(1.0)
+    )
+
+
 def test_report_builder_uses_sparse_benchmark_probe_rows_without_fixed_key_scans() -> None:
     sparse_row = _SparseProbeRow(
         {

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -433,12 +433,17 @@ def _collect_benchmark_probe_metrics(
 ) -> None:
     aggregates_by_label_and_key: dict[tuple[str, str], _NumericAggregate] = {}
     for row in _dict_rows(rows):
-        label = _benchmark_probe_label(row)
+        label = ""
         for key, raw_value in row.items():
             if key not in _REQUEST_PROBE_KEY_SET:
                 continue
-            value = _float_or_none(raw_value)
+            if isinstance(raw_value, (int, float)):
+                value = float(raw_value)
+            else:
+                value = _float_or_none(raw_value)
             if value is not None:
+                if not label:
+                    label = _benchmark_probe_label(row)
                 aggregate_key = (label, key)
                 aggregates_by_label_and_key[aggregate_key] = _update_numeric_aggregate(
                     aggregates_by_label_and_key.get(aggregate_key),
@@ -460,7 +465,10 @@ def _collect_evaluation_sample_probe_metrics(
         for key, raw_value in row.items():
             if key not in _EVALUATION_SAMPLE_PROBE_KEY_SET:
                 continue
-            value = _float_or_none(raw_value)
+            if isinstance(raw_value, (int, float)):
+                value = float(raw_value)
+            else:
+                value = _float_or_none(raw_value)
             if value is not None:
                 aggregate_key = (suite_id, key)
                 aggregates_by_suite_and_key[aggregate_key] = _update_numeric_aggregate(
@@ -516,24 +524,20 @@ def _aggregate_probe_values(key: str, values: list[float]) -> tuple[str, float]:
 def _benchmark_probe_label(row: dict[str, object]) -> str:
     if "cell_id" in row or ("suite_id" in row and "concurrency_level" in row):
         return _matrix_label(row)
-    parts = [
-        str(row.get("suite", row.get("suite_id", "suite"))),
-        f"ctx{row.get('context_length', 0)}",
-        f"gen{row.get('generation_length', 0)}",
-        f"b{row.get('batch_size', 0)}",
-    ]
-    return ".".join(part.replace(" ", "_") for part in parts)
+    suite = str(row.get("suite", row.get("suite_id", "suite"))).replace(" ", "_")
+    context_length = str(row.get("context_length", 0)).replace(" ", "_")
+    generation_length = str(row.get("generation_length", 0)).replace(" ", "_")
+    batch_size = str(row.get("batch_size", 0)).replace(" ", "_")
+    return f"{suite}.ctx{context_length}.gen{generation_length}.b{batch_size}"
 
 
 def _matrix_label(row: dict[str, object]) -> str:
-    parts = [
-        str(row.get("suite_id", "suite")),
-        f"ctx{row.get('context_length', 0)}",
-        f"gen{row.get('generation_length', 0)}",
-        f"b{row.get('batch_size', 0)}",
-        f"c{row.get('concurrency_level', 0)}",
-    ]
-    return ".".join(part.replace(" ", "_") for part in parts)
+    suite_id = str(row.get("suite_id", "suite")).replace(" ", "_")
+    context_length = str(row.get("context_length", 0)).replace(" ", "_")
+    generation_length = str(row.get("generation_length", 0)).replace(" ", "_")
+    batch_size = str(row.get("batch_size", 0)).replace(" ", "_")
+    concurrency_level = str(row.get("concurrency_level", 0)).replace(" ", "_")
+    return f"{suite_id}.ctx{context_length}.gen{generation_length}.b{batch_size}.c{concurrency_level}"
 
 
 def _report_rows(report: dict[str, object]) -> Iterator[dict[str, object]]:


### PR DESCRIPTION
## Summary
- Fast-path benchmark/evaluation probe metric aggregation for already numeric row values before falling back to string parsing.
- Avoid allocating temporary label part lists/generators for benchmark and matrix probe labels while preserving the same metric keys.
- Add a regression test for mixed int/float/bool/string probe values and update the governing performance plan.

## Plan or Spec
- `docs/plans/2026-04-30-benchmark-evaluation-report-streaming-aggregation.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# 25 passed in 0.06s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# TOTAL 490 statements, 6 missed, 99% coverage

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .tmp_probe_baseline.py
# baseline before change: {"elapsed_ms_mean": 174.278, "peak_bytes_mean": 3785244.0, "row_count": 5990.0}
# branch samples after change: 146.863 ms, 154.767 ms, 157.297 ms; peak_bytes_mean=3785244.0; row_count=5990.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 99% total; `benchmark_evaluation_report.py` 98%, `test_benchmark_evaluation_report.py` 99%.
- Registered probe: `benchmark-evaluation-report-running-aggregates` covers this path and has focused `test_command`, `coverage_command`, and `probe_command` entries in `infra/perf/pr_scoped_probes.json`.
- Local Linux probe comparison: old_mean=174.278 ms, new_mean=152.976 ms, delta_ms=-21.302 ms, speedup=1.139x (~12.22% faster). Peak traced allocation was unchanged at 3,785,244 bytes.
- CI PR-scoped performance workflow is required for the registered probe validation before merge.

## Known Gaps
- Local validation is Linux-only for this Python slice. No Swift runtime effects are claimed.
- CI registered probe report is pending at PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
