### PR TITLE
perf: reuse prompt-completion duplicate keys

### DIFF
--- a/docs/plans/2026-05-02-training-dataset-duplicate-key-fast-path.md
+++ b/docs/plans/2026-05-02-training-dataset-duplicate-key-fast-path.md
@@ -1,0 +1,45 @@
+# Training dataset duplicate-key fast path
+
+## Context
+
+This Linux-only optimization slice targets `services/mlx-worker-python/worker/model_ops/training_dataset.py`.
+The current `origin/main` implementation of `_build_quality_and_token_stats()` computes duplicate detection keys by hashing a JSON-sorted canonical string for every sample, even for the hot `prompt_completion` path where the relevant shape is already just `prompt` plus `completion`.
+
+The affected path is already covered by the registered PR-scoped probe `training-dataset-token-percentiles-single-sort` in `infra/perf/pr_scoped_probes.json`, so this slice can be locally verified on Linux and then validated again in CI.
+
+## Goal
+
+Reduce redundant per-sample work in the prompt/completion quality scan by reusing the native prompt/completion fields directly for duplicate detection while preserving duplicate counts, dirty-sample semantics, and token statistics.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset.py`
+- `services/mlx-worker-python/tests/test_training_dataset_builder.py`
+- `docs/plans/2026-05-02-training-dataset-duplicate-key-fast-path.md`
+
+## Probe and success metrics
+
+- **Scoped CI probe:** `training-dataset-token-percentiles-single-sort`
+- **Local probe command:** existing `probe_command` from `infra/perf/pr_scoped_probes.json`
+- **Primary success metric:** lower `elapsed_ms_mean` on the local training-dataset probe versus current `origin/main`
+- **Secondary metric:** no material regression in `peak_bytes_mean`
+- **Correctness gates:**
+  - focused pytest passes for touched training-dataset / scoped-performance tests
+  - changed-scope coverage is at least 95%
+  - duplicate and dirty counts remain unchanged on the synthetic probe workload
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_training_dataset_token_percentiles as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
+```
+
+## Risks
+
+- Prompt/completion duplicate detection must preserve current semantics for non-string values after coercion.
+- Non-`prompt_completion` sample formats must keep using the generic canonical path.
+- If the local probe does not beat `origin/main`, abandon the slice rather than pushing a semantic no-op refactor.

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -879,6 +879,65 @@ def test_build_quality_and_token_stats_uses_prompt_completion_fast_path(
     }
 
 
