### PR TITLE
perf: speed up evaluation job id priming

### DIFF
--- a/docs/plans/2026-05-01-evaluation-job-id-allocation-optimization.md
+++ b/docs/plans/2026-05-01-evaluation-job-id-allocation-optimization.md
@@ -10,27 +10,26 @@ Reduce redundant filesystem work in `EvaluationCore._next_job_id()` by avoiding 
 - The touched runtime path is Python under `services/mlx-worker-python`.
 - The change must remain small, behavior-preserving, and locally verifiable.
 - Pull request evidence must include focused tests, changed-scope coverage, and a measurable performance probe.
-- The change must register a PR-scoped performance probe in the existing scoped performance infrastructure.
+- The existing registered PR-scoped performance probe must remain the verification path; this slice does not modify the probe registry.
 
 ## Touched Files
 
 - `services/mlx-worker-python/worker/engine/evaluation_core.py`
 - `services/mlx-worker-python/tests/test_evaluation_core.py`
-- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
-- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
-- `infra/perf/pr_scoped_probes.json`
-- `scripts/changed_scope_coverage.py`
 
 ## Proposed Change
 
-1. Cache the next evaluation job index inside `EvaluationCore`.
-2. Prime that cache once from the highest existing `eval-####` run directory.
-3. Keep the existing on-disk uniqueness guarantee by still creating the run directory under the job-ID lock.
-4. Add regression tests for:
+1. Keep the cached next evaluation job index inside `EvaluationCore`.
+2. Prime that cache once from the highest existing `eval-` run directory whose suffix is at least four decimal digits, including rollover names such as `eval-10000`.
+3. Replace per-entry `re.fullmatch(...)` calls with a small helper that parses the `eval-` prefix plus decimal suffix directly.
+4. Preserve Melix-emitted rollover IDs and valid decimal-digit suffixes that `int(...)` can parse, while still rejecting malformed names.
+5. Keep the existing on-disk uniqueness guarantee by still creating the run directory under the job-ID lock.
+6. Add regression tests for:
+   - parser acceptance/rejection boundaries
    - existing run directories with gaps
    - repeated allocations from the same process
    - single-pass priming behavior
-5. Register a new PR-scoped performance probe for evaluation job-ID allocation.
+   - rollover directories beyond `9999`
 
 ## Performance Probe
 
@@ -40,7 +39,7 @@ Reduce redundant filesystem work in `EvaluationCore._next_job_id()` by avoiding 
 
 ### Measurement path
 
-- Seed a synthetic evaluation `runs/` tree with many existing `eval-####` directories.
+- Seed a synthetic evaluation `runs/` tree with many existing `eval-####` and rollover directories.
 - Call `_next_job_id()` repeatedly in the same process.
 - Compare base vs head mean elapsed milliseconds.
 
