### PR TITLE
perf: avoid full snapshot for derived-model lookups

### DIFF
--- a/docs/plans/2026-05-01-job-registry-derived-model-lookup-optimization.md
+++ b/docs/plans/2026-05-01-job-registry-derived-model-lookup-optimization.md
@@ -1,0 +1,45 @@
+# Job Registry Derived-Model Lookup Optimization
+
+## Goal
+
+Avoid building a full job-registry snapshot when the caller only needs active derived-model manifests or one derived-model target lookup.
+
+## Linux-Only Constraint
+
+This slice targets Python worker code only and will be verified locally on Linux.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/model_ops/job_registry.py`
+- `services/mlx-worker-python/tests/test_model_ops_job_registry.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/job_registry_derived_model_probe.py`
+
+## Hypothesis
+
+`active_derived_model_manifests()` and `resolve_derived_model_target()` currently materialize broad snapshot-style job payloads even though they only need a narrow subset of activation/removal data. A dedicated single-pass helper over in-memory jobs should reduce redundant work and temporary object creation.
+
+## Performance Probe
+
+Probe id: `job-registry-derived-model-single-pass`
+
+Measurement path:
+- construct a large synthetic `ModelOpsJobRegistry` with many completed `train_lora`, `activate_adapter`, and `remove_derived_model` jobs
+- measure `active_derived_model_manifests()` and `resolve_derived_model_target()` over multiple samples
+- record mean elapsed milliseconds and manifest count / lookup hit to prove semantics stay intact
+
+## Success Metrics
+
+- Preserve current lookup/removal behavior
+- Focused tests pass
+- Changed-scope automated coverage is at least 95%
+- Local probe shows lower `elapsed_ms_mean` for the active-manifest and target-lookup path versus `origin/main`
+
+## Verification Commands
+
+- Focused RED/GREEN pytest for the new regression tests
+- Focused pytest for touched scope
+- `coverage run -m pytest ...` + changed-scope coverage report
+- Local probe script on `origin/main` and the branch implementation
+- `git diff --check`

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -268,6 +268,37 @@
     ]
   },
   {
+    "id": "job-registry-derived-model-single-pass",
+    "name": "Job registry derived-model single pass",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/job_registry.py",
+      "services/mlx-worker-python/tests/test_model_ops_job_registry.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/job_registry_derived_model_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -lc 'if [ -f scripts/job_registry_derived_model_probe.py ]; then python3 scripts/job_registry_derived_model_probe.py; else python3 - <<\"PY\"\nimport json\nimport statistics\nimport sys\nimport time\nfrom pathlib import Path\n\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.model_ops.job_registry import ModelOpsJobRegistry\n\ndef seed_registry(job_count):\n    registry = ModelOpsJobRegistry()\n    removed_count = 0\n    for index in range(job_count):\n        model_id = f\"melix-dev-derived-{index:04d}\"\n        adapter_manifest_path = f\"/runtime/train/{model_id}/train_lora.adapter.json\"\n        train_job = registry.start(\"train_lora\", \"melix-dev-text\", f\"/runtime/train/{model_id}\")\n        registry.attach_manifest(train_job.job_id, json.dumps({\"adapter_name\": f\"adapter-{index:04d}\", \"adapter_set_hash\": f\"hash-{index:04d}\"}))\n        registry.complete(train_job.job_id, adapter_manifest_path)\n        activation_job = registry.start(\"activate_adapter\", \"melix-dev-text\", f\"/runtime/activate/{model_id}\")\n        activation_manifest_path = f\"/runtime/activate/{model_id}/manifest.json\"\n        registry.attach_manifest(activation_job.job_id, json.dumps({\"adapter_manifest_path\": adapter_manifest_path, \"adapter_weights_path\": f\"/runtime/train/{model_id}/adapters.safetensors\", \"adapter_set_hash\": f\"hash-{index:04d}\", \"derived_model_id\": model_id, \"derived_model_path\": f\"/runtime/activate/{model_id}\", \"derived_model_alias\": f\"alias-{index:04d}\", \"source_model\": \"melix-dev-text\", \"activation_mode\": \"fused_derived_model\"}))\n        registry.complete(activation_job.job_id, activation_manifest_path)\n        if index % 5 == 0:\n            removal_job = registry.start(\"remove_derived_model\", \"melix-dev-text\", f\"/runtime/remove/{model_id}\")\n            registry.attach_manifest(removal_job.job_id, json.dumps({\"derived_model_id\": model_id, \"activation_job_id\": activation_job.job_id, \"activation_manifest_path\": activation_manifest_path, \"adapter_manifest_path\": adapter_manifest_path}))\n            registry.complete(removal_job.job_id, f\"/runtime/remove/{model_id}/remove_derived_model.lifecycle.json\")\n            removed_count += 1\n    return registry, job_count - removed_count\n\njob_count = 1200\nsample_count = 6\nregistry, active_count = seed_registry(job_count)\ntarget_model_id = \"melix-dev-derived-1199\"\nactive_elapsed_ms = []\nresolve_elapsed_ms = []\nfor _ in range(sample_count):\n    started = time.perf_counter()\n    manifests = registry.active_derived_model_manifests()\n    active_elapsed_ms.append((time.perf_counter() - started) * 1000.0)\n    if len(manifests) != active_count:\n        raise RuntimeError(f\"expected {active_count} active manifests, got {len(manifests)}\")\n    started = time.perf_counter()\n    target = registry.resolve_derived_model_target(derived_model_id=target_model_id)\n    resolve_elapsed_ms.append((time.perf_counter() - started) * 1000.0)\n    if not target or target.get(\"derived_model_id\") != target_model_id:\n        raise RuntimeError(\"derived-model lookup returned the wrong target\")\nprint(json.dumps({\n    \"active_manifest_count\": float(active_count),\n    \"active_manifest_elapsed_ms_mean\": round(statistics.fmean(active_elapsed_ms), 6),\n    \"elapsed_ms_mean\": round(statistics.fmean(active_elapsed_ms) + statistics.fmean(resolve_elapsed_ms), 6),\n    \"job_count\": float(job_count),\n    \"removed_count\": float(job_count - active_count),\n    \"resolve_target_elapsed_ms_mean\": round(statistics.fmean(resolve_elapsed_ms), 6),\n    \"sample_count\": float(sample_count),\n}, sort_keys=True))\nPY\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "active_manifest_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "resolve_target_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "deterministic-rerank-query-context-reuse",
     "name": "Deterministic rerank query-context reuse",
     "runner": "ubuntu-latest",

--- a/scripts/job_registry_derived_model_probe.py
+++ b/scripts/job_registry_derived_model_probe.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+
+def _seed_registry(job_count: int):
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+    sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
+    from worker.model_ops.job_registry import ModelOpsJobRegistry
+
+    registry = ModelOpsJobRegistry()
+    removed_count = 0
+    for index in range(job_count):
+        model_id = f"melix-dev-derived-{index:04d}"
+        adapter_manifest_path = f"/runtime/train/{model_id}/train_lora.adapter.json"
+
+        train_job = registry.start("train_lora", "melix-dev-text", f"/runtime/train/{model_id}")
+        registry.attach_manifest(
+            train_job.job_id,
+            json.dumps({"adapter_name": f"adapter-{index:04d}", "adapter_set_hash": f"hash-{index:04d}"}),
+        )
+        registry.complete(train_job.job_id, adapter_manifest_path)
+
+        activation_job = registry.start("activate_adapter", "melix-dev-text", f"/runtime/activate/{model_id}")
+        activation_manifest_path = f"/runtime/activate/{model_id}/manifest.json"
+        registry.attach_manifest(
+            activation_job.job_id,
+            json.dumps(
+                {
+                    "adapter_manifest_path": adapter_manifest_path,
+                    "adapter_weights_path": f"/runtime/train/{model_id}/adapters.safetensors",
+                    "adapter_set_hash": f"hash-{index:04d}",
+                    "derived_model_id": model_id,
+                    "derived_model_path": f"/runtime/activate/{model_id}",
+                    "derived_model_alias": f"alias-{index:04d}",
+                    "source_model": "melix-dev-text",
+                    "activation_mode": "fused_derived_model",
+                }
+            ),
+        )
+        registry.complete(activation_job.job_id, activation_manifest_path)
+
+        if index % 5 == 0:
+            removal_job = registry.start("remove_derived_model", "melix-dev-text", f"/runtime/remove/{model_id}")
+            registry.attach_manifest(
+                removal_job.job_id,
+                json.dumps(
+                    {
+                        "derived_model_id": model_id,
+                        "activation_job_id": activation_job.job_id,
+                        "activation_manifest_path": activation_manifest_path,
+                        "adapter_manifest_path": adapter_manifest_path,
+                    }
+                ),
+            )
+            registry.complete(removal_job.job_id, f"/runtime/remove/{model_id}/remove_derived_model.lifecycle.json")
+            removed_count += 1
+    return registry, job_count - removed_count
+
+
+def main() -> int:
+    job_count = 1200
+    sample_count = 6
+    registry, active_count = _seed_registry(job_count)
+    target_model_id = "melix-dev-derived-1199"
+
+    active_elapsed_ms: list[float] = []
+    resolve_elapsed_ms: list[float] = []
+    for _ in range(sample_count):
+        started = time.perf_counter()
+        manifests = registry.active_derived_model_manifests()
+        active_elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+        if len(manifests) != active_count:
+            raise RuntimeError(f"expected {active_count} active manifests, got {len(manifests)}")
+
+        started = time.perf_counter()
+        target = registry.resolve_derived_model_target(derived_model_id=target_model_id)
+        resolve_elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+        if not target or target.get("derived_model_id") != target_model_id:
+            raise RuntimeError("derived-model lookup returned the wrong target")
+
+    payload = {
+        "active_manifest_count": float(active_count),
+        "active_manifest_elapsed_ms_mean": round(statistics.fmean(active_elapsed_ms), 6),
+        "elapsed_ms_mean": round(statistics.fmean(active_elapsed_ms) + statistics.fmean(resolve_elapsed_ms), 6),
+        "job_count": float(job_count),
+        "removed_count": float(job_count - active_count),
+        "resolve_target_elapsed_ms_mean": round(statistics.fmean(resolve_elapsed_ms), 6),
+        "sample_count": float(sample_count),
+    }
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from worker.model_ops.job_registry import ModelOpsJobRegistry
+from worker.model_ops.job_registry import ModelOpsJob, ModelOpsJobRegistry
 
 
 def test_collect_restore_manifest_paths_scans_expected_operations_once(tmp_path: Path) -> None:
@@ -104,3 +104,179 @@ def test_json_safe_reuses_clean_containers_and_copies_only_changed_branch() -> N
     assert safe is not unsafe
     assert safe["rows"] is not unsafe["rows"]
     assert safe["other"] is unsafe["other"]
+
+
+def test_job_manifest_handles_empty_registry_snapshot_and_uncached_json() -> None:
+    registry_snapshot_job = ModelOpsJobRegistry._job_manifest(
+        ModelOpsJob(
+            job_id="model-ops-0001",
+            operation="registry_snapshot",
+            source_model="melix-dev-text",
+            output_dir="/runtime/snapshot",
+        )
+    )
+    uncached_manifest = ModelOpsJobRegistry._job_manifest(
+        ModelOpsJob(
+            job_id="model-ops-0002",
+            operation="activate_adapter",
+            source_model="melix-dev-text",
+            output_dir="/runtime/activate",
+            manifest_json=json.dumps({"derived_model_id": "melix-dev-active"}),
+            manifest_cached=False,
+        )
+    )
+
+    assert registry_snapshot_job == {}
+    assert uncached_manifest == {"derived_model_id": "melix-dev-active"}
+
+
+def test_active_derived_model_manifests_avoids_full_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = ModelOpsJobRegistry()
+
+    train_job = registry.start("train_lora", "melix-dev-text", "/runtime/train")
+    adapter_manifest_path = "/runtime/train/train_lora.adapter.json"
+    registry.attach_manifest(
+        train_job.job_id,
+        json.dumps({"adapter_name": "adapter-a", "adapter_set_hash": "hash-a"}),
+    )
+    registry.complete(train_job.job_id, adapter_manifest_path)
+
+    active_job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+    active_manifest = {
+        "adapter_manifest_path": adapter_manifest_path,
+        "adapter_set_hash": "hash-a",
+        "derived_model_id": "melix-dev-active",
+        "derived_model_path": "/runtime/activate/melix-dev-active",
+        "activation_mode": "fused_derived_model",
+    }
+    registry.attach_manifest(active_job.job_id, json.dumps(active_manifest))
+    registry.complete(active_job.job_id, "/runtime/activate/melix-dev-active/manifest.json")
+
+    removed_job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+    removed_manifest = {
+        "adapter_manifest_path": adapter_manifest_path,
+        "adapter_set_hash": "hash-a",
+        "derived_model_id": "melix-dev-removed",
+        "derived_model_path": "/runtime/activate/melix-dev-removed",
+        "activation_mode": "fused_derived_model",
+    }
+    registry.attach_manifest(removed_job.job_id, json.dumps(removed_manifest))
+    registry.complete(removed_job.job_id, "/runtime/activate/melix-dev-removed/manifest.json")
+
+    removal_job = registry.start("remove_derived_model", "melix-dev-text", "/runtime/remove")
+    registry.attach_manifest(
+        removal_job.job_id,
+        json.dumps(
+            {
+                "derived_model_id": "melix-dev-removed",
+                "activation_job_id": removed_job.job_id,
+                "activation_manifest_path": "/runtime/activate/melix-dev-removed/manifest.json",
+                "adapter_manifest_path": adapter_manifest_path,
+            }
+        ),
+    )
+    registry.complete(removal_job.job_id, "/runtime/remove/remove_derived_model.lifecycle.json")
+
+    monkeypatch.setattr(
+        registry,
+        "snapshot",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("snapshot should not be used")),
+    )
+
+    assert registry.active_derived_model_manifests() == (active_manifest,)
+
+
+
+def test_active_derived_model_manifests_skips_removed_manifest_path_without_job_id() -> None:
+    registry = ModelOpsJobRegistry()
+
+    activation_job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+    activation_manifest_path = "/runtime/activate/melix-dev-active/manifest.json"
+    registry.attach_manifest(
+        activation_job.job_id,
+        json.dumps(
+            {
+                "derived_model_id": "melix-dev-active",
+                "derived_model_path": "/runtime/activate/melix-dev-active",
+                "activation_mode": "fused_derived_model",
+            }
+        ),
+    )
+    registry.complete(activation_job.job_id, activation_manifest_path)
+
+    removal_job = registry.start("remove_derived_model", "melix-dev-text", "/runtime/remove")
+    registry.attach_manifest(
+        removal_job.job_id,
+        json.dumps({"activation_manifest_path": activation_manifest_path}),
+    )
+    registry.complete(removal_job.job_id, "/runtime/remove/remove_derived_model.lifecycle.json")
+
+    assert registry.active_derived_model_manifests() == ()
+
+
+
+def test_resolve_derived_model_target_avoids_snapshot_jobs(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = ModelOpsJobRegistry()
+
+    train_job = registry.start("train_lora", "melix-dev-text", "/runtime/train")
+    adapter_manifest_path = "/runtime/train/train_lora.adapter.json"
+    registry.attach_manifest(
+        train_job.job_id,
+        json.dumps({"adapter_name": "adapter-a", "adapter_set_hash": "hash-a"}),
+    )
+    registry.complete(train_job.job_id, adapter_manifest_path)
+
+    active_job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+    active_output_path = "/runtime/activate/melix-dev-active/manifest.json"
+    registry.attach_manifest(
+        active_job.job_id,
+        json.dumps(
+            {
+                "adapter_manifest_path": adapter_manifest_path,
+                "adapter_weights_path": "/runtime/train/adapters.safetensors",
+                "adapter_set_hash": "hash-a",
+                "derived_model_id": "melix-dev-active",
+                "derived_model_path": "/runtime/activate/melix-dev-active",
+                "derived_model_alias": "active-alias",
+                "source_model": "melix-dev-text",
+                "activation_mode": "fused_derived_model",
+            }
+        ),
+    )
+    registry.complete(active_job.job_id, active_output_path)
+
+    removed_job = registry.start("remove_derived_model", "melix-dev-text", "/runtime/remove")
+    registry.attach_manifest(
+        removed_job.job_id,
+        json.dumps(
+            {
+                "derived_model_id": "melix-dev-removed",
+                "activation_job_id": "model-ops-9999",
+                "activation_manifest_path": "/runtime/activate/melix-dev-removed/manifest.json",
+                "adapter_manifest_path": adapter_manifest_path,
+            }
+        ),
+    )
+    registry.complete(removed_job.job_id, "/runtime/remove/remove_derived_model.lifecycle.json")
+
+    monkeypatch.setattr(
+        ModelOpsJobRegistry,
+        "_snapshot_job",
+        staticmethod(lambda job: (_ for _ in ()).throw(AssertionError("_snapshot_job should not be used"))),
+    )
+
+    target = registry.resolve_derived_model_target(derived_model_id="melix-dev-active")
+
+    assert target == {
+        "activation_job_id": active_job.job_id,
+        "activation_manifest_path": active_output_path,
+        "output_dir": "/runtime/activate",
+        "source_model": "melix-dev-text",
+        "derived_model_id": "melix-dev-active",
+        "derived_model_path": "/runtime/activate/melix-dev-active",
+        "derived_model_alias": "active-alias",
+        "activation_mode": "fused_derived_model",
+        "runtime_mode": 1,
+        "adapter_manifest_path": adapter_manifest_path,
+        "adapter_weights_path": "/runtime/train/adapters.safetensors",
+    }

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -111,6 +111,16 @@ def test_scope_report_selects_worker_registry_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "worker-registry-resident-bytes-accumulator"
 
 
+def test_scope_report_selects_job_registry_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/model_ops/job_registry.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "job-registry-derived-model-single-pass"
+
+
 def test_scope_report_selects_deterministic_rerank_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -168,6 +178,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "deterministic-rerank-query-context-reuse",
         "evaluation-job-id-high-water-mark",
         "evaluation-sample-probe-aggregation",
+        "job-registry-derived-model-single-pass",
         "training-dataset-token-percentiles-single-sort",
         "maintenance-bench-report-readback",
         "swift-cli-json-envelope-encoding",
@@ -362,6 +373,21 @@ def test_worker_registry_probe_script_emits_metrics(capsys: pytest.CaptureFixtur
     assert payload["request_stats_elapsed_ms_mean"] > 0
     assert payload["resident_bytes_mean"] > 0
     assert payload["sample_count"] == 3.0
+
+
+def test_job_registry_probe_script_emits_metrics(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(REPO_ROOT / "scripts/job_registry_derived_model_probe.py"), run_name="__main__")
+
+    assert excinfo.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["elapsed_ms_mean"] > 0
+    assert payload["active_manifest_elapsed_ms_mean"] > 0
+    assert payload["resolve_target_elapsed_ms_mean"] > 0
+    assert payload["job_count"] == 1200.0
+    assert payload["active_manifest_count"] == 960.0
+    assert payload["removed_count"] == 240.0
+    assert payload["sample_count"] == 6.0
 
 
 def test_upload_receipt_probe_script_emits_metrics(capsys: pytest.CaptureFixture[str]) -> None:

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -302,6 +302,73 @@ class ModelOpsJobRegistry:
             return manifest_path.parent
         return manifest_path.parent
 
+    def _ordered_jobs(self) -> tuple[ModelOpsJob, ...]:
+        with self._lock:
+            return tuple(sorted(self._jobs.values(), key=self._job_sort_key, reverse=True))
+
+    @classmethod
+    def _job_manifest(cls, job: ModelOpsJob) -> dict[str, Any]:
+        if job.operation == "registry_snapshot" or not job.manifest_json:
+            return {}
+        if job.manifest_cached:
+            return job.manifest
+        return cls._decode_manifest_json(job.manifest_json)
+
+    @classmethod
+    def _removed_derived_targets_from_ordered_jobs(
+        cls,
+        jobs: tuple[ModelOpsJob, ...],
+    ) -> dict[str, set[str]]:
+        removed_model_ids: set[str] = set()
+        removed_manifest_paths: set[str] = set()
+        removed_adapter_manifest_paths: set[str] = set()
+        removed_activation_job_ids: set[str] = set()
+        for job in jobs:
+            if job.operation != "remove_derived_model" or job.status != "completed":
+                continue
+            manifest = cls._job_manifest(job)
+            derived_model_id = str(manifest.get("derived_model_id", "")).strip()
+            if derived_model_id:
+                removed_model_ids.add(derived_model_id)
+            activation_manifest_path = str(manifest.get("activation_manifest_path", "")).strip()
+            if activation_manifest_path:
+                removed_manifest_paths.add(activation_manifest_path)
+            adapter_manifest_path = str(manifest.get("adapter_manifest_path", "")).strip()
+            if adapter_manifest_path:
+                removed_adapter_manifest_paths.add(adapter_manifest_path)
+            activation_job_id = str(manifest.get("activation_job_id", "")).strip()
+            if activation_job_id:
+                removed_activation_job_ids.add(activation_job_id)
+        return {
+            "model_ids": removed_model_ids,
+            "manifest_paths": removed_manifest_paths,
+            "adapter_manifest_paths": removed_adapter_manifest_paths,
+            "activation_job_ids": removed_activation_job_ids,
+        }
+
+    @classmethod
+    def _active_derived_model_job_rows(
+        cls,
+        jobs: tuple[ModelOpsJob, ...],
+    ) -> tuple[tuple[ModelOpsJob, dict[str, Any], str], ...]:
+        removed_targets = cls._removed_derived_targets_from_ordered_jobs(jobs)
+        removed_model_ids = removed_targets["model_ids"]
+        removed_manifest_paths = removed_targets["manifest_paths"]
+        removed_activation_job_ids = removed_targets["activation_job_ids"]
+        active_rows: list[tuple[ModelOpsJob, dict[str, Any], str]] = []
+        for job in jobs:
+            if job.operation != "activate_adapter" or job.status != "completed":
+                continue
+            if job.job_id in removed_activation_job_ids:
+                continue
+            activation_manifest_path = str(job.output_path).strip()
+            manifest = cls._job_manifest(job)
+            candidate_model_id = str(manifest.get("derived_model_id", "")).strip()
+            if candidate_model_id in removed_model_ids or activation_manifest_path in removed_manifest_paths:
+                continue
+            active_rows.append((job, manifest, activation_manifest_path))
+        return tuple(active_rows)
+
     def resolve_derived_model_target(
         self,
         *,
@@ -315,37 +382,19 @@ class ModelOpsJobRegistry:
         if not normalized_model_id and not normalized_manifest_path:
             return None
 
-        with self._lock:
-            jobs = [
-                self._snapshot_job(job)
-                for job in sorted(self._jobs.values(), key=self._job_sort_key, reverse=True)
-            ]
-
-        removed_targets = self._removed_derived_targets(jobs)
-        removed_model_ids = removed_targets["model_ids"]
-        removed_manifest_paths = removed_targets["manifest_paths"]
-        removed_activation_job_ids = removed_targets["activation_job_ids"]
-
-        for job in jobs:
-            if job["operation"] != "activate_adapter" or job["status"] != "completed":
-                continue
-            if job["job_id"] in removed_activation_job_ids:
-                continue
-            activation_manifest_path = str(
-                Path(str(job.get("output_path", ""))).expanduser().resolve()
+        for job, manifest, activation_manifest_path in self._active_derived_model_job_rows(self._ordered_jobs()):
+            resolved_activation_manifest_path = str(
+                Path(activation_manifest_path).expanduser().resolve()
             )
-            manifest = job.get("manifest") or {}
             candidate_model_id = str(manifest.get("derived_model_id", "")).strip()
-            if candidate_model_id in removed_model_ids or activation_manifest_path in removed_manifest_paths:
-                continue
             if normalized_model_id and candidate_model_id != normalized_model_id:
                 continue
-            if normalized_manifest_path and activation_manifest_path != normalized_manifest_path:
+            if normalized_manifest_path and resolved_activation_manifest_path != normalized_manifest_path:
                 continue
             return {
-                "activation_job_id": job["job_id"],
-                "activation_manifest_path": activation_manifest_path,
-                "output_dir": str(job.get("output_dir", "")),
+                "activation_job_id": job.job_id,
+                "activation_manifest_path": resolved_activation_manifest_path,
+                "output_dir": job.output_dir,
                 "source_model": str(manifest.get("source_model", "")),
                 "derived_model_id": candidate_model_id,
                 "derived_model_path": str(manifest.get("derived_model_path", "")),
@@ -358,23 +407,7 @@ class ModelOpsJobRegistry:
         return None
 
     def active_derived_model_manifests(self) -> tuple[dict[str, Any], ...]:
-        snapshot = self.snapshot()
-        active_manifest_paths = {
-            str(model.get("activation_manifest_path", "")).strip()
-            for model in snapshot.get("derived_models", [])
-            if str(model.get("activation_manifest_path", "")).strip()
-        }
-        manifests: list[dict[str, Any]] = []
-        for job in snapshot.get("jobs", []):
-            if job.get("operation") != "activate_adapter" or job.get("status") != "completed":
-                continue
-            output_path = str(job.get("output_path", "")).strip()
-            if output_path not in active_manifest_paths:
-                continue
-            manifest = job.get("manifest")
-            if isinstance(manifest, dict):
-                manifests.append(manifest)
-        return tuple(manifests)
+        return tuple(manifest for _, manifest, _ in self._active_derived_model_job_rows(self._ordered_jobs()))
 
     def _max_numeric_job_id(self) -> int:
         max_job_id = 0


### PR DESCRIPTION
## Summary
- avoid building a full registry snapshot for `active_derived_model_manifests()` and `resolve_derived_model_target()`
- add focused regression tests for uncached manifest decoding, active-manifest filtering, and direct derived-model target lookup
- register a `job-registry-derived-model-single-pass` scoped performance probe with a reusable local script and changed-scope coverage command

## Plan or Spec
- `docs/plans/2026-05-01-job-registry-derived-model-lookup-optimization.md`
- Governing repository rules: `AGENTS.md`, `docs/engineering-standards.md`, `docs/contributing.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py::test_active_derived_model_manifests_avoids_full_snapshot services/mlx-worker-python/tests/test_model_ops_job_registry.py::test_resolve_derived_model_target_avoids_snapshot_jobs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py`
- `python3 /tmp/job_registry_probe_compare.py /tmp/melix-base-job-registry-20260501233104 /tmp/melix-cron-opt-20260501231713`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `10 passed`
- Changed executable line coverage: `TOTAL 123 0 100%`
- Registered scoped CI probe: `job-registry-derived-model-single-pass`
- Local base vs head probe (`job_count=1200`, `removed_count=240`, `active_manifest_count=960`, `sample_count=6`):
  - `active_manifest_elapsed_ms_mean`: `50.662951` → `1.826518` ms (`96.39%` lower, `27.74x` faster)
  - `resolve_target_elapsed_ms_mean`: `4.430107` → `1.710970` ms (`61.38%` lower, `2.59x` faster)
  - combined `elapsed_ms_mean`: `55.093057` → `3.537488` ms (`93.58%` lower, `15.57x` faster)
- Semantic parity check from the probe: base and head both reported `active_manifest_count=960` and the same target lookup hit for `melix-dev-derived-1199`

## Known Gaps
- Linux-only local verification; no macOS/Swift checks were run because this slice only touches Python worker + PR-scoped perf config
- Updating `infra/perf/pr_scoped_probes.json` forces the full `pr-scoped-performance` matrix in CI, so auto-merge should only be enabled after that workflow is green

## Evidence Checklist
- [x] Relevant plan or spec is identified
- [x] Behavior changes are reflected in the relevant docs/plan for this slice
- [x] Protocol changes are not part of this change
- [x] Dependency changes are not part of this change
- [x] Relevant tests were run
- [x] The affected path has defined performance probes and target metrics
- [x] A metrics report is included
- [x] Command outcomes are recorded
- [x] Deferred work and known gaps are stated explicitly
