### PR TITLE
perf(model-ops): cache active derived model rows

### DIFF
--- a/docs/plans/2026-05-02-job-registry-targeted-lookup.md
+++ b/docs/plans/2026-05-02-job-registry-targeted-lookup.md
@@ -3,7 +3,7 @@
 ## Scope
 
 This performance slice is limited to the Python model-ops job registry derived-model lookup path.
-It keeps snapshot and active-manifest behavior unchanged while reducing work in `resolve_derived_model_target` when callers request one derived model by id or manifest path.
+It keeps snapshot and active-manifest behavior unchanged while caching the active derived-model row set between registry mutations so repeated `active_derived_model_manifests` and `resolve_derived_model_target` calls avoid rebuilding the same removal-filtered scan.
 
 ## Registered probe
 
@@ -17,9 +17,9 @@ The probe includes:
 
 ## Implementation plan
 
-1. Add a regression test proving derived-model id lookup does not resolve every non-matching activation path before finding the requested model.
-2. Change `resolve_derived_model_target` to iterate ordered jobs directly and return on the first matching active activation row instead of materializing the full active-derived tuple.
-3. Preserve removal filtering semantics by reusing `_removed_derived_targets_from_ordered_jobs` before the targeted scan.
+1. Add regression tests proving the active row set is reused across repeated reads and invalidated when registry mutations change derived-model activity.
+2. Store a cached active derived-model row tuple on `ModelOpsJobRegistry` and clear it from mutation methods that affect manifests, statuses, output paths, or output dirs.
+3. Route both `active_derived_model_manifests` and `resolve_derived_model_target` through the shared cached row builder while preserving removal filtering and delayed path-resolution semantics.
 4. Run focused tests, changed-scope coverage, and the registered probe locally on Linux before opening the PR.
 
 ## Verification commands

--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -185,6 +185,85 @@ def test_active_derived_model_manifests_avoids_full_snapshot(monkeypatch: pytest
 
     assert registry.active_derived_model_manifests() == (active_manifest,)
 
+def test_active_derived_model_row_cache_reuses_rows_and_invalidates() -> None:
+    registry = ModelOpsJobRegistry()
+    active_job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+    registry.attach_manifest(
+        active_job.job_id,
+        json.dumps(
+            {
+                "derived_model_id": "melix-dev-active",
+                "derived_model_path": "/runtime/activate/melix-dev-active",
+                "activation_mode": "fused_derived_model",
+            }
+        ),
+    )
+    registry.complete(active_job.job_id, "/runtime/activate/melix-dev-active/manifest.json")
+
+    first_rows = registry._cached_active_derived_model_job_rows()
+    second_rows = registry._cached_active_derived_model_job_rows()
+
+    assert first_rows is second_rows
+    assert registry.active_derived_model_manifests() == (
+        {
+            "derived_model_id": "melix-dev-active",
+            "derived_model_path": "/runtime/activate/melix-dev-active",
+            "activation_mode": "fused_derived_model",
+        },
+    )
+
+    removal_job = registry.start("remove_derived_model", "melix-dev-text", "/runtime/remove")
+    registry.attach_manifest(
+        removal_job.job_id,
+        json.dumps(
+            {
+                "derived_model_id": "melix-dev-active",
+                "activation_job_id": active_job.job_id,
+                "activation_manifest_path": "/runtime/activate/melix-dev-active/manifest.json",
+            }
+        ),
+    )
+    registry.complete(removal_job.job_id, "/runtime/remove/remove_derived_model.lifecycle.json")
+
+    assert registry._cached_active_derived_model_job_rows() is not first_rows
+    assert registry.active_derived_model_manifests() == ()
+
+
+
+def test_resolve_derived_model_target_reuses_active_row_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = ModelOpsJobRegistry()
+    active_job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+    registry.attach_manifest(
+        active_job.job_id,
+        json.dumps(
+            {
+                "derived_model_id": "melix-dev-active",
+                "derived_model_path": "/runtime/activate/melix-dev-active",
+                "activation_mode": "fused_derived_model",
+            }
+        ),
+    )
+    registry.complete(active_job.job_id, "/runtime/activate/melix-dev-active/manifest.json")
+
+    build_calls = 0
+    original_builder = ModelOpsJobRegistry._active_derived_model_job_rows.__func__
+
+    def counted_builder(cls, jobs):
+        nonlocal build_calls
+        build_calls += 1
+        return original_builder(cls, jobs)
+
+    monkeypatch.setattr(
+        ModelOpsJobRegistry,
+        "_active_derived_model_job_rows",
+        classmethod(counted_builder),
+    )
+
+    assert registry.resolve_derived_model_target(derived_model_id="melix-dev-active") is not None
+    assert registry.resolve_derived_model_target(derived_model_id="melix-dev-active") is not None
+    assert build_calls == 1
 
 
 def test_active_derived_model_manifests_skips_removed_manifest_path_without_job_id() -> None:

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -50,6 +50,7 @@ class ModelOpsJobRegistry:
         self._lock = Lock()
         self._next_id = 1
         self._jobs: dict[str, ModelOpsJob] = {}
+        self._active_derived_model_rows_cache: tuple[tuple[ModelOpsJob, dict[str, Any], str], ...] | None = None
         self._jobs_root = Path(jobs_root).expanduser().resolve() if jobs_root is not None else None
         self._lora_experiment_store = LoraExperimentStore()
         if self._jobs_root is not None:
@@ -66,6 +67,7 @@ class ModelOpsJobRegistry:
                 output_dir=output_dir,
             )
             self._jobs[job_id] = job
