### PR TITLE
perf: avoid rerank contiguous query slices

### DIFF
--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -372,6 +372,41 @@ def test_rerank_context_tuple_and_frozenset_collections_are_scored_directly() ->
     ) == family.score(backend, "swift runtime", "control swift runtime")
 
 
+def test_contiguous_query_scan_does_not_allocate_document_slices() -> None:
+    class NoSliceTokens:
+        def __init__(self, tokens: tuple[str, ...]) -> None:
+            self.tokens = tokens
+
+        def __len__(self) -> int:
+            return len(self.tokens)
+
+        def __getitem__(self, index):
+            if isinstance(index, slice):
+                raise AssertionError("contiguous query scan should compare tokens without slicing")
+            return self.tokens[index]
+
+    family = JinaV3RerankFamilyAdapter()
+
+    assert family._contains_contiguous_query(
+        NoSliceTokens(("control", "swift", "runtime", "worker")),
+        ("swift", "runtime"),
+    )
+    assert not family._contains_contiguous_query(
+        NoSliceTokens(("control", "runtime", "swift", "worker")),
+        ("swift", "runtime"),
+    )
+    assert family._contains_contiguous_query(
+        NoSliceTokens(("control", "swift")),
+        ("swift",),
+    )
+    assert not family._contains_contiguous_query(
+        NoSliceTokens(("control", "runtime")),
+        ("swift",),
+    )
+    with pytest.raises(AssertionError, match="without slicing"):
+        NoSliceTokens(("swift", "runtime"))[0:1]
+
+
 def test_rerank_rejects_missing_and_wrong_model_kinds() -> None:
     runtime_service, inference_service = build_services()
     text_handle = load_model(runtime_service, WorkerModelCatalog.dev_text_model())

--- a/services/mlx-worker-python/worker/runtime/rerank_backends.py
+++ b/services/mlx-worker-python/worker/runtime/rerank_backends.py
@@ -201,11 +201,21 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
 
     @staticmethod
     def _contains_contiguous_query(document_tokens: Sequence[str], query_tokens: Sequence[str]) -> bool:
-        if not query_tokens or len(query_tokens) > len(document_tokens):
+        query_length = len(query_tokens)
+        if query_length == 0 or query_length > len(document_tokens):
             return False
-        last_start = len(document_tokens) - len(query_tokens)
+        if query_length == 1:
+            query_token = query_tokens[0]
+            return any(document_token == query_token for document_token in document_tokens)
+        last_start = len(document_tokens) - query_length
+        first_query_token = query_tokens[0]
         for start in range(last_start + 1):
-            if document_tokens[start : start + len(query_tokens)] == query_tokens:
+            if document_tokens[start] != first_query_token:
+                continue
+            if all(
+                document_tokens[start + offset] == query_tokens[offset]
+                for offset in range(1, query_length)
+            ):
                 return True
         return False
 


### PR DESCRIPTION
## Summary
- Avoid per-start list slicing in the deterministic reranker contiguous-query scan.
- Add regression coverage that fails if `_contains_contiguous_query` allocates document-token slices.

## Plan or Spec
- N/A: this is a small registered Python performance slice for `deterministic-rerank-query-context-reuse`; no behavior or workflow semantics changed.
- Registered probe: `infra/perf/pr_scoped_probes.json` → `deterministic-rerank-query-context-reuse` covers `services/mlx-worker-python/worker/runtime/rerank_backends.py` with focused `test_command`, `coverage_command`, and `probe_command`.

## Commands Run
```text
# synced baseline before branch
 git -C /root/.hermes/profiles/coder/workspace/melix fetch origin main
 git worktree add -b perf/python-slice-20260502062056 /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-20260502062056 origin/main

# baseline probe (same base/head sanity before edits)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
# exit 0; 24 passed in 11.44s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-rerank-query-context-reuse --base-repo "$PWD" --head-repo "$PWD" --output .runtime/rerank-baseline.json
# exit 0; base elapsed_ms_mean=87.637600, head elapsed_ms_mean=83.027308

# focused regression test after edit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py::test_contiguous_query_scan_does_not_allocate_document_slices
# exit 0; 1 passed in 0.27s

# focused registered test command after edit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
# exit 0; 25 passed in 11.34s

# changed-scope coverage after edit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; TOTAL 27 0 100%

# registered probe comparing origin/main detached worktree vs this branch
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-rerank-query-context-reuse --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-rerank-noslice-20260502062056 --head-repo "$PWD" --output .runtime/rerank-noslice-result.json
# exit 0; base elapsed_ms_mean=98.116271, head elapsed_ms_mean=89.736771

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 27 0 100%`).
- Registered probe: `deterministic-rerank-query-context-reuse`.
- Local Linux probe result: `base elapsed_ms_mean=98.116271 ms`, `head elapsed_ms_mean=89.736771 ms`, `delta=-8.379500 ms`, `speedup=8.54%`.
- Non-timing invariants unchanged: `query_context_builds_mean=1.0`, `tokenize_calls_mean=2049.0`.
- GitHub Actions PR-scoped performance workflow is required as the merge gate.

## Known Gaps
- None for the Python slice. CI must still validate the registered probe on the PR runner before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is explained.
- [x] Protocol changes include regenerated generated artifacts, or N/A (no protocol changes).
- [x] Dependency changes include updated lockfiles, or N/A (no dependency changes).
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