+def test_build_quality_and_token_stats_uses_prompt_completion_duplicate_key_fast_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_generic_digest(sample: dict[str, object]) -> bytes:
+        raise AssertionError(f"normalized prompt_completion samples should not hash JSON digests ({sample=})")
+
+    monkeypatch.setattr(training_dataset_module, "_canonical_sample_digest", fail_generic_digest)
+
+    quality, token_stats = training_dataset_module._build_quality_and_token_stats(
+        [
+            {"prompt": "same text", "completion": "answer"},
+            {"prompt": "same text", "completion": "answer"},
+            {"prompt": "different", "completion": "answer"},
+        ],
+        "prompt_completion",
+    )
+
+    assert quality == {
+        "duplicate_count": 1,
+        "duplicate_sample_indices": [1],
+        "dirty_count": 0,
+        "dirty_samples": [],
+    }
+    assert token_stats["sample_count"] == 3
+
+
+def test_build_quality_and_token_stats_falls_back_to_generic_digest_for_non_normalized_prompt_completion_samples(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    digested_samples: list[dict[str, object]] = []
+    original_digest = training_dataset_module._canonical_sample_digest
+
+    def tracking_digest(sample: dict[str, object]) -> bytes:
+        digested_samples.append(sample)
+        return original_digest(sample)
+
+    monkeypatch.setattr(training_dataset_module, "_canonical_sample_digest", tracking_digest)
+
+    quality, token_stats = training_dataset_module._build_quality_and_token_stats(
+        [
+            {"prompt": "same text", "completion": "answer", "metadata": "a"},
+            {"prompt": "same text", "completion": "answer", "metadata": "b"},
+        ],
+        "prompt_completion",
+    )
+
+    assert digested_samples == [
+        {"prompt": "same text", "completion": "answer", "metadata": "a"},
+        {"prompt": "same text", "completion": "answer", "metadata": "b"},
+    ]
+    assert quality == {
+        "duplicate_count": 0,
+        "duplicate_sample_indices": [],
+        "dirty_count": 0,
+        "dirty_samples": [],
+    }
+    assert token_stats["sample_count"] == 2
+
+
 def test_resolve_dataset_build_source_reuses_existing_package_sample_lists(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1294,7 +1294,7 @@ def _build_quality_and_token_stats(
     samples: Iterable[dict[str, Any]],
     format_name: str,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    seen: set[bytes] = set()
+    seen: set[object] = set()
     duplicate_indices: list[int] = []
     dirty_samples: list[dict[str, Any]] = []
     duplicate_count = 0
@@ -1310,6 +1310,7 @@ def _build_quality_and_token_stats(
     duplicate_indices_append = duplicate_indices.append
     dirty_samples_append = dirty_samples.append
     canonical_sample_digest = _canonical_sample_digest
+    prompt_completion_duplicate_key = _prompt_completion_duplicate_key
     dirty_sample_reasons = (
         _prompt_completion_dirty_sample_reasons
         if is_prompt_completion
@@ -1320,13 +1321,16 @@ def _build_quality_and_token_stats(
     quality_report_sample_limit = _QUALITY_REPORT_SAMPLE_LIMIT
     for index, sample in enumerate(samples):
         sample_count += 1
-        sample_digest = canonical_sample_digest(sample)
-        if sample_digest in seen:
+        if is_prompt_completion:
+            sample_identity = prompt_completion_duplicate_key(sample)
+        else:
+            sample_identity = canonical_sample_digest(sample)
+        if sample_identity in seen:
             duplicate_count += 1
             if len(duplicate_indices) < quality_report_sample_limit:
                 duplicate_indices_append(index)
         else:
-            seen.add(sample_digest)
+            seen.add(sample_identity)
         reasons = dirty_sample_reasons(sample)
         if reasons:
             dirty_count += 1
@@ -1553,6 +1557,15 @@ def _sample_text_segments(sample: dict[str, Any]) -> list[str]:
 
 def _contains_problematic_control_characters(text: str) -> bool:
     return any(ord(character) < 32 and character not in _ALLOWED_CONTROL_CHARACTERS for character in text)
+
+
+def _prompt_completion_duplicate_key(sample: dict[str, Any]) -> tuple[str, str] | bytes:
+    if len(sample) == 2:
+        prompt = sample.get("prompt")
+        completion = sample.get("completion")
+        if isinstance(prompt, str) and isinstance(completion, str):
+            return prompt, completion
+    return _canonical_sample_digest(sample)
 
 
 def _canonical_sample_key(sample: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- optimize `prompt_completion` duplicate detection in `training_dataset.py` by reusing the native `(prompt, completion)` pair for normalized samples instead of hashing a JSON-canonicalized payload for every row
- preserve fallback semantics for non-normalized prompt/completion samples by keeping the generic digest path when extra fields or non-string values are present
- add focused tests plus a small slice plan documenting the Linux verification/probe contract

## Plan or Spec
- `docs/plans/2026-05-02-training-dataset-duplicate-key-fast-path.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_build_quality_and_token_stats_uses_prompt_completion_duplicate_key_fast_path services/mlx-worker-python/tests/test_training_dataset_builder.py::test_build_quality_and_token_stats_falls_back_to_generic_digest_for_non_normalized_prompt_completion_samples
2 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
73 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
TOTAL 32 1 97%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-token-percentiles-single-sort --base-repo /tmp/melix-origin-main-baseline-20260502-122456 --head-repo /tmp/melix-cron-opt-20260502-122456 --output /tmp/melix-training-dataset-probe-20260502-122456.json
probe ok; base vs head comparison emitted JSON report

git diff --check
ok
```

## Coverage and Metrics
- Changed-scope coverage: `97%` aggregate (`32` measurable changed lines, `31` covered, `1` missed)
- `services/mlx-worker-python/worker/model_ops/training_dataset.py` changed executable lines: `100%`
- Registered scoped probe: `training-dataset-token-percentiles-single-sort`
- Probe metrics on the synthetic 20,000-sample workload:
  - `elapsed_ms_mean`: `765.725` (base) → `328.937` (head), about `57.04%` lower
  - `peak_bytes_mean`: `2535956` (base) → `2362556` (head), about `6.84%` lower
  - `duplicate_count`: `784` → `784` (unchanged)
  - `dirty_count`: `393` → `393` (unchanged)
  - `sample_count`: `20000` → `20000` (unchanged)

## Known Gaps
- Linux-only local verification ran for the Python worker path; no macOS/Swift verification was run because this slice does not touch those surfaces.
- The registered `pr-scoped-performance` CI run remains the merge gate after PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
