### PR TITLE
[codex] Upgrade MLX runtime dependencies

### DIFF
--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -928,9 +928,11 @@ struct DesktopFoundationViewTests {
         let client = FakeControlPlaneXPCClient()
         let viewModel = RuntimeViewModel(client: client)
 
-        let view = hostView(DesktopModelRegistryEntriesView(viewModel: viewModel))
+        let registryView = DesktopModelRegistryEntriesView(viewModel: viewModel)
+        _ = hostView(registryView)
 
-        #expect(view.subviews.isEmpty == false)
+        #expect(registryView.entries.isEmpty)
+        #expect(registryView.selectedCard == nil)
         #expect(viewModel.modelRegistryEntries.isEmpty)
         #expect(viewModel.selectedHubModelCard == nil)
     }

--- a/docs/plans/2026-05-02-mlx-runtime-dependency-upgrade.md
+++ b/docs/plans/2026-05-02-mlx-runtime-dependency-upgrade.md
@@ -1,0 +1,95 @@
+# MLX Runtime Dependency Upgrade
+
+## Goal
+
+Upgrade Melix's Python and Swift MLX runtime stacks while keeping public HTTP,
+protobuf, and OpenAI-compatible request or response shapes unchanged.
+
+## Target Versions
+
+| Component | Current state | Target |
+| --- | --- | --- |
+| Python `mlx` | locked to `0.31.1` | `>=0.31.2,<0.32` |
+| Python `mlx-lm` | locked to `0.31.1` | `>=0.31.3,<0.32` |
+| Python `mlx-vlm` | Git pin at `43b9b207...`, version `0.4.3` | PyPI `>=0.4.4,<0.5` |
+| Python `mlx-audio` | `0.4.2` | unchanged |
+| Swift `mlx-swift-lm` | vendored Melix-patched fork from upstream `2.29.3` | upstream `2.31.3` plus Melix patches |
+| Swift `mlx-swift` | `0.29.1` | `0.31.3` |
+| Swift `swift-transformers` | `1.1.x` | `1.2.x` |
+
+`mlx-swift-lm` intentionally stays on the last 2.x tag. The 3.x release line is
+a separate breaking API migration and is outside this change.
+
+## Implementation Changes
+
+- Update `services/mlx-worker-python/pyproject.toml` and `uv.lock` for the
+  target Python MLX stack. Convert `mlx-vlm` from the Git source to a registry
+  dependency.
+- Keep the text/VLM `mlx` extra separate from the `mlx-audio 0.4.2` extras,
+  because the current audio dependency line pins `mlx-lm 0.31.1`.
+- Add lightweight runtime feature detection around Python `mlx-lm` and
+  `mlx-vlm` calls so Melix only passes optional generation arguments when the
+  installed runtime accepts them.
+- Keep existing `SamplingConfig` as the source for `temperature`, `top_p`,
+  `top_k`, `frequency_penalty`, `presence_penalty`, and `max_output_tokens`;
+  do not add protocol fields.
+- Resync `third_party/mlx-swift-lm` to upstream `2.31.3`, then reapply the
+  Melix TurboQuant, fused q4 attention, Qwen3.5 hybrid-cache, and probe patches
+  documented in `third_party/mlx-swift-lm/MELIX_PATCHES.md`.
+- Update the Swift text worker package pins to `mlx-swift 0.31.3` and the
+  matching 2.x `mlx-swift-lm` dependency surface.
+- Update `scripts/dev_up.py` so automatic `mlx.metallib` discovery can map the
+  Swift MLX package version to the compatible Python `mlx_metal` wheel version
+  instead of requiring a literal tag match.
+
+## Performance Probes And Success Metrics
+
+- Swift decode and TurboQuant:
+  - `swift_text.active_kv_kernel_path_code`
+  - `swift_text.active_kv_runtime_route_code`
+  - `swift_text.active_kv_fallback_count`
+  - `swift_text.active_kv_decode_model_eval_sync_avg_us`
+  - `worker_tps_overhead_pct` in Phase 2 metrics output
+- Python VLM:
+  - `image_feature_cache_hits`
+  - `image_feature_cache_misses`
+  - `multimodal_decode_mode`
+  - `multimodal_fallback_reason`
+  - `quantized_load_mode`
+  - `quantized_load_fallback_reason`
+- LoRA and model ops:
+  - `mlx_lm_version` in existing LoRA evidence
+  - training duration, tokens seen, tokens per second, and peak memory fields
+
+The Qwen3.5 Swift TurboQuant smoke must keep the fused route non-fallback,
+`active_kv_fallback_count = 0`, and a passing fused gate. Python VLM smokes
+must show text-only VLM chat, single-image VLM, repeated-image cache evidence,
+and explicit fallback reporting for unsupported video fast paths unless the
+installed runtime exposes a compatible video generation surface.
+
+## Verification
+
+- `uv lock --upgrade-package mlx --upgrade-package mlx-lm --upgrade-package mlx-vlm`
+- `uv sync --frozen --package melix-mlx-worker --extra mlx`
+- `swift package resolve --package-path services/mlx-text-worker-swift`
+- `PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_dev_up_script.py -q`
+- `swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter WorkerScaffoldTests`
+- `make proto`
+- `make swift-test`
+- `make py-test`
+- `make integration-test`
+
+Changed-scope coverage must be at least 95 percent where measurable. If a live
+real-model probe cannot run in the local worktree, the handoff must include the
+exact blocker and avoid making performance claims beyond the commands that ran.
+
+## Known Risks
+
+- `mlx-swift-lm` 2.31.3 uses Swift tools 6.1; local and CI builders must support
+  that version or newer.
+- Upstream `mlx-swift 0.31.3` currently reports MLX core `0.31.1` in its package
+  metadata, so `dev_up` must accept the compatible `mlx_metal 0.31.1` metallib
+  for that Swift package.
+- Resyncing the vendored Swift runtime can conflict with Melix's local
+  TurboQuant patches; those patches must be reapplied with focused tests before
+  relying on real-model Phase 2 evidence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,19 @@ dependencies = []
 
 [tool.uv.workspace]
 members = ["services/mlx-worker-python"]
+
+[tool.uv]
+conflicts = [
+  [
+    { package = "melix-mlx-worker", extra = "mlx" },
+    { package = "melix-mlx-worker", extra = "audio" },
+  ],
+  [
+    { package = "melix-mlx-worker", extra = "mlx" },
+    { package = "melix-mlx-worker", extra = "audio-stt" },
+  ],
+  [
+    { package = "melix-mlx-worker", extra = "mlx" },
+    { package = "melix-mlx-worker", extra = "audio-tts" },
+  ],
+]

--- a/scripts/dev_up.py
+++ b/scripts/dev_up.py
@@ -26,6 +26,11 @@ SWIFT_OPTIONAL_PARENT_ENV = (
     SWIFT_DFLASH_PROBE_ENV,
     SWIFT_DFLASH_PROBE_PATH_ENV,
 )