+            self._invalidate_active_derived_model_rows_cache()
             return job
 
     def progress(self, job_id: str, stage: str, pct: float) -> None:
@@ -75,6 +77,7 @@ class ModelOpsJobRegistry:
     def set_output_dir(self, job_id: str, output_dir: str) -> None:
         with self._lock:
             self._jobs[job_id].output_dir = output_dir
+            self._invalidate_active_derived_model_rows_cache()
 
     def attach_manifest(self, job_id: str, manifest_json: str) -> None:
         with self._lock:
@@ -82,12 +85,14 @@ class ModelOpsJobRegistry:
             job.manifest_json = manifest_json
             job.manifest = self._decode_manifest_json(manifest_json)
             job.manifest_cached = True
+            self._invalidate_active_derived_model_rows_cache()
 
     def complete(self, job_id: str, output_path: str) -> None:
         with self._lock:
             job = self._jobs[job_id]
             job.status = "completed"
             job.output_path = output_path
+            self._invalidate_active_derived_model_rows_cache()
 
     def fail(self, job_id: str, code: str, message: str) -> None:
         with self._lock:
@@ -95,6 +100,7 @@ class ModelOpsJobRegistry:
             job.status = "failed"
             job.error_code = code
             job.error_message = message
+            self._invalidate_active_derived_model_rows_cache()
 
     def snapshot(self, exclude_job_ids: set[str] | None = None) -> dict[str, Any]:
         excluded = exclude_job_ids or set()
@@ -306,6 +312,18 @@ class ModelOpsJobRegistry:
         with self._lock:
             return tuple(sorted(self._jobs.values(), key=self._job_sort_key, reverse=True))
 
+    def _invalidate_active_derived_model_rows_cache(self) -> None:
+        self._active_derived_model_rows_cache = None
+
+    def _cached_active_derived_model_job_rows(
+        self,
+    ) -> tuple[tuple[ModelOpsJob, dict[str, Any], str], ...]:
+        cached_rows = self._active_derived_model_rows_cache
+        if cached_rows is None:
+            cached_rows = self._active_derived_model_job_rows(self._ordered_jobs())
+            self._active_derived_model_rows_cache = cached_rows
+        return cached_rows
+
     @classmethod
     def _job_manifest(cls, job: ModelOpsJob) -> dict[str, Any]:
         if job.operation == "registry_snapshot" or not job.manifest_json:
@@ -382,22 +400,8 @@ class ModelOpsJobRegistry:
         if not normalized_model_id and not normalized_manifest_path:
             return None
 
