### PR TITLE
perf(benchmark-store): stream CSV rows through writerows

### DIFF
--- a/docs/plans/2026-05-02-benchmark-store-write-coalescing.md
+++ b/docs/plans/2026-05-02-benchmark-store-write-coalescing.md
@@ -17,10 +17,10 @@ This slice is Python-only under `services/mlx-worker-python`, so it can be fully
 
 The current writer loop does extra per-row work:
 
-1. JSONL output performs two writes per row (`payload` then newline) instead of one coalesced write.
-2. The loop repeatedly resolves hot callables and rebuilds the CSV row mapping through repeated global/attribute lookups.
+1. JSONL output must stay coalesced to one write per row.
+2. The loop should avoid repeated hot callables and should hand CSV row emission to `csv.writerows()` instead of calling `writerow()` once per Python row.
 
-Coalescing the JSONL write and binding hot loop helpers locally should reduce Python overhead on large benchmark matrix persists without changing semantics.
+Coalescing the JSONL write, binding hot loop helpers locally, and using `csv.writerows()` over a streaming generator should reduce Python overhead on large benchmark matrix persists without changing semantics.
 
 ## Performance probe
 

--- a/services/mlx-worker-python/worker/productization/benchmark_store.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_store.py
@@ -105,9 +105,11 @@ class BenchmarkStore:
             write_jsonl = jsonl_handle.write
             dump_json = json.dumps
             normalize_csv_value = _csv_value
-            write_csv_row = csv_writer.writerow
-            for row in rows:
-                payload = row.to_dict()
-                write_jsonl(dump_json(payload) + "\n")
-                payload_get = payload.get
-                write_csv_row([normalize_csv_value(payload_get(field, "")) for field in fieldnames])
+            def csv_rows() -> Iterable[list[str]]:
+                for row in rows:
+                    payload = row.to_dict()
+                    write_jsonl(dump_json(payload) + "\n")
+                    payload_get = payload.get
+                    yield [normalize_csv_value(payload_get(field, "")) for field in fieldnames]
+
+            csv_writer.writerows(csv_rows())


### PR DESCRIPTION
## Summary
- Stream benchmark matrix CSV rows through `csv.writerows()` while preserving the existing one-pass JSONL write and single `to_dict()` call per row.
- Update the BenchmarkStore write-coalescing plan to document the `writerows()` slice.

## Plan or Spec
- `docs/plans/2026-05-02-benchmark-store-write-coalescing.md`

## Commands Run
```text
# baseline from detached origin/main worktree, repeated 3 times
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/benchmark_store_probe.py
-> elapsed_ms_mean samples: 1201.613810, 1226.758079, 1206.046903
-> peak_bytes_mean samples: 177712.0, 178113.7, 178133.3

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_benchmark_store.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_store_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_script_emits_metrics
-> 7 passed in 4.73s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
  services/mlx-worker-python/tests/test_benchmark_store.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_store_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_script_emits_metrics
-> 7 passed in 16.57s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
-> Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/productization/benchmark_store.py \
  services/mlx-worker-python/tests/test_benchmark_store.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/benchmark_store_probe.py
-> TOTAL 7 0 100%

# optimized branch, repeated 3 times for comparison
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/benchmark_store_probe.py
-> elapsed_ms_mean samples: 1209.238098, 1227.023027, 1180.566634
-> peak_bytes_mean samples: 178713.7, 178733.3, 178733.3

# final registered probe smoke after coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/benchmark_store_probe.py
-> {"elapsed_ms_mean": 1214.304396, "peak_bytes_mean": 178713.7, "request_csv_line_count": 6001.0, "request_row_count": 6000.0, "sample_count": 3.0, "summary_row_count": 750.0}

git diff --check
-> passed
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`7/7` measurable changed lines).
- Registered probe: `benchmark-store-matrix-streaming` in `infra/perf/pr_scoped_probes.json` covers `services/mlx-worker-python/worker/productization/benchmark_store.py` with focused test, coverage, and probe commands.
- Local Linux probe comparison across three repeated command runs:
  - `old_mean=1211.472931 ms`
  - `new_mean=1205.609253 ms`
  - `delta_ms=-5.863678 ms`
  - `speedup=1.004864x` (`-0.4840%` elapsed)
  - peak memory changed from `177986.33` to `178726.77` bytes (`+0.42%`, below the 5% warning threshold).
- CI is required for the registered PR-scoped performance report before merge.

## Known Gaps
- Local probe improvement is small and should be treated as directional; the PR-scoped CI probe is the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
