### PR TITLE
[codex] Slim packaging Python runtime

### DIFF
--- a/.github/workflows/package-self-contained-app.yml
+++ b/.github/workflows/package-self-contained-app.yml
@@ -61,6 +61,12 @@ jobs:
       - name: Packaging smoke checks
         run: make package-smoke
 
+      - name: Prepare packaging Python runtime
+        run: |
+          UV_PROJECT_ENVIRONMENT="$GITHUB_WORKSPACE/.venv-package" \
+          UV_CACHE_DIR="$GITHUB_WORKSPACE/.uv-cache" \
+          uv sync --project services/mlx-worker-python --extra mlx --no-dev --frozen
+
       - name: Compute build metadata
         id: compute-build-metadata
         run: |
@@ -78,13 +84,16 @@ jobs:
       - name: Package self-contained Melix.app
         id: package-app
         run: |
+          PACKAGE_PYTHON="$GITHUB_WORKSPACE/.venv-package/bin/python"
+          PYTHON_RUNTIME_ROOT="$(dirname "$(dirname "$(realpath "$PACKAGE_PYTHON")")")"
+          PYTHON_SITE_PACKAGES="$("$PACKAGE_PYTHON" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
           PYTHONPATH="$GITHUB_WORKSPACE:$GITHUB_WORKSPACE/services/mlx-worker-python" \
-          UV_CACHE_DIR="$GITHUB_WORKSPACE/.uv-cache" \
-          uv run --project services/mlx-worker-python \
-          python scripts/package_macos_menubar_app.py \
+          "$PACKAGE_PYTHON" scripts/package_macos_menubar_app.py \
             --repo-root "$GITHUB_WORKSPACE" \
             --output-path "$RUNNER_TEMP/Melix.app" \
             --archive-path "$RUNNER_TEMP/${{ steps.compute-build-metadata.outputs.artifact_name }}.zip" \
+            --python-runtime-root "$PYTHON_RUNTIME_ROOT" \
+            --python-site-packages-path "$PYTHON_SITE_PACKAGES" \
             --version "${{ steps.compute-build-metadata.outputs.version }}" \
             --json
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ docs/product-brief.md
 .runtime
 .claude
 .venv
+.venv-*
 __pycache__/
 .pytest_cache/
 .coverage

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ package-smoke:
 	mkdir -p "$(UV_CACHE_DIR)"
 	PYTHONPATH="$(ROOT):$(ROOT)/services/mlx-worker-python" UV_CACHE_DIR="$(UV_CACHE_DIR)" uv run --project services/mlx-worker-python --extra mlx pytest \
 		services/mlx-worker-python/tests/test_build_metadata.py \
+		services/mlx-worker-python/tests/test_packaging_dependencies.py \
 		services/mlx-worker-python/tests/test_packaging_targets.py \
 		services/mlx-worker-python/tests/test_macos_app_bundle.py \
 		services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py \

