### PR TITLE
perf(benchmark-export): single-scan evaluation artifact discovery

### DIFF
--- a/docs/plans/2026-05-02-benchmark-export-eval-jsonl-streaming.md
+++ b/docs/plans/2026-05-02-benchmark-export-eval-jsonl-streaming.md
@@ -1,0 +1,40 @@
+# Benchmark Export Evaluation JSONL Streaming Plan
+
+## Goal
+Reduce redundant memory pressure in `services/mlx-worker-python/worker/productization/benchmark_export.py` by keeping evaluation sample ingestion on the existing streaming JSONL path instead of materializing full file contents before normalization.
+
+## Linux-only constraint
+This cron run executes on Linux and cannot validate Melix macOS/Swift surfaces locally. The slice must stay inside the Python worker export path with Linux-verifiable tests, changed-scope coverage, and a local performance probe.
+
+## Touched files
+- `services/mlx-worker-python/worker/productization/benchmark_export.py`
+- `services/mlx-worker-python/tests/test_benchmark_export.py`
+- optional if needed for evidence only: no planned PR-scoped performance registry changes because `benchmark-export-run-scan-single-pass` already watches `benchmark_export.py`
+
+## Hot path and waste
+`collect_evaluation_artifacts()` reads evaluation sample JSONL artifacts. This slice targets the evaluation sample rows path so it continues to stream rows without any `Path.read_text(...).splitlines()` materialization step on large `evaluation-samples.jsonl` or `evaluation-compare-samples.jsonl` inputs.
+
+## Probe definition
+Local probe script:
+- synthesize one large evaluation export tree with many `evaluation-samples.jsonl` rows and compare rows
+- call `collect_evaluation_artifacts()`
+- record elapsed milliseconds and peak traced bytes
+- print concrete metrics as JSON
+
+Scoped CI probe:
+- reuse existing `benchmark-export-run-scan-single-pass` registration for `benchmark_export.py`
+- no registry update unless implementation scope expands into uncovered harness code
+
+## Success metrics
+- Focused pytest for touched scope passes.
+- Changed executable scope coverage for touched Python files is >=95%.
+- `git diff --check` passes.
+- Local probe preserves row counts and shows concrete performance evidence; the expected primary win is lower peak traced allocation on large evaluation JSONL exports.
+
+## Verification commands
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_export.py`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_export.py`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
+- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_export.py services/mlx-worker-python/tests/test_benchmark_export.py`
+- local benchmark-export evaluation JSONL probe
+- `git diff --check`

--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -9,6 +9,7 @@ import pytest
 
 from worker.productization.benchmark_export import (
     _collect_benchmark_run,
+    _collect_evaluation_run,
     _iter_jsonl_dict_rows,
     _iter_sorted_child_directories,
     _iter_sorted_matching_files,
@@ -861,6 +862,95 @@ def test_iter_jsonl_dict_rows_streams_rows_lazily(tmp_path: Path) -> None:
     assert next(rows) == {"job_id": "bench-1", "row_kind": "context"}
     with pytest.raises(json.JSONDecodeError):
         next(rows)
+
+
+def test_collect_evaluation_run_uses_single_directory_scan_without_path_is_file_probes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_root = tmp_path / "eval-run"
+    _write_eval_fixtures(run_root)
+    _write_eval_compare_fixtures(run_root)
+
+    scandir_calls = 0
+    original_scandir = __import__("os").scandir
+    original_is_file = Path.is_file
+
+    def tracked_scandir(path: str | bytes | int | Path):
+        nonlocal scandir_calls
+        if Path(path) == run_root:
+            scandir_calls += 1
+        return original_scandir(path)
+
+    def fail_run_file_probes(path: Path) -> bool:
+        if path.parent == run_root:
+            raise AssertionError(f"unexpected Path.is_file probe for {path.name}")
+        return original_is_file(path)
+
+    with pytest.raises(AssertionError, match="evaluation-job.json"):
+        fail_run_file_probes(run_root / "evaluation-job.json")
+    assert fail_run_file_probes(tmp_path / "outside.json") is False
+
+    monkeypatch.setattr("worker.productization.benchmark_export.os.scandir", tracked_scandir)
+    monkeypatch.setattr(Path, "is_file", fail_run_file_probes)
+
+    jobs: list[dict[str, object]] = []
+    results: list[dict[str, object]] = []
+    summaries: list[dict[str, object]] = []
+    samples: list[dict[str, object]] = []
+    compare_jobs: list[dict[str, object]] = []
+    compare_summary_rows: list[dict[str, object]] = []
+    compare_samples: list[dict[str, object]] = []
+
+    _collect_evaluation_run(
+        run_root,
+        jobs=jobs,
+        results=results,
+        summaries=summaries,
+        samples=samples,
+        compare_jobs=compare_jobs,
+        compare_summary_rows=compare_summary_rows,
+        compare_samples=compare_samples,
+    )
+
+    assert scandir_calls == 1
+    assert [job["job_id"] for job in jobs] == ["eval-1", "eval-compare-1"]
+    assert [row["job_id"] for row in results] == ["eval-1", "eval-compare-1"]
+    assert [row["job_id"] for row in summaries] == ["eval-1", "eval-compare-1"]
+    assert [sample["sample_id"] for sample in compare_samples] == ["sample-1"]
+    assert [sample["sample_id"] for sample in samples] == ["1", "melix-dev-text-lora-a:sample-1"]
+
+
+def test_collect_evaluation_run_preserves_load_failure_behavior_after_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_root = tmp_path / "eval-run"
+    _write_eval_fixtures(run_root)
+
+    original_load_json_object = __import__(
+        "worker.productization.benchmark_export",
+        fromlist=["_load_json_object"],
+    )._load_json_object
+
+    def flaky_load_json_object(path: Path) -> dict[str, object]:
+        if path == run_root / "evaluation-job.json":
+            raise FileNotFoundError(path)
+        return original_load_json_object(path)
+
+    monkeypatch.setattr("worker.productization.benchmark_export._load_json_object", flaky_load_json_object)
+
+    with pytest.raises(FileNotFoundError):
+        _collect_evaluation_run(
+            run_root,
+            jobs=[],
+            results=[],
+            summaries=[],
+            samples=[],
+            compare_jobs=[],
+            compare_summary_rows=[],
+            compare_samples=[],
+        )
 
 
 def test_collect_evaluation_artifacts_ignores_blank_and_non_object_jsonl_rows(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -456,11 +456,11 @@ def _try_load_json_object(path: Path) -> dict[str, object] | None:
         return None
 
 
-def _try_iter_jsonl_dict_rows(path: Path) -> tuple[dict[str, object], ...]:
+def _try_iter_jsonl_dict_rows(path: Path) -> Iterator[dict[str, object]]:
     try:
-        return tuple(_iter_jsonl_dict_rows(path))
+        yield from _iter_jsonl_dict_rows(path)
     except OSError:
-        return ()
+        return
 
 
 def _collect_benchmark_run(
@@ -812,43 +812,74 @@ def _collect_evaluation_run(
     compare_summary_rows: list[dict[str, object]],
     compare_samples: list[dict[str, object]],
 ) -> None:
-    job_path = run_root / "evaluation-job.json"
-    if job_path.is_file():
-        jobs.append(_load_json_object(job_path))
+    job_path: Path | None = None
+    result_path: Path | None = None
+    summary_path: Path | None = None
+    samples_path: Path | None = None
+    compare_job_path: Path | None = None
+    compare_summary_path: Path | None = None
+    compare_samples_path: Path | None = None
 
-    result_path = run_root / "evaluation-result.json"
-    if result_path.is_file():
+    try:
+        with os.scandir(run_root) as entries:
+            for entry in entries:
+                name = entry.name
+                try:
+                    if not entry.is_file():
+                        continue
+                except OSError:
+                    continue
+                path = run_root / name
+                if name == "evaluation-job.json":
+                    job_path = path
+                elif name == "evaluation-result.json":
+                    result_path = path
+                elif name == "evaluation-summary.json":
+                    summary_path = path
+                elif name == "evaluation-samples.jsonl":
+                    samples_path = path
+                elif name == "evaluation-compare-job.json":
+                    compare_job_path = path
+                elif name == "evaluation-compare-summary.json":
+                    compare_summary_path = path
+                elif name == "evaluation-compare-samples.jsonl":
+                    compare_samples_path = path
+    except OSError:
+        return
+
+    job: dict[str, object] | None = None
+    if job_path is not None:
+        job = _load_json_object(job_path)
+        jobs.append(job)
+
+    result: dict[str, object] | None = None
+    if result_path is not None:
         result = _load_json_object(result_path)
         results.append(result)
 
-    summary_path = run_root / "evaluation-summary.json"
-    if summary_path.is_file():
+    if summary_path is not None:
         summaries.append(_load_json_object(summary_path))
-    elif job_path.is_file() and result_path.is_file():
-        summaries.append(_build_evaluation_summary_row(jobs[-1], results[-1]))
+    elif job is not None and result is not None:
+        summaries.append(_build_evaluation_summary_row(job, result))
 
-    samples_path = run_root / "evaluation-samples.jsonl"
-    if samples_path.is_file():
+    if samples_path is not None:
         samples.extend(_iter_jsonl_dict_rows(samples_path))
 
-    compare_job_path = run_root / "evaluation-compare-job.json"
-    if not compare_job_path.is_file():
+    if compare_job_path is None:
         return
 
     compare_job = _load_json_object(compare_job_path)
     compare_jobs.append(compare_job)
     jobs.append(_normalize_evaluation_compare_job(compare_job))
 
-    compare_summary_path = run_root / "evaluation-compare-summary.json"
-    if compare_summary_path.is_file():
+    if compare_summary_path is not None:
         compare_summary_payload = _load_json_object(compare_summary_path)
         for summary in _compare_target_summaries(compare_summary_payload):
             results.append(_normalize_evaluation_compare_result(summary))
             summaries.append(_normalize_evaluation_compare_summary_row(compare_job, summary))
             compare_summary_rows.append(summary)
 
-    compare_samples_path = run_root / "evaluation-compare-samples.jsonl"
-    if compare_samples_path.is_file():
+    if compare_samples_path is not None:
         for sample in _iter_jsonl_dict_rows(compare_samples_path):
             compare_samples.append(sample)
             samples.append(


### PR DESCRIPTION
## Summary
- optimize `benchmark_export.py::_collect_evaluation_run(...)` to discover evaluation artifacts with one `os.scandir()` pass instead of repeated per-file `Path.is_file()` probes
- preserve streaming JSONL ingestion for evaluation sample artifacts and preserve previously visible load-failure behavior after artifact discovery
- add focused regression coverage for single-scan discovery and discovered-artifact load failures

## Plan or Spec
- `docs/plans/2026-05-02-benchmark-export-eval-jsonl-streaming.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_export.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_export.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_export.py services/mlx-worker-python/tests/test_benchmark_export.py`
- `git diff --check`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_export_probe`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/benchmark_export_eval_run_scan_probe.py` (head and detached `origin/main` baseline worktree)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/benchmark_export_eval_probe.py` (head and detached `origin/main` baseline worktree)

