### PR TITLE
perf(download): bind directory-size direntry helpers

### DIFF
--- a/services/mlx-worker-python/worker/model_ops/download_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/download_pipeline.py
@@ -456,15 +456,18 @@ class DownloadPipeline:
         append_directory = stack.append
         pop_directory = stack.pop
         scandir = os.scandir
+        is_dir = os.DirEntry.is_dir
+        is_file = os.DirEntry.is_file
+        stat_entry = os.DirEntry.stat
         while stack:
             current = pop_directory()
             with scandir(current) as entries:
                 for entry in entries:
-                    if entry.is_dir(follow_symlinks=False):
+                    if is_dir(entry, follow_symlinks=False):
                         append_directory(entry.path)
                         continue
-                    if entry.is_file(follow_symlinks=False):
-                        total_bytes += entry.stat(follow_symlinks=False).st_size
+                    if is_file(entry, follow_symlinks=False):
+                        total_bytes += stat_entry(entry, follow_symlinks=False).st_size
         return total_bytes
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Bind `os.DirEntry` helper methods once per `_directory_size()` call so the hot scan loop performs less repeated attribute lookup.
- Preserve the existing explicit `os.scandir()` stack traversal and non-following symlink behavior.

## Plan or Spec
- `docs/plans/2026-05-01-download-directory-size-single-stat.md`

## Commands Run
```text
$ git fetch origin && git worktree add -b perf/python-download-dirsize-scandir-20260502141143 /root/.hermes/profiles/coder/workspace/worktrees/melix-perf/python-download-dirsize-scandir-20260502141143 origin/main
# exit 0; branch based on origin/main f751dfc

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_download_pipeline_unit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_download_pipeline_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 8 passed in 0.30s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_download_pipeline_unit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_download_pipeline_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 8 passed in 0.27s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/download_pipeline.py services/mlx-worker-python/tests/test_download_pipeline_unit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; TOTAL 6 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
# registered download-pipeline-directory-size-single-stat probe body from infra/perf/pr_scoped_probes.json
PY
# exit 0; {"directory_count": 180.0, "elapsed_ms_mean": 19.954159, "elapsed_ms_min": 18.95417, "files_per_directory": 40.0, "sample_count": 5.0, "total_bytes": 36000.0}

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
# local old-vs-new comparison over the registered synthetic tree shape, 9 samples per implementation
PY
# exit 0; old_mean_ms=21.494652, new_mean_ms=18.669453, delta_ms=-2.825199, speedup_pct=13.144, totals unchanged at 36000 bytes

$ git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`6/6` measurable changed lines) for `download_pipeline.py` plus focused unit/PR-scoped tests.
- Registered local probe (`download-pipeline-directory-size-single-stat`): `elapsed_ms_mean=19.954159`, `elapsed_ms_min=18.95417`, `total_bytes=36000`.
- Local old-vs-new comparison on the same synthetic tree: `old_mean=21.494652 ms`, `new_mean=18.669453 ms`, `delta=-2.825199 ms`, `speedup=13.144%`; byte totals unchanged.
- CI PR-scoped performance report is required before merge for the registered probe comparison against base.

## Known Gaps
- Full repository `make py-test` was not run; this is scoped to the registered download directory-size probe and focused tests.
- Swift runtime effects are not applicable to this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
