### PR TITLE
perf(eval): stream compare summary csv writes

### DIFF
--- a/docs/plans/2026-05-02-evaluation-compare-summary-csv-streaming.md
+++ b/docs/plans/2026-05-02-evaluation-compare-summary-csv-streaming.md
@@ -1,0 +1,70 @@
+# Evaluation compare summary CSV streaming
+
+## Goal
+
+Reduce peak memory in `EvaluationStore.persist_compare_result(...)` by streaming `evaluation-compare-summary.csv` rows directly to disk instead of building one giant CSV string in memory.
+
+## Linux-only constraint
+
+This cron run happens on Linux, so the slice must stay inside the Python worker and use Linux-verifiable tests, coverage, and local performance probes.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/productization/evaluation_store.py`
+- `services/mlx-worker-python/tests/test_evaluation_store.py`
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Task
+
+1. Add a streamed compare-summary CSV writer for `persist_compare_result(...)`.
+2. Preserve the exact CSV header, row ordering, quoting, and adapter-lineage column behavior.
+3. Add focused tests proving the persistence path does not fall back to `_compare_summary_csv(...)` and that the streaming writer emits the same bytes as the legacy builder.
+4. Register a dedicated PR-scoped performance probe for the compare-summary path so CI measures the actual optimization path.
+
+## Performance probe
+
+- **Probe ID:** `evaluation-store-compare-summary-csv-streaming`
+- **Path measured:** `EvaluationStore._write_compare_summary_csv(...)`
+- **Synthetic workload:** write a compare-summary CSV for thousands of target summaries through the dedicated streaming writer, without sample-row persistence.
+- **Metrics:**
+  - `peak_bytes_mean` — primary metric, lower is better
+  - `elapsed_ms_mean` — secondary metric, lower is better
+  - `summary_count` and `csv_line_count` — correctness guard rails
+
+## Success metrics
+
+- Lower `peak_bytes_mean` versus `origin/main` on the dedicated compare-summary probe.
+- No change to emitted CSV contents.
+- Changed-scope automated coverage at or above 95% for the touched executable scope.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_evaluation_store.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_compare_summary_probe
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_evaluation_store.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_compare_summary_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/productization/evaluation_store.py \
+  services/mlx-worker-python/worker/productization/pr_scoped_performance.py \
+  services/mlx-worker-python/tests/test_evaluation_store.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_evaluation_store_compare_summary_csv_streaming as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
+
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -178,6 +178,37 @@
     ]
   },
   {
+    "id": "evaluation-store-compare-summary-csv-streaming",
+    "name": "Evaluation store compare summary CSV streaming",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/evaluation_store.py",
+      "services/mlx-worker-python/tests/test_evaluation_store.py",
+      "services/mlx-worker-python/worker/productization/pr_scoped_performance.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_store.py::test_write_compare_summary_csv_streams_rows_without_building_one_giant_payload services/mlx-worker-python/tests/test_evaluation_store.py::test_persist_compare_result_streams_compare_summary_csv_without_calling_legacy_builder services/mlx-worker-python/tests/test_evaluation_store.py::test_persist_compare_result_writes_expected_compare_artifact_names_and_payloads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_compare_summary_probe",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_store.py::test_write_compare_summary_csv_streams_rows_without_building_one_giant_payload services/mlx-worker-python/tests/test_evaluation_store.py::test_persist_compare_result_streams_compare_summary_csv_without_calling_legacy_builder services/mlx-worker-python/tests/test_evaluation_store.py::test_persist_compare_result_writes_expected_compare_artifact_names_and_payloads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_compare_summary_probe && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c \"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_evaluation_store_compare_summary_csv_streaming as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))\"",
+    "probe_impl": "evaluation_store_compare_summary_csv_streaming",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "evaluation-store-samples-csv-streaming",
     "name": "Evaluation store samples CSV streaming",
     "runner": "ubuntu-latest",
@@ -188,8 +219,8 @@
       "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
       "scripts/changed_scope_coverage.py"
     ],
-    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe",
-    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_store.py::test_write_jsonl_streams_rows_without_building_one_giant_payload services/mlx-worker-python/tests/test_evaluation_store.py::test_write_samples_csv_streams_rows_without_building_one_giant_payload services/mlx-worker-python/tests/test_evaluation_store.py::test_persist_result_streams_samples_csv_without_calling_samples_csv_builder services/mlx-worker-python/tests/test_evaluation_store.py::test_samples_csv_quotes_fields_with_commas_newlines_and_quotes services/mlx-worker-python/tests/test_evaluation_store.py::test_samples_csv_preserves_explicit_zero_char_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_store.py::test_write_jsonl_streams_rows_without_building_one_giant_payload services/mlx-worker-python/tests/test_evaluation_store.py::test_write_samples_csv_streams_rows_without_building_one_giant_payload services/mlx-worker-python/tests/test_evaluation_store.py::test_persist_result_streams_samples_csv_without_calling_samples_csv_builder services/mlx-worker-python/tests/test_evaluation_store.py::test_samples_csv_quotes_fields_with_commas_newlines_and_quotes services/mlx-worker-python/tests/test_evaluation_store.py::test_samples_csv_preserves_explicit_zero_char_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
     "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c \"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_evaluation_store_samples_csv_streaming as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))\"",
     "probe_impl": "evaluation_store_samples_csv_streaming",
     "coverage_replays_tests": true,

--- a/services/mlx-worker-python/tests/test_evaluation_store.py
+++ b/services/mlx-worker-python/tests/test_evaluation_store.py
@@ -448,6 +448,231 @@ def test_persist_result_exports_code_execution_evidence_fields(tmp_path: Path) -
     )
 
 
+def test_write_compare_summary_csv_streams_rows_without_building_one_giant_payload(monkeypatch) -> None:
+    writes: list[str] = []
+
+    class FakeFile:
+        def write(self, chunk: str) -> int:
+            writes.append(chunk)
+            return len(chunk)
+
+        def __enter__(self) -> FakeFile:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+            return None
+
+    target_path = Path("/tmp/evaluation-compare-summary.csv")
+
+    def fake_open(self: Path, mode: str = "r", encoding: str | None = None) -> FakeFile:
+        assert self == target_path
+        assert mode == "w"
+        assert encoding == "utf-8"
+        return FakeFile()
+
+    monkeypatch.setattr(Path, "open", fake_open)
+    compare_job = build_evaluation_compare_job_record(
+        job_id="eval-compare-1",
+        base_model_id="melix-dev-text",
+        target_model_ids=("melix-dev-text-lora-a", "melix-dev-text-lora-b,quoted"),
+        task_kind="text-generation",
+        source_repo="HuggingFaceH4/ultrachat_200k",
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_size=2,
+        scoring_mode="multiple_choice_accuracy",
+        parameters={"compare_mode": "base_vs_targets"},
+        status="completed",
+        output_dir="",
+        created_at_unix_ms=101,
+        updated_at_unix_ms=202,
+        target_lineage=(
+            EvaluationCompareTargetLineage(
+                target_model_id="melix-dev-text-lora-b,quoted",
+                materialization_kind="ephemeral_adapter",
+                adapter_manifest_path='adapters/manifest"beta".json',
+                adapter_set_hash="hash,lineage",
+            ),
+        ),
+    )
+    summaries = (
+        build_evaluation_compare_summary_record(
+            job_id="eval-compare-1",
+            base_model_id="melix-dev-text",
+            target_model_id="melix-dev-text-lora-a",
+            suite_id="mmlu",
+            dataset_id="mmlu-dev",
+            sample_size=2,
+            scoring_mode="multiple_choice_accuracy",
+            win_count=1,
+            loss_count=0,
+            tie_count=1,
+            regression_count=0,
+            base_accuracy=0.5,
+            target_accuracy=1.0,
+            delta_accuracy=0.5,
+            effect_threshold=0.1,
+            verdict="improvement",
+            category_breakdown={},
+            statistical_evidence={
+                "bootstrap": {"lower_bound": 0.15, "upper_bound": 0.8},
+                "analytical": {"lower_bound": 0.12, "upper_bound": 0.88},
+            },
+            release_gate_summary={},
+            duration_seconds=0.25,
+            metrics={},
+            report_path="",
+        ),
+        build_evaluation_compare_summary_record(
+            job_id="eval-compare-1",
+            base_model_id="melix-dev-text",
+            target_model_id="melix-dev-text-lora-b,quoted",
+            suite_id="mmlu",
+            dataset_id="mmlu-dev",
+            sample_size=2,
+            scoring_mode="multiple_choice_accuracy",
+            win_count=0,
+            loss_count=1,
+            tie_count=1,
+            regression_count=1,
+            base_accuracy=1.0,
+            target_accuracy=0.5,
+            delta_accuracy=-0.5,
+            effect_threshold=0.1,
+            verdict='regression "needs review"',
+            category_breakdown={},
+            statistical_evidence={
+                "bootstrap": {"lower_bound": -0.8, "upper_bound": -0.15},
+                "analytical": {"lower_bound": -0.88, "upper_bound": -0.12},
+            },
+            release_gate_summary={},
+            duration_seconds=0.5,
+            metrics={},
+            report_path="",
+        ),
+    )
+
+    EvaluationStore._write_compare_summary_csv(target_path, job=compare_job, summaries=summaries)
+
+    expected_payload = EvaluationStore._compare_summary_csv(job=compare_job, summaries=summaries)
+    assert "".join(writes) == expected_payload
+    assert len(writes) == 3
+    assert writes[0].startswith("job_id,base_model_id,target_model_id")
+    assert writes[1].endswith(",,\n")
+    assert '"melix-dev-text-lora-b,quoted"' in writes[2]
+    assert '"regression ""needs review"""' in writes[2]
+    assert '"adapters/manifest""beta"".json"' in writes[2]
+    assert '"hash,lineage"' in writes[2]
+
+
+
+def test_persist_compare_result_streams_compare_summary_csv_without_calling_legacy_builder(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = EvaluationStore()
+    jobs_root = tmp_path / "evaluation"
+    run_root = jobs_root / "runs" / "eval-compare-stream"
+    compare_job = build_evaluation_compare_job_record(
+        job_id="eval-compare-stream",
+        base_model_id="melix-dev-text",
+        target_model_ids=("melix-dev-text-lora-a",),
+        task_kind="text-generation",
+        source_repo="HuggingFaceH4/ultrachat_200k",
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_size=1,
+        scoring_mode="multiple_choice_accuracy",
+        parameters={"compare_mode": "base_vs_targets"},
+        status="completed",
+        output_dir=str(run_root),
+        created_at_unix_ms=101,
+        updated_at_unix_ms=202,
+        target_lineage=(
+            EvaluationCompareTargetLineage(
+                target_model_id="melix-dev-text-lora-a",
+                materialization_kind="ephemeral_adapter",
+                adapter_manifest_path="adapters/a.json",
+                adapter_set_hash="hash-a",
+            ),
+        ),
+    )
+    compare_summary = build_evaluation_compare_summary_record(
+        job_id="eval-compare-stream",
+        base_model_id="melix-dev-text",
+        target_model_id="melix-dev-text-lora-a",
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_size=1,
+        scoring_mode="multiple_choice_accuracy",
+        win_count=1,
+        loss_count=0,
+        tie_count=0,
+        regression_count=0,
+        base_accuracy=0.0,
+        target_accuracy=1.0,
+        delta_accuracy=1.0,
+        effect_threshold=0.1,
+        verdict="improvement",
+        category_breakdown={},
+        statistical_evidence={
+            "bootstrap": {"lower_bound": 1.0, "upper_bound": 1.0},
+            "analytical": {"lower_bound": 1.0, "upper_bound": 1.0},
+        },
+        release_gate_summary={},
+        duration_seconds=0.25,
+        metrics={},
+        report_path=str(run_root / "evaluation-compare-report.md"),
+    )
+    compare_sample = build_evaluation_compare_sample_record(
+        job_id="eval-compare-stream",
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_id="sample-1",
+        target_model_id="melix-dev-text-lora-a",
+        input_text="2+2?",
+        target="4",
+        base_extracted_result="4",
+        target_extracted_result="4",
+        base_raw_response="Answer: 4",
+        target_raw_response="Answer: 4",
+        base_typed_score=1.0,
+        target_typed_score=1.0,
+        outcome="score_tie",
+        regression_kind="",
+        base_time_s=0.01,
+        target_time_s=0.02,
+        base_extraction_status="extracted",
+        target_extraction_status="extracted",
+        base_validation_status="validated",
+        target_validation_status="validated",
+        base_failure_reason="",
+        target_failure_reason="",
+        base_parse_status="parsed_answer_prefix",
+        target_parse_status="parsed_answer_prefix",
+        category_label="math",
+        subject_label="algebra",
+    )
+    expected_csv = EvaluationStore._compare_summary_csv(job=compare_job, summaries=(compare_summary,))
+
+    def fail_compare_summary_csv(*, job: object, summaries: tuple[object, ...]) -> str:
+        raise AssertionError(
+            "persist_compare_result should stream compare summary CSV instead of calling _compare_summary_csv"
+        )
+
+    monkeypatch.setattr(EvaluationStore, "_compare_summary_csv", staticmethod(fail_compare_summary_csv))
+
+    persisted = store.persist_compare_result(
+        jobs_root=jobs_root,
+        job=compare_job,
+        summaries=(compare_summary,),
+        samples=(compare_sample,),
+    )
+
+    assert persisted["summary_csv"].read_text(encoding="utf-8") == expected_csv
+
+
+
 def test_persist_compare_result_writes_expected_compare_artifact_names_and_payloads(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -35,6 +35,7 @@ from worker.productization.pr_scoped_performance import (
     _probe_deterministic_rerank_query_context_reuse,
     _probe_evaluation_job_id,
     _probe_evaluation_sample_probe_aggregation,
+    _probe_evaluation_store_compare_summary_csv_streaming,
     _probe_evaluation_store_samples_csv_streaming,
     _probe_training_dataset_token_percentiles,
     _probe_command_json,
@@ -110,8 +111,12 @@ def test_scope_report_selects_evaluation_store_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/productization/evaluation_store.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "evaluation-store-samples-csv-streaming"
+    probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert scope["selected_count"] == 2
+    assert probe_ids == {
+        "evaluation-store-compare-summary-csv-streaming",
+        "evaluation-store-samples-csv-streaming",
+    }
 
 
 def test_scope_report_selects_worker_registry_probe() -> None:
@@ -223,6 +228,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "deterministic-rerank-query-context-reuse",
         "evaluation-job-id-high-water-mark",
         "evaluation-sample-probe-aggregation",
+        "evaluation-store-compare-summary-csv-streaming",
         "evaluation-store-samples-csv-streaming",
         "job-registry-derived-model-single-pass",
         "training-dataset-token-percentiles-single-sort",
@@ -357,6 +363,7 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     rerank_metrics = _probe_deterministic_rerank_query_context_reuse(REPO_ROOT)
     evaluation_job_id_metrics = _probe_evaluation_job_id(REPO_ROOT)
     evaluation_sample_probe_metrics = _probe_evaluation_sample_probe_aggregation(REPO_ROOT)
+    evaluation_store_compare_summary_metrics = _probe_evaluation_store_compare_summary_csv_streaming(REPO_ROOT)
     evaluation_store_metrics = _probe_evaluation_store_samples_csv_streaming(REPO_ROOT)
     training_dataset_metrics = _probe_training_dataset_token_percentiles(REPO_ROOT)
 
@@ -384,6 +391,11 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     assert evaluation_sample_probe_metrics["per_call_ms_mean"] > 0
     assert evaluation_sample_probe_metrics["sample_count"] == 20000.0
     assert evaluation_sample_probe_metrics["metric_count"] == 7.0
+    assert evaluation_store_compare_summary_metrics["elapsed_ms_mean"] > 0
+    assert evaluation_store_compare_summary_metrics["peak_bytes_mean"] > 0
+    assert evaluation_store_compare_summary_metrics["summary_count"] == 10000.0
+    assert evaluation_store_compare_summary_metrics["csv_line_count"] == 10001.0
+    assert evaluation_store_compare_summary_metrics["csv_bytes"] > 0
     assert evaluation_store_metrics["elapsed_ms_mean"] > 0
     assert evaluation_store_metrics["peak_bytes_mean"] > 0
     assert evaluation_store_metrics["sample_count"] == 10000.0
@@ -393,6 +405,49 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     assert training_dataset_metrics["sample_count"] == 20000.0
     assert training_dataset_metrics["duplicate_count"] > 0
     assert training_dataset_metrics["dirty_count"] > 0
+
+
+def test_probe_evaluation_store_compare_summary_csv_streaming_targets_direct_writer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_command: list[str] = []
+
+    class FakeCompletedProcess:
+        def __init__(self) -> None:
+            self.stdout = json.dumps(
+                {
+                    "elapsed_ms_mean": 1.25,
+                    "peak_bytes_mean": 2048.0,
+                    "summary_count": 10000.0,
+                    "csv_line_count": 10001.0,
+                    "csv_bytes": 4096.0,
+                },
+                sort_keys=True,
+            )
+
+    def fake_run(command: list[str], **kwargs: object) -> FakeCompletedProcess:
+        del kwargs
+        captured_command.extend(command)
+        return FakeCompletedProcess()
+
+    monkeypatch.setattr(pr_scoped_performance_module.subprocess, "run", fake_run)
+
+    metrics = _probe_evaluation_store_compare_summary_csv_streaming(REPO_ROOT)
+
+    assert metrics["csv_bytes"] == 4096.0
+    assert captured_command[:6] == [
+        "uv",
+        "run",
+        "--project",
+        str(REPO_ROOT / "services/mlx-worker-python"),
+        "python3",
+        "-c",
+    ]
+    probe_script = captured_command[6]
+    assert "writer(summary_csv_path, job=job, summaries=summaries)" in probe_script
+    assert "writer = getattr(store, '_write_compare_summary_csv', None)" in probe_script
+    assert "store._compare_summary_csv(job=job, summaries=summaries)" in probe_script
+    assert "persist_compare_result(" not in probe_script
 
 
 def test_dispatch_probe_impl_supports_deterministic_rerank_probe() -> None:
@@ -589,6 +644,28 @@ def test_dispatch_probe_impl_supports_evaluation_job_id_probe() -> None:
     assert metrics["elapsed_ms_mean"] > 0
     assert metrics["per_call_ms_mean"] > 0
     assert metrics["allocation_count"] == 200.0
+
+
+def test_dispatch_probe_impl_supports_evaluation_store_compare_summary_probe() -> None:
+    probe = ProbeDefinition(
+        probe_id="evaluation-store-compare-summary-csv-streaming",
+        name="Evaluation store compare summary CSV streaming",
+        runner="ubuntu-latest",
+        watch_globs=("services/mlx-worker-python/worker/productization/evaluation_store.py",),
+        test_command="true",
+        coverage_command="true",
+        probe_impl="evaluation_store_compare_summary_csv_streaming",
+        probe_command='python3 -c "{}"',
+        metrics=(MetricDefinition(key="elapsed_ms_mean", unit="ms", direction="lower_is_better"),),
+    )
+
+    metrics = _dispatch_probe_impl(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["summary_count"] == 10000.0
+    assert metrics["csv_line_count"] == 10001.0
+
 
 
 def test_dispatch_probe_impl_supports_evaluation_store_probe() -> None:

--- a/services/mlx-worker-python/worker/productization/evaluation_store.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_store.py
@@ -91,10 +91,7 @@ class EvaluationStore:
         )
 
         summary_csv_path = run_root / "evaluation-compare-summary.csv"
-        summary_csv_path.write_text(
-            self._compare_summary_csv(job=job, summaries=summaries),
-            encoding="utf-8",
-        )
+        self._write_compare_summary_csv(summary_csv_path, job=job, summaries=summaries)
 
         samples_jsonl_path = run_root / "evaluation-compare-samples.jsonl"
         self._write_jsonl(samples_jsonl_path, (sample.to_dict() for sample in samples))
@@ -129,6 +126,21 @@ class EvaluationStore:
             write(",".join(EvaluationStore._samples_csv_header()) + "\n")
             for sample in samples:
                 write(sample_csv_row(sample) + "\n")
+
+    @staticmethod
+    def _write_compare_summary_csv(
+        path: Path,
+        *,
+        job: EvaluationCompareJob,
+        summaries: tuple[EvaluationCompareSummary, ...],
+    ) -> None:
+        lineage_by_target_id = {entry.target_model_id: entry for entry in job.target_lineage}
+        with path.open("w", encoding="utf-8") as handle:
+            write = handle.write
+            compare_summary_csv_row = EvaluationStore._compare_summary_csv_row
+            write(",".join(EvaluationStore._compare_summary_csv_header()) + "\n")
+            for summary in summaries:
+                write(compare_summary_csv_row(job=job, summary=summary, lineage_by_target_id=lineage_by_target_id) + "\n")
 
     @staticmethod
     def _summary_payload(*, job: EvaluationJob, result: EvaluationResult) -> dict[str, object]:
@@ -218,12 +230,26 @@ class EvaluationStore:
         job: EvaluationCompareJob,
         summaries: tuple[EvaluationCompareSummary, ...],
     ) -> str:
+        lineage_by_target_id = {entry.target_model_id: entry for entry in job.target_lineage}
+        rows = [",".join(EvaluationStore._compare_summary_csv_header())]
+        for summary in summaries:
+            rows.append(
+                EvaluationStore._compare_summary_csv_row(
+                    job=job,
+                    summary=summary,
+                    lineage_by_target_id=lineage_by_target_id,
+                )
+            )
+        return "\n".join(rows) + "\n"
+
+    @staticmethod
+    def _compare_summary_csv_header() -> list[str]:
         # Module 2 adds two trailing columns carrying adapter lineage. New
         # columns land at the end of the header row so downstream parsers
         # keyed on column order preserve their existing behavior for the
         # first 21 columns; the two new columns are empty for registered
         # (non-adapter) targets.
-        header = [
+        return [
             "job_id",
             "base_model_id",
             "target_model_id",
@@ -248,45 +274,46 @@ class EvaluationStore:
             "target_adapter_manifest_path",
             "target_adapter_set_hash",
         ]
-        # Index lineage entries by target_model_id for O(1) lookup during
-        # row emission. Targets without a lineage record (legacy jobs or
-        # registered models) get empty-string adapter columns.
-        lineage_by_target_id = {entry.target_model_id: entry for entry in job.target_lineage}
-        rows = [",".join(header)]
-        for summary in summaries:
-            bootstrap_interval = summary.statistical_evidence.get("bootstrap", {})
-            analytical_interval = summary.statistical_evidence.get("analytical", {})
-            lineage = lineage_by_target_id.get(summary.target_model_id)
-            rows.append(
-                ",".join(
-                    [
-                        EvaluationStore._csv_field(job.job_id),
-                        EvaluationStore._csv_field(job.base_model_id),
-                        EvaluationStore._csv_field(summary.target_model_id),
-                        EvaluationStore._csv_field(job.suite_id),
-                        EvaluationStore._csv_field(job.dataset_id),
-                        EvaluationStore._csv_field(str(job.sample_size)),
-                        EvaluationStore._csv_field(str(summary.win_count)),
-                        EvaluationStore._csv_field(str(summary.loss_count)),
-                        EvaluationStore._csv_field(str(summary.tie_count)),
-                        EvaluationStore._csv_field(str(summary.regression_count)),
-                        EvaluationStore._csv_field(str(summary.base_accuracy)),
-                        EvaluationStore._csv_field(str(summary.target_accuracy)),
-                        EvaluationStore._csv_field(str(summary.delta_accuracy)),
-                        EvaluationStore._csv_field(str(summary.effect_threshold)),
-                        EvaluationStore._csv_field(summary.verdict),
-                        EvaluationStore._csv_field(str(bootstrap_interval.get("lower_bound", ""))),
-                        EvaluationStore._csv_field(str(bootstrap_interval.get("upper_bound", ""))),
-                        EvaluationStore._csv_field(str(analytical_interval.get("lower_bound", ""))),
-                        EvaluationStore._csv_field(str(analytical_interval.get("upper_bound", ""))),
-                        EvaluationStore._csv_field(str(summary.duration_seconds)),
-                        EvaluationStore._csv_field(str(job.created_at_unix_ms)),
-                        EvaluationStore._csv_field(lineage.adapter_manifest_path if lineage else ""),
-                        EvaluationStore._csv_field(lineage.adapter_set_hash if lineage else ""),
-                    ]
-                )
-            )
-        return "\n".join(rows) + "\n"
+
+    @staticmethod
+    def _compare_summary_csv_row(
+        *,
+        job: EvaluationCompareJob,
+        summary: EvaluationCompareSummary,
+        lineage_by_target_id: dict[str, object] | None = None,
+    ) -> str:
+        bootstrap_interval = summary.statistical_evidence.get("bootstrap", {})
+        analytical_interval = summary.statistical_evidence.get("analytical", {})
+        if lineage_by_target_id is None:
+            lineage_by_target_id = {entry.target_model_id: entry for entry in job.target_lineage}
+        lineage = lineage_by_target_id.get(summary.target_model_id)
+        return ",".join(
+            [
+                EvaluationStore._csv_field(job.job_id),
+                EvaluationStore._csv_field(job.base_model_id),
+                EvaluationStore._csv_field(summary.target_model_id),
+                EvaluationStore._csv_field(job.suite_id),
+                EvaluationStore._csv_field(job.dataset_id),
+                EvaluationStore._csv_field(str(job.sample_size)),
+                EvaluationStore._csv_field(str(summary.win_count)),
+                EvaluationStore._csv_field(str(summary.loss_count)),
+                EvaluationStore._csv_field(str(summary.tie_count)),
+                EvaluationStore._csv_field(str(summary.regression_count)),
+                EvaluationStore._csv_field(str(summary.base_accuracy)),
+                EvaluationStore._csv_field(str(summary.target_accuracy)),
+                EvaluationStore._csv_field(str(summary.delta_accuracy)),
+                EvaluationStore._csv_field(str(summary.effect_threshold)),
+                EvaluationStore._csv_field(summary.verdict),
+                EvaluationStore._csv_field(str(bootstrap_interval.get("lower_bound", ""))),
+                EvaluationStore._csv_field(str(bootstrap_interval.get("upper_bound", ""))),
+                EvaluationStore._csv_field(str(analytical_interval.get("lower_bound", ""))),
+                EvaluationStore._csv_field(str(analytical_interval.get("upper_bound", ""))),
+                EvaluationStore._csv_field(str(summary.duration_seconds)),
+                EvaluationStore._csv_field(str(job.created_at_unix_ms)),
+                EvaluationStore._csv_field(lineage.adapter_manifest_path if lineage else ""),
+                EvaluationStore._csv_field(lineage.adapter_set_hash if lineage else ""),
+            ]
+        )
 
     @staticmethod
     def _samples_csv(samples: tuple[EvaluationSample, ...]) -> str:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -373,6 +373,8 @@ def _dispatch_probe_impl(*, probe: ProbeDefinition, repo_root: Path) -> dict[str
         return _probe_closure_audit(repo_root)
     if probe.probe_impl == "deterministic_rerank_query_context_reuse":
         return _probe_deterministic_rerank_query_context_reuse(repo_root)
+    if probe.probe_impl == "evaluation_store_compare_summary_csv_streaming":
+        return _probe_evaluation_store_compare_summary_csv_streaming(repo_root)
     if probe.probe_impl == "evaluation_store_samples_csv_streaming":
         return _probe_evaluation_store_samples_csv_streaming(repo_root)
     if probe.probe_impl == "evaluation_sample_probe_aggregation":
@@ -624,6 +626,133 @@ def _probe_deterministic_rerank_query_context_reuse(repo_root: Path) -> dict[str
         "sample_count": float(sample_count),
         "tokenize_calls_mean": round(sum(tokenize_call_samples) / len(tokenize_call_samples), 6),
     }
+
+
+def _probe_evaluation_store_compare_summary_csv_streaming(repo_root: Path) -> dict[str, float]:
+    summary_count = 10000
+    probe_script = f"""
+import gc
+import json
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+repo_root = Path({str(repo_root)!r})
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / 'services/mlx-worker-python'))
+from worker.productization.evaluation_schemas import (
+    build_evaluation_compare_job_record,
+    build_evaluation_compare_summary_record,
+)
+from worker.productization.evaluation_store import EvaluationStore
+
+summary_count = {summary_count}
+summaries = tuple(
+    build_evaluation_compare_summary_record(
+        job_id='eval-compare-perf',
+        base_model_id='melix-dev-text',
+        target_model_id=f'melix-dev-text-target-{{index:05d}}',
+        suite_id='mmlu',
+        dataset_id='mmlu.synthetic',
+        sample_size=64,
+        scoring_mode='multiple_choice_accuracy',
+        win_count=index % 7,
+        loss_count=(index + 1) % 5,
+        tie_count=(index + 2) % 3,
+        regression_count=index % 2,
+        base_accuracy=0.5,
+        target_accuracy=0.5 + ((index % 9) * 0.01),
+        delta_accuracy=((index % 9) * 0.01),
+        effect_threshold=0.02,
+        verdict='improvement' if index % 2 == 0 else 'watch',
+        category_breakdown={{}},
+        statistical_evidence={{
+            'bootstrap': {{
+                'lower_bound': -0.01 + ((index % 7) * 0.001),
+                'upper_bound': 0.03 + ((index % 7) * 0.001),
+            }},
+            'analytical': {{
+                'lower_bound': -0.02 + ((index % 5) * 0.001),
+                'upper_bound': 0.04 + ((index % 5) * 0.001),
+            }},
+        }},
+        release_gate_summary={{}},
+        duration_seconds=0.1 + ((index % 11) * 0.01),
+        metrics={{'eval.compare.delta_accuracy': ((index % 9) * 0.01)}},
+        report_path='',
+    )
+    for index in range(summary_count)
+)
+job = build_evaluation_compare_job_record(
+    job_id='eval-compare-perf',
+    base_model_id='melix-dev-text',
+    target_model_ids=tuple(summary.target_model_id for summary in summaries),
+    task_kind='text-generation',
+    source_repo='synthetic',
+    suite_id='mmlu',
+    dataset_id='mmlu.synthetic',
+    sample_size=64,
+    scoring_mode='multiple_choice_accuracy',
+    parameters={{'compare_mode': 'base_vs_targets'}},
+    status='completed',
+    output_dir='',
+    created_at_unix_ms=101,
+    updated_at_unix_ms=202,
+)
+store = EvaluationStore()
+writer = getattr(store, '_write_compare_summary_csv', None)
+elapsed_samples = []
+peak_samples = []
+csv_line_count = 0
+csv_bytes = 0
+for _ in range(3):
+    with tempfile.TemporaryDirectory(prefix='melix-pr-perf-eval-compare-store-') as temp_dir:
+        summary_csv_path = Path(temp_dir) / 'evaluation-compare-summary.csv'
+        gc.collect()
+        tracemalloc.start()
+        started = time.perf_counter()
+        if writer is not None:
+            writer(summary_csv_path, job=job, summaries=summaries)
+        else:
+            summary_csv_path.write_text(
+                store._compare_summary_csv(job=job, summaries=summaries),
+                encoding='utf-8',
+            )
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        peak_samples.append(float(peak_bytes))
+        tracemalloc.stop()
+        csv_line_count = float(len(summary_csv_path.read_text(encoding='utf-8').splitlines()))
+        if csv_line_count != float(summary_count + 1):
+            raise ValueError(f'unexpected compare summary CSV line count: {{csv_line_count}}')
+        csv_bytes = float(summary_csv_path.stat().st_size)
+print(json.dumps({{
+    'elapsed_ms_mean': round(sum(elapsed_samples) / len(elapsed_samples), 6),
+    'peak_bytes_mean': round(sum(peak_samples) / len(peak_samples), 1),
+    'summary_count': float(summary_count),
+    'csv_line_count': float(csv_line_count),
+    'csv_bytes': float(csv_bytes),
+}}, sort_keys=True))
+"""
+    completed = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--project",
+            str(repo_root / "services/mlx-worker-python"),
+            "python3",
+            "-c",
+            probe_script,
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads((completed.stdout or "").strip())
+
 
 
 def _probe_evaluation_store_samples_csv_streaming(repo_root: Path) -> dict[str, float]:


### PR DESCRIPTION
## Summary
- stream `evaluation-compare-summary.csv` writes in `EvaluationStore.persist_compare_result(...)` instead of building one giant CSV string first
- preserve compare-summary CSV header order, row order, quoting, and adapter-lineage columns via shared row/header helpers plus focused regression tests
- add a dedicated `evaluation-store-compare-summary-csv-streaming` PR-scoped performance probe and narrow the existing samples probe command so the two probe paths stay isolated

## Plan or Spec
- `docs/plans/2026-05-02-evaluation-compare-summary-csv-streaming.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_compare_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_evaluation_store_compare_summary_csv_streaming_targets_direct_writer
- 19 passed in 17.99s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_store_compare_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_evaluation_store_compare_summary_csv_streaming_targets_direct_writer
- 19 passed in 40.06s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
- wrote coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
- TOTAL 109 2 98%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .tmp_probe_eval_compare_summary_base.py
- {"csv_bytes": 1705144.0, "csv_line_count": 10001.0, "elapsed_ms_mean": 473.790823, "peak_bytes_mean": 5601201.0, "summary_count": 10000.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .tmp_probe_eval_compare_summary.py
- {"csv_bytes": 1705144.0, "csv_line_count": 10001.0, "elapsed_ms_mean": 441.431703, "peak_bytes_mean": 25949.7, "summary_count": 10000.0}

git diff --check
- pass
```

## Coverage and Metrics
- Changed-scope coverage: `98%` (`107/109` changed executable lines covered)
- `services/mlx-worker-python/worker/productization/evaluation_store.py`: `96.15%` changed-line coverage (`25/26`)
- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`: `100.00%` changed-line coverage (`7/7`)
- `services/mlx-worker-python/tests/test_evaluation_store.py`: `97.62%` changed-line coverage (`41/42`)
- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`: `100.00%` changed-line coverage (`34/34`)
- Dedicated scoped probe: `evaluation-store-compare-summary-csv-streaming`
- Local base vs head probe:
  - `origin/main`: `elapsed_ms_mean=473.790823`, `peak_bytes_mean=5601201.0`, `csv_line_count=10001.0`
  - branch: `elapsed_ms_mean=441.431703`, `peak_bytes_mean=25949.7`, `csv_line_count=10001.0`
- Interpretation:
  - peak traced memory dropped by ~`99.54%` (`5,575,251.3` fewer bytes)
  - mean elapsed time improved by ~`6.83%`
  - output-size and line-count guard rails stayed identical

## Known Gaps
- Local verification is Linux-only. I did not run macOS/Swift checks locally.
- Because `infra/perf/pr_scoped_probes.json` changed, the repo's `pr-scoped-performance` workflow should force-run the full registered probe matrix in CI before merge.
- I did not claim full-repo verification; only the focused Python tests/coverage/probes above were run.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
