### PR TITLE
perf(training): speed prompt completion token stats

### DIFF
--- a/docs/plans/2026-05-01-training-token-stats-prompt-completion-fast-path.md
+++ b/docs/plans/2026-05-01-training-token-stats-prompt-completion-fast-path.md
@@ -16,10 +16,11 @@ The affected path is covered by the registered PR-scoped probe `training-dataset
 ## Implementation plan
 
 1. Keep token count collection behavior unchanged.
-2. Add a direct `prompt_completion` branch in `_collect_token_stats()` so the common training-dataset path avoids dispatching through the generic format helper for every sample.
-3. Preserve the generic helper path for chat and text-completion formats.
-4. Add focused regression coverage that fails if the prompt/completion path falls back to the generic helper.
-5. Validate with the focused training dataset tests, changed-scope coverage, and the registered PR-scoped performance probe on Linux.
+2. Keep the direct `prompt_completion` branch in `_collect_token_stats()` so the common training-dataset path avoids dispatching through the generic format helper for every sample.
+3. Collect prompt/completion token series with list-comprehension fast paths and inline the unchanged whitespace split count for that hot branch, avoiding an extra list copy for already-materialized sample lists while preserving one-shot iterable support and percentile semantics.
+4. Preserve the generic helper path for chat and text-completion formats.
+5. Keep focused regression coverage that fails if the prompt/completion path falls back to the generic helper and now exercises a one-shot iterable input.
+6. Validate with the focused training dataset tests, changed-scope coverage, and the registered PR-scoped performance probe on Linux.
 
 ## Success criteria
 

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -637,13 +637,17 @@ def test_build_token_stats_reuses_single_sorted_pass_per_token_series(monkeypatc
     monkeypatch.setattr(training_dataset_module, "_percentile_value", fail_percentile_value)
     monkeypatch.setattr(training_dataset_module, "_sample_token_counts", fail_generic_token_counter)
 
-    assert training_dataset_module._build_token_stats(
+    prompt_completion_samples = iter(
         [
             {"prompt": "a b c", "completion": "d e"},
             {"prompt": "f", "completion": "g h i j"},
             {"prompt": "k l", "completion": "m"},
             {"prompt": "n o p q", "completion": "r s t"},
-        ],
+        ]
+    )
+
+    assert training_dataset_module._build_token_stats(
+        prompt_completion_samples,
         "prompt_completion",
     ) == {
         "estimator": "whitespace_v1",

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1354,21 +1354,31 @@ def _collect_token_stats(samples: Iterable[dict[str, Any]], format_name: str) ->
     total_tokens: list[int] = []
     sample_count = 0
     if format_name == "prompt_completion":
-        count_tokens = _whitespace_token_count
-        for sample in samples:
-            sample_count += 1
-            prompt_count = count_tokens(str(sample.get("prompt", "")))
-            completion_count = count_tokens(str(sample.get("completion", "")))
-            prompt_tokens.append(prompt_count)
-            completion_tokens.append(completion_count)
-            total_tokens.append(prompt_count + completion_count)
+        materialized_samples = samples if isinstance(samples, list) else list(samples)
+        sample_count = len(materialized_samples)
+        prompt_tokens = [
+            len(str(sample.get("prompt", "")).split())
+            for sample in materialized_samples
+        ]
+        completion_tokens = [
+            len(str(sample.get("completion", "")).split())
+            for sample in materialized_samples
+        ]
+        total_tokens = [
+            prompt_count + completion_count
+            for prompt_count, completion_count in zip(prompt_tokens, completion_tokens)
+        ]
     else:
+        prompt_tokens_append = prompt_tokens.append
+        completion_tokens_append = completion_tokens.append
+        total_tokens_append = total_tokens.append
+        sample_token_counts = _sample_token_counts
         for sample in samples:
             sample_count += 1
-            prompt_count, completion_count = _sample_token_counts(sample, format_name)
-            prompt_tokens.append(prompt_count)
-            completion_tokens.append(completion_count)
-            total_tokens.append(prompt_count + completion_count)
+            prompt_count, completion_count = sample_token_counts(sample, format_name)
+            prompt_tokens_append(prompt_count)
+            completion_tokens_append(completion_count)
+            total_tokens_append(prompt_count + completion_count)
 
     prompt_summary = _summarize_token_values(prompt_tokens)
     completion_summary = _summarize_token_values(completion_tokens)


### PR DESCRIPTION
## Summary
- Optimize the Python training dataset `prompt_completion` token-stats hot path by collecting prompt/completion token series with list-comprehension fast paths.
- Avoid an extra list copy when callers already pass a materialized sample list, while still preserving one-shot iterable support.
- Keep the registered PR-scoped probe coverage for `training-dataset-token-percentiles-single-sort`.

## Plan or Spec
- `docs/plans/2026-05-01-training-token-stats-prompt-completion-fast-path.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; 41 passed in 6.71s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; 41 passed; TOTAL 92%; changed test file 97%; pr_scoped_performance.py 96%; training_dataset.py 85% module-level focused coverage

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json --ignore-errors -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/tests/test_training_dataset_builder.py
# exit 0; changed-line coverage 100.00% (15/15)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-token-percentiles-single-sort --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-slice-20260501132704 --head-repo "$PWD" --output /tmp/melix-training-token-local-bindings-report.json
# exit 0; base elapsed_ms_mean=15.147, head elapsed_ms_mean=12.789

git diff --check
# exit 0
```

## Coverage and Metrics
- Registered probe: `training-dataset-token-percentiles-single-sort` in `infra/perf/pr_scoped_probes.json`.
- Local registered probe result: `elapsed_ms_mean` base `15.147 ms`, head `12.789 ms`, delta `-2.358 ms` (`-15.57%`, lower is better).
- Output parity: `sample_count=20000`, `prompt_tokens_p95=9`, `total_tokens_p95=14` for both base/head probe runs.
- Changed-line coverage: `100.00%` (15/15 measurable changed lines).
- CI PR-scoped performance validation is still required before merge.

## Known Gaps
- Linux local validation covers the Python worker path only; no Swift runtime behavior is touched.
- Module-level focused coverage for `training_dataset.py` remains below 95% because the file contains broader dataset/HF paths outside this slice; changed-line coverage for this slice is 100%.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
