### PR TITLE
perf(report): fast-path exact numeric collectors

### DIFF
--- a/docs/plans/2026-04-30-benchmark-evaluation-report-streaming-aggregation.md
+++ b/docs/plans/2026-04-30-benchmark-evaluation-report-streaming-aggregation.md
@@ -12,6 +12,10 @@ Reduce redundant memory use and per-row overhead in `worker/productization/bench
 
 A follow-up Linux-verifiable slice fast-paths exact `float`, `int`, and `bool` values inside `_float_or_none` before falling back to string parsing. The registered synthetic benchmark-evaluation report probe repeatedly normalizes already-numeric JSON rows, so this removes the tuple `isinstance` check from the hot path while preserving bool and string coercion semantics.
 
+## 2026-05-01 exact numeric collector fast-path slice
+
+A second follow-up Linux-verifiable slice extends the exact-type numeric fast path into metric-row comparison plus benchmark request-row and evaluation sample-row collectors. Already-decoded JSON probe metrics are commonly exact `float`, `int`, or `bool` values, so these hot paths now avoid a generic tuple `isinstance` check and skip `_float_or_none` unless the value needs string parsing, while preserving bool rate/count semantics.
+
 ## Touched Files
 
 - `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -10,7 +10,9 @@ from worker.productization.benchmark_evaluation_report import (
     _METRIC_DIRECTION_BY_KEY,
     _aggregate_probe_values,
     _benchmark_probe_label,
+    _build_metric_row,
     _collect_benchmark_probe_metrics,
+    _collect_evaluation_sample_probe_metrics,
     _dict_rows,
     _finalize_numeric_aggregate,
     _label_part,
@@ -326,6 +328,79 @@ def test_collect_benchmark_probe_metrics_groups_aggregates_by_label_and_preserve
         f"bench.{label}.decode_ms_mean": 22.0,
         f"bench.{label}.speculative_fallback_count_sum": 4.0,
     }
