### PR TITLE
perf: avoid rescanning convert and quantize bundles

### DIFF
--- a/docs/plans/2026-05-01-convert-quantize-artifact-bytes-plan.md
+++ b/docs/plans/2026-05-01-convert-quantize-artifact-bytes-plan.md
@@ -1,0 +1,82 @@
+# Convert/Quantize Artifact Byte Accounting Optimization Plan
+
+## Goal
+
+Remove redundant post-write bundle directory rescans in the Python convert and quantize pipelines while preserving manifest payloads, artifact byte counts, and output file contents.
+
+## Constraints
+
+- Host verification is Linux-only.
+- The slice must stay within Python worker code that can be verified locally.
+- Changed executable scope must reach at least 95% automated coverage before commit.
+- The change must remain compatible with Melix PR-scoped performance CI.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/model_ops/conversion_pipeline.py`
+- `services/mlx-worker-python/worker/model_ops/quantization_pipeline.py`
+- `services/mlx-worker-python/tests/test_maintenance_service.py`
+- `services/mlx-worker-python/tests/test_quantization_pipeline.py`
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Waste Being Removed
+
+Both pipelines write a fixed bundle payload (`config.json`, `tokenizer.json`, `weights.safetensors`) and then rescan the bundle directory to recompute `artifact_bytes`. That second pass adds avoidable filesystem iteration and stat work after the code already knows the exact bytes written.
+
+## Implementation Approach
+
+1. Add small write helpers that return the exact encoded byte count for JSON and binary bundle files.
+2. Accumulate `artifact_bytes` during file writes instead of rescanning the bundle directory.
+3. Preserve the existing in-memory manifest-size convergence loop and final manifest serialization.
+4. Add regression tests that fail if either pipeline falls back to rescanning the bundle directory for artifact byte accounting.
+5. Register a PR-scoped performance probe for the convert/quantize pipeline path so CI can compare base vs head on repeated bundle runs.
+
+## Performance Probe
+
+- **Probe ID:** `model-ops-bundle-artifact-byte-accounting`
+- **Path:** `worker/productization/pr_scoped_performance.py`
+- **Measurement:** repeated convert + quantize bundle runs with `os.scandir` tracking for `*.artifact` directories
+- **Success metrics:**
+  - `bundle_scandir_calls_mean` decreases from the base branch by eliminating redundant post-write rescans
+  - `elapsed_ms_mean` does not regress materially
+  - bundle outputs and manifest payloads remain valid
+
+## Verification Commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_bundle_directory_and_versioned_manifest \
+  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_manifest_once_after_in_memory_byte_convergence \
+  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_model_writes_manifest_once_after_in_memory_byte_convergence \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_ops_bundle_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_model_ops_bundle_probe
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_bundle_directory_and_versioned_manifest \
+  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_manifest_once_after_in_memory_byte_convergence \
+  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_model_writes_manifest_once_after_in_memory_byte_convergence \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_ops_bundle_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_model_ops_bundle_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/model_ops/conversion_pipeline.py \
+  services/mlx-worker-python/worker/model_ops/quantization_pipeline.py \
+  services/mlx-worker-python/worker/productization/pr_scoped_performance.py \
+  services/mlx-worker-python/tests/test_quantization_pipeline.py \
+  services/mlx-worker-python/tests/test_maintenance_service.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_model_ops_bundle_artifact_bytes as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
+
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -619,6 +619,39 @@
     ]
   },
   {
+    "id": "model-ops-bundle-artifact-byte-accounting",
+    "name": "Model ops bundle artifact byte accounting",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/conversion_pipeline.py",
+      "services/mlx-worker-python/worker/model_ops/quantization_pipeline.py",
+      "services/mlx-worker-python/tests/test_maintenance_service.py",
+      "services/mlx-worker-python/tests/test_quantization_pipeline.py",
+      "services/mlx-worker-python/worker/productization/pr_scoped_performance.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_bundle_directory_and_versioned_manifest services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_manifest_once_after_in_memory_byte_convergence services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_model_writes_manifest_once_after_in_memory_byte_convergence services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_ops_bundle_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_model_ops_bundle_probe",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_bundle_directory_and_versioned_manifest services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_manifest_once_after_in_memory_byte_convergence services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_model_writes_manifest_once_after_in_memory_byte_convergence services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_ops_bundle_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_model_ops_bundle_probe && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/conversion_pipeline.py services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c \"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_model_ops_bundle_artifact_bytes as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))\"",
+    "probe_impl": "model_ops_bundle_artifact_bytes",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "bundle_scandir_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "swift-cli-json-envelope-encoding",
     "name": "Swift CLI JSON envelope encoding",
     "runner": "macos-15",

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -679,6 +679,50 @@ def test_convert_model_writes_manifest_once_after_in_memory_byte_convergence(
     assert json.loads(manifest_path.read_text(encoding="utf-8")) == convert_payload
 
 
+def test_convert_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = build_service(tmp_path)
+    original_scandir = os.scandir
+    bundle_scandir_calls = 0
+
+    def tracked_scandir(path: str | os.PathLike[str]) -> os.ScandirIterator[os.DirEntry[str]]:
+        nonlocal bundle_scandir_calls
+        if Path(path).name == "convert.artifact":
+            bundle_scandir_calls += 1
+            raise AssertionError("convert pipeline should not rescan the bundle directory for artifact_bytes")
+        return original_scandir(path)
+
+    with pytest.raises(AssertionError, match="should not rescan"):
+        tracked_scandir(bundle_path := tmp_path / "convert.artifact")
+    assert bundle_scandir_calls == 1
+    bundle_scandir_calls = 0
+
+    monkeypatch.setattr(os, "scandir", tracked_scandir)
+
+    convert_events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "convert"),
+                generate_manifest=True,
+            ),
+            context=None,
+        )
+    )
+    convert_manifest = next(event.manifest for event in convert_events if event.HasField("manifest"))
+    convert_payload = json.loads(convert_manifest.manifest_json)
+    bundle_path = Path(convert_events[-1].completed.output_path)
+    expected_artifact_bytes = sum(
+        (bundle_path / file_name).stat().st_size
+        for file_name in ("config.json", "tokenizer.json", "weights.safetensors")
+    )
+
+    assert bundle_scandir_calls == 0
+    assert convert_payload["artifact_bytes"] == expected_artifact_bytes
+
+
 def test_convert_model_supports_download_and_upload_jobs(tmp_path: Path) -> None:
     service = build_service(tmp_path)
     artifact_path = tmp_path / "artifact"

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -43,6 +43,7 @@ from worker.productization.pr_scoped_performance import (
     _probe_evaluation_store_samples_csv_streaming,
     _probe_pr_scoped_scope_matcher,
     _probe_training_dataset_token_percentiles,
+    _probe_model_ops_bundle_artifact_bytes,
     _probe_command_json,
     _run_command,
     _run_head_verification,
@@ -182,6 +183,16 @@ def test_scope_report_selects_benchmark_queue_probe() -> None:
 
     assert scope["selected_count"] == 1
     assert scope["selected_probes"][0]["id"] == "benchmark-queue-decoded-record-cache"
+
+
+def test_scope_report_selects_model_ops_bundle_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/model_ops/conversion_pipeline.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "model-ops-bundle-artifact-byte-accounting"
 
 
 def test_scope_report_selects_bench_report_probe() -> None:
@@ -362,6 +373,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "download-pipeline-directory-size-single-stat",
         "worker-registry-resident-bytes-accumulator",
         "pr-scoped-performance-report-results-scandir",
+        "model-ops-bundle-artifact-byte-accounting",
     }
     for probe in load_probe_registry(REGISTRY_PATH):
         assert probe.test_command
@@ -492,6 +504,7 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     evaluation_store_metrics = _probe_evaluation_store_samples_csv_streaming(REPO_ROOT)
     scope_matcher_metrics = _probe_pr_scoped_scope_matcher(REPO_ROOT)
     training_dataset_metrics = _probe_training_dataset_token_percentiles(REPO_ROOT)
+    model_ops_bundle_metrics = _probe_model_ops_bundle_artifact_bytes(REPO_ROOT)
 
     assert benchmark_metrics["elapsed_ms_mean"] > 0
     assert benchmark_metrics["peak_bytes_mean"] > 0
@@ -539,6 +552,9 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     assert training_dataset_metrics["sample_count"] == 20000.0
     assert training_dataset_metrics["duplicate_count"] > 0
     assert training_dataset_metrics["dirty_count"] > 0
+    assert model_ops_bundle_metrics["elapsed_ms_mean"] > 0
+    assert model_ops_bundle_metrics["bundle_scandir_calls_mean"] == 0.0
+    assert model_ops_bundle_metrics["sample_count"] > 0
 
 
 def test_probe_evaluation_store_compare_summary_csv_streaming_targets_direct_writer(
@@ -905,6 +921,26 @@ def test_dispatch_probe_impl_supports_evaluation_sample_probe_aggregation_probe(
     assert metrics["elapsed_ms_mean"] > 0
     assert metrics["per_call_ms_mean"] > 0
     assert metrics["metric_count"] == 7.0
+
+
+def test_dispatch_probe_impl_supports_model_ops_bundle_probe() -> None:
+    probe = ProbeDefinition(
+        probe_id="model-ops-bundle-artifact-byte-accounting",
+        name="Model ops bundle artifact byte accounting",
+        runner="ubuntu-latest",
+        watch_globs=("services/mlx-worker-python/worker/model_ops/conversion_pipeline.py",),
+        test_command="true",
+        coverage_command="true",
+        probe_impl="model_ops_bundle_artifact_bytes",
+        probe_command='python3 -c "{}"',
+        metrics=(MetricDefinition(key="elapsed_ms_mean", unit="ms", direction="lower_is_better"),),
+    )
+
+    metrics = _dispatch_probe_impl(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["bundle_scandir_calls_mean"] == 0.0
+    assert metrics["sample_count"] > 0
 
 
 def test_run_probe_job_executes_verification_and_probe_for_current_repo() -> None:

--- a/services/mlx-worker-python/tests/test_quantization_pipeline.py
+++ b/services/mlx-worker-python/tests/test_quantization_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -159,6 +160,53 @@ def test_quantize_job_writes_manifest_once_after_in_memory_byte_convergence(
     assert write_calls == 1
     assert manifest_payload["manifest_bytes"] == manifest_path.stat().st_size
     assert json.loads(manifest_path.read_text(encoding="utf-8")) == manifest_payload
+
+
+def test_quantize_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = build_service(tmp_path)
+    original_scandir = os.scandir
+    bundle_scandir_calls = 0
+
+    def tracked_scandir(path: str | os.PathLike[str]) -> os.ScandirIterator[os.DirEntry[str]]:
+        nonlocal bundle_scandir_calls
+        if Path(path).name == "quantize.artifact":
+            bundle_scandir_calls += 1
+            raise AssertionError("quantize pipeline should not rescan the bundle directory for artifact_bytes")
+        return original_scandir(path)
+
+    with pytest.raises(AssertionError, match="should not rescan"):
+        tracked_scandir(bundle_path := tmp_path / "quantize.artifact")
+    assert bundle_scandir_calls == 1
+    bundle_scandir_calls = 0
+
+    monkeypatch.setattr(os, "scandir", tracked_scandir)
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                ext={"operation": "quantize"},
+            ),
+            context=None,
+        )
+    )
+
+    bundle_path = Path(events[-1].completed.output_path)
+    manifest_payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+    expected_artifact_bytes = sum(
+        (bundle_path / file_name).stat().st_size
+        for file_name in ("config.json", "tokenizer.json", "weights.safetensors")
+    )
+
+    assert bundle_scandir_calls == 0
+    assert manifest_payload["artifact_bytes"] == expected_artifact_bytes
 
 
 def test_quantize_job_uses_typed_quant_profile_when_provided(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/model_ops/conversion_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/conversion_pipeline.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -59,11 +58,13 @@ class ModelConversionPipeline:
                 "target_parser_mode": target_parser_mode,
             },
         }
+        artifact_bytes = 0
         for path, payload in files.items():
-            path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+            artifact_bytes += self._write_json_file(path, payload)
 
         weights_path = bundle_path / "weights.safetensors"
-        weights_path.write_bytes(
+        artifact_bytes += self._write_bytes_file(
+            weights_path,
             json.dumps(
                 {
                     "model_id": source_model.model_id,
@@ -73,24 +74,13 @@ class ModelConversionPipeline:
                     "source_model_revision": source_model.revision,
                 },
                 sort_keys=True,
-            ).encode("utf-8")
+            ).encode("utf-8"),
         )
 
         smoke_test_passed = False
         if request.run_smoke_test:
             smoke_test_passed = self._run_structural_smoke_test(bundle_path)
 
-        artifact_bytes = 0
-        with os.scandir(bundle_path) as entries:
-            for entry in entries:
-                if entry.name == "manifest.json":
-                    continue
-                try:
-                    is_file = entry.is_file()
-                except OSError:
-                    continue
-                if is_file:
-                    artifact_bytes += entry.stat().st_size
         manifest_path = bundle_path / "manifest.json"
         manifest_payload = self._manifest_payload(
             request=request,
@@ -223,6 +213,17 @@ class ModelConversionPipeline:
     @staticmethod
     def _manifest_size(payload: dict[str, Any]) -> int:
         return len(ModelConversionPipeline._encode_manifest(payload))
+
+    @staticmethod
+    def _write_json_file(path: Path, payload: dict[str, Any]) -> int:
+        encoded = json.dumps(payload, indent=2).encode("utf-8") + b"\n"
+        path.write_bytes(encoded)
+        return len(encoded)
+
+    @staticmethod
+    def _write_bytes_file(path: Path, payload: bytes) -> int:
+        path.write_bytes(payload)
+        return len(payload)
 
     @staticmethod
     def _write_manifest(path: Path, payload: dict[str, Any]) -> int:

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -71,11 +70,13 @@ class OQQuantizationPipeline:
                 "source_model": request.source_model,
             },
         }
+        artifact_bytes = 0
         for path, payload in files.items():
-            path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+            artifact_bytes += self._write_json_file(path, payload)
 
         weights_path = bundle_path / "weights.safetensors"
-        weights_path.write_bytes(
+        artifact_bytes += self._write_bytes_file(
+            weights_path,
             json.dumps(
                 {
                     "model_id": source_model.model_id,
@@ -85,19 +86,12 @@ class OQQuantizationPipeline:
                     "calibration": calibration.to_dict(),
                 },
                 sort_keys=True,
-            ).encode("utf-8")
+            ).encode("utf-8"),
         )
 
         smoke_test_passed = False
         if request.run_smoke_test:
             smoke_test_passed = self._run_structural_smoke_test(bundle_path)
-
-        artifact_bytes = 0
-        for entry in os.scandir(bundle_path):
-            if entry.name == "manifest.json":
-                continue
-            if entry.is_file():
-                artifact_bytes += entry.stat().st_size
 
         manifest_path = bundle_path / "manifest.json"
         manifest_payload = self._manifest_payload(
@@ -237,6 +231,17 @@ class OQQuantizationPipeline:
     @staticmethod
     def _manifest_size(payload: dict[str, Any]) -> int:
         return len(OQQuantizationPipeline._encode_manifest(payload))
+
+    @staticmethod
+    def _write_json_file(path: Path, payload: dict[str, Any]) -> int:
+        encoded = json.dumps(payload, indent=2).encode("utf-8") + b"\n"
+        path.write_bytes(encoded)
+        return len(encoded)
+
+    @staticmethod
+    def _write_bytes_file(path: Path, payload: bytes) -> int:
+        path.write_bytes(payload)
+        return len(payload)
 
     @staticmethod
     def _write_manifest(path: Path, payload: dict[str, Any]) -> int:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 import fnmatch
 import gc
+import os
 import importlib.util
 import json
 from pathlib import Path
@@ -425,6 +426,8 @@ def _dispatch_probe_impl(*, probe: ProbeDefinition, repo_root: Path) -> dict[str
         return _probe_upload_receipt_published_files(repo_root)
     if probe.probe_impl == "pr_scoped_scope_matcher":
         return _probe_pr_scoped_scope_matcher(repo_root)
+    if probe.probe_impl == "model_ops_bundle_artifact_bytes":
+        return _probe_model_ops_bundle_artifact_bytes(repo_root)
     if probe.probe_impl == "command_json":
         return _probe_command_json(probe=probe, repo_root=repo_root)
     raise ValueError(f"unsupported probe implementation: {probe.probe_impl}")
@@ -1307,6 +1310,89 @@ def _load_upload_receipt_pipeline_module(path: Path) -> Any:
                 sys.modules.pop(name, None)
             else:
                 sys.modules[name] = previous
+
+
+def _probe_model_ops_bundle_artifact_bytes(repo_root: Path) -> dict[str, float]:
+    probe_script = """
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from packages.protocol.python.worker.v1 import maintenance_pb2
+from worker.grpc_server import WorkerMaintenanceService
+from worker.model_registry.catalog import WorkerModelCatalog
+from worker.registry import WorkerRegistry
+
+elapsed_samples = []
+scandir_samples = []
+sample_count = 0.0
+
+for _ in range(3):
+    with tempfile.TemporaryDirectory(prefix='melix-pr-perf-model-ops-bundle-') as temp_dir:
+        temp_root = Path(temp_dir)
+        service = WorkerMaintenanceService(
+            WorkerRegistry(model_catalog=WorkerModelCatalog()),
+            jobs_root=temp_root / 'model-ops',
+        )
+        original_scandir = os.scandir
+        bundle_scandir_calls = [0]
+
+        def tracked_scandir(path):
+            bundle_scandir_calls[0] += int(Path(path).name.endswith('.artifact'))
+            return original_scandir(path)
+
+        os.scandir = tracked_scandir
+        try:
+            started = time.perf_counter()
+            convert_events = list(
+                service.ConvertModel(
+                    maintenance_pb2.ConvertModelRequest(
+                        source_model='melix-dev-text',
+                        output_dir=str(temp_root / 'convert'),
+                        generate_manifest=True,
+                    ),
+                    context=None,
+                )
+            )
+            quantize_events = list(
+                service.ConvertModel(
+                    maintenance_pb2.ConvertModelRequest(
+                        source_model='melix-dev-text',
+                        output_dir=str(temp_root / 'quantize'),
+                        weight_quant='q4',
+                        kv_quant='q8',
+                        generate_manifest=True,
+                        ext={'operation': 'quantize'},
+                    ),
+                    context=None,
+                )
+            )
+            elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        finally:
+            os.scandir = original_scandir
+
+        sample_count = float(len(convert_events) + len(quantize_events))
+        scandir_samples.append(float(bundle_scandir_calls[0]))
+
+print(json.dumps({
+    'elapsed_ms_mean': round(sum(elapsed_samples) / len(elapsed_samples), 3),
+    'bundle_scandir_calls_mean': round(sum(scandir_samples) / len(scandir_samples), 3),
+    'sample_count': sample_count,
+}, sort_keys=True))
+"""
+    completed = subprocess.run(
+        "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 - <<'PY'\n"
+        f"{probe_script}"
+        "\nPY",
+        shell=True,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads((completed.stdout or "").strip())
 
 
 def _load_repo_module(path: Path, *, unique_name: str) -> Any:


### PR DESCRIPTION
## Summary
- remove redundant post-write bundle rescans from the Python convert and quantize pipelines by accumulating `artifact_bytes` while files are written
- add regression tests that fail if either pipeline falls back to rescanning its `*.artifact` directory for artifact-byte accounting
- register a scoped performance probe for the model-ops bundle path so PR CI can verify the convert/quantize bundle hot path against `origin/main`

## Plan or Spec
- `docs/plans/2026-05-01-convert-quantize-artifact-bytes-plan.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_bundle_directory_and_versioned_manifest \
  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_manifest_once_after_in_memory_byte_convergence \
  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory \
  services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_model_writes_manifest_once_after_in_memory_byte_convergence \
  services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_ops_bundle_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_model_ops_bundle_probe
