### PR TITLE
perf(mlx-worker-python): optimize benchmark probe aggregates

### DIFF
--- a/docs/plans/2026-05-01-benchmark-evaluation-probe-aggregate-fast-path.md
+++ b/docs/plans/2026-05-01-benchmark-evaluation-probe-aggregate-fast-path.md
@@ -1,0 +1,41 @@
+# Benchmark Evaluation Probe Aggregate Fast Path
+
+## Goal
+
+Reduce redundant dictionary-key allocation and aggregate-map churn inside `worker/productization/benchmark_evaluation_report.py` while preserving benchmark/evaluation report metric names, values, and warning semantics.
+
+## Scope
+
+This Linux-verifiable Python optimization slice is limited to:
+
+- `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`
+- `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`
+
+No Swift, protobuf, workflow, dependency, or generated-artifact changes are in scope.
+
+## Performance Probe
+
+Use the already-registered PR-scoped performance probe `benchmark-evaluation-report-running-aggregates` from `infra/perf/pr_scoped_probes.json`.
+
+Tracked metrics:
+
+- `elapsed_ms_mean` — lower is better
+- `peak_bytes_mean` — lower is better
+- `row_count` — parity guard
+
+## Success Metrics
+
+- Focused pytest for `test_benchmark_evaluation_report.py` passes.
+- Changed-scope automated coverage for the touched executable Python file is at least 95%.
+- The local probe reports identical `row_count` and non-regressing `elapsed_ms_mean` / `peak_bytes_mean` versus the pre-change baseline.
+
+## Implementation Plan
+
+1. Rework benchmark probe aggregation to store aggregates per label, then per probe key, instead of building a `(label, key)` tuple for every numeric sample.
+2. Keep sparse-row compatibility by continuing to discover probe values from `row.items()` rather than fixed-key `.get(...)` scans.
+3. Add a focused regression test that exercises multiple probe keys for one label and preserves the existing exported metric names and values.
+4. Run focused pytest, changed-scope coverage, `git diff --check`, and the registered local performance probe before commit.
+
+## Validation Boundary
+
+This is a Python-only Linux-local optimization slice. The existing PR-scoped performance CI probe for this path remains the CI merge gate after the PR is opened.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -9,6 +9,7 @@ from worker.productization.benchmark_evaluation_report import (
     _METRIC_DIRECTION_BY_KEY,
     _aggregate_probe_values,
     _benchmark_probe_label,
+    _collect_benchmark_probe_metrics,
     _dict_rows,
     _finalize_numeric_aggregate,
     _label_part,
@@ -16,6 +17,7 @@ from worker.productization.benchmark_evaluation_report import (
     _metric_direction,
     _report_rows,
     _update_numeric_aggregate,
+    _update_probe_aggregates_by_label,
     build_benchmark_evaluation_report,
     build_sticky_comment_body,
     load_report_input,
@@ -260,6 +262,57 @@ def test_numeric_aggregate_helpers_track_running_totals() -> None:
     assert _finalize_numeric_aggregate("prefill_ms", aggregate) == ("mean", 4.0)
     assert _finalize_numeric_aggregate("cache_hit", aggregate) == ("rate", 4.0)
     assert _finalize_numeric_aggregate("speculative_fallback_count", aggregate) == ("sum", 8.0)
+
+
+def test_collect_benchmark_probe_metrics_groups_aggregates_by_label_and_preserves_metrics() -> None:
+    row_a = _SparseProbeRow(
+        {
+            "suite_id": "smoke",
+            "context_length": 1024,
+            "generation_length": 128,
+            "batch_size": 1,
+            "concurrency_level": 1,
+            "prefill_ms": 10.0,
+            "decode_ms": 20.0,
+            "speculative_fallback_count": 1,
+        },
+        forbidden_keys={"prefill_ms", "decode_ms", "speculative_fallback_count"},
+    )
+    row_b = _SparseProbeRow(
+        {
+            "suite_id": "smoke",
+            "context_length": 1024,
+            "generation_length": 128,
+            "batch_size": 1,
+            "concurrency_level": 1,
+            "prefill_ms": 14.0,
+            "decode_ms": 24.0,
+            "speculative_fallback_count": 3,
+        },
+        forbidden_keys={"prefill_ms", "decode_ms", "speculative_fallback_count"},
+    )
+
+    aggregates_by_label: dict[str, dict[str, tuple[float, int]]] = {}
+    _update_probe_aggregates_by_label(aggregates_by_label, label="shared", key="prefill_ms", value=10.0)
+    _update_probe_aggregates_by_label(aggregates_by_label, label="shared", key="prefill_ms", value=14.0)
+    _update_probe_aggregates_by_label(aggregates_by_label, label="shared", key="decode_ms", value=20.0)
+
+    assert aggregates_by_label == {
+        "shared": {
+            "prefill_ms": (24.0, 2),
+            "decode_ms": (20.0, 1),
+        }
+    }
+
+    metrics: dict[str, object] = {}
+    _collect_benchmark_probe_metrics(metrics, [row_a, row_b], prefix="bench")
+
+    label = "smoke.ctx1024.gen128.b1.c1"
+    assert metrics == {
+        f"bench.{label}.prefill_ms_mean": 12.0,
+        f"bench.{label}.decode_ms_mean": 22.0,
+        f"bench.{label}.speculative_fallback_count_sum": 4.0,
+    }
 
 
 def test_dict_rows_returns_lazy_iterable_of_dict_rows() -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -431,7 +431,7 @@ def _collect_benchmark_probe_metrics(
     *,
     prefix: str,
 ) -> None:
-    aggregates_by_label_and_key: dict[tuple[str, str], _NumericAggregate] = {}
+    aggregates_by_label: dict[str, dict[str, _NumericAggregate]] = {}
     matrix_label_cache: dict[tuple[object, object, object, object, object], str] = {}
     for row in _dict_rows(rows):
         label = ""
@@ -445,14 +445,16 @@ def _collect_benchmark_probe_metrics(
             if value is not None:
                 if not label:
                     label = _benchmark_probe_label(row, matrix_label_cache=matrix_label_cache)
-                aggregate_key = (label, key)
-                aggregates_by_label_and_key[aggregate_key] = _update_numeric_aggregate(
-                    aggregates_by_label_and_key.get(aggregate_key),
-                    value,
+                _update_probe_aggregates_by_label(
+                    aggregates_by_label,
+                    label=label,
+                    key=key,
+                    value=value,
                 )
-    for (label, key), aggregate in aggregates_by_label_and_key.items():
-        suffix, value = _finalize_numeric_aggregate(key, aggregate)
-        metrics[f"{prefix}.{label}.{key}_{suffix}"] = value
+    for label, aggregates_by_key in aggregates_by_label.items():
+        for key, aggregate in aggregates_by_key.items():
+            suffix, value = _finalize_numeric_aggregate(key, aggregate)
+            metrics[f"{prefix}.{label}.{key}_{suffix}"] = value
 
 
 def _collect_evaluation_sample_probe_metrics(
@@ -495,6 +497,20 @@ def _update_numeric_aggregate(
     if aggregate is None:
         return (value, 1)
     return (aggregate[0] + value, aggregate[1] + 1)
+
+
+def _update_probe_aggregates_by_label(
+    aggregates_by_label: dict[str, dict[str, _NumericAggregate]],
+    *,
+    label: str,
+    key: str,
+    value: float,
+) -> None:
+    aggregates_by_key = aggregates_by_label.get(label)
+    if aggregates_by_key is None:
+        aggregates_by_key = {}
+        aggregates_by_label[label] = aggregates_by_key
+    aggregates_by_key[key] = _update_numeric_aggregate(aggregates_by_key.get(key), value)
 
 
 def _finalize_numeric_aggregate(


### PR DESCRIPTION
## Summary
- Optimize benchmark probe aggregation in `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py` by grouping running aggregates per label and probe key instead of allocating a `(label, key)` tuple for each numeric sample.
- Preserve existing exported metric names, values, and warning semantics.
- Add focused regression coverage for the grouped aggregation path and record the governing optimization plan.

## Plan or Spec
- `docs/plans/2026-05-01-benchmark-evaluation-probe-aggregate-fast-path.md`

## Commands Run
```text
git diff --check
PASS

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
28 passed in 0.06s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py 97%
services/mlx-worker-python/tests/test_benchmark_evaluation_report.py 99%
TOTAL 98.32%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
measurable_changed_lines=[434, 448, 454, 455, 456, 457, 502, 509, 510, 511, 512, 513]
covered_changed_lines=[434, 448, 454, 455, 456, 457, 502, 509, 510, 511, 512, 513]
TOTAL 12 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_benchmark_evaluation_report as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
head probe: {"elapsed_ms_mean": 148.36, "peak_bytes_mean": 3809180.0, "row_count": 5990.0}
base probe on origin/main: {"elapsed_ms_mean": 160.914, "peak_bytes_mean": 3799820.0, "row_count": 5990.0}

Spec review: PASS
Quality review: APPROVED
```

## Coverage and Metrics
- Focused pytest: `28 passed in 0.06s` for `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`.
- Whole-file coverage:
  - `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`: `97%`
  - `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`: `99%`
  - Total: `98.32%`
- Changed-scope coverage for `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`:
  - `measurable_changed_lines=[434, 448, 454, 455, 456, 457, 502, 509, 510, 511, 512, 513]`
  - `covered_changed_lines=[434, 448, 454, 455, 456, 457, 502, 509, 510, 511, 512, 513]`
  - `TOTAL 12 0 100%`
- Registered PR-scoped probe `benchmark-evaluation-report-running-aggregates`:
  - head: `{"elapsed_ms_mean": 148.36, "peak_bytes_mean": 3809180.0, "row_count": 5990.0}`
  - base (`origin/main`): `{"elapsed_ms_mean": 160.914, "peak_bytes_mean": 3799820.0, "row_count": 5990.0}`
  - interpretation: `row_count` unchanged; elapsed improved by about `7.8%`; peak traced bytes regressed by about `0.25%`, below the `5%` warning threshold.

## Known Gaps
- Linux-only local verification covered the Python path only; no Swift/macOS-local checks were run because this slice is Python-only and the registered scoped CI probe is the remote gate.
- None otherwise.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (No protocol changes in this slice.)
- [x] Dependency changes include updated lockfiles. (No dependency changes in this slice.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
