### PR TITLE
perf(swift): reuse CLI metric locale

### DIFF
--- a/Sources/MelixCLICore/MelixCLIJSON.swift
+++ b/Sources/MelixCLICore/MelixCLIJSON.swift
@@ -8,6 +8,8 @@ func elapsedMilliseconds(since start: DispatchTime) -> Double {
 }
 
 enum MelixCLIJSONMetricPatch {
+    private static let metricLiteralLocale = Locale(identifier: "en_US_POSIX")
+
     struct Placeholder {
         let token: String
 
@@ -28,7 +30,7 @@ enum MelixCLIJSONMetricPatch {
         let finiteValue = value.isFinite ? max(value, 0) : 0
         return String(
             format: "%.16e",
-            locale: Locale(identifier: "en_US_POSIX"),
+            locale: metricLiteralLocale,
             finiteValue
         )
     }

--- a/docs/plans/2026-05-01-swift-cli-json-envelope-performance.md
+++ b/docs/plans/2026-05-01-swift-cli-json-envelope-performance.md
@@ -19,9 +19,11 @@ Optimize the Swift CLI JSON envelope metric-object assembly path and register a 
 
 ## Design
 
-`MelixCLIJSONEnvelope` currently converts `[String: Double]` into `[String: Any]` through `reduce(into:)` starting from an empty dictionary, then appends the measured JSON encode placeholder. The slice introduces a small helper that preallocates `metrics.count + 1` slots and is shared by success and error envelope construction.
+`MelixCLIJSONEnvelope` currently converts `[String: Double]` into `[String: Any]` through `reduce(into:)` starting from an empty dictionary, then appends the measured JSON encode placeholder. The first slice introduced a small helper that preallocates `metrics.count + 1` slots and is shared by success and error envelope construction.
 
-The PR-scoped performance registry gains a `command_json` probe mode so Swift probes can execute a shell command on a macOS runner and emit JSON metrics without requiring Python to import Swift code directly.
+The next slice keeps the same JSON literal formatting semantics but reuses the POSIX `Locale` object used by `String(format:locale:)` for metric placeholder replacement. This avoids constructing `Locale(identifier: "en_US_POSIX")` on every success/error envelope metric patch while preserving stable decimal formatting.
+
+The PR-scoped performance registry uses a `command_json` probe mode so Swift probes can execute a shell command on a macOS runner and emit JSON metrics without requiring Python to import Swift code directly.
 
 ## Success Metrics
 

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -184,6 +184,8 @@ struct MelixCLIRunnerTests {
         #expect(throws: MelixCLIError.runtime("Pipeline metrics placeholder is too short for the encoded metric.")) {
             try MelixCLIJSONMetricPatch.paddedLiteralData(for: 1, byteCount: 1)
         }
+        #expect(MelixCLIJSONMetricPatch.literal(for: 1.5) == "1.5000000000000000e+00")
+        #expect(MelixCLIJSONMetricPatch.literal(for: -1) == "0.0000000000000000e+00")
     }
 
     @Test("json metric patching preserves user artifact strings that look like the old sentinel")


### PR DESCRIPTION
## Summary
- Reuse a single POSIX `Locale` for Swift CLI metric literal formatting instead of constructing `Locale(identifier: "en_US_POSIX")` on every JSON envelope metric patch.
- Add focused Swift assertions that the metric literal helper preserves stable exponential formatting and clamps negative values as before.

## Plan or Spec
- `docs/plans/2026-05-01-swift-cli-json-envelope-performance.md`

## Commands Run
```text
# Synced slice base
cd /root/.hermes/profiles/coder/workspace/worktrees/melix-base-training-token-local-bindings-20260501125933 && git fetch origin && git reset --hard origin/main
# result: exit 0, base at c258b13

# Registered probe preflight
python3 - <<'PY'
import json
from pathlib import Path
probes=json.loads(Path('infra/perf/pr_scoped_probes.json').read_text())
probe=next(p for p in probes if p['id']=='swift-cli-json-envelope-encoding')
print(probe['id'])
for key in ('test_command','coverage_command','probe_command'):
    print(f'{key}:', bool(probe.get(key)))
print('watch_globs:', ', '.join(probe['watch_globs']))
PY
# result: exit 0; swift-cli-json-envelope-encoding has test_command, coverage_command, and probe_command

command -v swift
# result: no swift binary in this Linux environment; Swift runtime validation deferred to macOS CI

git diff --check
# result: exit 0
```

## Coverage and Metrics
- Local Linux coverage/metrics: N/A for Swift runtime effect because this environment has no `swift` toolchain.
- Registered PR-scoped probe: `swift-cli-json-envelope-encoding` (`runner: macos-15`) covers `Sources/MelixCLICore/MelixCLIJSON.swift` and `tests/MelixCLITests/MelixCLIRunnerTests.swift` with focused `test_command`, `coverage_command`, and `probe_command` entries.
- CI required: macOS PR-scoped performance probe must complete successfully before merge.

## Known Gaps
- Swift performance effect is not locally validated on Linux; macOS CI is the validation source for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run. Local static/probe-registry checks ran; Swift tests require macOS CI.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
