### PR TITLE
perf: scan benchmark evaluation probe keys directly

### DIFF
--- a/docs/plans/2026-05-02-benchmark-evaluation-probe-key-scan.md
+++ b/docs/plans/2026-05-02-benchmark-evaluation-probe-key-scan.md
@@ -1,0 +1,40 @@
+# Benchmark Evaluation Probe Key Scan Slice
+
+## Scope
+
+This Python-only slice narrows the hot path in
+`services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`.
+The registered PR-scoped probe `benchmark-evaluation-report-running-aggregates`
+already covers this file with focused test, coverage, and probe commands in
+`infra/perf/pr_scoped_probes.json`.
+
+## Optimization
+
+The report collectors now scan the fixed registered probe-key tuples directly
+instead of walking every row item and filtering unrelated fields. This preserves
+metric aggregation semantics while reducing per-row dictionary iteration work in
+large benchmark/evaluation export bundles.
+
+## Verification
+
+Linux-local verification commands for this slice:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_probe_benchmark_evaluation_report.py
+```
+
+## Metrics
+
+Local old/new module comparison against `origin/main` on the registered synthetic
+bundle:
+
+- old mean: `155.946 ms`
+- new mean: `141.918 ms`
+- delta: `-14.028 ms`
+- speedup: `1.0988x`
+- row count parity: `5990`
+- peak bytes mean parity: `3904530.4`
+
+PR-scoped performance CI remains the merge gate for the registered probe report.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -403,6 +403,48 @@ def test_probe_collectors_fast_path_exact_numeric_values(monkeypatch: pytest.Mon
     assert evaluation_metrics["eval.sample.smoke.validation_ms_mean"] == 0.0
 
 
+def test_probe_collectors_use_registered_probe_key_order_without_items_scan() -> None:
+    class NoItemsDict(dict[str, object]):
+        def items(self):  # type: ignore[override]
+            raise AssertionError("collector should scan registered probe keys directly")
+
+    benchmark_metrics: dict[str, object] = {}
+    _collect_benchmark_probe_metrics(
+        benchmark_metrics,
+        [
+            NoItemsDict(
+                {
+                    "suite_id": "smoke",
+                    "context_length": 1024,
+                    "generation_length": 128,
+                    "batch_size": 1,
+                    "concurrency_level": 2,
+                    "prefill_ms": 10.0,
+                    "irrelevant_payload": "skip",
+                }
+            )
+        ],
+        prefix="bench",
+    )
+
+    evaluation_metrics: dict[str, object] = {}
+    _collect_evaluation_sample_probe_metrics(
+        evaluation_metrics,
+        [
+            NoItemsDict(
+                {
+                    "suite_id": "smoke",
+                    "sample_render_ms": 3.0,
+                    "irrelevant_payload": "skip",
+                }
+            )
+        ],
+    )
+
+    assert benchmark_metrics["bench.smoke.ctx1024.gen128.b1.c2.prefill_ms_mean"] == 10.0
+    assert evaluation_metrics["eval.sample.smoke.sample_render_ms_mean"] == 3.0
+
+
 def test_collect_benchmark_probe_metrics_reuses_matrix_labels(monkeypatch: pytest.MonkeyPatch) -> None:
     original = benchmark_evaluation_report._matrix_label
     matrix_label_calls = 0

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -42,7 +42,6 @@ _REQUEST_PROBE_KEYS = (
     "dflash_rollback_count",
     "dflash_target_hidden_layers",
 )
-_REQUEST_PROBE_KEY_SET = frozenset(_REQUEST_PROBE_KEYS)
 _COUNT_PROBE_KEYS = {
     "speculative_accepted_tokens",
     "speculative_rejected_tokens",
@@ -63,7 +62,6 @@ _EVALUATION_SAMPLE_PROBE_KEYS = (
     "raw_response_chars",
     "extracted_result_chars",
 )
-_EVALUATION_SAMPLE_PROBE_KEY_SET = frozenset(_EVALUATION_SAMPLE_PROBE_KEYS)
 _LOWER_IS_BETTER_METRIC_FRAGMENTS = (
     "latency",
     "ttft",
@@ -458,9 +456,10 @@ def _collect_benchmark_probe_metrics(
     matrix_label_cache: dict[tuple[object, object, object, object, object], str] = {}
     for row in _dict_rows(rows):
         label = ""
-        for key, raw_value in row.items():
-            if key not in _REQUEST_PROBE_KEY_SET:
+        for key in _REQUEST_PROBE_KEYS:
+            if key not in row:
                 continue
+            raw_value = row[key]
             raw_value_type = type(raw_value)
             if raw_value_type is float:
                 value = raw_value
@@ -495,9 +494,10 @@ def _collect_evaluation_sample_probe_metrics(
     failure_stage_counts: dict[tuple[str, str], int] = {}
     for row in _dict_rows(rows):
         suite_id = str(row.get("suite_id", "")).strip() or "suite"
-        for key, raw_value in row.items():
-            if key not in _EVALUATION_SAMPLE_PROBE_KEY_SET:
+        for key in _EVALUATION_SAMPLE_PROBE_KEYS:
+            if key not in row:
                 continue
+            raw_value = row[key]
             raw_value_type = type(raw_value)
             if raw_value_type is float:
                 value = raw_value


### PR DESCRIPTION
## Summary
- Optimize benchmark/evaluation report probe aggregation by scanning the registered probe-key tuples directly instead of walking every row item and filtering unrelated fields.
- Add a regression test that fails if benchmark/evaluation probe collectors fall back to `dict.items()` scanning.
- Document the Python-only performance slice and local metrics in `docs/plans/2026-05-02-benchmark-evaluation-probe-key-scan.md`.

## Plan or Spec
- `docs/plans/2026-05-02-benchmark-evaluation-probe-key-scan.md`
- Registered PR-scoped probe: `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# 35 passed in 0.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# 35 passed in 0.12s
# TOTAL 656 statements, 6 missed, 99% coverage

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_probe_benchmark_evaluation_report.py
# {"elapsed_ms_mean": 151.777, "peak_bytes_mean": 3904837.7, "row_count": 5990.0}

git show origin/main:services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py > /tmp/melix_benchmark_evaluation_report_old.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_compare_benchmark_evaluation_report.py
# {"delta_ms": -14.028, "new": {"mean_ms": 141.918, "median_ms": 142.8, "peak_bytes_mean": 3904530.4, "row_count": 5990, "samples_ms": [136.833, 143.626, 142.8, 140.281, 143.508, 144.386, 141.99]}, "old": {"mean_ms": 155.946, "median_ms": 159.102, "peak_bytes_mean": 3904530.4, "row_count": 5990, "samples_ms": [163.803, 159.102, 168.663, 147.87, 163.321, 143.182, 145.68]}, "speedup": 1.0988}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 99% total for `benchmark_evaluation_report.py` and `test_benchmark_evaluation_report.py`.
- Local registered probe after change: `elapsed_ms_mean=151.777`, `peak_bytes_mean=3904837.7`, `row_count=5990.0`.
- Local old/new comparison against `origin/main`: `old_mean=155.946 ms`, `new_mean=141.918 ms`, `delta=-14.028 ms`, `speedup=1.0988x`; row count and peak bytes remained equal in the comparison harness.
- CI PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- Full repository `make` gates were not run locally; this slice is focused to the registered Python benchmark/evaluation report path.
- No Swift runtime behavior is touched.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
