### PR TITLE
perf(rerank): reuse query context collections

### DIFF
--- a/docs/plans/2026-05-01-rerank-query-context-collection-reuse.md
+++ b/docs/plans/2026-05-01-rerank-query-context-collection-reuse.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This slice keeps the existing deterministic rerank semantics and narrows the hot path inside `worker/runtime/rerank_backends.py`. The default Jina v3 and causal-lm rerank families already build one `RerankQueryContext` per request; this slice reuses the context's immutable tuple/frozenset collections directly while scoring each document instead of rebuilding per-document list/set copies.
+This slice keeps the existing deterministic rerank semantics and narrows the hot path inside `worker/runtime/rerank_backends.py`. The default Jina v3 and causal-lm rerank families already build one `RerankQueryContext` per request; this slice reuses the context's immutable tuple/frozenset collections directly while scoring each document instead of rebuilding per-document query list/set copies. It also derives Jaccard union counts from set sizes plus the already-computed overlap count so scoring does not allocate an additional union set per document.
 
 ## Registered probe
 

--- a/docs/plans/2026-05-01-rerank-query-context-collection-reuse.md
+++ b/docs/plans/2026-05-01-rerank-query-context-collection-reuse.md
@@ -1,0 +1,29 @@
+# Rerank Query Context Collection Reuse
+
+## Scope
+
+This slice keeps the existing deterministic rerank semantics and narrows the hot path inside `worker/runtime/rerank_backends.py`. The default Jina v3 and causal-lm rerank families already build one `RerankQueryContext` per request; this slice reuses the context's immutable tuple/frozenset collections directly while scoring each document instead of rebuilding per-document list/set copies.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped probe `deterministic-rerank-query-context-reuse` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes:
+
+- `test_command` for focused rerank runtime tests and probe selection/dispatch tests.
+- `coverage_command` for changed-scope coverage across rerank runtime/backends, PR-scoped performance support, and focused tests.
+- `probe_command` that measures repeated deterministic rerank scoring for 2,048 documents and reports elapsed time plus context-build/tokenize counters.
+
+## Verification plan
+
+Run the registered focused command set locally on Linux:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_rerank_probe.py
+```
+
+CI remains the merge gate for the registered PR-scoped performance report.

--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -352,6 +352,26 @@ def test_rerank_family_query_context_preserves_scoring_semantics(
     assert optimized_score == baseline_score
 
 
+def test_rerank_context_tuple_and_frozenset_collections_are_scored_directly() -> None:
+    backend = DeterministicRerankBackend()
+    family = JinaV3RerankFamilyAdapter()
+    query_context = family.build_query_context(backend, "swift runtime")
+
+    assert isinstance(query_context.query_tokens, tuple)
+    assert isinstance(query_context.query_token_set, frozenset)
+    assert family._ordered_pair_bonus(query_context.query_tokens, ("swift", "runtime")) > 0.0
+    assert family._contains_contiguous_query(
+        ("control", "swift", "runtime"),
+        query_context.query_tokens,
+    )
+    assert family.score(
+        backend,
+        "swift runtime",
+        "control swift runtime",
+        query_context=query_context,
+    ) == family.score(backend, "swift runtime", "control swift runtime")
+
+
 def test_rerank_rejects_missing_and_wrong_model_kinds() -> None:
     runtime_service, inference_service = build_services()
     text_handle = load_model(runtime_service, WorkerModelCatalog.dev_text_model())

--- a/services/mlx-worker-python/worker/runtime/rerank_backends.py
+++ b/services/mlx-worker-python/worker/runtime/rerank_backends.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 import hashlib
 import re
@@ -95,7 +96,7 @@ class RerankFamilyAdapter:
         raise NotImplementedError
 
 
-def _build_adjacent_pairs(tokens: tuple[str, ...] | list[str]) -> tuple[tuple[str, str], ...]:
+def _build_adjacent_pairs(tokens: Sequence[str]) -> tuple[tuple[str, str], ...]:
     return tuple(
         (tokens[index], tokens[index + 1])
         for index in range(len(tokens) - 1)
@@ -125,7 +126,7 @@ class BasicRerankFamilyAdapter(RerankFamilyAdapter):
                 query_tokens=query_tokens,
                 query_token_set=query_token_set,
             )
-        query_token_set = set(query_context.query_token_set)
+        query_token_set = query_context.query_token_set
         document_tokens = set(backend.tokenize(document))
         if not query_token_set and not document_tokens:
             overlap_score = 1.0
@@ -158,9 +159,9 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
                 query_tokens=query_tokens,
                 query_token_set=query_token_set,
             )
-        query_tokens = list(query_context.query_tokens)
+        query_tokens = query_context.query_tokens
         document_tokens = backend.tokenize(document)
-        query_token_set = set(query_context.query_token_set)
+        query_token_set = query_context.query_token_set
         document_token_set = set(document_tokens)
 
         if not query_token_set and not document_token_set:
@@ -180,8 +181,8 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
 
     @staticmethod
     def _ordered_pair_bonus(
-        query_tokens: list[str],
-        document_tokens: list[str],
+        query_tokens: Sequence[str],
+        document_tokens: Sequence[str],
         *,
         query_pairs: frozenset[tuple[str, str]] | None = None,
     ) -> float:
@@ -197,7 +198,7 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
         return (len(query_pairs & document_pairs) / len(query_pairs)) * 0.15
 
     @staticmethod
-    def _contains_contiguous_query(document_tokens: list[str], query_tokens: list[str]) -> bool:
+    def _contains_contiguous_query(document_tokens: Sequence[str], query_tokens: Sequence[str]) -> bool:
         if not query_tokens or len(query_tokens) > len(document_tokens):
             return False
         last_start = len(document_tokens) - len(query_tokens)
@@ -235,9 +236,9 @@ class CausalLMRerankFamilyAdapter(RerankFamilyAdapter):
                 query_tokens=query_tokens,
                 query_token_set=query_token_set,
             )
-        query_tokens = list(query_context.query_tokens)
+        query_tokens = query_context.query_tokens
         document_tokens = backend.tokenize(document)
-        query_token_set = set(query_context.query_token_set)
+        query_token_set = query_context.query_token_set
         document_token_set = set(document_tokens)
         overlap = len(query_token_set & document_token_set) / (len(query_token_set) or 1)
         pair_bonus = JinaV3RerankFamilyAdapter._ordered_pair_bonus(

--- a/services/mlx-worker-python/worker/runtime/rerank_backends.py
+++ b/services/mlx-worker-python/worker/runtime/rerank_backends.py
@@ -131,8 +131,9 @@ class BasicRerankFamilyAdapter(RerankFamilyAdapter):
         if not query_token_set and not document_tokens:
             overlap_score = 1.0
         else:
-            union = len(query_token_set | document_tokens) or 1
-            overlap_score = len(query_token_set & document_tokens) / union
+            overlap_count = len(query_token_set & document_tokens)
+            union = (len(query_token_set) + len(document_tokens) - overlap_count) or 1
+            overlap_score = overlap_count / union
         return round(overlap_score + backend.tie_breaker(query, document), 6)
 
 
@@ -167,8 +168,9 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
         if not query_token_set and not document_token_set:
             overlap_score = 1.0
         else:
-            union = len(query_token_set | document_token_set) or 1
-            overlap_score = len(query_token_set & document_token_set) / union
+            overlap_count = len(query_token_set & document_token_set)
+            union = (len(query_token_set) + len(document_token_set) - overlap_count) or 1
+            overlap_score = overlap_count / union
 
         pair_bonus = self._ordered_pair_bonus(query_tokens, document_tokens, query_pairs=query_context.ordered_pairs)
         exact_order_bonus = 0.1 if self._contains_contiguous_query(document_tokens, query_tokens) else 0.0
@@ -240,7 +242,8 @@ class CausalLMRerankFamilyAdapter(RerankFamilyAdapter):
         document_tokens = backend.tokenize(document)
         query_token_set = query_context.query_token_set
         document_token_set = set(document_tokens)
-        overlap = len(query_token_set & document_token_set) / (len(query_token_set) or 1)
+        overlap_count = len(query_token_set & document_token_set)
+        overlap = overlap_count / (len(query_token_set) or 1)
         pair_bonus = JinaV3RerankFamilyAdapter._ordered_pair_bonus(
             query_tokens,
             document_tokens,
@@ -256,7 +259,7 @@ class CausalLMRerankFamilyAdapter(RerankFamilyAdapter):
 
         no_logit = 1.5
         no_logit -= overlap * 3.0
-        if not (query_token_set & document_token_set):
+        if overlap_count == 0:
             no_logit += 0.3
 
         return round(yes_logit - no_logit + backend.tie_breaker(query, document), 6)


### PR DESCRIPTION
## Summary
- Reuse the immutable `RerankQueryContext` tuple/frozenset collections directly while scoring deterministic rerank documents.
- Broaden helper type hints to `Sequence[str]` so the Jina v3 and causal-lm paths do not rebuild per-document query list/set copies.
- Avoid an extra per-document union set allocation by deriving the Jaccard union size from set sizes plus the already-computed overlap count.
- Add regression coverage for scoring directly from the context collections.

## Plan or Spec
- `docs/plans/2026-05-01-rerank-query-context-collection-reuse.md`
- Registered probe: `deterministic-rerank-query-context-reuse` in `infra/perf/pr_scoped_probes.json`

## Commands Run
```text
# Baseline local probe on origin/main before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_rerank_probe.py
exit 0; elapsed_ms_mean=96.783157, query_context_builds_mean=1.0, tokenize_calls_mean=2049.0

