### PR TITLE
perf(rerank): short-circuit ordered pair scoring

### DIFF
--- a/docs/plans/2026-05-02-rerank-ordered-pair-short-circuit.md
+++ b/docs/plans/2026-05-02-rerank-ordered-pair-short-circuit.md
@@ -1,0 +1,46 @@
+# Deterministic Rerank Ordered-Pair Short-Circuit Slice
+
+## Goal
+
+Reduce deterministic rerank scoring overhead for Jina-v3 and causal-LM family adapters by avoiding construction of a full document adjacent-pair set when the document already contains all query adjacent pairs early.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/rerank_backends.py`
+- `services/mlx-worker-python/tests/test_rerank_runtime.py`
+- `infra/perf/pr_scoped_probes.json` registered probe `deterministic-rerank-query-context-reuse`
+
+## Linux Constraint
+
+This slice is Python-only and is locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered PR-scoped performance probe.
+
+## Optimization Hypothesis
+
+`JinaV3RerankFamilyAdapter._ordered_pair_bonus()` previously built a set of every adjacent pair in each document, then intersected it with the much smaller query-pair set. Scanning adjacent document pairs and stopping once every query pair has matched preserves the same unique-pair score while avoiding avoidable allocations and tail scans for early-matching documents.
+
+## Registered Probe
+
+- Probe ID: `deterministic-rerank-query-context-reuse`
+- Workload: score 2,048 deterministic rerank documents across repeated iterations with a reused query context.
+- Metrics:
+  - `elapsed_ms_mean` lower is better
+  - `query_context_builds_mean` lower is better
+  - `tokenize_calls_mean` lower is better
+
+## Success Metrics
+
+- Focused tests prove query context behavior and ordered-pair score semantics remain unchanged.
+- Changed-scope coverage for touched rerank runtime files and tests remains at or above 95%.
+- Local registered probe improves versus the pre-change baseline without increasing query-context builds or tokenize calls.
+- PR-scoped performance CI selects and completes the registered probe for this path.
+
+## Verification Commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/run_probe_rerank.py
+git diff --check
+```

--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -416,6 +416,38 @@ def test_rerank_context_tuple_and_frozenset_collections_are_scored_directly() ->
     ) == family.score(backend, "swift runtime", "control swift runtime")
 
 
+def test_ordered_pair_bonus_stops_after_matching_all_query_pairs() -> None:
+    class CountingTokens:
+        def __init__(self, tokens: tuple[str, ...]) -> None:
+            self.tokens = tokens
+            self.access_count = 0
+
+        def __len__(self) -> int:
+            return len(self.tokens)
+
+        def __getitem__(self, index: int) -> str:
+            self.access_count += 1
+            return self.tokens[index]
+
+    document_tokens = CountingTokens(
+        (
+            "swift",
+            "runtime",
+            "padding-1",
+            "padding-2",
+            "padding-3",
+            "padding-4",
+            "padding-5",
+        )
+    )
+
+    assert (
+        JinaV3RerankFamilyAdapter._ordered_pair_bonus(("swift", "runtime"), document_tokens)
+        == 0.15
+    )
+    assert document_tokens.access_count <= 2
+
+
 def test_contiguous_query_scan_does_not_allocate_document_slices() -> None:
     class NoSliceTokens:
         def __init__(self, tokens: tuple[str, ...]) -> None:

--- a/services/mlx-worker-python/worker/runtime/rerank_backends.py
+++ b/services/mlx-worker-python/worker/runtime/rerank_backends.py
@@ -197,11 +197,16 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
 
         if query_pairs is None:
             query_pairs = frozenset(_build_adjacent_pairs(query_tokens))
-        document_pairs = {
-            (document_tokens[index], document_tokens[index + 1])
-            for index in range(len(document_tokens) - 1)
-        }
-        return (len(query_pairs & document_pairs) / len(query_pairs)) * 0.15
+        matched_pairs: set[tuple[str, str]] = set()
+        query_pair_count = len(query_pairs)
+        for index in range(len(document_tokens) - 1):
+            pair = (document_tokens[index], document_tokens[index + 1])
+            if pair not in query_pairs:
+                continue
+            matched_pairs.add(pair)
+            if len(matched_pairs) == query_pair_count:
+                break
+        return (len(matched_pairs) / query_pair_count) * 0.15
 
     @staticmethod
     def _contains_contiguous_query(document_tokens: Sequence[str], query_tokens: Sequence[str]) -> bool:


### PR DESCRIPTION
## Summary
- Short-circuit deterministic rerank ordered-pair scoring once every query adjacent pair has been matched.
- Avoid building a full document adjacent-pair set for early-match documents while preserving unique-pair scoring semantics.
- Add a focused regression test and a governing plan for the slice.

## Plan or Spec
- `docs/plans/2026-05-02-rerank-ordered-pair-short-circuit.md`
- Registered PR-scoped probe: `deterministic-rerank-query-context-reuse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py::test_ordered_pair_bonus_stops_after_matching_all_query_pairs
# RED before implementation: failed because the previous full document-pair set scan touched 12 token accesses.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
# PASS: 28 passed in 12.80s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# PASS: 28 passed; TOTAL 23 0 100%

git diff --check
# PASS
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (23/23 measurable changed lines).
- Local registered probe command: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/run_probe_rerank.py`
- Baseline probe samples on `origin/main` elapsed_ms_mean: `80.399728`, `94.523617`, `85.272461`; mean `86.731935` ms.
- Head probe samples elapsed_ms_mean: `80.882029`, `79.017296`, `78.517231`; mean `79.472185` ms.
- Delta: `-7.259750` ms (`8.370%` faster, `1.091350x` speedup).
- Query-context and tokenize-count metrics remained unchanged: `query_context_builds_mean=1.0`, `tokenize_calls_mean=2049.0`.
- CI must run the registered PR-scoped performance workflow and publish the authoritative probe report for this PR.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime effect is claimed for this Python slice.
- The repository root worktree has pre-existing unrelated dirty files from an older slice, so this PR was created in an isolated clean worktree under `/root/.hermes/profiles/coder/workspace/worktrees/`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
