### PR TITLE
perf(job-registry): target derived-model lookup

### DIFF
--- a/docs/plans/2026-05-02-job-registry-targeted-lookup.md
+++ b/docs/plans/2026-05-02-job-registry-targeted-lookup.md
@@ -1,0 +1,35 @@
+# Job Registry Targeted Derived-Model Lookup
+
+## Scope
+
+This performance slice is limited to the Python model-ops job registry derived-model lookup path.
+It keeps snapshot and active-manifest behavior unchanged while reducing work in `resolve_derived_model_target` when callers request one derived model by id or manifest path.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped probe `job-registry-derived-model-single-pass` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes:
+
+- `test_command` for `test_model_ops_job_registry.py` and probe registry smoke tests.
+- `coverage_command` for changed-scope coverage across `job_registry.py`, focused tests, and the probe script.
+- `probe_command` through `scripts/job_registry_derived_model_probe.py`, reporting `active_manifest_elapsed_ms_mean`, `resolve_target_elapsed_ms_mean`, and combined `elapsed_ms_mean`.
+
+## Implementation plan
+
+1. Add a regression test proving derived-model id lookup does not resolve every non-matching activation path before finding the requested model.
+2. Change `resolve_derived_model_target` to iterate ordered jobs directly and return on the first matching active activation row instead of materializing the full active-derived tuple.
+3. Preserve removal filtering semantics by reusing `_removed_derived_targets_from_ordered_jobs` before the targeted scan.
+4. Run focused tests, changed-scope coverage, and the registered probe locally on Linux before opening the PR.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
+```
+
+CI remains the merge gate for the registered PR-scoped performance report.

--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -280,3 +280,95 @@ def test_resolve_derived_model_target_avoids_snapshot_jobs(monkeypatch: pytest.M
         "adapter_manifest_path": adapter_manifest_path,
         "adapter_weights_path": "/runtime/train/adapters.safetensors",
     }
+
+
+def test_resolve_derived_model_target_delays_path_resolution_until_id_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = ModelOpsJobRegistry()
+    target_job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+    registry.attach_manifest(
+        target_job.job_id,
+        json.dumps(
+            {
+                "derived_model_id": "melix-dev-target",
+                "derived_model_path": "/runtime/activate/melix-dev-target",
+                "activation_mode": "fused_derived_model",
+            }
+        ),
+    )
+    registry.complete(target_job.job_id, "/runtime/activate/melix-dev-target/manifest.json")
+
+    removed_by_job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+    registry.attach_manifest(
+        removed_by_job.job_id,
+        json.dumps(
+            {
+                "derived_model_id": "melix-dev-removed-by-job",
+                "derived_model_path": "/runtime/activate/melix-dev-removed-by-job",
+                "activation_mode": "fused_derived_model",
+            }
+        ),
+    )
+    removed_by_job_path = "/runtime/activate/melix-dev-removed-by-job/manifest.json"
+    registry.complete(removed_by_job.job_id, removed_by_job_path)
+    removal_by_job = registry.start("remove_derived_model", "melix-dev-text", "/runtime/remove")
+    registry.attach_manifest(
+        removal_by_job.job_id,
+        json.dumps(
+            {
+                "derived_model_id": "melix-dev-removed-by-job",
+                "activation_job_id": removed_by_job.job_id,
+                "activation_manifest_path": removed_by_job_path,
+            }
+        ),
+    )
+    registry.complete(removal_by_job.job_id, "/runtime/remove/removed-by-job.json")
+
+    removed_by_model = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+    registry.attach_manifest(
+        removed_by_model.job_id,
+        json.dumps(
+            {
+                "derived_model_id": "melix-dev-removed-by-model",
+                "derived_model_path": "/runtime/activate/melix-dev-removed-by-model",
+                "activation_mode": "fused_derived_model",
+            }
+        ),
+    )
+    registry.complete(removed_by_model.job_id, "/runtime/activate/melix-dev-removed-by-model/manifest.json")
+    removal_by_model = registry.start("remove_derived_model", "melix-dev-text", "/runtime/remove")
+    registry.attach_manifest(
+        removal_by_model.job_id,
+        json.dumps({"derived_model_id": "melix-dev-removed-by-model"}),
+    )
+    registry.complete(removal_by_model.job_id, "/runtime/remove/removed-by-model.json")
+
+    for index in range(12):
+        job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+        registry.attach_manifest(
+            job.job_id,
+            json.dumps(
+                {
+                    "derived_model_id": f"melix-dev-other-{index}",
+                    "derived_model_path": f"/runtime/activate/melix-dev-other-{index}",
+                    "activation_mode": "fused_derived_model",
+                }
+            ),
+        )
+        registry.complete(job.job_id, f"/runtime/activate/melix-dev-other-{index}/manifest.json")
+
+    resolve_calls = 0
+
+    def counted_resolve(self: Path) -> Path:
+        nonlocal resolve_calls
+        resolve_calls += 1
+        return self
+
+    monkeypatch.setattr(Path, "resolve", counted_resolve)
+
+    target = registry.resolve_derived_model_target(derived_model_id="melix-dev-target")
+
+    assert target is not None
+    assert target["activation_job_id"] == target_job.job_id
+    assert resolve_calls == 1

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -382,13 +382,27 @@ class ModelOpsJobRegistry:
         if not normalized_model_id and not normalized_manifest_path:
             return None
 
-        for job, manifest, activation_manifest_path in self._active_derived_model_job_rows(self._ordered_jobs()):
+        ordered_jobs = self._ordered_jobs()
+        removed_targets = self._removed_derived_targets_from_ordered_jobs(ordered_jobs)
+        removed_model_ids = removed_targets["model_ids"]
+        removed_manifest_paths = removed_targets["manifest_paths"]
+        removed_activation_job_ids = removed_targets["activation_job_ids"]
+
+        for job in ordered_jobs:
+            if job.operation != "activate_adapter" or job.status != "completed":
+                continue
+            if job.job_id in removed_activation_job_ids:
+                continue
+            activation_manifest_path = str(job.output_path).strip()
+            manifest = self._job_manifest(job)
+            candidate_model_id = str(manifest.get("derived_model_id", "")).strip()
+            if candidate_model_id in removed_model_ids or activation_manifest_path in removed_manifest_paths:
+                continue
+            if normalized_model_id and candidate_model_id != normalized_model_id:
+                continue
             resolved_activation_manifest_path = str(
                 Path(activation_manifest_path).expanduser().resolve()
             )
-            candidate_model_id = str(manifest.get("derived_model_id", "")).strip()
-            if normalized_model_id and candidate_model_id != normalized_model_id:
-                continue
             if normalized_manifest_path and resolved_activation_manifest_path != normalized_manifest_path:
                 continue
             return {


### PR DESCRIPTION
## Summary
- Optimize `ModelOpsJobRegistry.resolve_derived_model_target` so targeted derived-model lookup scans ordered jobs directly and returns on the first matching active activation row.
- Avoid materializing the full active-derived row tuple for single-target lookup and defer `Path.resolve()` until after derived-model id filtering.
- Add regression coverage for delayed path resolution while preserving removed-derived-model filtering semantics.

## Plan or Spec
- Governing plan: `docs/plans/2026-05-02-job-registry-targeted-lookup.md`
- Registered PR-scoped probe: `job-registry-derived-model-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline registered probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
# exit 0; {"active_manifest_count": 960.0, "active_manifest_elapsed_ms_mean": 2.079284, "elapsed_ms_mean": 4.111725, "job_count": 1200.0, "removed_count": 240.0, "resolve_target_elapsed_ms_mean": 2.032441, "sample_count": 6.0}

