### PR TITLE
perf: stream evaluation sample CSV writes

### DIFF
--- a/docs/plans/2026-05-02-evaluation-store-samples-csv-streaming.md
+++ b/docs/plans/2026-05-02-evaluation-store-samples-csv-streaming.md
@@ -1,0 +1,49 @@
+# Evaluation Store Samples CSV Streaming Optimization Plan
+
+## Goal
+
+Reduce peak memory and redundant large-string assembly in `EvaluationStore.persist_result(...)` by streaming `evaluation-samples.csv` writes instead of building the full CSV payload in memory before writing it to disk.
+
+## Linux-Only Constraint
+
+This slice is limited to the Python worker evaluation artifact writer, its focused tests, and the PR-scoped performance harness so it can be fully verified on Linux without relying on macOS or Swift-only execution paths.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/productization/evaluation_store.py`
+- `services/mlx-worker-python/tests/test_evaluation_store.py`
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Optimization Slice
+
+- Add a streamed CSV writer for evaluation samples that writes the header and each row directly to the file handle.
+- Route `persist_result(...)` through the streamed writer for `evaluation-samples.csv` while preserving the existing CSV schema and quoting behavior.
+- Keep `_samples_csv(...)` behavior intact for existing direct callers/tests.
+- Register a PR-scoped performance probe for the evaluation-store sample-artifact path.
+- Add focused regression tests for the streamed writer, the `persist_result(...)` fast path, and the new probe wiring.
+
+## Performance Probe
+
+Measure `EvaluationStore.persist_result(...)` on a synthetic large evaluation run that persists JSON, JSONL, and sample CSV artifacts for a large sample tuple. Record:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- `sample_count`
+
+Compare the probe on `origin/main` vs the branch implementation through the PR-scoped performance harness.
+
+## Success Metrics
+
+- Persisted artifact contents and CSV quoting remain unchanged.
+- Changed executable scope coverage is at least 95%.
+- Local probe shows lower peak traced allocation for the large sample persistence path.
+- The new registered PR-scoped CI probe selects this path and can compare `origin/main` against the branch implementation.
+
+## Verification Commands
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `git diff --check`
+- Local old-vs-new evaluation-store sample persistence probe against `origin/main`

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -153,6 +153,37 @@
     ]
   },
   {
+    "id": "evaluation-store-samples-csv-streaming",
+    "name": "Evaluation store samples CSV streaming",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/evaluation_store.py",
+      "services/mlx-worker-python/tests/test_evaluation_store.py",
+      "services/mlx-worker-python/worker/productization/pr_scoped_performance.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c \"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_evaluation_store_samples_csv_streaming as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))\"",
+    "probe_impl": "evaluation_store_samples_csv_streaming",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "training-dataset-token-percentiles-single-sort",
     "name": "Training dataset quality/token summary",
     "runner": "ubuntu-latest",

--- a/services/mlx-worker-python/tests/test_evaluation_store.py
+++ b/services/mlx-worker-python/tests/test_evaluation_store.py
@@ -55,6 +55,57 @@ def test_write_jsonl_streams_rows_without_building_one_giant_payload(monkeypatch
     assert writes == [json.dumps(rows[0]), "\n", json.dumps(rows[1]), "\n"]
 
 
+def test_write_samples_csv_streams_rows_without_building_one_giant_payload(monkeypatch) -> None:
+    writes: list[str] = []
+
+    class FakeFile:
+        def write(self, chunk: str) -> int:
+            writes.append(chunk)
+            return len(chunk)
+
+        def __enter__(self) -> FakeFile:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+            return None
+
+    target_path = Path("/tmp/evaluation-samples.csv")
+
+    def fake_open(self: Path, mode: str = "r", encoding: str | None = None) -> FakeFile:
+        assert self == target_path
+        assert mode == "w"
+        assert encoding == "utf-8"
+        return FakeFile()
+
+    monkeypatch.setattr(Path, "open", fake_open)
+    sample = build_evaluation_sample_record(
+        job_id="eval-local",
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_id="sample-1",
+        system="",
+        input_text="Question?",
+        target="Answer",
+        raw_response="response",
+        extracted_result="result",
+        typed_score=1.0,
+        time_s=0.01,
+        extraction_status="extracted",
+        validation_status="validated",
+        failure_reason="",
+        task_kind="text-generation",
+    )
+
+    EvaluationStore._write_samples_csv(target_path, (sample,))
+
+    expected_payload = EvaluationStore._samples_csv((sample,))
+    assert "".join(writes) == expected_payload
+    assert writes[0].startswith("id,task_kind,target,extracted_result")
+    assert writes[1] == "\n"
+    assert writes[2].startswith("sample-1,text-generation,Answer,result,Question?,response,1.0,0.01")
+    assert writes[3] == "\n"
+
+
 def test_persist_result_writes_expected_artifact_names_and_payloads(tmp_path: Path) -> None:
     store = EvaluationStore()
     jobs_root = tmp_path / "evaluation"
@@ -155,6 +206,81 @@ def test_persist_result_writes_expected_artifact_names_and_payloads(tmp_path: Pa
         "sample_render_ms,inference_ms,extraction_ms,validation_ms,scoring_ms,raw_response_chars,extracted_result_chars,failure_stage"
         in export_samples_header
     )
+
+
+def test_persist_result_streams_samples_csv_without_calling_samples_csv_builder(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = EvaluationStore()
+    jobs_root = tmp_path / "evaluation"
+    run_root = jobs_root / "runs" / "eval-local"
+    job = build_evaluation_job_record(
+        job_id="eval-local",
+        model_id="melix-dev-text",
+        task_kind="text-generation",
+        source_repo="HuggingFaceH4/ultrachat_200k",
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_size=1,
+        scoring_mode="deterministic_accuracy",
+        few_shot=4,
+        seed=7,
+        code_exec_policy="sandboxed",
+        parameters={"dataset_root": str(tmp_path / "datasets" / "mmlu-dev")},
+        status="completed",
+        output_dir=str(run_root),
+        created_at_unix_ms=101,
+        updated_at_unix_ms=202,
+    )
+    result = build_evaluation_result_record(
+        job_id="eval-local",
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_size=1,
+        primary_score_name="normalized_exact_match",
+        primary_score_value=1.0,
+        extraction_success_count=1,
+        validation_success_count=1,
+        scored_sample_count=1,
+        failure_count=0,
+        duration_seconds=0.25,
+        metrics={"eval.mmlu.accuracy": 1.0},
+        report_path=str(run_root / "evaluation-result.json"),
+        units={"eval.mmlu.accuracy": "ratio"},
+    )
+    sample = build_evaluation_sample_record(
+        job_id="eval-local",
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_id="sample-1",
+        system="",
+        input_text="2+2?",
+        target="4",
+        raw_response="4",
+        extracted_result="4",
+        typed_score=1.0,
+        time_s=0.01,
+        extraction_status="extracted",
+        validation_status="validated",
+        failure_reason="",
+        task_kind="text-generation",
+    )
+    expected_csv = EvaluationStore._samples_csv((sample,))
+
+    def fail_samples_csv(_: tuple[object, ...]) -> str:
+        raise AssertionError("persist_result should stream samples CSV instead of calling _samples_csv")
+
+    monkeypatch.setattr(EvaluationStore, "_samples_csv", staticmethod(fail_samples_csv))
+
+    persisted = store.persist_result(
+        jobs_root=jobs_root,
+        job=job,
+        result=result,
+        samples=(sample,),
+    )
+
+    assert persisted["samples_csv"].read_text(encoding="utf-8") == expected_csv
 
 
 def test_samples_csv_quotes_fields_with_commas_newlines_and_quotes() -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -34,6 +34,7 @@ from worker.productization.pr_scoped_performance import (
     _probe_deterministic_rerank_query_context_reuse,
     _probe_evaluation_job_id,
     _probe_evaluation_sample_probe_aggregation,
+    _probe_evaluation_store_samples_csv_streaming,
     _probe_training_dataset_token_percentiles,
     _probe_command_json,
     _run_command,
@@ -100,6 +101,16 @@ def test_scope_report_selects_evaluation_probes() -> None:
         "evaluation-job-id-high-water-mark",
         "evaluation-sample-probe-aggregation",
     }
+
+
+def test_scope_report_selects_evaluation_store_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/evaluation_store.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "evaluation-store-samples-csv-streaming"
 
 
 def test_scope_report_selects_worker_registry_probe() -> None:
@@ -190,6 +201,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "deterministic-rerank-query-context-reuse",
         "evaluation-job-id-high-water-mark",
         "evaluation-sample-probe-aggregation",
+        "evaluation-store-samples-csv-streaming",
         "job-registry-derived-model-single-pass",
         "training-dataset-token-percentiles-single-sort",
         "maintenance-bench-report-readback",
@@ -322,6 +334,7 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     rerank_metrics = _probe_deterministic_rerank_query_context_reuse(REPO_ROOT)
     evaluation_job_id_metrics = _probe_evaluation_job_id(REPO_ROOT)
     evaluation_sample_probe_metrics = _probe_evaluation_sample_probe_aggregation(REPO_ROOT)
+    evaluation_store_metrics = _probe_evaluation_store_samples_csv_streaming(REPO_ROOT)
     training_dataset_metrics = _probe_training_dataset_token_percentiles(REPO_ROOT)
 
     assert benchmark_metrics["elapsed_ms_mean"] > 0
@@ -348,6 +361,10 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     assert evaluation_sample_probe_metrics["per_call_ms_mean"] > 0
     assert evaluation_sample_probe_metrics["sample_count"] == 20000.0
     assert evaluation_sample_probe_metrics["metric_count"] == 7.0
+    assert evaluation_store_metrics["elapsed_ms_mean"] > 0
+    assert evaluation_store_metrics["peak_bytes_mean"] > 0
+    assert evaluation_store_metrics["sample_count"] == 10000.0
+    assert evaluation_store_metrics["csv_line_count"] == 10001.0
     assert training_dataset_metrics["elapsed_ms_mean"] > 0
     assert training_dataset_metrics["peak_bytes_mean"] > 0
     assert training_dataset_metrics["sample_count"] == 20000.0
@@ -537,6 +554,27 @@ def test_dispatch_probe_impl_supports_evaluation_job_id_probe() -> None:
     assert metrics["elapsed_ms_mean"] > 0
     assert metrics["per_call_ms_mean"] > 0
     assert metrics["allocation_count"] == 200.0
+
+
+def test_dispatch_probe_impl_supports_evaluation_store_probe() -> None:
+    probe = ProbeDefinition(
+        probe_id="evaluation-store-samples-csv-streaming",
+        name="Evaluation store samples CSV streaming",
+        runner="ubuntu-latest",
+        watch_globs=("services/mlx-worker-python/worker/productization/evaluation_store.py",),
+        test_command="true",
+        coverage_command="true",
+        probe_impl="evaluation_store_samples_csv_streaming",
+        probe_command='python3 -c "{}"',
+        metrics=(MetricDefinition(key="elapsed_ms_mean", unit="ms", direction="lower_is_better"),),
+    )
+
+    metrics = _dispatch_probe_impl(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["sample_count"] == 10000.0
+    assert metrics["csv_line_count"] == 10001.0
 
 
 def test_dispatch_probe_impl_supports_evaluation_sample_probe_aggregation_probe() -> None:

--- a/services/mlx-worker-python/worker/productization/evaluation_store.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_store.py
@@ -61,10 +61,7 @@ class EvaluationStore:
             jsonl_path = run_root / "evaluation-samples.jsonl"
             self._write_jsonl(jsonl_path, (sample.to_dict() for sample in samples))
             csv_path = run_root / "evaluation-samples.csv"
-            csv_path.write_text(
-                self._samples_csv(samples),
-                encoding="utf-8",
-            )
+            self._write_samples_csv(csv_path, samples)
             persisted["samples_jsonl"] = jsonl_path
             persisted["samples_csv"] = csv_path
         return persisted
@@ -121,6 +118,15 @@ class EvaluationStore:
         with path.open("w", encoding="utf-8") as handle:
             for row in rows:
                 handle.write(json.dumps(row))
+                handle.write("\n")
+
+    @staticmethod
+    def _write_samples_csv(path: Path, samples: tuple[EvaluationSample, ...]) -> None:
+        with path.open("w", encoding="utf-8") as handle:
+            handle.write(",".join(EvaluationStore._samples_csv_header()))
+            handle.write("\n")
+            for sample in samples:
+                handle.write(EvaluationStore._sample_csv_row(sample))
                 handle.write("\n")
 
     @staticmethod
@@ -283,7 +289,14 @@ class EvaluationStore:
 
     @staticmethod
     def _samples_csv(samples: tuple[EvaluationSample, ...]) -> str:
-        header = [
+        rows = [",".join(EvaluationStore._samples_csv_header())]
+        for sample in samples:
+            rows.append(EvaluationStore._sample_csv_row(sample))
+        return "\n".join(rows) + "\n"
+
+    @staticmethod
+    def _samples_csv_header() -> list[str]:
+        return [
             "id",
             "task_kind",
             "target",
@@ -317,47 +330,45 @@ class EvaluationStore:
             "extracted_result_chars",
             "failure_stage",
         ]
-        rows = [",".join(header)]
-        for sample in samples:
-            rows.append(
-                ",".join(
-                    [
-                        EvaluationStore._csv_field(sample.sample_id),
-                        EvaluationStore._csv_field(sample.task_kind),
-                        EvaluationStore._csv_field(sample.target),
-                        EvaluationStore._csv_field(sample.extracted_result),
-                        EvaluationStore._csv_field(sample.input_text),
-                        EvaluationStore._csv_field(sample.raw_response),
-                        EvaluationStore._csv_field(str(sample.typed_score)),
-                        EvaluationStore._csv_field(str(sample.time_s)),
-                        EvaluationStore._csv_field(sample.extraction_status),
-                        EvaluationStore._csv_field(sample.validation_status),
-                        EvaluationStore._csv_field(sample.failure_reason),
-                        EvaluationStore._csv_field(",".join(sample.input_modalities)),
-                        EvaluationStore._csv_field(",".join(sample.media_references)),
-                        EvaluationStore._csv_field(sample.code_language),
-                        EvaluationStore._csv_field(sample.code_entry_point),
-                        EvaluationStore._csv_field(sample.code_compile_status),
-                        EvaluationStore._csv_field(sample.code_runtime_status),
-                        EvaluationStore._csv_field(sample.code_timeout_status),
-                        EvaluationStore._csv_field(sample.code_test_status),
-                        EvaluationStore._csv_field(str(sample.code_tests_passed)),
-                        EvaluationStore._csv_field(str(sample.code_tests_total)),
-                        EvaluationStore._csv_field(sample.code_failure_detail),
-                        EvaluationStore._csv_field(sample.category_label),
-                        EvaluationStore._csv_field(sample.subject_label),
-                        EvaluationStore._csv_field(str(sample.sample_render_ms)),
-                        EvaluationStore._csv_field(str(sample.inference_ms)),
-                        EvaluationStore._csv_field(str(sample.extraction_ms)),
-                        EvaluationStore._csv_field(str(sample.validation_ms)),
-                        EvaluationStore._csv_field(str(sample.scoring_ms)),
-                        EvaluationStore._csv_field(str(sample.raw_response_chars)),
-                        EvaluationStore._csv_field(str(sample.extracted_result_chars)),
-                        EvaluationStore._csv_field(sample.failure_stage),
-                    ]
-                )
-            )
-        return "\n".join(rows) + "\n"
+
+    @staticmethod
+    def _sample_csv_row(sample: EvaluationSample) -> str:
+        return ",".join(
+            [
+                EvaluationStore._csv_field(sample.sample_id),
+                EvaluationStore._csv_field(sample.task_kind),
+                EvaluationStore._csv_field(sample.target),
+                EvaluationStore._csv_field(sample.extracted_result),
+                EvaluationStore._csv_field(sample.input_text),
+                EvaluationStore._csv_field(sample.raw_response),
+                EvaluationStore._csv_field(str(sample.typed_score)),
+                EvaluationStore._csv_field(str(sample.time_s)),
+                EvaluationStore._csv_field(sample.extraction_status),
+                EvaluationStore._csv_field(sample.validation_status),
+                EvaluationStore._csv_field(sample.failure_reason),
+                EvaluationStore._csv_field(",".join(sample.input_modalities)),
+                EvaluationStore._csv_field(",".join(sample.media_references)),
+                EvaluationStore._csv_field(sample.code_language),
+                EvaluationStore._csv_field(sample.code_entry_point),
+                EvaluationStore._csv_field(sample.code_compile_status),
+                EvaluationStore._csv_field(sample.code_runtime_status),
+                EvaluationStore._csv_field(sample.code_timeout_status),
+                EvaluationStore._csv_field(sample.code_test_status),
+                EvaluationStore._csv_field(str(sample.code_tests_passed)),
+                EvaluationStore._csv_field(str(sample.code_tests_total)),
+                EvaluationStore._csv_field(sample.code_failure_detail),
+                EvaluationStore._csv_field(sample.category_label),
+                EvaluationStore._csv_field(sample.subject_label),
+                EvaluationStore._csv_field(str(sample.sample_render_ms)),
+                EvaluationStore._csv_field(str(sample.inference_ms)),
+                EvaluationStore._csv_field(str(sample.extraction_ms)),
+                EvaluationStore._csv_field(str(sample.validation_ms)),
+                EvaluationStore._csv_field(str(sample.scoring_ms)),
+                EvaluationStore._csv_field(str(sample.raw_response_chars)),
+                EvaluationStore._csv_field(str(sample.extracted_result_chars)),
+                EvaluationStore._csv_field(sample.failure_stage),
+            ]
+        )
 
     @staticmethod
     def _csv_field(value: str) -> str:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -373,6 +373,8 @@ def _dispatch_probe_impl(*, probe: ProbeDefinition, repo_root: Path) -> dict[str
         return _probe_closure_audit(repo_root)
     if probe.probe_impl == "deterministic_rerank_query_context_reuse":
         return _probe_deterministic_rerank_query_context_reuse(repo_root)
+    if probe.probe_impl == "evaluation_store_samples_csv_streaming":
+        return _probe_evaluation_store_samples_csv_streaming(repo_root)
     if probe.probe_impl == "evaluation_sample_probe_aggregation":
         return _probe_evaluation_sample_probe_aggregation(repo_root)
     if probe.probe_impl == "evaluation_job_id":
@@ -622,6 +624,134 @@ def _probe_deterministic_rerank_query_context_reuse(repo_root: Path) -> dict[str
         "sample_count": float(sample_count),
         "tokenize_calls_mean": round(sum(tokenize_call_samples) / len(tokenize_call_samples), 6),
     }
+
+
+def _probe_evaluation_store_samples_csv_streaming(repo_root: Path) -> dict[str, float]:
+    sample_count = 10000
+    probe_script = f"""
+import gc
+import json
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+repo_root = Path({str(repo_root)!r})
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / 'services/mlx-worker-python'))
+from worker.productization.evaluation_schemas import (
+    build_evaluation_job_record,
+    build_evaluation_result_record,
+    build_evaluation_sample_record,
+)
+from worker.productization.evaluation_store import EvaluationStore
+
+sample_count = {sample_count}
+samples = tuple(
+    build_evaluation_sample_record(
+        job_id='eval-perf',
+        suite_id='mmlu',
+        dataset_id='mmlu.synthetic',
+        sample_id=f'sample-{{index:05d}}',
+        system='',
+        input_text=f'Question {{index}}?',
+        target=str(index % 5),
+        raw_response=f'Answer {{index % 5}}',
+        extracted_result=str(index % 5),
+        typed_score=1.0 if index % 2 == 0 else 0.0,
+        time_s=0.01,
+        extraction_status='extracted',
+        validation_status='validated',
+        failure_reason='',
+        task_kind='text-generation',
+        input_modalities=('text',),
+        media_references=(),
+        raw_response_chars=0 if index % 19 == 0 else len(f'Answer {{index % 5}}'),
+        extracted_result_chars=0 if index % 23 == 0 else len(str(index % 5)),
+    )
+    for index in range(sample_count)
+)
+job = build_evaluation_job_record(
+    job_id='eval-perf',
+    model_id='melix-dev-text',
+    task_kind='text-generation',
+    source_repo='synthetic',
+    suite_id='mmlu',
+    dataset_id='mmlu.synthetic',
+    sample_size=sample_count,
+    scoring_mode='deterministic_accuracy',
+    few_shot=0,
+    seed=7,
+    code_exec_policy='sandboxed',
+    parameters={{}},
+    status='completed',
+    output_dir='',
+    created_at_unix_ms=101,
+    updated_at_unix_ms=202,
+)
+result = build_evaluation_result_record(
+    job_id='eval-perf',
+    suite_id='mmlu',
+    dataset_id='mmlu.synthetic',
+    sample_size=sample_count,
+    primary_score_name='normalized_exact_match',
+    primary_score_value=0.5,
+    extraction_success_count=sample_count,
+    validation_success_count=sample_count,
+    scored_sample_count=sample_count,
+    failure_count=0,
+    duration_seconds=0.25,
+    metrics={{'eval.mmlu.accuracy': 0.5}},
+    report_path='',
+    units={{'eval.mmlu.accuracy': 'ratio'}},
+)
+store = EvaluationStore()
+elapsed_samples = []
+peak_samples = []
+csv_line_count = 0
+for _ in range(3):
+    with tempfile.TemporaryDirectory(prefix='melix-pr-perf-eval-store-') as temp_dir:
+        jobs_root = Path(temp_dir) / 'evaluation'
+        gc.collect()
+        tracemalloc.start()
+        started = time.perf_counter()
+        persisted = store.persist_result(
+            jobs_root=jobs_root,
+            job=job,
+            result=result,
+            samples=samples,
+        )
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        peak_samples.append(float(peak_bytes))
+        tracemalloc.stop()
+        csv_line_count = float(len(persisted['samples_csv'].read_text(encoding='utf-8').splitlines()))
+        if csv_line_count != float(sample_count + 1):
+            raise ValueError(f'unexpected evaluation samples CSV line count: {{csv_line_count}}')
+print(json.dumps({{
+    'elapsed_ms_mean': round(sum(elapsed_samples) / len(elapsed_samples), 6),
+    'peak_bytes_mean': round(sum(peak_samples) / len(peak_samples), 1),
+    'sample_count': float(sample_count),
+    'csv_line_count': float(csv_line_count),
+}}, sort_keys=True))
+"""
+    completed = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--project",
+            str(repo_root / "services/mlx-worker-python"),
+            "python3",
+            "-c",
+            probe_script,
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads((completed.stdout or "").strip())
 
 
 def _probe_evaluation_sample_probe_aggregation(repo_root: Path) -> dict[str, float]:


### PR DESCRIPTION
## Summary
- stream `evaluation-samples.csv` writes in `EvaluationStore.persist_result(...)` instead of building one giant CSV string in memory before writing
- keep the existing sample CSV schema and quoting behavior while refactoring the row/header assembly into reusable helpers
- register a new `evaluation-store-samples-csv-streaming` PR-scoped performance probe and add focused tests for the streamed writer plus probe wiring

## Plan or Spec
- `docs/plans/2026-05-02-evaluation-store-samples-csv-streaming.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe
- 15 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
- 15 passed
- changed-scope coverage: TOTAL 80 1 99%

