### PR TITLE
perf: cache resolved derived-model manifest paths

### DIFF
--- a/docs/plans/2026-05-02-job-registry-derived-model-id-lookup.md
+++ b/docs/plans/2026-05-02-job-registry-derived-model-id-lookup.md
@@ -12,9 +12,9 @@ Reduce repeated derived-model target resolution cost in `ModelOpsJobRegistry` wh
 
 ## Implementation
 
-The existing active-derived-model row cache avoids rebuilding the active row list, but each repeated `resolve_derived_model_target(derived_model_id=...)` call still scans the cached rows. This slice adds a cache-derived `derived_model_id -> active row` lookup that is invalidated together with the row cache. Manifest-path-only lookups keep the existing row scan semantics.
+The existing active-derived-model row cache avoids rebuilding the active row list, and the first derived-model ID slice added a cache-derived `derived_model_id -> active row` lookup. This follow-up slice keeps the resolved activation manifest path inside the cached lookup row so repeated `resolve_derived_model_target(derived_model_id=...)` calls do not re-run `Path(...).expanduser().resolve()` while constructing the response payload. Manifest-path-only lookups keep the existing normalized manifest-path cache semantics.
 
-The probe now resolves an older active model ID (`melix-dev-derived-0001`) so the registered metric exercises the cached-ID path instead of mostly measuring the newest-row fast case.
+The probe resolves an older active model ID (`melix-dev-derived-0001`) so the registered metric exercises the cached-ID path instead of mostly measuring the newest-row fast case.
 
 ## Validation Plan
 

--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -310,6 +310,38 @@ def test_resolve_derived_model_target_uses_cached_model_id_lookup(
     assert row_iterations == 0
 
 
+def test_resolve_derived_model_target_model_id_uses_cached_resolved_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = ModelOpsJobRegistry()
+    job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+    manifest_path = "/runtime/activate/melix-dev-active/manifest.json"
+    registry.attach_manifest(
+        job.job_id,
+        json.dumps(
+            {
+                "derived_model_id": "melix-dev-active",
+                "derived_model_path": "/runtime/activate/melix-dev-active",
+                "activation_mode": "fused_derived_model",
+            }
+        ),
+    )
+    registry.complete(job.job_id, manifest_path)
+
+    first_target = registry.resolve_derived_model_target(derived_model_id="melix-dev-active")
+    assert first_target is not None
+    assert first_target["activation_manifest_path"] == manifest_path
+
+    def fail_resolve(self: Path, *args: Any, **kwargs: Any) -> Path:
+        raise AssertionError("resolved activation manifest path should be cached")  # pragma: no cover
+
+    monkeypatch.setattr(Path, "resolve", fail_resolve)
+
+    second_target = registry.resolve_derived_model_target(derived_model_id="melix-dev-active")
+    assert second_target is not None
+    assert second_target["activation_manifest_path"] == manifest_path
+
+
 def test_resolve_derived_model_target_id_lookup_negative_paths() -> None:
     registry = ModelOpsJobRegistry()
     job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -45,11 +45,12 @@ class ModelOpsJob:
     error_message: str = ""
 
 
-@dataclass(frozen=True)
+@dataclass
 class _ActiveDerivedModelLookup:
     job: ModelOpsJob
     manifest: dict[str, Any]
     activation_manifest_path: str
+    resolved_activation_manifest_path: str | None = None
 
 
 class ModelOpsJobRegistry:
@@ -365,6 +366,7 @@ class ModelOpsJobRegistry:
                         job=job,
                         manifest=manifest,
                         activation_manifest_path=activation_manifest_path,
+                        resolved_activation_manifest_path=resolved_activation_manifest_path,
                     )
             self._active_derived_model_by_manifest_path_cache = cached_by_manifest_path
         return cached_by_manifest_path
@@ -474,9 +476,12 @@ class ModelOpsJobRegistry:
             lookup = self._cached_active_derived_model_by_id().get(normalized_model_id)
             if lookup is None:
                 return None
-            resolved_activation_manifest_path = str(
-                Path(lookup.activation_manifest_path).expanduser().resolve()
-            )
+            resolved_activation_manifest_path = lookup.resolved_activation_manifest_path
+            if resolved_activation_manifest_path is None:
+                resolved_activation_manifest_path = str(
+                    Path(lookup.activation_manifest_path).expanduser().resolve()
+                )
+                lookup.resolved_activation_manifest_path = resolved_activation_manifest_path
             if normalized_manifest_path and resolved_activation_manifest_path != normalized_manifest_path:
                 return None
             return self._derived_model_target_payload(


### PR DESCRIPTION
## Summary
- Cache the resolved activation manifest path on `ModelOpsJobRegistry` derived-model lookup rows after the first `derived_model_id` resolution.
- Add a regression test proving repeated `derived_model_id` lookups reuse the cached resolved path instead of calling `Path.resolve()` again.
- Update the derived-model ID lookup performance plan for this follow-up slice.

## Plan or Spec
- `docs/plans/2026-05-02-job-registry-derived-model-id-lookup.md`
- Registered PR-scoped probe: `job-registry-derived-model-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe from origin/main worktree (3 runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
# resolve_target_elapsed_ms_mean: 0.028779, 0.029779, 0.030909
# elapsed_ms_mean: 0.069071, 0.069784, 0.077109

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
# 18 passed in 0.15s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py
# TOTAL 20 0 100%

# Registered local probe after change (3 runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
# resolve_target_elapsed_ms_mean: 0.002699, 0.002793, 0.002672
# elapsed_ms_mean: 0.041302, 0.051367, 0.040460

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 20 0 100%`.
- Local registered probe metric over 3 runs:
  - `resolve_target_elapsed_ms_mean`: old_mean=0.029822 ms, new_mean=0.002721 ms, delta=-0.027101 ms, speedup=10.96x, improvement=90.87%.
  - `elapsed_ms_mean`: old_mean=0.071988 ms, new_mean=0.044376 ms, delta=-0.027612 ms, improvement=38.36%.
- GitHub Actions PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime path is touched.
- CI PR-scoped performance report must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
