### PR TITLE
perf: lazily collect runtime metadata sets

### DIFF
--- a/docs/plans/2026-05-02-benchmark-evaluation-runtime-metadata-sparse-cache.md
+++ b/docs/plans/2026-05-02-benchmark-evaluation-runtime-metadata-sparse-cache.md
@@ -1,0 +1,25 @@
+# Benchmark Evaluation Runtime Metadata Sparse Cache
+
+## Scope
+
+This performance slice targets `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py` only. The report builder collects runtime metadata for benchmark and evaluation job groups while building PR benchmark/evaluation comparison reports.
+
+## Probe Coverage
+
+The affected path is covered by the registered PR-scoped performance probe `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes:
+
+- `test_command` for `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`
+- `coverage_command` for changed-scope coverage on the report builder and tests
+- `probe_command` for `_probe_benchmark_evaluation_report`
+
+## Change
+
+Runtime metadata collection now creates per-key value sets lazily instead of preallocating empty sets for every registered runtime parameter key on each collection call. Output ordering still follows `_RUNTIME_PARAMETER_KEYS`, and value ordering remains sorted within each key.
+
+## Success Criteria
+
+- Focused benchmark evaluation report tests pass.
+- Changed-scope coverage stays at or above 95%.
+- Registered probe reports non-regressing `elapsed_ms_mean` and `peak_bytes_mean` versus `origin/main`.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -13,6 +13,7 @@ from worker.productization.benchmark_evaluation_report import (
     _build_metric_row,
     _collect_benchmark_probe_metrics,
     _collect_evaluation_sample_probe_metrics,
+    _collect_runtime_metadata,
     _dict_rows,
     _finalize_numeric_aggregate,
     _label_part,
@@ -190,6 +191,37 @@ def test_report_builder_treats_cache_hit_rate_as_higher_is_better() -> None:
 
     assert row["direction"] == "higher_is_better"
     assert row["status"] == "warning"
+
+
+def test_collect_runtime_metadata_preserves_key_order_with_sparse_values() -> None:
+    metrics: dict[str, object] = {}
+
+    _collect_runtime_metadata(
+        metrics,
+        [
+            {
+                "parameters": {
+                    "runtime_model_id": "target/head",
+                    "runtime_kind": "swift-text",
+                }
+            },
+            {
+                "parameters": {
+                    "runtime_kind": "python-worker",
+                    "runtime_model_id": "target/base",
+                    "unused_runtime_value": "ignored",
+                }
+            },
+            {"parameters": {"runtime_model_id": ""}},
+            {"parameters": "invalid"},
+        ],
+        prefix="bench.runtime",
+    )
+
+    assert metrics == {
+        "bench.runtime.runtime_kind": "python-worker,swift-text",
+        "bench.runtime.runtime_model_id": "target/base,target/head",
+    }
 
 
 def test_report_builder_includes_runtime_metadata_and_decode_probes() -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -431,7 +431,7 @@ def _collect_runtime_metadata(
     *,
     prefix: str,
 ) -> None:
-    values_by_key: dict[str, set[str]] = {key: set() for key in _RUNTIME_PARAMETER_KEYS}
+    values_by_key: dict[str, set[str]] = {}
     for job in _dict_rows(jobs):
         parameters = job.get("parameters", {})
         if not isinstance(parameters, dict):
@@ -439,8 +439,9 @@ def _collect_runtime_metadata(
         for key in _RUNTIME_PARAMETER_KEYS:
             value = str(parameters.get(key, "")).strip()
             if value:
-                values_by_key[key].add(value)
-    for key, values in values_by_key.items():
+                values_by_key.setdefault(key, set()).add(value)
+    for key in _RUNTIME_PARAMETER_KEYS:
+        values = values_by_key.get(key)
         if values:
             metrics[f"{prefix}.{key}"] = ",".join(sorted(values))
 


### PR DESCRIPTION
## Summary
- Lazily allocate runtime metadata value sets while building benchmark/evaluation reports.
- Preserve registered runtime-key output ordering and sorted metadata values.
- Add focused regression coverage for sparse runtime metadata rows.

## Plan or Spec
- docs/plans/2026-05-02-benchmark-evaluation-runtime-metadata-sparse-cache.md
- Registered probe: `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline sync/worktree
 git fetch origin
 git worktree add -b perf/python-next-slice-20260502160107 /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-next-20260502160107 origin/main

# Focused test
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
-> exit 0; 36 passed in 0.15s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
-> exit 0; TOTAL 99% coverage

# Registered local probe comparing origin/main base worktree to this head
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-evaluation-report-running-aggregates --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-benchmark-eval-runtime-metadata-20260502160107 --head-repo "$PWD" --output /tmp/benchmark_eval_probe_head.json
-> exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 99% total (`benchmark_evaluation_report.py` 99%, `test_benchmark_evaluation_report.py` 99%).
- Local registered probe (`benchmark-evaluation-report-running-aggregates`):
  - `elapsed_ms_mean`: base `152.596` ms, head `148.33` ms, delta `-4.266` ms (`~2.80%` faster; lower is better).
  - `peak_bytes_mean`: base `3,904,837.7`, head `3,904,837.7`, delta `0`.
  - `row_count`: base/head `5990`.
- GitHub Actions PR-scoped performance workflow must validate the registered probe in CI before merge.

## Known Gaps
- Full repository test suite was not run locally; this slice is limited to the registered focused test, changed-scope coverage, and registered probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
