### PR TITLE
perf: skip saturated closure-audit probe checks

### DIFF
--- a/docs/plans/2026-05-01-closure-audit-pending-probe-short-circuit.md
+++ b/docs/plans/2026-05-01-closure-audit-pending-probe-short-circuit.md
@@ -1,0 +1,55 @@
+# Closure Audit Pending-Probe Short-Circuit Optimization Plan
+
+## Goal
+
+Reduce redundant probe-name substring checks in `worker/productization/closure_audit.py` by removing already-saturated probe names from later file scans while preserving retained source ordering and probe-gap behavior.
+
+## Constraints
+
+- Host verification is Linux-only.
+- The touched runtime path is Python under `services/mlx-worker-python`.
+- The change must remain small, behavior-preserving, and locally verifiable.
+- Pull request evidence must include focused tests, changed-scope coverage, and a measurable performance probe.
+- The change must stay compatible with the existing `closure-audit-probe-source-short-circuit` PR-scoped performance probe.
+
+## Touched Files
+
+- `docs/plans/2026-05-01-closure-audit-pending-probe-short-circuit.md`
+- `services/mlx-worker-python/worker/productization/closure_audit.py`
+- `services/mlx-worker-python/tests/test_closure_audit.py`
+
+## Proposed Change
+
+1. Track the still-unsatisfied probe names during `_collect_probe_sources(...)`.
+2. Update `_scan_probe_source_file(...)` so it only checks substring membership for probes that have not yet reached their retained-source cap.
+3. Keep retained source ordering, duplicate suppression, and full-scan fallback behavior unchanged.
+4. Add a focused regression test proving saturated probe names are not re-checked on later files.
+
+## Performance Probe
+
+### Probe name
+
+`closure-audit-probe-source-short-circuit`
+
+### Measurement path
+
+- Seed a synthetic repository with closure-audit evidence files.
+- Run the existing PR-scoped closure-audit probe against `origin/main` and the branch worktree.
+- Compare `elapsed_ms_mean` while preserving `probe_file_reads_mean` and `finding_count` semantics.
+
+### Success metric
+
+- Lower `elapsed_ms_mean` is better.
+- `probe_file_reads_mean` should stay the same or lower.
+- `finding_count` must remain unchanged.
+
+## Local Verification Commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/closure_audit.py services/mlx-worker-python/tests/test_closure_audit.py
+python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id closure-audit-probe-source-short-circuit --base-repo /root/.openclaw/workspace/melix --head-repo . --output /tmp/closure-audit-probe-run
+git diff --check
+```

--- a/services/mlx-worker-python/tests/test_closure_audit.py
+++ b/services/mlx-worker-python/tests/test_closure_audit.py
@@ -186,6 +186,64 @@ def test_collect_probe_sources_stops_discovering_files_after_probe_slots_are_fil
         ]
 
 
+def test_collect_probe_sources_stops_checking_saturated_probe_names(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = _seed_repo(tmp_path)
+    docs_root = repo_root / "docs"
+    probe_names = [
+        probe_name
+        for probe_group in closure_audit_module._REQUIRED_PROBES.values()
+        for probe_name in probe_group
+    ]
+    saturated_probe = probe_names[0]
+    remaining_probe_names = probe_names[1:]
+    for index in range(3):
+        (docs_root / f"a-saturated-{index}.md").write_text(f"{saturated_probe}\n", encoding="utf-8")
+    (docs_root / "b-fill-remaining.md").write_text(
+        "\n".join(remaining_probe_names) + "\n",
+        encoding="utf-8",
+    )
+
+    contains_checks: list[tuple[str, str]] = []
+    original_read_text = Path.read_text
+
+    class TrackingText(str):
+        def __new__(cls, value: str, *, relative_path: str):
+            instance = super().__new__(cls, value)
+            instance.relative_path = relative_path
+            return instance
+
+        def __contains__(self, item: object) -> bool:
+            if isinstance(item, str):
+                contains_checks.append((self.relative_path, item))
+            return super().__contains__(item)
+
+    def tracked_read_text(self: Path, *args, **kwargs) -> str:
+        return TrackingText(
+            original_read_text(self, *args, **kwargs),
+            relative_path=self.relative_to(repo_root).as_posix(),
+        )
+
+    monkeypatch.setattr(Path, "read_text", tracked_read_text)
+
+    probe_sources = closure_audit_module._collect_probe_sources(repo_root)
+
+    assert probe_sources[saturated_probe] == [
+        "docs/a-saturated-0.md",
+        "docs/a-saturated-1.md",
+        "docs/a-saturated-2.md",
+    ]
+    assert (
+        "docs/b-fill-remaining.md",
+        saturated_probe,
+    ) not in contains_checks
+    assert (
+        "docs/b-fill-remaining.md",
+        remaining_probe_names[0],
+    ) in contains_checks
+
+
 def test_collect_probe_sources_prefers_curated_evidence_files_before_full_scan(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/closure_audit.py
+++ b/services/mlx-worker-python/worker/productization/closure_audit.py
@@ -377,24 +377,27 @@ def _collect_probe_sources(root: Path) -> dict[str, list[str]]:
         for probe_names in _REQUIRED_PROBES.values()
         for probe_name in probe_names
     }
+    pending_probe_names = list(probe_sources)
     scanned_relative_paths: set[str] = set()
     for file_path in _iter_preferred_probe_text_files(root):
         _scan_probe_source_file(
             file_path=file_path,
             root=root,
             probe_sources=probe_sources,
+            pending_probe_names=pending_probe_names,
             scanned_relative_paths=scanned_relative_paths,
         )
-        if _probe_sources_complete(probe_sources):
+        if not pending_probe_names:
             return probe_sources
     for file_path in _iter_probe_text_files(root):
         _scan_probe_source_file(
             file_path=file_path,
             root=root,
             probe_sources=probe_sources,
+            pending_probe_names=pending_probe_names,
             scanned_relative_paths=scanned_relative_paths,
         )
-        if _probe_sources_complete(probe_sources):
+        if not pending_probe_names:
             break
     return probe_sources
 
@@ -404,6 +407,7 @@ def _scan_probe_source_file(
     file_path: Path,
     root: Path,
     probe_sources: dict[str, list[str]],
+    pending_probe_names: list[str],
     scanned_relative_paths: set[str],
 ) -> None:
     relative_path = file_path.relative_to(root).as_posix()
@@ -411,11 +415,14 @@ def _scan_probe_source_file(
         return
     scanned_relative_paths.add(relative_path)
     contents = file_path.read_text(encoding="utf-8", errors="ignore")
-    for probe_name, matches in probe_sources.items():
-        if len(matches) >= 3:
-            continue
+    next_pending_probe_names: list[str] = []
+    for probe_name in pending_probe_names:
+        matches = probe_sources[probe_name]
         if probe_name in contents:
             matches.append(relative_path)
+        if len(matches) < 3:
+            next_pending_probe_names.append(probe_name)
+    pending_probe_names[:] = next_pending_probe_names
 
 
 def _probe_sources_complete(probe_sources: dict[str, list[str]]) -> bool:


### PR DESCRIPTION
## Summary
- stop checking closure-audit probe names after each one has already reached its retained three-source cap
- preserve retained source ordering, duplicate suppression, and probe-gap behavior
- add a focused regression test plus an explicit optimization plan for this slice

## Plan or Spec
- `docs/plans/2026-05-01-closure-audit-pending-probe-short-circuit.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
=> 15 passed in 2.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/closure_audit.py services/mlx-worker-python/tests/test_closure_audit.py
=> TOTAL 36 0 100%

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id closure-audit-probe-source-short-circuit --base-repo /tmp/melix-cron-opt-base-20260501-114110 --head-repo . --output /tmp/closure-audit-probe-run-main-base
=> base elapsed_ms_mean=0.964, head elapsed_ms_mean=0.869, base probe_file_reads_mean=7.0, head probe_file_reads_mean=7.0, finding_count unchanged at 2.0

git diff --check
=> clean
```

## Coverage and Metrics
- Changed executable line coverage: `100.00%` (`36/36` changed measurable lines covered)
- Registered scoped CI probe: `closure-audit-probe-source-short-circuit`
- Local probe result against `origin/main`:
  - `elapsed_ms_mean`: `0.964 ms` -> `0.869 ms` (~`9.85%` lower, ~`1.11x` faster)
  - `probe_file_reads_mean`: `7.0` -> `7.0` (unchanged)
  - `finding_count`: `2.0` -> `2.0` (unchanged)

## Known Gaps
- Linux-only verification for this cron run; no macOS/Swift validation was run because the slice is confined to Python closure-audit logic.
- The registered `pr-scoped-performance` GitHub Actions run is still required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. (Plan added for this optimization slice.)
- [x] Protocol changes include regenerated generated artifacts. (Not applicable: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (Not applicable: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
