### PR TITLE
perf(ci): optimize pr-scoped scope matcher

### DIFF
--- a/docs/plans/2026-05-02-pr-scoped-performance-scope-matcher-optimization.md
+++ b/docs/plans/2026-05-02-pr-scoped-performance-scope-matcher-optimization.md
@@ -1,0 +1,51 @@
+# PR-Scoped Performance Scope Matcher Optimization Plan
+
+## Goal
+Reduce redundant glob-matching work in Melix's PR-scoped performance harness when `build_scope_report(...)` selects probes for a changed file set.
+
+## Why this slice
+The current implementation repeatedly runs glob matching for every changed path against every probe watch glob and the force-all globs. On large diffs this repeats equivalent matcher setup work and is a safe Linux-verifiable Python-only optimization target.
+
+## Linux-only constraint
+This cron run executes on Linux and cannot validate the macOS/Swift app directly. The optimization must therefore stay inside the Python PR-scoped performance harness and use local focused pytest, changed-scope coverage, and an explicit local base-vs-head probe.
+
+## Planned touched files
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Proposed implementation
+1. Introduce a small internal fast path for scope selection that avoids repeating equivalent glob translation/matching work across every path × glob comparison.
+2. Preserve existing scope-selection semantics exactly, including:
+   - force-all behavior
+   - watch glob matching behavior
+   - selected probe IDs and ordering
+3. Add focused regression tests for the optimized matcher path and the dedicated probe selection.
+4. Register/update a dedicated PR-scoped performance probe for the harness so CI measures the optimized scope-selection path directly.
+
+## Performance probe
+- Probe target: `build_scope_report(...)` on a synthetic large changed-file set and current probe registry.
+- Primary metrics:
+  - `build_scope_report_ms_mean` lower is better
+  - `selected_probe_count_mean` unchanged from baseline
+  - `force_all_selected_mean` unchanged from baseline
+- Probe strategy:
+  - load the current registry from `infra/perf/pr_scoped_probes.json`
+  - synthesize a representative large changed-file list with both matching and non-matching paths
+  - compare `origin/main` vs head through the PR-scoped performance harness
+
+## Success metrics
+- Focused tests pass.
+- Changed-scope automated coverage is at least 95% for touched executable scope.
+- Local explicit probe shows lower `build_scope_report_ms_mean` with unchanged selection semantics.
+- `git diff --check` passes.
+
+## Verification commands
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::<focused nodes>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::<focused nodes>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "... dedicated scope probe ..."
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -461,6 +461,42 @@
     ]
   },
   {
+    "id": "pr-scoped-performance-scope-matcher",
+    "name": "PR-scoped performance scope matcher",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/pr_scoped_performance.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c \"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_pr_scoped_scope_matcher as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))\"",
+    "probe_impl": "pr_scoped_scope_matcher",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "build_scope_report_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "selected_probe_count_mean",
+        "unit": "probes",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "force_all_selected_mean",
+        "unit": "bool",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "pr-scoped-performance-report-results-scandir",
     "name": "PR-scoped performance report results scandir",
     "runner": "ubuntu-latest",

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -11,6 +11,7 @@ import worker.productization.pr_scoped_performance as pr_scoped_performance_modu
 
 from worker.productization.pr_scoped_performance import (
     _build_large_benchmark_bundle,
+    _build_large_scope_probe_changed_files,
     _build_large_training_dataset_quality_samples,
     _build_large_training_dataset_samples,
     _build_metric_row,
@@ -18,6 +19,7 @@ from worker.productization.pr_scoped_performance import (
     _build_probe_report_row,
     _build_probe_details,
     _closure_index_text,
+    _compiled_glob_pattern,
     _dict_list,
     _dispatch_probe_impl,
     _float_or_none,
@@ -28,6 +30,7 @@ from worker.productization.pr_scoped_performance import (
     _load_repo_module,
     _markdown_cell,
     _matches_any_glob,
+    _match_probe_indexes,
     _parse_coverage_percent,
     _probe_benchmark_evaluation_report,
     _probe_benchmark_export_run_scan,
@@ -37,6 +40,7 @@ from worker.productization.pr_scoped_performance import (
     _probe_evaluation_sample_probe_aggregation,
     _probe_evaluation_store_compare_summary_csv_streaming,
     _probe_evaluation_store_samples_csv_streaming,
+    _probe_pr_scoped_scope_matcher,
     _probe_training_dataset_token_percentiles,
     _probe_command_json,
     _run_command,
@@ -227,6 +231,88 @@ def test_scope_report_force_selects_all_on_infra_change() -> None:
 
     assert scope["force_all"] is True
     assert scope["selected_count"] == len(load_probe_registry(REGISTRY_PATH))
+    probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert "pr-scoped-performance-scope-matcher" in probe_ids
+
+
+def test_scope_report_large_changed_set_preserves_exact_selection_semantics() -> None:
+    changed_files = _build_large_scope_probe_changed_files() + [
+        "services/mlx-worker-python/worker/engine/evaluation_core.py",
+        "",
+        "README.md",
+    ]
+
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=changed_files,
+    )
+
+    assert scope["force_all"] is False
+    assert scope["changed_files"] == sorted({path for path in changed_files if path})
+    assert [probe["id"] for probe in scope["selected_probes"]] == [
+        "benchmark-export-run-scan-single-pass",
+        "evaluation-job-id-high-water-mark",
+        "evaluation-sample-probe-aggregation",
+        "download-pipeline-directory-size-single-stat",
+    ]
+    assert scope["selected_count"] == 4
+
+
+def test_match_probe_indexes_deduplicates_repeated_watch_globs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    probes = (
+        ProbeDefinition(
+            probe_id="alpha",
+            name="Alpha",
+            runner="ubuntu-latest",
+            watch_globs=("services/a.py", "shared.py"),
+            test_command="true",
+            coverage_command="true",
+            probe_impl="benchmark_evaluation_report",
+            probe_command="",
+            metrics=(MetricDefinition(key="elapsed_ms_mean", unit="ms", direction="lower_is_better"),),
+        ),
+        ProbeDefinition(
+            probe_id="beta",
+            name="Beta",
+            runner="ubuntu-latest",
+            watch_globs=("shared.py", "services/b.py"),
+            test_command="true",
+            coverage_command="true",
+            probe_impl="benchmark_evaluation_report",
+            probe_command="",
+            metrics=(MetricDefinition(key="elapsed_ms_mean", unit="ms", direction="lower_is_better"),),
+        ),
+        ProbeDefinition(
+            probe_id="gamma",
+            name="Gamma",
+            runner="ubuntu-latest",
+            watch_globs=("shared.py",),
+            test_command="true",
+            coverage_command="true",
+            probe_impl="benchmark_evaluation_report",
+            probe_command="",
+            metrics=(MetricDefinition(key="elapsed_ms_mean", unit="ms", direction="lower_is_better"),),
+        ),
+    )
+    calls: list[tuple[str, str]] = []
+
+    def fake_glob_matches_path(path: str, glob: str) -> bool:
+        calls.append((path, glob))
+        return path == glob
+
+    monkeypatch.setattr(pr_scoped_performance_module, "_glob_matches_path", fake_glob_matches_path)
+
+    matched = _match_probe_indexes(changed_paths=("shared.py", "unmatched.py"), probes=probes)
+
+    assert matched == {0, 1, 2}
+    assert len(calls) == 6
+    assert calls.count(("shared.py", "shared.py")) == 1
+
+
+def test_compiled_glob_pattern_reuses_cached_regex() -> None:
+    assert _compiled_glob_pattern("services/*.py") is _compiled_glob_pattern("services/*.py")
 
 
 def test_registered_probes_expose_focused_commands() -> None:
@@ -242,6 +328,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "evaluation-store-samples-csv-streaming",
         "job-registry-derived-model-single-pass",
         "package-macos-resolve-fallback-scandir",
+        "pr-scoped-performance-scope-matcher",
         "training-dataset-token-percentiles-single-sort",
         "maintenance-bench-report-readback",
         "swift-cli-json-envelope-encoding",
@@ -376,6 +463,7 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     evaluation_sample_probe_metrics = _probe_evaluation_sample_probe_aggregation(REPO_ROOT)
     evaluation_store_compare_summary_metrics = _probe_evaluation_store_compare_summary_csv_streaming(REPO_ROOT)
     evaluation_store_metrics = _probe_evaluation_store_samples_csv_streaming(REPO_ROOT)
+    scope_matcher_metrics = _probe_pr_scoped_scope_matcher(REPO_ROOT)
     training_dataset_metrics = _probe_training_dataset_token_percentiles(REPO_ROOT)
 
     assert benchmark_metrics["elapsed_ms_mean"] > 0
@@ -411,6 +499,10 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     assert evaluation_store_metrics["peak_bytes_mean"] > 0
     assert evaluation_store_metrics["sample_count"] == 10000.0
     assert evaluation_store_metrics["csv_line_count"] == 10001.0
+    assert scope_matcher_metrics["build_scope_report_ms_mean"] > 0
+    assert scope_matcher_metrics["changed_file_count"] == float(len(_build_large_scope_probe_changed_files()))
+    assert scope_matcher_metrics["selected_probe_count_mean"] == 4.0
+    assert scope_matcher_metrics["force_all_selected_mean"] == 0.0
     assert training_dataset_metrics["elapsed_ms_mean"] > 0
     assert training_dataset_metrics["peak_bytes_mean"] > 0
     assert training_dataset_metrics["sample_count"] == 20000.0
@@ -605,6 +697,27 @@ def test_dispatch_probe_impl_supports_upload_receipt_published_files_probe() -> 
     assert metrics["files_per_directory"] == 40.0
     assert metrics["published_file_count"] == 7201.0
     assert metrics["sample_count"] == 5.0
+
+
+def test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe() -> None:
+    probe = ProbeDefinition(
+        probe_id="pr-scoped-performance-scope-matcher",
+        name="PR-scoped performance scope matcher",
+        runner="ubuntu-latest",
+        watch_globs=("services/mlx-worker-python/worker/productization/pr_scoped_performance.py",),
+        test_command="true",
+        coverage_command="true",
+        probe_impl="pr_scoped_scope_matcher",
+        probe_command='python3 -c "{}"',
+        metrics=(MetricDefinition(key="build_scope_report_ms_mean", unit="ms", direction="lower_is_better"),),
+    )
+
+    metrics = _dispatch_probe_impl(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["build_scope_report_ms_mean"] > 0
+    assert metrics["changed_file_count"] == float(len(_build_large_scope_probe_changed_files()))
+    assert metrics["selected_probe_count_mean"] == 4.0
+    assert metrics["force_all_selected_mean"] == 0.0
 
 
 def test_upload_receipt_probe_loader_stubs_external_imports(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 import fnmatch
 import gc
 import importlib.util
@@ -122,11 +123,8 @@ def build_scope_report(
     if force_all:
         selected = probes
     else:
-        selected = tuple(
-            probe
-            for probe in probes
-            if any(_matches_any_glob(path, probe.watch_globs) for path in changed_paths)
-        )
+        matched_probe_indexes = _match_probe_indexes(changed_paths=changed_paths, probes=probes)
+        selected = tuple(probe for index, probe in enumerate(probes) if index in matched_probe_indexes)
     return {
         "schema_version": _SCOPE_SCHEMA_VERSION,
         "changed_files": list(changed_paths),
@@ -385,6 +383,8 @@ def _dispatch_probe_impl(*, probe: ProbeDefinition, repo_root: Path) -> dict[str
         return _probe_training_dataset_token_percentiles(repo_root)
     if probe.probe_impl == "upload_receipt_published_files":
         return _probe_upload_receipt_published_files(repo_root)
+    if probe.probe_impl == "pr_scoped_scope_matcher":
+        return _probe_pr_scoped_scope_matcher(repo_root)
     if probe.probe_impl == "command_json":
         return _probe_command_json(probe=probe, repo_root=repo_root)
     raise ValueError(f"unsupported probe implementation: {probe.probe_impl}")
@@ -1104,6 +1104,47 @@ def _probe_upload_receipt_published_files(repo_root: Path) -> dict[str, float]:
     }
 
 
+def _probe_pr_scoped_scope_matcher(repo_root: Path) -> dict[str, float]:
+    registry_path = repo_root / "infra/perf/pr_scoped_probes.json"
+    changed_files = _build_large_scope_probe_changed_files()
+    sample_count = 6
+    elapsed_samples: list[float] = []
+    selected_probe_counts: list[float] = []
+    force_all_selected_samples: list[float] = []
+    for _ in range(sample_count):
+        started = time.perf_counter()
+        scope = build_scope_report(registry_path=registry_path, changed_files=changed_files)
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        selected_probe_counts.append(float(scope["selected_count"]))
+        force_all_selected_samples.append(1.0 if scope["force_all"] else 0.0)
+    return {
+        "build_scope_report_ms_mean": round(sum(elapsed_samples) / len(elapsed_samples), 6),
+        "build_scope_report_ms_min": round(min(elapsed_samples), 6),
+        "changed_file_count": float(len(changed_files)),
+        "selected_probe_count_mean": round(sum(selected_probe_counts) / len(selected_probe_counts), 6),
+        "force_all_selected_mean": round(sum(force_all_selected_samples) / len(force_all_selected_samples), 6),
+        "sample_count": float(sample_count),
+    }
+
+
+def _build_large_scope_probe_changed_files() -> list[str]:
+    changed_files: list[str] = []
+    for index in range(1600):
+        changed_files.append(f"docs/perf/synthetic/doc-{index:04d}.md")
+    for index in range(1600):
+        changed_files.append(f"services/mlx-worker-python/tests/synthetic/test_scope_{index:04d}.py")
+    changed_files.extend(
+        [
+            "services/mlx-worker-python/worker/productization/benchmark_export.py",
+            "services/mlx-worker-python/worker/engine/evaluation_core.py",
+            "services/mlx-worker-python/worker/model_ops/download_pipeline.py",
+            "README.md",
+            "",
+        ]
+    )
+    return changed_files
+
+
 def _load_upload_receipt_pipeline_module(path: Path) -> Any:
     module_names = (
         "packages",
@@ -1652,8 +1693,30 @@ def _float_or_none(value: object) -> float | None:
     return None
 
 
+def _match_probe_indexes(*, changed_paths: tuple[str, ...], probes: tuple[ProbeDefinition, ...]) -> set[int]:
+    glob_to_probe_indexes: dict[str, list[int]] = {}
+    for probe_index, probe in enumerate(probes):
+        for glob in probe.watch_globs:
+            glob_to_probe_indexes.setdefault(glob, []).append(probe_index)
+    matched_probe_indexes: set[int] = set()
+    for path in changed_paths:
+        for glob, probe_indexes in glob_to_probe_indexes.items():
+            if _glob_matches_path(path, glob):
+                matched_probe_indexes.update(probe_indexes)
+    return matched_probe_indexes
+
+
+@lru_cache(maxsize=None)
+def _compiled_glob_pattern(glob: str) -> re.Pattern[str]:
+    return re.compile(fnmatch.translate(glob))
+
+
+def _glob_matches_path(path: str, glob: str) -> bool:
+    return _compiled_glob_pattern(glob).match(path) is not None
+
+
 def _matches_any_glob(path: str, globs: tuple[str, ...]) -> bool:
-    return any(fnmatch.fnmatch(path, glob) for glob in globs)
+    return any(_glob_matches_path(path, glob) for glob in globs)
 
 
 def _is_relative_to(path: Path, root: Path) -> bool:


### PR DESCRIPTION
## Summary
- Optimize `build_scope_report(...)` in the PR-scoped performance harness by deduplicating watch-glob matching work and caching compiled glob regexes.
- Add a dedicated `pr-scoped-performance-scope-matcher` probe so PR-scoped CI measures this harness path directly.
- Add focused regression coverage for large changed-file sets, repeated watch globs, compiled-glob cache reuse, and probe dispatch/smoke behavior.

## Plan or Spec
- `docs/plans/2026-05-02-pr-scoped-performance-scope-matcher-optimization.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo
# 7 passed in 10.55s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo
# 7 passed in 34.97s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/productization/pr_scoped_performance.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 78 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_pr_scoped_scope_matcher as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
# build_scope_report_ms_mean=39.696918, build_scope_report_ms_min=35.633993, changed_file_count=3205, selected_probe_count_mean=4.0, force_all_selected_mean=0.0

python3 <local base-vs-head comparison script using detached origin/main worktree>
# base_build_scope_report_ms_mean=167.101663, head_build_scope_report_ms_mean=36.435927, speedup_pct=78.195, selection_ids_match=true

git diff --check
# clean
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 78 0 100%`
- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py` changed-line coverage: `100.00%`
- `services/mlx-worker-python/tests/test_pr_scoped_performance.py` changed-line coverage: `100.00%`
- Dedicated local probe (`pr-scoped-performance-scope-matcher`):
  - `build_scope_report_ms_mean`: `39.696918 ms`
  - `build_scope_report_ms_min`: `35.633993 ms`
  - `changed_file_count`: `3205`
  - `selected_probe_count_mean`: `4.0`
  - `force_all_selected_mean`: `0.0`
- Explicit local `origin/main` vs head comparison on the same synthetic workload:
  - `base_build_scope_report_ms_mean`: `167.101663 ms`
  - `head_build_scope_report_ms_mean`: `36.435927 ms`
  - `delta_ms_mean`: `-130.665737 ms`
  - `speedup_pct`: `78.195%`
  - `selection_ids_match`: `true`
  - `base_selected_count/head_selected_count`: `4 / 4`
  - `base_force_all/head_force_all`: `false / false`

## Known Gaps
- Full-repo verification (`make py-test`, `make integration-test`, Swift/macOS checks) was not run for this Linux-scoped optimization slice.
- Because this PR touches `infra/perf/pr_scoped_probes.json` and the PR-scoped harness, the repository's `pr-scoped-performance` workflow is expected to force the full scoped-probe matrix, including non-Linux-only probes. Local verification here only covers the targeted Python slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