+KNOWN_SWIFT_MLX_CORE_VERSION_BY_PACKAGE_VERSION = {
+    # mlx-swift 0.31.3 vendors MLX core 0.31.1, so its Metal library ABI
+    # matches the mlx_metal 0.31.1 wheel rather than the Swift package tag.
+    "0.31.3": "0.31.1",
+}
 USAGE_TEXT = """Usage: bash scripts/dev_up.sh [--prefer-built]
 
 Options:
@@ -244,6 +249,50 @@ def resolve_swift_mlx_package_version(repo_root: Path) -> str | None:
     return None
 
 
+def read_swift_mlx_core_version(package_swift_path: Path) -> str | None:
+    try:
+        payload = package_swift_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    for line in payload.splitlines():
+        if "MLX_VERSION" not in line:
+            continue
+        match = re.search(r"(?P<version>[0-9]+(?:\.[0-9]+){1,2})", line)
+        if match:
+            return match.group("version")
+    return None
+
+
+def resolve_swift_mlx_core_version(repo_root: Path) -> str | None:
+    for package_swift_path in (
+        repo_root / SWIFT_TEXT_WORKER_PACKAGE_DIR / ".build/checkouts/mlx-swift/Package.swift",
+        repo_root / ".build/checkouts/mlx-swift/Package.swift",
+    ):
+        core_version = read_swift_mlx_core_version(package_swift_path)
+        if core_version is not None:
+            return core_version
+    return None
+
+
+def compatible_mlx_metal_versions_for_swift_mlx(repo_root: Path) -> tuple[str, ...]:
+    package_version = resolve_swift_mlx_package_version(repo_root)
+    if package_version is None:
+        return ()
+
+    candidates = (
+        resolve_swift_mlx_core_version(repo_root),
+        KNOWN_SWIFT_MLX_CORE_VERSION_BY_PACKAGE_VERSION.get(package_version),
+        package_version,
+    )
+    compatible_versions: list[str] = []
+    for candidate in candidates:
+        if candidate is None or candidate in compatible_versions:
+            continue
+        compatible_versions.append(candidate)
+    return tuple(compatible_versions)
+
+
 def read_mlx_metal_dist_info_version(metallib_path: Path) -> str | None:
     for ancestor in metallib_path.resolve().parents:
         for metadata_path in ancestor.glob("mlx_metal-*.dist-info/METADATA"):
@@ -284,7 +333,8 @@ def iter_mlx_metallib_candidates(root: Path):
 
 
 def resolve_local_mlx_metallib(repo_root: Path, *, uv_cache_dir: Path | None = None) -> Path | None:
-    expected_mlx_metal_version = resolve_swift_mlx_package_version(repo_root)
+    swift_mlx_package_version = resolve_swift_mlx_package_version(repo_root)
+    compatible_mlx_metal_versions = compatible_mlx_metal_versions_for_swift_mlx(repo_root)
     candidate_search_roots: list[Path] = []
     if uv_cache_dir is not None:
         candidate_search_roots.append(uv_cache_dir)
@@ -305,23 +355,26 @@ def resolve_local_mlx_metallib(repo_root: Path, *, uv_cache_dir: Path | None = N
         seen.add(resolved_root)
         for candidate in iter_mlx_metallib_candidates(resolved_root):
             resolved_candidate = candidate.resolve()
-            if expected_mlx_metal_version is None:
+            if not compatible_mlx_metal_versions:
                 return resolved_candidate
 
             candidate_version = read_mlx_metal_dist_info_version(resolved_candidate)
-            if candidate_version == expected_mlx_metal_version:
+            if candidate_version in compatible_mlx_metal_versions:
                 return resolved_candidate
 
             rejected_versions.setdefault(candidate_version or "unknown", []).append(resolved_candidate)
 
-    if expected_mlx_metal_version is not None and rejected_versions:
+    if swift_mlx_package_version is not None and rejected_versions:
         observed = ", ".join(
             f"{version} at {paths[0]}" for version, paths in sorted(rejected_versions.items())
         )
+        compatible_display = " or ".join(
+            f"mlx_metal {version}" for version in compatible_mlx_metal_versions
+        )
         raise RuntimeError(
             "No compatible Swift MLX metallib was found. "
-            f"{SWIFT_TEXT_WORKER_PACKAGE_DIR}/Package.resolved pins mlx-swift {expected_mlx_metal_version}, "
-            f"so the Swift text worker needs mlx_metal {expected_mlx_metal_version} mlx.metallib. "
+            f"{SWIFT_TEXT_WORKER_PACKAGE_DIR}/Package.resolved pins mlx-swift {swift_mlx_package_version}, "
+            f"so the Swift text worker needs {compatible_display} mlx.metallib. "
             f"Observed incompatible candidates: {observed}. "
             f"Set {SWIFT_MLX_METALLIB_PATH_ENV} to a matching mlx.metallib or install the matching mlx_metal wheel."
         )

--- a/services/mlx-text-worker-swift/Package.resolved
+++ b/services/mlx-text-worker-swift/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "491836d08658246adaae332de518c359e38fe9e23b8d036edc26313d40aee84d",
+  "originHash" : "dfef422eb88087969505bbfeea458d119f0151f53dae6444b59c6861487ba41b",
   "pins" : [
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
     {
       "identity" : "grpc-swift-2",
       "kind" : "remoteSourceControl",
@@ -33,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "072b684acaae80b6a463abab3a103732f33774bf",
-        "version" : "0.29.1"
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
       }
     },
     {
@@ -116,6 +125,15 @@
       "state" : {
         "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
         "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
       }
     },
     {
@@ -222,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
-        "version" : "1.1.9"
+        "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
+        "version" : "1.2.1"
       }
     },
     {

--- a/services/mlx-text-worker-swift/Package.swift
+++ b/services/mlx-text-worker-swift/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 
 import PackageDescription
 
@@ -16,8 +16,8 @@ let package = Package(
         .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
         .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.6.1"),
         .package(path: "../../third_party/mlx-swift-lm"),
-        .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.29.1")),
-        .package(url: "https://github.com/huggingface/swift-transformers", .upToNextMinor(from: "1.1.6")),
+        .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.31.3")),
+        .package(url: "https://github.com/huggingface/swift-transformers", .upToNextMinor(from: "1.2.0")),
     ],
     targets: [
         .target(

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -986,6 +986,34 @@ final class WorkerScaffoldTests: XCTestCase {
         XCTAssertEqual(templated, [1, 2])
     }
 
+    func testVendoredModelContainerSerialAccessCompactsQueuedWaiters() async throws {
+        let container = makeLiveSwiftMLXModelContainer(promptTokens: [1, 2, 3])
+        let gate = WorkerScaffoldAsyncGate()
+
+        let holder = Task {
+            await container.perform { _ in
+                await gate.enterAndWait()
+                return ()
+            }
+        }
+        await gate.waitUntilEntered()
+
+        let waiters = (0 ..< 40).map { _ in
+            Task {
+                await container.decode(tokens: [1])
+            }
+        }
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        await gate.open()
+        await holder.value
+
+        for waiter in waiters {
+            let decoded = await waiter.value
+            XCTAssertEqual(decoded, "tok1")
+        }
+    }
+
     func testAutoSwiftMLXBackendPrefillUsesLiveModelContainerBridge() async throws {
         let backend = AutoSwiftMLXBackend()
         let promptTokens = [1, 2, 3, 4, 5]
@@ -9437,6 +9465,41 @@ private struct DeterministicTokenizer: Tokenizer {
         additionalContext: [String: any Sendable]?
     ) throws -> [Int] {
         try applyChatTemplate(messages: messages)
+    }
+}
+
+private actor WorkerScaffoldAsyncGate {
+    private var isEntered = false
+    private var isOpen = false
+    private var enteredContinuation: CheckedContinuation<Void, Never>?
+    private var waitingContinuation: CheckedContinuation<Void, Never>?
+
+    func waitUntilEntered() async {
+        if isEntered {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            enteredContinuation = continuation
+        }
+    }
+
+    func enterAndWait() async {
+        isEntered = true
+        enteredContinuation?.resume()
+        enteredContinuation = nil
+
+        if isOpen {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waitingContinuation = continuation
+        }
+    }
+
+    func open() {
+        isOpen = true
+        waitingContinuation?.resume()
+        waitingContinuation = nil
     }
 }
 

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -960,6 +960,32 @@ final class WorkerScaffoldTests: XCTestCase {
         XCTAssertNotNil(summary.tokensPerSecond)
     }
 
+    func testVendoredChatSessionClearUsesAsyncSerialAccess() async {
+        let session = ChatSession(
+            makeLiveSwiftMLXModelContainer(promptTokens: [1, 2, 3]),
+            instructions: "system"
+        )
+
+        await session.clear()
+    }
+
+    @available(*, deprecated, message: "Exercises the deprecated ModelContainer chat-template compatibility shim.")
+    func testVendoredModelContainerConvenienceMethodsUseSerialRead() async throws {
+        let container = makeLiveSwiftMLXModelContainer(promptTokens: [4, 5, 6])
+
+        let prepared = try await container.prepare(input: UserInput(prompt: "hello"))
+        let decoded = await container.decode(tokens: [1, 2])
+        let encoded = await container.encode("tok3 tok4")
+        let templated = try await container.applyChatTemplate(messages: [
+            ["role": "user", "content": "hello"]
+        ])
+
+        XCTAssertEqual(prepared.text.tokens.size, 3)
+        XCTAssertEqual(decoded, "tok1 tok2")
+        XCTAssertEqual(encoded, [3, 4])
+        XCTAssertEqual(templated, [1, 2])
+    }
+
     func testAutoSwiftMLXBackendPrefillUsesLiveModelContainerBridge() async throws {
         let backend = AutoSwiftMLXBackend()
         let promptTokens = [1, 2, 3, 4, 5]

--- a/services/mlx-worker-python/pyproject.toml
+++ b/services/mlx-worker-python/pyproject.toml
@@ -18,9 +18,9 @@ dev = [
 
 [project.optional-dependencies]
 mlx = [
-  "mlx>=0.25.0",
-  "mlx-lm>=0.22.0",
-  "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm.git@43b9b2078b7027e7622f34a434b2d94aada7eaad",
+  "mlx>=0.31.2,<0.32",
+  "mlx-lm>=0.31.3,<0.32",
+  "mlx-vlm>=0.4.4,<0.5",
 ]
 audio-stt = [
   "mlx-audio==0.4.2",

--- a/services/mlx-worker-python/tests/test_dev_up_script.py
+++ b/services/mlx-worker-python/tests/test_dev_up_script.py
@@ -469,6 +469,26 @@ def test_prepare_swift_worker_launch_cwd_prefers_matching_swift_mlx_metallib_fro
     assert default_metallib.resolve() == matching_metallib_path.resolve()
 
 
+def test_prepare_swift_worker_launch_cwd_accepts_mlx_swift_0313_compatible_mlx_metal_0311(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dev_up = load_dev_up_module()
+    repo_root = tmp_path / "repo"
+    write_swift_mlx_package_resolved(repo_root, "0.31.3")
+    layout = replace(make_layout(dev_up, repo_root), uv_cache_dir=repo_root / ".uv-cache")
+    layout.runtime_dir.mkdir(parents=True, exist_ok=True)
+    compatible_metallib_path = write_mlx_metal_fixture(layout.uv_cache_dir / "archive-v0/good", "0.31.1")
+    monkeypatch.setattr(dev_up.Path, "home", lambda: tmp_path / "empty-home")
+
+    launch_cwd = dev_up.prepare_swift_worker_launch_cwd(layout, repo_root)
+
+    default_metallib = launch_cwd / "default.metallib"
+    assert launch_cwd == layout.runtime_dir / "swift-text-worker-cwd"
+    assert default_metallib.is_symlink()
+    assert default_metallib.resolve() == compatible_metallib_path.resolve()
+
+
 def test_prepare_swift_worker_launch_cwd_rejects_incompatible_auto_discovered_metallib(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/tests/test_mlx_backend.py
+++ b/services/mlx-worker-python/tests/test_mlx_backend.py
@@ -238,7 +238,7 @@ def test_auto_backend_records_installed_mlx_package_versions(monkeypatch: pytest
             "mlx-lm": "0.31.3",
         }[package_name]
 
-    monkeypatch.setattr(mlx_text_runtime_module.importlib.metadata, "version", fake_version)
+    monkeypatch.setattr(mlx_text_runtime_module, "_installed_package_version", fake_version)
     backend = AutoMLXBackend(
         load_fn=lambda model_source, **kwargs: (object(), FakeTokenizer()),
         stream_generate_fn=lambda *args, **kwargs: iter(()),

--- a/services/mlx-worker-python/tests/test_mlx_backend.py
+++ b/services/mlx-worker-python/tests/test_mlx_backend.py
@@ -12,6 +12,7 @@ import pytest
 from packages.protocol.python.worker.v1 import common_pb2
 
 from worker.model_registry.catalog import WorkerModelCatalog
+from worker.runtime import mlx_text_runtime as mlx_text_runtime_module
 from worker.runtime.mlx_executor import MLXRuntimeExecutor
 from worker.runtime.mlx_text_runtime import AutoMLXBackend, MLXTextRuntime, RuntimeUnavailableError
 
@@ -228,6 +229,26 @@ def test_auto_backend_uses_mlx_load_stream_and_sampler_hooks() -> None:
     assert chunks[-1].speculative_draft_model_configured is True
     assert chunks[-1].dflash_enabled is True
     assert chunks[-1].dflash_rollback_count == 2
+
+
+def test_auto_backend_records_installed_mlx_package_versions(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_version(package_name: str) -> str:
+        return {
+            "mlx": "0.31.2",
+            "mlx-lm": "0.31.3",
+        }[package_name]
+
+    monkeypatch.setattr(mlx_text_runtime_module.importlib.metadata, "version", fake_version)
+    backend = AutoMLXBackend(
+        load_fn=lambda model_source, **kwargs: (object(), FakeTokenizer()),
+        stream_generate_fn=lambda *args, **kwargs: iter(()),
+        sampler_factory=lambda **kwargs: "unused",
+    )
+
+    loaded_model = backend.load_model(WorkerModelCatalog.dev_text_model())
+
+    assert loaded_model["mlx_version"] == "0.31.2"
+    assert loaded_model["mlx_lm_version"] == "0.31.3"
 
 
 def test_text_runtime_load_and_generation_run_on_mlx_executor_thread() -> None:
@@ -503,6 +524,61 @@ def test_auto_backend_lazy_import_wires_runtime_modules(monkeypatch) -> None:
     assert seen["load"] == ("mlx-community/lazy-model", {"lazy": False})
     assert seen["stream"] == {"prompt": "lazy prompt", "max_tokens": 8, "sampler": "lazy-sampler"}
     assert [chunk.text for chunk in chunks] == ["token"]
+
+
+def test_auto_backend_passes_sampling_penalties_when_sampler_accepts_them() -> None:
+    seen: dict[str, object] = {}
+
+    def fake_make_sampler(
+        *,
+        temp: float,
+        top_p: float,
+        top_k: int,
+        frequency_penalty: float,
+        presence_penalty: float,
+    ):
+        seen["sampler"] = {
+            "temp": temp,
+            "top_p": top_p,
+            "top_k": top_k,
+            "frequency_penalty": frequency_penalty,
+            "presence_penalty": presence_penalty,
+        }
+        return "penalty-aware-sampler"
+
+    def fake_stream_generate(model, tokenizer, prompt: str, max_tokens: int, sampler):
+        seen["stream"] = {"sampler": sampler, "max_tokens": max_tokens}
+        yield FakeGenerationResponse(text="token", prompt_tokens=3, generation_tokens=1, finish_reason="stop")
+
+    backend = AutoMLXBackend(
+        load_fn=lambda model_source, **kwargs: (object(), FakeTokenizer()),
+        stream_generate_fn=fake_stream_generate,
+        sampler_factory=fake_make_sampler,
+    )
+    loaded_model = backend.load_model(WorkerModelCatalog.dev_text_model())
+
+    list(
+        backend.generate_tokens(
+            loaded_model,
+            "prompt",
+            common_pb2.SamplingConfig(
+                temperature=0.25,
+                top_p=0.75,
+                top_k=5,
+                frequency_penalty=0.4,
+                presence_penalty=0.6,
+                max_output_tokens=9,
+            ),
+            Event(),
+        )
+    )
+
+    assert seen["sampler"]["temp"] == pytest.approx(0.25)
+    assert seen["sampler"]["top_p"] == pytest.approx(0.75)
+    assert seen["sampler"]["top_k"] == 5
+    assert seen["sampler"]["frequency_penalty"] == pytest.approx(0.4)
+    assert seen["sampler"]["presence_penalty"] == pytest.approx(0.6)
+    assert seen["stream"] == {"sampler": "penalty-aware-sampler", "max_tokens": 9}
 
 
 def test_auto_backend_handles_unavailable_runtime_and_skips_empty_segments(monkeypatch) -> None:

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -14,9 +14,11 @@ from packages.protocol.python.worker.v1 import common_pb2
 from worker.registry import WorkerRegistry
 from worker.runtime.multimodal_preprocessing import (
     PreparedImageInput,
+    PreparedVideoInput,
     PreparedVideoFramePolicy,
     PreparedVisionRequest,
 )
+from worker.runtime import mlx_vlm_runtime as mlx_vlm_runtime_module
 from worker.runtime.mlx_vlm_runtime import (
     AutoMLXVLMBackend,
     MLXVLMRuntime,
@@ -183,6 +185,133 @@ def test_mlx_vlm_runtime_streams_backend_tokens_and_records_probe() -> None:
     assert probe.multimodal_decode_mode == "native_quantized"
     assert probe.multimodal_decode_sync_mode == "executor_stream"
     assert probe.multi_image_scatter_mode == "none"
+
+
+def test_mlx_vlm_runtime_records_installed_package_versions(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_version(package_name: str) -> str:
+        return {
+            "mlx": "0.31.2",
+            "mlx-lm": "0.31.3",
+            "mlx-vlm": "0.4.4",
+        }[package_name]
+
+    def fake_load(model_path: str, revision: str = "main"):
+        _ = model_path
+        _ = revision
+        model = SimpleNamespace(
+            config=SimpleNamespace(model_type="gemma4"),
+            vision_tower=object(),
+            embed_vision=object(),
+        )
+        processor = SimpleNamespace(image_processor=object())
+        return model, processor
+
+    monkeypatch.setattr(mlx_vlm_runtime_module.importlib.metadata, "version", fake_version)
+    runtime = MLXVLMRuntime(
+        backend=AutoMLXVLMBackend(
+            load_fn=fake_load,
+            stream_generate_fn=lambda *args, **kwargs: iter(()),
+            apply_chat_template_fn=lambda *args, **kwargs: "formatted::prompt",
+        )
+    )
+
+    loaded_model = runtime.load_model(imported_gemma4_vlm_model())
+
+    assert loaded_model["metadata"]["mlx_version"] == "0.31.2"
+    assert loaded_model["metadata"]["mlx_lm_version"] == "0.31.3"
+    assert loaded_model["metadata"]["mlx_vlm_version"] == "0.4.4"
+
+
+def test_mlx_vlm_runtime_passes_video_when_backend_accepts_video_argument() -> None:
+    stream_calls: list[dict[str, object]] = []
+
+    def fake_load(model_path: str, revision: str = "main"):
+        _ = model_path
+        _ = revision
+        model = SimpleNamespace(
+            config=SimpleNamespace(model_type="qwen2_vl"),
+            vision_tower=object(),
+            embed_vision=object(),
+        )
+        processor = SimpleNamespace(image_processor=object())
+        return model, processor
+
+    def fake_apply_chat_template(processor, config, prompt: str, num_images: int = 0, **kwargs):
+        _ = processor
+        _ = config
+        _ = num_images
+        _ = kwargs
+        return f"formatted::{prompt}"
+
+    def fake_stream_generate(model, processor, prompt: str, image=None, video=None, **kwargs):
+        _ = model
+        _ = processor
+        _ = image
+        _ = kwargs
+        video_paths = list(video or [])
+        stream_calls.append({"prompt": prompt, "video": video_paths})
+        yield SimpleNamespace(text="video summary", generation_tokens=1)
+
+    runtime = MLXVLMRuntime(
+        backend=AutoMLXVLMBackend(
+            load_fn=fake_load,
+            stream_generate_fn=fake_stream_generate,
+            apply_chat_template_fn=fake_apply_chat_template,
+        )
+    )
+    loaded_model = runtime.load_model(imported_gemma4_vlm_model())
+    prepared = PreparedVisionRequest(
+        prompt_text="Describe the video.",
+        images=[],
+        videos=[
+            PreparedVideoInput(
+                source_kind="inline",
+                reference="inline:video",
+                bytes_data=b"fake-video-payload",
+                mime_type="video/mp4",
+                format="mp4",
+                filename="sample.mp4",
+                byte_length=len(b"fake-video-payload"),
+                duration_ms=1000,
+                frame_budget=4,
+                start_ms=0,
+                end_ms=1000,
+                sha256_hex="beef",
+            )
+        ],
+        video_frame_policies=[
+            PreparedVideoFramePolicy(
+                reference="inline:video",
+                sampling_strategy="uniform",
+                requested_frame_budget=4,
+                effective_frame_count=4,
+                clip_start_ms=0,
+                clip_end_ms=1000,
+                clip_duration_ms=1000,
+            )
+        ],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=len(b"fake-video-payload"),
+        preprocess_peak_memory_bytes=len(b"fake-video-payload"),
+        prompt_hash_hex="11" * 32,
+        multimodal_hash_hex="22" * 32,
+    )
+
+    events = list(
+        runtime.generate_tokens(
+            loaded_model,
+            prepared,
+            common_pb2.SamplingConfig(max_output_tokens=8),
+            Event(),
+        )
+    )
+
+    assert [event.text for event in events] == ["video summary"]
+    assert stream_calls[0]["prompt"] == "formatted::Describe the video."
+    video_paths = stream_calls[0]["video"]
+    assert isinstance(video_paths, list)
+    assert len(video_paths) == 1
+    assert not Path(video_paths[0]).exists()
 
 
 def test_mlx_vlm_runtime_plans_fast_path_when_generate_is_called_directly() -> None:

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -314,6 +314,127 @@ def test_mlx_vlm_runtime_passes_video_when_backend_accepts_video_argument() -> N
     assert not Path(video_paths[0]).exists()
 
 
+def test_mlx_vlm_runtime_records_video_fallback_when_backend_omits_video_argument(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stream_calls: list[dict[str, object]] = []
+
+    def fake_load(model_path: str, revision: str = "main"):
+        _ = model_path
+        _ = revision
+        model = SimpleNamespace(
+            config=SimpleNamespace(model_type="qwen2_vl"),
+            vision_tower=object(),
+            embed_vision=object(),
+        )
+        processor = SimpleNamespace(image_processor=object())
+        return model, processor
+
+    def fake_apply_chat_template(processor, config, prompt: str, num_images: int = 0):
+        _ = processor
+        _ = config
+        _ = num_images
+        return f"formatted::{prompt}"
+
+    def fake_stream_generate(
+        model,
+        processor,
+        prompt: str,
+        image=None,
+        max_tokens: int = 64,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+        top_k: int = 0,
+        verbose: bool = False,
+    ):
+        _ = model
+        _ = processor
+        stream_calls.append(
+            {
+                "prompt": prompt,
+                "image": image,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "top_p": top_p,
+                "top_k": top_k,
+                "verbose": verbose,
+            }
+        )
+        yield SimpleNamespace(text="fallback summary", generation_tokens=1)
+
+    runtime = MLXVLMRuntime(
+        backend=AutoMLXVLMBackend(
+            load_fn=fake_load,
+            stream_generate_fn=fake_stream_generate,
+            apply_chat_template_fn=fake_apply_chat_template,
+        )
+    )
+    loaded_model = runtime.load_model(imported_gemma4_vlm_model())
+    prepared = PreparedVisionRequest(
+        prompt_text="Describe the video.",
+        images=[],
+        videos=[
+            PreparedVideoInput(
+                source_kind="inline",
+                reference="inline:video",
+                bytes_data=b"fake-video-payload",
+                mime_type="video/mp4",
+                format="mp4",
+                filename="sample.mp4",
+                byte_length=len(b"fake-video-payload"),
+                duration_ms=1000,
+                frame_budget=4,
+                start_ms=0,
+                end_ms=1000,
+                sha256_hex="beef",
+            )
+        ],
+        video_frame_policies=[
+            PreparedVideoFramePolicy(
+                reference="inline:video",
+                sampling_strategy="uniform",
+                requested_frame_budget=4,
+                effective_frame_count=4,
+                clip_start_ms=0,
+                clip_end_ms=1000,
+                clip_duration_ms=1000,
+            )
+        ],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=len(b"fake-video-payload"),
+        preprocess_peak_memory_bytes=len(b"fake-video-payload"),
+        prompt_hash_hex="11" * 32,
+        multimodal_hash_hex="22" * 32,
+    )
+
+    caplog.set_level("WARNING", logger=mlx_vlm_runtime_module.__name__)
+    events = list(
+        runtime.generate_tokens(
+            loaded_model,
+            prepared,
+            common_pb2.SamplingConfig(max_output_tokens=8),
+            Event(),
+        )
+    )
+
+    assert [event.text for event in events] == ["fallback summary"]
+    assert stream_calls == [
+        {
+            "prompt": "formatted::Describe the video.",
+            "image": None,
+            "max_tokens": 8,
+            "temperature": 0.0,
+            "top_p": 0.0,
+            "top_k": 0,
+            "verbose": False,
+        }
+    ]
+    probe = runtime.last_probe_snapshot()
+    assert probe.multimodal_decode_mode == "fallback"
+    assert probe.multimodal_fallback_reason == "backend_video_kwarg_unsupported"
+    assert "does not accept video=" in caplog.text
+
+
 def test_mlx_vlm_runtime_plans_fast_path_when_generate_is_called_directly() -> None:
     def fake_load(model_path: str, revision: str = "main"):
         _ = model_path

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -206,7 +206,7 @@ def test_mlx_vlm_runtime_records_installed_package_versions(monkeypatch: pytest.
         processor = SimpleNamespace(image_processor=object())
         return model, processor
 
-    monkeypatch.setattr(mlx_vlm_runtime_module.importlib.metadata, "version", fake_version)
+    monkeypatch.setattr(mlx_vlm_runtime_module, "_installed_package_version", fake_version)
     runtime = MLXVLMRuntime(
         backend=AutoMLXVLMBackend(
             load_fn=fake_load,

--- a/services/mlx-worker-python/tests/test_runtime_utils.py
+++ b/services/mlx-worker-python/tests/test_runtime_utils.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import importlib.metadata
+
+import pytest
+
+from worker.runtime import runtime_utils
+
+
+def test_callable_accepts_kwarg_returns_false_for_non_introspectable_object() -> None:
+    assert runtime_utils.callable_accepts_kwarg(object(), "temperature") is False
+
+
+def test_installed_package_version_returns_empty_for_missing_package(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_version(package_name: str) -> str:
+        _ = package_name
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(runtime_utils.importlib.metadata, "version", fake_version)
+
+    assert runtime_utils.installed_package_version("missing-package") == ""

--- a/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-import importlib.metadata
-import inspect
 import importlib.util
 import json
 from pathlib import Path
 from typing import Any
 
 from worker.runtime.mlx_executor import MLXRuntimeExecutor
+from worker.runtime.runtime_utils import (
+    callable_accepts_kwarg as _callable_accepts_kwarg,
+    installed_package_version as _installed_package_version,
+)
 from worker.runtime.text_family_adapters import resolve_text_family_config
 
 
@@ -51,34 +53,6 @@ class RuntimeToolCallEvent:
 
 def _normalized_ext_value(model_spec, key: str) -> str:
     return str(getattr(model_spec, "ext", {}).get(key, "") or "").strip()
-
-
-def _callable_accepts_kwarg(callable_obj: Any, keyword: str) -> bool:
-    try:
-        signature = inspect.signature(callable_obj)
-    except (TypeError, ValueError):
-        return False
-
-    if any(
-        parameter.kind == inspect.Parameter.VAR_KEYWORD
-        for parameter in signature.parameters.values()
-    ):
-        return True
-
-    parameter = signature.parameters.get(keyword)
-    if parameter is None:
-        return False
-    return parameter.kind in (
-        inspect.Parameter.POSITIONAL_OR_KEYWORD,
-        inspect.Parameter.KEYWORD_ONLY,
-    )
-
-
-def _installed_package_version(package_name: str) -> str:
-    try:
-        return importlib.metadata.version(package_name)
-    except importlib.metadata.PackageNotFoundError:
-        return ""
 
 
 # String constants for the ext-field activation_mode signal. Kept as the

--- a/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
+import importlib.metadata
+import inspect
 import importlib.util
 import json
 from pathlib import Path
@@ -49,6 +51,34 @@ class RuntimeToolCallEvent:
 
 def _normalized_ext_value(model_spec, key: str) -> str:
     return str(getattr(model_spec, "ext", {}).get(key, "") or "").strip()
+
+
+def _callable_accepts_kwarg(callable_obj: Any, keyword: str) -> bool:
+    try:
+        signature = inspect.signature(callable_obj)
+    except (TypeError, ValueError):
+        return False
+
+    if any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    ):
+        return True
+
+    parameter = signature.parameters.get(keyword)
+    if parameter is None:
+        return False
+    return parameter.kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )
+
+
+def _installed_package_version(package_name: str) -> str:
+    try:
+        return importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        return ""
 
 
 # String constants for the ext-field activation_mode signal. Kept as the
@@ -246,6 +276,8 @@ class AutoMLXBackend:
             "model_path": model_spec.model_path,
             "model": model,
             "tokenizer": tokenizer,
+            "mlx_version": _installed_package_version("mlx"),
+            "mlx_lm_version": _installed_package_version("mlx-lm"),
             **adapter_metadata,
             **family_config.runtime_metadata(),
         }
@@ -257,11 +289,15 @@ class AutoMLXBackend:
         if not self._available:
             raise RuntimeUnavailableError("mlx-lm is not installed") from self._error
         self._ensure_runtime()
-        sampler = self._sampler_factory(
-            temp=float(sampling.temperature),
-            top_p=float(sampling.top_p),
-            top_k=int(sampling.top_k),
-        )
+        sampler_kwargs: dict[str, Any] = {
+            "temp": float(sampling.temperature),
+            "top_p": float(sampling.top_p),
+            "top_k": int(sampling.top_k),
+        }
+        for penalty_name in ("frequency_penalty", "presence_penalty"):
+            if _callable_accepts_kwarg(self._sampler_factory, penalty_name):
+                sampler_kwargs[penalty_name] = float(getattr(sampling, penalty_name, 0.0))
+        sampler = self._sampler_factory(**sampler_kwargs)
         max_tokens = int(sampling.max_output_tokens) if int(sampling.max_output_tokens) > 0 else 256
 
         for response in self._stream_generate_fn(

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 import hashlib
-import importlib.metadata
-import inspect
 import importlib.util
 import logging
 import os
@@ -17,6 +15,10 @@ from worker.runtime.mlx_executor import MLXRuntimeExecutor
 from worker.runtime.mlx_text_runtime import RuntimeTokenEvent
 from worker.runtime.multimodal_fast_paths import MultimodalFastPathController, fast_path_probe_signature
 from worker.runtime.multimodal_preprocessing import PreparedVisionRequest, prepare_vision_request, rebuild_multimodal_hash
+from worker.runtime.runtime_utils import (
+    callable_accepts_kwarg as _callable_accepts_kwarg,
+    installed_package_version as _installed_package_version,
+)
 from worker.runtime.temp_media_lifecycle import TempMediaSession
 from worker.runtime.vision_family_adapters import resolve_vision_family_config
 
@@ -29,36 +31,8 @@ class RuntimeUnavailableError(RuntimeError):
 
 @dataclass(frozen=True)
 class MaterializedMediaPaths:
-    image_paths: list[str]
-    video_paths: list[str]
-
-
-def _callable_accepts_kwarg(callable_obj: Any, keyword: str) -> bool:
-    try:
-        signature = inspect.signature(callable_obj)
-    except (TypeError, ValueError):
-        return False
-
-    if any(
-        parameter.kind == inspect.Parameter.VAR_KEYWORD
-        for parameter in signature.parameters.values()
-    ):
-        return True
-
-    parameter = signature.parameters.get(keyword)
-    if parameter is None:
-        return False
-    return parameter.kind in (
-        inspect.Parameter.POSITIONAL_OR_KEYWORD,
-        inspect.Parameter.KEYWORD_ONLY,
-    )
-
-
-def _installed_package_version(package_name: str) -> str:
-    try:
-        return importlib.metadata.version(package_name)
-    except importlib.metadata.PackageNotFoundError:
-        return ""
+    image_paths: tuple[str, ...]
+    video_paths: tuple[str, ...]
 
 
 def _gemma4_multimodal_weight_presence(weight_names: list[str] | tuple[str, ...] | set[str]) -> tuple[bool, bool]:
@@ -452,7 +426,7 @@ class MLXVLMRuntime:
                     prepared_request.prompt_text,
                     num_images=len(media_paths.image_paths),
                 )
-                image_argument = media_paths.image_paths if media_paths.image_paths else None
+                image_argument = list(media_paths.image_paths) if media_paths.image_paths else None
                 stream_kwargs: dict[str, Any] = {
                     "image": image_argument,
                     "max_tokens": int(getattr(sampling, "max_output_tokens", 0) or 64),
@@ -463,7 +437,7 @@ class MLXVLMRuntime:
                 }
                 if media_paths.video_paths:
                     if _callable_accepts_kwarg(self._backend.stream_generate_fn, "video"):
-                        stream_kwargs["video"] = media_paths.video_paths
+                        stream_kwargs["video"] = list(media_paths.video_paths)
                     else:
                         logger.warning(
                             "mlx-vlm stream_generate does not accept video=; "
@@ -605,7 +579,7 @@ class MLXVLMRuntime:
             suffix = MLXVLMRuntime._media_suffix(video.filename, video.format)
             video_path = temp_media_session.write_bytes(f"video-{index}.{suffix}", video.bytes_data)
             video_paths.append(str(video_path))
-        return MaterializedMediaPaths(image_paths=image_paths, video_paths=video_paths)
+        return MaterializedMediaPaths(image_paths=tuple(image_paths), video_paths=tuple(video_paths))
 
     @staticmethod
     def _media_suffix(filename: str, format_name: str) -> str:

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 import hashlib
+import importlib.metadata
+import inspect
 import importlib.util
 import os
 import time
@@ -20,6 +22,40 @@ from worker.runtime.vision_family_adapters import resolve_vision_family_config
 
 class RuntimeUnavailableError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class MaterializedMediaPaths:
+    image_paths: list[str]
+    video_paths: list[str]
+
+
+def _callable_accepts_kwarg(callable_obj: Any, keyword: str) -> bool:
+    try:
+        signature = inspect.signature(callable_obj)
+    except (TypeError, ValueError):
+        return False
+
+    if any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    ):
+        return True
+
+    parameter = signature.parameters.get(keyword)
+    if parameter is None:
+        return False
+    return parameter.kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )
+
+
+def _installed_package_version(package_name: str) -> str:
+    try:
+        return importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        return ""
 
 
 def _gemma4_multimodal_weight_presence(weight_names: list[str] | tuple[str, ...] | set[str]) -> tuple[bool, bool]:
@@ -133,6 +169,9 @@ class AutoMLXVLMBackend:
             raise RuntimeUnavailableError("mlx-vlm is not installed") from self._error
         self._ensure_runtime()
         metadata = dict(model_spec.ext)
+        metadata["mlx_version"] = _installed_package_version("mlx")
+        metadata["mlx_lm_version"] = _installed_package_version("mlx-lm")
+        metadata["mlx_vlm_version"] = _installed_package_version("mlx-vlm")
         execution_mode = metadata.get("melix.vlm.execution_mode", "").strip() or "multimodal"
         try:
             model, processor = self.load_fn(
@@ -394,7 +433,7 @@ class MLXVLMRuntime:
             prefix="melix-vlm-",
         )
         try:
-            image_paths = self._materialize_media(prepared_request, temp_media_session)
+            media_paths = self._materialize_media(prepared_request, temp_media_session)
 
             def backend_events():
                 # Must run on the executor-owned thread so the MLX runtime is
@@ -408,9 +447,22 @@ class MLXVLMRuntime:
                     loaded_model["processor"],
                     loaded_model["model"].config,
                     prepared_request.prompt_text,
-                    num_images=len(image_paths),
+                    num_images=len(media_paths.image_paths),
                 )
-                image_argument = image_paths if image_paths else None
+                image_argument = media_paths.image_paths if media_paths.image_paths else None
+                stream_kwargs: dict[str, Any] = {
+                    "image": image_argument,
+                    "max_tokens": int(getattr(sampling, "max_output_tokens", 0) or 64),
+                    "temperature": float(getattr(sampling, "temperature", 0.0)),
+                    "top_p": float(getattr(sampling, "top_p", 1.0)),
+                    "top_k": int(getattr(sampling, "top_k", 0)),
+                    "verbose": False,
+                }
+                if media_paths.video_paths and _callable_accepts_kwarg(
+                    self._backend.stream_generate_fn,
+                    "video",
+                ):
+                    stream_kwargs["video"] = media_paths.video_paths
 
                 started_at = time.perf_counter()
                 first_token_at: float | None = None
@@ -419,12 +471,7 @@ class MLXVLMRuntime:
                     loaded_model["model"],
                     loaded_model["processor"],
                     formatted_prompt,
-                    image=image_argument,
-                    max_tokens=int(getattr(sampling, "max_output_tokens", 0) or 64),
-                    temperature=float(getattr(sampling, "temperature", 0.0)),
-                    top_p=float(getattr(sampling, "top_p", 1.0)),
-                    top_k=int(getattr(sampling, "top_k", 0)),
-                    verbose=False,
+                    **stream_kwargs,
                 ):
                     if cancel_event.is_set():
                         return
@@ -533,18 +580,20 @@ class MLXVLMRuntime:
     def _materialize_media(
         prepared_request: PreparedVisionRequest,
         temp_media_session: TempMediaSession,
-    ) -> list[str]:
+    ) -> MaterializedMediaPaths:
         image_paths: list[str] = []
         for index, image in enumerate(prepared_request.images):
             suffix = MLXVLMRuntime._media_suffix(image.filename, image.format)
             image_path = temp_media_session.write_bytes(f"image-{index}.{suffix}", image.bytes_data)
             image_paths.append(str(image_path))
+        video_paths: list[str] = []
         for index, video in enumerate(prepared_request.videos):
             if not video.bytes_data:
                 continue
             suffix = MLXVLMRuntime._media_suffix(video.filename, video.format)
-            temp_media_session.write_bytes(f"video-{index}.{suffix}", video.bytes_data)
-        return image_paths
+            video_path = temp_media_session.write_bytes(f"video-{index}.{suffix}", video.bytes_data)
+            video_paths.append(str(video_path))
+        return MaterializedMediaPaths(image_paths=image_paths, video_paths=video_paths)
 
     @staticmethod
     def _media_suffix(filename: str, format_name: str) -> str:

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -5,6 +5,7 @@ import hashlib
 import importlib.metadata
 import inspect
 import importlib.util
+import logging
 import os
 import time
 from pathlib import Path
@@ -18,6 +19,8 @@ from worker.runtime.multimodal_fast_paths import MultimodalFastPathController, f
 from worker.runtime.multimodal_preprocessing import PreparedVisionRequest, prepare_vision_request, rebuild_multimodal_hash
 from worker.runtime.temp_media_lifecycle import TempMediaSession
 from worker.runtime.vision_family_adapters import resolve_vision_family_config
+
+logger = logging.getLogger(__name__)
 
 
 class RuntimeUnavailableError(RuntimeError):
@@ -458,11 +461,20 @@ class MLXVLMRuntime:
                     "top_k": int(getattr(sampling, "top_k", 0)),
                     "verbose": False,
                 }
-                if media_paths.video_paths and _callable_accepts_kwarg(
-                    self._backend.stream_generate_fn,
-                    "video",
-                ):
-                    stream_kwargs["video"] = media_paths.video_paths
+                if media_paths.video_paths:
+                    if _callable_accepts_kwarg(self._backend.stream_generate_fn, "video"):
+                        stream_kwargs["video"] = media_paths.video_paths
+                    else:
+                        logger.warning(
+                            "mlx-vlm stream_generate does not accept video=; "
+                            "falling back to prompt/image-only routing for %d video artifact(s)",
+                            len(media_paths.video_paths),
+                        )
+                        self._last_probe = replace(
+                            self._last_probe,
+                            multimodal_decode_mode="fallback",
+                            multimodal_fallback_reason="backend_video_kwarg_unsupported",
+                        )
 
                 started_at = time.perf_counter()
                 first_token_at: float | None = None

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import importlib.metadata
+import inspect
+from typing import Any
+
+
+def callable_accepts_kwarg(callable_obj: Any, keyword: str) -> bool:
+    try:
+        signature = inspect.signature(callable_obj)
+    except (TypeError, ValueError):
+        return False
+
+    if any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    ):
+        return True
+
+    parameter = signature.parameters.get(keyword)
+    if parameter is None:
+        return False
+    return parameter.kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )
+
+
+def installed_package_version(package_name: str) -> str:
+    try:
+        return importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        return ""

--- a/third_party/mlx-swift-lm/Libraries/MLXLMCommon/Chat.swift
+++ b/third_party/mlx-swift-lm/Libraries/MLXLMCommon/Chat.swift
@@ -66,7 +66,7 @@ public enum Chat {
 ///     let messages = Qwen2VLMessageGenerator().generate(from: input)
 ///     ...
 /// ```
-public protocol MessageGenerator {
+public protocol MessageGenerator: Sendable {
 
     /// Generates messages from the input.
     func generate(from input: UserInput) -> [Message]

--- a/third_party/mlx-swift-lm/Libraries/MLXLMCommon/ChatSession.swift
+++ b/third_party/mlx-swift-lm/Libraries/MLXLMCommon/ChatSession.swift
@@ -92,37 +92,14 @@ public final class ChatSession {
     ) async throws -> String {
         messages.append(.user(prompt, images: images, videos: videos))
 
-        func generate(context: ModelContext) async throws -> String {
-            let userInput = UserInput(
-                chat: messages, processing: processing, additionalContext: additionalContext)
-            let input = try await context.processor.prepare(input: userInput)
-
-            if cache.isEmpty {
-                cache = context.model.newCache(parameters: generateParameters)
-            }
-
-            var output = ""
-            for await generation in try MLXLMCommon.generate(
-                input: input, cache: cache, parameters: generateParameters, context: context
-            ) {
-                if let chunk = generation.chunk {
-                    output += chunk
-                }
-            }
-
-            Stream().synchronize()
-
-            return output
-        }
-
         let output: String
         switch model {
         case .container(let container):
-            output = try await container.perform { context in
-                try await generate(context: context)
+            output = try await container.perform(values: self) { context, session in
+                try await session.generateResponse(context: context)
             }
         case .context(let context):
-            output = try await generate(context: context)
+            output = try await generateResponse(context: context)
         }
 
         messages.append(.assistant(output))
@@ -164,9 +141,10 @@ public final class ChatSession {
 
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
 
+        let session = SendableBox(self)
         let task = Task {
             do {
-                try await self.performStreaming(continuation: continuation)
+                try await session.consume().performStreaming(continuation: continuation)
             } catch {
                 continuation.finish(throwing: error)
             }
@@ -209,38 +187,64 @@ public final class ChatSession {
     private func performStreaming(
         continuation: AsyncThrowingStream<String, Error>.Continuation
     ) async throws {
-        func stream(context: ModelContext) async throws {
-            let userInput = UserInput(
-                chat: messages, processing: processing, additionalContext: additionalContext)
-            let input = try await context.processor.prepare(input: userInput)
-
-            if cache.isEmpty {
-                cache = context.model.newCache(parameters: generateParameters)
-            }
-
-            var fullResponse = ""
-            for await item in try MLXLMCommon.generate(
-                input: input, cache: cache, parameters: generateParameters, context: context
-            ) {
-                if let chunk = item.chunk {
-                    fullResponse += chunk
-                    continuation.yield(chunk)
-                }
-            }
-
-            Stream().synchronize()
-
-            messages.append(.assistant(fullResponse))
-            continuation.finish()
-        }
-
         switch model {
         case .container(let container):
-            try await container.perform { context in
-                try await stream(context: context)
+            try await container.perform(values: self) { context, session in
+                try await session.streamResponse(context: context, continuation: continuation)
             }
         case .context(let context):
-            try await stream(context: context)
+            try await streamResponse(context: context, continuation: continuation)
         }
+    }
+
+    private func generateResponse(context: ModelContext) async throws -> String {
+        let userInput = UserInput(
+            chat: messages, processing: processing, additionalContext: additionalContext)
+        let input = try await context.processor.prepare(input: userInput)
+
+        if cache.isEmpty {
+            cache = context.model.newCache(parameters: generateParameters)
+        }
+
+        var output = ""
+        for await generation in try MLXLMCommon.generate(
+            input: input, cache: cache, parameters: generateParameters, context: context
+        ) {
+            if let chunk = generation.chunk {
+                output += chunk
+            }
+        }
+
+        Stream().synchronize()
+
+        return output
+    }
+
+    private func streamResponse(
+        context: ModelContext,
+        continuation: AsyncThrowingStream<String, Error>.Continuation
+    ) async throws {
+        let userInput = UserInput(
+            chat: messages, processing: processing, additionalContext: additionalContext)
+        let input = try await context.processor.prepare(input: userInput)
+
+        if cache.isEmpty {
+            cache = context.model.newCache(parameters: generateParameters)
+        }
+
+        var fullResponse = ""
+        for await item in try MLXLMCommon.generate(
+            input: input, cache: cache, parameters: generateParameters, context: context
+        ) {
+            if let chunk = item.chunk {
+                fullResponse += chunk
+                continuation.yield(chunk)
+            }
+        }
+
+        Stream().synchronize()
+
+        messages.append(.assistant(fullResponse))
+        continuation.finish()
     }
 }

--- a/third_party/mlx-swift-lm/Libraries/MLXLMCommon/ChatSession.swift
+++ b/third_party/mlx-swift-lm/Libraries/MLXLMCommon/ChatSession.swift
@@ -1,7 +1,6 @@
 // Copyright © 2025 Apple Inc.
 
 import CoreGraphics
-import Dispatch
 import Foundation
 import MLX
 
@@ -190,17 +189,11 @@ public final class ChatSession: @unchecked Sendable {
     }
 
     /// Clear the session history and cache, preserving system instructions.
-    public func clear() {
-        let semaphore = DispatchSemaphore(value: 0)
-        let sessionAccess = self.sessionAccess
-        Task.detached {
-            await sessionAccess.update { _ in
-                self.messages = self.messages.filter { $0.role == .system }
-                self.cache = []
-            }
-            semaphore.signal()
+    public func clear() async {
+        await sessionAccess.update { _ in
+            self.messages = self.messages.filter { $0.role == .system }
+            self.cache = []
         }
-        semaphore.wait()
     }
 
     // MARK: - Private

--- a/third_party/mlx-swift-lm/Libraries/MLXLMCommon/ChatSession.swift
+++ b/third_party/mlx-swift-lm/Libraries/MLXLMCommon/ChatSession.swift
@@ -1,6 +1,7 @@
 // Copyright © 2025 Apple Inc.
 
 import CoreGraphics
+import Dispatch
 import Foundation
 import MLX
 
@@ -15,10 +16,10 @@ import MLX
 /// print(try await session.respond(to: "How about a great place to eat?"))
 /// ```
 ///
-/// - Note: `ChatSession` is not thread-safe. Each session should be used from a single
-///   task/thread at a time. The underlying `ModelContainer` handles thread safety for
-///   model operations.
-public final class ChatSession {
+/// - Note: Concurrent response calls are serialized so the session history and KV cache
+///   remain consistent. The underlying `ModelContainer` handles thread safety for model
+///   operations.
+public final class ChatSession: @unchecked Sendable {
 
     private enum Model {
         case container(ModelContainer)
@@ -31,6 +32,7 @@ public final class ChatSession {
     private let processing: UserInput.Processing
     private let generateParameters: GenerateParameters
     private let additionalContext: [String: any Sendable]?
+    private let sessionAccess = SerialAccessContainer(())
 
     /// Initialize the `ChatSession`.
     ///
@@ -90,20 +92,26 @@ public final class ChatSession {
         images: [UserInput.Image],
         videos: [UserInput.Video]
     ) async throws -> String {
-        messages.append(.user(prompt, images: images, videos: videos))
+        let images = SendableBox(images)
+        let videos = SendableBox(videos)
+        return try await sessionAccess.update { _ in
+            let images = images.consume()
+            let videos = videos.consume()
+            self.messages.append(.user(prompt, images: images, videos: videos))
 
-        let output: String
-        switch model {
-        case .container(let container):
-            output = try await container.perform(values: self) { context, session in
-                try await session.generateResponse(context: context)
+            let output: String
+            switch self.model {
+            case .container(let container):
+                output = try await container.perform(values: self) { context, session in
+                    try await session.generateResponse(context: context)
+                }
+            case .context(let context):
+                output = try await self.generateResponse(context: context)
             }
-        case .context(let context):
-            output = try await generateResponse(context: context)
-        }
 
-        messages.append(.assistant(output))
-        return output
+            self.messages.append(.assistant(output))
+            return output
+        }
     }
 
     /// Produces a response to a prompt.
@@ -137,14 +145,19 @@ public final class ChatSession {
         images: [UserInput.Image],
         videos: [UserInput.Video]
     ) -> AsyncThrowingStream<String, Error> {
-        messages.append(.user(prompt, images: images, videos: videos))
-
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
 
-        let session = SendableBox(self)
+        let sessionAccess = self.sessionAccess
+        let images = SendableBox(images)
+        let videos = SendableBox(videos)
         let task = Task {
             do {
-                try await session.consume().performStreaming(continuation: continuation)
+                try await sessionAccess.update { _ in
+                    let images = images.consume()
+                    let videos = videos.consume()
+                    self.messages.append(.user(prompt, images: images, videos: videos))
+                    try await self.performStreaming(continuation: continuation)
+                }
             } catch {
                 continuation.finish(throwing: error)
             }
@@ -178,8 +191,16 @@ public final class ChatSession {
 
     /// Clear the session history and cache, preserving system instructions.
     public func clear() {
-        messages = messages.filter { $0.role == .system }
-        cache = []
+        let semaphore = DispatchSemaphore(value: 0)
+        let sessionAccess = self.sessionAccess
+        Task.detached {
+            await sessionAccess.update { _ in
+                self.messages = self.messages.filter { $0.role == .system }
+                self.cache = []
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
     }
 
     // MARK: - Private

--- a/third_party/mlx-swift-lm/Libraries/MLXLMCommon/Evaluate.swift
+++ b/third_party/mlx-swift-lm/Libraries/MLXLMCommon/Evaluate.swift
@@ -816,11 +816,11 @@ public func generate(
     let promptTokenCount = input.text.tokens.size
     let modelConfiguration = context.configuration
     let tokenizer = context.tokenizer
-    let iterator = SendableBox(iterator)
+    let iteratorBox = SendableBox(iterator)
 
     // Launch a Task to perform iteration asynchronously.
     let task = Task {
-        var iterator = iterator.consume()
+        let iterator = iteratorBox.consume()
         var start = Date.timeIntervalSinceReferenceDate
         var promptTime: TimeInterval = 0
 

--- a/third_party/mlx-swift-lm/Libraries/MLXLMCommon/Evaluate.swift
+++ b/third_party/mlx-swift-lm/Libraries/MLXLMCommon/Evaluate.swift
@@ -813,20 +813,25 @@ public func generate(
 ) -> AsyncStream<Generation> {
 
     let (stream, continuation) = AsyncStream<Generation>.makeStream()
+    let promptTokenCount = input.text.tokens.size
+    let modelConfiguration = context.configuration
+    let tokenizer = context.tokenizer
+    let iterator = SendableBox(iterator)
 
     // Launch a Task to perform iteration asynchronously.
     let task = Task {
+        var iterator = iterator.consume()
         var start = Date.timeIntervalSinceReferenceDate
         var promptTime: TimeInterval = 0
 
         let additionalEOSTokenIds = Set(
-            context.configuration.extraEOSTokens
+            modelConfiguration.extraEOSTokens
                 .compactMap {
-                    context.tokenizer.convertTokenToId($0)
+                    tokenizer.convertTokenToId($0)
                 })
 
         var tokenCount = 0
-        var detokenizer = NaiveStreamingDetokenizer(tokenizer: context.tokenizer)
+        var detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
         let toolCallProcessor = ToolCallProcessor()
 
         for token in iterator {
@@ -840,8 +845,8 @@ public func generate(
                 start = now
             }
 
-            if token == context.tokenizer.unknownTokenId
-                || token == context.tokenizer.eosTokenId
+            if token == tokenizer.unknownTokenId
+                || token == tokenizer.eosTokenId
                 || additionalEOSTokenIds.contains(token)
             {
                 break
@@ -867,7 +872,7 @@ public func generate(
         let generateTime = now - start
 
         let info = GenerateCompletionInfo(
-            promptTokenCount: input.text.tokens.size,
+            promptTokenCount: promptTokenCount,
             generationTokenCount: tokenCount,
             promptTime: promptTime + iterator.promptPrefillTime,
             generationTime: generateTime

--- a/third_party/mlx-swift-lm/Libraries/MLXLMCommon/ModelContainer.swift
+++ b/third_party/mlx-swift-lm/Libraries/MLXLMCommon/ModelContainer.swift
@@ -128,8 +128,10 @@ public final class ModelContainer: Sendable {
     /// - Note: The `sending` keyword indicates the return value is transferred (not shared),
     ///   allowing non-Sendable types like `LMInput` to safely cross isolation boundaries.
     public func prepare(input: consuming sending UserInput) async throws -> sending LMInput {
-        let processor = await self.processor
-        return try await processor.prepare(input: input)
+        let input = SendableBox(input)
+        return try await context.read { context in
+            try await context.processor.prepare(input: input.consume())
+        }
     }
 
     /// Generate tokens from prepared input, returning an AsyncStream.
@@ -176,8 +178,9 @@ public final class ModelContainer: Sendable {
     /// - Parameter tokens: Array of token IDs
     /// - Returns: Decoded string
     public func decode(tokens: [Int]) async -> String {
-        let tokenizer = await self.tokenizer
-        return tokenizer.decode(tokens: tokens)
+        await context.read {
+            $0.tokenizer.decode(tokens: tokens)
+        }
     }
 
     /// Encode a string to token IDs.
@@ -185,8 +188,9 @@ public final class ModelContainer: Sendable {
     /// - Parameter text: Text to encode
     /// - Returns: Array of token IDs
     public func encode(_ text: String) async -> [Int] {
-        let tokenizer = await self.tokenizer
-        return tokenizer.encode(text: text)
+        await context.read {
+            $0.tokenizer.encode(text: text)
+        }
     }
 
     /// Apply chat template to messages and return token IDs.
@@ -195,7 +199,8 @@ public final class ModelContainer: Sendable {
     /// - Returns: Array of token IDs
     @available(*, deprecated, message: "Use applyChatTemplate directly on tokenizer")
     public func applyChatTemplate(messages: [[String: String]]) async throws -> [Int] {
-        let tokenizer = await self.tokenizer
-        return try tokenizer.applyChatTemplate(messages: messages)
+        try await context.read {
+            try $0.tokenizer.applyChatTemplate(messages: messages)
+        }
     }
 }

--- a/third_party/mlx-swift-lm/Libraries/MLXLMCommon/ModelContainer.swift
+++ b/third_party/mlx-swift-lm/Libraries/MLXLMCommon/ModelContainer.swift
@@ -31,31 +31,54 @@ import Tokenizers
 ///     }
 /// }
 /// ```
-public actor ModelContainer {
-    var context: ModelContext
-    public var configuration: ModelConfiguration { context.configuration }
+public final class ModelContainer: Sendable {
+    private let context: SerialAccessContainer<ModelContext>
 
-    public init(context: ModelContext) {
-        self.context = context
+    public var configuration: ModelConfiguration {
+        get async {
+            await context.read { $0.configuration }
+        }
+    }
+
+    public var processor: UserInputProcessor {
+        get async {
+            await context.read { $0.processor }
+        }
+    }
+
+    public var tokenizer: Tokenizer {
+        get async {
+            await context.read { $0.tokenizer }
+        }
+    }
+
+    public init(context: consuming ModelContext) {
+        self.context = .init(context)
     }
 
     /// Perform an action on the model and/or tokenizer. Callers _must_ eval any `MLXArray` before returning as
     /// `MLXArray` is not `Sendable`.
     @available(*, deprecated, message: "prefer perform(_:) that uses a ModelContext")
-    public func perform<R>(_ action: @Sendable (any LanguageModel, Tokenizer) throws -> R) rethrows
+    public func perform<R: Sendable>(
+        _ action: @Sendable (any LanguageModel, Tokenizer) throws -> sending R
+    ) async rethrows
         -> R
     {
-        try action(context.model, context.tokenizer)
+        try await context.read {
+            try action($0.model, $0.tokenizer)
+        }
     }
 
     /// Perform an action on the model and/or tokenizer with additional context values.
     /// Callers _must_ eval any `MLXArray` before returning as
     /// `MLXArray` is not `Sendable`.
     @available(*, deprecated, message: "prefer perform(values:_:) that uses a ModelContext")
-    public func perform<V: Sendable, R>(
-        values: V, _ action: @Sendable (any LanguageModel, Tokenizer, V) throws -> R
-    ) rethrows -> R {
-        try action(context.model, context.tokenizer, values)
+    public func perform<V: Sendable, R: Sendable>(
+        values: V, _ action: @Sendable (any LanguageModel, Tokenizer, V) throws -> sending R
+    ) async rethrows -> sending R {
+        try await context.read {
+            try action($0.model, $0.tokenizer, values)
+        }
     }
 
     /// Perform an action on the ``ModelContext``. Callers _must_ eval any `MLXArray` before returning as
@@ -65,25 +88,32 @@ public actor ModelContainer {
     ///   the closure runs within the actor's isolation, ensuring thread-safe access to the model.
     /// - Note: The `sending` keyword indicates the return value is transferred (not shared) across
     ///   isolation boundaries, allowing non-Sendable types to be safely returned.
-    public func perform<R>(
-        _ action: (ModelContext) async throws -> sending R
+    public func perform<R: Sendable>(
+        _ action: @Sendable (ModelContext) async throws -> sending R
     ) async rethrows -> sending R {
-        try await action(context)
+        try await context.read {
+            try await action($0)
+        }
     }
 
     /// Perform an action on the ``ModelContext`` with additional context values.
     /// Callers _must_ eval any `MLXArray` before returning as
     /// `MLXArray` is not `Sendable`.
-    public func perform<V: Sendable, R>(
-        values: V, _ action: (ModelContext, V) async throws -> sending R
+    public func perform<V, R: Sendable>(
+        values: consuming V, _ action: @Sendable (ModelContext, V) async throws -> R
     ) async rethrows -> sending R {
-        try await action(context, values)
+        let values = SendableBox(values)
+        return try await context.read {
+            try await action($0, values.consume())
+        }
     }
 
     /// Update the owned `ModelContext`.
     /// - Parameter action: update action
-    public func update(_ action: @Sendable (inout ModelContext) -> Void) {
-        action(&context)
+    public func update(_ action: @Sendable (inout ModelContext) -> Void) async {
+        await context.update {
+            action(&$0)
+        }
     }
 
     // MARK: - Thread-safe convenience methods
@@ -97,8 +127,9 @@ public actor ModelContainer {
     /// - Returns: Prepared language model input (transferred via `sending`)
     /// - Note: The `sending` keyword indicates the return value is transferred (not shared),
     ///   allowing non-Sendable types like `LMInput` to safely cross isolation boundaries.
-    public func prepare(input: UserInput) async throws -> sending LMInput {
-        try await context.processor.prepare(input: input)
+    public func prepare(input: consuming sending UserInput) async throws -> sending LMInput {
+        let processor = await self.processor
+        return try await processor.prepare(input: input)
     }
 
     /// Generate tokens from prepared input, returning an AsyncStream.
@@ -126,37 +157,45 @@ public actor ModelContainer {
     /// - Note: The `sending` parameter indicates the input is transferred (not shared),
     ///   allowing non-Sendable types like `LMInput` to safely cross isolation boundaries.
     public func generate(
-        input: sending LMInput,
+        input: consuming sending LMInput,
         parameters: GenerateParameters
-    ) throws -> AsyncStream<Generation> {
-        try MLXLMCommon.generate(
-            input: input,
-            parameters: parameters,
-            context: context
-        )
+    ) async throws -> AsyncStream<Generation> {
+        let input = SendableBox(input)
+
+        return try await context.read { context in
+            try MLXLMCommon.generate(
+                input: input.consume(),
+                parameters: parameters,
+                context: context
+            )
+        }
     }
 
     /// Decode token IDs to a string.
     ///
     /// - Parameter tokens: Array of token IDs
     /// - Returns: Decoded string
-    public func decode(tokens: [Int]) -> String {
-        context.tokenizer.decode(tokens: tokens)
+    public func decode(tokens: [Int]) async -> String {
+        let tokenizer = await self.tokenizer
+        return tokenizer.decode(tokens: tokens)
     }
 
     /// Encode a string to token IDs.
     ///
     /// - Parameter text: Text to encode
     /// - Returns: Array of token IDs
-    public func encode(_ text: String) -> [Int] {
-        context.tokenizer.encode(text: text)
+    public func encode(_ text: String) async -> [Int] {
+        let tokenizer = await self.tokenizer
+        return tokenizer.encode(text: text)
     }
 
     /// Apply chat template to messages and return token IDs.
     ///
     /// - Parameter messages: Array of message dictionaries with "role" and "content" keys
     /// - Returns: Array of token IDs
-    public func applyChatTemplate(messages: [[String: String]]) throws -> [Int] {
-        try context.tokenizer.applyChatTemplate(messages: messages)
+    @available(*, deprecated, message: "Use applyChatTemplate directly on tokenizer")
+    public func applyChatTemplate(messages: [[String: String]]) async throws -> [Int] {
+        let tokenizer = await self.tokenizer
+        return try tokenizer.applyChatTemplate(messages: messages)
     }
 }

--- a/third_party/mlx-swift-lm/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/third_party/mlx-swift-lm/Libraries/MLXLMCommon/ModelFactory.swift
@@ -91,7 +91,7 @@ public protocol ModelFactory: Sendable {
     func _load(
         hub: HubApi, configuration: ModelConfiguration,
         progressHandler: @Sendable @escaping (Progress) -> Void
-    ) async throws -> sending ModelContext
+    ) async throws -> ModelContext
 
     func _loadContainer(
         hub: HubApi, configuration: ModelConfiguration,

--- a/third_party/mlx-swift-lm/Libraries/MLXLMCommon/UserInput.swift
+++ b/third_party/mlx-swift-lm/Libraries/MLXLMCommon/UserInput.swift
@@ -314,7 +314,7 @@ public struct UserInput {
 /// Protocol for a type that can convert ``UserInput`` to ``LMInput``.
 ///
 /// See also ``ModelContext``.
-public protocol UserInputProcessor {
+public protocol UserInputProcessor: Sendable {
     func prepare(input: UserInput) async throws -> LMInput
 }
 

--- a/third_party/mlx-swift-lm/Libraries/MLXLMCommon/Utilities/SerialAccessContainer.swift
+++ b/third_party/mlx-swift-lm/Libraries/MLXLMCommon/Utilities/SerialAccessContainer.swift
@@ -1,0 +1,85 @@
+// Copyright © 2025 Apple Inc.
+
+/// A mutex providing exclusive access with `async` blocks.
+///
+/// This is used as a building block for ``SerialAccessContainer``. Normal locks
+/// do not work with `async` blocks and an `actor` does not guarantee exclusive access
+/// for the duration of an `async` function.
+private actor AsyncMutex {
+    private var isLocked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    private func lock() async {
+        if !isLocked {
+            isLocked = true
+            return
+        }
+
+        await withCheckedContinuation { cont in
+            waiters.append(cont)
+        }
+    }
+
+    private func unlock() {
+        if let next = waiters.first {
+            waiters.removeFirst()
+            next.resume()
+        } else {
+            isLocked = false
+        }
+    }
+
+    func withLock<T>(_ body: () async throws -> sending T) async rethrows -> sending T {
+        await lock()
+        defer { unlock() }
+        return try await body()
+    }
+}
+
+/// Provide serial exclusive access to state `<T>` to async callers.
+///
+/// Unlike an `actor`, this guarantees exclusive access for the duration of the async
+/// call. This is important for model containers that have to perform async work but
+/// also need to prevent other callers from using any internal state concurrently.
+final class SerialAccessContainer<T>: @unchecked Sendable {
+
+    private var value: T
+    private let lock = AsyncMutex()
+
+    init(_ value: consuming T) {
+        self.value = consume value
+    }
+
+    func read<R>(_ body: @Sendable (T) async throws -> sending R) async rethrows -> sending R {
+        try await lock.withLock {
+            try await body(value)
+        }
+    }
+
+    func update<R>(_ body: @Sendable (inout T) async throws -> sending R) async rethrows
+        -> sending R
+    {
+        try await lock.withLock {
+            try await body(&value)
+        }
+    }
+}
+
+/// Internal box to wrap non-Sendable data transferred across task boundaries.
+///
+/// The wrapped value must be consumed exactly once.
+final class SendableBox<T>: @unchecked Sendable {
+    private var value: T?
+
+    init(_ value: consuming T) {
+        self.value = consume value
+    }
+
+    consuming func consume() -> T {
+        guard let value else {
+            fatalError("value already consumed")
+        }
+        self.value = nil
+        return value
+    }
+}

--- a/third_party/mlx-swift-lm/Libraries/MLXLMCommon/Utilities/SerialAccessContainer.swift
+++ b/third_party/mlx-swift-lm/Libraries/MLXLMCommon/Utilities/SerialAccessContainer.swift
@@ -6,6 +6,8 @@
 /// do not work with `async` blocks and an `actor` does not guarantee exclusive access
 /// for the duration of an `async` function.
 private actor AsyncMutex {
+    private static let waiterCompactionThreshold = 32
+
     private var isLocked = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
     private var waiterHead = 0
@@ -25,9 +27,9 @@ private actor AsyncMutex {
         if waiterHead < waiters.count {
             let next = waiters[waiterHead]
             waiterHead += 1
-            // Amortize the O(n) compaction cost: compact only after enough
+            // Amortize the O(n) compaction cost by trimming only after enough
             // consumed slots have accumulated to make at least half the queue dead.
-            if waiterHead > 32 && waiterHead * 2 >= waiters.count {
+            if waiterHead >= Self.waiterCompactionThreshold && waiterHead * 2 >= waiters.count {
                 waiters.removeFirst(waiterHead)
                 waiterHead = 0
             }

--- a/third_party/mlx-swift-lm/Libraries/MLXLMCommon/Utilities/SerialAccessContainer.swift
+++ b/third_party/mlx-swift-lm/Libraries/MLXLMCommon/Utilities/SerialAccessContainer.swift
@@ -8,6 +8,7 @@
 private actor AsyncMutex {
     private var isLocked = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var waiterHead = 0
 
     private func lock() async {
         if !isLocked {
@@ -21,10 +22,17 @@ private actor AsyncMutex {
     }
 
     private func unlock() {
-        if let next = waiters.first {
-            waiters.removeFirst()
+        if waiterHead < waiters.count {
+            let next = waiters[waiterHead]
+            waiterHead += 1
+            if waiterHead > 32 && waiterHead * 2 >= waiters.count {
+                waiters.removeFirst(waiterHead)
+                waiterHead = 0
+            }
             next.resume()
         } else {
+            waiters.removeAll(keepingCapacity: true)
+            waiterHead = 0
             isLocked = false
         }
     }

--- a/third_party/mlx-swift-lm/Libraries/MLXLMCommon/Utilities/SerialAccessContainer.swift
+++ b/third_party/mlx-swift-lm/Libraries/MLXLMCommon/Utilities/SerialAccessContainer.swift
@@ -25,6 +25,8 @@ private actor AsyncMutex {
         if waiterHead < waiters.count {
             let next = waiters[waiterHead]
             waiterHead += 1
+            // Amortize the O(n) compaction cost: compact only after enough
+            // consumed slots have accumulated to make at least half the queue dead.
             if waiterHead > 32 && waiterHead * 2 >= waiters.count {
                 waiters.removeFirst(waiterHead)
                 waiterHead = 0

--- a/third_party/mlx-swift-lm/MELIX_PATCHES.md
+++ b/third_party/mlx-swift-lm/MELIX_PATCHES.md
@@ -1,8 +1,11 @@
 # Melix patches for mlx-swift-lm
 
-Vendored from `ml-explore/mlx-swift-lm` at commit:
+Upstream alignment target:
 
-`5064b8c5d8ed3b0bbb71385c4124f0fc102e74a2`
+- `ml-explore/mlx-swift-lm` tag `2.31.3`
+- tag commit `25b00d4e22e61ec9c41efda47990cd2084ec87ff`
+
+The local tree retains Melix runtime patches on top of the upstream 2.x line.
 
 Melix patches:
 
@@ -17,3 +20,7 @@ Melix patches:
 - Add an experimental `fusedQ4AffineKeyValueQuantizedForDecode(...)` q4 affine key/value decode quantizer, including bfloat16 output casting, gated by `MELIX_SWIFT_TURBOQUANT_FUSED_QUANTIZE=1` because real-model metrics show it is slower than MLX native `quantized(...)`.
 - Optimize the fused q4 decode attention kernel by computing online-softmax state on one lane and broadcasting it to value lanes, and by hoisting each lane's eight query values out of the historical-token loop. The single-lane online-softmax design is intentional for the current 4096-token cap; raising that cap should revisit a two-pass or parallel softmax reduction.
 - Keep `fusedQ4AffineKeyValueQuantizedForDecode(...)` opt-in and scoped to the fused decode contract; its packed/scales/biases output is validated by Melix tests but should be revalidated before any new non-fused consumer reuses it.
+- Keep the DFlash draft runtime and Qwen3/Qwen3.5 hidden-state hooks used by Melix speculative decode tests.
+- Carry the upstream 2.31.x Swift 6.1 concurrency compatibility surface for
+  `ModelContainer`, `UserInputProcessor`, `MessageGenerator`, and async
+  generation task capture while preserving Melix's existing service call paths.

--- a/third_party/mlx-swift-lm/Package.swift
+++ b/third_party/mlx-swift-lm/Package.swift
@@ -1,11 +1,16 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "mlx-swift-lm",
-    platforms: [.macOS(.v14), .iOS(.v16)],
+    platforms: [
+        .macOS(.v14),
+        .iOS(.v17),
+        .tvOS(.v17),
+        .visionOS(.v1),
+    ],
     products: [
         .library(
             name: "MLXLLM",
@@ -21,10 +26,10 @@ let package = Package(
             targets: ["MLXEmbedders"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.29.1")),
+        .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.31.3")),
         .package(
             url: "https://github.com/huggingface/swift-transformers",
-            .upToNextMinor(from: "1.1.6")
+            .upToNextMinor(from: "1.2.0")
         ),
     ],
     targets: [

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,16 @@ resolution-markers = [
     "python_full_version == '3.13.*'",
     "python_full_version < '3.13'",
 ]
+conflicts = [[
+    { package = "melix-mlx-worker", extra = "mlx" },
+    { package = "melix-mlx-worker", extra = "audio" },
+], [
+    { package = "melix-mlx-worker", extra = "mlx" },
+    { package = "melix-mlx-worker", extra = "audio-stt" },
+], [
+    { package = "melix-mlx-worker", extra = "mlx" },
+    { package = "melix-mlx-worker", extra = "audio-tts" },
+]]
 
 [manifest]
 members = [
@@ -480,12 +490,12 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dill" },
     { name = "filelock" },
-    { name = "fsspec", extra = ["http"] },
+    { name = "fsspec", extra = ["http"], marker = "extra == 'extra-16-melix-mlx-worker-mlx'" },
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "multiprocess" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
     { name = "packaging" },
     { name = "pandas" },
     { name = "pyarrow" },
@@ -880,8 +890,8 @@ dependencies = [
     { name = "lazy-loader" },
     { name = "msgpack" },
     { name = "numba" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
     { name = "pooch" },
     { name = "scikit-learn" },
     { name = "scipy" },
@@ -1025,7 +1035,7 @@ audio-tts = [
 ]
 mlx = [
     { name = "mlx" },
-    { name = "mlx-lm" },
+    { name = "mlx-lm", version = "0.31.3", source = { registry = "https://pypi.org/simple" } },
     { name = "mlx-vlm" },
 ]
 
@@ -1039,12 +1049,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "grpcio", specifier = ">=1.71.0" },
-    { name = "mlx", marker = "extra == 'mlx'", specifier = ">=0.25.0" },
+    { name = "mlx", marker = "extra == 'mlx'", specifier = ">=0.31.2,<0.32" },
     { name = "mlx-audio", marker = "extra == 'audio'", specifier = "==0.4.2" },
     { name = "mlx-audio", marker = "extra == 'audio-stt'", specifier = "==0.4.2" },
     { name = "mlx-audio", marker = "extra == 'audio-tts'", specifier = "==0.4.2" },
-    { name = "mlx-lm", marker = "extra == 'mlx'", specifier = ">=0.22.0" },
-    { name = "mlx-vlm", marker = "extra == 'mlx'", git = "https://github.com/Blaizzy/mlx-vlm.git?rev=43b9b2078b7027e7622f34a434b2d94aada7eaad" },
+    { name = "mlx-lm", marker = "extra == 'mlx'", specifier = ">=0.31.3,<0.32" },
+    { name = "mlx-vlm", marker = "extra == 'mlx'", specifier = ">=0.4.4,<0.5" },
     { name = "protobuf", specifier = ">=5.29.0" },
 ]
 provides-extras = ["mlx", "audio-stt", "audio-tts", "audio"]
@@ -1082,27 +1092,27 @@ wheels = [
 
 [[package]]
 name = "mlx"
-version = "0.31.1"
+version = "0.31.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/29/71fe1f68756f515856e6930973c23245810d4aa3cd22fddd719d86a709dc/mlx-0.31.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8a63b31a398c9519f2bb0c81cf3865d9baca4ff573ffc31ead465d18286184e8", size = 574308 },
-    { url = "https://files.pythonhosted.org/packages/21/be/70654a2cee0d71fd10bd237a50a79d06ae51679a194db6a3b16c0c84e6a5/mlx-0.31.1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:a7a9347df4dcc41f0d16ff70b65650820af4879f686534b233b16826a22afa00", size = 574309 },
-    { url = "https://files.pythonhosted.org/packages/ad/69/c7bc7b04f76b0cbd678f328011d1634bd0bcfc2da45aba06e084cb031127/mlx-0.31.1-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:6cdb797ea31787d1ce9e5be77991c4bd5cbf129ab15f7253b78e09737f535fce", size = 574289 },
-    { url = "https://files.pythonhosted.org/packages/55/f7/dcc129228faab4d406041d91413c5999250ab79da6fe5417ac84f1616ff1/mlx-0.31.1-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:1ed1991c8e39f841d5756c0c543beb819763a2f80fba3f4b150bc6cad4d973de", size = 626439 },
-    { url = "https://files.pythonhosted.org/packages/90/1d/8b32e46ea98ab5c1c15cf1b37ac97af651977f84e72e1800412a700c51d9/mlx-0.31.1-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:195c5cb27328380287c0ffe9ef48f860ab75ec5d3dfce153d475dc2c99369708", size = 668679 },
-    { url = "https://files.pythonhosted.org/packages/44/45/04465da443634b23fb11670bbd2f7538b1ed43ffc5e0de44a95b3c29e9c1/mlx-0.31.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:9a6d3410fc951bd28508fed9c1ab5d9903f6f6bb101c3a5d63d4191d49a384a1", size = 574268 },
-    { url = "https://files.pythonhosted.org/packages/85/7b/84956960356ff36e8c1bbed68fac96709e98e6a1adbc8e3d0ff71022d84e/mlx-0.31.1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:20bd7ba19882603ac22711092d0e799f1ff7b5183c2c641d417dab4d2423d99e", size = 574265 },
-    { url = "https://files.pythonhosted.org/packages/86/01/d6f0ef5b8c0b390af08246d1301e9717dfb076b3920012b53105a888ed8c/mlx-0.31.1-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:4c4565d6f4f8ce295613ee342d313ee5ab0b0eab9a6272954450f8343f7876bc", size = 574172 },
-    { url = "https://files.pythonhosted.org/packages/df/05/eb29e9eb0cff9c7dfd872e26663e6e9512629730740e1db629086c80ac5a/mlx-0.31.1-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:9dc564a8b38b9aec279a1c7d34551068b1cc1f8e43b5ac044b56b2a9a4205195", size = 626558 },
-    { url = "https://files.pythonhosted.org/packages/25/45/ecb746fbb6acb75d03760e41cc7bd21c2e2b544528b3033f7d70402334ac/mlx-0.31.1-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:78f51ab929278366006ee7793dbb5c942b121542c793c33eb9b894a2ce8e27e1", size = 668625 },
-    { url = "https://files.pythonhosted.org/packages/99/65/208f511acd5fb1ed0b08f047bd6229583845cc6f4b5aa6547a3219332dbb/mlx-0.31.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:bba9d471ba20e050676292b1089a355c8042d3fc9462e4c1738a9735d7d40cfa", size = 576300 },
-    { url = "https://files.pythonhosted.org/packages/98/58/2d925cb3fa3cd28d279ed6f44508ab7fbbf7359b17359914aa3652a7d734/mlx-0.31.1-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:d90b0529b22553eb1353b113b7233aa391ca55e24b1ba69024c732fcc21c5c49", size = 576303 },
-    { url = "https://files.pythonhosted.org/packages/e1/17/abec0bd0f9347dae13e60b33325cb199312798842901953495e19f3bb3c8/mlx-0.31.1-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:69bc88b41ddd61b44cd6a4d417790f9971ba3fdf58d824934cea95a95b9b4031", size = 576275 },
-    { url = "https://files.pythonhosted.org/packages/a2/91/85c73f7cc3a661416d05315623458c719eda7de958b05f4e10ba40c52d07/mlx-0.31.1-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:b973506fd49ba39df6dc4ff655b77bd35ea193cee878e71d6ee3d1a951d2b3a6", size = 628701 },
-    { url = "https://files.pythonhosted.org/packages/7d/e9/d87638e00a44dcf346fe838caaf1e2dae96a88d5779edbd66ce27d4bbdcc/mlx-0.31.1-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:3987282a1e63252bdd7c636138812c67316c3f7c7a7acad08e76c8843648a056", size = 668959 },
+    { url = "https://files.pythonhosted.org/packages/c3/47/5f33906cb03d6a378a697cd2d2641a26b37dea17ee3d9124d7e39e8eca01/mlx-0.31.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e5067aaf2be1f3d7bba5be52348775804f111173c1ed04639618fd713b1a530f", size = 584863 },
+    { url = "https://files.pythonhosted.org/packages/08/e7/a851a451b1327af9fb4df3991b9ae87d066b6f6630e854af55c288b0995a/mlx-0.31.2-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:edb9797db7d852477ca1c99708058654ee860d4148fe5765f0d55528e2b1aa22", size = 584860 },
+    { url = "https://files.pythonhosted.org/packages/3b/15/0d1dc0597644e5e7b011ca954ba0c47e13cd880a3b909b0c3f1b4d8bf8f1/mlx-0.31.2-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:51ca102db641b01e7cb083ce8ecb580e281530a141a7ca12544bb370641630ae", size = 584887 },
+    { url = "https://files.pythonhosted.org/packages/5d/c3/00664239a98e8bd614733c4182cd402d2bacad2d7f79eca66562ac406870/mlx-0.31.2-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:117c7583cae0ca107cd53c591cc34f8e75f97a505aa47088844b7dc0fc69dc67", size = 627863 },
+    { url = "https://files.pythonhosted.org/packages/53/7b/af6cd73a79772af6f19eab2cb4c48eda23a9294d1650a4c1269a9996e532/mlx-0.31.2-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:99572133181481640a8bf8d449daf083816d0af3ee050c8adfc5bf45ceca91c6", size = 685090 },
+    { url = "https://files.pythonhosted.org/packages/a3/3f/888f8664d4f8e23a1363a5f50024be5216e199ab7ad0ba20988c7ed6d729/mlx-0.31.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:1b3fb0dda955b0d552ce57bdd6f42b3309ab21b067e40587d6848443d307e91f", size = 584796 },
+    { url = "https://files.pythonhosted.org/packages/dd/14/e9cd18b51f9e1dbcb060eec0fafc2d2428c8e1eacd9b0a02d7c5ce75b661/mlx-0.31.2-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:34b0171cd9eb5c43fdd82091f6135d6ccc5a065363a4a3e68fac64fb4e53d37c", size = 584790 },
+    { url = "https://files.pythonhosted.org/packages/ca/20/c6c5fb998c7834d094b2bfb9f003b5246cb270f0266da055c55546c34999/mlx-0.31.2-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:c05981684279a8935d58b0dde3ea5b02d210c3bad3319aa0e9934ec2df165752", size = 584795 },
+    { url = "https://files.pythonhosted.org/packages/0b/19/aca251d4c5f3532ce9c2c1e95ad76740d9c6c298f406f62d992f465b9be0/mlx-0.31.2-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:cd1f4189e5f1bc68735f44eb63ce98ae09d66ac75d7ab5b15a41afae7e9f0513", size = 627843 },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/b89364883b98f21c2fe29e52d4ac8bc2fa2fe0d79293b36ec421efc1854a/mlx-0.31.2-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:53c8d57ffa9ce77f8355663be05014c0dd37280e57f19126fb0a24389a30684b", size = 685064 },
+    { url = "https://files.pythonhosted.org/packages/8b/f5/e63f6a9316ded2d14a8ebc7a9ca25734c784e8c54d064a78b4dceeacec0e/mlx-0.31.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a13c9ce23c3deef6aa5a09315e7953e1a5dc311e851fa16fc74c81fb2509c0b9", size = 588417 },
+    { url = "https://files.pythonhosted.org/packages/31/50/9d0c03ea3134cd85c132df7b0e4b75e6344bd8b4881a0b9c465cfa27f724/mlx-0.31.2-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:b0764bf11fc3a71dee988e19275eef67775cab63112d8bb7ef173ca8b2a1247c", size = 588421 },
+    { url = "https://files.pythonhosted.org/packages/ef/5b/d364cc793bcb504621313acb55627cf0d5403ab2e0a594aa081cdbe4591f/mlx-0.31.2-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:59ccbd0f0044d4f97f11ebcbf0c480bc9e962935fd96275f120954afea65be8a", size = 588384 },
+    { url = "https://files.pythonhosted.org/packages/1b/a4/e822202dd2e4e7d08671f2ecf7b6500af74f5bad5ceb27086b1aa6902f3a/mlx-0.31.2-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:e81798c610f95a09c642c89214ba5c23b72ce18ce4728184aceabe7eddca33d7", size = 630473 },
+    { url = "https://files.pythonhosted.org/packages/40/6f/da48d2d7a76e644d35438ef6f33c68755fdd382e2c546fd1804ccba01d04/mlx-0.31.2-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:69fbc94bf53607a75af9eb3e22c354738a6fe4e25aa4e2b20934b009a4bba1f3", size = 685459 },
 ]
 
 [[package]]
@@ -1114,10 +1124,10 @@ dependencies = [
     { name = "librosa" },
     { name = "miniaudio" },
     { name = "mlx" },
-    { name = "mlx-lm" },
+    { name = "mlx-lm", version = "0.31.1", source = { registry = "https://pypi.org/simple" } },
     { name = "numba" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
     { name = "protobuf" },
     { name = "pyloudnorm" },
     { name = "sounddevice" },
@@ -1133,11 +1143,16 @@ wheels = [
 name = "mlx-lm"
 version = "0.31.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 dependencies = [
     { name = "jinja2" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
     { name = "protobuf" },
     { name = "pyyaml" },
     { name = "sentencepiece" },
@@ -1149,33 +1164,61 @@ wheels = [
 ]
 
 [[package]]
+name = "mlx-lm"
+version = "0.31.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
+dependencies = [
+    { name = "jinja2" },
+    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "protobuf" },
+    { name = "pyyaml" },
+    { name = "sentencepiece" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/02/9a67b8e4f87e3e2e5cd7b1ad79304b93c09a0db6af34bee75e6551c06c60/mlx_lm-0.31.3-py3-none-any.whl", hash = "sha256:758cfddf1180053b7613db76fad3d246a331a2a905808e1164a275621fc983b8", size = 408890 },
+]
+
+[[package]]
 name = "mlx-metal"
-version = "0.31.1"
+version = "0.31.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/66/2313497fdbc7fbadf8e026c09366e3f049f9114e65ca4edc23cdb8699186/mlx_metal-0.31.1-py3-none-macosx_14_0_arm64.whl", hash = "sha256:70741174131dbf7fdd479cb730e06e08c358eac3bf7905d9e884e7960cfdd5b8", size = 38624074 },
-    { url = "https://files.pythonhosted.org/packages/c7/34/4c3c6890ce6095b2ab2ba2f5f15c9a7ba17208d47f8cacb572885a2dc0eb/mlx_metal-0.31.1-py3-none-macosx_15_0_arm64.whl", hash = "sha256:6c56bd8cd27743e635f5a90a22535af7c31bd22b4b126d46b6da2da52d72e413", size = 38618950 },
-    { url = "https://files.pythonhosted.org/packages/51/bc/987cb99e3aafb296aa11ce5133838a10eae8447edd53168d0804d4fb3a14/mlx_metal-0.31.1-py3-none-macosx_26_0_arm64.whl", hash = "sha256:e7324b7c56b519ae67c025d3ced07e5d35bc3a9f19d4c45fe4927f385148c59e", size = 49256543 },
+    { url = "https://files.pythonhosted.org/packages/3f/69/fe3b783ebe999f3118234e1e940feb622518bfb1dea6ac5d13b1d36a8449/mlx_metal-0.31.2-py3-none-macosx_14_0_arm64.whl", hash = "sha256:b25385bcee18fc194092255b8b53b9a3d8489eb650e59160f1b57aadd07aa2dc", size = 40055588 },
+    { url = "https://files.pythonhosted.org/packages/4f/5d/4c690d5b93c30ba002656c37363159d978705bf8eb801b8481840fb942c2/mlx_metal-0.31.2-py3-none-macosx_15_0_arm64.whl", hash = "sha256:e9d4e5fce6ca10a87a0e388597f99519ad594d09e674708b5312bd8bd4f5997d", size = 40053220 },
+    { url = "https://files.pythonhosted.org/packages/99/82/11fd62a8d7a3e96e5c43220b17de0151e3f10101f8bb3b865f5bd9cdd074/mlx_metal-0.31.2-py3-none-macosx_26_0_arm64.whl", hash = "sha256:84ffb60ee503f03eb684f5fb168d5cff31e2a16b7f27c1731eaf7662bd6e9b46", size = 55792151 },
 ]
 
 [[package]]
 name = "mlx-vlm"
-version = "0.4.3"
-source = { git = "https://github.com/Blaizzy/mlx-vlm.git?rev=43b9b2078b7027e7622f34a434b2d94aada7eaad#43b9b2078b7027e7622f34a434b2d94aada7eaad" }
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datasets" },
     { name = "fastapi" },
     { name = "miniaudio" },
     { name = "mlx" },
-    { name = "mlx-lm" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "mlx-lm", version = "0.31.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "requests" },
     { name = "tqdm" },
     { name = "transformers" },
     { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/ec/108aec30efb159940ea29d133d5d8ec14840edbec914869b46eaafac5552/mlx_vlm-0.4.4.tar.gz", hash = "sha256:3197e277c1be9ed1712ea04624df029e486f7747ad93e40e7bd1c9c771f8b179", size = 836370 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/81/235518176c3c8230e5274e91346ecf940591f653e73b0daeb505fb37eea9/mlx_vlm-0.4.4-py3-none-any.whl", hash = "sha256:3ff86ea738ab1914dc1b07e4fa5d4cc34bec5909e540692cfad0af808af13c11", size = 1014936 },
 ]
 
 [[package]]
@@ -1344,8 +1387,8 @@ version = "0.65.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llvmlite" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/61/7299643b9c18d669e04be7c5bcb64d985070d07553274817b45b049e7bfe/numba-0.65.0.tar.gz", hash = "sha256:edad0d9f6682e93624c00125a471ae4df186175d71fd604c983c377cdc03e68b", size = 2764131 }
 wheels = [
@@ -1503,8 +1546,8 @@ name = "opencv-python"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/6f/5a28fef4c4a382be06afe3938c64cc168223016fa520c5abaf37e8862aa5/opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19", size = 46247052 },
@@ -1531,8 +1574,8 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -1915,8 +1958,8 @@ name = "pyloudnorm"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
     { name = "scipy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/00/f915eaa75326f4209941179c2b93ac477f2040e4aeff5bb21d16eb8058f9/pyloudnorm-0.2.0.tar.gz", hash = "sha256:8bf597658ea4e1975c275adf490f6deb5369ea409f2901f939915efa4b681b16", size = 14037 }
@@ -1929,7 +1972,7 @@ name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
@@ -2151,8 +2194,8 @@ version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
     { name = "scipy" },
     { name = "threadpoolctl" },
 ]
@@ -2195,8 +2238,8 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822 }
 wheels = [
@@ -2348,8 +2391,8 @@ version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/41/9b873a8c055582859b239be17902a85339bec6a30ad162f98c9b0288a2cc/soundfile-0.13.1.tar.gz", hash = "sha256:b2c68dab1e30297317080a5b43df57e302584c49e2942defdde0acccc53f0e5b", size = 46156 }
 wheels = [
@@ -2367,8 +2410,8 @@ name = "soxr"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/7e/f4b461944662ad75036df65277d6130f9411002bfb79e9df7dff40a31db9/soxr-1.0.0.tar.gz", hash = "sha256:e07ee6c1d659bc6957034f4800c60cb8b98de798823e34d2a2bba1caa85a4509", size = 171415 }
 wheels = [
@@ -2484,8 +2527,8 @@ version = "5.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },


### PR DESCRIPTION
## Summary
- Upgrade the Python MLX runtime stack to `mlx 0.31.2`, `mlx-lm 0.31.3`, and PyPI `mlx-vlm 0.4.4` while leaving `mlx-audio 0.4.2` isolated behind conflicting extras.
- Align the Swift text worker package pins and vendored `mlx-swift-lm` compatibility surface with upstream 2.31.3 / `mlx-swift 0.31.3` while preserving Melix TurboQuant and DFlash patches.
- Add runtime package-version metadata, signature-gated sampler/video routing, and a more tolerant `mlx.metallib` resolver for Swift/Python MLX core version skew.
- Address review feedback by serializing `ChatSession` response state, making `clear()` async, making VLM media paths structurally immutable, sharing runtime introspection helpers, making unsupported VLM `video=` routing observable, closing `ModelContainer` serial-read TOCTOU gaps, and documenting/covering the async mutex waiter compaction threshold.
- Fix the menu bar empty-registry test to assert the public view state instead of depending on SwiftUI internal AppKit subviews.

## Plan or Spec
- `docs/plans/2026-05-02-mlx-runtime-dependency-upgrade.md`

## Commands Run
```text
uv sync --frozen --package melix-mlx-worker --extra mlx
# Passed: Audited 75 packages.

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_dev_up_script.py services/mlx-worker-python/tests/test_runtime_utils.py -q
# Passed: 87 passed.

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_dev_up_script.py services/mlx-worker-python/tests/test_runtime_utils.py -q
# Passed: 87 passed.

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx coverage json -o /tmp/melix_mlx_runtime_review_python_coverage.json
# Passed.

python3 scripts/python_changed_line_coverage.py --diff-from e9313711a --coverage-json /tmp/melix_mlx_runtime_review_python_coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_runtime_utils.py
# Passed: TOTAL 100.00% (41/41 changed lines).

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_mlx_vlm_runtime.py -q
# Passed: 23 passed.

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_m9_release_gate_smoke.py -q
# Passed: 3 passed.

swift package resolve --package-path services/mlx-text-worker-swift
# Passed.

swift test --package-path services/mlx-text-worker-swift --filter WorkerScaffoldTests
# Passed: 184 tests, 0 failures.

swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter WorkerScaffoldTests
# Passed: 187 tests, 0 failures.

python3 scripts/swift_changed_line_coverage.py --diff-from e9313711a --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata third_party/mlx-swift-lm/Libraries/MLXLMCommon/ChatSession.swift third_party/mlx-swift-lm/Libraries/MLXLMCommon/Evaluate.swift third_party/mlx-swift-lm/Libraries/MLXLMCommon/ModelContainer.swift third_party/mlx-swift-lm/Libraries/MLXLMCommon/Utilities/SerialAccessContainer.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
# Passed: TOTAL 97.98% (97/99 changed lines).

make proto
# Passed.

make swift-test
# Passed.

make py-test
# Passed: 1379 passed, 5 skipped, 2 warnings.

make integration-test
# Passed: 86 passed, 1 skipped.

make py-coverage
# Passed: 1379 passed, 5 skipped; TOTAL 95%.

make swift-coverage
# Passed; summaries emitted for text worker, control plane, and menu bar.

git diff --check
# Passed.
```

## Coverage and Metrics
- Python coverage: TOTAL `95%` from `make py-coverage`.
- Follow-up Python changed-line coverage: `100.00%` (`41/41`) across the shared runtime helper, text/VLM runtime call sites, and focused tests.
- Swift coverage command completed successfully, with package summaries: text worker `93.45%`, control plane `91.98%`, menu bar `93.22%`.
- Follow-up Swift changed-line coverage: `97.98%` (`97/99`) across `ChatSession`, `Evaluate`, `ModelContainer`, `SerialAccessContainer`, and focused worker tests.
- Review-fix verification: Python VLM fallback routing has focused coverage (`23 passed`), Python MLX/dev-up focused scope passed (`87 passed`), and Swift WorkerScaffold coverage-mode scope passed (`187 tests, 0 failures`).
- Runtime probe coverage added/kept in code paths for `mlx_version`, `mlx_lm_version`, `mlx_vlm_version`, sampler penalty support, VLM video support/fallback reporting, and Swift/Python metallib compatibility resolution.
- Real performance metrics for Qwen3.5 TurboQuant, VLM image/video, and LoRA train/activate were not collected in this PR because they require local model assets and a named Melix runtime instance.

## Known Gaps
- Real runtime smoke was not run for Qwen3.5 Swift TurboQuant Phase 2, VLM image/video, repeated-image cache evidence, or LoRA train/activate.
- Swift coverage totals remain below the repository's 95% target even though `make swift-coverage` passes and emits summaries; follow-up changed-line Swift coverage is above 95%.
- Swift build still reports upstream MLX API rename deprecation warnings and existing Swift Sendable warnings in `SwiftMLXBackend.swift`.
- A direct `swift test --package-path third_party/mlx-swift-lm --enable-code-coverage --filter ReviewConcurrencyTests` attempt was abandoned because that package test target also compiles MLXVLM, which currently fails on existing non-final `UserInputProcessor: Sendable` conformances outside this review-fix scope; no vendored test file from that attempt is retained.
- The worker Python test environment does not expose `pytest-cov` options directly; coverage evidence is from repository `coverage` commands and `make py-coverage`.
- The working tree had pre-existing unstaged `artifacts/lora-marketing-screenshots/...` PNG modifications; they were intentionally excluded from this PR.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema changes.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
