### PR TITLE
perf: prime evaluation job ids with scandir

### DIFF
--- a/docs/plans/2026-05-01-evaluation-job-id-scandir.md
+++ b/docs/plans/2026-05-01-evaluation-job-id-scandir.md
@@ -1,0 +1,41 @@
+# Evaluation Job ID Scandir Optimization Plan
+
+## Goal
+
+Reduce evaluation job-id allocation overhead when an evaluation jobs directory already contains many persisted runs.
+
+## Linux Verification Scope
+
+This slice is limited to Python worker code and the registered PR-scoped performance probe, so it is fully verifiable on Linux.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/engine/evaluation_core.py`
+- `services/mlx-worker-python/tests/test_evaluation_core.py`
+- `docs/plans/2026-05-01-evaluation-job-id-scandir.md`
+
+## Registered Probe
+
+The affected path is already covered by the `evaluation-job-id-high-water-mark` entry in `infra/perf/pr_scoped_probes.json`:
+
+- `watch_globs` includes `services/mlx-worker-python/worker/engine/evaluation_core.py` and the focused tests.
+- `test_command` runs the evaluation job-id regression tests and PR-scoped performance probe dispatch checks.
+- `coverage_command` measures changed-scope coverage for `evaluation_core.py` and `pr_scoped_performance.py`.
+- `probe_command` runs `_probe_evaluation_job_id(...)`, which seeds 2,000 existing `eval-NNNN` run directories and allocates 200 new job IDs.
+
+## Optimization Slice
+
+Replace the `_prime_next_job_index(...)` `Path.iterdir()` loop with an `os.scandir()` loop that reads `DirEntry.name` and checks directories with `follow_symlinks=False`. This avoids allocating `Path` objects for every existing run directory while preserving the same high-water-mark semantics.
+
+## Success Metrics
+
+- Functional behavior remains unchanged for existing and conflicting `eval-NNNN` run directories.
+- Changed-scope coverage remains at least 95%.
+- The registered `evaluation-job-id-high-water-mark` probe should show lower `elapsed_ms_mean` and `per_call_ms_mean` versus the `origin/main` baseline.
+
+## Verification Commands
+
+- Registered focused `test_command` from `infra/perf/pr_scoped_probes.json`.
+- Registered `coverage_command` from `infra/perf/pr_scoped_probes.json`.
+- Registered `probe_command` from `infra/perf/pr_scoped_probes.json`, run locally before and after the implementation.
+- `git diff --check`.

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -677,16 +677,20 @@ def test_next_job_id_only_scans_existing_runs_once_per_process(
     runs_root = jobs_root / "runs"
     (runs_root / "eval-0002").mkdir(parents=True)
     runner = EvaluationCore(jobs_root=jobs_root)
-    original_iterdir = Path.iterdir
+    original_scandir = evaluation_core_module.os.scandir
     scan_count = 0
 
-    def tracked_iterdir(path: Path):
+    def tracked_scandir(path: str | bytes | Path):
         nonlocal scan_count
-        if path == runs_root:
+        if Path(path) == runs_root:
             scan_count += 1
-        return original_iterdir(path)
+        return original_scandir(path)
 
-    monkeypatch.setattr(Path, "iterdir", tracked_iterdir)
+    def fail_iterdir(path: Path):
+        raise AssertionError("_prime_next_job_index should use os.scandir instead of Path.iterdir")
+
+    monkeypatch.setattr(evaluation_core_module.os, "scandir", tracked_scandir)
+    monkeypatch.setattr(Path, "iterdir", fail_iterdir)
 
     assert runner._next_job_id() == "eval-0003"
     assert runner._next_job_id() == "eval-0004"

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import gc
 import json
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 import random
@@ -1690,13 +1691,14 @@ class EvaluationCore:
         if self._next_job_index is not None:
             return self._next_job_index
         highest_index = 0
-        for child in runs_root.iterdir():
-            if not child.is_dir():
-                continue
-            match = re.fullmatch(r"eval-(\d{4})", child.name)
-            if match is None:
-                continue
-            highest_index = max(highest_index, int(match.group(1)))
+        with os.scandir(os.fspath(runs_root)) as entries:
+            for entry in entries:
+                if not entry.is_dir(follow_symlinks=False):
+                    continue
+                match = re.fullmatch(r"eval-(\d{4})", entry.name)
+                if match is None:
+                    continue
+                highest_index = max(highest_index, int(match.group(1)))
         self._next_job_index = highest_index + 1
         return self._next_job_index
 


### PR DESCRIPTION
## Summary
- Replace evaluation job-id high-water-mark priming from `Path.iterdir()` to `os.scandir()` to avoid per-entry `Path` allocation on large run directories.
- Keep behavior unchanged for existing `eval-NNNN` directories, non-directory conflicts, and cached next-index allocation.
- Add a focused regression assertion that `_prime_next_job_index()` uses the scandir path and does not fall back to `Path.iterdir()`.

## Plan or Spec
- `docs/plans/2026-05-01-evaluation-job-id-scandir.md`
- Registered PR-scoped performance probe: `evaluation-job-id-high-water-mark` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Registered probe coverage check before implementation
python3 .tmp_probe_registry_check.py
# result: evaluation-job-id-high-water-mark has test_command, coverage_command, and probe_command.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_primes_from_highest_existing_run_directory services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_only_scans_existing_runs_once_per_process services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_skips_conflicting_cached_index_and_non_directory_entries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_job_id_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
# result: 6 passed in 3.27s

# Baseline registered-probe implementation smoke, equivalent to the registry probe_command but run through a temp file to avoid shell quoting issues in this environment.
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .tmp_eval_probe.py
# result: {"allocation_count": 200.0, "elapsed_ms_mean": 21.903, "first_job_id_numeric": 2001.0, "last_job_id_numeric": 2200.0, "per_call_ms_mean": 0.109514, "seeded_run_count": 2000.0}

# Focused post-change test command, covering the registered test_command plus the persistence smoke from the registry entry.
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_executes_packaged_dataset_and_persists_result services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_primes_from_highest_existing_run_directory services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_only_scans_existing_runs_once_per_process services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_skips_conflicting_cached_index_and_non_directory_entries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_job_id_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
# result: 7 passed in 2.64s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_executes_packaged_dataset_and_persists_result services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_primes_from_highest_existing_run_directory services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_only_scans_existing_runs_once_per_process services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_skips_conflicting_cached_index_and_non_directory_entries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_job_id_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py
# result: 7 passed in 7.21s; TOTAL 9 0 100%

# Post-change registered-probe implementation smoke, equivalent to the registry probe_command.
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .tmp_eval_probe.py
# result: {"allocation_count": 200.0, "elapsed_ms_mean": 13.694, "first_job_id_numeric": 2001.0, "last_job_id_numeric": 2200.0, "per_call_ms_mean": 0.068469, "seeded_run_count": 2000.0}

git diff --check
# result: exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 9 0 100%` from `scripts/changed_scope_coverage.py`.
- Local registered probe equivalent, `evaluation-job-id-high-water-mark`:
  - baseline `elapsed_ms_mean=21.903`, `per_call_ms_mean=0.109514`
  - branch `elapsed_ms_mean=13.694`, `per_call_ms_mean=0.068469`
  - delta `elapsed_ms_mean=-8.209ms`, speedup `1.599x`, improvement `37.48%`
- CI PR-scoped performance workflow is required to validate the registered probe in GitHub Actions before merge.

## Known Gaps
- None for the Python/Linux scope. No Swift runtime behavior is changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