# Focused tests after final implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
exit 0; 24 passed in 5.86s

# Changed-scope coverage after final implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
exit 0; TOTAL 9 0 100%

# Local final head probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_rerank_probe.py
exit 0; elapsed_ms_mean=81.208711, query_context_builds_mean=1.0, tokenize_calls_mean=2049.0

# Registered local base/head probe runner after final implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-rerank-query-context-reuse --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-rerank-20260501220010 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-20260501220010 --output /tmp/rerank_probe_compare_v2.json
exit 0; base elapsed_ms_mean=83.521206, head elapsed_ms_mean=80.403694

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 9 0 100%` for the final incremental diff; the registered CI coverage command reruns the full selected PR scope.
- Registered local probe comparison (`deterministic-rerank-query-context-reuse`):
  - `elapsed_ms_mean`: base `83.521206` ms, head `80.403694` ms, delta `-3.117512` ms, speedup `1.039x`.
  - `query_context_builds_mean`: base `1.0`, head `1.0`.
  - `tokenize_calls_mean`: base `2049.0`, head `2049.0`.
- GitHub Actions PR-scoped performance workflow is still required as the merge gate.

## Known Gaps
- Local validation is Linux/Python-only. This PR does not touch Swift runtime code.
- The registered CI probe report must complete successfully on the latest head before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.