### PR TITLE
perf(swift): cache CLI metric placeholder literals

### DIFF
--- a/Sources/MelixCLICore/MelixCLIJSON.swift
+++ b/Sources/MelixCLICore/MelixCLIJSON.swift
@@ -12,9 +12,13 @@ enum MelixCLIJSONMetricPatch {
 
     struct Placeholder {
         let token: String
+        let jsonLiteral: String
+        let jsonLiteralData: Data
 
-        var jsonLiteral: String {
-            "\"\(token)\""
+        init(token: String) {
+            self.token = token
+            self.jsonLiteral = "\"\(token)\""
+            self.jsonLiteralData = Data(jsonLiteral.utf8)
         }
     }
 
@@ -71,7 +75,7 @@ enum MelixCLIJSONMetricPatch {
         in data: Data,
         placeholder: Placeholder
     ) throws -> Range<Data.Index> {
-        let placeholderData = Data(placeholder.jsonLiteral.utf8)
+        let placeholderData = placeholder.jsonLiteralData
         guard let range = data.range(of: placeholderData) else {
             throw MelixCLIError.runtime("Failed to locate pipeline metrics placeholder.")
         }

--- a/docs/plans/2026-05-01-swift-cli-json-envelope-performance.md
+++ b/docs/plans/2026-05-01-swift-cli-json-envelope-performance.md
@@ -21,7 +21,7 @@ Optimize the Swift CLI JSON envelope metric-object assembly path and register a 
 
 `MelixCLIJSONEnvelope` currently converts `[String: Double]` into `[String: Any]` through `reduce(into:)` starting from an empty dictionary, then appends the measured JSON encode placeholder. The first slice introduced a small helper that preallocates `metrics.count + 1` slots and is shared by success and error envelope construction.
 
-The next slice keeps the same JSON literal formatting semantics but reuses the POSIX `Locale` object used by `String(format:locale:)` for metric placeholder replacement. This avoids constructing `Locale(identifier: "en_US_POSIX")` on every success/error envelope metric patch while preserving stable decimal formatting.
+The next slice keeps the same JSON literal formatting semantics but stores each generated placeholder's quoted JSON literal and UTF-8 data alongside the token. This avoids rebuilding the same quoted string and `Data` buffer while success/error envelope patching or pipeline placeholder lookup validates uniqueness, while preserving stable placeholder tokens and decimal formatting.
 
 The PR-scoped performance registry uses a `command_json` probe mode so Swift probes can execute a shell command on a macOS runner and emit JSON metrics without requiring Python to import Swift code directly.
 


### PR DESCRIPTION
## Summary
- Cache each Swift CLI JSON metric placeholder's quoted JSON literal and UTF-8 bytes when the placeholder is created.
- Reuse the cached data during pipeline placeholder lookup instead of rebuilding `Data(placeholder.jsonLiteral.utf8)` on each call.
- Update the Swift CLI JSON envelope performance plan for this placeholder-literal caching slice.

## Plan or Spec
- `docs/plans/2026-05-01-swift-cli-json-envelope-performance.md`
- Registered PR-scoped probe: `swift-cli-json-envelope-encoding` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline sync
cd /root/.hermes/profiles/coder/workspace/worktrees/melix-base-training-token-local-bindings-20260501125933
git fetch origin && git reset --hard origin/main
# exit code 0; origin/main at 9f38383

# Probe registration check
python3 - <<'PY'
import json
from pathlib import Path
p=Path('infra/perf/pr_scoped_probes.json')
probe=next(x for x in json.loads(p.read_text()) if x['id']=='swift-cli-json-envelope-encoding')
for k in ['id','runner','test_command','coverage_command','probe_impl','probe_command']:
    print(f'{k}: {probe.get(k)}')
print('watch_globs:', probe['watch_globs'])
PY
# exit code 0; probe has test_command, coverage_command, and command_json probe_command on macos-15

command -v swift
# exit code 1; swift is not installed in this Linux environment

git diff --check
# exit code 0

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.pretty.json
# exit code 0
```

## Coverage and Metrics
- Local Linux coverage/Swift metrics: N/A because `swift` is not installed in this Linux environment.
- Required CI validation: registered PR-scoped performance probe `swift-cli-json-envelope-encoding` on `macos-15` runs `swift test --filter MelixCLITests/MelixCLIRunnerTests` and emits `elapsed_ms_mean` via its `command_json` probe.
- Expected metric direction: `elapsed_ms_mean` lower is better; CI report is the source of truth for this Swift slice.

## Known Gaps
- Swift runtime effect is not claimed from local Linux validation; it must be validated by macOS GitHub Actions and the registered PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run. Local static checks ran; Swift tests are delegated to macOS CI because local `swift` is unavailable.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
