### PR TITLE
perf(rerank): skip pair scan for no-overlap docs

### DIFF
--- a/docs/plans/2026-05-02-rerank-no-overlap-pair-skip.md
+++ b/docs/plans/2026-05-02-rerank-no-overlap-pair-skip.md
@@ -1,0 +1,46 @@
+# Deterministic Rerank No-Overlap Pair-Bonus Skip Slice
+
+## Goal
+
+Reduce deterministic rerank scoring overhead for documents that share no tokens with the query by skipping ordered-pair bonus scans that cannot affect the score.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/rerank_backends.py`
+- `services/mlx-worker-python/tests/test_rerank_runtime.py`
+- Registered probe: `deterministic-rerank-query-context-reuse` in `infra/perf/pr_scoped_probes.json`
+
+## Linux Constraint
+
+This slice is Python-only and is locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered PR-scoped performance probe.
+
+## Optimization Hypothesis
+
+For both Jina-v3 and causal-LM rerank families, an ordered adjacent query pair cannot be present when `overlap_count == 0`. The previous implementation still called the ordered-pair helper for those no-overlap documents. Short-circuiting `pair_bonus` to `0.0` in that branch preserves scoring semantics while avoiding avoidable adjacent-pair iteration for negative candidates.
+
+## Registered Probe
+
+- Probe ID: `deterministic-rerank-query-context-reuse`
+- Workload: score 2,048 deterministic rerank documents across repeated iterations with a reused query context; half of the synthetic documents intentionally miss the query terms.
+- Metrics:
+  - `elapsed_ms_mean` lower is better
+  - `query_context_builds_mean` lower is better
+  - `tokenize_calls_mean` lower is better
+
+## Success Metrics
+
+- Focused tests prove no-overlap Jina-v3 and causal-LM scoring skips pair and contiguous-query helpers while keeping score polarity intact.
+- Changed-scope coverage for touched rerank runtime files and tests remains at or above 95%.
+- Local registered probe improves versus the pre-change baseline without increasing query-context builds or tokenize calls.
+- PR-scoped performance CI selects and completes the registered probe for this path.
+
+## Verification Commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/run_probe_rerank.py
+git diff --check
+```

--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -195,11 +195,17 @@ def test_causal_lm_rerank_produces_positive_and_negative_logits() -> None:
     assert rerank.items[1].score < 0
 
 
-def test_jina_v3_skips_contiguous_query_check_when_document_misses_query_terms(monkeypatch) -> None:
+def test_jina_v3_skips_pair_and_contiguous_query_checks_when_document_misses_query_terms(monkeypatch) -> None:
     adapter = JinaV3RerankFamilyAdapter()
     backend = DeterministicRerankBackend()
+    ordered_pair_bonus = Mock(return_value=0.0)
     contains = Mock(return_value=False)
 
