### PR TITLE
perf(worker): cache benchmark matrix probe labels

### DIFF
--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -316,6 +316,39 @@ def test_collect_benchmark_probe_metrics_groups_aggregates_by_label_and_preserve
     }
 
 
+def test_collect_benchmark_probe_metrics_reuses_matrix_labels(monkeypatch: pytest.MonkeyPatch) -> None:
+    original = benchmark_evaluation_report._matrix_label
+    matrix_label_calls = 0
+
+    def tracked_matrix_label(
+        row: dict[str, object],
+        *,
+        label_cache: dict[tuple[str, str, str, str, str, str], str] | None = None,
+    ) -> str:
+        nonlocal matrix_label_calls
+        matrix_label_calls += 1
+        return original(row, label_cache=label_cache)
+
+    monkeypatch.setattr(benchmark_evaluation_report, "_matrix_label", tracked_matrix_label)
+    rows = [
+        {
+            "suite_id": "smoke",
+            "context_length": 1024,
+            "generation_length": 128,
+            "batch_size": 1,
+            "concurrency_level": 4,
+            "prefill_ms": float(index),
+        }
+        for index in range(5)
+    ]
+
+    metrics: dict[str, object] = {}
+    _collect_benchmark_probe_metrics(metrics, rows, prefix="bench")
+
+    assert matrix_label_calls == 1
+    assert metrics["bench.smoke.ctx1024.gen128.b1.c4.prefill_ms_mean"] == 2.0
+
+
 def test_dict_rows_returns_lazy_iterable_of_dict_rows() -> None:
     rows = [{"name": "first"}, "skip", {"name": "second"}]
 

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -438,6 +438,7 @@ def _collect_benchmark_probe_metrics(
     label_cache: dict[_BenchmarkLabelCacheKey, str] | None = None,
 ) -> None:
     aggregates_by_label: dict[str, dict[str, _NumericAggregate]] = {}
+    matrix_label_cache: dict[tuple[object, object, object, object, object], str] = {}
     for row in _dict_rows(rows):
         label = ""
         for key, raw_value in row.items():
@@ -449,7 +450,11 @@ def _collect_benchmark_probe_metrics(
                 value = _float_or_none(raw_value)
             if value is not None:
                 if not label:
-                    label = _benchmark_probe_label(row, label_cache=label_cache)
+                    label = _benchmark_probe_label(
+                        row,
+                        label_cache=label_cache,
+                        matrix_label_cache=matrix_label_cache,
+                    )
                 _update_probe_aggregates_by_label(
                     aggregates_by_label,
                     label=label,


### PR DESCRIPTION
## Summary
- Cache matrix-style benchmark probe labels inside `_collect_benchmark_probe_metrics()` so repeated matrix request rows reuse the same formatted label.
- Add a focused regression test proving repeated matrix rows only compute the matrix label once while preserving aggregate metric output.

## Plan or Spec
- `docs/plans/2026-05-01-benchmark-evaluation-matrix-label-cache.md`
- Registered PR-scoped probe: `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline registered probe smoke before edits (base=head=origin/main worktree)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-evaluation-report-running-aggregates --base-repo . --head-repo . --output /tmp/melix-benchmark-baseline.json
exit 0; baseline head_verification coverage 99%; probe base elapsed_ms_mean=161.588, head elapsed_ms_mean=162.782, row_count=5990

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
exit 0; 31 passed in 0.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
exit 0; total coverage 99%; benchmark_evaluation_report.py 98%; test file 99%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-evaluation-report-running-aggregates --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-benchmark-matrix-label-20260501214708 --head-repo . --output /tmp/melix-benchmark-compare.json
exit 0; registered probe base elapsed_ms_mean=171.235, head elapsed_ms_mean=155.305, row_count=5990

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 99% total; `benchmark_evaluation_report.py` 98%; `test_benchmark_evaluation_report.py` 99%.
- Registered local Linux probe (`benchmark-evaluation-report-running-aggregates`): `elapsed_ms_mean` improved from `171.235 ms` to `155.305 ms` (`-15.930 ms`, about `1.10x` faster); `row_count` unchanged at `5990`; `peak_bytes_mean` changed from `3,889,796` to `3,904,308` bytes (~0.37% increase, below the 5% warning threshold).
- CI is still required to validate the registered PR-scoped performance workflow on GitHub Actions before merge.

## Known Gaps
- Local verification was Linux/Python only; no Swift runtime effect is involved in this slice.
- Full repository `make` gates were not run locally because this is a focused registered performance slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