--- a/docs/plans/2026-05-02-packaging-runtime-dependency-slimming.md
+++ b/docs/plans/2026-05-02-packaging-runtime-dependency-slimming.md
@@ -1,0 +1,49 @@
+# Packaging Runtime Dependency Slimming
+
+## Goal
+
+Reduce the Python payload copied into the preview macOS app bundle by separating Python worker
+runtime dependencies from test and build-time tooling dependencies.
+
+## Scope
+
+- Keep the default local developer bootstrap behavior intact for tests.
+- Move Python-only test and code-generation tooling out of the worker's base runtime dependency set.
+- Make the package workflow create a separate runtime-only virtual environment for the app bundle.
+- Keep packaging smoke tests on the developer environment so they can still use pytest.
+
+## Performance Probes and Metrics
+
+- `packaging.python_runtime_site_packages_bytes`: size of the runtime-only package site-packages tree.
+- `packaging.python_runtime_site_packages_file_count`: file count of the runtime-only package site-packages tree.
+- `packaging.bundle_write_seconds`: elapsed time to materialize the app bundle.
+- `packaging.archive_seconds`: elapsed time to create the zip archive.
+
+The current local baseline for the developer environment is approximately 650 MB and 10,910 files
+under `.venv/lib/python3.13/site-packages`; the self-contained app probe wrote a 704 MB bundle and
+spent 13.675 seconds materializing the bundle plus 24.474 seconds archiving it.
+
+## Files
+
+- `services/mlx-worker-python/pyproject.toml`
+- `uv.lock`
+- `.github/workflows/package-self-contained-app.yml`
+- `services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py`
+- `services/mlx-worker-python/tests/test_packaging_dependencies.py`
+
+## Verification
+
+- Focused packaging dependency tests.
+- `make package-smoke`
+- Runtime-only environment size and file-count probe.
+
+## Implementation Results
+
+- Runtime-only package environment: `.venv-package/lib/python3.13/site-packages` measured at
+  approximately 622 MB and 10,269 files.
+- Developer environment baseline after the same lock update:
+  `.venv/lib/python3.13/site-packages` measured at approximately 653 MB.
+- Removed from the runtime-only package environment: `pytest`, `coverage`, and `grpc_tools`.
+- Runtime-only bundle probe with fake Swift executables wrote a 676,480,751 byte `.app`, produced a
+  216,059,040 byte archive, and reported `write_total_seconds=5.714668`,
+  `copy_python_site_packages_seconds=4.719971`, and `archive_seconds=19.918`.

--- a/scripts/m9_release_gate_smoke.py
+++ b/scripts/m9_release_gate_smoke.py
@@ -139,6 +139,7 @@ def _build_fixture_report(
         "evaluation_compare": _build_passing_evaluation_compare_report(),
         "real_workload": _build_passing_real_workload_report(),
         "m9": m9,
+        "lora_path": _build_passing_lora_path_report(),
     }
     if fixture_mode == "passing" and m9_failures:
         raise RuntimeError(f"Passing M9 fixture unexpectedly failed: {m9_failures}")
@@ -301,6 +302,24 @@ def _build_passing_real_workload_report() -> dict[str, object]:
                     "peak_memory_gb": 9.8,
                 },
             },
+        },
+    }
+
+
+def _build_passing_lora_path_report() -> dict[str, object]:
+    stage_names = ("dataset_build", "train", "activate", "compare", "publish")
+    return {
+        "stages": {
+            stage_name: {
+                "success": 1.0,
+                "duration_ms": 1.0,
+            }
+            for stage_name in stage_names
+        },
+        "summary": {
+            "stages_success_count": float(len(stage_names)),
+            "stages_failure_count": 0.0,
+            "full_path_success": 1.0,
         },
     }
 

--- a/scripts/package_macos_menubar_app.py
+++ b/scripts/package_macos_menubar_app.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import time
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -13,6 +15,7 @@ sys.path.insert(0, str(ROOT / "services/mlx-worker-python"))
 
 from worker.productization.macos_app_bundle import (
     archive_macos_app_bundle,
+    elapsed_seconds,
     resolve_python_runtime_root,
     resolve_site_packages_root,
     write_unsigned_macos_app_bundle,
@@ -43,6 +46,16 @@ def resolve_built_swift_text_worker_binary(repo_root: Path) -> Path:
     raise FileNotFoundError(
         "Unable to find built `melix-text-worker-swift`. Run `swift test --package-path services/mlx-text-worker-swift` first."
     )
+
+
+def _manifest_timings(manifest: dict[str, Any]) -> dict[str, float]:
+    """Return mutable manifest timings for tests that stub bundle writing."""
+    timings = manifest.get("timings")
+    if isinstance(timings, dict):
+        return timings
+    timings = {}
+    manifest["timings"] = timings
+    return timings
 
 
 def main() -> int:
@@ -95,9 +108,23 @@ def main() -> int:
         icon_source_path=args.icon_source_path,
     )
     if args.archive_path:
+        started_at = time.perf_counter()
         manifest["archive_path"] = str(
             archive_macos_app_bundle(manifest["app_path"], args.archive_path)
         )
