### PR TITLE
perf: cache derived model id lookups

### DIFF
--- a/docs/plans/2026-05-02-job-registry-derived-model-id-lookup.md
+++ b/docs/plans/2026-05-02-job-registry-derived-model-id-lookup.md
@@ -1,0 +1,31 @@
+# Job Registry Derived-Model ID Lookup Slice
+
+## Goal
+
+Reduce repeated derived-model target resolution cost in `ModelOpsJobRegistry` when callers provide a `derived_model_id`.
+
+## Scope
+
+- Affected path: `services/mlx-worker-python/worker/model_ops/job_registry.py`.
+- Registered PR-scoped probe: `job-registry-derived-model-single-pass` in `infra/perf/pr_scoped_probes.json`.
+- Probe support path: `scripts/job_registry_derived_model_probe.py`.
+
+## Implementation
+
+The existing active-derived-model row cache avoids rebuilding the active row list, but each repeated `resolve_derived_model_target(derived_model_id=...)` call still scans the cached rows. This slice adds a cache-derived `derived_model_id -> active row` lookup that is invalidated together with the row cache. Manifest-path-only lookups keep the existing row scan semantics.
+
+The probe now resolves an older active model ID (`melix-dev-derived-0001`) so the registered metric exercises the cached-ID path instead of mostly measuring the newest-row fast case.
+
+## Validation Plan
+
+Run the registered probe's focused local Linux commands:
+
+1. Focused tests from `job-registry-derived-model-single-pass`.
+2. Changed-scope coverage from `job-registry-derived-model-single-pass`.
+3. Registered probe command from `job-registry-derived-model-single-pass`.
+
+## Success Criteria
+
+- Focused tests pass.
+- Changed-scope coverage remains at or above 95%.
+- Registered probe shows lower `resolve_target_elapsed_ms_mean` for repeated `derived_model_id` resolution.

--- a/scripts/job_registry_derived_model_probe.py
+++ b/scripts/job_registry_derived_model_probe.py
@@ -68,7 +68,10 @@ def main() -> int:
     job_count = 1200
     sample_count = 6
     registry, active_count = _seed_registry(job_count)
-    target_model_id = "melix-dev-derived-1199"
+    target_model_id = "melix-dev-derived-0001"
+    warmup_target = registry.resolve_derived_model_target(derived_model_id=target_model_id)
+    if not warmup_target or warmup_target.get("derived_model_id") != target_model_id:
+        raise RuntimeError("derived-model warmup lookup returned the wrong target")
 
     active_elapsed_ms: list[float] = []
     resolve_elapsed_ms: list[float] = []

