### PR TITLE
perf(report): cache benchmark metric directions

### DIFF
--- a/docs/plans/2026-05-01-benchmark-report-metric-direction-cache.md
+++ b/docs/plans/2026-05-01-benchmark-report-metric-direction-cache.md
@@ -1,0 +1,33 @@
+# Benchmark Report Metric Direction Cache Performance Slice
+
+## Summary
+
+Optimize benchmark/evaluation report row construction by caching metric-direction classification by metric suffix.
+
+## Goals
+
+1. Keep benchmark/evaluation report output unchanged.
+2. Avoid repeatedly scanning the same metric-key fragments while building large comparison reports.
+3. Validate the Python slice locally on Linux with the registered PR-scoped performance probe.
+
+## Scope
+
+- `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`
+- `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`
+- Registered probe `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json`.
+
+## Design
+
+`build_benchmark_evaluation_report()` calls `_metric_direction()` once for every emitted row. Large benchmark and evaluation exports create many rows that share the same final metric key, such as `prefill_ms_mean`, `decode_ms_mean`, or `failed_count`, while differing only in the suite/context label prefix.
+
+This slice keeps `_metric_direction(metric_name)` as the public internal helper, but delegates the suffix-only classification to an unbounded `lru_cache`. The cache key is the final metric suffix after `rsplit(".", 1)`, so repeated labels reuse the same fragment-scan result without changing direction semantics.
+
+## Success Metrics
+
+- Focused benchmark/evaluation report tests pass.
+- Changed-scope coverage remains at or above the repository requirement.
+- Registered probe `benchmark-evaluation-report-running-aggregates` reports lower `elapsed_ms_mean` for the PR head than the base checkout without increasing `peak_bytes_mean` beyond the configured warning threshold.
+
+## Known Constraints
+
+- The local Linux probe is the validation source for this Python slice. CI reruns the same registered probe for base/head comparison before merge.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -16,6 +16,7 @@ from worker.productization.benchmark_evaluation_report import (
     _label_part,
     _markdown_cell,
     _metric_direction,
+    _metric_key_direction,
     _report_rows,
     _update_numeric_aggregate,
     _update_probe_aggregates_by_label,
@@ -108,6 +109,17 @@ def test_report_builder_computes_direction_aware_deltas() -> None:
     )
     assert report["summary"]["warning_count"] == 4
     assert report["summary"]["status"] == "warning"
+
+
+def test_metric_direction_reuses_metric_key_cache_for_repeated_suffixes() -> None:
+    _metric_key_direction.cache_clear()
+
+    assert _metric_direction("bench.context.ctx1024.prefill_ms_mean") == "lower_is_better"
+    assert _metric_direction("bench.context.ctx2048.prefill_ms_mean") == "lower_is_better"
+
+    cache_info = _metric_key_direction.cache_info()
+    assert cache_info.misses == 1
+    assert cache_info.hits == 1
 
 
 def test_report_builder_warns_on_zero_baseline_regressions() -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from functools import lru_cache
 import json
 from pathlib import Path
 from typing import Any
@@ -397,7 +398,11 @@ def _build_metric_row(
 
 
 def _metric_direction(metric_name: str) -> str:
-    metric_key = metric_name.rsplit(".", maxsplit=1)[-1]
+    return _metric_key_direction(metric_name.rsplit(".", maxsplit=1)[-1])
+
+
+@lru_cache(maxsize=None)
+def _metric_key_direction(metric_key: str) -> str:
     known_direction = _METRIC_DIRECTION_BY_KEY.get(metric_key)
     if known_direction is not None:
         return known_direction


### PR DESCRIPTION
## Summary
- Cache benchmark/evaluation metric direction classification by final metric suffix.
- Add a focused regression test proving repeated metric suffixes reuse the cache.
- Add the governing performance-slice plan for this benchmark report optimization.

## Plan or Spec
- `docs/plans/2026-05-01-benchmark-report-metric-direction-cache.md`

## Commands Run
```text
# Baseline setup
cd /root/.hermes/profiles/coder/workspace/melix && git fetch origin
cd /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-slice-20260501225713 && git checkout -b perf/benchmark-report-row-status-counts

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo
Result: 35 passed in 5.40s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
Result: 35 passed in 26.80s; benchmark_evaluation_report.py 98%, test_benchmark_evaluation_report.py 99%, total 99%

# Registered PR-scoped performance probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-evaluation-report-running-aggregates --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-benchmark-direction-20260501225713 --head-repo "$PWD" --output /tmp/benchmark_direction_probe_result.json
Result: success
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py` 98%; `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py` 99%; total 99%.
- Registered probe `benchmark-evaluation-report-running-aggregates`:
  - `elapsed_ms_mean`: base 159.554 ms, head 151.561 ms, delta -7.993 ms, improvement 5.010%.
  - `peak_bytes_mean`: base 3,904,308.0 bytes, head 3,904,837.7 bytes, delta +529.7 bytes (+0.013567%), within the 5% warning threshold.
  - `row_count`: 5,990.0 for both base and head.

## Known Gaps
- None. CI must rerun the registered PR-scoped probe before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
