### PR TITLE
perf(rerank): skip cold contiguous-query slices

### DIFF
--- a/docs/plans/2026-05-02-rerank-contiguous-query-scan.md
+++ b/docs/plans/2026-05-02-rerank-contiguous-query-scan.md
@@ -1,0 +1,37 @@
+# Deterministic rerank contiguous-query scan
+
+## Scope
+
+This performance slice keeps deterministic rerank scoring semantics unchanged and narrows the default Jina v3 / causal-lm hot path inside `worker/runtime/rerank_backends.py`.
+
+The contiguous-query bonus previously sliced the document token sequence for every possible start offset. This slice checks the first query token before building a candidate slice and reuses the query length inside the loop. The optimization reduces per-document slice allocation when the first query token is absent or sparse in long candidate documents while preserving exact contiguous-query matching semantics.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped probe `deterministic-rerank-query-context-reuse` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes:
+
+- `test_command` for focused rerank runtime tests and probe selection/dispatch tests.
+- `coverage_command` for changed-scope coverage across rerank runtime/backends, PR-scoped performance support, and focused tests.
+- `probe_command` that measures repeated deterministic rerank scoring for 2,048 documents and reports elapsed time plus context-build/tokenize counters.
+
+## Verification plan
+
+Run the registered commands locally on Linux:
+
+1. Focused tests from the registered probe.
+2. Changed-scope coverage from the registered probe.
+3. Registered probe command and compare against the pre-change baseline.
+
+CI remains the merge gate for the registered PR-scoped performance workflow.
+
+## Metrics
+
+Baseline probe before this slice on the isolated Linux worktree:
+
+```json
+{"document_count": 2048.0, "elapsed_ms_mean": 84.314528, "iteration_count": 8.0, "query_context_builds_mean": 1.0, "sample_count": 5.0, "tokenize_calls_mean": 2049.0}
+```
+
+Post-change metrics are recorded in the PR evidence after the local registered probe run.

--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -364,6 +364,14 @@ def test_rerank_context_tuple_and_frozenset_collections_are_scored_directly() ->
         ("control", "swift", "runtime"),
         query_context.query_tokens,
     )
+    assert family._contains_contiguous_query(
+        ("control", "plane", "swift", "runtime"),
+        query_context.query_tokens,
+    )
+    assert not family._contains_contiguous_query(
+        ("control", "plane", "runtime"),
+        query_context.query_tokens,
+    )
     assert family.score(
         backend,
         "swift runtime",

--- a/services/mlx-worker-python/worker/runtime/rerank_backends.py
+++ b/services/mlx-worker-python/worker/runtime/rerank_backends.py
@@ -203,9 +203,11 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
     def _contains_contiguous_query(document_tokens: Sequence[str], query_tokens: Sequence[str]) -> bool:
         if not query_tokens or len(query_tokens) > len(document_tokens):
             return False
-        last_start = len(document_tokens) - len(query_tokens)
+        first_query_token = query_tokens[0]
+        query_length = len(query_tokens)
+        last_start = len(document_tokens) - query_length
         for start in range(last_start + 1):
-            if document_tokens[start : start + len(query_tokens)] == query_tokens:
+            if document_tokens[start] == first_query_token and document_tokens[start : start + query_length] == query_tokens:
                 return True
         return False
 


### PR DESCRIPTION
## Summary
- Optimize deterministic rerank contiguous-query matching by checking the first query token before slicing a candidate document window.
- Add focused coverage for later contiguous matches and missing-first-token cases.

## Plan or Spec
- `docs/plans/2026-05-02-rerank-contiguous-query-scan.md`
- Registered PR-scoped probe: `deterministic-rerank-query-context-reuse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
# 24 passed in 5.97s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 24 passed in 29.84s; changed-line coverage TOTAL 6 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .tmp_rerank_probe.py
# baseline: {"document_count": 2048.0, "elapsed_ms_mean": 84.314528, "iteration_count": 8.0, "query_context_builds_mean": 1.0, "sample_count": 5.0, "tokenize_calls_mean": 2049.0}
# post-change: {"document_count": 2048.0, "elapsed_ms_mean": 78.371124, "iteration_count": 8.0, "query_context_builds_mean": 1.0, "sample_count": 5.0, "tokenize_calls_mean": 2049.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-line coverage: 100% (`TOTAL 6 0 100%`).
- Registered local probe (`deterministic-rerank-query-context-reuse`): `elapsed_ms_mean` improved from `84.314528` ms to `78.371124` ms (`-5.943404` ms, about `7.05%` faster).
- Query context builds stayed at `1.0`; tokenize calls stayed at `2049.0`, so the slice only changes contiguous-window scanning overhead.

## Known Gaps
- Full repository test suite was not run locally; this PR uses the registered focused probe commands for the touched rerank path.
- CI PR-scoped performance report is still required as the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