-        ordered_jobs = self._ordered_jobs()
-        removed_targets = self._removed_derived_targets_from_ordered_jobs(ordered_jobs)
-        removed_model_ids = removed_targets["model_ids"]
-        removed_manifest_paths = removed_targets["manifest_paths"]
-        removed_activation_job_ids = removed_targets["activation_job_ids"]
-
-        for job in ordered_jobs:
-            if job.operation != "activate_adapter" or job.status != "completed":
-                continue
-            if job.job_id in removed_activation_job_ids:
-                continue
-            activation_manifest_path = str(job.output_path).strip()
-            manifest = self._job_manifest(job)
+        for job, manifest, activation_manifest_path in self._cached_active_derived_model_job_rows():
             candidate_model_id = str(manifest.get("derived_model_id", "")).strip()
-            if candidate_model_id in removed_model_ids or activation_manifest_path in removed_manifest_paths:
-                continue
             if normalized_model_id and candidate_model_id != normalized_model_id:
                 continue
             resolved_activation_manifest_path = str(
@@ -421,7 +425,7 @@ class ModelOpsJobRegistry:
         return None
 
     def active_derived_model_manifests(self) -> tuple[dict[str, Any], ...]:
-        return tuple(manifest for _, manifest, _ in self._active_derived_model_job_rows(self._ordered_jobs()))
+        return tuple(manifest for _, manifest, _ in self._cached_active_derived_model_job_rows())
 
     def _max_numeric_job_id(self) -> int:
         max_job_id = 0


### PR DESCRIPTION
## Summary
- Cache the model-ops job registry active derived-model row set between registry mutations.
- Reuse the cached removal-filtered rows for both `active_derived_model_manifests` and `resolve_derived_model_target`.
- Add regression coverage for cache reuse and mutation invalidation, and update the governing performance plan.

## Plan or Spec
- `docs/plans/2026-05-02-job-registry-targeted-lookup.md`

## Commands Run
```text
# Baseline registered probe on origin/main before the slice:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
# exit 0; {"active_manifest_count": 960.0, "active_manifest_elapsed_ms_mean": 1.800999, "elapsed_ms_mean": 2.825827, "job_count": 1200.0, "removed_count": 240.0, "resolve_target_elapsed_ms_mean": 1.024828, "sample_count": 6.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py::test_active_derived_model_row_cache_reuses_rows_and_invalidates services/mlx-worker-python/tests/test_model_ops_job_registry.py::test_resolve_derived_model_target_reuses_active_row_cache services/mlx-worker-python/tests/test_model_ops_job_registry.py::test_resolve_derived_model_target_delays_path_resolution_until_id_match
# exit 0; 3 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
# exit 0; {"active_manifest_count": 960.0, "active_manifest_elapsed_ms_mean": 0.414763, "elapsed_ms_mean": 0.463967, "job_count": 1200.0, "removed_count": 240.0, "resolve_target_elapsed_ms_mean": 0.049204, "sample_count": 6.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
# exit 0; 13 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py
# exit 0; aggregate changed-line coverage: TOTAL 44 2 95%

git diff --check
# exit 0
```

## Coverage and Metrics
- Registered probe: `job-registry-derived-model-single-pass` covers `services/mlx-worker-python/worker/model_ops/job_registry.py` and includes focused test, coverage, and probe commands.
- Changed-scope coverage: `TOTAL 44 2 95%` from `scripts/changed_scope_coverage.py`.
- Local Linux probe delta:
  - `elapsed_ms_mean`: 2.825827 -> 0.463967 ms; delta -2.361860 ms (-83.58%); speedup 6.09x.
  - `active_manifest_elapsed_ms_mean`: 1.800999 -> 0.414763 ms; delta -1.386236 ms (-76.97%); speedup 4.34x.
  - `resolve_target_elapsed_ms_mean`: 1.024828 -> 0.049204 ms; delta -0.975624 ms (-95.20%); speedup 20.83x.
- CI PR-scoped performance report is still required as the merge gate.

## Known Gaps
- None for local Python verification. Do not merge until GitHub Actions, including the registered PR-scoped performance probe, completes successfully.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
