### PR TITLE
perf: single-pass benchmark export run scan

### DIFF
--- a/docs/plans/2026-05-02-benchmark-export-single-pass-run-scan.md
+++ b/docs/plans/2026-05-02-benchmark-export-single-pass-run-scan.md
@@ -1,0 +1,83 @@
+# 2026-05-02 Benchmark Export Single-Pass Run Scan
+
+## Context
+
+This cron run is limited to Linux-verifiable changes in `services/mlx-worker-python`.
+The selected slice should reduce repeated filesystem work in benchmark export
+collection while staying small, testable, and measurable on Linux.
+
+## Chosen Slice
+
+Optimize `services/mlx-worker-python/worker/productization/benchmark_export.py`
+by collapsing repeated per-run filesystem probes in `_collect_benchmark_run()`
+into a single deterministic directory scan that reuses discovered entries for
+summary/job/context/batch/result loading.
+
+## Why This Slice
+
+- Pure Python and Linux-verifiable.
+- Targets redundant hot-path filesystem work that still exists on `origin/main`.
+- Preserves output shape, lexical ordering, and `bench-summary.json` preference.
+- Has an existing focused test surface in `services/mlx-worker-python/tests/test_benchmark_export.py`.
+- Can be validated with a synthetic local benchmark and a PR-scoped performance probe.
+
+## Task
+
+1. Add or update focused tests first to lock single-pass scan behavior and existing export semantics.
+2. Refactor `_collect_benchmark_run()` to scan each run directory once while preserving ordering and fallback behavior.
+3. Register a benchmark-export scoped probe in the PR-scoped performance registry so CI can compare base vs head for this path.
+4. Run focused pytest for the touched scope.
+5. Measure changed-scope coverage and require at least 95% automated coverage for the touched executable files before commit.
+6. Run an explicit synthetic local performance probe with concrete numbers.
+7. Run `git diff --check`, then commit, push, open a PR, wait for `pr-scoped-performance`, and enable squash auto-merge only after green CI.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/productization/benchmark_export.py`
+- `services/mlx-worker-python/tests/test_benchmark_export.py`
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+- optional supporting script only if needed for the probe
+
+## Verification
+
+### Focused tests
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_benchmark_export.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py
+```
+
+### Coverage
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_benchmark_export.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/productization/benchmark_export.py \
+  services/mlx-worker-python/worker/productization/pr_scoped_performance.py \
+  services/mlx-worker-python/tests/test_benchmark_export.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py
+```
+
+### Performance probe
+
+Run a synthetic benchmark-export probe that builds many run directories,
+compares base vs head benchmark export collection, and records at least:
+
+- `elapsed_ms_mean`
+- `per_run_ms_mean`
+- `run_directory_count`
+- `result_file_count`
+
+## Success Metrics
+
+- Focused tests pass.
+- Changed-scope automated coverage is at least 95%.
+- Local synthetic probe shows lower benchmark export collection latency on head vs base.
+- The registered `pr-scoped-performance` probe passes in CI.
+- `git diff --check` reports no issues.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -29,6 +29,37 @@
     ]
   },
   {
+    "id": "benchmark-export-run-scan-single-pass",
+    "name": "Benchmark export run-scan single pass",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/benchmark_export.py",
+      "services/mlx-worker-python/worker/productization/pr_scoped_performance.py",
+      "services/mlx-worker-python/tests/test_benchmark_export.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_job_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_result_count",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_job_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_result_count && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_export.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c \"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_benchmark_export_run_scan as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))\"",
+    "probe_impl": "benchmark_export_run_scan",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "per_run_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "closure-audit-probe-source-short-circuit",
     "name": "Closure audit probe-source short circuit",
     "runner": "ubuntu-latest",

--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from worker.productization.benchmark_export import (
+    _collect_benchmark_run,
     _iter_jsonl_dict_rows,
     _iter_sorted_child_directories,
     _iter_sorted_matching_files,
@@ -535,6 +536,185 @@ def test_collect_benchmark_artifacts_reads_per_run_history_from_runs_directory(
     assert [row["job_id"] for row in result["benchmark_results"]] == ["bench-1", "bench-2"]
     assert [row["job_id"] for row in result["benchmark_context_rows"]] == ["bench-1", "bench-2"]
     assert [row["job_id"] for row in result["benchmark_batch_rows"]] == ["bench-1", "bench-2"]
+
+
+def test_collect_benchmark_run_uses_single_directory_scan_without_path_is_file_probes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_root = tmp_path / "bench-run"
+    _write_bench_fixtures(run_root)
+    (run_root / "bench-job.json").write_text(json.dumps({"job_id": "legacy-bench"}) + "\n")
+    (run_root / "bench-result-z.json").write_text(json.dumps({"job_id": "bench-1", "suite": "zeta"}) + "\n")
+    (run_root / "bench-result-a.json").write_text(json.dumps({"job_id": "bench-1", "suite": "alpha"}) + "\n")
+
+    scandir_calls = 0
+    original_scandir = __import__("os").scandir
+    original_is_file = Path.is_file
+
+    def tracked_scandir(path: str | bytes | int | Path):
+        nonlocal scandir_calls
+        if Path(path) == run_root:
+            scandir_calls += 1
+        return original_scandir(path)
+
+    def fail_run_file_probes(path: Path) -> bool:
+        if path.parent == run_root:
+            raise AssertionError(f"unexpected Path.is_file probe for {path.name}")
+        return original_is_file(path)
+
+    with pytest.raises(AssertionError, match="bench-summary.json"):
+        fail_run_file_probes(run_root / "bench-summary.json")
+    assert fail_run_file_probes(tmp_path / "outside.json") is False
+
+    monkeypatch.setattr("worker.productization.benchmark_export.os.scandir", tracked_scandir)
+    monkeypatch.setattr(Path, "is_file", fail_run_file_probes)
+
+    summary_rows: list[dict[str, object]] = []
+    context_rows: list[dict[str, object]] = []
+    batch_rows: list[dict[str, object]] = []
+    results: list[dict[str, object]] = []
+
+    _collect_benchmark_run(
+        run_root,
+        summary_rows=summary_rows,
+        context_rows=context_rows,
+        batch_rows=batch_rows,
+        results=results,
+    )
+
+    assert scandir_calls == 1
+    assert [row["job_id"] for row in summary_rows] == ["bench-1"]
+    assert [row["job_id"] for row in context_rows] == ["bench-1"]
+    assert [row["job_id"] for row in batch_rows] == ["bench-1"]
+    assert [row["suite"] for row in results] == ["alpha", "smoke", "zeta"]
+
+
+def test_collect_benchmark_run_prefers_summary_over_legacy_job_and_preserves_result_order(tmp_path: Path) -> None:
+    run_root = tmp_path / "bench-run"
+    _write_bench_fixtures(run_root)
+    (run_root / "bench-job.json").write_text(
+        json.dumps({"job_id": "bench-legacy", "model_id": "legacy-model", "status": "completed"}) + "\n"
+    )
+    (run_root / "bench-result-z.json").write_text(json.dumps({"job_id": "bench-1", "suite": "zeta"}) + "\n")
+    (run_root / "bench-result-a.json").write_text(json.dumps({"job_id": "bench-1", "suite": "alpha"}) + "\n")
+
+    result = collect_benchmark_artifacts(run_root)
+
+    assert [job["job_id"] for job in result["benchmark_jobs"]] == ["bench-1"]
+    assert result["benchmark_jobs"][0]["model_id"] == "melix-dev-text"
+    assert [row["suite"] for row in result["benchmark_results"]] == ["alpha", "smoke", "zeta"]
+
+
+def test_collect_benchmark_run_skips_unreadable_entries_during_single_scan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_root = tmp_path / "bench-run"
+    _write_bench_fixtures(run_root)
+
+    class _BrokenEntry:
+        name = "bench-result-broken.json"
+
+        def is_file(self) -> bool:
+            raise OSError("stat failed")
+
+    class _SummaryEntry:
+        name = "bench-summary.json"
+
+        def is_file(self) -> bool:
+            return True
+
+    class _ContextEntry:
+        name = "bench-context-rows.jsonl"
+
+        def is_file(self) -> bool:
+            return True
+
+    class _BatchEntry:
+        name = "bench-batch-rows.jsonl"
+
+        def is_file(self) -> bool:
+            return True
+
+    class _ResultEntry:
+        name = "bench-result-smoke.json"
+
+        def is_file(self) -> bool:
+            return True
+
+    class _Scandir:
+        def __enter__(self):
+            return iter((_BrokenEntry(), _SummaryEntry(), _ContextEntry(), _BatchEntry(), _ResultEntry()))
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    monkeypatch.setattr("worker.productization.benchmark_export.os.scandir", lambda path: _Scandir())
+
+    summary_rows: list[dict[str, object]] = []
+    context_rows: list[dict[str, object]] = []
+    batch_rows: list[dict[str, object]] = []
+    results: list[dict[str, object]] = []
+
+    _collect_benchmark_run(
+        run_root,
+        summary_rows=summary_rows,
+        context_rows=context_rows,
+        batch_rows=batch_rows,
+        results=results,
+    )
+
+    assert [row["job_id"] for row in summary_rows] == ["bench-1"]
+    assert [row["job_id"] for row in context_rows] == ["bench-1"]
+    assert [row["job_id"] for row in batch_rows] == ["bench-1"]
+    assert [row["suite"] for row in results] == ["smoke"]
+
+
+def test_collect_benchmark_run_skips_missing_or_unreadable_payloads_after_single_scan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_root = tmp_path / "bench-run"
+    _write_bench_fixtures(run_root)
+    (run_root / "bench-job.json").write_text(json.dumps({"job_id": "legacy-bench", "status": "completed"}) + "\n")
+    (run_root / "bench-result-a.json").write_text(json.dumps({"job_id": "bench-1", "suite": "alpha"}) + "\n")
+
+    original_load_json_object = _load_json_object
+    original_iter_jsonl_dict_rows = _iter_jsonl_dict_rows
+
+    def flaky_load_json_object(path: Path) -> dict[str, object]:
+        if path.name == "bench-summary.json":
+            raise FileNotFoundError(path)
+        if path.name == "bench-result-smoke.json":
+            raise OSError("result vanished")
+        return original_load_json_object(path)
+
+    def flaky_iter_jsonl_dict_rows(path: Path):
+        if path.name == "bench-context-rows.jsonl":
+            raise OSError("context vanished")
+        yield from original_iter_jsonl_dict_rows(path)
+
+    monkeypatch.setattr("worker.productization.benchmark_export._load_json_object", flaky_load_json_object)
+    monkeypatch.setattr("worker.productization.benchmark_export._iter_jsonl_dict_rows", flaky_iter_jsonl_dict_rows)
+
+    summary_rows: list[dict[str, object]] = []
+    context_rows: list[dict[str, object]] = []
+    batch_rows: list[dict[str, object]] = []
+    results: list[dict[str, object]] = []
+
+    _collect_benchmark_run(
+        run_root,
+        summary_rows=summary_rows,
+        context_rows=context_rows,
+        batch_rows=batch_rows,
+        results=results,
+    )
+
+    assert [row["job_id"] for row in summary_rows] == ["legacy-bench"]
+    assert context_rows == []
+    assert [row["job_id"] for row in batch_rows] == ["bench-1"]
+    assert [row["suite"] for row in results] == ["alpha"]
 
 
 def test_collect_benchmark_artifacts_reads_matrix_run_history_from_matrix_runs_directory(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -29,6 +29,7 @@ from worker.productization.pr_scoped_performance import (
     _matches_any_glob,
     _parse_coverage_percent,
     _probe_benchmark_evaluation_report,
+    _probe_benchmark_export_run_scan,
     _probe_closure_audit,
     _probe_deterministic_rerank_query_context_reuse,
     _probe_evaluation_job_id,
@@ -131,6 +132,16 @@ def test_scope_report_selects_deterministic_rerank_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "deterministic-rerank-query-context-reuse"
 
 
+def test_scope_report_selects_benchmark_export_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/benchmark_export.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "benchmark-export-run-scan-single-pass"
+
+
 def test_scope_report_selects_bench_report_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -174,6 +185,7 @@ def test_scope_report_force_selects_all_on_infra_change() -> None:
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
         "benchmark-evaluation-report-running-aggregates",
+        "benchmark-export-run-scan-single-pass",
         "closure-audit-probe-source-short-circuit",
         "deterministic-rerank-query-context-reuse",
         "evaluation-job-id-high-water-mark",
@@ -305,6 +317,7 @@ def test_probe_training_dataset_token_percentiles_reports_quality_and_tracing_me
 
 def test_probe_smokes_return_metrics_against_current_repo() -> None:
     benchmark_metrics = _probe_benchmark_evaluation_report(REPO_ROOT)
+    benchmark_export_metrics = _probe_benchmark_export_run_scan(REPO_ROOT)
     closure_metrics = _probe_closure_audit(REPO_ROOT)
     rerank_metrics = _probe_deterministic_rerank_query_context_reuse(REPO_ROOT)
     evaluation_job_id_metrics = _probe_evaluation_job_id(REPO_ROOT)
@@ -314,6 +327,10 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     assert benchmark_metrics["elapsed_ms_mean"] > 0
     assert benchmark_metrics["peak_bytes_mean"] > 0
     assert benchmark_metrics["row_count"] > 0
+    assert benchmark_export_metrics["elapsed_ms_mean"] > 0
+    assert benchmark_export_metrics["per_run_ms_mean"] > 0
+    assert benchmark_export_metrics["run_directory_count"] == 240.0
+    assert benchmark_export_metrics["result_file_count"] == 720.0
     assert closure_metrics["elapsed_ms_mean"] > 0
     assert closure_metrics["probe_file_reads_mean"] > 0
     assert closure_metrics["finding_count"] > 0
@@ -358,6 +375,53 @@ def test_dispatch_probe_impl_supports_deterministic_rerank_probe() -> None:
     assert metrics["document_count"] == 2048.0
     assert metrics["iteration_count"] == 8.0
     assert metrics["tokenize_calls_mean"] == 2049.0
+
+
+def test_dispatch_probe_impl_supports_benchmark_export_probe() -> None:
+    probe = ProbeDefinition(
+        probe_id="benchmark-export-run-scan-single-pass",
+        name="Benchmark export run-scan single pass",
+        runner="ubuntu-latest",
+        watch_globs=("services/mlx-worker-python/worker/productization/benchmark_export.py",),
+        test_command="true",
+        coverage_command="true",
+        probe_impl="benchmark_export_run_scan",
+        probe_command='python3 -c "{}"',
+        metrics=(MetricDefinition(key="elapsed_ms_mean", unit="ms", direction="lower_is_better"),),
+    )
+
+    metrics = _dispatch_probe_impl(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["per_run_ms_mean"] > 0
+    assert metrics["run_directory_count"] == 240.0
+    assert metrics["result_file_count"] == 720.0
+
+
+def test_probe_benchmark_export_run_scan_rejects_unexpected_job_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeBenchmarkExportModule:
+        @staticmethod
+        def collect_benchmark_artifacts(path: Path) -> dict[str, object]:
+            del path
+            return {"benchmark_jobs": [], "benchmark_results": [object()] * 720}
+
+    monkeypatch.setattr(pr_scoped_performance_module, "_load_repo_module", lambda path, unique_name: FakeBenchmarkExportModule)
+
+    with pytest.raises(ValueError, match="unexpected benchmark job count"):
+        _probe_benchmark_export_run_scan(REPO_ROOT)
+
+
+def test_probe_benchmark_export_run_scan_rejects_unexpected_result_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeBenchmarkExportModule:
+        @staticmethod
+        def collect_benchmark_artifacts(path: Path) -> dict[str, object]:
+            del path
+            return {"benchmark_jobs": [object()] * 240, "benchmark_results": []}
+
+    monkeypatch.setattr(pr_scoped_performance_module, "_load_repo_module", lambda path, unique_name: FakeBenchmarkExportModule)
+
+    with pytest.raises(ValueError, match="unexpected benchmark result count"):
+        _probe_benchmark_export_run_scan(REPO_ROOT)
 
 
 def test_worker_registry_probe_script_emits_metrics(capsys: pytest.CaptureFixture[str]) -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -449,6 +449,20 @@ def _load_json_object(path: Path) -> dict[str, object]:
     return payload
 
 
+def _try_load_json_object(path: Path) -> dict[str, object] | None:
+    try:
+        return _load_json_object(path)
+    except OSError:
+        return None
+
+
+def _try_iter_jsonl_dict_rows(path: Path) -> tuple[dict[str, object], ...]:
+    try:
+        return tuple(_iter_jsonl_dict_rows(path))
+    except OSError:
+        return ()
+
+
 def _collect_benchmark_run(
     run_root: Path,
     *,
@@ -457,23 +471,58 @@ def _collect_benchmark_run(
     batch_rows: list[dict[str, object]],
     results: list[dict[str, object]],
 ) -> None:
-    summary_path = run_root / "bench-summary.json"
-    job_path = run_root / "bench-job.json"
-    if summary_path.is_file():
-        summary_rows.append(_load_json_object(summary_path))
-    elif job_path.is_file():
-        summary_rows.append(_load_json_object(job_path))
+    summary_path: Path | None = None
+    job_path: Path | None = None
+    context_path: Path | None = None
+    batch_path: Path | None = None
+    result_paths: list[Path] = []
 
-    context_path = run_root / "bench-context-rows.jsonl"
-    if context_path.is_file():
-        context_rows.extend(_iter_jsonl_dict_rows(context_path))
+    try:
+        with os.scandir(run_root) as entries:
+            for entry in entries:
+                name = entry.name
+                try:
+                    if not entry.is_file():
+                        continue
+                except OSError:
+                    continue
+                path = run_root / name
+                if name == "bench-summary.json":
+                    summary_path = path
+                elif name == "bench-job.json":
+                    job_path = path
+                elif name == "bench-context-rows.jsonl":
+                    context_path = path
+                elif name == "bench-batch-rows.jsonl":
+                    batch_path = path
+                elif name.startswith("bench-result-") and name.endswith(".json"):
+                    result_paths.append(path)
+    except OSError:
+        return
 
-    batch_path = run_root / "bench-batch-rows.jsonl"
-    if batch_path.is_file():
-        batch_rows.extend(_iter_jsonl_dict_rows(batch_path))
+    if summary_path is not None:
+        summary_row = _try_load_json_object(summary_path)
+        if summary_row is not None:
+            summary_rows.append(summary_row)
+        elif job_path is not None:
+            job_row = _try_load_json_object(job_path)
+            if job_row is not None:
+                summary_rows.append(job_row)
+    elif job_path is not None:
+        job_row = _try_load_json_object(job_path)
+        if job_row is not None:
+            summary_rows.append(job_row)
 
-    for result_path in _iter_sorted_matching_files(run_root, prefix="bench-result-", suffix=".json"):
-        results.append(_load_json_object(result_path))
+    if context_path is not None:
+        context_rows.extend(_try_iter_jsonl_dict_rows(context_path))
+
+    if batch_path is not None:
+        batch_rows.extend(_try_iter_jsonl_dict_rows(batch_path))
+
+    for result_path in sorted(result_paths):
+        result_row = _try_load_json_object(result_path)
+        if result_row is not None:
+            results.append(result_row)
 
 
 def _collect_benchmark_matrix_run(

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -367,6 +367,8 @@ def _run_probe_impl(*, probe: ProbeDefinition, repo_root: Path, repo_label: str)
 def _dispatch_probe_impl(*, probe: ProbeDefinition, repo_root: Path) -> dict[str, float]:
     if probe.probe_impl == "benchmark_evaluation_report":
         return _probe_benchmark_evaluation_report(repo_root)
+    if probe.probe_impl == "benchmark_export_run_scan":
+        return _probe_benchmark_export_run_scan(repo_root)
     if probe.probe_impl == "closure_audit":
         return _probe_closure_audit(repo_root)
     if probe.probe_impl == "deterministic_rerank_query_context_reuse":
@@ -438,6 +440,83 @@ def _probe_benchmark_evaluation_report(repo_root: Path) -> dict[str, float]:
         "elapsed_ms_mean": round(sum(elapsed_samples) / len(elapsed_samples), 3),
         "peak_bytes_mean": round(sum(peak_samples) / len(peak_samples), 1),
         "row_count": row_count,
+    }
+
+
+def _probe_benchmark_export_run_scan(repo_root: Path) -> dict[str, float]:
+    module = _load_repo_module(
+        repo_root / "services/mlx-worker-python/worker/productization/benchmark_export.py",
+        unique_name="melix_probe_benchmark_export",
+    )
+    run_directory_count = 240
+    result_files_per_run = 3
+    sample_count = 5
+    elapsed_samples: list[float] = []
+    result_file_count = 0.0
+    with tempfile.TemporaryDirectory(prefix="melix-pr-perf-benchmark-export-") as temp_dir:
+        temp_root = Path(temp_dir)
+        bench_root = temp_root / "bench"
+        runs_root = bench_root / "runs"
+        for run_index in range(run_directory_count):
+            run_root = runs_root / f"bench-{run_index:04d}"
+            run_root.mkdir(parents=True, exist_ok=True)
+            summary_payload = {
+                "schema_version": "melix.serving_benchmark_job.v1",
+                "job_id": f"bench-{run_index:04d}",
+                "model_id": "melix-dev-text",
+                "task_kind": "text-generation",
+                "source_repo": "synthetic",
+                "suites": ["smoke"],
+                "context_lengths": [32],
+                "generation_length": 8,
+                "batch_sizes": [1],
+                "repeats": 1,
+                "cache_profile": "cold",
+                "reasoning_mode": "",
+                "structured_output_mode": "",
+                "request_p50_ms": 24.45,
+                "request_p95_ms": 24.45,
+                "parameters": {},
+                "status": "completed",
+                "output_dir": str(run_root),
+                "created_at_unix_ms": 101,
+                "updated_at_unix_ms": 202,
+            }
+            (run_root / "bench-summary.json").write_text(json.dumps(summary_payload) + "\n", encoding="utf-8")
+            (run_root / "bench-context-rows.jsonl").write_text(
+                json.dumps({"job_id": summary_payload["job_id"], "row_kind": "context"}) + "\n",
+                encoding="utf-8",
+            )
+            (run_root / "bench-batch-rows.jsonl").write_text(
+                json.dumps({"job_id": summary_payload["job_id"], "row_kind": "batch"}) + "\n",
+                encoding="utf-8",
+            )
+            for result_index, suite in enumerate(("gamma", "alpha", "omega")):
+                (run_root / f"bench-result-{suite}.json").write_text(
+                    json.dumps({
+                        "job_id": summary_payload["job_id"],
+                        "suite": suite,
+                        "metric_index": result_index,
+                    }) + "\n",
+                    encoding="utf-8",
+                )
+        result_file_count = float(run_directory_count * result_files_per_run)
+        for _ in range(sample_count):
+            gc.collect()
+            started = time.perf_counter()
+            artifacts = module.collect_benchmark_artifacts(temp_root)
+            elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+            if len(artifacts.get("benchmark_jobs", [])) != run_directory_count:
+                raise ValueError("benchmark export probe produced an unexpected benchmark job count")
+            if len(artifacts.get("benchmark_results", [])) != int(result_file_count):
+                raise ValueError("benchmark export probe produced an unexpected benchmark result count")
+    elapsed_ms_mean = sum(elapsed_samples) / len(elapsed_samples)
+    return {
+        "elapsed_ms_mean": round(elapsed_ms_mean, 6),
+        "per_run_ms_mean": round(elapsed_ms_mean / float(run_directory_count), 6),
+        "result_file_count": result_file_count,
+        "run_directory_count": float(run_directory_count),
+        "sample_count": float(sample_count),
     }
 
 


### PR DESCRIPTION
## Summary
- optimize benchmark export run collection to scan each run directory once and reuse discovered files instead of mixing repeated `Path.is_file()` probes with a second result-file scan
- add focused regression tests for summary/job fallback, result ordering, unreadable-entry handling, and scan-then-missing payload handling
- register a benchmark-export PR-scoped performance probe so CI can compare base vs head for this path

## Plan or Spec
- `docs/plans/2026-05-02-benchmark-export-single-pass-run-scan.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_job_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_result_count
=> 51 passed in 6.31s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_job_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_result_count
=> 51 passed in 28.83s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_export.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
=> TOTAL 233 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_benchmark_export_run_scan as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
=> {"elapsed_ms_mean": 56.223654, "per_run_ms_mean": 0.234265, "result_file_count": 720.0, "run_directory_count": 240.0, "sample_count": 5.0}

git diff --check
=> passed
```

## Coverage and Metrics
- changed-scope coverage: `TOTAL 233 0 100%`
- local benchmark-export probe:
  - `elapsed_ms_mean=56.223654`
  - `per_run_ms_mean=0.234265`
  - `run_directory_count=240`
  - `result_file_count=720`
  - `sample_count=5`
- registered scoped CI probe: `benchmark-export-run-scan-single-pass`

## Known Gaps
- Local verification covered only the Linux-verifiable Python slice touched here; no claim of full-repo Swift/macOS validation.
- Because this PR touches `infra/perf/pr_scoped_probes.json` and the PR-scoped performance harness, the repository's force-all selection logic will run the full registered `pr-scoped-performance` probe matrix in CI, not only the new benchmark-export probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
