### PR TITLE
perf: specialize training quality stats hot loop

### DIFF
--- a/docs/plans/2026-05-01-training-quality-token-stats-local-bindings.md
+++ b/docs/plans/2026-05-01-training-quality-token-stats-local-bindings.md
@@ -1,0 +1,50 @@
+# Training Quality/Token Stats Local Binding Optimization
+
+## Goal
+
+Reduce Python overhead in `training_dataset._build_quality_and_token_stats()` for large `prompt_completion` training datasets while preserving the single-pass quality and token-stat behavior.
+
+## Constraints
+
+- Host verification is Linux-only.
+- The touched runtime path is Python under `services/mlx-worker-python`.
+- The optimization is intentionally limited to one hot loop in `training_dataset.py`.
+- The affected path is covered by the registered PR-scoped probe `training-dataset-token-percentiles-single-sort`, which declares focused test, coverage, and probe commands in `infra/perf/pr_scoped_probes.json`.
+
+## Proposed Change
+
+Bind hot-loop append methods and helper functions once before iterating samples in `_build_quality_and_token_stats()`, and route `prompt_completion` rows through a specialized dirty-sample checker that avoids building intermediate text-segment lists.
+
+This keeps the existing semantics:
+
+- duplicate detection still uses canonical sample digests;
+- dirty-sample reporting still caps retained examples at `_QUALITY_REPORT_SAMPLE_LIMIT` while preserving total counts;
+- `prompt_completion` still uses the direct whitespace-token fast path;
+- non-`prompt_completion` formats still dispatch through `_sample_token_counts()`.
+
+## Performance Probe
+
+### Probe name
+
+`training-dataset-token-percentiles-single-sort`
+
+### Measurement path
+
+The registered probe builds a large synthetic training dataset and repeatedly calls `_build_quality_and_token_stats(samples, "prompt_completion")`, recording mean elapsed time and peak bytes.
+
+### Success metric
+
+- Lower `elapsed_ms_mean` is better.
+- Peak allocation should not materially regress.
+- Token stats and quality counters must remain unchanged.
+
+## Local Verification Commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-token-percentiles-single-sort --base-repo <base-repo> --head-repo <head-repo> --output <output-json>
+git diff --check
+```

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -795,6 +795,20 @@ def test_build_quality_and_token_stats_caps_retained_examples_but_preserves_tota
     assert token_stats["total_tokens_max"] == 4
 
 
+def test_prompt_completion_dirty_sample_reasons_match_generic_quality_rules() -> None:
+    samples = [
+        {"prompt": "hello", "completion": "world"},
+        {"prompt": "same text", "completion": " same text "},
+        {"prompt": "bad\x00prompt", "completion": "clean"},
+        {"prompt": "bad\x00same", "completion": "bad\x00same"},
+    ]
+
+    for sample in samples:
+        assert training_dataset_module._prompt_completion_dirty_sample_reasons(
+            sample
+        ) == training_dataset_module._dirty_sample_reasons(sample)
+
+
 def test_build_quality_and_token_stats_uses_prompt_completion_fast_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1303,29 +1303,42 @@ def _build_quality_and_token_stats(
     total_tokens: list[int] = []
     sample_count = 0
     is_prompt_completion = format_name == "prompt_completion"
-    count_tokens = _whitespace_token_count if is_prompt_completion else None
+    prompt_tokens_append = prompt_tokens.append
+    completion_tokens_append = completion_tokens.append
+    total_tokens_append = total_tokens.append
+    duplicate_indices_append = duplicate_indices.append
+    dirty_samples_append = dirty_samples.append
+    canonical_sample_digest = _canonical_sample_digest
+    dirty_sample_reasons = (
+        _prompt_completion_dirty_sample_reasons
+        if is_prompt_completion
+        else _dirty_sample_reasons
+    )
+    sample_token_counts = _sample_token_counts
+    whitespace_token_count = _whitespace_token_count
+    quality_report_sample_limit = _QUALITY_REPORT_SAMPLE_LIMIT
     for index, sample in enumerate(samples):
         sample_count += 1
-        sample_digest = _canonical_sample_digest(sample)
+        sample_digest = canonical_sample_digest(sample)
         if sample_digest in seen:
             duplicate_count += 1
-            if len(duplicate_indices) < _QUALITY_REPORT_SAMPLE_LIMIT:
-                duplicate_indices.append(index)
+            if len(duplicate_indices) < quality_report_sample_limit:
+                duplicate_indices_append(index)
         else:
             seen.add(sample_digest)
-        reasons = _dirty_sample_reasons(sample)
+        reasons = dirty_sample_reasons(sample)
         if reasons:
             dirty_count += 1
-            if len(dirty_samples) < _QUALITY_REPORT_SAMPLE_LIMIT:
-                dirty_samples.append({"index": index, "reasons": reasons})
+            if len(dirty_samples) < quality_report_sample_limit:
+                dirty_samples_append({"index": index, "reasons": reasons})
         if is_prompt_completion:
-            prompt_count = count_tokens(str(sample.get("prompt", "")))
-            completion_count = count_tokens(str(sample.get("completion", "")))
+            prompt_count = whitespace_token_count(str(sample.get("prompt", "")))
+            completion_count = whitespace_token_count(str(sample.get("completion", "")))
         else:
-            prompt_count, completion_count = _sample_token_counts(sample, format_name)
-        prompt_tokens.append(prompt_count)
-        completion_tokens.append(completion_count)
-        total_tokens.append(prompt_count + completion_count)
+            prompt_count, completion_count = sample_token_counts(sample, format_name)
+        prompt_tokens_append(prompt_count)
+        completion_tokens_append(completion_count)
+        total_tokens_append(prompt_count + completion_count)
 
     finalized_prompt_summary = _summarize_token_values(prompt_tokens)
     finalized_completion_summary = _summarize_token_values(completion_tokens)
@@ -1477,6 +1490,26 @@ def _dirty_sample_reasons(sample: dict[str, Any]) -> list[str]:
         if reason not in unique_reasons:
             unique_reasons.append(reason)
     return unique_reasons
+
+
+def _prompt_completion_dirty_sample_reasons(sample: dict[str, Any]) -> list[str]:
+    prompt = str(sample.get("prompt", ""))
+    completion = str(sample.get("completion", ""))
+    has_control_characters = _contains_problematic_control_characters(
+        prompt
+    ) or _contains_problematic_control_characters(completion)
+    stripped_prompt = prompt.strip()
+    stripped_completion = completion.strip()
+    has_duplicate_prompt_completion = bool(
+        stripped_prompt and stripped_completion and stripped_prompt == stripped_completion
+    )
+    if has_control_characters:
+        if has_duplicate_prompt_completion:
+            return ["control_characters", "duplicate_prompt_completion"]
+        return ["control_characters"]
+    if has_duplicate_prompt_completion:
+        return ["duplicate_prompt_completion"]
+    return []
 
 
 def _sample_text_segments(sample: dict[str, Any]) -> list[str]:


### PR DESCRIPTION
## Summary
- Specialize the `prompt_completion` dirty-sample path inside `training_dataset._build_quality_and_token_stats()` so the hot loop avoids building intermediate text segment lists.
- Bind hot-loop helper functions and append methods once before iterating large training datasets.
- Add a parity regression test for the specialized dirty-sample checker.

## Plan or Spec
- `docs/plans/2026-05-01-training-quality-token-stats-local-bindings.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; 46 passed in 9.40s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; 46 passed; TOTAL 40 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-token-percentiles-single-sort --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-training-quality-20260501170028 --head-repo "$PWD" --output /tmp/melix-training-quality-pr-scoped.json
# exit 0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 40 0 100%`.
- Registered probe: `training-dataset-token-percentiles-single-sort`.
- Local registered probe result:
  - `base.elapsed_ms_mean=799.488 ms`
  - `head.elapsed_ms_mean=781.353 ms`
  - `delta=-18.135 ms` (`~2.27%` faster)
  - `base.peak_bytes_mean=2,535,892 bytes`
  - `head.peak_bytes_mean=2,535,956 bytes` (`+64 bytes`, effectively flat)
  - parity counters unchanged: `sample_count=20000`, `duplicate_count=784`, `dirty_count=393`.
- CI is still required to validate the registered PR-scoped performance workflow on the GitHub runner before merge.

## Known Gaps
- Linux-local validation only; this slice touches Python worker code and does not claim Swift/macOS runtime effects.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