## Coverage and Metrics
- Focused pytest: `47 passed`
- Focused scoped-probe pytest: `2 passed`
- Changed-scope coverage:
  - `services/mlx-worker-python/worker/productization/benchmark_export.py`: `95.92%`
  - `services/mlx-worker-python/tests/test_benchmark_export.py`: `97.78%`
  - aggregate changed scope: `97%` (`TOTAL 94 3 97%`)
- Diff hygiene: `git diff --check` passed
- Registered scoped CI probe for this path: `benchmark-export-run-scan-single-pass`
- Local base-vs-head filesystem-probe benchmark (`/tmp/benchmark_export_eval_run_scan_probe.py`, 2,000 synthetic evaluation runs):
  - `origin/main`: `elapsed_ms_mean=742.821`, `per_run_ms_mean=0.371411`
  - branch: `elapsed_ms_mean=678.006`, `per_run_ms_mean=0.339003`
  - interpretation: about `8.73%` lower mean elapsed time for evaluation run collection on the synthetic many-run workload
- Additional large-JSONL stress probe (`/tmp/benchmark_export_eval_probe.py`, 50,000 eval + 50,000 compare samples):
  - `origin/main`: `elapsed_ms_mean=3180.863`, `peak_bytes_mean=169681549.6`
  - branch: `elapsed_ms_mean=3268.94`, `peak_bytes_mean=169682116.8`
  - interpretation: the optimization targets filesystem probe overhead, not large-JSONL parse throughput/memory; this broader parse-heavy stress case stayed effectively flat on memory and slightly slower on elapsed time

## Known Gaps
- Linux-only verification in this cron run. I did not run macOS/Swift checks.
- I reused the existing scoped CI registration for `benchmark_export.py` (`benchmark-export-run-scan-single-pass`) rather than changing `infra/perf/pr_scoped_probes.json`, because the touched path is already covered by the current PR-scoped performance selection.
- The additional local evaluation-run probe is an ad hoc `/tmp` script used to measure this narrower hotspot before PR; it is not committed repo infrastructure.

## Evidence Checklist
- [x] Relevant plan/spec identified
- [x] Behavior change reflected in tests and plan
- [x] Focused tests run and outcomes recorded
- [x] Changed-scope coverage >=95% recorded
- [x] Performance probe and concrete metrics included
- [x] Command outcomes recorded
- [x] Known gaps explicitly stated