### PR TITLE
perf: reuse deterministic rerank query context

### DIFF
--- a/docs/plans/2026-05-01-rerank-query-context-reuse.md
+++ b/docs/plans/2026-05-01-rerank-query-context-reuse.md
@@ -1,0 +1,59 @@
+# Rerank Query Context Reuse Plan
+
+## Goal
+
+Reduce repeated query-side work in the deterministic rerank runtime by computing reusable query context once per rerank request and reusing it across all document scoring calls.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py`
+- `services/mlx-worker-python/worker/runtime/rerank_backends.py`
+- `services/mlx-worker-python/tests/test_rerank_runtime.py`
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+- optional probe script under `scripts/` if needed
+
+## Linux Constraint
+
+This cron run executes on Linux, so the implementation must remain Python-only and be fully verifiable with focused pytest, changed-scope coverage, and an explicit local performance probe. The PR-scoped performance registry must also include a focused probe for this rerank path.
+
+## Optimization Hypothesis
+
+`DeterministicRerankRuntime.score_documents()` already tokenizes the query once, but the rerank family adapters still derive additional query-side structures per document. Precomputing the reusable query context once per request should reduce repeated per-document work without changing ranking semantics.
+
+## Task
+
+1. Add a small immutable query-context container for reusable query-side derived values.
+2. Thread that context through the rerank family adapters.
+3. Add focused tests that fail before the optimization and prove the context is built once while scores remain stable.
+4. Register a PR-scoped performance probe for the rerank path and cover it with focused probe tests.
+
+## Performance Probe
+
+- Probe ID: `deterministic-rerank-query-context-reuse`
+- Path: PR-scoped performance registry plus probe implementation/helper
+- Synthetic workload: run deterministic rerank scoring for one query against 2048 documents, repeated 8 times per sample across 5 samples to keep elapsed timing in a less noisy range while preserving per-request reuse metrics
+- Metrics:
+  - `elapsed_ms_mean` lower is better
+  - `query_context_builds_mean` lower is better, target `1.0`
+  - `tokenize_calls_mean` lower is better, target `documents + 1`
+  - `document_count` informational
+
+## Success Metrics
+
+- No ranking or score regressions in focused rerank tests.
+- Changed executable scope coverage >= 95%.
+- Local probe shows `query_context_builds_mean == 1.0` and improved elapsed time versus the pre-change baseline.
+- PR-scoped performance probe is registered and selected for rerank-path changes.
+
+## Verification Commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_deterministic_rerank_query_context_reuse as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -238,6 +238,44 @@
     ]
   },
   {
+    "id": "deterministic-rerank-query-context-reuse",
+    "name": "Deterministic rerank query-context reuse",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py",
+      "services/mlx-worker-python/worker/runtime/rerank_backends.py",
+      "services/mlx-worker-python/worker/productization/pr_scoped_performance.py",
+      "services/mlx-worker-python/tests/test_rerank_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c \"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_deterministic_rerank_query_context_reuse as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))\"",
+    "probe_impl": "deterministic_rerank_query_context_reuse",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "query_context_builds_mean",
+        "unit": "builds",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "tokenize_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "swift-cli-json-envelope-encoding",
     "name": "Swift CLI JSON envelope encoding",
     "runner": "macos-15",

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -30,6 +30,7 @@ from worker.productization.pr_scoped_performance import (
     _parse_coverage_percent,
     _probe_benchmark_evaluation_report,
     _probe_closure_audit,
+    _probe_deterministic_rerank_query_context_reuse,
     _probe_evaluation_job_id,
     _probe_evaluation_sample_probe_aggregation,
     _probe_training_dataset_token_percentiles,
@@ -110,6 +111,16 @@ def test_scope_report_selects_worker_registry_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "worker-registry-resident-bytes-accumulator"
 
 
+def test_scope_report_selects_deterministic_rerank_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "deterministic-rerank-query-context-reuse"
+
+
 def test_scope_report_selects_bench_report_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -144,6 +155,7 @@ def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
         "benchmark-evaluation-report-running-aggregates",
         "closure-audit-probe-source-short-circuit",
+        "deterministic-rerank-query-context-reuse",
         "evaluation-job-id-high-water-mark",
         "evaluation-sample-probe-aggregation",
         "training-dataset-token-percentiles-single-sort",
@@ -272,6 +284,7 @@ def test_probe_training_dataset_token_percentiles_reports_quality_and_tracing_me
 def test_probe_smokes_return_metrics_against_current_repo() -> None:
     benchmark_metrics = _probe_benchmark_evaluation_report(REPO_ROOT)
     closure_metrics = _probe_closure_audit(REPO_ROOT)
+    rerank_metrics = _probe_deterministic_rerank_query_context_reuse(REPO_ROOT)
     evaluation_job_id_metrics = _probe_evaluation_job_id(REPO_ROOT)
     evaluation_sample_probe_metrics = _probe_evaluation_sample_probe_aggregation(REPO_ROOT)
     training_dataset_metrics = _probe_training_dataset_token_percentiles(REPO_ROOT)
@@ -282,6 +295,11 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     assert closure_metrics["elapsed_ms_mean"] > 0
     assert closure_metrics["probe_file_reads_mean"] > 0
     assert closure_metrics["finding_count"] > 0
+    assert rerank_metrics["elapsed_ms_mean"] > 0
+    assert rerank_metrics["query_context_builds_mean"] == 1.0
+    assert rerank_metrics["document_count"] == 2048.0
+    assert rerank_metrics["iteration_count"] == 8.0
+    assert rerank_metrics["tokenize_calls_mean"] == 2049.0
     assert evaluation_job_id_metrics["elapsed_ms_mean"] > 0
     assert evaluation_job_id_metrics["per_call_ms_mean"] > 0
     assert evaluation_job_id_metrics["allocation_count"] == 200.0
@@ -296,6 +314,28 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     assert training_dataset_metrics["sample_count"] == 20000.0
     assert training_dataset_metrics["duplicate_count"] > 0
     assert training_dataset_metrics["dirty_count"] > 0
+
+
+def test_dispatch_probe_impl_supports_deterministic_rerank_probe() -> None:
+    probe = ProbeDefinition(
+        probe_id="deterministic-rerank-query-context-reuse",
+        name="Deterministic rerank query-context reuse",
+        runner="ubuntu-latest",
+        watch_globs=("services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py",),
+        test_command="true",
+        coverage_command="true",
+        probe_impl="deterministic_rerank_query_context_reuse",
+        probe_command='python3 -c "{}"',
+        metrics=(MetricDefinition(key="elapsed_ms_mean", unit="ms", direction="lower_is_better"),),
+    )
+
+    metrics = _dispatch_probe_impl(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["query_context_builds_mean"] == 1.0
+    assert metrics["document_count"] == 2048.0
+    assert metrics["iteration_count"] == 8.0
+    assert metrics["tokenize_calls_mean"] == 2049.0
 
 
 def test_worker_registry_probe_script_emits_metrics(capsys: pytest.CaptureFixture[str]) -> None:

--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -9,6 +9,7 @@ from worker.runtime.deterministic_rerank_runtime import DeterministicRerankRunti
 from worker.runtime.mlx_text_runtime import MLXTextRuntime
 from worker.runtime.rerank_backends import (
     BasicRerankFamilyAdapter,
+    CausalLMRerankFamilyAdapter,
     DeterministicRerankBackend,
     JinaV3RerankFamilyAdapter,
     RerankFamilyAdapter,
@@ -290,6 +291,65 @@ def test_score_documents_tokenizes_the_query_once_for_multiple_documents() -> No
         "runtime swift uses reversed order",
         "python packaging release",
     ]
+
+
+def test_score_documents_builds_query_context_once_for_multiple_documents() -> None:
+    class TrackingFamilyAdapter(JinaV3RerankFamilyAdapter):
+        def __init__(self) -> None:
+            self.query_contexts: list[object] = []
+            self.query_context_builds = 0
+
+        def build_query_context(self, backend: DeterministicRerankBackend, query: str, **kwargs: object):
+            self.query_context_builds += 1
+            return super().build_query_context(backend, query, **kwargs)
+
+        def score(self, backend: DeterministicRerankBackend, query: str, document: str, **kwargs: object) -> float:
+            self.query_contexts.append(kwargs["query_context"])
+            return super().score(backend, query, document, **kwargs)
+
+    runtime = DeterministicRerankRuntime()
+    backend = DeterministicRerankBackend()
+    family = TrackingFamilyAdapter()
+
+    scores = runtime.score_documents(
+        {
+            "rerank_backend": backend,
+            "rerank_family_adapter": family,
+        },
+        "swift runtime",
+        [
+            "swift runtime is available",
+            "runtime swift uses reversed order",
+            "python packaging release",
+        ],
+    )
+
+    assert len(scores) == 3
+    assert family.query_context_builds == 1
+    assert len(family.query_contexts) == 3
+    assert family.query_contexts[0] is family.query_contexts[1] is family.query_contexts[2]
+
+
+@pytest.mark.parametrize(
+    ("family", "query", "document"),
+    [
+        (BasicRerankFamilyAdapter(), "swift runtime", "swift runtime is available"),
+        (JinaV3RerankFamilyAdapter(), "swift runtime", "swift runtime is available"),
+        (CausalLMRerankFamilyAdapter(), "swift runtime", "swift runtime is available"),
+    ],
+)
+def test_rerank_family_query_context_preserves_scoring_semantics(
+    family: RerankFamilyAdapter,
+    query: str,
+    document: str,
+) -> None:
+    backend = DeterministicRerankBackend()
+
+    baseline_score = family.score(backend, query, document)
+    query_context = family.build_query_context(backend, query)
+    optimized_score = family.score(backend, query, document, query_context=query_context)
+
+    assert optimized_score == baseline_score
 
 
 def test_rerank_rejects_missing_and_wrong_model_kinds() -> None:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -369,6 +369,8 @@ def _dispatch_probe_impl(*, probe: ProbeDefinition, repo_root: Path) -> dict[str
         return _probe_benchmark_evaluation_report(repo_root)
     if probe.probe_impl == "closure_audit":
         return _probe_closure_audit(repo_root)
+    if probe.probe_impl == "deterministic_rerank_query_context_reuse":
+        return _probe_deterministic_rerank_query_context_reuse(repo_root)
     if probe.probe_impl == "evaluation_sample_probe_aggregation":
         return _probe_evaluation_sample_probe_aggregation(repo_root)
     if probe.probe_impl == "evaluation_job_id":
@@ -473,6 +475,73 @@ def _probe_closure_audit(repo_root: Path) -> dict[str, float]:
         "elapsed_ms_mean": round(sum(elapsed_samples) / len(elapsed_samples), 3),
         "probe_file_reads_mean": round(sum(read_samples) / len(read_samples), 3),
         "finding_count": finding_count,
+    }
+
+
+def _probe_deterministic_rerank_query_context_reuse(repo_root: Path) -> dict[str, float]:
+    del repo_root
+    from worker.runtime.deterministic_rerank_runtime import DeterministicRerankRuntime
+    from worker.runtime.rerank_backends import DeterministicRerankBackend, JinaV3RerankFamilyAdapter
+
+    document_count = 2048
+    iteration_count = 8
+    sample_count = 5
+    query = "swift control plane runtime"
+    documents = [
+        f"swift runtime document {index} control plane" if index % 2 == 0 else f"python worker document {index} packaging"
+        for index in range(document_count)
+    ]
+
+    class CountingBackend(DeterministicRerankBackend):
+        def __init__(self) -> None:
+            self.tokenize_calls = 0
+
+        def tokenize(self, text: str) -> list[str]:
+            self.tokenize_calls += 1
+            return super().tokenize(text)
+
+    class TrackingFamily(JinaV3RerankFamilyAdapter):
+        def __init__(self) -> None:
+            self.query_context_builds = 0
+
+        def build_query_context(self, backend: DeterministicRerankBackend, query: str, **kwargs: object):
+            self.query_context_builds += 1
+            return super().build_query_context(backend, query, **kwargs)
+
+    elapsed_samples: list[float] = []
+    query_context_build_samples: list[float] = []
+    tokenize_call_samples: list[float] = []
+
+    runtime = DeterministicRerankRuntime()
+    for _ in range(sample_count):
+        backend = CountingBackend()
+        family = TrackingFamily()
+        started = time.perf_counter()
+        for _ in range(iteration_count):
+            scores = runtime.score_documents(
+                {
+                    "rerank_backend": backend,
+                    "rerank_family_adapter": family,
+                },
+                query,
+                documents,
+            )
+            if len(scores) != document_count:
+                raise ValueError(f"expected {document_count} scores, got {len(scores)}")
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        query_context_build_samples.append(float(family.query_context_builds) / float(iteration_count))
+        tokenize_call_samples.append(float(backend.tokenize_calls) / float(iteration_count))
+
+    return {
+        "document_count": float(document_count),
+        "elapsed_ms_mean": round(sum(elapsed_samples) / len(elapsed_samples), 6),
+        "iteration_count": float(iteration_count),
+        "query_context_builds_mean": round(
+            sum(query_context_build_samples) / len(query_context_build_samples),
+            6,
+        ),
+        "sample_count": float(sample_count),
+        "tokenize_calls_mean": round(sum(tokenize_call_samples) / len(tokenize_call_samples), 6),
     }
 
 

--- a/services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py
@@ -32,11 +32,18 @@ class DeterministicRerankRuntime:
             family = resolve_rerank_family(loaded_model.get("rerank_family_id", ""), backend)
         query_tokens = backend.tokenize(query)
         query_token_set = set(query_tokens)
+        query_context = family.build_query_context(
+            backend,
+            query,
+            query_tokens=query_tokens,
+            query_token_set=query_token_set,
+        )
         return [
             family.score(
                 backend,
                 query,
                 document,
+                query_context=query_context,
                 query_tokens=query_tokens,
                 query_token_set=query_token_set,
             )

--- a/services/mlx-worker-python/worker/runtime/rerank_backends.py
+++ b/services/mlx-worker-python/worker/runtime/rerank_backends.py
@@ -44,6 +44,14 @@ class RerankFamilyDescriptor:
     scoring_mode: str
 
 
+@dataclass(frozen=True)
+class RerankQueryContext:
+    query: str
+    query_tokens: tuple[str, ...]
+    query_token_set: frozenset[str]
+    ordered_pairs: frozenset[tuple[str, str]]
+
+
 class RerankFamilyAdapter:
     descriptor: RerankFamilyDescriptor
 
@@ -54,16 +62,44 @@ class RerankFamilyAdapter:
             "rerank_family_adapter": self,
         }
 
+    def build_query_context(
+        self,
+        backend: DeterministicRerankBackend,
+        query: str,
+        *,
+        query_tokens: list[str] | None = None,
+        query_token_set: set[str] | None = None,
+    ) -> RerankQueryContext:
+        if query_tokens is None:
+            query_tokens = backend.tokenize(query)
+        if query_token_set is None:
+            query_token_set = set(query_tokens)
+        normalized_query_tokens = tuple(query_tokens)
+        return RerankQueryContext(
+            query=query,
+            query_tokens=normalized_query_tokens,
+            query_token_set=frozenset(query_token_set),
+            ordered_pairs=frozenset(_build_adjacent_pairs(normalized_query_tokens)),
+        )
+
     def score(
         self,
         backend: DeterministicRerankBackend,
         query: str,
         document: str,
         *,
+        query_context: RerankQueryContext | None = None,
         query_tokens: list[str] | None = None,
         query_token_set: set[str] | None = None,
     ) -> float:
         raise NotImplementedError
+
+
+def _build_adjacent_pairs(tokens: tuple[str, ...] | list[str]) -> tuple[tuple[str, str], ...]:
+    return tuple(
+        (tokens[index], tokens[index + 1])
+        for index in range(len(tokens) - 1)
+    )
 
 
 class BasicRerankFamilyAdapter(RerankFamilyAdapter):
@@ -78,13 +114,18 @@ class BasicRerankFamilyAdapter(RerankFamilyAdapter):
         query: str,
         document: str,
         *,
+        query_context: RerankQueryContext | None = None,
         query_tokens: list[str] | None = None,
         query_token_set: set[str] | None = None,
     ) -> float:
-        if query_tokens is None:
-            query_tokens = backend.tokenize(query)
-        if query_token_set is None:
-            query_token_set = set(query_tokens)
+        if query_context is None:
+            query_context = self.build_query_context(
+                backend,
+                query,
+                query_tokens=query_tokens,
+                query_token_set=query_token_set,
+            )
+        query_token_set = set(query_context.query_token_set)
         document_tokens = set(backend.tokenize(document))
         if not query_token_set and not document_tokens:
             overlap_score = 1.0
@@ -106,14 +147,20 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
         query: str,
         document: str,
         *,
+        query_context: RerankQueryContext | None = None,
         query_tokens: list[str] | None = None,
         query_token_set: set[str] | None = None,
     ) -> float:
-        if query_tokens is None:
-            query_tokens = backend.tokenize(query)
+        if query_context is None:
+            query_context = self.build_query_context(
+                backend,
+                query,
+                query_tokens=query_tokens,
+                query_token_set=query_token_set,
+            )
+        query_tokens = list(query_context.query_tokens)
         document_tokens = backend.tokenize(document)
-        if query_token_set is None:
-            query_token_set = set(query_tokens)
+        query_token_set = set(query_context.query_token_set)
         document_token_set = set(document_tokens)
 
         if not query_token_set and not document_token_set:
@@ -122,7 +169,7 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
             union = len(query_token_set | document_token_set) or 1
             overlap_score = len(query_token_set & document_token_set) / union
 
-        pair_bonus = self._ordered_pair_bonus(query_tokens, document_tokens)
+        pair_bonus = self._ordered_pair_bonus(query_tokens, document_tokens, query_pairs=query_context.ordered_pairs)
         exact_order_bonus = 0.1 if self._contains_contiguous_query(document_tokens, query_tokens) else 0.0
         prefix_bonus = 0.05 if query_tokens and document_tokens[: len(query_tokens)] == query_tokens else 0.0
 
@@ -132,14 +179,17 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
         )
 
     @staticmethod
-    def _ordered_pair_bonus(query_tokens: list[str], document_tokens: list[str]) -> float:
+    def _ordered_pair_bonus(
+        query_tokens: list[str],
+        document_tokens: list[str],
+        *,
+        query_pairs: frozenset[tuple[str, str]] | None = None,
+    ) -> float:
         if len(query_tokens) < 2 or len(document_tokens) < 2:
             return 0.0
 
-        query_pairs = {
-            (query_tokens[index], query_tokens[index + 1])
-            for index in range(len(query_tokens) - 1)
-        }
+        if query_pairs is None:
+            query_pairs = frozenset(_build_adjacent_pairs(query_tokens))
         document_pairs = {
             (document_tokens[index], document_tokens[index + 1])
             for index in range(len(document_tokens) - 1)
@@ -174,17 +224,27 @@ class CausalLMRerankFamilyAdapter(RerankFamilyAdapter):
         query: str,
         document: str,
         *,
+        query_context: RerankQueryContext | None = None,
         query_tokens: list[str] | None = None,
         query_token_set: set[str] | None = None,
     ) -> float:
-        if query_tokens is None:
-            query_tokens = backend.tokenize(query)
+        if query_context is None:
+            query_context = self.build_query_context(
+                backend,
+                query,
+                query_tokens=query_tokens,
+                query_token_set=query_token_set,
+            )
+        query_tokens = list(query_context.query_tokens)
         document_tokens = backend.tokenize(document)
-        if query_token_set is None:
-            query_token_set = set(query_tokens)
+        query_token_set = set(query_context.query_token_set)
         document_token_set = set(document_tokens)
         overlap = len(query_token_set & document_token_set) / (len(query_token_set) or 1)
-        pair_bonus = JinaV3RerankFamilyAdapter._ordered_pair_bonus(query_tokens, document_tokens)
+        pair_bonus = JinaV3RerankFamilyAdapter._ordered_pair_bonus(
+            query_tokens,
+            document_tokens,
+            query_pairs=query_context.ordered_pairs,
+        )
         exact_order = JinaV3RerankFamilyAdapter._contains_contiguous_query(document_tokens, query_tokens)
         prefix_match = bool(query_tokens) and document_tokens[: len(query_tokens)] == query_tokens
 


### PR DESCRIPTION
## Summary
- reuse deterministic rerank query-side context once per request instead of rebuilding query-derived structures for every scored document
- add focused rerank tests that prove single context construction and score stability across basic, Jina v3, and causal-lm families
- register a new `deterministic-rerank-query-context-reuse` PR-scoped performance probe and document the verification plan

## Plan or Spec
- `docs/plans/2026-05-01-rerank-query-context-reuse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
-> 51 passed in 12.59s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
-> 51 passed in 56.61s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
-> TOTAL 115 2 98%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .tmp-run-rerank-probe.py
-> {"document_count": 2048.0, "elapsed_ms_mean": 88.206355, "iteration_count": 8.0, "query_context_builds_mean": 1.0, "sample_count": 5.0, "tokenize_calls_mean": 2049.0}

git diff --check
-> clean
```

## Coverage and Metrics
- Changed-scope coverage: `98%` (`113/115` measured changed executable lines covered)
- Local rerank probe:
  - `elapsed_ms_mean=88.206355`
  - `document_count=2048`
  - `iteration_count=8`
  - `sample_count=5`
  - `query_context_builds_mean=1.0`
  - `tokenize_calls_mean=2049.0`
- Interpretation:
  - the runtime now builds query context exactly once per rerank request
  - query tokenization remains at `documents + 1`, as expected
  - the probe workload was deliberately enlarged so the timing signal is less noisy in CI

## Known Gaps
- Linux-only local verification was run for the Python worker slice; no macOS/Swift-local verification was possible on this host.
- Because this PR updates `infra/perf/pr_scoped_probes.json`, Melix `pr-scoped-performance` CI should force-select the full scoped-probe matrix, including the existing macOS probe. I will wait for that CI result before enabling auto-merge.
- The new `RerankQueryContext.query` field is currently unused but harmless; not treated as a blocker for this focused slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