+    monkeypatch.setattr(
+        JinaV3RerankFamilyAdapter,
+        "_ordered_pair_bonus",
+        staticmethod(ordered_pair_bonus),
+    )
     monkeypatch.setattr(
         JinaV3RerankFamilyAdapter,
         "_contains_contiguous_query",
@@ -213,14 +219,21 @@ def test_jina_v3_skips_contiguous_query_check_when_document_misses_query_terms(m
     )
 
     assert score >= 0.0
+    ordered_pair_bonus.assert_not_called()
     contains.assert_not_called()
 
 
-def test_causal_lm_skips_contiguous_query_check_when_document_misses_query_terms(monkeypatch) -> None:
+def test_causal_lm_skips_pair_and_contiguous_query_checks_when_document_misses_query_terms(monkeypatch) -> None:
     adapter = CausalLMRerankFamilyAdapter()
     backend = DeterministicRerankBackend()
+    ordered_pair_bonus = Mock(return_value=0.0)
     contains = Mock(return_value=False)
 
+    monkeypatch.setattr(
+        JinaV3RerankFamilyAdapter,
+        "_ordered_pair_bonus",
+        staticmethod(ordered_pair_bonus),
+    )
     monkeypatch.setattr(
         JinaV3RerankFamilyAdapter,
         "_contains_contiguous_query",
@@ -234,6 +247,7 @@ def test_causal_lm_skips_contiguous_query_check_when_document_misses_query_terms
     )
 
     assert score < 0.0
+    ordered_pair_bonus.assert_not_called()
     contains.assert_not_called()
 
 

--- a/services/mlx-worker-python/worker/runtime/rerank_backends.py
+++ b/services/mlx-worker-python/worker/runtime/rerank_backends.py
@@ -179,7 +179,10 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
             union = (len(query_token_set) + len(document_token_set) - overlap_count) or 1
             overlap_score = overlap_count / union
 
-        pair_bonus = self._ordered_pair_bonus(query_tokens, document_tokens, query_pairs=query_context.ordered_pairs)
+        if overlap_count == 0:
+            pair_bonus = 0.0
+        else:
+            pair_bonus = self._ordered_pair_bonus(query_tokens, document_tokens, query_pairs=query_context.ordered_pairs)
         has_all_query_terms = overlap_count >= len(query_token_set)
         exact_order_bonus = (
             0.1 if has_all_query_terms and self._contains_contiguous_query(document_tokens, query_tokens) else 0.0
@@ -273,11 +276,14 @@ class CausalLMRerankFamilyAdapter(RerankFamilyAdapter):
         document_token_set = set(document_tokens)
         overlap_count = len(query_token_set & document_token_set)
         overlap = overlap_count / (len(query_token_set) or 1)
-        pair_bonus = JinaV3RerankFamilyAdapter._ordered_pair_bonus(
-            query_tokens,
-            document_tokens,
-            query_pairs=query_context.ordered_pairs,
-        )
+        if overlap_count == 0:
+            pair_bonus = 0.0
+        else:
+            pair_bonus = JinaV3RerankFamilyAdapter._ordered_pair_bonus(
+                query_tokens,
+                document_tokens,
+                query_pairs=query_context.ordered_pairs,
+            )
         exact_order = (
             JinaV3RerankFamilyAdapter._contains_contiguous_query(document_tokens, query_tokens)
             if overlap_count >= len(query_token_set)


### PR DESCRIPTION
## Summary
- Skip ordered-pair bonus scans for deterministic rerank documents with zero query-token overlap.
- Extend rerank tests to prove both Jina-v3 and causal-LM no-overlap paths bypass pair and contiguous-query helpers.
- Add a governing plan for this Python performance slice.

## Plan or Spec
- `docs/plans/2026-05-02-rerank-no-overlap-pair-skip.md`

## Commands Run
```text
# Baseline before changes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
# exit 0; 28 passed in 12.89s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/run_probe_rerank.py
# exit 0; {"document_count": 2048.0, "elapsed_ms_mean": 79.79047, "iteration_count": 8.0, "query_context_builds_mean": 1.0, "sample_count": 5.0, "tokenize_calls_mean": 2049.0}

# After changes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
# exit 0; 28 passed in 12.70s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
# exit 0; 28 passed in 35.85s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# exit 0; wrote coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; TOTAL 14 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/run_probe_rerank.py
# exit 0; {"document_count": 2048.0, "elapsed_ms_mean": 76.627245, "iteration_count": 8.0, "query_context_builds_mean": 1.0, "sample_count": 5.0, "tokenize_calls_mean": 2049.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 14 0 100%`.
- Registered probe: `deterministic-rerank-query-context-reuse` is already registered in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command`.
- Local Linux probe: `elapsed_ms_mean` improved from `79.79047` ms to `76.627245` ms (`-3.163225` ms, `~3.96%` faster); `query_context_builds_mean` stayed `1.0`; `tokenize_calls_mean` stayed `2049.0`.
- CI PR-scoped performance report is required as the merge validation source for the registered probe comparison.

## Known Gaps
- Full repository `make` gates were not run locally; this PR uses the focused registered probe commands for the touched Python slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