+
+
+def test_metric_row_fast_paths_exact_numeric_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    parsed_values: list[object] = []
+    original = benchmark_evaluation_report._float_or_none
+
+    def tracked_float_or_none(value: object) -> float | None:
+        parsed_values.append(value)
+        return original(value)
+
+    monkeypatch.setattr(benchmark_evaluation_report, "_float_or_none", tracked_float_or_none)
+
+    numeric_row = _build_metric_row(metric_name="bench.smoke.prefill_ms", baseline=10.0, candidate=12)
+    bool_row = _build_metric_row(metric_name="bench.smoke.cache_hit", baseline=True, candidate=False)
+    metadata_row = _build_metric_row(metric_name="bench.smoke.runtime_kind", baseline="mlx", candidate="mlx")
+
+    assert parsed_values == ["mlx", "mlx"]
+    assert numeric_row["delta"] == 2.0
+    assert numeric_row["direction"] == "lower_is_better"
+    assert bool_row["baseline"] == 1.0
+    assert bool_row["candidate"] == 0.0
+    assert metadata_row["status"] == "ok"
+
+
+def test_probe_collectors_fast_path_exact_numeric_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    parsed_values: list[object] = []
+    original = benchmark_evaluation_report._float_or_none
+
+    def tracked_float_or_none(value: object) -> float | None:
+        parsed_values.append(value)
+        return original(value)
+
+    monkeypatch.setattr(benchmark_evaluation_report, "_float_or_none", tracked_float_or_none)
+
+    benchmark_metrics: dict[str, object] = {}
+    _collect_benchmark_probe_metrics(
+        benchmark_metrics,
+        [
+            {
+                "suite_id": "smoke",
+                "context_length": 1024,
+                "generation_length": 128,
+                "batch_size": 1,
+                "concurrency_level": 1,
+                "prefill_ms": 10.0,
+                "decode_ms": 20,
+                "cache_hit": True,
+                "warmup_ms": "2.5",
+            }
+        ],
+        prefix="bench",
+    )
+    evaluation_metrics: dict[str, object] = {}
+    _collect_evaluation_sample_probe_metrics(
+        evaluation_metrics,
+        [
+            {
+                "suite_id": "smoke",
+                "sample_render_ms": 3.0,
+                "inference_ms": 4,
+                "validation_ms": False,
+                "scoring_ms": "5.5",
+            }
+        ],
+    )
+
+    assert parsed_values == ["2.5", "5.5"]
+    assert benchmark_metrics["bench.smoke.ctx1024.gen128.b1.c1.prefill_ms_mean"] == 10.0
+    assert benchmark_metrics["bench.smoke.ctx1024.gen128.b1.c1.decode_ms_mean"] == 20.0
+    assert benchmark_metrics["bench.smoke.ctx1024.gen128.b1.c1.cache_hit_rate"] == 1.0
+    assert evaluation_metrics["eval.sample.smoke.sample_render_ms_mean"] == 3.0
+    assert evaluation_metrics["eval.sample.smoke.inference_ms_mean"] == 4.0
+    assert evaluation_metrics["eval.sample.smoke.validation_ms_mean"] == 0.0
 
 
 def test_collect_benchmark_probe_metrics_reuses_matrix_labels(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -358,8 +358,20 @@ def _build_metric_row(
             "direction": direction,
             "status": "missing",
         }
-    baseline_number = _float_or_none(baseline)
-    candidate_number = _float_or_none(candidate)
+    baseline_type = type(baseline)
+    if baseline_type is float:
+        baseline_number = baseline
+    elif baseline_type is int or baseline_type is bool:
+        baseline_number = float(baseline)
+    else:
+        baseline_number = _float_or_none(baseline)
+    candidate_type = type(candidate)
+    if candidate_type is float:
+        candidate_number = candidate
+    elif candidate_type is int or candidate_type is bool:
+        candidate_number = float(candidate)
+    else:
+        candidate_number = _float_or_none(candidate)
     if baseline_number is None or candidate_number is None:
         return {
             "metric": metric_name,
@@ -449,7 +461,10 @@ def _collect_benchmark_probe_metrics(
         for key, raw_value in row.items():
             if key not in _REQUEST_PROBE_KEY_SET:
                 continue
-            if isinstance(raw_value, (int, float)):
+            raw_value_type = type(raw_value)
+            if raw_value_type is float:
+                value = raw_value
+            elif raw_value_type is int or raw_value_type is bool:
                 value = float(raw_value)
             else:
                 value = _float_or_none(raw_value)
@@ -483,7 +498,10 @@ def _collect_evaluation_sample_probe_metrics(
         for key, raw_value in row.items():
             if key not in _EVALUATION_SAMPLE_PROBE_KEY_SET:
                 continue
-            if isinstance(raw_value, (int, float)):
+            raw_value_type = type(raw_value)
+            if raw_value_type is float:
+                value = raw_value
+            elif raw_value_type is int or raw_value_type is bool:
                 value = float(raw_value)
             else:
                 value = _float_or_none(raw_value)


### PR DESCRIPTION
## Summary
- Fast-path exact `float`, `int`, and `bool` values in benchmark/evaluation report metric-row comparison and probe row collectors.
- Keep string parsing fallback for metadata/string metrics while avoiding `_float_or_none` on already-decoded numeric JSON values.
- Add focused regression coverage proving exact numeric values bypass the generic parser and bool semantics are preserved.

## Plan or Spec
- `docs/plans/2026-04-30-benchmark-evaluation-report-streaming-aggregation.md`

## Commands Run
```text
# Baseline sync/context
 git fetch origin --prune
 git worktree add -b perf/python-next-slice-20260501234454 /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-20260501234454 origin/main
 git status --short && git branch --show-current && git rev-parse HEAD origin/main
 -> clean worktree, branch perf/python-next-slice-20260501234454, HEAD/origin/main 4bb21ffa8a02ae0440d905b1b1fefcc41ee9f88c

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
-> 34 passed in 0.12s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
-> 34 passed; TOTAL 99% (benchmark_evaluation_report.py 99%, test_benchmark_evaluation_report.py 99%)

# Registered local probe comparison via run_probe_job against detached origin/main baseline
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .tmp_run_probe_job.py
-> success=true; base elapsed_ms_mean=176.733 ms, head elapsed_ms_mean=164.335 ms; base/head peak_bytes_mean=3904837.7; row_count=5990

# Registered head probe smoke
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .tmp_run_benchmark_eval_probe.py
-> {"elapsed_ms_mean": 159.063, "peak_bytes_mean": 3904837.7, "row_count": 5990.0}

git diff --check
-> passed
```

## Coverage and Metrics
- Changed-scope coverage: 99% total (`benchmark_evaluation_report.py` 99%, `test_benchmark_evaluation_report.py` 99%).
- Registered probe: `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json` covers the touched Python path with focused `test_command`, `coverage_command`, and `probe_command`.
- Local registered probe comparison: `old_mean=176.733ms`, `new_mean=164.335ms`, `delta_ms=-12.398ms`, `speedup=1.075x`; peak traced bytes unchanged at `3904837.7`.
- CI PR-scoped performance report is still required as the merge gate.

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime behavior is touched.
- Local timing is synthetic and subject to host noise, so the registered CI PR-scoped performance report remains authoritative for merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
