### PR TITLE
perf: memoize benchmark report labels

### DIFF
--- a/docs/plans/2026-05-01-benchmark-evaluation-report-label-memoization.md
+++ b/docs/plans/2026-05-01-benchmark-evaluation-report-label-memoization.md
@@ -1,0 +1,41 @@
+# Benchmark Evaluation Report Label Memoization Plan
+
+## Goal
+
+Reduce repeated string assembly in the benchmark evaluation report hot path by memoizing benchmark row labels so repeated row shapes reuse the same label instead of rebuilding identical `suite/context/generation/batch/concurrency` strings for every row.
+
+## Linux-Only Constraint
+
+This slice is limited to the Python benchmark evaluation report implementation and its focused tests so it can be fully verified on Linux.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`
+- `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`
+
+## Optimization Slice
+
+- Add a tiny internal label-cache helper keyed by the benchmark row shape used to construct context, batch, and matrix probe labels.
+- Reuse cached labels in `_collect_benchmark_probe_metrics(...)` and the matrix-summary metric collection path.
+- Preserve metric names, ordering, and report output exactly.
+- Add focused regression coverage proving repeated identical row shapes only build a label once while keeping emitted metric keys unchanged.
+
+## Performance Probe
+
+Use the already-registered PR-scoped performance probe `benchmark-evaluation-report-running-aggregates`, which compares `build_benchmark_evaluation_report(...)` on a large synthetic export bundle and reports:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+
+## Success Metrics
+
+- Report rows and summary remain identical for existing focused tests.
+- Changed executable scope coverage is at least 95%.
+- The registered local probe shows lower `elapsed_ms_mean` than `origin/main` for the synthetic benchmark evaluation report path.
+
+## Verification Commands
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_benchmark_evaluation_report as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"`
+- `git diff --check`

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import worker.productization.benchmark_evaluation_report as benchmark_evaluation_report
 from worker.productization.benchmark_evaluation_report import (
     _METRIC_DIRECTION_BY_KEY,
     _aggregate_probe_values,
@@ -328,6 +329,93 @@ def test_aggregate_probe_values_handles_empty_inputs() -> None:
     assert _aggregate_probe_values("prefill_ms", []) == ("mean", 0.0)
     assert _aggregate_probe_values("cache_hit", []) == ("rate", 0.0)
     assert _aggregate_probe_values("speculative_fallback_count", []) == ("sum", 0.0)
+
+
+def test_benchmark_probe_label_cache_reuses_identical_shapes(monkeypatch: pytest.MonkeyPatch) -> None:
+    original = benchmark_evaluation_report._build_benchmark_label
+    built_keys: list[tuple[str, str, str, str, str, str]] = []
+
+    def tracked(key: tuple[str, str, str, str, str, str]) -> str:
+        built_keys.append(key)
+        return original(key)
+
+    monkeypatch.setattr(benchmark_evaluation_report, "_build_benchmark_label", tracked)
+
+    cache: dict[tuple[str, str, str, str, str, str], str] = {}
+    context_row = {
+        "suite": "smoke suite",
+        "context_length": 128,
+        "generation_length": 32,
+        "batch_size": 1,
+    }
+    matrix_row = {
+        "suite_id": "smoke suite",
+        "context_length": 128,
+        "generation_length": 32,
+        "batch_size": 1,
+        "concurrency_level": 2,
+    }
+
+    assert (
+        benchmark_evaluation_report._benchmark_probe_label(context_row, label_cache=cache)
+        == "smoke_suite.ctx128.gen32.b1"
+    )
+    assert (
+        benchmark_evaluation_report._benchmark_probe_label(
+            {**context_row, "prefill_ms": 7.0},
+            label_cache=cache,
+        )
+        == "smoke_suite.ctx128.gen32.b1"
+    )
+    assert benchmark_evaluation_report._matrix_label(matrix_row, label_cache=cache) == (
+        "smoke_suite.ctx128.gen32.b1.c2"
+    )
+    assert (
+        benchmark_evaluation_report._benchmark_probe_label(
+            {**matrix_row, "prefill_ms": 9.0},
+            label_cache=cache,
+        )
+        == "smoke_suite.ctx128.gen32.b1.c2"
+    )
+
+    assert built_keys == [
+        ("bench", "smoke suite", "128", "32", "1", ""),
+        ("matrix", "smoke suite", "128", "32", "1", "2"),
+    ]
+
+
+def test_benchmark_probe_label_cache_preserves_stringified_shape_boundaries() -> None:
+    cache: dict[tuple[str, str, str, str, str, str], str] = {}
+
+    numeric_row = {
+        "suite": "shape",
+        "context_length": 1,
+        "generation_length": 2,
+        "batch_size": True,
+    }
+    float_row = {
+        "suite": "shape",
+        "context_length": 1.0,
+        "generation_length": 2,
+        "batch_size": 1,
+    }
+    unhashable_row = {
+        "suite": ["shape", "list"],
+        "context_length": {"nested": "value"},
+        "generation_length": 2,
+        "batch_size": 1,
+    }
+
+    assert benchmark_evaluation_report._benchmark_probe_label(numeric_row, label_cache=cache) == (
+        "shape.ctx1.gen2.bTrue"
+    )
+    assert benchmark_evaluation_report._benchmark_probe_label(float_row) == "shape.ctx1.0.gen2.b1"
+    assert benchmark_evaluation_report._benchmark_probe_label(float_row, label_cache=cache) == (
+        "shape.ctx1.0.gen2.b1"
+    )
+    assert benchmark_evaluation_report._benchmark_probe_label(unhashable_row, label_cache=cache) == (
+        "['shape',_'list'].ctx{'nested':_'value'}.gen2.b1"
+    )
 
 
 def test_row_iterators_filter_invalid_entries_without_materializing_copies() -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -126,6 +126,7 @@ _METRIC_DIRECTION_BY_KEY = {
 }
 
 _NumericAggregate = tuple[float, int]
+_BenchmarkLabelCacheKey = tuple[str, str, str, str, str, str]
 
 
 def load_report_input(path: str | Path) -> dict[str, object]:
@@ -271,6 +272,7 @@ def write_report_outputs(
 
 def _collect_metrics(bundle: dict[str, object]) -> dict[str, object]:
     metrics: dict[str, object] = {}
+    label_cache: dict[_BenchmarkLabelCacheKey, str] = {}
     _collect_runtime_metadata(
         metrics,
         bundle.get("benchmark_jobs", []),
@@ -296,14 +298,16 @@ def _collect_metrics(bundle: dict[str, object]) -> dict[str, object]:
         metrics,
         bundle.get("benchmark_context_rows", []),
         prefix="bench.context",
+        label_cache=label_cache,
     )
     _collect_benchmark_probe_metrics(
         metrics,
         bundle.get("benchmark_batch_rows", []),
         prefix="bench.batch",
+        label_cache=label_cache,
     )
     for row in _dict_rows(bundle.get("benchmark_matrix_summary_rows", [])):
-        label = _matrix_label(row)
+        label = _matrix_label(row, label_cache=label_cache)
         for key in (
             "request_latency_mean_ms",
             "request_latency_p95_ms",
@@ -320,6 +324,7 @@ def _collect_metrics(bundle: dict[str, object]) -> dict[str, object]:
         metrics,
         bundle.get("benchmark_matrix_request_rows", []),
         prefix="bench.matrix.request",
+        label_cache=label_cache,
     )
     for row in _dict_rows(bundle.get("evaluation_summary_rows", [])):
         suite_id = str(row.get("suite_id", "")).strip() or "suite"
@@ -430,9 +435,9 @@ def _collect_benchmark_probe_metrics(
     rows: object,
     *,
     prefix: str,
+    label_cache: dict[_BenchmarkLabelCacheKey, str] | None = None,
 ) -> None:
     aggregates_by_label: dict[str, dict[str, _NumericAggregate]] = {}
-    matrix_label_cache: dict[tuple[object, object, object, object, object], str] = {}
     for row in _dict_rows(rows):
         label = ""
         for key, raw_value in row.items():
@@ -444,7 +449,7 @@ def _collect_benchmark_probe_metrics(
                 value = _float_or_none(raw_value)
             if value is not None:
                 if not label:
-                    label = _benchmark_probe_label(row, matrix_label_cache=matrix_label_cache)
+                    label = _benchmark_probe_label(row, label_cache=label_cache)
                 _update_probe_aggregates_by_label(
                     aggregates_by_label,
                     label=label,
@@ -540,6 +545,7 @@ def _aggregate_probe_values(key: str, values: list[float]) -> tuple[str, float]:
 
 def _benchmark_probe_label(
     row: dict[str, object],
+    label_cache: dict[_BenchmarkLabelCacheKey, str] | None = None,
     *,
     matrix_label_cache: dict[tuple[object, object, object, object, object], str] | None = None,
 ) -> str:
@@ -555,26 +561,64 @@ def _benchmark_probe_label(
             try:
                 return matrix_label_cache[cache_key]
             except KeyError:
-                label = _matrix_label(row)
+                label = _matrix_label(row, label_cache=label_cache)
                 matrix_label_cache[cache_key] = label
                 return label
             except TypeError:
                 pass
-        return _matrix_label(row)
-    suite = _label_part(row.get("suite", row.get("suite_id", "suite")))
-    context_length = _label_part(row.get("context_length", 0))
-    generation_length = _label_part(row.get("generation_length", 0))
-    batch_size = _label_part(row.get("batch_size", 0))
-    return f"{suite}.ctx{context_length}.gen{generation_length}.b{batch_size}"
+        return _matrix_label(row, label_cache=label_cache)
+    key = (
+        "bench",
+        str(row.get("suite", row.get("suite_id", "suite"))),
+        str(row.get("context_length", 0)),
+        str(row.get("generation_length", 0)),
+        str(row.get("batch_size", 0)),
+        "",
+    )
+    return _cached_benchmark_label(key, label_cache=label_cache)
 
 
-def _matrix_label(row: dict[str, object]) -> str:
-    suite_id = _label_part(row.get("suite_id", "suite"))
-    context_length = _label_part(row.get("context_length", 0))
-    generation_length = _label_part(row.get("generation_length", 0))
-    batch_size = _label_part(row.get("batch_size", 0))
-    concurrency_level = _label_part(row.get("concurrency_level", 0))
-    return f"{suite_id}.ctx{context_length}.gen{generation_length}.b{batch_size}.c{concurrency_level}"
+def _matrix_label(
+    row: dict[str, object],
+    label_cache: dict[_BenchmarkLabelCacheKey, str] | None = None,
+) -> str:
+    key = (
+        "matrix",
+        str(row.get("suite_id", "suite")),
+        str(row.get("context_length", 0)),
+        str(row.get("generation_length", 0)),
+        str(row.get("batch_size", 0)),
+        str(row.get("concurrency_level", 0)),
+    )
+    return _cached_benchmark_label(key, label_cache=label_cache)
+
+
+def _cached_benchmark_label(
+    key: _BenchmarkLabelCacheKey,
+    *,
+    label_cache: dict[_BenchmarkLabelCacheKey, str] | None,
+) -> str:
+    if label_cache is None:
+        return _build_benchmark_label(key)
+    cached = label_cache.get(key)
+    if cached is not None:
+        return cached
+    label = _build_benchmark_label(key)
+    label_cache[key] = label
+    return label
+
+
+def _build_benchmark_label(key: _BenchmarkLabelCacheKey) -> str:
+    kind, suite, context_length, generation_length, batch_size, concurrency_level = key
+    parts = [
+        suite.replace(" ", "_"),
+        f"ctx{_label_part(context_length)}",
+        f"gen{_label_part(generation_length)}",
+        f"b{_label_part(batch_size)}",
+    ]
+    if kind == "matrix":
+        parts.append(f"c{_label_part(concurrency_level)}")
+    return ".".join(parts)
 
 
 def _label_part(value: object) -> str:


### PR DESCRIPTION
## Summary
- memoize benchmark report row labels inside `build_benchmark_evaluation_report(...)` so repeated context/batch/matrix row shapes reuse the same assembled label string
- preserve existing metric-key formatting by caching stringified shape tuples rather than raw objects
- add focused regression tests for cache reuse and stringified-shape boundary behavior

## Plan or Spec
- `docs/plans/2026-05-01-benchmark-evaluation-report-label-memoization.md`
- existing scoped probe coverage already applies through `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json`; no registry update was required for this path

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
  -> 26 passed in 0.10s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
  -> TOTAL 50 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_probe_compare.py /tmp/melix-baseline-probe
  -> {"elapsed_ms_mean": 176.521, "peak_bytes_mean": 3785244.0, "row_count": 5990.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_probe_compare.py /tmp/melix-cron-opt-20260501-110655
  -> {"elapsed_ms_mean": 167.694, "peak_bytes_mean": 3880372.0, "row_count": 5990.0}

git diff --check
  -> clean
```

## Coverage and Metrics
- changed-scope coverage: `TOTAL 50 0 100%`
- registered scoped CI probe: `benchmark-evaluation-report-running-aggregates`
- local probe wall time: `176.521 ms -> 167.694 ms` (`-5.00%`, faster)
- local probe peak traced bytes: `3,785,244 -> 3,880,372` (`+2.51%`)
- local probe row count: unchanged at `5990`

## Known Gaps
- Local Linux verification covered the Python worker path only; no full-repo or macOS/Swift validation was run in this slice.
- The optimization improves local wall time for the registered probe, but peak traced bytes regressed slightly in the same probe. The PR-scoped performance CI should validate whether that trade-off is acceptable on the repo’s canonical runner before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
