### PR TITLE
perf: coalesce evaluation sample writes

### DIFF
--- a/docs/plans/2026-05-02-evaluation-store-row-write-coalescing.md
+++ b/docs/plans/2026-05-02-evaluation-store-row-write-coalescing.md
@@ -1,0 +1,34 @@
+# Evaluation store row write coalescing performance slice
+
+## Goal
+
+Reduce per-row write overhead in the Python evaluation store sample artifact path without changing the persisted JSONL or CSV payloads.
+
+## Scope
+
+This slice is limited to:
+
+- `services/mlx-worker-python/worker/productization/evaluation_store.py`
+- `services/mlx-worker-python/tests/test_evaluation_store.py`
+- the registered PR-scoped probe coverage already defined for `evaluation-store-samples-csv-streaming`
+
+## Registered probe
+
+The affected path is covered by `evaluation-store-samples-csv-streaming` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries and measures:
+
+- `elapsed_ms_mean` for persisting 10,000 evaluation samples
+- `peak_bytes_mean` during the same persist operation
+
+## Implementation plan
+
+1. Preserve streaming semantics and output bytes for JSONL and CSV sample artifacts.
+2. Coalesce each row and newline into one `write()` call in `_write_jsonl()` and `_write_samples_csv()` so the store performs one write per row rather than two.
+3. Bind hot-loop writer and CSV-field formatter callables once per function call to avoid repeated attribute lookups while preserving row formatting semantics.
+4. Update focused unit assertions to prove payload parity and reduced write-call shape.
+5. Validate with the registered focused test command, coverage command, and local registered probe before pushing.
+
+## Success criteria
+
+- Persisted artifact content remains byte-for-byte identical for the covered cases.
+- Changed-scope coverage remains at least 95%.
+- The registered `evaluation-store-samples-csv-streaming` probe shows a clear `elapsed_ms_mean` improvement or a non-regressive result with lower per-row write overhead.

