### PR TITLE
perf(training): single-pass prompt-completion token stats

### DIFF
--- a/docs/plans/2026-05-01-training-dataset-token-stats-single-pass.md
+++ b/docs/plans/2026-05-01-training-dataset-token-stats-single-pass.md
@@ -1,0 +1,48 @@
+# Training dataset token stats single-pass optimization
+
+## Goal
+
+Reduce redundant work in `services/mlx-worker-python/worker/model_ops/training_dataset.py` when computing `prompt_completion` token statistics by keeping the direct fast path but avoiding extra materialization and repeated list-comprehension passes.
+
+## Scope
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset.py`
+- `services/mlx-worker-python/tests/test_training_dataset_builder.py`
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- Reuse the existing scoped CI probe registration for `training-dataset-token-percentiles-single-sort`
+
+## Linux-only constraint
+
+This slice is Python-only and must be verified locally on Linux with focused pytest, changed-scope coverage, and an explicit local performance probe before commit.
+
+## Intended change
+
+- Keep `_collect_token_stats(..., "prompt_completion")` on a specialized fast path.
+- Replace the current materialize-plus-multiple-list-comprehensions approach with one direct pass over the samples.
+- Preserve the existing output schema and metric semantics exactly.
+- Add or update focused regression tests to prove the optimized path still uses the specialized direct logic and handles non-list iterables correctly.
+
+## Performance probe
+
+Use the already-registered PR-scoped performance probe:
+
+- Probe id: `training-dataset-token-percentiles-single-sort`
+- Local command:
+  - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_training_dataset_token_percentiles as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"`
+
+## Success metrics
+
+- `elapsed_ms_mean` from the training-dataset token-percentiles probe improves versus `origin/main`, or at minimum does not regress while removing redundant traversal/materialization.
+- `prompt_tokens_p95`, `total_tokens_p95`, and `sample_count` remain unchanged.
+- Changed executable scope coverage is at least 95%.
+
+## Verification commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_training_dataset_token_percentiles as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"`
+```

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -12,6 +12,7 @@ from worker.productization.pr_scoped_performance import (
     _build_large_benchmark_bundle,
     _build_large_training_dataset_samples,
     _build_metric_row,
+    _single_pass_sample_iterable,
     _build_probe_report_row,
     _build_probe_details,
     _closure_index_text,
@@ -163,6 +164,57 @@ def test_load_probe_registry_rejects_invalid_payloads(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="non-empty list"):
         load_probe_registry(invalid_metrics)
+
+
+def test_single_pass_sample_iterable_rejects_repeated_iteration() -> None:
+    samples = _build_large_training_dataset_samples()[:2]
+    iterable = _single_pass_sample_iterable(samples)
+
+    assert list(iterable) == samples
+    with pytest.raises(RuntimeError, match="consumed more than once"):
+        list(iterable)
+
+
+def test_probe_training_dataset_token_percentiles_uses_single_pass_non_list_iterables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sample_rows = _build_large_training_dataset_samples()[:4]
+    calls = 0
+
+    class FakeTrainingDatasetModule:
+        @staticmethod
+        def _build_token_stats(samples: object, format_name: str) -> dict[str, float]:
+            nonlocal calls
+            calls += 1
+            assert format_name == "prompt_completion"
+            assert not isinstance(samples, list)
+            assert list(samples) == sample_rows
+            with pytest.raises(RuntimeError, match="consumed more than once"):
+                list(samples)
+            return {
+                "prompt_tokens_p95": 9.0,
+                "total_tokens_p95": 16.0,
+                "sample_count": float(len(sample_rows)),
+            }
+
+    monkeypatch.setattr(
+        pr_scoped_performance_module,
+        "_load_repo_module",
+        lambda path, *, unique_name: FakeTrainingDatasetModule(),
+    )
+    monkeypatch.setattr(
+        pr_scoped_performance_module,
+        "_build_large_training_dataset_samples",
+        lambda: sample_rows,
+    )
+
+    metrics = _probe_training_dataset_token_percentiles(REPO_ROOT)
+
+    assert calls == 3
+    assert metrics["sample_count"] == float(len(sample_rows))
+    assert metrics["prompt_tokens_p95"] == 9.0
+    assert metrics["total_tokens_p95"] == 16.0
+    assert metrics["elapsed_ms_mean"] >= 0
 
 
 def test_probe_smokes_return_metrics_against_current_repo() -> None:

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -634,17 +634,27 @@ def test_build_token_stats_reuses_single_sorted_pass_per_token_series(monkeypatc
     def fail_generic_token_counter(sample: dict[str, object], format_name: str) -> tuple[int, int]:
         raise AssertionError(f"prompt_completion token stats should use the direct fast path ({format_name=})")
 
+    class SinglePassPromptCompletionSamples:
+        def __init__(self) -> None:
+            self.iterations = 0
+
+        def __iter__(self):
+            self.iterations += 1
+            if self.iterations > 1:
+                raise AssertionError("prompt_completion token stats should consume the iterable only once")
+            return iter(
+                [
+                    {"prompt": "a b c", "completion": "d e"},
+                    {"prompt": "f", "completion": "g h i j"},
+                    {"prompt": "k l", "completion": "m"},
+                    {"prompt": "n o p q", "completion": "r s t"},
+                ]
+            )
+
     monkeypatch.setattr(training_dataset_module, "_percentile_value", fail_percentile_value)
     monkeypatch.setattr(training_dataset_module, "_sample_token_counts", fail_generic_token_counter)
 
-    prompt_completion_samples = iter(
-        [
-            {"prompt": "a b c", "completion": "d e"},
-            {"prompt": "f", "completion": "g h i j"},
-            {"prompt": "k l", "completion": "m"},
-            {"prompt": "n o p q", "completion": "r s t"},
-        ]
-    )
+    prompt_completion_samples = SinglePassPromptCompletionSamples()
 
     assert training_dataset_module._build_token_stats(
         prompt_completion_samples,
@@ -665,6 +675,7 @@ def test_build_token_stats_reuses_single_sorted_pass_per_token_series(monkeypatc
         "total_tokens_p95": 5,
         "total_tokens_max": 7,
     }
+    assert prompt_completion_samples.iterations == 1
 
     monkeypatch.undo()
     assert training_dataset_module._build_token_stats(

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1354,20 +1354,9 @@ def _collect_token_stats(samples: Iterable[dict[str, Any]], format_name: str) ->
     total_tokens: list[int] = []
     sample_count = 0
     if format_name == "prompt_completion":
-        materialized_samples = samples if isinstance(samples, list) else list(samples)
-        sample_count = len(materialized_samples)
-        prompt_tokens = [
-            len(str(sample.get("prompt", "")).split())
-            for sample in materialized_samples
-        ]
-        completion_tokens = [
-            len(str(sample.get("completion", "")).split())
-            for sample in materialized_samples
-        ]
-        total_tokens = [
-            prompt_count + completion_count
-            for prompt_count, completion_count in zip(prompt_tokens, completion_tokens)
-        ]
+        sample_count, prompt_tokens, completion_tokens, total_tokens = _collect_prompt_completion_token_counts(
+            samples
+        )
     else:
         prompt_tokens_append = prompt_tokens.append
         completion_tokens_append = completion_tokens.append
@@ -1400,6 +1389,28 @@ def _collect_token_stats(samples: Iterable[dict[str, Any]], format_name: str) ->
         "total_tokens_p95": total_summary["p95"],
         "total_tokens_max": total_summary["max"],
     }
+
+
+def _collect_prompt_completion_token_counts(
+    samples: Iterable[dict[str, Any]],
+) -> tuple[int, list[int], list[int], list[int]]:
+    prompt_tokens: list[int] = []
+    completion_tokens: list[int] = []
+    total_tokens: list[int] = []
+    prompt_tokens_append = prompt_tokens.append
+    completion_tokens_append = completion_tokens.append
+    total_tokens_append = total_tokens.append
+    sample_count = 0
+
+    for sample in samples:
+        sample_count += 1
+        prompt_count = len(str(sample.get("prompt", "")).split())
+        completion_count = len(str(sample.get("completion", "")).split())
+        prompt_tokens_append(prompt_count)
+        completion_tokens_append(completion_count)
+        total_tokens_append(prompt_count + completion_count)
+
+    return sample_count, prompt_tokens, completion_tokens, total_tokens
 
 
 def _sample_token_counts(sample: dict[str, Any], format_name: str) -> tuple[int, int]:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -540,7 +540,7 @@ def _probe_training_dataset_token_percentiles(repo_root: Path) -> dict[str, floa
         repo_root / "services/mlx-worker-python/worker/model_ops/training_dataset.py",
         unique_name="melix_probe_training_dataset_token_percentiles",
     )
-    samples = _build_large_training_dataset_samples()
+    sample_rows = _build_large_training_dataset_samples()
     elapsed_samples: list[float] = []
     prompt_p95 = 0.0
     total_p95 = 0.0
@@ -548,7 +548,10 @@ def _probe_training_dataset_token_percentiles(repo_root: Path) -> dict[str, floa
     for _ in range(3):
         gc.collect()
         started = time.perf_counter()
-        token_stats = module._build_token_stats(samples, "prompt_completion")
+        token_stats = module._build_token_stats(
+            _single_pass_sample_iterable(sample_rows),
+            "prompt_completion",
+        )
         elapsed_samples.append((time.perf_counter() - started) * 1000.0)
         prompt_p95 = float(token_stats["prompt_tokens_p95"])
         total_p95 = float(token_stats["total_tokens_p95"])
@@ -679,6 +682,21 @@ def _build_large_training_dataset_samples() -> list[dict[str, str]]:
         }
         for index in range(20000)
     ]
+
+
+def _single_pass_sample_iterable(samples: list[dict[str, str]]) -> Iterable[dict[str, str]]:
+    class _SinglePassIterable:
+        def __init__(self, rows: list[dict[str, str]]) -> None:
+            self._rows = rows
+            self._iterated = False
+
+        def __iter__(self) -> Iterable[dict[str, str]]:
+            if self._iterated:
+                raise RuntimeError("training dataset sample iterable was consumed more than once")
+            self._iterated = True
+            return iter(self._rows)
+
+    return _SinglePassIterable(samples)
 
 
 def _seed_closure_audit_repo(root: Path) -> Path:


### PR DESCRIPTION
## Summary
- make `prompt_completion` token-stat collection in `training_dataset.py` use a dedicated single-pass helper instead of materializing and repeatedly traversing sample iterables
- tighten the existing `training-dataset-token-percentiles-single-sort` scoped probe so it exercises the optimized one-shot iterable path rather than a prebuilt list input
- add focused regression tests for both the dataset-builder fast path and the scoped probe contract

## Plan or Spec
- `docs/plans/2026-05-01-training-dataset-token-stats-single-pass.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 43 passed in 6.09s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 43 passed in 31.94s
# TOTAL 67 1 99%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_melix_training_probe.py
# head: {"elapsed_ms_mean": 12.727, "prompt_tokens_p95": 9.0, "sample_count": 20000.0, "total_tokens_p95": 14.0}
# base(origin/main): {"elapsed_ms_mean": 12.704, "prompt_tokens_p95": 9.0, "sample_count": 20000.0, "total_tokens_p95": 14.0}

git diff --check
# clean
```

## Coverage and Metrics
- Changed-scope coverage: `99%` (`TOTAL 67 1 99%`)
- Changed executable lines:
  - `training_dataset.py`: `100%`
  - `pr_scoped_performance.py`: `100%`
  - `test_training_dataset_builder.py`: `90%`
  - `test_pr_scoped_performance.py`: `100%`
- Local scoped probe (`training-dataset-token-percentiles-single-sort`):
  - head `elapsed_ms_mean=12.727 ms`
  - base `elapsed_ms_mean=12.704 ms`
  - `prompt_tokens_p95=9.0` unchanged
  - `total_tokens_p95=14.0` unchanged
  - `sample_count=20000.0` unchanged
- Interpretation: this slice removes redundant traversal/materialization for one-shot iterables and updates the scoped probe to validate that path directly. Local timing was effectively flat within noise on this host, so the PR-scoped performance CI remains the final gate.

## Known Gaps
- Full-repo verification was not run; this Linux-only slice was verified with focused Python tests, changed-scope coverage, and the scoped local probe.
- macOS/Swift validation was not run locally on this Linux host.
- Local probe timing was near-noise-flat rather than clearly faster, so CI is the final accept/reject signal for regression detection.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
