### PR TITLE
perf: speed up deterministic rerank query reuse

### DIFF
--- a/docs/plans/2026-05-01-rerank-query-context-reuse-micro-optimization.md
+++ b/docs/plans/2026-05-01-rerank-query-context-reuse-micro-optimization.md
@@ -1,0 +1,68 @@
+# Deterministic rerank query-context reuse micro-optimization
+
+## Goal
+
+Eliminate per-document reconstruction of query-derived `list(...)` and `set(...)` objects in the deterministic rerank family adapters while preserving score semantics exactly.
+
+## Linux-only constraint
+
+This cron run executes on Linux, so the slice must stay inside the Python worker and use Linux-verifiable evidence only. No macOS-only validation is required for this change.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/rerank_backends.py`
+- `services/mlx-worker-python/tests/test_rerank_runtime.py`
+
+## Performance probe
+
+Use the existing PR-scoped performance probe `deterministic-rerank-query-context-reuse`.
+
+Probe command:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
+uv run --project services/mlx-worker-python python3 -c \
+"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_deterministic_rerank_query_context_reuse as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
+```
+
+## Success metrics
+
+- Preserve existing rerank scores and ordering for supported families.
+- Preserve `query_context_builds_mean == 1.0`.
+- Preserve `tokenize_calls_mean == 2049.0` for the synthetic probe workload.
+- Improve `elapsed_ms_mean` relative to `origin/main`.
+- Achieve at least 95% changed-scope automated coverage for the touched executable files before commit.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
+uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_rerank_runtime.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
+uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_rerank_runtime.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
+uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py \
+  services/mlx-worker-python/worker/runtime/rerank_backends.py \
+  services/mlx-worker-python/worker/productization/pr_scoped_performance.py \
+  services/mlx-worker-python/tests/test_rerank_runtime.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
+uv run --project services/mlx-worker-python python3 -c \
+"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_deterministic_rerank_query_context_reuse as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
+
+git diff --check
+```

--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -1,4 +1,5 @@
-from unittest.mock import Mock
+import builtins
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -388,6 +389,72 @@ def test_score_documents_builds_query_context_once_for_multiple_documents() -> N
     assert family.query_contexts[0] is family.query_contexts[1] is family.query_contexts[2]
 
 
+def test_basic_rerank_family_reuses_query_context_token_set_without_copying() -> None:
+    adapter = BasicRerankFamilyAdapter()
+    backend = DeterministicRerankBackend()
+    query_context = adapter.build_query_context(backend, "swift runtime")
+    original_set = builtins.set
+    copied_query_token_sets = 0
+
+    def tracking_set(values=()):
+        nonlocal copied_query_token_sets
+        copied_query_token_sets += int(values is query_context.query_token_set)
+        return original_set(values)
+
+    with patch("builtins.set", tracking_set):
+        score = adapter.score(
+            backend,
+            query_context.query,
+            "swift runtime is available",
+            query_context=query_context,
+        )
+
+    assert score > 0.0
+    assert copied_query_token_sets == 0
+
+
+@pytest.mark.parametrize(
+    ("family", "query", "document"),
+    [
+        (JinaV3RerankFamilyAdapter(), "swift runtime", "swift runtime is available"),
+        (CausalLMRerankFamilyAdapter(), "swift runtime", "swift runtime is available"),
+    ],
+)
+def test_order_aware_rerank_families_reuse_query_context_sequences_without_copying(
+    family: RerankFamilyAdapter,
+    query: str,
+    document: str,
+) -> None:
+    backend = DeterministicRerankBackend()
+    query_context = family.build_query_context(backend, query)
+    original_list = builtins.list
+    original_set = builtins.set
+    copied_query_tokens = 0
+    copied_query_token_sets = 0
+
+    def tracking_list(values=()):
+        nonlocal copied_query_tokens
+        copied_query_tokens += int(values is query_context.query_tokens)
+        return original_list(values)
+
+    def tracking_set(values=()):
+        nonlocal copied_query_token_sets
+        copied_query_token_sets += int(values is query_context.query_token_set)
+        return original_set(values)
+
+    with patch("builtins.list", tracking_list), patch("builtins.set", tracking_set):
+        score = family.score(
+            backend,
+            query,
+            document,
+            query_context=query_context,
+        )
+
+    assert score > 0.0
+    assert copied_query_tokens == 0
+    assert copied_query_token_sets == 0
+
+
 @pytest.mark.parametrize(
     ("family", "query", "document"),
     [
@@ -417,9 +484,8 @@ def test_rerank_context_tuple_and_frozenset_collections_are_scored_directly() ->
 
     assert isinstance(query_context.query_tokens, tuple)
     assert isinstance(query_context.query_token_set, frozenset)
-    assert query_context.tie_breaker_prefix == b"swift runtime\0"
-    assert backend.tie_breaker_from_prefix(
-        query_context.tie_breaker_prefix,
+    assert backend.tie_breaker_from_seed(
+        query_context.tie_breaker_seed,
         "control swift runtime",
     ) == backend.tie_breaker("swift runtime", "control swift runtime")
     assert family._ordered_pair_bonus(query_context.query_tokens, ("swift", "runtime")) > 0.0
@@ -501,6 +567,40 @@ def test_contiguous_query_scan_does_not_allocate_document_slices() -> None:
     with pytest.raises(AssertionError, match="without slicing"):
         NoSliceTokens(("swift", "runtime"))[0:1]
 
+
+@pytest.mark.parametrize(
+    ("family", "expected_exact_order_bonus", "expected_prefix_bonus", "expected_pair_bonus"),
+    [
+        (JinaV3RerankFamilyAdapter(), 0.1, 0.05, 0.15),
+        (CausalLMRerankFamilyAdapter(), 0.75, 0.5, 0.45),
+    ],
+)
+def test_order_aware_query_context_preserves_exact_order_and_prefix_bonuses(
+    family: RerankFamilyAdapter,
+    expected_exact_order_bonus: float,
+    expected_prefix_bonus: float,
+    expected_pair_bonus: float,
+) -> None:
+    backend = DeterministicRerankBackend()
+    query = "swift runtime"
+    prefix_document = "swift runtime adapters"
+    exact_order_document = "adapters swift runtime"
+    shuffled_document = "runtime swift adapters"
+    query_context = family.build_query_context(backend, query)
+
+    prefix_score = family.score(backend, query, prefix_document, query_context=query_context)
+    exact_order_score = family.score(backend, query, exact_order_document, query_context=query_context)
+    shuffled_score = family.score(backend, query, shuffled_document, query_context=query_context)
+
+    normalized_prefix_score = prefix_score - backend.tie_breaker(query, prefix_document)
+    normalized_exact_order_score = exact_order_score - backend.tie_breaker(query, exact_order_document)
+    normalized_shuffled_score = shuffled_score - backend.tie_breaker(query, shuffled_document)
+
+    assert normalized_prefix_score - normalized_exact_order_score == pytest.approx(expected_prefix_bonus, abs=1e-6)
+    assert normalized_exact_order_score - normalized_shuffled_score == pytest.approx(
+        expected_exact_order_bonus + expected_pair_bonus,
+        abs=1e-6,
+    )
 
 def test_rerank_rejects_missing_and_wrong_model_kinds() -> None:
     runtime_service, inference_service = build_services()

--- a/services/mlx-worker-python/worker/runtime/rerank_backends.py
+++ b/services/mlx-worker-python/worker/runtime/rerank_backends.py
@@ -34,13 +34,27 @@ class DeterministicRerankBackend:
         return TOKEN_RE.findall(text.lower())
 
     @staticmethod
-    def tie_breaker(query: str, document: str) -> float:
-        return DeterministicRerankBackend.tie_breaker_from_prefix(f"{query}\0".encode("utf-8"), document)
+    def build_tie_breaker_seed(query: str):
+        return hashlib.sha256(f"{query}\0".encode("utf-8"))
+
+    @staticmethod
+    def tie_breaker_from_seed(seed, document: str) -> float:
+        digest_builder = seed.copy()
+        digest_builder.update(document.encode("utf-8"))
+        digest = digest_builder.digest()
+        return int.from_bytes(digest[:4], "little") / 0xFFFFFFFF * 0.0001
 
     @staticmethod
     def tie_breaker_from_prefix(query_prefix: bytes, document: str) -> float:
         digest = hashlib.sha256(query_prefix + document.encode("utf-8")).digest()
         return int.from_bytes(digest[:4], "little") / 0xFFFFFFFF * 0.0001
+
+    @staticmethod
+    def tie_breaker(query: str, document: str) -> float:
+        return DeterministicRerankBackend.tie_breaker_from_seed(
+            DeterministicRerankBackend.build_tie_breaker_seed(query),
+            document,
+        )
 
 
 @dataclass(frozen=True)
@@ -55,7 +69,7 @@ class RerankQueryContext:
     query_tokens: tuple[str, ...]
     query_token_set: frozenset[str]
     ordered_pairs: frozenset[tuple[str, str]]
-    tie_breaker_prefix: bytes
+    tie_breaker_seed: object
 
 
 class RerankFamilyAdapter:
@@ -86,7 +100,7 @@ class RerankFamilyAdapter:
             query_tokens=normalized_query_tokens,
             query_token_set=frozenset(query_token_set),
             ordered_pairs=frozenset(_build_adjacent_pairs(normalized_query_tokens)),
-            tie_breaker_prefix=f"{query}\0".encode("utf-8"),
+            tie_breaker_seed=backend.build_tie_breaker_seed(query),
         )
 
     def score(
@@ -107,6 +121,14 @@ def _build_adjacent_pairs(tokens: Sequence[str]) -> tuple[tuple[str, str], ...]:
         (tokens[index], tokens[index + 1])
         for index in range(len(tokens) - 1)
     )
+
+
+def _sequence_matches_at(
+    haystack: Sequence[str],
+    needle: Sequence[str],
+    start: int,
+) -> bool:
+    return all(haystack[start + offset] == token for offset, token in enumerate(needle))
 
 
 class BasicRerankFamilyAdapter(RerankFamilyAdapter):
@@ -132,15 +154,20 @@ class BasicRerankFamilyAdapter(RerankFamilyAdapter):
                 query_tokens=query_tokens,
                 query_token_set=query_token_set,
             )
-        query_token_set = query_context.query_token_set
+        reusable_query_token_set = query_token_set
+        if reusable_query_token_set is None:
+            reusable_query_token_set = query_context.query_token_set
         document_tokens = set(backend.tokenize(document))
-        if not query_token_set and not document_tokens:
+        if not reusable_query_token_set and not document_tokens:
             overlap_score = 1.0
         else:
-            overlap_count = len(query_token_set & document_tokens)
-            union = (len(query_token_set) + len(document_tokens) - overlap_count) or 1
+            overlap_count = len(reusable_query_token_set & document_tokens)
+            union = (len(reusable_query_token_set) + len(document_tokens) - overlap_count) or 1
             overlap_score = overlap_count / union
-        return round(overlap_score + backend.tie_breaker_from_prefix(query_context.tie_breaker_prefix, document), 6)
+        return round(
+            overlap_score + backend.tie_breaker_from_seed(query_context.tie_breaker_seed, document),
+            6,
+        )
 
 
 class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
@@ -166,35 +193,43 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
                 query_tokens=query_tokens,
                 query_token_set=query_token_set,
             )
-        query_tokens = query_context.query_tokens
+        reusable_query_tokens = query_tokens
+        if reusable_query_tokens is None:
+            reusable_query_tokens = query_context.query_tokens
+        reusable_query_token_set = query_token_set
+        if reusable_query_token_set is None:
+            reusable_query_token_set = query_context.query_token_set
         document_tokens = backend.tokenize(document)
-        query_token_set = query_context.query_token_set
         document_token_set = set(document_tokens)
 
-        if not query_token_set and not document_token_set:
+        if not reusable_query_token_set and not document_token_set:
             overlap_count = 0
             overlap_score = 1.0
         else:
-            overlap_count = len(query_token_set & document_token_set)
-            union = (len(query_token_set) + len(document_token_set) - overlap_count) or 1
+            overlap_count = len(reusable_query_token_set & document_token_set)
+            union = (len(reusable_query_token_set) + len(document_token_set) - overlap_count) or 1
             overlap_score = overlap_count / union
 
         if overlap_count == 0:
             pair_bonus = 0.0
         else:
-            pair_bonus = self._ordered_pair_bonus(query_tokens, document_tokens, query_pairs=query_context.ordered_pairs)
-        has_all_query_terms = overlap_count >= len(query_token_set)
+            pair_bonus = self._ordered_pair_bonus(
+                reusable_query_tokens,
+                document_tokens,
+                query_pairs=query_context.ordered_pairs,
+            )
+        has_all_query_terms = overlap_count >= len(reusable_query_token_set)
         exact_order_bonus = (
-            0.1 if has_all_query_terms and self._contains_contiguous_query(document_tokens, query_tokens) else 0.0
+            0.1 if has_all_query_terms and self._contains_contiguous_query(document_tokens, reusable_query_tokens) else 0.0
         )
-        prefix_bonus = 0.05 if has_all_query_terms and document_tokens[: len(query_tokens)] == query_tokens else 0.0
+        prefix_bonus = 0.05 if has_all_query_terms and self._has_query_prefix(document_tokens, reusable_query_tokens) else 0.0
 
         return round(
             overlap_score
             + pair_bonus
             + exact_order_bonus
             + prefix_bonus
-            + backend.tie_breaker_from_prefix(query_context.tie_breaker_prefix, document),
+            + backend.tie_breaker_from_seed(query_context.tie_breaker_seed, document),
             6,
         )
 
@@ -222,24 +257,31 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
         return (len(matched_pairs) / query_pair_count) * 0.15
 
     @staticmethod
-    def _contains_contiguous_query(document_tokens: Sequence[str], query_tokens: Sequence[str]) -> bool:
-        query_length = len(query_tokens)
-        if query_length == 0 or query_length > len(document_tokens):
+    def _has_query_prefix(document_tokens: Sequence[str], query_tokens: Sequence[str]) -> bool:
+        if not query_tokens or len(query_tokens) > len(document_tokens):
             return False
-        if query_length == 1:
-            query_token = query_tokens[0]
-            return any(document_token == query_token for document_token in document_tokens)
+        return _sequence_matches_at(document_tokens, query_tokens, 0)
+
+    @staticmethod
+    def _contains_contiguous_query(document_tokens: Sequence[str], query_tokens: Sequence[str]) -> bool:
+        if not query_tokens or len(query_tokens) > len(document_tokens):
+            return False
+        query_length = len(query_tokens)
         last_start = len(document_tokens) - query_length
-        first_query_token = query_tokens[0]
         for start in range(last_start + 1):
-            if document_tokens[start] != first_query_token:
-                continue
-            if all(
-                document_tokens[start + offset] == query_tokens[offset]
-                for offset in range(1, query_length)
-            ):
+            if _sequence_matches_at(document_tokens, query_tokens, start):
                 return True
         return False
+
+    @staticmethod
+    def _query_order_matches(
+        document_tokens: Sequence[str],
+        query_tokens: Sequence[str],
+    ) -> tuple[bool, bool]:
+        prefix_match = JinaV3RerankFamilyAdapter._has_query_prefix(document_tokens, query_tokens)
+        if prefix_match:
+            return True, True
+        return JinaV3RerankFamilyAdapter._contains_contiguous_query(document_tokens, query_tokens), False
 
 
 class CausalLMRerankFamilyAdapter(RerankFamilyAdapter):
@@ -270,26 +312,33 @@ class CausalLMRerankFamilyAdapter(RerankFamilyAdapter):
                 query_tokens=query_tokens,
                 query_token_set=query_token_set,
             )
-        query_tokens = query_context.query_tokens
+        reusable_query_tokens = query_tokens
+        if reusable_query_tokens is None:
+            reusable_query_tokens = query_context.query_tokens
+        reusable_query_token_set = query_token_set
+        if reusable_query_token_set is None:
+            reusable_query_token_set = query_context.query_token_set
         document_tokens = backend.tokenize(document)
-        query_token_set = query_context.query_token_set
         document_token_set = set(document_tokens)
-        overlap_count = len(query_token_set & document_token_set)
-        overlap = overlap_count / (len(query_token_set) or 1)
+        overlap_count = len(reusable_query_token_set & document_token_set)
+        overlap = overlap_count / (len(reusable_query_token_set) or 1)
         if overlap_count == 0:
             pair_bonus = 0.0
         else:
             pair_bonus = JinaV3RerankFamilyAdapter._ordered_pair_bonus(
-                query_tokens,
+                reusable_query_tokens,
                 document_tokens,
                 query_pairs=query_context.ordered_pairs,
             )
         exact_order = (
-            JinaV3RerankFamilyAdapter._contains_contiguous_query(document_tokens, query_tokens)
-            if overlap_count >= len(query_token_set)
+            JinaV3RerankFamilyAdapter._contains_contiguous_query(document_tokens, reusable_query_tokens)
+            if overlap_count >= len(reusable_query_token_set)
             else False
         )
-        prefix_match = overlap_count >= len(query_token_set) and document_tokens[: len(query_tokens)] == query_tokens
+        prefix_match = (
+            overlap_count >= len(reusable_query_token_set)
+            and JinaV3RerankFamilyAdapter._has_query_prefix(document_tokens, reusable_query_tokens)
+        )
 
         yes_logit = overlap * 6.0
         yes_logit += pair_bonus * 3.0
@@ -301,7 +350,10 @@ class CausalLMRerankFamilyAdapter(RerankFamilyAdapter):
         if overlap_count == 0:
             no_logit += 0.3
 
-        return round(yes_logit - no_logit + backend.tie_breaker_from_prefix(query_context.tie_breaker_prefix, document), 6)
+        return round(
+            yes_logit - no_logit + backend.tie_breaker_from_seed(query_context.tie_breaker_seed, document),
+            6,
+        )
 
 
 def resolve_rerank_backend(backend_id: str) -> DeterministicRerankBackend:


### PR DESCRIPTION
## Summary
- Reuse deterministic rerank query-side structures across document scoring without rebuilding per-document query-derived objects.
- Keep direct-call compatibility when only `query_context` is provided while preserving exact-order and prefix score semantics.
- Cache the query-side tie-breaker seed inside `RerankQueryContext` so each scored document reuses the precomputed hash prefix instead of rebuilding it.

## Plan or Spec
- `docs/plans/2026-05-01-rerank-query-context-reuse-micro-optimization.md`

## Commands Run
```text
# Focused tests
uv run --project services/mlx-worker-python python3 - <<'PY'
import pathlib, sys, pytest
root = pathlib.Path.cwd()
sys.path.insert(0, str(root / 'services/mlx-worker-python'))
sys.path.insert(0, str(root))
raise SystemExit(pytest.main([
    '-q',
    'services/mlx-worker-python/tests/test_rerank_runtime.py',
    'services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe',
    'services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands',
    'services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo',
    'services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe',
]))
PY
# Result: 28 passed

