### PR TITLE
perf: cache PR-scoped performance registry loads

### DIFF
--- a/docs/plans/2026-05-02-pr-scoped-performance-registry-cache.md
+++ b/docs/plans/2026-05-02-pr-scoped-performance-registry-cache.md
@@ -1,0 +1,45 @@
+# PR-Scoped Performance Registry Cache Plan
+
+## Goal
+
+Reduce repeated registry JSON parsing and file reads in the PR-scoped performance selector by caching parsed probe definitions for an unchanged registry file.
+
+## Linux-Only Constraint
+
+This slice targets Python-only CI/performance infrastructure under `services/mlx-worker-python`. It is fully verifiable on Linux without macOS or Swift execution.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Proposed Change
+
+1. Add a small cache in `load_probe_registry()` keyed by the registry path plus file metadata sufficient to invalidate when the JSON file changes.
+2. Keep output semantics unchanged: callers still receive the same tuple of `ProbeDefinition` values.
+3. Register a dedicated PR-scoped performance probe for the registry-cache path so CI measures the touched helper directly.
+4. Add focused tests for cache hit behavior, invalidation on file change, probe selection, and probe execution.
+
+## Performance Probe
+
+Probe ID: `pr-scoped-performance-registry-cache`
+
+Measure repeated registry loading / scope selection on a stable registry file.
+
+Metrics:
+- `load_probe_registry_ms_mean` (lower is better)
+- `build_scope_report_ms_mean` (lower is better)
+
+## Success Metrics
+
+- No behavior regression in scope selection or probe execution tests.
+- Changed-scope automated coverage >= 95%.
+- Local probe shows lower mean time for repeated `load_probe_registry()` and/or `build_scope_report()` versus `origin/main`.
+
+## Verification Commands
+
+- Focused pytest for `test_pr_scoped_performance.py` nodes covering the cache and probe.
+- `coverage run -m pytest ...` plus `scripts/changed_scope_coverage.py` for changed executable lines.
+- Dedicated local base-vs-head probe command for `pr-scoped-performance-registry-cache`.
+- `git diff --check`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -535,6 +535,36 @@
     ]
   },
   {
+    "id": "pr-scoped-performance-registry-cache",
+    "name": "PR-scoped performance registry cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/pr_scoped_performance.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_refreshes_cache_when_file_changes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_registry_cache_probe",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_refreshes_cache_when_file_changes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_registry_cache_probe && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "",
+    "probe_impl": "pr_scoped_performance_registry_cache",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "load_probe_registry_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "build_scope_report_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "pr-scoped-performance-scope-matcher",
     "name": "PR-scoped performance scope matcher",
     "runner": "ubuntu-latest",

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import time
 import runpy
 import sys
 
@@ -266,6 +267,16 @@ def test_scope_report_selects_dev_up_mlx_metal_dist_info_probe() -> None:
     assert "dev-up-mlx-metal-dist-info-scandir" in probe_ids
 
 
+def test_scope_report_selects_registry_cache_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/pr_scoped_performance.py"],
+    )
+
+    probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert "pr-scoped-performance-registry-cache" in probe_ids
+
+
 def test_scope_report_force_selects_all_on_infra_change() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -410,6 +421,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "training-dataset-token-percentiles-single-sort",
         "maintenance-bench-report-readback",
         "phase8-metrics-closure-audit-reuse",
+        "pr-scoped-performance-registry-cache",
         "swift-cli-json-envelope-encoding",
         "upload-receipt-published-files-scandir",
         "download-pipeline-directory-size-single-stat",
@@ -460,6 +472,100 @@ def test_load_probe_registry_rejects_invalid_payloads(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="non-empty list"):
         load_probe_registry(invalid_metrics)
