### PR TITLE
perf: short-circuit rerank contiguous checks

### DIFF
--- a/docs/plans/2026-05-02-deterministic-rerank-contiguous-check-short-circuit.md
+++ b/docs/plans/2026-05-02-deterministic-rerank-contiguous-check-short-circuit.md
@@ -1,0 +1,34 @@
+# Deterministic Rerank Contiguous-Check Short Circuit
+
+## Scope
+
+This slice targets the Python deterministic rerank scoring path only:
+
+- `services/mlx-worker-python/worker/runtime/rerank_backends.py`
+- `services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py`
+- `services/mlx-worker-python/tests/test_rerank_runtime.py`
+
+The goal is to keep scoring semantics unchanged while avoiding the ordered contiguous-query scan for documents that cannot contain all query terms.
+
+## Registered Probe
+
+The affected path is covered by the PR-scoped registered probe `deterministic-rerank-query-context-reuse` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes:
+
+- `test_command`: focused rerank runtime tests plus PR-scoped performance selection/dispatch tests.
+- `coverage_command`: changed-scope coverage for the rerank runtime, rerank backend, PR-scoped performance harness, and related tests.
+- `probe_command`: local/CI command for `_probe_deterministic_rerank_query_context_reuse`.
+
+## Implementation Plan
+
+1. Add a focused regression test proving the contiguous-query helper is not invoked when a document misses required query terms.
+2. Gate exact-order and prefix bonuses behind the already computed overlap count in Jina-v3 and causal-LM scoring.
+3. Run the focused tests, changed-scope coverage, and registered probe locally on Linux.
+4. Compare the registered probe against `origin/main` before accepting the slice.
+
+## Success Criteria
+
+- Focused rerank behavior remains unchanged.
+- Changed-scope coverage remains at or above 95%.
+- Registered probe `elapsed_ms_mean` improves or shows an explainable neutral boundary without semantic regression.

--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from packages.protocol.python.worker.v1 import common_pb2, inference_pb2, runtime_pb2
@@ -191,6 +193,48 @@ def test_causal_lm_rerank_produces_positive_and_negative_logits() -> None:
     assert [item.index for item in rerank.items] == [0, 1]
     assert rerank.items[0].score > 0
     assert rerank.items[1].score < 0
+
+
+def test_jina_v3_skips_contiguous_query_check_when_document_misses_query_terms(monkeypatch) -> None:
+    adapter = JinaV3RerankFamilyAdapter()
+    backend = DeterministicRerankBackend()
+    contains = Mock(return_value=False)
+
+    monkeypatch.setattr(
+        JinaV3RerankFamilyAdapter,
+        "_contains_contiguous_query",
+        staticmethod(contains),
+    )
+
+    score = adapter.score(
+        backend,
+        "swift control plane runtime",
+        "python worker packaging",
+    )
+
+    assert score >= 0.0
+    contains.assert_not_called()
+
+
+def test_causal_lm_skips_contiguous_query_check_when_document_misses_query_terms(monkeypatch) -> None:
+    adapter = CausalLMRerankFamilyAdapter()
+    backend = DeterministicRerankBackend()
+    contains = Mock(return_value=False)
+
+    monkeypatch.setattr(
+        JinaV3RerankFamilyAdapter,
+        "_contains_contiguous_query",
+        staticmethod(contains),
+    )
+
+    score = adapter.score(
+        backend,
+        "swift control plane runtime",
+        "python worker packaging",
+    )
+
+    assert score < 0.0
+    contains.assert_not_called()
 
 
 def test_load_model_rejects_unsupported_rerank_family() -> None:

--- a/services/mlx-worker-python/worker/runtime/rerank_backends.py
+++ b/services/mlx-worker-python/worker/runtime/rerank_backends.py
@@ -166,6 +166,7 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
         document_token_set = set(document_tokens)
 
         if not query_token_set and not document_token_set:
+            overlap_count = 0
             overlap_score = 1.0
         else:
             overlap_count = len(query_token_set & document_token_set)
@@ -173,8 +174,11 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
             overlap_score = overlap_count / union
 
         pair_bonus = self._ordered_pair_bonus(query_tokens, document_tokens, query_pairs=query_context.ordered_pairs)
-        exact_order_bonus = 0.1 if self._contains_contiguous_query(document_tokens, query_tokens) else 0.0
-        prefix_bonus = 0.05 if query_tokens and document_tokens[: len(query_tokens)] == query_tokens else 0.0
+        has_all_query_terms = overlap_count >= len(query_token_set)
+        exact_order_bonus = (
+            0.1 if has_all_query_terms and self._contains_contiguous_query(document_tokens, query_tokens) else 0.0
+        )
+        prefix_bonus = 0.05 if has_all_query_terms and document_tokens[: len(query_tokens)] == query_tokens else 0.0
 
         return round(
             overlap_score + pair_bonus + exact_order_bonus + prefix_bonus + backend.tie_breaker(query, document),
@@ -259,8 +263,12 @@ class CausalLMRerankFamilyAdapter(RerankFamilyAdapter):
             document_tokens,
             query_pairs=query_context.ordered_pairs,
         )
-        exact_order = JinaV3RerankFamilyAdapter._contains_contiguous_query(document_tokens, query_tokens)
-        prefix_match = bool(query_tokens) and document_tokens[: len(query_tokens)] == query_tokens
+        exact_order = (
+            JinaV3RerankFamilyAdapter._contains_contiguous_query(document_tokens, query_tokens)
+            if overlap_count >= len(query_token_set)
+            else False
+        )
+        prefix_match = overlap_count >= len(query_token_set) and document_tokens[: len(query_tokens)] == query_tokens
 
         yes_logit = overlap * 6.0
         yes_logit += pair_bonus * 3.0


### PR DESCRIPTION
## Summary
- Short-circuit deterministic rerank exact-order and prefix checks when the document does not contain all query terms.
- Add focused regression coverage for Jina-v3 and causal-LM adapters to prove the contiguous-query scan is skipped on impossible matches.

## Plan or Spec
- `docs/plans/2026-05-02-deterministic-rerank-contiguous-check-short-circuit.md`
- Registered probe: `deterministic-rerank-query-context-reuse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
$ git fetch origin
origin/main=e77066df84c7751ff1d05ab58a1e52c801a48338

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
27 passed in 14.22s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
27 passed in 38.18s
TOTAL 23 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/probe_rerank.py
{"document_count": 2048.0, "elapsed_ms_mean": 98.784715, "iteration_count": 8.0, "query_context_builds_mean": 1.0, "sample_count": 5.0, "tokenize_calls_mean": 2049.0}

$ for label in base branch base branch base branch; do ...; done
base elapsed_ms_mean samples: 84.636856, 85.284173, 86.128416
branch elapsed_ms_mean samples: 81.077503, 86.214840, 80.781865
computed means: base_mean=85.349815, branch_mean=82.691403, delta_ms=-2.658412, improvement_pct=3.115

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 23 0 100%`).
- Registered local probe: `deterministic-rerank-query-context-reuse`.
- Local repeated probe comparison vs `origin/main`: `base_mean=85.349815ms`, `branch_mean=82.691403ms`, `delta_ms=-2.658412ms`, `improvement_pct=3.115%`.
- CI is required to validate the registered PR-scoped performance report on GitHub Actions.

## Known Gaps
- Local validation is Linux/Python only. No Swift runtime effect is claimed.
- The single branch probe run was noisier (`98.784715ms`), so the decision uses the repeated alternating base/branch samples listed above.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
