### PR TITLE
perf: cache job registry manifest path lookups

### DIFF
--- a/docs/plans/2026-05-02-job-registry-manifest-path-lookup-cache.md
+++ b/docs/plans/2026-05-02-job-registry-manifest-path-lookup-cache.md
@@ -1,0 +1,33 @@
+# Job registry manifest-path lookup cache
+
+## Scope
+
+This Linux-verifiable Python performance slice targets `services/mlx-worker-python/worker/model_ops/job_registry.py` only. It keeps derived-model resolution semantics unchanged while narrowing the hot path for `ModelOpsJobRegistry.resolve_derived_model_target(manifest_path=...)`.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped probe `job-registry-derived-model-single-pass` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes:
+
+- `test_command` for focused job-registry behavior tests and PR-scoped probe registration tests.
+- `coverage_command` for changed-scope coverage across `job_registry.py`, its focused tests, PR-scoped performance tests, and the probe script.
+- `probe_command` via `scripts/job_registry_derived_model_probe.py`, now reporting `manifest_path_elapsed_ms_mean` in addition to active-manifest and model-id lookup timings.
+
+## Optimization
+
+Before this slice, model-id resolution used a cached dictionary, but manifest-path-only resolution still iterated active derived-model rows and resolved each activation manifest path until it found a match. This slice adds a sibling cache keyed by resolved activation manifest path and invalidates it together with the existing active-row/model-id caches.
+
+## Verification plan
+
+Run from the repository root:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
+```
+
+CI remains the merge gate for the registered PR-scoped performance report.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -382,6 +382,12 @@
         "unit": "ms",
         "direction": "lower_is_better",
         "warn_pct": 5.0
+      },
+      {
+        "key": "manifest_path_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
       }
     ]
   },

--- a/scripts/job_registry_derived_model_probe.py
+++ b/scripts/job_registry_derived_model_probe.py
@@ -72,9 +72,14 @@ def main() -> int:
     warmup_target = registry.resolve_derived_model_target(derived_model_id=target_model_id)
     if not warmup_target or warmup_target.get("derived_model_id") != target_model_id:
         raise RuntimeError("derived-model warmup lookup returned the wrong target")
+    target_manifest_path = str(warmup_target.get("activation_manifest_path", ""))
+    warmup_manifest_path_target = registry.resolve_derived_model_target(manifest_path=target_manifest_path)
+    if not warmup_manifest_path_target or warmup_manifest_path_target.get("derived_model_id") != target_model_id:
+        raise RuntimeError("manifest-path warmup lookup returned the wrong target")  # pragma: no cover
 
     active_elapsed_ms: list[float] = []
     resolve_elapsed_ms: list[float] = []
+    manifest_path_elapsed_ms: list[float] = []
     for _ in range(sample_count):
         started = time.perf_counter()
         manifests = registry.active_derived_model_manifests()
@@ -88,11 +93,23 @@ def main() -> int:
         if not target or target.get("derived_model_id") != target_model_id:
             raise RuntimeError("derived-model lookup returned the wrong target")
 
+        started = time.perf_counter()
+        manifest_path_target = registry.resolve_derived_model_target(manifest_path=target_manifest_path)
+        manifest_path_elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+        if not manifest_path_target or manifest_path_target.get("derived_model_id") != target_model_id:
+            raise RuntimeError("manifest-path lookup returned the wrong target")  # pragma: no cover
+
     payload = {
         "active_manifest_count": float(active_count),
         "active_manifest_elapsed_ms_mean": round(statistics.fmean(active_elapsed_ms), 6),
-        "elapsed_ms_mean": round(statistics.fmean(active_elapsed_ms) + statistics.fmean(resolve_elapsed_ms), 6),
+        "elapsed_ms_mean": round(
+            statistics.fmean(active_elapsed_ms)
+            + statistics.fmean(resolve_elapsed_ms)
+            + statistics.fmean(manifest_path_elapsed_ms),
+            6,
+        ),
         "job_count": float(job_count),
+        "manifest_path_elapsed_ms_mean": round(statistics.fmean(manifest_path_elapsed_ms), 6),
         "removed_count": float(job_count - active_count),
         "resolve_target_elapsed_ms_mean": round(statistics.fmean(resolve_elapsed_ms), 6),
         "sample_count": float(sample_count),

--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -355,6 +355,49 @@ def test_resolve_derived_model_target_manifest_only_uses_payload_helper() -> Non
     assert target["activation_manifest_path"] == manifest_path
 
 
+def test_resolve_derived_model_target_uses_cached_manifest_path_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = ModelOpsJobRegistry()
+    for index in range(25):
+        job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+        registry.attach_manifest(
+            job.job_id,
+            json.dumps(
+                {
+                    "derived_model_id": f"melix-dev-active-{index:02d}",
+                    "derived_model_path": f"/runtime/activate/melix-dev-active-{index:02d}",
+                    "activation_mode": "fused_derived_model",
+                }
+            ),
+        )
+        registry.complete(job.job_id, f"/runtime/activate/melix-dev-active-{index:02d}/manifest.json")
+
+    rows = registry._cached_active_derived_model_job_rows()
+    row_iterations = 0
+
+    def counted_rows():
+        nonlocal row_iterations
+        for row in rows:
+            row_iterations += 1
+            yield row
+
+    monkeypatch.setattr(registry, "_cached_active_derived_model_job_rows", counted_rows)
+
+    target_manifest_path = "/runtime/activate/melix-dev-active-00/manifest.json"
+    target = registry.resolve_derived_model_target(manifest_path=target_manifest_path)
+    assert target is not None
+    assert target["derived_model_id"] == "melix-dev-active-00"
+    assert row_iterations == len(rows)
+
+    row_iterations = 0
+    target = registry.resolve_derived_model_target(manifest_path=target_manifest_path)
+    assert target is not None
+    assert target["derived_model_id"] == "melix-dev-active-00"
+    assert row_iterations == 0
+    assert registry.resolve_derived_model_target(manifest_path="/runtime/missing/manifest.json") is None
+
+
 def test_active_derived_model_manifests_skips_removed_manifest_path_without_job_id() -> None:
     registry = ModelOpsJobRegistry()
 

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -59,6 +59,7 @@ class ModelOpsJobRegistry:
         self._jobs: dict[str, ModelOpsJob] = {}
         self._active_derived_model_rows_cache: tuple[tuple[ModelOpsJob, dict[str, Any], str], ...] | None = None
         self._active_derived_model_by_id_cache: dict[str, _ActiveDerivedModelLookup] | None = None
+        self._active_derived_model_by_manifest_path_cache: dict[str, _ActiveDerivedModelLookup] | None = None
         self._jobs_root = Path(jobs_root).expanduser().resolve() if jobs_root is not None else None
         self._lora_experiment_store = LoraExperimentStore()
         if self._jobs_root is not None:
@@ -323,6 +324,7 @@ class ModelOpsJobRegistry:
     def _invalidate_active_derived_model_rows_cache(self) -> None:
         self._active_derived_model_rows_cache = None
         self._active_derived_model_by_id_cache = None
+        self._active_derived_model_by_manifest_path_cache = None
 
     def _cached_active_derived_model_job_rows(
         self,
@@ -347,6 +349,23 @@ class ModelOpsJobRegistry:
                     )
             self._active_derived_model_by_id_cache = cached_by_id
         return cached_by_id
+
+    def _cached_active_derived_model_by_manifest_path(self) -> dict[str, _ActiveDerivedModelLookup]:
+        cached_by_manifest_path = self._active_derived_model_by_manifest_path_cache
+        if cached_by_manifest_path is None:
+            cached_by_manifest_path = {}
+            for job, manifest, activation_manifest_path in self._cached_active_derived_model_job_rows():
+                resolved_activation_manifest_path = str(
+                    Path(activation_manifest_path).expanduser().resolve()
+                )
+                if resolved_activation_manifest_path and resolved_activation_manifest_path not in cached_by_manifest_path:
+                    cached_by_manifest_path[resolved_activation_manifest_path] = _ActiveDerivedModelLookup(
+                        job=job,
+                        manifest=manifest,
+                        activation_manifest_path=activation_manifest_path,
+                    )
+            self._active_derived_model_by_manifest_path_cache = cached_by_manifest_path
+        return cached_by_manifest_path
 
     @staticmethod
     def _derived_model_target_payload(
@@ -465,19 +484,15 @@ class ModelOpsJobRegistry:
                 resolved_activation_manifest_path=resolved_activation_manifest_path,
             )
 
-        for job, manifest, activation_manifest_path in self._cached_active_derived_model_job_rows():
-            resolved_activation_manifest_path = str(
-                Path(activation_manifest_path).expanduser().resolve()
-            )
-            if normalized_manifest_path and resolved_activation_manifest_path != normalized_manifest_path:
-                continue
-            return self._derived_model_target_payload(
-                job,
-                manifest,
-                activation_manifest_path,
-                resolved_activation_manifest_path=resolved_activation_manifest_path,
-            )
-        return None
+        lookup = self._cached_active_derived_model_by_manifest_path().get(normalized_manifest_path)
+        if lookup is None:
+            return None
+        return self._derived_model_target_payload(
+            lookup.job,
+            lookup.manifest,
+            lookup.activation_manifest_path,
+            resolved_activation_manifest_path=normalized_manifest_path,
+        )
 
     def active_derived_model_manifests(self) -> tuple[dict[str, Any], ...]:
         return tuple(manifest for _, manifest, _ in self._cached_active_derived_model_job_rows())


### PR DESCRIPTION
## Summary
- Cache active derived-model lookups by resolved activation manifest path in `ModelOpsJobRegistry`.
- Extend the registered job-registry PR-scoped probe with `manifest_path_elapsed_ms_mean`.
- Add a focused regression test proving repeated manifest-path lookups avoid active-row iteration.

## Plan or Spec
- `docs/plans/2026-05-02-job-registry-manifest-path-lookup-cache.md`

## Commands Run
```text
# Baseline from origin/main, custom manifest-path probe with warmup
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/job_manifest_path_probe.py
exit 0; manifest_path_elapsed_ms_mean=22.619851 ms; manifest_path_elapsed_ms_min=21.713017 ms

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
exit 0; 17 passed in 0.17s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py
exit 0; TOTAL 48 0 100%

# Registered local probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
exit 0; {"active_manifest_count": 960.0, "active_manifest_elapsed_ms_mean": 0.062013, "elapsed_ms_mean": 0.136537, "job_count": 1200.0, "manifest_path_elapsed_ms_mean": 0.029704, "removed_count": 240.0, "resolve_target_elapsed_ms_mean": 0.04482, "sample_count": 6.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 48 0 100%`).
- Baseline manifest-path lookup mean: `22.619851 ms`.
- New local registered-probe manifest-path lookup mean: `0.029704 ms`.
- Custom warmed comparison against the new worktree: `0.028104 ms`.
- Delta: `-22.591747 ms`; speedup: `804.86x`; reduction: `99.876%`.
- CI PR-scoped performance report is still required as the merge gate.

## Known Gaps
- Local verification is Linux/Python-only; no Swift or macOS runtime behavior is touched.
- The registered CI PR-scoped performance workflow must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