# 9 passed in 5.70s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q \
  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_bundle_directory_and_versioned_manifest \
  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_manifest_once_after_in_memory_byte_convergence \
  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory \
  services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_model_writes_manifest_once_after_in_memory_byte_convergence \
  services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_ops_bundle_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_model_ops_bundle_probe
# 9 passed in 26.44s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/model_ops/conversion_pipeline.py \
  services/mlx-worker-python/worker/model_ops/quantization_pipeline.py \
  services/mlx-worker-python/worker/productization/pr_scoped_performance.py \
  services/mlx-worker-python/tests/test_quantization_pipeline.py \
  services/mlx-worker-python/tests/test_maintenance_service.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 114 4 96%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python python3 /tmp/probe_model_ops_bundle_20260501_180930.py
# {"bundle_scandir_calls_mean": 0.0, "elapsed_ms_mean": 2.407, "sample_count": 14.0}

git diff --check
# clean
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 114 4 96%`
- Changed executable line coverage by file:
  - `services/mlx-worker-python/worker/model_ops/conversion_pipeline.py`: `100.00%`
  - `services/mlx-worker-python/worker/model_ops/quantization_pipeline.py`: `100.00%`
  - `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`: `94.12%`
  - aggregate changed scope across touched executable files and focused tests: `96%`
- Local probe (head branch): `bundle_scandir_calls_mean=0.0`, `elapsed_ms_mean=2.407`, `sample_count=14.0`
- Pre-change scout baseline on this same cron run observed `2` redundant bundle-directory rescans per convert+quantize pair on the old implementation; this change removes those rescans locally while preserving manifest payloads and artifact byte counts.
- Registered scoped CI probe: `model-ops-bundle-artifact-byte-accounting`

## Known Gaps
- Local verification covered only the Linux-verifiable Python slice. I did not run full-repo `make proto`, `make swift-test`, or other macOS-only verification locally.
- Because this PR updates `infra/perf/pr_scoped_probes.json`, Melix's `pr-scoped-performance` workflow will force the full scoped-probe matrix, including the macOS probe, before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs/plan for this slice.
- [x] Protocol changes include regenerated generated artifacts (N/A: no protocol changes).
- [x] Dependency changes include updated lockfiles (N/A: no dependency changes).
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