--- a/services/mlx-worker-python/tests/test_evaluation_store.py
+++ b/services/mlx-worker-python/tests/test_evaluation_store.py
@@ -52,7 +52,7 @@ def test_write_jsonl_streams_rows_without_building_one_giant_payload(monkeypatch
 
     expected_payload = "".join(json.dumps(row) + "\n" for row in rows)
     assert "".join(writes) == expected_payload
-    assert writes == [json.dumps(rows[0]), "\n", json.dumps(rows[1]), "\n"]
+    assert writes == [json.dumps(rows[0]) + "\n", json.dumps(rows[1]) + "\n"]
 
 
 def test_write_samples_csv_streams_rows_without_building_one_giant_payload(monkeypatch) -> None:
@@ -100,10 +100,11 @@ def test_write_samples_csv_streams_rows_without_building_one_giant_payload(monke
 
     expected_payload = EvaluationStore._samples_csv((sample,))
     assert "".join(writes) == expected_payload
+    assert len(writes) == 2
     assert writes[0].startswith("id,task_kind,target,extracted_result")
-    assert writes[1] == "\n"
-    assert writes[2].startswith("sample-1,text-generation,Answer,result,Question?,response,1.0,0.01")
-    assert writes[3] == "\n"
+    assert writes[0].endswith("\n")
+    assert writes[1].startswith("sample-1,text-generation,Answer,result,Question?,response,1.0,0.01")
+    assert writes[1].endswith("\n")
 
 
 def test_persist_result_writes_expected_artifact_names_and_payloads(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/productization/evaluation_store.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_store.py
@@ -116,18 +116,19 @@ class EvaluationStore:
     @staticmethod
     def _write_jsonl(path: Path, rows: Iterable[object]) -> None:
         with path.open("w", encoding="utf-8") as handle:
+            write = handle.write
+            dumps = json.dumps
             for row in rows:
-                handle.write(json.dumps(row))
-                handle.write("\n")
+                write(dumps(row) + "\n")
 
     @staticmethod
     def _write_samples_csv(path: Path, samples: tuple[EvaluationSample, ...]) -> None:
         with path.open("w", encoding="utf-8") as handle:
-            handle.write(",".join(EvaluationStore._samples_csv_header()))
-            handle.write("\n")
+            write = handle.write
+            sample_csv_row = EvaluationStore._sample_csv_row
+            write(",".join(EvaluationStore._samples_csv_header()) + "\n")
             for sample in samples:
-                handle.write(EvaluationStore._sample_csv_row(sample))
-                handle.write("\n")
+                write(sample_csv_row(sample) + "\n")
 
     @staticmethod
     def _summary_payload(*, job: EvaluationJob, result: EvaluationResult) -> dict[str, object]:
@@ -333,40 +334,41 @@ class EvaluationStore:
 
     @staticmethod
     def _sample_csv_row(sample: EvaluationSample) -> str:
+        csv_field = EvaluationStore._csv_field
         return ",".join(
             [
-                EvaluationStore._csv_field(sample.sample_id),
-                EvaluationStore._csv_field(sample.task_kind),
-                EvaluationStore._csv_field(sample.target),
-                EvaluationStore._csv_field(sample.extracted_result),
-                EvaluationStore._csv_field(sample.input_text),
-                EvaluationStore._csv_field(sample.raw_response),
-                EvaluationStore._csv_field(str(sample.typed_score)),
-                EvaluationStore._csv_field(str(sample.time_s)),
-                EvaluationStore._csv_field(sample.extraction_status),
-                EvaluationStore._csv_field(sample.validation_status),
-                EvaluationStore._csv_field(sample.failure_reason),
-                EvaluationStore._csv_field(",".join(sample.input_modalities)),
-                EvaluationStore._csv_field(",".join(sample.media_references)),
-                EvaluationStore._csv_field(sample.code_language),
-                EvaluationStore._csv_field(sample.code_entry_point),
-                EvaluationStore._csv_field(sample.code_compile_status),
-                EvaluationStore._csv_field(sample.code_runtime_status),
-                EvaluationStore._csv_field(sample.code_timeout_status),
-                EvaluationStore._csv_field(sample.code_test_status),
-                EvaluationStore._csv_field(str(sample.code_tests_passed)),
-                EvaluationStore._csv_field(str(sample.code_tests_total)),
-                EvaluationStore._csv_field(sample.code_failure_detail),
-                EvaluationStore._csv_field(sample.category_label),
-                EvaluationStore._csv_field(sample.subject_label),
-                EvaluationStore._csv_field(str(sample.sample_render_ms)),
-                EvaluationStore._csv_field(str(sample.inference_ms)),
-                EvaluationStore._csv_field(str(sample.extraction_ms)),
-                EvaluationStore._csv_field(str(sample.validation_ms)),
-                EvaluationStore._csv_field(str(sample.scoring_ms)),
-                EvaluationStore._csv_field(str(sample.raw_response_chars)),
-                EvaluationStore._csv_field(str(sample.extracted_result_chars)),
-                EvaluationStore._csv_field(sample.failure_stage),
+                csv_field(sample.sample_id),
+                csv_field(sample.task_kind),
+                csv_field(sample.target),
+                csv_field(sample.extracted_result),
+                csv_field(sample.input_text),
+                csv_field(sample.raw_response),
+                csv_field(str(sample.typed_score)),
+                csv_field(str(sample.time_s)),
+                csv_field(sample.extraction_status),
+                csv_field(sample.validation_status),
+                csv_field(sample.failure_reason),
+                csv_field(",".join(sample.input_modalities)),
+                csv_field(",".join(sample.media_references)),
+                csv_field(sample.code_language),
+                csv_field(sample.code_entry_point),
+                csv_field(sample.code_compile_status),
+                csv_field(sample.code_runtime_status),
+                csv_field(sample.code_timeout_status),
+                csv_field(sample.code_test_status),
+                csv_field(str(sample.code_tests_passed)),
+                csv_field(str(sample.code_tests_total)),
+                csv_field(sample.code_failure_detail),
+                csv_field(sample.category_label),
+                csv_field(sample.subject_label),
+                csv_field(str(sample.sample_render_ms)),
+                csv_field(str(sample.inference_ms)),
+                csv_field(str(sample.extraction_ms)),
+                csv_field(str(sample.validation_ms)),
+                csv_field(str(sample.scoring_ms)),
+                csv_field(str(sample.raw_response_chars)),
+                csv_field(str(sample.extracted_result_chars)),
+                csv_field(sample.failure_stage),
             ]
         )
 


### PR DESCRIPTION
## Summary
- Coalesce evaluation sample JSONL/CSV row writes so each row and newline are emitted with a single write call.
- Bind hot-loop writer and CSV-field formatter callables once per persistence call to reduce repeated attribute lookup overhead.
- Update focused tests to preserve artifact payload parity while asserting the reduced write-call shape.

## Plan or Spec
- `docs/plans/2026-05-02-evaluation-store-row-write-coalescing.md`
- Registered probe: `evaluation-store-samples-csv-streaming` in `infra/perf/pr_scoped_probes.json` (includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# Baseline local registered probe equivalent on origin/main worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/run_eval_store_probe.py
# exit 0; samples included elapsed_ms_mean=1466.608650 and 1486.609553 in preliminary baseline runs

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe
# exit 0; 15 passed in 14.29s

# Focused coverage / changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; TOTAL 13 0 100%

# Registered PR-scoped probe runner comparing origin/main base worktree to this branch
uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-store-samples-csv-streaming --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-eval-store-rowwrite-20260502035413 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-20260502035041 --output .runtime/evaluation-store-rowwrite-pr-probe.json
# exit 0; base elapsed_ms_mean=1496.104102, head elapsed_ms_mean=1409.944391

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Local registered probe (`evaluation-store-samples-csv-streaming`) from `scripts/pr_scoped_performance_run.py`:
  - `elapsed_ms_mean`: base `1496.104102 ms`, head `1409.944391 ms`, delta `-86.159711 ms`, improvement `5.759%`, speedup `1.0611x`.
  - `peak_bytes_mean`: base `43098.7`, head `42742.3`, delta `-356.4 bytes`, improvement `0.827%`.
  - `csv_line_count`: `10001.0` for both base and head.
- CI must rerun the registered PR-scoped performance workflow before merge.

## Known Gaps
- Linux-local validation covers the Python evaluation store path only. No Swift runtime path is changed.
- The registered CI probe remains the merge gate for hosted PR evidence.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