@@ -53,11 +52,11 @@ Reduce redundant filesystem work in `EvaluationCore._next_job_id()` by avoiding 
 ## Local Verification Commands
 
 ```text
-PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
-PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
-PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_executes_packaged_dataset_and_persists_result services/mlx-worker-python/tests/test_evaluation_core.py::test_parse_run_directory_index_accepts_melix_ids_and_python_decimal_suffixes services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_primes_from_highest_existing_run_directory services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_primes_from_rollover_run_directories services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_only_scans_existing_runs_once_per_process services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_skips_conflicting_cached_index_and_non_directory_entries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_job_id_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_executes_packaged_dataset_and_persists_result services/mlx-worker-python/tests/test_evaluation_core.py::test_parse_run_directory_index_accepts_melix_ids_and_python_decimal_suffixes services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_primes_from_highest_existing_run_directory services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_primes_from_rollover_run_directories services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_only_scans_existing_runs_once_per_process services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_skips_conflicting_cached_index_and_non_directory_entries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_job_id_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
-python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-job-id-high-water-mark --base-repo . --head-repo . --output /tmp/evaluation-job-id-probe.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-job-id-high-water-mark --base-repo /tmp/melix-base-20260501-162400 --head-repo /tmp/melix-cron-opt-20260501-162400 --output /tmp/melix-cron-opt-20260501-162400/pr-scoped-evaluation-job-id.json
 git diff --check
 ```
 

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -652,6 +652,31 @@ def test_run_local_suite_executes_packaged_dataset_and_persists_result(tmp_path:
     assert queue_payload["completed_at_unix_ms"] > 0
 
 
+@pytest.mark.parametrize(
+    ("name", "expected_index"),
+    [
+        ("eval-0000", 0),
+        ("eval-0421", 421),
+        ("eval-9999", 9999),
+        ("eval-10000", 10000),
+        ("eval-１２３４", 1234),
+        ("eval-١٢٣٤", 1234),
+        ("eval-123", None),
+        ("eval-²345", None),
+        ("eval-ⅫⅢⅣⅤ", None),
+        ("eval-12x4", None),
+        ("Eval-0001", None),
+        ("eval_0001", None),
+        ("notes", None),
+    ],
+)
+def test_parse_run_directory_index_accepts_melix_ids_and_python_decimal_suffixes(
+    name: str,
+    expected_index: int | None,
+) -> None:
+    assert EvaluationCore._parse_run_directory_index(name) == expected_index
+
+
 def test_next_job_id_primes_from_highest_existing_run_directory(tmp_path: Path) -> None:
     jobs_root = tmp_path / "runs" / "mmlu"
     runs_root = jobs_root / "runs"
@@ -660,13 +685,29 @@ def test_next_job_id_primes_from_highest_existing_run_directory(tmp_path: Path) 
     (runs_root / "notes").mkdir(parents=True)
     (runs_root / "README.txt").write_text("ignore me\n", encoding="utf-8")
     (runs_root / "eval-999x").mkdir(parents=True)
+    (runs_root / "eval-１２３４").mkdir(parents=True)
+    (runs_root / "eval-١٢٣٤").mkdir(parents=True)
 
     runner = EvaluationCore(jobs_root=jobs_root)
 
-    assert runner._next_job_id() == "eval-0004"
-    assert runner._next_job_id() == "eval-0005"
-    assert (runs_root / "eval-0004").is_dir()
-    assert (runs_root / "eval-0005").is_dir()
+    assert runner._next_job_id() == "eval-1235"
+    assert runner._next_job_id() == "eval-1236"
+    assert (runs_root / "eval-1235").is_dir()
+    assert (runs_root / "eval-1236").is_dir()
+
+
+def test_next_job_id_primes_from_rollover_run_directories(tmp_path: Path) -> None:
+    jobs_root = tmp_path / "runs" / "mmlu"
+    runs_root = jobs_root / "runs"
+    (runs_root / "eval-9999").mkdir(parents=True)
+    (runs_root / "eval-10000").mkdir(parents=True)
+
+    runner = EvaluationCore(jobs_root=jobs_root)
+
+    assert runner._next_job_id() == "eval-10001"
+    assert runner._next_job_id() == "eval-10002"
+    assert (runs_root / "eval-10001").is_dir()
+    assert (runs_root / "eval-10002").is_dir()
 
 
 def test_next_job_id_only_scans_existing_runs_once_per_process(

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -1687,6 +1687,15 @@ class EvaluationCore:
                     next_index += 1
                     self._next_job_index = next_index
 
+    @staticmethod
+    def _parse_run_directory_index(name: str) -> int | None:
+        if not name.startswith("eval-"):
+            return None
+        suffix = name[5:]
+        if len(suffix) < 4 or not suffix.isdecimal():
+            return None
+        return int(suffix)
+
     def _prime_next_job_index(self, runs_root: Path) -> int:
         if self._next_job_index is not None:
             return self._next_job_index
@@ -1695,10 +1704,10 @@ class EvaluationCore:
             for entry in entries:
                 if not entry.is_dir(follow_symlinks=False):
                     continue
-                match = re.fullmatch(r"eval-(\d{4})", entry.name)
-                if match is None:
+                index = self._parse_run_directory_index(entry.name)
+                if index is None:
                     continue
-                highest_index = max(highest_index, int(match.group(1)))
+                highest_index = max(highest_index, index)
         self._next_job_index = highest_index + 1
         return self._next_job_index
 


### PR DESCRIPTION
## Summary
- Replace per-entry `re.fullmatch(...)` work in `EvaluationCore._prime_next_job_index(...)` with a lightweight `_parse_run_directory_index(...)` helper.
- Preserve Melix job-ID semantics across restart by continuing to recognize decimal-suffix run directories, including rollover IDs such as `eval-10000`.
- Add focused regression coverage for parser acceptance boundaries, Unicode decimal suffixes, and rollover priming behavior.
- Update the governing plan note so the documented priming contract matches the shipped behavior and existing registered probe path.

## Plan or Spec
- `docs/plans/2026-05-01-evaluation-job-id-allocation-optimization.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_executes_packaged_dataset_and_persists_result services/mlx-worker-python/tests/test_evaluation_core.py::test_parse_run_directory_index_accepts_melix_ids_and_python_decimal_suffixes services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_primes_from_highest_existing_run_directory services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_primes_from_rollover_run_directories services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_only_scans_existing_runs_once_per_process services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_skips_conflicting_cached_index_and_non_directory_entries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_job_id_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
- 21 passed in 2.42s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage erase
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_executes_packaged_dataset_and_persists_result services/mlx-worker-python/tests/test_evaluation_core.py::test_parse_run_directory_index_accepts_melix_ids_and_python_decimal_suffixes services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_primes_from_highest_existing_run_directory services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_primes_from_rollover_run_directories services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_only_scans_existing_runs_once_per_process services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_skips_conflicting_cached_index_and_non_directory_entries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_job_id_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py
- 21 passed in 7.83s
- TOTAL 11 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-job-id-high-water-mark --base-repo /tmp/melix-base-20260501-162400 --head-repo /tmp/melix-cron-opt-20260501-162400 --output /tmp/melix-cron-opt-20260501-162400/pr-scoped-evaluation-job-id.json
- base elapsed_ms_mean=14.834, per_call_ms_mean=0.074169
- head elapsed_ms_mean=13.596, per_call_ms_mean=0.06798
- allocation_count=200, first_job_id_numeric=2001, last_job_id_numeric=2200 preserved

git diff --check
- passed
```

## Coverage and Metrics
- Changed executable line coverage: `TOTAL 11 0 100%`
- Touched executable file: `services/mlx-worker-python/worker/engine/evaluation_core.py`
  - measurable changed lines: `[1690, 1691, 1692, 1693, 1694, 1695, 1696, 1697, 1707, 1708, 1710]`
  - covered changed lines: all 11
- Registered scoped probe: `evaluation-job-id-high-water-mark`
- Local probe result against `origin/main` base worktree:
  - `elapsed_ms_mean`: `14.834` -> `13.596` ms (`~8.35%` lower)
  - `per_call_ms_mean`: `0.074169` -> `0.06798` ms (`~8.35%` lower)
  - invariant metrics preserved: `allocation_count=200`, `first_job_id_numeric=2001`, `last_job_id_numeric=2200`, `seeded_run_count=2000`

## Known Gaps
- Linux-only local verification. I did not run macOS/Swift checks.
- CI remains the final authority for the registered PR-scoped probe and repository merge gates.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
