### PR TITLE
perf(model-ops): cache active derived manifest tuple

### DIFF
--- a/docs/plans/2026-05-02-job-registry-active-manifest-tuple-cache.md
+++ b/docs/plans/2026-05-02-job-registry-active-manifest-tuple-cache.md
@@ -1,0 +1,35 @@
+# Job Registry Active Manifest Tuple Cache
+
+## Scope
+
+This performance slice is limited to the Python model-ops job registry active derived-model manifest accessor.
+
+Affected files:
+
+- `services/mlx-worker-python/worker/model_ops/job_registry.py`
+- `services/mlx-worker-python/tests/test_model_ops_job_registry.py`
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped probe `job-registry-derived-model-single-pass` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes focused `test_command`, `coverage_command`, and `probe_command` entries. Its `active_manifest_elapsed_ms_mean` metric repeatedly calls `ModelOpsJobRegistry.active_derived_model_manifests()` after cache warmup, so it directly measures this slice.
+
+## Implementation Plan
+
+1. Add a regression assertion that repeated `active_derived_model_manifests()` calls reuse the cached manifest tuple and still invalidate when derived-model activity changes.
+2. Cache the manifest tuple alongside the active row cache instead of rebuilding a tuple from cached rows on every call.
+3. Keep the existing row, derived-model-id, and manifest-path cache invalidation path as the single invalidation point.
+4. Run the registered focused tests, changed-scope coverage, and registered probe locally on Linux before opening a PR.
+
+## Validation Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
+```
+
+CI remains the merge gate for the registered PR-scoped performance report.

--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -202,9 +202,12 @@ def test_active_derived_model_row_cache_reuses_rows_and_invalidates() -> None:
 
     first_rows = registry._cached_active_derived_model_job_rows()
     second_rows = registry._cached_active_derived_model_job_rows()
+    first_manifests = registry.active_derived_model_manifests()
+    second_manifests = registry.active_derived_model_manifests()
 
     assert first_rows is second_rows
-    assert registry.active_derived_model_manifests() == (
+    assert first_manifests is second_manifests
+    assert first_manifests == (
         {
             "derived_model_id": "melix-dev-active",
             "derived_model_path": "/runtime/activate/melix-dev-active",

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -58,6 +58,7 @@ class ModelOpsJobRegistry:
         self._next_id = 1
         self._jobs: dict[str, ModelOpsJob] = {}
         self._active_derived_model_rows_cache: tuple[tuple[ModelOpsJob, dict[str, Any], str], ...] | None = None
+        self._active_derived_model_manifests_cache: tuple[dict[str, Any], ...] | None = None
         self._active_derived_model_by_id_cache: dict[str, _ActiveDerivedModelLookup] | None = None
         self._active_derived_model_by_manifest_path_cache: dict[str, _ActiveDerivedModelLookup] | None = None
         self._jobs_root = Path(jobs_root).expanduser().resolve() if jobs_root is not None else None
@@ -323,6 +324,7 @@ class ModelOpsJobRegistry:
 
     def _invalidate_active_derived_model_rows_cache(self) -> None:
         self._active_derived_model_rows_cache = None
+        self._active_derived_model_manifests_cache = None
         self._active_derived_model_by_id_cache = None
         self._active_derived_model_by_manifest_path_cache = None
 
@@ -495,7 +497,13 @@ class ModelOpsJobRegistry:
         )
 
     def active_derived_model_manifests(self) -> tuple[dict[str, Any], ...]:
-        return tuple(manifest for _, manifest, _ in self._cached_active_derived_model_job_rows())
+        cached_manifests = self._active_derived_model_manifests_cache
+        if cached_manifests is None:
+            cached_manifests = tuple(
+                manifest for _, manifest, _ in self._cached_active_derived_model_job_rows()
+            )
+            self._active_derived_model_manifests_cache = cached_manifests
+        return cached_manifests
 
     def _max_numeric_job_id(self) -> int:
         max_job_id = 0


### PR DESCRIPTION
## Summary
- Cache the `active_derived_model_manifests()` tuple alongside the active derived-model row cache so repeated reads do not rebuild a tuple from cached rows.
- Extend the registry cache regression test to prove repeated manifest reads reuse the tuple and still invalidate through the existing row-cache invalidation path.

## Plan or Spec
- `docs/plans/2026-05-02-job-registry-active-manifest-tuple-cache.md`
- Registered PR-scoped probe: `job-registry-derived-model-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe before this branch change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
-> exit 0; {"active_manifest_elapsed_ms_mean": 0.059951, "elapsed_ms_mean": 0.124648, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
-> exit 0; 17 passed in 0.29s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
-> exit 0; 17 passed in 0.42s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
-> exit 0

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py
-> exit 0; TOTAL 11 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
-> exit 0; {"active_manifest_elapsed_ms_mean": 0.007312, "elapsed_ms_mean": 0.061571, ...}

for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py; done
-> exit 0; active_manifest_elapsed_ms_mean samples: 0.012857, 0.016117, 0.021143; elapsed_ms_mean samples: 0.070005, 0.086317, 0.079203

git diff --check
-> exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (11/11 measurable changed lines).
- Registered local probe (`job-registry-derived-model-single-pass`) on Linux:
  - Baseline before change: `active_manifest_elapsed_ms_mean=0.059951`, `elapsed_ms_mean=0.124648`.
  - Post-change 3-run mean: `active_manifest_elapsed_ms_mean=0.016706`, `elapsed_ms_mean=0.078508`.
  - Delta: active manifest read `-0.043245 ms` / `72.13%` faster / `3.59x`; total probe `-0.046140 ms` / `37.02%` faster / `1.59x`.
- CI is still required for the registered PR-scoped performance workflow report before merge.

## Known Gaps
- None for the Python slice. No Swift runtime validation is involved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