# Changed-scope coverage
uv run --project services/mlx-worker-python python3 - <<'PY'
import pathlib, sys
from coverage import Coverage
import pytest
root = pathlib.Path.cwd()
sys.path.insert(0, str(root / 'services/mlx-worker-python'))
sys.path.insert(0, str(root))
args = [
    '-q',
    'services/mlx-worker-python/tests/test_rerank_runtime.py',
    'services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe',
    'services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands',
    'services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo',
    'services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe',
]
cov = Coverage()
cov.start()
code = pytest.main(args)
cov.stop()
cov.save()
cov.json_report(outfile='coverage.json')
raise SystemExit(code)
PY
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py \
  services/mlx-worker-python/worker/runtime/rerank_backends.py \
  services/mlx-worker-python/worker/productization/pr_scoped_performance.py \
  services/mlx-worker-python/tests/test_rerank_runtime.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py
# Result: TOTAL 120 3 98%

# Local probe on branch
uv run --project services/mlx-worker-python python3 - <<'PY'
import json, pathlib, sys
root = pathlib.Path.cwd()
sys.path.insert(0, str(root / 'services/mlx-worker-python'))
sys.path.insert(0, str(root))
from worker.productization.pr_scoped_performance import _probe_deterministic_rerank_query_context_reuse as probe
print(json.dumps(probe(root), sort_keys=True))
PY
# Result: elapsed_ms_mean=83.713142, query_context_builds_mean=1.0, tokenize_calls_mean=2049.0

# Local comparison against origin/main
# Branch result: elapsed_ms_mean=83.713142
# origin/main result: elapsed_ms_mean=89.988523
# git diff --check: clean
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 120 3 98%`
- `services/mlx-worker-python/worker/runtime/rerank_backends.py`: `98.57%` changed-line coverage
- `services/mlx-worker-python/tests/test_rerank_runtime.py`: `96.00%` changed-line coverage
- Registered scoped probe: `deterministic-rerank-query-context-reuse`
- Branch probe metrics:
  - `elapsed_ms_mean = 83.713142`
  - `query_context_builds_mean = 1.0`
  - `tokenize_calls_mean = 2049.0`
  - `document_count = 2048.0`
  - `iteration_count = 8.0`
- Local base-vs-head comparison:
  - `origin/main elapsed_ms_mean = 89.988523`
  - `head elapsed_ms_mean = 83.713142`
  - improvement: `6.275381 ms` lower on the branch

## Known Gaps
- Full-repo verification (`make py-test`, `make swift-test`, `make integration-test`) was not run for this Linux-only cron slice; evidence is limited to the focused Python worker path and the scoped rerank probe.
- Probe timing is naturally somewhat noisy, but the direct local base-vs-head comparison still favored the branch in the verification run recorded above.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.