### PR TITLE
perf(productization): fast-path benchmark report labels

### DIFF
--- a/docs/plans/2026-05-01-benchmark-evaluation-label-fast-path.md
+++ b/docs/plans/2026-05-01-benchmark-evaluation-label-fast-path.md
@@ -1,0 +1,35 @@
+# Benchmark Evaluation Probe Label Fast Path
+
+## Goal
+
+Reduce label-formatting overhead in the benchmark/evaluation report builder while preserving existing metric names and report semantics.
+
+## Scope
+
+This Linux-verifiable Python slice is limited to:
+
+- `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`
+- `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`
+
+No Swift, protobuf, dependency, or generated artifact changes are in scope.
+
+## Probe
+
+The affected path is covered by registered PR-scoped probe `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json`. The registered probe already has focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+Tracked metrics:
+
+- `elapsed_ms_mean` (lower is better)
+- `peak_bytes_mean` (lower is better)
+- `row_count` (parity guard)
+
+## Implementation Plan
+
+1. Add a small `_label_part` helper that keeps numeric probe dimensions on a direct `str(value)` path and only applies space normalization for textual values.
+2. Route benchmark and matrix label construction through that helper.
+3. Add focused regression coverage for numeric and textual label normalization.
+4. Run the focused tests, changed-scope coverage, and registered local probe before opening the PR.
+
+## Validation Boundary
+
+This slice is Python-only and locally validated on Linux. The registered PR-scoped performance workflow remains the merge gate for CI probe validation.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -10,6 +10,7 @@ from worker.productization.benchmark_evaluation_report import (
     _aggregate_probe_values,
     _dict_rows,
     _finalize_numeric_aggregate,
+    _label_part,
     _markdown_cell,
     _metric_direction,
     _report_rows,
@@ -511,6 +512,13 @@ def test_report_builder_aggregates_numeric_probe_values_without_normalizing_all_
     assert rows_by_metric["bench.context.mixed.ctx128.gen32.b1.cache_hit_rate"]["candidate"] == (
         pytest.approx(1.0)
     )
+
+
+def test_label_part_preserves_numeric_labels_and_normalizes_text_spaces() -> None:
+    assert _label_part(1024) == "1024"
+    assert _label_part(1.5) == "1.5"
+    assert _label_part(True) == "True"
+    assert _label_part("long suite") == "long_suite"
 
 
 def test_report_builder_uses_sparse_benchmark_probe_rows_without_fixed_key_scans() -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -524,20 +524,26 @@ def _aggregate_probe_values(key: str, values: list[float]) -> tuple[str, float]:
 def _benchmark_probe_label(row: dict[str, object]) -> str:
     if "cell_id" in row or ("suite_id" in row and "concurrency_level" in row):
         return _matrix_label(row)
-    suite = str(row.get("suite", row.get("suite_id", "suite"))).replace(" ", "_")
-    context_length = str(row.get("context_length", 0)).replace(" ", "_")
-    generation_length = str(row.get("generation_length", 0)).replace(" ", "_")
-    batch_size = str(row.get("batch_size", 0)).replace(" ", "_")
+    suite = _label_part(row.get("suite", row.get("suite_id", "suite")))
+    context_length = _label_part(row.get("context_length", 0))
+    generation_length = _label_part(row.get("generation_length", 0))
+    batch_size = _label_part(row.get("batch_size", 0))
     return f"{suite}.ctx{context_length}.gen{generation_length}.b{batch_size}"
 
 
 def _matrix_label(row: dict[str, object]) -> str:
-    suite_id = str(row.get("suite_id", "suite")).replace(" ", "_")
-    context_length = str(row.get("context_length", 0)).replace(" ", "_")
-    generation_length = str(row.get("generation_length", 0)).replace(" ", "_")
-    batch_size = str(row.get("batch_size", 0)).replace(" ", "_")
-    concurrency_level = str(row.get("concurrency_level", 0)).replace(" ", "_")
+    suite_id = _label_part(row.get("suite_id", "suite"))
+    context_length = _label_part(row.get("context_length", 0))
+    generation_length = _label_part(row.get("generation_length", 0))
+    batch_size = _label_part(row.get("batch_size", 0))
+    concurrency_level = _label_part(row.get("concurrency_level", 0))
     return f"{suite_id}.ctx{context_length}.gen{generation_length}.b{batch_size}.c{concurrency_level}"
+
+
+def _label_part(value: object) -> str:
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    return str(value).replace(" ", "_")
 
 
 def _report_rows(report: dict[str, object]) -> Iterator[dict[str, object]]:


### PR DESCRIPTION
## Summary
- Fast-path benchmark/evaluation report label formatting by avoiding `.replace(" ", "_")` for numeric probe dimensions.
- Add focused coverage for numeric label parity and textual space normalization.

## Plan or Spec
- `docs/plans/2026-05-01-benchmark-evaluation-label-fast-path.md`

## Commands Run
```text
# Baseline sync and branch/worktree
cd /root/.hermes/profiles/coder/workspace/melix && git fetch origin
git worktree add -b perf/python-next-slice-20260501115148 /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-20260501115148 origin/main

# Focused test
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# exit 0; 26 passed in 0.10s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# exit 0; TOTAL 99%; benchmark_evaluation_report.py 98%; test_benchmark_evaluation_report.py 99%

# Registered local probe, baseline origin/main worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .tmp_probe_benchmark_eval.py
# {"elapsed_ms_mean": 158.008, "peak_bytes_mean": 3785244.0, "row_count": 5990.0}

# Registered local probe, head worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .tmp_probe_benchmark_eval.py
# {"elapsed_ms_mean": 150.788, "peak_bytes_mean": 3785308.0, "row_count": 5990.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 99% total; `benchmark_evaluation_report.py` 98%; `test_benchmark_evaluation_report.py` 99%.
- Registered probe: `benchmark-evaluation-report-running-aggregates`.
- Local Linux probe delta: `elapsed_ms_mean` 158.008 -> 150.788 ms (`-7.220 ms`, `-4.57%`); `peak_bytes_mean` 3,785,244.0 -> 3,785,308.0 bytes (`+64 bytes`, effectively neutral); `row_count` stayed 5,990.
- CI PR-scoped performance workflow is required as the final registered-probe validation before merge.

## Known Gaps
- None for the Python slice. Swift/macOS runtime effects are not involved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