+
+
+def test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry_path = tmp_path / "probe-registry.json"
+    registry_path.write_text(
+        json.dumps(
+            [
+                {
+                    "id": "demo",
+                    "name": "Demo",
+                    "probe_impl": "command_json",
+                    "probe_command": "python3 -c \"import json; print(json.dumps({'elapsed_ms_mean': 1.0}))\"",
+                    "metrics": [{"key": "elapsed_ms_mean", "unit": "ms", "direction": "lower_is_better"}],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    read_calls = 0
+    original_read_text = Path.read_text
+
+    def tracked_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        nonlocal read_calls
+        if self == registry_path:
+            read_calls += 1
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", tracked_read_text)
+
+    first = load_probe_registry(registry_path)
+    second = load_probe_registry(registry_path)
+
+    assert read_calls == 1
+    assert second is first
+
+
+def test_load_probe_registry_refreshes_cache_when_file_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry_path = tmp_path / "probe-registry.json"
+    registry_path.write_text(
+        json.dumps(
+            [
+                {
+                    "id": "demo-a",
+                    "name": "Demo A",
+                    "probe_impl": "command_json",
+                    "probe_command": "python3 -c \"import json; print(json.dumps({'elapsed_ms_mean': 1.0}))\"",
+                    "metrics": [{"key": "elapsed_ms_mean", "unit": "ms", "direction": "lower_is_better"}],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    read_calls = 0
+    original_read_text = Path.read_text
+
+    def tracked_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        nonlocal read_calls
+        if self == registry_path:
+            read_calls += 1
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", tracked_read_text)
+
+    first = load_probe_registry(registry_path)
+    time.sleep(0.001)
+    registry_path.write_text(
+        json.dumps(
+            [
+                {
+                    "id": "demo-b",
+                    "name": "Demo B",
+                    "probe_impl": "command_json",
+                    "probe_command": "python3 -c \"import json; print(json.dumps({'elapsed_ms_mean': 2.0, 'build_scope_report_ms_mean': 3.0}))\"",
+                    "metrics": [
+                        {"key": "elapsed_ms_mean", "unit": "ms", "direction": "lower_is_better"},
+                        {"key": "build_scope_report_ms_mean", "unit": "ms", "direction": "lower_is_better"},
+                    ],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    second = load_probe_registry(registry_path)
+
+    assert read_calls == 2
+    assert first[0].probe_id == "demo-a"
+    assert second[0].probe_id == "demo-b"
 
 
 def test_single_pass_sample_iterable_rejects_repeated_iteration() -> None:
@@ -1015,6 +1121,20 @@ def test_run_probe_job_executes_verification_and_probe_for_current_repo() -> Non
     assert result["head_verification"]["test"]["ok"] is True
     assert result["head_verification"]["coverage"]["coverage_pct"] >= 95.0
     assert result["base_probe"]["metrics"]["elapsed_ms_mean"] > 0
+
+
+def test_dispatch_probe_impl_supports_registry_cache_probe() -> None:
+    probe = next(
+        probe
+        for probe in load_probe_registry(REGISTRY_PATH)
+        if probe.probe_id == "pr-scoped-performance-registry-cache"
+    )
+
+    metrics = _dispatch_probe_impl(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["load_probe_registry_ms_mean"] > 0
+    assert metrics["build_scope_report_ms_mean"] > 0
+    assert metrics["sample_count"] == 6.0
 
 
 def test_run_head_verification_skips_standalone_test_when_coverage_replays_tests(

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -82,8 +82,18 @@ class ProbeDefinition:
         }
 
 
+_PROBE_REGISTRY_CACHE: dict[str, tuple[int, int, tuple[ProbeDefinition, ...]]] = {}
+
+
 def load_probe_registry(path: str | Path) -> tuple[ProbeDefinition, ...]:
-    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    path_obj = Path(path)
+    resolved_path = str(path_obj.resolve())
+    stat_result = path_obj.stat()
+    cached = _PROBE_REGISTRY_CACHE.get(resolved_path)
+    if cached is not None and cached[0] == stat_result.st_mtime_ns and cached[1] == stat_result.st_size:
+        return cached[2]
+
+    payload = json.loads(path_obj.read_text(encoding="utf-8"))
     if not isinstance(payload, list):
         raise ValueError("probe registry must be a JSON list")
     probes: list[ProbeDefinition] = []
@@ -117,7 +127,9 @@ def load_probe_registry(path: str | Path) -> tuple[ProbeDefinition, ...]:
                 coverage_replays_tests=bool(raw_probe.get("coverage_replays_tests", False)),
             )
         )
-    return tuple(probes)
+    probe_tuple = tuple(probes)
+    _PROBE_REGISTRY_CACHE[resolved_path] = (stat_result.st_mtime_ns, stat_result.st_size, probe_tuple)
+    return probe_tuple
 
 
 def load_probe_registry_for_scope(path: str | Path) -> tuple[ProbeDefinition, ...]:
@@ -428,6 +440,8 @@ def _dispatch_probe_impl(*, probe: ProbeDefinition, repo_root: Path) -> dict[str
         return _probe_pr_scoped_scope_matcher(repo_root)
     if probe.probe_impl == "model_ops_bundle_artifact_bytes":
         return _probe_model_ops_bundle_artifact_bytes(repo_root)
+    if probe.probe_impl == "pr_scoped_performance_registry_cache":
+        return _probe_pr_scoped_performance_registry_cache(repo_root)
     if probe.probe_impl == "command_json":
         return _probe_command_json(probe=probe, repo_root=repo_root)
     raise ValueError(f"unsupported probe implementation: {probe.probe_impl}")
@@ -461,6 +475,47 @@ def _probe_command_json(*, probe: ProbeDefinition, repo_root: Path) -> dict[str,
             raise ValueError(f"probe_command metric {key} must be numeric")
         metrics[str(key)] = float(value)
     return metrics
+
+
+def _probe_pr_scoped_performance_registry_cache(repo_root: Path) -> dict[str, float]:
+    module = _load_repo_module(
+        repo_root / "services/mlx-worker-python/worker/productization/pr_scoped_performance.py",
+        unique_name="melix_probe_pr_scoped_performance_registry_cache",
+    )
+    registry_path = repo_root / "infra/perf/pr_scoped_probes.json"
+    changed_files = [
+        "services/mlx-worker-python/worker/productization/pr_scoped_performance.py",
+        "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    ]
+    load_iterations = 400
+    scope_iterations = 200
+    sample_count = 6
+    load_samples: list[float] = []
+    scope_samples: list[float] = []
+    cache = getattr(module, "_PROBE_REGISTRY_CACHE", None)
+
+    for _ in range(sample_count):
+        if isinstance(cache, dict):
+            cache.clear()
+        started = time.perf_counter()
+        for _ in range(load_iterations):
+            module.load_probe_registry(registry_path)
+        load_samples.append((time.perf_counter() - started) * 1000.0)
+
+        if isinstance(cache, dict):
+            cache.clear()
+        started = time.perf_counter()
+        for _ in range(scope_iterations):
+            module.build_scope_report(registry_path=registry_path, changed_files=changed_files)
+        scope_samples.append((time.perf_counter() - started) * 1000.0)
+
+    return {
+        "load_probe_registry_iterations": float(load_iterations),
+        "load_probe_registry_ms_mean": round(sum(load_samples) / len(load_samples), 6),
+        "build_scope_report_iterations": float(scope_iterations),
+        "build_scope_report_ms_mean": round(sum(scope_samples) / len(scope_samples), 6),
+        "sample_count": float(sample_count),
+    }
 
 
 def _probe_benchmark_evaluation_report(repo_root: Path) -> dict[str, float]:


### PR DESCRIPTION
## Summary
- Cache parsed PR-scoped performance probe registries by resolved path + file metadata so repeated scope selection stops rereading and reparsing the same JSON file.
- Add focused regression tests for cache hits, invalidation after registry edits, scope selection, and probe dispatch.
- Register a dedicated `pr-scoped-performance-registry-cache` probe so the touched helper has an explicit scoped CI signal.

## Plan or Spec
- `docs/plans/2026-05-02-pr-scoped-performance-registry-cache.md`

## Commands Run
```text
# Focused TDD red step
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_registry_cache_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_refreshes_cache_when_file_changes \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registry_cache_probe_command_emits_metrics
# outcome: 3 failed, 1 passed (expected before implementation)

# Focused green step / probe registration verification
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_registry_cache_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_refreshes_cache_when_file_changes \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_registry_cache_probe
# outcome: 5 passed

# Focused changed-scope coverage gate
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_registry_cache_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_refreshes_cache_when_file_changes \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_registry_cache_probe \
  && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json \
  && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
     services/mlx-worker-python/worker/productization/pr_scoped_performance.py \
     services/mlx-worker-python/tests/test_pr_scoped_performance.py
# outcome: 5 passed; TOTAL 79 0 100%

# Broader touched-file regression check
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py
# outcome: 52 passed

# Local scoped probe comparison against origin/main worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
import json
from pathlib import Path
from worker.productization.pr_scoped_performance import _probe_pr_scoped_performance_registry_cache
head = Path('/tmp/melix-cron-20260502100654')
base = Path('/tmp/melix-base-20260502101919')
print(json.dumps({
    'base': _probe_pr_scoped_performance_registry_cache(base),
    'head': _probe_pr_scoped_performance_registry_cache(head),
}, sort_keys=True))
PY
# outcome: base/head metrics captured; see Coverage and Metrics section

# Diff hygiene
git diff --check
# outcome: clean
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 79 0 100%`
  - `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`: `37/37` changed executable lines covered (`100%`)
  - `services/mlx-worker-python/tests/test_pr_scoped_performance.py`: `42/42` changed executable lines covered (`100%`)
- Local scoped probe: `pr-scoped-performance-registry-cache`
  - `load_probe_registry_ms_mean`: `131.189887` (base) → `12.269923` (head), `90.65%` lower, `10.69x` faster
  - `build_scope_report_ms_mean`: `70.078230` (base) → `11.717283` (head), `83.28%` lower, `5.98x` faster
  - Probe sample size: `6` samples with `400` repeated registry loads and `200` repeated scope-report builds per sample

## Known Gaps
- This is a Linux-only verification slice for Python/CI infrastructure. No macOS/Swift local verification was run because the touched path is entirely under `services/mlx-worker-python` and the PR-scoped performance harness.
- Because `infra/perf/pr_scoped_probes.json` changed, the repository's `pr-scoped-performance` workflow will fan out to the full registered matrix, including unrelated existing probes; local verification here only proves the touched Python slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
