### PR TITLE
perf(swift-cli): skip redundant metric exponent scan

### DIFF
--- a/Sources/MelixCLICore/MelixCLIJSON.swift
+++ b/Sources/MelixCLICore/MelixCLIJSON.swift
@@ -36,7 +36,7 @@ enum MelixCLIJSONMetricPatch {
             format: "%.16e",
             locale: metricLiteralLocale,
             finiteValue
-        ).replacingOccurrences(of: "E", with: "e")
+        )
     }
 
     static func replacePlaceholder(in text: String, with value: Double) throws -> String {

--- a/docs/plans/2026-05-01-swift-cli-json-envelope-performance.md
+++ b/docs/plans/2026-05-01-swift-cli-json-envelope-performance.md
@@ -23,6 +23,8 @@ Optimize the Swift CLI JSON envelope metric-object assembly path and register a 
 
 The next slice keeps the same JSON literal formatting semantics but stores each generated placeholder's quoted JSON literal and UTF-8 data alongside the token. This avoids rebuilding the same quoted string and `Data` buffer while success/error envelope patching or pipeline placeholder lookup validates uniqueness, while preserving stable placeholder tokens and decimal formatting.
 
+The follow-up literal-format slice keeps the same `%.16e` POSIX formatting contract while dropping the redundant uppercase-exponent replacement pass. The format specifier already requests lowercase scientific notation, so avoiding the second string scan reduces per-envelope metric literal work without changing encoded output.
+
 The PR-scoped performance registry uses a `command_json` probe mode so Swift probes can execute a shell command on a macOS runner and emit JSON metrics without requiring Python to import Swift code directly.
 
 ## Success Metrics


### PR DESCRIPTION
## Summary
- Optimizes the Swift CLI JSON metric literal helper by removing the redundant uppercase-exponent replacement pass after `String(format: "%.16e", locale: en_US_POSIX, ...)`.
- Keeps the JSON metric literal contract unchanged; the existing focused Swift tests assert lowercase scientific notation.

## Plan or Spec
- `docs/plans/2026-05-01-swift-cli-json-envelope-performance.md`

## Commands Run
```text
python3 - <<'PY'
import json
from pathlib import Path
probes=json.loads(Path('infra/perf/pr_scoped_probes.json').read_text())
matching=[p for p in probes if 'Sources/MelixCLICore/MelixCLIJSON.swift' in p.get('watch_globs', [])]
assert len(matching)==1, matching
p=matching[0]
for key in ('test_command','coverage_command','probe_command'):
    assert p.get(key), key
print(json.dumps({'id':p['id'],'runner':p['runner'],'probe_impl':p['probe_impl']}, sort_keys=True))
PY
# exit 0; selected registered probe swift-cli-json-envelope-encoding on macos-15

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe
# exit 0; 2 passed in 0.11s

if command -v swift >/dev/null 2>&1; then swift test --filter MelixCLITests/MelixCLIRunnerTests; else echo 'swift unavailable on local Linux; macOS CI registered probe required'; fi
# exit 0; local Linux has no swift toolchain, so Swift runtime/effect validation is deferred to macOS CI.

python3 scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json /tmp/melix-changed-swift-json.json
# exit 0; selected_count=1, selected_probes[0].id=swift-cli-json-envelope-encoding

git diff --check
# exit 0
```

## Coverage and Metrics
- Registered PR-scoped probe: `swift-cli-json-envelope-encoding` (`runner: macos-15`, `probe_impl: command_json`).
- Local Linux coverage for Swift is not available because `swift` is not installed in this cron environment.
- The registered macOS CI probe is required to validate the focused Swift test command and report `elapsed_ms_mean` for base/head.

## Known Gaps
- Swift runtime effect and Swift coverage are not claimed locally; validation source is the GitHub Actions macOS PR-scoped performance run.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
