### PR TITLE
perf(download): guard directory size file stats

### DIFF
--- a/docs/plans/2026-05-01-download-directory-size-single-stat.md
+++ b/docs/plans/2026-05-01-download-directory-size-single-stat.md
@@ -29,9 +29,12 @@ Metrics:
 ## Implementation plan
 
 1. Preserve the explicit `os.scandir()` stack and non-recursive traversal shape.
-2. Keep `DirEntry.is_dir(follow_symlinks=False)` as the directory fast path, then replace the file branch's `is_file()` + `stat()` pair with one `DirEntry.stat(follow_symlinks=False)` and `stat.S_ISREG` classification.
+2. Use `DirEntry.is_dir(follow_symlinks=False)` as the directory fast path and `DirEntry.is_file(follow_symlinks=False)` before reading file size so Linux directory entries that can answer from `d_type` avoid unnecessary stat calls for non-file entries.
 3. Keep directory symlinks and file symlinks out of the size calculation, matching the non-following traversal contract.
-4. Validate with focused tests, changed-scope coverage, and the registered probe locally on Linux before pushing.
+4. Bind the hot-loop stack and scandir helpers once per call so the synthetic directory-size probe measures less repeated attribute lookup while keeping the same traversal shape.
+5. Validate with focused tests, changed-scope coverage, and the registered probe locally on Linux before pushing.
+
+Deviation note: the earlier single-`stat()` branch was semantically correct, but local Linux probe runs showed the `is_file()` guard is faster for the registered synthetic workload because regular directory entries can be classified before their size stat is needed.
 
 ## Success criteria
 

--- a/services/mlx-worker-python/worker/model_ops/download_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/download_pipeline.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-import stat
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -454,16 +453,18 @@ class DownloadPipeline:
     def _directory_size(path: Path) -> int:
         total_bytes = 0
         stack = [os.fspath(path)]
+        append_directory = stack.append
+        pop_directory = stack.pop
+        scandir = os.scandir
         while stack:
-            current = stack.pop()
-            with os.scandir(current) as entries:
+            current = pop_directory()
+            with scandir(current) as entries:
                 for entry in entries:
                     if entry.is_dir(follow_symlinks=False):
-                        stack.append(entry.path)
+                        append_directory(entry.path)
                         continue
-                    entry_stat = entry.stat(follow_symlinks=False)
-                    if stat.S_ISREG(entry_stat.st_mode):
-                        total_bytes += entry_stat.st_size
+                    if entry.is_file(follow_symlinks=False):
+                        total_bytes += entry.stat(follow_symlinks=False).st_size
         return total_bytes
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Optimizes `DownloadPipeline._directory_size()` by keeping the explicit `os.scandir()` stack while using `DirEntry.is_file(follow_symlinks=False)` before taking the size stat.
- Keeps symlinked files and directories out of the managed snapshot byte total, matching the non-following traversal contract.

## Plan or Spec
- `docs/plans/2026-05-01-download-directory-size-single-stat.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_download_pipeline_unit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_download_pipeline_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 8 passed in 0.10s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_download_pipeline_unit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_download_pipeline_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/download_pipeline.py services/mlx-worker-python/tests/test_download_pipeline_unit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; 8 passed in 0.25s; changed-scope coverage 100.00%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
# registered probe body from infra/perf/pr_scoped_probes.json for download-pipeline-directory-size-single-stat
PY
# exit 0; current elapsed_ms_mean=18.900422, elapsed_ms_min=18.457168

# Baseline comparison from /root/.hermes/profiles/coder/workspace/worktrees/melix-base-download-dirsize-bindings-20260502042000
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
# same registered probe body against baseline
PY
# exit 0; baseline elapsed_ms_mean=20.214606, elapsed_ms_min=19.835875

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% for `services/mlx-worker-python/worker/model_ops/download_pipeline.py`, `services/mlx-worker-python/tests/test_download_pipeline_unit.py`, and `services/mlx-worker-python/tests/test_pr_scoped_performance.py`.
- Registered probe: `download-pipeline-directory-size-single-stat` in `infra/perf/pr_scoped_probes.json`.
- Local Linux probe comparison: old_mean=20.214606 ms, new_mean=18.900422 ms, delta=-1.314184 ms, speedup=1.069532x, improvement=6.501%.
- Local Linux min comparison: old_min=19.835875 ms, new_min=18.457168 ms, delta=-1.378707 ms, improvement=6.951%.
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- Full repository `make py-test` was not run locally; this slice used the registered focused test, coverage, and probe commands.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