# Red regression test before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py::test_resolve_derived_model_target_delays_path_resolution_until_id_match
# exit 1; failed with resolve_calls == 13 instead of 1

# Focused regression tests after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py::test_resolve_derived_model_target_delays_path_resolution_until_id_match services/mlx-worker-python/tests/test_model_ops_job_registry.py::test_resolve_derived_model_target_avoids_snapshot_jobs
# exit 0; 2 passed

# Registered focused test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
# exit 0; 11 passed

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py
# exit 0; TOTAL 46 0 100%

# Registered probe after implementation, repeated 3x
for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py; done
# exit 0; resolve_target_elapsed_ms_mean samples: 1.195317, 1.183032, 1.179480

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`46/46` measurable changed lines covered).
- Registered probe: `job-registry-derived-model-single-pass`.
- Local Linux probe comparison for `resolve_target_elapsed_ms_mean`:
  - old: `2.032441 ms`
  - new mean across 3 post-change probe runs: `1.185943 ms`
  - delta: `-0.846498 ms`
  - speedup: `1.714x` (`41.65%` lower)
- Combined `elapsed_ms_mean` improved from baseline `4.111725 ms` to post-change samples `3.211525`, `3.339008`, `3.114217` ms.

## Known Gaps
- CI is required as the merge gate for the registered PR-scoped performance workflow and report.
- This is a Python-only slice validated locally on Linux; no Swift runtime behavior is changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
