### PR TITLE
perf: scan mlx metal dist-info once

### DIFF
--- a/docs/plans/2026-05-02-dev-up-mlx-metal-dist-info-scandir.md
+++ b/docs/plans/2026-05-02-dev-up-mlx-metal-dist-info-scandir.md
@@ -1,0 +1,49 @@
+# Dev-up MLX Metal Dist-info Scandir Slice
+
+## Goal
+
+Reduce filesystem overhead in `scripts/dev_up.py` when resolving the installed `mlx_metal` wheel version for a discovered `mlx.metallib` candidate.
+
+## Scope
+
+- `scripts/dev_up.py`
+- `services/mlx-worker-python/tests/test_dev_up_script.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux Constraint
+
+This slice is Python-only and is locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered PR-scoped probe. It does not validate Swift runtime effects locally.
+
+## Optimization Hypothesis
+
+`read_mlx_metal_dist_info_version()` currently calls `Path.glob()` twice for every ancestor of a discovered `mlx.metallib`: once for `mlx_metal-*.dist-info/METADATA` and once for `mlx_metal-*.dist-info`. Replacing those glob calls with one `os.scandir()` pass per ancestor preserves the metadata-first behavior while avoiding pathlib glob allocation and duplicate directory scans.
+
+## Registered Probe
+
+- Probe ID: `dev-up-mlx-metal-dist-info-scandir`
+- Workload: create a synthetic site-packages ancestor containing 2,000 non-matching dist-info directories, one matching `mlx_metal` dist-info directory with `METADATA`, and then resolve the version seven times.
+- Metrics:
+  - `elapsed_ms_mean` lower is better
+  - `elapsed_ms_min` lower is better
+  - `dist_info_count` and `sample_count` informational
+
+## Success Metrics
+
+- Focused tests prove the version resolver no longer relies on `Path.glob()` and still prefers the `METADATA` version over the directory-name fallback.
+- Changed-scope coverage for the touched script, tests, and registry remains at or above 95%.
+- Local registered probe improves versus the pre-change baseline.
+- PR-scoped performance CI selects and completes the registered probe for this path.
+
+## Verification Commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_falls_back_to_dist_info_directory_name services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_skips_scandir_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dev_up_mlx_metal_dist_info_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_falls_back_to_dist_info_directory_name services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_skips_scandir_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dev_up_mlx_metal_dist_info_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/dev_up.py services/mlx-worker-python/tests/test_dev_up_script.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
+# Registered probe command from infra/perf/pr_scoped_probes.json.
+PY
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -558,6 +558,36 @@
     ]
   },
   {
+    "id": "dev-up-mlx-metal-dist-info-scandir",
+    "name": "Dev-up MLX Metal dist-info scandir",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "scripts/dev_up.py",
+      "services/mlx-worker-python/tests/test_dev_up_script.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_falls_back_to_dist_info_directory_name services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_skips_scandir_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dev_up_mlx_metal_dist_info_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_falls_back_to_dist_info_directory_name services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_skips_scandir_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dev_up_mlx_metal_dist_info_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/dev_up.py services/mlx-worker-python/tests/test_dev_up_script.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 - <<'PY'\nimport importlib.util\nimport json\nimport statistics\nimport tempfile\nimport time\nfrom pathlib import Path\nrepo_root = Path.cwd()\nmodule_path = repo_root / \"scripts\" / \"dev_up.py\"\nspec = importlib.util.spec_from_file_location(\"melix_dev_up_probe\", module_path)\nif spec is None or spec.loader is None:\n    raise RuntimeError(f\"Unable to load {module_path}\")\nmodule = importlib.util.module_from_spec(spec)\nimport sys\nsys.modules[spec.name] = module\nspec.loader.exec_module(module)\ndist_info_count = 2000\nsample_count = 7\nelapsed_samples = []\nresolved_version = None\nwith tempfile.TemporaryDirectory(prefix=\"melix-pr-perf-dev-up-dist-info-\") as temp_dir:\n    site_packages = Path(temp_dir) / \"site-packages\"\n    metallib_path = site_packages / \"mlx/lib/mlx.metallib\"\n    metallib_path.parent.mkdir(parents=True, exist_ok=True)\n    metallib_path.write_text(\"mlx\", encoding=\"utf-8\")\n    for index in range(dist_info_count):\n        (site_packages / f\"other_package_{index:05d}-1.0.0.dist-info\").mkdir(parents=True, exist_ok=True)\n    metadata_path = site_packages / \"mlx_metal-0.31.1.dist-info/METADATA\"\n    metadata_path.parent.mkdir(parents=True, exist_ok=True)\n    metadata_path.write_text(\"Name: mlx-metal\\nVersion: 0.31.1\\n\", encoding=\"utf-8\")\n    for _ in range(sample_count):\n        started = time.perf_counter()\n        resolved_version = module.read_mlx_metal_dist_info_version(metallib_path)\n        elapsed_samples.append((time.perf_counter() - started) * 1000.0)\nif resolved_version != \"0.31.1\":\n    raise AssertionError(f\"expected 0.31.1, got {resolved_version}\")\nprint(json.dumps({\"dist_info_count\": float(dist_info_count), \"elapsed_ms_mean\": round(statistics.fmean(elapsed_samples), 6), \"elapsed_ms_min\": round(min(elapsed_samples), 6), \"sample_count\": float(sample_count)}, sort_keys=True))\nPY",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "swift-cli-json-envelope-encoding",
     "name": "Swift CLI JSON envelope encoding",
     "runner": "macos-15",

--- a/scripts/dev_up.py
+++ b/scripts/dev_up.py
@@ -294,8 +294,22 @@ def compatible_mlx_metal_versions_for_swift_mlx(repo_root: Path) -> tuple[str, .
 
 
 def read_mlx_metal_dist_info_version(metallib_path: Path) -> str | None:
+    fallback_version: str | None = None
     for ancestor in metallib_path.resolve().parents:
-        for metadata_path in ancestor.glob("mlx_metal-*.dist-info/METADATA"):
+        try:
+            with os.scandir(ancestor) as entries:
+                dist_info_names = sorted(
+                    entry.name
+                    for entry in entries
+                    if entry.name.startswith("mlx_metal-")
+                    and entry.name.endswith(".dist-info")
+                    and entry.is_dir(follow_symlinks=False)
+                )
+        except OSError:
+            continue
+
+        for dist_info_name in dist_info_names:
+            metadata_path = ancestor / dist_info_name / "METADATA"
             try:
                 metadata = metadata_path.read_text(encoding="utf-8")
             except OSError:
@@ -306,10 +320,13 @@ def read_mlx_metal_dist_info_version(metallib_path: Path) -> str | None:
                     if version:
                         return version
 
-        for dist_info_path in ancestor.glob("mlx_metal-*.dist-info"):
-            match = re.fullmatch(r"mlx_metal-(?P<version>.+)\.dist-info", dist_info_path.name)
+        for dist_info_name in dist_info_names:
+            match = re.fullmatch(r"mlx_metal-(?P<version>.+)\.dist-info", dist_info_name)
             if match:
-                return match.group("version")
+                fallback_version = match.group("version")
+                break
+        if fallback_version is not None:
+            return fallback_version
 
     return None
 

--- a/services/mlx-worker-python/tests/test_dev_up_script.py
+++ b/services/mlx-worker-python/tests/test_dev_up_script.py
@@ -392,6 +392,49 @@ def test_resolve_local_mlx_metallib_uses_scandir_stack_without_path_rglob(
     assert dev_up.resolve_local_mlx_metallib(tmp_path, uv_cache_dir=layout.uv_cache_dir) == metallib_path.resolve()
 
 
+def test_read_mlx_metal_dist_info_version_uses_scandir_without_path_glob(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dev_up = load_dev_up_module()
+    metallib_path = write_mlx_metal_fixture(tmp_path / "site-packages", "0.29.1")
+
+    def fail_glob(self: Path, pattern: str):  # pragma: no cover - exercised only on regression
+        raise AssertionError("read_mlx_metal_dist_info_version() should not allocate Path.glob() results")
+
+    monkeypatch.setattr(dev_up.Path, "glob", fail_glob)
+
+    assert dev_up.read_mlx_metal_dist_info_version(metallib_path) == "0.29.1"
+
+
+def test_read_mlx_metal_dist_info_version_falls_back_to_dist_info_directory_name(tmp_path: Path) -> None:
+    dev_up = load_dev_up_module()
+    metallib_path = tmp_path / "site-packages/mlx/lib/mlx.metallib"
+    metallib_path.parent.mkdir(parents=True)
+    metallib_path.write_text("mlx", encoding="utf-8")
+    dist_info_path = tmp_path / "site-packages/mlx_metal-0.31.1.dist-info"
+    dist_info_path.mkdir()
+
+    assert dev_up.read_mlx_metal_dist_info_version(metallib_path) == "0.31.1"
+
+
+def test_read_mlx_metal_dist_info_version_skips_scandir_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dev_up = load_dev_up_module()
+    metallib_path = tmp_path / "site-packages/mlx/lib/mlx.metallib"
+    metallib_path.parent.mkdir(parents=True)
+    metallib_path.write_text("mlx", encoding="utf-8")
+
+    def fail_scandir(path: Path):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(dev_up.os, "scandir", fail_scandir)
+
+    assert dev_up.read_mlx_metal_dist_info_version(metallib_path) is None
+
+
 def test_iter_mlx_metallib_candidates_skips_scandir_errors(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -223,6 +223,16 @@ def test_scope_report_selects_package_macos_resolve_probe() -> None:
     assert "package-macos-resolve-fallback-scandir" in probe_ids
 
 
+def test_scope_report_selects_dev_up_mlx_metal_dist_info_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["scripts/dev_up.py"],
+    )
+
+    probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert "dev-up-mlx-metal-dist-info-scandir" in probe_ids
+
+
 def test_scope_report_force_selects_all_on_infra_change() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -322,6 +332,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "benchmark-store-matrix-streaming",
         "closure-audit-probe-source-short-circuit",
         "deterministic-rerank-query-context-reuse",
+        "dev-up-mlx-metal-dist-info-scandir",
         "evaluation-job-id-high-water-mark",
         "evaluation-sample-probe-aggregation",
         "evaluation-store-compare-summary-csv-streaming",


### PR DESCRIPTION
## Summary
- Replace the `mlx_metal` dist-info version lookup in `scripts/dev_up.py` with one `os.scandir()` pass per ancestor instead of two `Path.glob()` calls.
- Add focused regression coverage for metadata-first resolution, directory-name fallback, and scandir error handling.
- Register the `dev-up-mlx-metal-dist-info-scandir` PR-scoped performance probe for the touched path.

## Plan or Spec
- `docs/plans/2026-05-02-dev-up-mlx-metal-dist-info-scandir.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_falls_back_to_dist_info_directory_name services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_skips_scandir_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dev_up_mlx_metal_dist_info_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 5 passed in 0.23s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_falls_back_to_dist_info_directory_name services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_skips_scandir_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dev_up_mlx_metal_dist_info_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/dev_up.py services/mlx-worker-python/tests/test_dev_up_script.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 40 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 <registered dev-up probe command>
# {"dist_info_count": 2000.0, "elapsed_ms_mean": 1.221452, "elapsed_ms_min": 1.154236, "sample_count": 7.0}

git show origin/main:scripts/dev_up.py > /tmp/.../dev_up.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 <same probe against base module>
# {"dist_info_count": 2000.0, "elapsed_ms_mean": 1.348226, "elapsed_ms_min": 1.20959, "sample_count": 7.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 40 0 100%`).
- Local Linux registered-probe comparison:
  - old_mean=1.348226 ms, new_mean=1.221452 ms
  - delta_ms=-0.126774 ms, speedup=1.103790x, improvement=9.403%
  - old_min=1.209590 ms, new_min=1.154236 ms, min_delta_ms=-0.055354 ms
- Registered PR-scoped probe ID: `dev-up-mlx-metal-dist-info-scandir`.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- The slice is Python-only and locally verified on Linux. It does not claim local Swift runtime-effect validation.
- Because this PR adds a registry entry, CI may force-select all registered probes for registry-change validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