git diff --check
- clean

Local base-vs-head probe via `_probe_evaluation_store_samples_csv_streaming(...)`
- base: {"elapsed_ms_mean": 1542.897877, "peak_bytes_mean": 4431263.0, "sample_count": 10000.0, "csv_line_count": 10001.0}
- head: {"elapsed_ms_mean": 1544.750556, "peak_bytes_mean": 43098.7, "sample_count": 10000.0, "csv_line_count": 10001.0}
```

## Coverage and Metrics
- Changed-scope coverage: `99%` (`79/80` measured changed executable lines covered; 1 missed line in a focused test file)
- Registered scoped CI probe: `evaluation-store-samples-csv-streaming`
- Local probe interpretation:
  - peak traced allocation dropped from `4,431,263` bytes on `origin/main` to `43,098.7` bytes on this branch (~`99.03%` lower, ~`4.39 MB` less)
  - elapsed time was effectively flat/slightly slower locally (`1542.897877 ms` -> `1544.750556 ms`, ~`0.12%` slower) while preserving the same `10001` CSV line count for `10000` samples
- Targeted verification only; no full-repo `make py-test` / `make integration-test` run in this Linux cron slice

## Known Gaps
- This cron run verified only the touched Python scope plus the new scoped probe wiring, not the full repository test matrix.
- Because this change touches the PR-scoped performance registry/harness, the GitHub `pr-scoped-performance` workflow will run the full selected matrix before merge; auto-merge should only be enabled after that CI is green.
- The local host is Linux, so no macOS/Swift-only verification was attempted.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
