### PR TITLE
perf: cache benchmark matrix labels

### DIFF
--- a/docs/plans/2026-05-01-benchmark-evaluation-matrix-label-cache.md
+++ b/docs/plans/2026-05-01-benchmark-evaluation-matrix-label-cache.md
@@ -1,0 +1,21 @@
+# Benchmark evaluation matrix label cache optimization
+
+## Goal
+
+Reduce repeated label construction in `benchmark_evaluation_report` while preserving the benchmark/evaluation report schema and metric names.
+
+## Scope
+
+- Cache matrix-style benchmark probe labels within `_collect_benchmark_probe_metrics()` for repeated request rows that share `suite_id`, `context_length`, `generation_length`, `batch_size`, and `concurrency_level`.
+- Keep non-matrix benchmark context labels uncached because those rows are commonly unique in the PR-scoped probe workload.
+- Do not change exported report rows, warning semantics, metric direction handling, or sticky comment formatting.
+
+## Probe
+
+The affected path is covered by the registered PR-scoped probe `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json`, including focused pytest, changed-scope coverage, and the local Linux probe command.
+
+## Success Criteria
+
+- Focused benchmark-evaluation report tests pass.
+- Changed-scope coverage remains at least 95%.
+- Registered probe reports a non-regressing `elapsed_ms_mean` and unchanged `row_count`.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -8,6 +8,7 @@ import pytest
 from worker.productization.benchmark_evaluation_report import (
     _METRIC_DIRECTION_BY_KEY,
     _aggregate_probe_values,
+    _benchmark_probe_label,
     _dict_rows,
     _finalize_numeric_aggregate,
     _label_part,
@@ -519,6 +520,24 @@ def test_label_part_preserves_numeric_labels_and_normalizes_text_spaces() -> Non
     assert _label_part(1.5) == "1.5"
     assert _label_part(True) == "True"
     assert _label_part("long suite") == "long_suite"
+
+
+def test_benchmark_probe_label_reuses_cached_matrix_labels() -> None:
+    cache: dict[tuple[object, object, object, object, object], str] = {}
+    row = {
+        "suite_id": "smoke",
+        "context_length": 128,
+        "generation_length": 32,
+        "batch_size": 1,
+        "concurrency_level": 2,
+    }
+
+    first = _benchmark_probe_label(row, matrix_label_cache=cache)
+    second = _benchmark_probe_label(dict(row), matrix_label_cache=cache)
+
+    assert first == "smoke.ctx128.gen32.b1.c2"
+    assert second == first
+    assert cache == {("smoke", 128, 32, 1, 2): first}
 
 
 def test_report_builder_uses_sparse_benchmark_probe_rows_without_fixed_key_scans() -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -432,6 +432,7 @@ def _collect_benchmark_probe_metrics(
     prefix: str,
 ) -> None:
     aggregates_by_label_and_key: dict[tuple[str, str], _NumericAggregate] = {}
+    matrix_label_cache: dict[tuple[object, object, object, object, object], str] = {}
     for row in _dict_rows(rows):
         label = ""
         for key, raw_value in row.items():
@@ -443,7 +444,7 @@ def _collect_benchmark_probe_metrics(
                 value = _float_or_none(raw_value)
             if value is not None:
                 if not label:
-                    label = _benchmark_probe_label(row)
+                    label = _benchmark_probe_label(row, matrix_label_cache=matrix_label_cache)
                 aggregate_key = (label, key)
                 aggregates_by_label_and_key[aggregate_key] = _update_numeric_aggregate(
                     aggregates_by_label_and_key.get(aggregate_key),
@@ -521,8 +522,28 @@ def _aggregate_probe_values(key: str, values: list[float]) -> tuple[str, float]:
     return _finalize_numeric_aggregate(key, aggregate)
 
 
-def _benchmark_probe_label(row: dict[str, object]) -> str:
+def _benchmark_probe_label(
+    row: dict[str, object],
+    *,
+    matrix_label_cache: dict[tuple[object, object, object, object, object], str] | None = None,
+) -> str:
     if "cell_id" in row or ("suite_id" in row and "concurrency_level" in row):
+        if matrix_label_cache is not None:
+            cache_key = (
+                row.get("suite_id", "suite"),
+                row.get("context_length", 0),
+                row.get("generation_length", 0),
+                row.get("batch_size", 0),
+                row.get("concurrency_level", 0),
+            )
+            try:
+                return matrix_label_cache[cache_key]
+            except KeyError:
+                label = _matrix_label(row)
+                matrix_label_cache[cache_key] = label
+                return label
+            except TypeError:
+                pass
         return _matrix_label(row)
     suite = _label_part(row.get("suite", row.get("suite_id", "suite")))
     context_length = _label_part(row.get("context_length", 0))


### PR DESCRIPTION
## Summary
- Cache repeated matrix-style benchmark probe labels while aggregating benchmark/evaluation report metrics.
- Add focused coverage for the cache path and document the optimization slice plan.

## Plan or Spec
- `docs/plans/2026-05-01-benchmark-evaluation-matrix-label-cache.md`
- Registered probe: `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# exit 0; 27 passed in 0.11s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# exit 0; total coverage 98%; source file coverage 97%; test file coverage 99%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-evaluation-report-running-aggregates --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-benchmark-eval-current --head-repo "$PWD" --output /tmp/melix_probe_label_cache_<timestamp>/report.json
# exit 0; base elapsed_ms_mean=154.337, head elapsed_ms_mean=143.547, row_count=5990.0 both sides

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 98% total; `benchmark_evaluation_report.py` 97%; `test_benchmark_evaluation_report.py` 99%.
- Registered local Linux probe `benchmark-evaluation-report-running-aggregates`:
  - `elapsed_ms_mean`: base `154.337 ms`, head `143.547 ms`, delta `-10.790 ms` (`6.991%` faster).
  - `peak_bytes_mean`: base `3,785,308 bytes`, head `3,799,820 bytes`, delta `+14,512 bytes` (`0.383%`, below 5% warning threshold).
  - `row_count`: base/head `5990.0`.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local validation covers Python/Linux only; no Swift runtime effect is claimed for this Python slice.
- The label cache intentionally applies only to matrix-style rows because non-matrix benchmark context rows are often unique in the registered probe workload.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