--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -266,6 +266,95 @@ def test_resolve_derived_model_target_reuses_active_row_cache(
     assert build_calls == 1
 
 
+def test_resolve_derived_model_target_uses_cached_model_id_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = ModelOpsJobRegistry()
+    for index in range(25):
+        job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+        registry.attach_manifest(
+            job.job_id,
+            json.dumps(
+                {
+                    "derived_model_id": f"melix-dev-active-{index:02d}",
+                    "derived_model_path": f"/runtime/activate/melix-dev-active-{index:02d}",
+                    "activation_mode": "fused_derived_model",
+                }
+            ),
+        )
+        registry.complete(job.job_id, f"/runtime/activate/melix-dev-active-{index:02d}/manifest.json")
+
+    rows = registry._cached_active_derived_model_job_rows()
+    row_iterations = 0
+
+    def counted_rows():
+        nonlocal row_iterations
+        for row in rows:
+            row_iterations += 1
+            yield row
+
+    monkeypatch.setattr(registry, "_cached_active_derived_model_job_rows", counted_rows)
+
+    target = registry.resolve_derived_model_target(derived_model_id="melix-dev-active-00")
+    assert target is not None
+    assert target["derived_model_id"] == "melix-dev-active-00"
+    assert row_iterations == len(rows)
+
+    row_iterations = 0
+    target = registry.resolve_derived_model_target(derived_model_id="melix-dev-active-00")
+    assert target is not None
+    assert target["derived_model_id"] == "melix-dev-active-00"
+    assert row_iterations == 0
+
+
+def test_resolve_derived_model_target_id_lookup_negative_paths() -> None:
+    registry = ModelOpsJobRegistry()
+    job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+    registry.attach_manifest(
+        job.job_id,
+        json.dumps(
+            {
+                "derived_model_id": "melix-dev-active",
+                "derived_model_path": "/runtime/activate/melix-dev-active",
+                "activation_mode": "fused_derived_model",
+            }
+        ),
+    )
+    registry.complete(job.job_id, "/runtime/activate/melix-dev-active/manifest.json")
+
+    assert registry.resolve_derived_model_target(derived_model_id="melix-dev-missing") is None
+    assert (
+        registry.resolve_derived_model_target(
+            derived_model_id="melix-dev-active",
+            manifest_path="/runtime/activate/other/manifest.json",
+        )
+        is None
+    )
+
+
+def test_resolve_derived_model_target_manifest_only_uses_payload_helper() -> None:
+    registry = ModelOpsJobRegistry()
+    job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+    manifest_path = "/runtime/activate/melix-dev-active/manifest.json"
+    registry.attach_manifest(
+        job.job_id,
+        json.dumps(
+            {
+                "derived_model_id": "melix-dev-active",
+                "derived_model_path": "/runtime/activate/melix-dev-active",
+                "activation_mode": "fused_derived_model",
+            }
+        ),
+    )
+    registry.complete(job.job_id, manifest_path)
+
+    target = registry.resolve_derived_model_target(manifest_path=manifest_path)
+
+    assert target is not None
+    assert target["derived_model_id"] == "melix-dev-active"
+    assert target["activation_manifest_path"] == manifest_path
+
+
 def test_active_derived_model_manifests_skips_removed_manifest_path_without_job_id() -> None:
     registry = ModelOpsJobRegistry()
 

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -45,12 +45,20 @@ class ModelOpsJob:
     error_message: str = ""
 
 
+@dataclass(frozen=True)
+class _ActiveDerivedModelLookup:
+    job: ModelOpsJob
+    manifest: dict[str, Any]
+    activation_manifest_path: str
+
+
 class ModelOpsJobRegistry:
     def __init__(self, jobs_root: str | Path | None = None) -> None:
         self._lock = Lock()
         self._next_id = 1
         self._jobs: dict[str, ModelOpsJob] = {}
         self._active_derived_model_rows_cache: tuple[tuple[ModelOpsJob, dict[str, Any], str], ...] | None = None
+        self._active_derived_model_by_id_cache: dict[str, _ActiveDerivedModelLookup] | None = None
         self._jobs_root = Path(jobs_root).expanduser().resolve() if jobs_root is not None else None
         self._lora_experiment_store = LoraExperimentStore()
         if self._jobs_root is not None:
@@ -314,6 +322,7 @@ class ModelOpsJobRegistry:
 
     def _invalidate_active_derived_model_rows_cache(self) -> None:
         self._active_derived_model_rows_cache = None
+        self._active_derived_model_by_id_cache = None
 
     def _cached_active_derived_model_job_rows(
         self,
@@ -323,6 +332,46 @@ class ModelOpsJobRegistry:
             cached_rows = self._active_derived_model_job_rows(self._ordered_jobs())
             self._active_derived_model_rows_cache = cached_rows
         return cached_rows
+
+    def _cached_active_derived_model_by_id(self) -> dict[str, _ActiveDerivedModelLookup]:
+        cached_by_id = self._active_derived_model_by_id_cache
+        if cached_by_id is None:
+            cached_by_id = {}
+            for job, manifest, activation_manifest_path in self._cached_active_derived_model_job_rows():
+                candidate_model_id = str(manifest.get("derived_model_id", "")).strip()
+                if candidate_model_id and candidate_model_id not in cached_by_id:
+                    cached_by_id[candidate_model_id] = _ActiveDerivedModelLookup(
+                        job=job,
+                        manifest=manifest,
+                        activation_manifest_path=activation_manifest_path,
+                    )
+            self._active_derived_model_by_id_cache = cached_by_id
+        return cached_by_id
+
+    @staticmethod
+    def _derived_model_target_payload(
+        job: ModelOpsJob,
+        manifest: dict[str, Any],
+        activation_manifest_path: str,
+        *,
+        resolved_activation_manifest_path: str | None = None,
+    ) -> dict[str, Any]:
+        if resolved_activation_manifest_path is None:
+            resolved_activation_manifest_path = str(Path(activation_manifest_path).expanduser().resolve())
+        candidate_model_id = str(manifest.get("derived_model_id", "")).strip()
+        return {
+            "activation_job_id": job.job_id,
+            "activation_manifest_path": resolved_activation_manifest_path,
+            "output_dir": job.output_dir,
+            "source_model": str(manifest.get("source_model", "")),
+            "derived_model_id": candidate_model_id,
+            "derived_model_path": str(manifest.get("derived_model_path", "")),
+            "derived_model_alias": str(manifest.get("derived_model_alias", "")),
+            "activation_mode": str(manifest.get("activation_mode", "")),
+            "runtime_mode": _runtime_mode_from_activation(str(manifest.get("activation_mode", ""))),
+            "adapter_manifest_path": str(manifest.get("adapter_manifest_path", "")),
+            "adapter_weights_path": str(manifest.get("adapter_weights_path", "")),
+        }
 
     @classmethod
     def _job_manifest(cls, job: ModelOpsJob) -> dict[str, Any]:
@@ -400,28 +449,34 @@ class ModelOpsJobRegistry:
         if not normalized_model_id and not normalized_manifest_path:
             return None
 
+        if normalized_model_id:
+            lookup = self._cached_active_derived_model_by_id().get(normalized_model_id)
+            if lookup is None:
+                return None
+            resolved_activation_manifest_path = str(
+                Path(lookup.activation_manifest_path).expanduser().resolve()
+            )
+            if normalized_manifest_path and resolved_activation_manifest_path != normalized_manifest_path:
+                return None
+            return self._derived_model_target_payload(
+                lookup.job,
+                lookup.manifest,
+                lookup.activation_manifest_path,
+                resolved_activation_manifest_path=resolved_activation_manifest_path,
+            )
+
         for job, manifest, activation_manifest_path in self._cached_active_derived_model_job_rows():
-            candidate_model_id = str(manifest.get("derived_model_id", "")).strip()
-            if normalized_model_id and candidate_model_id != normalized_model_id:
-                continue
             resolved_activation_manifest_path = str(
                 Path(activation_manifest_path).expanduser().resolve()
             )
             if normalized_manifest_path and resolved_activation_manifest_path != normalized_manifest_path:
                 continue
-            return {
-                "activation_job_id": job.job_id,
-                "activation_manifest_path": resolved_activation_manifest_path,
-                "output_dir": job.output_dir,
-                "source_model": str(manifest.get("source_model", "")),
-                "derived_model_id": candidate_model_id,
-                "derived_model_path": str(manifest.get("derived_model_path", "")),
-                "derived_model_alias": str(manifest.get("derived_model_alias", "")),
-                "activation_mode": str(manifest.get("activation_mode", "")),
-                "runtime_mode": _runtime_mode_from_activation(str(manifest.get("activation_mode", ""))),
-                "adapter_manifest_path": str(manifest.get("adapter_manifest_path", "")),
-                "adapter_weights_path": str(manifest.get("adapter_weights_path", "")),
-            }
+            return self._derived_model_target_payload(
+                job,
+                manifest,
+                activation_manifest_path,
+                resolved_activation_manifest_path=resolved_activation_manifest_path,
+            )
         return None
 
     def active_derived_model_manifests(self) -> tuple[dict[str, Any], ...]:


### PR DESCRIPTION
## Summary
- Add a cache-derived `derived_model_id` lookup for active derived-model rows in `ModelOpsJobRegistry`.
- Keep manifest-path-only resolution on the existing row scan path while reusing the shared payload builder.
- Update the registered job-registry probe to measure repeated lookup of an older active derived-model ID after warmup.

## Plan or Spec
- `docs/plans/2026-05-02-job-registry-derived-model-id-lookup.md`
- Registered probe: `job-registry-derived-model-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline before code change on origin/main / old newest-row probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
# exit 0; 13 passed in 0.32s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
# exit 0; {"active_manifest_count": 960.0, "active_manifest_elapsed_ms_mean": 0.697088, "elapsed_ms_mean": 0.779877, "job_count": 1200.0, "removed_count": 240.0, "resolve_target_elapsed_ms_mean": 0.082789, "sample_count": 6.0}

# Baseline comparison with the updated older-ID warmup probe against origin/main implementation
PYTHONPATH="$BASE_WT:$BASE_WT/services/mlx-worker-python" uv run --project "$BASE_WT/services/mlx-worker-python" python3 "$BASE_WT/scripts/job_registry_derived_model_probe.py"
# exit 0; {"active_manifest_count": 960.0, "active_manifest_elapsed_ms_mean": 0.043243, "elapsed_ms_mean": 0.183979, "job_count": 1200.0, "removed_count": 240.0, "resolve_target_elapsed_ms_mean": 0.140736, "sample_count": 6.0}

# Focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
# exit 0; 16 passed in 0.11s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py
# exit 0; TOTAL 75 2 97%

# Registered local probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
# exit 0; {"active_manifest_count": 960.0, "active_manifest_elapsed_ms_mean": 0.047005, "elapsed_ms_mean": 0.086362, "job_count": 1200.0, "removed_count": 240.0, "resolve_target_elapsed_ms_mean": 0.039357, "sample_count": 6.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `97%` aggregate (`TOTAL 75 2 97%`).
- Registered probe local Linux comparison using the updated older-ID warmup scenario:
  - base `resolve_target_elapsed_ms_mean=0.140736 ms`
  - head `resolve_target_elapsed_ms_mean=0.039357 ms`
  - delta `-0.101379 ms`, about `3.58x` faster for repeated `derived_model_id` resolution.
  - base `elapsed_ms_mean=0.183979 ms`; head `elapsed_ms_mean=0.086362 ms`; delta `-0.097617 ms`.
- CI PR-scoped performance must run `job-registry-derived-model-single-pass` before merge.

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime path is changed.
- The first derived-model ID lookup after cache invalidation still pays the one-time cost to build the lookup map; the probe intentionally warms this path to measure repeated lookup behavior.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
