### PR TITLE
perf(rerank): reuse tie-breaker query prefix

### DIFF
--- a/docs/plans/2026-05-02-rerank-tie-breaker-prefix.md
+++ b/docs/plans/2026-05-02-rerank-tie-breaker-prefix.md
@@ -1,0 +1,46 @@
+# Deterministic Rerank Tie-Breaker Prefix Slice
+
+## Goal
+
+Reduce deterministic rerank scoring overhead by reusing the query-side bytes for the stable tie-breaker hash across all documents in a `score_documents` call.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/rerank_backends.py`
+- `services/mlx-worker-python/tests/test_rerank_runtime.py`
+- `infra/perf/pr_scoped_probes.json` registered probe `deterministic-rerank-query-context-reuse`
+
+## Linux Constraint
+
+This slice is Python-only and locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered PR-scoped performance probe.
+
+## Optimization Hypothesis
+
+The deterministic rerank runtime already builds one query context per `score_documents` call. The tie-breaker hash currently encodes `query + NUL + document` for every scored document. Storing the encoded `query + NUL` prefix in the query context preserves deterministic scores while avoiding repeated query-prefix formatting and encoding for each document.
+
+## Registered Probe
+
+- Probe ID: `deterministic-rerank-query-context-reuse`
+- Workload: score 2,048 deterministic rerank documents across repeated iterations with a reused query context.
+- Metrics:
+  - `elapsed_ms_mean` lower is better
+  - `query_context_builds_mean` lower is better
+  - `tokenize_calls_mean` lower is better
+
+## Success Metrics
+
+- Focused tests prove query context behavior and tie-breaker semantics remain unchanged.
+- Changed-scope coverage for touched rerank runtime files and tests remains at or above 95%.
+- Local registered probe improves versus the pre-change baseline without increasing query-context builds or tokenize calls.
+- PR-scoped performance CI selects and completes the registered probe for this path.
+
+## Verification Commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-rerank-query-context-reuse --base-repo <baseline-worktree> --head-repo "$PWD" --output /tmp/rerank_prefix_probe.json
+git diff --check
+```

--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -403,6 +403,11 @@ def test_rerank_context_tuple_and_frozenset_collections_are_scored_directly() ->
 
     assert isinstance(query_context.query_tokens, tuple)
     assert isinstance(query_context.query_token_set, frozenset)
+    assert query_context.tie_breaker_prefix == b"swift runtime\0"
+    assert backend.tie_breaker_from_prefix(
+        query_context.tie_breaker_prefix,
+        "control swift runtime",
+    ) == backend.tie_breaker("swift runtime", "control swift runtime")
     assert family._ordered_pair_bonus(query_context.query_tokens, ("swift", "runtime")) > 0.0
     assert family._contains_contiguous_query(
         ("control", "swift", "runtime"),

--- a/services/mlx-worker-python/worker/runtime/rerank_backends.py
+++ b/services/mlx-worker-python/worker/runtime/rerank_backends.py
@@ -35,7 +35,11 @@ class DeterministicRerankBackend:
 
     @staticmethod
     def tie_breaker(query: str, document: str) -> float:
-        digest = hashlib.sha256(f"{query}\0{document}".encode("utf-8")).digest()
+        return DeterministicRerankBackend.tie_breaker_from_prefix(f"{query}\0".encode("utf-8"), document)
+
+    @staticmethod
+    def tie_breaker_from_prefix(query_prefix: bytes, document: str) -> float:
+        digest = hashlib.sha256(query_prefix + document.encode("utf-8")).digest()
         return int.from_bytes(digest[:4], "little") / 0xFFFFFFFF * 0.0001
 
 
@@ -51,6 +55,7 @@ class RerankQueryContext:
     query_tokens: tuple[str, ...]
     query_token_set: frozenset[str]
     ordered_pairs: frozenset[tuple[str, str]]
+    tie_breaker_prefix: bytes
 
 
 class RerankFamilyAdapter:
@@ -81,6 +86,7 @@ class RerankFamilyAdapter:
             query_tokens=normalized_query_tokens,
             query_token_set=frozenset(query_token_set),
             ordered_pairs=frozenset(_build_adjacent_pairs(normalized_query_tokens)),
+            tie_breaker_prefix=f"{query}\0".encode("utf-8"),
         )
 
     def score(
@@ -134,7 +140,7 @@ class BasicRerankFamilyAdapter(RerankFamilyAdapter):
             overlap_count = len(query_token_set & document_tokens)
             union = (len(query_token_set) + len(document_tokens) - overlap_count) or 1
             overlap_score = overlap_count / union
-        return round(overlap_score + backend.tie_breaker(query, document), 6)
+        return round(overlap_score + backend.tie_breaker_from_prefix(query_context.tie_breaker_prefix, document), 6)
 
 
 class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
@@ -181,7 +187,11 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
         prefix_bonus = 0.05 if has_all_query_terms and document_tokens[: len(query_tokens)] == query_tokens else 0.0
 
         return round(
-            overlap_score + pair_bonus + exact_order_bonus + prefix_bonus + backend.tie_breaker(query, document),
+            overlap_score
+            + pair_bonus
+            + exact_order_bonus
+            + prefix_bonus
+            + backend.tie_breaker_from_prefix(query_context.tie_breaker_prefix, document),
             6,
         )
 
@@ -285,7 +295,7 @@ class CausalLMRerankFamilyAdapter(RerankFamilyAdapter):
         if overlap_count == 0:
             no_logit += 0.3
 
-        return round(yes_logit - no_logit + backend.tie_breaker(query, document), 6)
+        return round(yes_logit - no_logit + backend.tie_breaker_from_prefix(query_context.tie_breaker_prefix, document), 6)
 
 
 def resolve_rerank_backend(backend_id: str) -> DeterministicRerankBackend:


### PR DESCRIPTION
## Summary
- Reuses the deterministic rerank query tie-breaker prefix from the per-request query context.
- Preserves stable tie-breaker scores for basic, Jina-v3, and causal-LM rerank families while avoiding repeated query-prefix formatting/encoding per document.

## Plan or Spec
- docs/plans/2026-05-02-rerank-tie-breaker-prefix.md
- Registered probe: `deterministic-rerank-query-context-reuse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
# exit 0; 28 passed in 12.58s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; 28 passed in 35.69s; changed-scope coverage TOTAL 9 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-rerank-query-context-reuse --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-rerank-prefix-20260502103735 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-20260502103735 --output /tmp/rerank_prefix_probe.json
# exit 0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (9/9 changed measurable lines covered).
- Local registered probe (`deterministic-rerank-query-context-reuse`):
  - `elapsed_ms_mean`: base 76.203918 ms -> head 74.714884 ms (delta -1.489034 ms; ~1.95% faster)
  - `query_context_builds_mean`: base 1.0 -> head 1.0
  - `tokenize_calls_mean`: base 2049.0 -> head 2049.0
- CI PR-scoped performance is required as the merge validation source for the registered probe report.

## Known Gaps
- None for the Python slice; Swift/macOS runtime effects are not applicable.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
