### PR TITLE
perf(ci): cache PR scope matcher indexes

### DIFF
--- a/docs/plans/2026-05-02-pr-scoped-performance-scope-matcher-optimization.md
+++ b/docs/plans/2026-05-02-pr-scoped-performance-scope-matcher-optimization.md
@@ -23,6 +23,11 @@ This cron run executes on Linux and cannot validate the macOS/Swift app directly
 3. Add focused regression tests for the optimized matcher path and the dedicated probe selection.
 4. Register/update a dedicated PR-scoped performance probe for the harness so CI measures the optimized scope-selection path directly.
 
+## Implemented slice
+- Split force-all and watch-glob matching into exact-path and wildcard paths so exact changed files avoid regex glob checks.
+- Cache the derived watch-glob index and the scope-report registry load by path, mtime, and size for repeated scope computations in the same process.
+- Keep the public `load_probe_registry(...)` parser uncached so direct validation callers still observe file contents immediately.
+
 ## Performance probe
 - Probe target: `build_scope_report(...)` on a synthetic large changed-file set and current probe registry.
 - Primary metrics:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -277,7 +277,7 @@ def test_match_probe_indexes_deduplicates_repeated_watch_globs(
             probe_id="beta",
             name="Beta",
             runner="ubuntu-latest",
-            watch_globs=("shared.py", "services/b.py"),
+            watch_globs=("shared.py", "services/*.py"),
             test_command="true",
             coverage_command="true",
             probe_impl="benchmark_evaluation_report",
@@ -300,15 +300,18 @@ def test_match_probe_indexes_deduplicates_repeated_watch_globs(
 
     def fake_glob_matches_path(path: str, glob: str) -> bool:
         calls.append((path, glob))
-        return path == glob
+        return path == "services/b.py" and glob == "services/*.py"
 
     monkeypatch.setattr(pr_scoped_performance_module, "_glob_matches_path", fake_glob_matches_path)
 
-    matched = _match_probe_indexes(changed_paths=("shared.py", "unmatched.py"), probes=probes)
+    matched = _match_probe_indexes(changed_paths=("shared.py", "services/b.py", "unmatched.py"), probes=probes)
 
     assert matched == {0, 1, 2}
-    assert len(calls) == 6
-    assert calls.count(("shared.py", "shared.py")) == 1
+    assert calls == [
+        ("shared.py", "services/*.py"),
+        ("services/b.py", "services/*.py"),
+        ("unmatched.py", "services/*.py"),
+    ]
 
 
 def test_compiled_glob_pattern_reuses_cached_regex() -> None:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -16,6 +16,11 @@ import tracemalloc
 import types
 from typing import Any
 
+
+def _glob_has_magic(glob: str) -> bool:
+    return any(character in glob for character in "*?[")
+
+
 _COMMENT_MARKER = "<!-- melix-pr-scoped-performance-report -->"
 _SCOPE_SCHEMA_VERSION = "melix.pr_scoped_performance_scope.v1"
 _PROBE_RESULT_SCHEMA_VERSION = "melix.pr_scoped_performance_probe_result.v1"
@@ -27,6 +32,8 @@ _FORCE_ALL_GLOBS = (
     "services/mlx-worker-python/worker/productization/pr_scoped_performance.py",
     "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
 )
+_FORCE_ALL_EXACT_PATHS = frozenset(glob for glob in _FORCE_ALL_GLOBS if not _glob_has_magic(glob))
+_FORCE_ALL_WILDCARD_GLOBS = tuple(glob for glob in _FORCE_ALL_GLOBS if _glob_has_magic(glob))
 _COVERAGE_PERCENT_RE = re.compile(r"TOTAL\s+\d+\s+\d+\s+(\d+)%")
 _TEXT_FILE_SUFFIXES = {".md", ".py", ".json", ".txt", ".yaml", ".yml"}
 
@@ -112,14 +119,33 @@ def load_probe_registry(path: str | Path) -> tuple[ProbeDefinition, ...]:
     return tuple(probes)
 
 
+def load_probe_registry_for_scope(path: str | Path) -> tuple[ProbeDefinition, ...]:
+    registry_path = Path(path).resolve()
+    stat_result = registry_path.stat()
+    return _load_probe_registry_for_scope_cached(
+        registry_path.as_posix(),
+        stat_result.st_mtime_ns,
+        stat_result.st_size,
+    )
+
+
+@lru_cache(maxsize=None)
+def _load_probe_registry_for_scope_cached(
+    registry_path: str,
+    _mtime_ns: int,
+    _size: int,
+) -> tuple[ProbeDefinition, ...]:
+    return load_probe_registry(registry_path)
+
+
 def build_scope_report(
     *,
     registry_path: str | Path,
     changed_files: list[str],
 ) -> dict[str, object]:
-    probes = load_probe_registry(registry_path)
+    probes = load_probe_registry_for_scope(registry_path)
     changed_paths = tuple(sorted({path for path in changed_files if path}))
-    force_all = any(_matches_any_glob(path, _FORCE_ALL_GLOBS) for path in changed_paths)
+    force_all = any(_path_matches_force_all(path) for path in changed_paths)
     if force_all:
         selected = probes
     else:
@@ -1694,16 +1720,32 @@ def _float_or_none(value: object) -> float | None:
 
 
 def _match_probe_indexes(*, changed_paths: tuple[str, ...], probes: tuple[ProbeDefinition, ...]) -> set[int]:
-    glob_to_probe_indexes: dict[str, list[int]] = {}
-    for probe_index, probe in enumerate(probes):
-        for glob in probe.watch_globs:
-            glob_to_probe_indexes.setdefault(glob, []).append(probe_index)
+    exact_path_to_probe_indexes, wildcard_glob_to_probe_indexes = _probe_match_indexes(probes)
     matched_probe_indexes: set[int] = set()
     for path in changed_paths:
-        for glob, probe_indexes in glob_to_probe_indexes.items():
+        matched_probe_indexes.update(exact_path_to_probe_indexes.get(path, ()))
+        for glob, probe_indexes in wildcard_glob_to_probe_indexes.items():
             if _glob_matches_path(path, glob):
                 matched_probe_indexes.update(probe_indexes)
     return matched_probe_indexes
+
+
+@lru_cache(maxsize=None)
+def _probe_match_indexes(
+    probes: tuple[ProbeDefinition, ...],
+) -> tuple[dict[str, tuple[int, ...]], dict[str, tuple[int, ...]]]:
+    exact_path_to_probe_indexes: dict[str, list[int]] = {}
+    wildcard_glob_to_probe_indexes: dict[str, list[int]] = {}
+    for probe_index, probe in enumerate(probes):
+        for glob in probe.watch_globs:
+            if _glob_has_magic(glob):
+                wildcard_glob_to_probe_indexes.setdefault(glob, []).append(probe_index)
+            else:
+                exact_path_to_probe_indexes.setdefault(glob, []).append(probe_index)
+    return (
+        {path: tuple(probe_indexes) for path, probe_indexes in exact_path_to_probe_indexes.items()},
+        {glob: tuple(probe_indexes) for glob, probe_indexes in wildcard_glob_to_probe_indexes.items()},
+    )
 
 
 @lru_cache(maxsize=None)
@@ -1713,6 +1755,10 @@ def _compiled_glob_pattern(glob: str) -> re.Pattern[str]:
 
 def _glob_matches_path(path: str, glob: str) -> bool:
     return _compiled_glob_pattern(glob).match(path) is not None
+
+
+def _path_matches_force_all(path: str) -> bool:
+    return path in _FORCE_ALL_EXACT_PATHS or _matches_any_glob(path, _FORCE_ALL_WILDCARD_GLOBS)
 
 
 def _matches_any_glob(path: str, globs: tuple[str, ...]) -> bool:


### PR DESCRIPTION
## Summary
- Optimizes the PR-scoped performance scope matcher by splitting exact-path checks from wildcard glob checks.
- Adds cached scope-registry loading keyed by path, mtime, and size, plus cached watch-glob indexes for repeated scope computations in one process.
- Updates the scope-matcher plan and focused matcher test coverage.

## Plan or Spec
- `docs/plans/2026-05-02-pr-scoped-performance-scope-matcher-optimization.md`

## Commands Run
```text
# Baseline/current probe before edits (base=head current branch at origin/main)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id pr-scoped-performance-scope-matcher --base-repo . --head-repo . --output /tmp/pr-scope-before.json
exit 0; base_mean=46.362225 ms, head_mean=40.256815 ms, selected_probe_count_mean=4.0, force_all_selected_mean=0.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo
exit 0; 7 passed in 10.06s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
exit 0; 7 passed in 32.61s; TOTAL 31 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id pr-scoped-performance-scope-matcher --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-pr-scope-matcher-20260502153242 --head-repo . --output /tmp/pr-scope-after3.json
exit 0; base_mean=3.856042 ms, head_mean=3.474491 ms, selected_probe_count_mean=4.0, force_all_selected_mean=0.0

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 31 0 100%`.
- Registered local probe: `pr-scoped-performance-scope-matcher`.
- Local base-vs-head metrics: `build_scope_report_ms_mean` 3.856042 ms -> 3.474491 ms (`-0.381551 ms`, about `9.90%` faster).
- Semantics preserved: `selected_probe_count_mean=4.0`; `force_all_selected_mean=0.0`.
- CI PR-scoped performance report is required for final registered-probe validation before merge.

## Known Gaps
- Linux-only Python harness slice; no Swift/macOS runtime behavior changed.
- Local probe timing is synthetic and CI remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