+        timings = _manifest_timings(manifest)
+        timings["archive_seconds"] = elapsed_seconds(started_at)
+        write_seconds = timings.get("write_total_seconds")
+        if write_seconds is None:
+            raise KeyError("write_total_seconds missing from bundle manifest timings")
+        timings["total_seconds"] = round(
+            float(write_seconds) + timings["archive_seconds"],
+            6,
+        )
+    else:
+        timings = _manifest_timings(manifest)
+        if "write_total_seconds" in timings:
+            timings["total_seconds"] = float(timings["write_total_seconds"])
 
     if args.json:
         print(json.dumps(manifest, indent=2, sort_keys=True))

--- a/services/mlx-worker-python/pyproject.toml
+++ b/services/mlx-worker-python/pyproject.toml
@@ -5,10 +5,14 @@ description = "Python worker for the Melix execution plane."
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }
 dependencies = [
-  "coverage>=7.10.0",
   "grpcio>=1.71.0",
-  "grpcio-tools>=1.71.0",
   "protobuf>=5.29.0",
+]
+
+[dependency-groups]
+dev = [
+  "coverage>=7.10.0",
+  "grpcio-tools>=1.71.0",
   "pytest>=8.3.0",
 ]
 

--- a/services/mlx-worker-python/tests/test_macos_app_bundle.py
+++ b/services/mlx-worker-python/tests/test_macos_app_bundle.py
@@ -120,6 +120,22 @@ def test_resolve_site_packages_root_requires_virtualenv_site_packages(tmp_path: 
         raise AssertionError("expected resolve_site_packages_root() to fail without site-packages")
 
 
+def test_resolve_site_packages_root_skips_non_site_package_entries(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    lib_root = repo_root / ".venv/lib"
+    lib_root.mkdir(parents=True)
+    (lib_root / "not-python").mkdir()
+    (lib_root / "python-not-a-directory").write_text("", encoding="utf-8")
+    (lib_root / "python3.12").mkdir()
+
+    try:
+        resolve_site_packages_root(repo_root)
+    except FileNotFoundError as error:
+        assert str(lib_root) in str(error)
+    else:
+        raise AssertionError("expected resolve_site_packages_root() to fail without site-packages")
+
+
 def test_write_unsigned_macos_app_bundle_writes_self_contained_layout(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     (repo_root / "services/mlx-worker-python/worker").mkdir(parents=True)
@@ -184,6 +200,20 @@ def test_write_unsigned_macos_app_bundle_writes_self_contained_layout(tmp_path: 
     target_payload = json.loads(Path(manifest["packaging_target_manifest_path"]).read_text(encoding="utf-8"))
     assert target_payload["packaging_target_id"] == "macos_app_bundle_preview"
     assert target_payload["logical_product_identity"] == "io.melix"
+    timings = manifest["timings"]
+    for key in (
+        "copy_app_binary_seconds",
+        "copy_swift_worker_binary_seconds",
+        "copy_icon_seconds",
+        "copy_python_runtime_seconds",
+        "copy_python_site_packages_seconds",
+        "copy_repo_subset_seconds",
+        "write_metadata_seconds",
+        "chmod_seconds",
+        "write_total_seconds",
+    ):
+        assert isinstance(timings[key], float)
+        assert timings[key] >= 0.0
 
 
 def test_write_unsigned_macos_app_bundle_requires_an_icon_file(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
+++ b/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -10,6 +11,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MODULE_PATH = REPO_ROOT / "scripts" / "package_macos_menubar_app.py"
+PACKAGE_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "package-self-contained-app.yml"
 
 
 def load_package_macos_app_module():
@@ -75,3 +77,175 @@ def test_main_forwards_packaging_target_and_update_channel(
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["packaging_target_id"] == "macos_app_bundle_preview"
+
+
+def test_package_workflow_uses_runtime_only_python_environment_for_bundle() -> None:
+    workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    runtime_sync = re.search(
+        r"UV_PROJECT_ENVIRONMENT=\"\$GITHUB_WORKSPACE/\.venv-package\".*?uv sync (?P<args>[^\n]+)",
+        workflow,
+        flags=re.DOTALL,
+    )
+    assert runtime_sync is not None
+    sync_args = runtime_sync.group("args")
+    assert "--project services/mlx-worker-python" in sync_args
+    assert "--extra mlx" in sync_args
+    assert "--no-dev" in sync_args
+    assert "--frozen" in sync_args
+    assert re.search(r'PACKAGE_PYTHON="\$GITHUB_WORKSPACE/\.venv-package/bin/python"', workflow)
+    assert "--python-runtime-root" in workflow
+    assert "$PYTHON_RUNTIME_ROOT" in workflow
+    assert "--python-site-packages-path" in workflow
+    assert "$PYTHON_SITE_PACKAGES" in workflow
+
+
+def test_main_resolves_default_build_outputs_and_prints_app_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_package_macos_app_module()
+    repo_root = tmp_path / "repo"
+    menubar_binary = repo_root / "apps/macos-menubar/.build/debug/melix-menubar"
+    swift_worker_binary = (
+        repo_root / "services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/melix-text-worker-swift"
+    )
+    python_executable = repo_root / ".venv/bin/python"
+    site_packages = repo_root / ".venv/lib/python3.13/site-packages"
+    for path in (menubar_binary, swift_worker_binary, python_executable):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    site_packages.mkdir(parents=True)
+    seen: dict[str, object] = {}
+
+    def fake_write_unsigned_macos_app_bundle(**kwargs):
+        seen.update(kwargs)
+        return {
+            "app_path": str(tmp_path / "Melix.app"),
+            "packaging_target_id": "macos_app_bundle_preview",
+            "timings": {
+                "write_total_seconds": 0.125,
+            },
+        }
+
+    monkeypatch.setattr(module, "write_unsigned_macos_app_bundle", fake_write_unsigned_macos_app_bundle)
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        [
+            "package_macos_menubar_app.py",
+            "--repo-root",
+            str(repo_root),
+            "--output-path",
+            str(tmp_path / "Melix.app"),
+        ],
+    )
+
+    assert module.main() == 0
+
+    assert capsys.readouterr().out.strip() == str(tmp_path / "Melix.app")
+    assert seen["executable_path"] == menubar_binary.resolve()
+    assert seen["swift_text_worker_executable_path"] == swift_worker_binary.resolve()
+    assert seen["python_runtime_root"] == python_executable.resolve().parent.parent
+    assert seen["python_site_packages_path"] == site_packages.resolve()
+
+
+def test_main_records_archive_timing_in_json_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_package_macos_app_module()
+    archive_path = tmp_path / "Melix.zip"
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr(module, "resolve_built_binary", lambda repo_root: tmp_path / "melix-menubar")
+    monkeypatch.setattr(
+        module,
+        "resolve_built_swift_text_worker_binary",
+        lambda repo_root: tmp_path / "melix-text-worker-swift",
+    )
+    monkeypatch.setattr(module, "resolve_python_runtime_root", lambda executable: tmp_path / "python-runtime")
+    monkeypatch.setattr(module, "resolve_site_packages_root", lambda repo_root: tmp_path / "site-packages")
+
+    def fake_write_unsigned_macos_app_bundle(**kwargs):
+        return {
+            "app_path": str(tmp_path / "Melix.app"),
+            "packaging_target_id": "macos_app_bundle_preview",
+            "timings": {
+                "write_total_seconds": 0.25,
+            },
+        }
+
+    def fake_archive_macos_app_bundle(app_path, requested_archive_path):
+        seen["app_path"] = app_path
+        seen["archive_path"] = requested_archive_path
+        return Path(requested_archive_path)
+
+    monkeypatch.setattr(module, "write_unsigned_macos_app_bundle", fake_write_unsigned_macos_app_bundle)
+    monkeypatch.setattr(module, "archive_macos_app_bundle", fake_archive_macos_app_bundle)
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        [
+            "package_macos_menubar_app.py",
+            "--repo-root",
+            str(tmp_path / "repo"),
+            "--output-path",
+            str(tmp_path / "Melix.app"),
+            "--archive-path",
+            str(archive_path),
+            "--json",
+        ],
+    )
+
+    assert module.main() == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["archive_path"] == str(archive_path)
+    assert seen["archive_path"] == str(archive_path)
+    assert payload["timings"]["write_total_seconds"] == 0.25
+    assert isinstance(payload["timings"]["archive_seconds"], float)
+    assert payload["timings"]["archive_seconds"] >= 0.0
+    assert payload["timings"]["total_seconds"] >= payload["timings"]["write_total_seconds"]
+
+
+def test_main_requires_write_timing_when_archive_is_requested(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = load_package_macos_app_module()
+    archive_path = tmp_path / "Melix.zip"
+
+    monkeypatch.setattr(module, "resolve_built_binary", lambda repo_root: tmp_path / "melix-menubar")
+    monkeypatch.setattr(
+        module,
+        "resolve_built_swift_text_worker_binary",
+        lambda repo_root: tmp_path / "melix-text-worker-swift",
+    )
+    monkeypatch.setattr(module, "resolve_python_runtime_root", lambda executable: tmp_path / "python-runtime")
+    monkeypatch.setattr(module, "resolve_site_packages_root", lambda repo_root: tmp_path / "site-packages")
+    monkeypatch.setattr(
+        module,
+        "write_unsigned_macos_app_bundle",
+        lambda **kwargs: {"app_path": str(tmp_path / "Melix.app"), "timings": {}},
+    )
+    monkeypatch.setattr(module, "archive_macos_app_bundle", lambda app_path, requested_archive_path: archive_path)
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        [
+            "package_macos_menubar_app.py",
+            "--repo-root",
+            str(tmp_path / "repo"),
+            "--output-path",
+            str(tmp_path / "Melix.app"),
+            "--archive-path",
+            str(archive_path),
+            "--json",
+        ],
+    )
+
+    with pytest.raises(KeyError, match="write_total_seconds missing"):
+        module.main()

--- a/services/mlx-worker-python/tests/test_packaging_dependencies.py
+++ b/services/mlx-worker-python/tests/test_packaging_dependencies.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKER_PYPROJECT = REPO_ROOT / "services" / "mlx-worker-python" / "pyproject.toml"
+
+
+def _dependency_names(entries: list[str]) -> set[str]:
+    return {Requirement(entry).name.lower() for entry in entries}
+
+
+def test_worker_base_dependencies_exclude_test_and_codegen_tools() -> None:
+    payload = tomllib.loads(WORKER_PYPROJECT.read_text(encoding="utf-8"))
+
+    runtime_dependencies = _dependency_names(payload["project"]["dependencies"])
+    dev_dependencies = _dependency_names(payload["dependency-groups"]["dev"])
+
+    assert "coverage" not in runtime_dependencies
+    assert "pytest" not in runtime_dependencies
+    assert "grpcio-tools" not in runtime_dependencies
+    assert {"coverage", "pytest", "grpcio-tools"} <= dev_dependencies

--- a/services/mlx-worker-python/worker/productization/macos_app_bundle.py
+++ b/services/mlx-worker-python/worker/productization/macos_app_bundle.py
@@ -5,6 +5,7 @@ import os
 import plistlib
 import shutil
 import subprocess
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -194,6 +195,10 @@ def render_launcher_script(
     )
 
 
+def elapsed_seconds(started_at: float) -> float:
+    return round(time.perf_counter() - started_at, 6)
+
+
 def write_unsigned_macos_app_bundle(
     *,
     repo_root: str | Path,
@@ -208,7 +213,9 @@ def write_unsigned_macos_app_bundle(
     packaging_target_id: str = "macos_app_bundle_preview",
     update_channel_path: str | Path | None = None,
     icon_source_path: str | Path | None = None,
-) -> dict[str, str]:
+) -> dict[str, Any]:
+    write_started_at = time.perf_counter()
+    timings: dict[str, float] = {}
     repo_root_path = Path(repo_root).expanduser().resolve()
     executable = Path(executable_path).expanduser().resolve()
     swift_worker_executable = Path(swift_text_worker_executable_path).expanduser().resolve()
@@ -249,14 +256,27 @@ def write_unsigned_macos_app_bundle(
     layout.macos_path.mkdir(parents=True, exist_ok=True)
     layout.resources_path.mkdir(parents=True, exist_ok=True)
 
+    started_at = time.perf_counter()
     shutil.copy2(executable, layout.bundled_app_binary_path)
+    timings["copy_app_binary_seconds"] = elapsed_seconds(started_at)
+    started_at = time.perf_counter()
     shutil.copy2(swift_worker_executable, layout.bundled_swift_worker_binary_path)
+    timings["copy_swift_worker_binary_seconds"] = elapsed_seconds(started_at)
+    started_at = time.perf_counter()
     shutil.copy2(resolved_icon_source_path, layout.bundled_icon_path)
+    timings["copy_icon_seconds"] = elapsed_seconds(started_at)
+    started_at = time.perf_counter()
     shutil.copytree(python_runtime, layout.bundled_python_runtime_path, dirs_exist_ok=True, symlinks=True)
+    timings["copy_python_runtime_seconds"] = elapsed_seconds(started_at)
+    started_at = time.perf_counter()
     shutil.copytree(python_site_packages, layout.bundled_site_packages_path, dirs_exist_ok=True, symlinks=True)
+    timings["copy_python_site_packages_seconds"] = elapsed_seconds(started_at)
 
+    started_at = time.perf_counter()
     _copy_repo_subset(repo_root_path, layout.bundled_repo_root_path)
+    timings["copy_repo_subset_seconds"] = elapsed_seconds(started_at)
 
+    started_at = time.perf_counter()
     layout.embedded_env_script_path.write_text(
         render_portable_environment_script(
             product_version=version,
@@ -267,7 +287,6 @@ def write_unsigned_macos_app_bundle(
         ),
         encoding="utf-8",
     )
-    os.chmod(layout.embedded_env_script_path, 0o755)
     layout.packaging_target_manifest_path.write_text(
         json.dumps(target_metadata, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
@@ -293,7 +312,10 @@ def write_unsigned_macos_app_bundle(
         ),
         encoding="utf-8",
     )
+    timings["write_metadata_seconds"] = elapsed_seconds(started_at)
 
+    started_at = time.perf_counter()
+    os.chmod(layout.embedded_env_script_path, 0o755)
     for path in (
         layout.launcher_path,
         layout.bundled_app_binary_path,
@@ -301,6 +323,8 @@ def write_unsigned_macos_app_bundle(
         layout.bundled_python_executable_path,
     ):
         os.chmod(path, 0o755)
+    timings["chmod_seconds"] = elapsed_seconds(started_at)
+    timings["write_total_seconds"] = elapsed_seconds(write_started_at)
 
     return {
         "app_path": str(layout.app_path),
@@ -321,6 +345,7 @@ def write_unsigned_macos_app_bundle(
         "packaging_kind": str(target_metadata["packaging_kind"]),
         "logical_product_identity": str(target_metadata["logical_product_identity"]),
         "update_channel_path": str(target_metadata["update_channel_path"]),
+        "timings": timings,
     }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1009,11 +1009,8 @@ name = "melix-mlx-worker"
 version = "0.1.0"
 source = { virtual = "services/mlx-worker-python" }
 dependencies = [
-    { name = "coverage" },
     { name = "grpcio" },
-    { name = "grpcio-tools" },
     { name = "protobuf" },
-    { name = "pytest" },
 ]
 
 [package.optional-dependencies]
@@ -1032,11 +1029,16 @@ mlx = [
     { name = "mlx-vlm" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "coverage" },
+    { name = "grpcio-tools" },
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
-    { name = "coverage", specifier = ">=7.10.0" },
     { name = "grpcio", specifier = ">=1.71.0" },
-    { name = "grpcio-tools", specifier = ">=1.71.0" },
     { name = "mlx", marker = "extra == 'mlx'", specifier = ">=0.25.0" },
     { name = "mlx-audio", marker = "extra == 'audio'", specifier = "==0.4.2" },
     { name = "mlx-audio", marker = "extra == 'audio-stt'", specifier = "==0.4.2" },
@@ -1044,9 +1046,15 @@ requires-dist = [
     { name = "mlx-lm", marker = "extra == 'mlx'", specifier = ">=0.22.0" },
     { name = "mlx-vlm", marker = "extra == 'mlx'", git = "https://github.com/Blaizzy/mlx-vlm.git?rev=43b9b2078b7027e7622f34a434b2d94aada7eaad" },
     { name = "protobuf", specifier = ">=5.29.0" },
-    { name = "pytest", specifier = ">=8.3.0" },
 ]
 provides-extras = ["mlx", "audio-stt", "audio-tts", "audio"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "coverage", specifier = ">=7.10.0" },
+    { name = "grpcio-tools", specifier = ">=1.71.0" },
+    { name = "pytest", specifier = ">=8.3.0" },
+]
 
 [[package]]
 name = "melix-workspace"


### PR DESCRIPTION
## Summary
- Split the Python worker package into runtime dependencies and dev/test/codegen dependencies, then package the macOS app from a runtime-only `.venv-package` environment.
- Added packaging timing fields for bundle writing and archive creation; review follow-up now uses one shared elapsed-time helper and requires `write_total_seconds` when archive timing is computed.
- Tightened packaging tests around dependency separation, runtime-only workflow behavior, site-packages discovery, and the M9 release-gate fixture `lora_path` evidence.
- Addressed review feedback by replacing workflow heredocs with simpler shell one-liners and using `packaging.requirements.Requirement` instead of a hand-rolled dependency parser.

## Plan or Spec
- `docs/plans/2026-05-02-packaging-runtime-dependency-slimming.md`

## Commands Run
```text
PYTHONPATH=/private/tmp/melix-pr-open/repo:/private/tmp/melix-pr-open/repo/services/mlx-worker-python UV_CACHE_DIR=/Users/ChenYu/.codex/worktrees/32f5/melix/.uv-cache uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py services/mlx-worker-python/tests/test_packaging_dependencies.py services/mlx-worker-python/tests/test_macos_app_bundle.py
# 17 passed in 0.08s

UV_CACHE_DIR=/Users/ChenYu/.codex/worktrees/32f5/melix/.uv-cache make package-smoke
# 25 passed; m8 packaging target smoke passed with packaging_target_smoke_ms=15.22

make py-coverage
# 1380 passed, 5 skipped, 2 warnings in 56.47s
# TOTAL coverage: 95%; services/mlx-worker-python/worker/productization/macos_app_bundle.py: 95%

git diff --check
# passed

UV_PROJECT_ENVIRONMENT="$(pwd)/.venv-package" UV_CACHE_DIR="$(pwd)/.uv-cache" uv sync --project services/mlx-worker-python --extra mlx --no-dev --frozen
# runtime-only environment synced earlier for this PR

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" .venv-package/bin/python - <<'PY'
import importlib.util
assert importlib.util.find_spec("grpc") is not None
assert importlib.util.find_spec("google.protobuf") is not None
assert importlib.util.find_spec("pytest") is None
assert importlib.util.find_spec("coverage") is None
assert importlib.util.find_spec("grpc_tools") is None
print("runtime imports ok; dev tools absent")
PY
# runtime imports ok; dev tools absent
```

## Coverage and Metrics
- Worker Python coverage for the touched scope remains at the repository threshold: total 95%; `services/mlx-worker-python/worker/productization/macos_app_bundle.py` 95%.
- Runtime-only package environment audit: `.venv-package/lib/python3.13/site-packages` is about 622 MB / 10,269 files versus the dev environment at about 653 MB / 10,910 files.
- Runtime-only bundle probe: `.app` 676,480,751 bytes; zip 216,059,040 bytes; `write_total_seconds=5.714668`, `copy_python_site_packages_seconds=4.719971`, `archive_seconds=19.918`.
- Scoped performance workflow reported no selected probes, regressions, or verification failures for this PR.

## Known Gaps
- Did not run `make proto`, `make swift-test`, or `make integration-test`; this change is limited to Python packaging dependency selection, packaging tests, release-gate fixture evidence, and GitHub Actions packaging wiring.
- PR remains a draft.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (`N/A`: no protocol changes.)
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
