### PR TITLE
perf: cache decoded benchmark queue records

### DIFF
--- a/docs/plans/2026-05-02-benchmark-queue-record-cache.md
+++ b/docs/plans/2026-05-02-benchmark-queue-record-cache.md
@@ -1,0 +1,56 @@
+# Benchmark Queue Record Cache Optimization Plan
+
+## Goal
+
+Reduce redundant JSON parsing in `BenchmarkQueueStore.list_records()` by reusing decoded queue records when the underlying queue-item file has not changed between repeated polls.
+
+## Constraints
+
+- Work from Linux only.
+- Keep the slice Python-only and locally verifiable.
+- Preserve queue ordering, file format, transition semantics, and error behavior.
+- Keep the cache worktree-local/in-memory only; do not change persisted payload shapes.
+
+## Performance Probe
+
+Probe ID: `benchmark-queue-decoded-record-cache`
+
+Measure repeated `BenchmarkQueueStore.list_records()` scans across a synthetic queue directory with many stable JSON records.
+
+Success metrics:
+- lower `warm_elapsed_ms_mean`
+- lower `warm_json_loads_mean`
+- preserve `record_count`
+
+## Files Expected
+
+- `services/mlx-worker-python/worker/productization/benchmark_queue.py`
+- `services/mlx-worker-python/tests/test_benchmark_queue.py`
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+- `scripts/changed_scope_coverage.py` (read-only, reused by coverage command)
+
+## Task 1
+
+Implement a metadata-keyed decoded-record cache for benchmark queue records.
+
+Requirements:
+- cache decoded `BenchmarkQueueRecord` values inside `BenchmarkQueueStore`
+- key cache reuse on stable file metadata so changed files are reloaded automatically
+- invalidate or refresh cache entries on enqueue/transition writes
+- preserve current sort order and failure behavior when files disappear or become unreadable
+- add focused tests proving unchanged files avoid redundant JSON loads while changed files still reload
+- register a PR-scoped performance probe for the touched path with focused test and changed-scope coverage commands
+
+## Verification Commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_queue.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_benchmark_queue_cache as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
+
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -60,6 +60,37 @@
     ]
   },
   {
+    "id": "benchmark-queue-decoded-record-cache",
+    "name": "Benchmark queue decoded-record cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/benchmark_queue.py",
+      "services/mlx-worker-python/worker/productization/pr_scoped_performance.py",
+      "services/mlx-worker-python/tests/test_benchmark_queue.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_queue.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c \"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_benchmark_queue_cache as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))\"",
+    "probe_impl": "benchmark_queue_cache",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "warm_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "warm_json_loads_mean",
+        "unit": "loads",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "benchmark-store-matrix-streaming",
     "name": "Benchmark store matrix streaming",
     "runner": "ubuntu-latest",

--- a/services/mlx-worker-python/tests/test_benchmark_queue.py
+++ b/services/mlx-worker-python/tests/test_benchmark_queue.py
@@ -372,3 +372,124 @@ def test_queue_snapshot_returns_empty_for_empty_directory(tmp_path: Path) -> Non
     assert snapshot["total"] == 0
     assert snapshot["by_status"] == {}
     assert snapshot["records"] == []
+
+
+def test_list_records_reuses_cached_decoded_records_for_unchanged_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    queue_root = tmp_path / "queue"
+    queue_root.mkdir()
+    payload = BenchmarkQueueRecord(
+        queue_item_id="queue-1",
+        job_kind="benchmark",
+        model_id="melix-dev-text",
+        suite_ids=("smoke",),
+        parameters={"sample_size": "32"},
+        status="queued",
+        created_at_unix_ms=100,
+        updated_at_unix_ms=100,
+    ).to_dict()
+    (queue_root / "queue-1.json").write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    store = BenchmarkQueueStore()
+    loads = 0
+    original_loads = json.loads
+
+    def tracked_loads(raw: str, *args: object, **kwargs: object) -> object:
+        nonlocal loads
+        loads += 1
+        return original_loads(raw, *args, **kwargs)
+
+    monkeypatch.setattr("worker.productization.benchmark_queue.json.loads", tracked_loads)
+
+    first = store.list_records(queue_root=queue_root)
+    second = store.list_records(queue_root=queue_root)
+
+    assert [record.queue_item_id for record in first] == ["queue-1"]
+    assert [record.queue_item_id for record in second] == ["queue-1"]
+    assert loads == 1
+
+
+def test_list_records_reload_changed_files_and_transition_refreshes_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    queue_root = tmp_path / "queue"
+    queue_root.mkdir()
+    path = queue_root / "queue-1.json"
+    initial_payload = BenchmarkQueueRecord(
+        queue_item_id="queue-1",
+        job_kind="benchmark",
+        model_id="melix-dev-text",
+        suite_ids=("smoke",),
+        parameters={"sample_size": "32"},
+        status="queued",
+        created_at_unix_ms=100,
+        updated_at_unix_ms=100,
+    ).to_dict()
+    path.write_text(json.dumps(initial_payload) + "\n", encoding="utf-8")
+    store = BenchmarkQueueStore()
+    loads = 0
+    original_loads = json.loads
+
+    def tracked_loads(raw: str, *args: object, **kwargs: object) -> object:
+        nonlocal loads
+        loads += 1
+        return original_loads(raw, *args, **kwargs)
+
+    monkeypatch.setattr("worker.productization.benchmark_queue.json.loads", tracked_loads)
+
+    first = store.list_records(queue_root=queue_root)
+    updated_payload = dict(initial_payload)
+    updated_payload["status"] = "running"
+    updated_payload["updated_at_unix_ms"] = 150
+    path.write_text(json.dumps(updated_payload, indent=2) + "\n", encoding="utf-8")
+    reloaded = store.list_records(queue_root=queue_root)
+    transitioned = store.transition(
+        queue_root=queue_root,
+        queue_item_id="queue-1",
+        status="completed",
+        updated_at_unix_ms=200,
+    )
+    cached_after_transition = store.list_records(queue_root=queue_root)
+
+    assert first[0].status == "queued"
+    assert reloaded[0].status == "running"
+    assert transitioned.status == "completed"
+    assert cached_after_transition[0].status == "completed"
+    assert loads == 2
+
+
+def test_list_records_and_transition_do_not_observe_mutated_returned_parameters(tmp_path: Path) -> None:
+    store = BenchmarkQueueStore()
+    queue_root = tmp_path / "queue"
+    enqueued = store.enqueue(
+        queue_root=queue_root,
+        record=BenchmarkQueueRecord(
+            queue_item_id="queue-1",
+            job_kind="benchmark",
+            model_id="melix-dev-text",
+            suite_ids=("smoke",),
+            parameters={"sample_size": "32"},
+            status="queued",
+            created_at_unix_ms=100,
+            updated_at_unix_ms=100,
+        ),
+    )
+
+    enqueued.parameters["sample_size"] = "999"
+    first_read = store.list_records(queue_root=queue_root)
+    first_read[0].parameters["batch_factor"] = "4"
+    second_read = store.list_records(queue_root=queue_root)
+    transitioned = store.transition(
+        queue_root=queue_root,
+        queue_item_id="queue-1",
+        status="running",
+        updated_at_unix_ms=150,
+    )
+    persisted = json.loads((queue_root / "queue-1.json").read_text(encoding="utf-8"))
+
+    assert first_read[0].parameters == {"sample_size": "32", "batch_factor": "4"}
+    assert second_read[0].parameters == {"sample_size": "32"}
+    assert transitioned.parameters == {"sample_size": "32"}
+    assert persisted["parameters"] == {"sample_size": "32"}

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -34,6 +34,7 @@ from worker.productization.pr_scoped_performance import (
     _parse_coverage_percent,
     _probe_benchmark_evaluation_report,
     _probe_benchmark_export_run_scan,
+    _probe_benchmark_queue_cache,
     _probe_closure_audit,
     _probe_deterministic_rerank_query_context_reuse,
     _probe_evaluation_job_id,
@@ -171,6 +172,16 @@ def test_scope_report_selects_benchmark_store_probe() -> None:
 
     assert scope["selected_count"] == 1
     assert scope["selected_probes"][0]["id"] == "benchmark-store-matrix-streaming"
+
+
+def test_scope_report_selects_benchmark_queue_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/benchmark_queue.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "benchmark-queue-decoded-record-cache"
 
 
 def test_scope_report_selects_bench_report_probe() -> None:
@@ -319,6 +330,7 @@ def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
         "benchmark-evaluation-report-running-aggregates",
         "benchmark-export-run-scan-single-pass",
+        "benchmark-queue-decoded-record-cache",
         "benchmark-store-matrix-streaming",
         "closure-audit-probe-source-short-circuit",
         "deterministic-rerank-query-context-reuse",
@@ -457,6 +469,7 @@ def test_probe_training_dataset_token_percentiles_reports_quality_and_tracing_me
 def test_probe_smokes_return_metrics_against_current_repo() -> None:
     benchmark_metrics = _probe_benchmark_evaluation_report(REPO_ROOT)
     benchmark_export_metrics = _probe_benchmark_export_run_scan(REPO_ROOT)
+    benchmark_queue_metrics = _probe_benchmark_queue_cache(REPO_ROOT)
     closure_metrics = _probe_closure_audit(REPO_ROOT)
     rerank_metrics = _probe_deterministic_rerank_query_context_reuse(REPO_ROOT)
     evaluation_job_id_metrics = _probe_evaluation_job_id(REPO_ROOT)
@@ -473,6 +486,10 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     assert benchmark_export_metrics["per_run_ms_mean"] > 0
     assert benchmark_export_metrics["run_directory_count"] == 240.0
     assert benchmark_export_metrics["result_file_count"] == 720.0
+    assert benchmark_queue_metrics["cold_json_loads"] == 128.0
+    assert benchmark_queue_metrics["record_count"] == 128.0
+    assert benchmark_queue_metrics["warm_json_loads_mean"] == 0.0
+    assert benchmark_queue_metrics["warm_elapsed_ms_mean"] >= 0
     assert closure_metrics["elapsed_ms_mean"] > 0
     assert closure_metrics["probe_file_reads_mean"] > 0
     assert closure_metrics["finding_count"] > 0
@@ -620,6 +637,49 @@ def test_probe_benchmark_export_run_scan_rejects_unexpected_result_count(monkeyp
 
     with pytest.raises(ValueError, match="unexpected benchmark result count"):
         _probe_benchmark_export_run_scan(REPO_ROOT)
+
+
+def test_dispatch_probe_impl_supports_benchmark_queue_probe() -> None:
+    probe = ProbeDefinition(
+        probe_id="benchmark-queue-decoded-record-cache",
+        name="Benchmark queue decoded-record cache",
+        runner="ubuntu-latest",
+        watch_globs=("services/mlx-worker-python/worker/productization/benchmark_queue.py",),
+        test_command="true",
+        coverage_command="true",
+        probe_impl="benchmark_queue_cache",
+        probe_command='python3 -c "{}"',
+        metrics=(MetricDefinition(key="warm_elapsed_ms_mean", unit="ms", direction="lower_is_better"),),
+    )
+
+    metrics = _dispatch_probe_impl(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["cold_json_loads"] == 128.0
+    assert metrics["record_count"] == 128.0
+    assert metrics["warm_json_loads_mean"] == 0.0
+    assert metrics["warm_elapsed_ms_mean"] >= 0
+
+
+def test_probe_benchmark_queue_cache_rejects_unexpected_record_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeBenchmarkQueueModule:
+        json = json
+
+        class BenchmarkQueueStore:
+            def list_records(self, *, queue_root: Path) -> list[object]:
+                del queue_root
+                return []
+
+        class BenchmarkQueueRecord:
+            def __init__(self, **kwargs: object) -> None:
+                self._payload = kwargs
+
+            def to_dict(self) -> dict[str, object]:
+                return dict(self._payload)
+
+    monkeypatch.setattr(pr_scoped_performance_module, "_load_repo_module", lambda path, unique_name: FakeBenchmarkQueueModule)
+
+    with pytest.raises(ValueError, match="unexpected benchmark queue record count"):
+        _probe_benchmark_queue_cache(REPO_ROOT)
 
 
 def test_worker_registry_probe_script_emits_metrics(capsys: pytest.CaptureFixture[str]) -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_queue.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_queue.py
@@ -7,6 +7,12 @@ from pathlib import Path
 
 
 @dataclass(frozen=True)
+class _RecordCacheEntry:
+    metadata_key: tuple[int, int, int, int]
+    record: BenchmarkQueueRecord
+
+
+@dataclass(frozen=True)
 class BenchmarkQueueRecord:
     queue_item_id: str
     job_kind: str
@@ -57,14 +63,18 @@ class BenchmarkQueueRecord:
 
 
 class BenchmarkQueueStore:
+    def __init__(self) -> None:
+        self._decoded_record_cache: dict[Path, _RecordCacheEntry] = {}
+
     def enqueue(
         self,
         *,
         queue_root: Path,
         record: BenchmarkQueueRecord,
     ) -> BenchmarkQueueRecord:
-        self._write_record(queue_root=queue_root, record=record)
-        return record
+        persisted_record = self._clone_record(record)
+        self._write_record(queue_root=queue_root, record=persisted_record)
+        return self._clone_record(persisted_record)
 
     def list_records(self, *, queue_root: Path) -> list[BenchmarkQueueRecord]:
         if not queue_root.is_dir():
@@ -81,10 +91,14 @@ class BenchmarkQueueStore:
                             continue
                     except OSError:
                         continue
-                    records.append(self._load_record(Path(entry.path)))
+                    path = Path(entry.path)
+                    records.append(self._load_record(path, metadata_key=self._metadata_key(path)))
         except OSError:
             return []
-        return sorted(records, key=lambda record: (record.created_at_unix_ms, record.queue_item_id))
+        return sorted(
+            (self._clone_record(record) for record in records),
+            key=lambda record: (record.created_at_unix_ms, record.queue_item_id),
+        )
 
     def transition(
         self,
@@ -113,18 +127,38 @@ class BenchmarkQueueStore:
             completed_at_unix_ms=completed_at_unix_ms,
         )
         self._write_record(queue_root=queue_root, record=updated)
-        return updated
+        return self._clone_record(updated)
 
     def _write_record(self, *, queue_root: Path, record: BenchmarkQueueRecord) -> None:
         queue_root.mkdir(parents=True, exist_ok=True)
-        self._record_path(queue_root=queue_root, queue_item_id=record.queue_item_id).write_text(
-            json.dumps(record.to_dict(), indent=2) + "\n",
+        path = self._record_path(queue_root=queue_root, queue_item_id=record.queue_item_id)
+        persisted_record = self._clone_record(record)
+        path.write_text(
+            json.dumps(persisted_record.to_dict(), indent=2) + "\n",
             encoding="utf-8",
         )
+        self._decoded_record_cache[path] = _RecordCacheEntry(
+            metadata_key=self._metadata_key(path),
+            record=persisted_record,
+        )
 
-    @staticmethod
-    def _load_record(path: Path) -> BenchmarkQueueRecord:
-        return BenchmarkQueueRecord.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    def _load_record(
+        self,
+        path: Path,
+        *,
+        metadata_key: tuple[int, int, int, int] | None = None,
+    ) -> BenchmarkQueueRecord:
+        current_metadata_key = self._metadata_key(path) if metadata_key is None else metadata_key
+        cached = self._decoded_record_cache.get(path)
+        if cached is not None and cached.metadata_key == current_metadata_key:
+            return cached.record
+        record = BenchmarkQueueRecord.from_dict(json.loads(path.read_text(encoding="utf-8")))
+        cached_record = self._clone_record(record)
+        self._decoded_record_cache[path] = _RecordCacheEntry(
+            metadata_key=current_metadata_key,
+            record=cached_record,
+        )
+        return cached_record
 
     def queue_snapshot(self, *, queue_root: Path) -> dict[str, object]:
         records = self.list_records(queue_root=queue_root)
@@ -138,5 +172,30 @@ class BenchmarkQueueStore:
         }
 
     @staticmethod
+    def _clone_record(record: BenchmarkQueueRecord) -> BenchmarkQueueRecord:
+        return BenchmarkQueueRecord(
+            queue_item_id=record.queue_item_id,
+            job_kind=record.job_kind,
+            model_id=record.model_id,
+            suite_ids=record.suite_ids,
+            parameters=dict(record.parameters),
+            status=record.status,
+            created_at_unix_ms=record.created_at_unix_ms,
+            updated_at_unix_ms=record.updated_at_unix_ms,
+            started_at_unix_ms=record.started_at_unix_ms,
+            completed_at_unix_ms=record.completed_at_unix_ms,
+        )
+
+    @staticmethod
     def _record_path(*, queue_root: Path, queue_item_id: str) -> Path:
         return queue_root / f"{queue_item_id}.json"
+
+    @staticmethod
+    def _metadata_key(path: Path) -> tuple[int, int, int, int]:
+        stat_result = path.stat()
+        return (
+            int(stat_result.st_mtime_ns),
+            int(stat_result.st_size),
+            int(stat_result.st_ino),
+            int(stat_result.st_dev),
+        )

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -379,6 +379,8 @@ def _dispatch_probe_impl(*, probe: ProbeDefinition, repo_root: Path) -> dict[str
         return _probe_benchmark_evaluation_report(repo_root)
     if probe.probe_impl == "benchmark_export_run_scan":
         return _probe_benchmark_export_run_scan(repo_root)
+    if probe.probe_impl == "benchmark_queue_cache":
+        return _probe_benchmark_queue_cache(repo_root)
     if probe.probe_impl == "closure_audit":
         return _probe_closure_audit(repo_root)
     if probe.probe_impl == "deterministic_rerank_query_context_reuse":
@@ -533,6 +535,67 @@ def _probe_benchmark_export_run_scan(repo_root: Path) -> dict[str, float]:
         "result_file_count": result_file_count,
         "run_directory_count": float(run_directory_count),
         "sample_count": float(sample_count),
+    }
+
+
+def _probe_benchmark_queue_cache(repo_root: Path) -> dict[str, float]:
+    module = _load_repo_module(
+        repo_root / "services/mlx-worker-python/worker/productization/benchmark_queue.py",
+        unique_name="melix_probe_benchmark_queue",
+    )
+    record_count = 128
+    warm_sample_count = 5
+    with tempfile.TemporaryDirectory(prefix="melix-pr-perf-benchmark-queue-") as temp_dir:
+        queue_root = Path(temp_dir) / "queue"
+        queue_root.mkdir(parents=True, exist_ok=True)
+        for index in range(record_count):
+            record = module.BenchmarkQueueRecord(
+                queue_item_id=f"queue-{index:04d}",
+                job_kind="benchmark",
+                model_id="melix-dev-text",
+                suite_ids=("smoke", "latency"),
+                parameters={"sample_size": str(16 + (index % 4))},
+                status="queued",
+                created_at_unix_ms=1_000 + index,
+                updated_at_unix_ms=1_000 + index,
+            )
+            (queue_root / f"queue-{index:04d}.json").write_text(
+                json.dumps(record.to_dict(), indent=2) + "\n",
+                encoding="utf-8",
+            )
+        store = module.BenchmarkQueueStore()
+        tracked_loads = 0
+        original_loads = module.json.loads
+
+        def counting_loads(raw: str, *args: object, **kwargs: object) -> object:
+            nonlocal tracked_loads
+            tracked_loads += 1
+            return original_loads(raw, *args, **kwargs)
+
+        module.json.loads = counting_loads
+        try:
+            cold_records = store.list_records(queue_root=queue_root)
+            if len(cold_records) != record_count:
+                raise ValueError("benchmark queue probe produced an unexpected benchmark queue record count")
+            cold_json_loads = tracked_loads
+            warm_elapsed_samples: list[float] = []
+            warm_json_load_samples: list[float] = []
+            for _ in range(warm_sample_count):
+                before_loads = tracked_loads
+                started = time.perf_counter()
+                warm_records = store.list_records(queue_root=queue_root)
+                warm_elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+                if len(warm_records) != record_count:
+                    raise ValueError("benchmark queue probe produced an unexpected benchmark queue record count")
+                warm_json_load_samples.append(float(tracked_loads - before_loads))
+        finally:
+            module.json.loads = original_loads
+    return {
+        "cold_json_loads": float(cold_json_loads),
+        "record_count": float(record_count),
+        "warm_elapsed_ms_mean": round(sum(warm_elapsed_samples) / len(warm_elapsed_samples), 6),
+        "warm_json_loads_mean": round(sum(warm_json_load_samples) / len(warm_json_load_samples), 6),
+        "warm_sample_count": float(warm_sample_count),
     }
 
 


### PR DESCRIPTION
## Summary
- cache decoded benchmark queue records in `BenchmarkQueueStore` using file-metadata keys so repeated queue polls avoid redundant JSON parsing
- return defensive copies so cached records cannot be mutated by callers and accidentally written back during later transitions
- register a dedicated `benchmark-queue-decoded-record-cache` PR-scoped performance probe plus focused tests and changed-scope coverage wiring

## Plan or Spec
- `docs/plans/2026-05-02-benchmark-queue-record-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
# 22 passed in 10.33s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_queue.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 22 passed in 33.62s
# TOTAL 157 1 99%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/benchmark_queue_probe_compare.py
# base @ origin/main: {"cold_json_loads": 128.0, "record_count": 128.0, "warm_elapsed_ms_mean": 4.547694, "warm_json_loads_mean": 128.0, "warm_sample_count": 5.0}
# head: {"cold_json_loads": 128.0, "record_count": 128.0, "warm_elapsed_ms_mean": 2.026146, "warm_json_loads_mean": 0.0, "warm_sample_count": 5.0}

git diff --check
# clean
```

## Coverage and Metrics
- Changed-scope coverage: `99%` aggregate (`156/157` measured changed lines covered)
- `services/mlx-worker-python/worker/productization/benchmark_queue.py`: `100.00%` changed-line coverage
- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`: `97.22%` changed-line coverage
- Registered scoped probe: `benchmark-queue-decoded-record-cache`
- Probe comparison vs `origin/main` on the same synthetic workload:
  - `warm_elapsed_ms_mean`: `4.547694 ms` -> `2.026146 ms` (~`55.45%` lower, `2.24x` faster)
  - `warm_json_loads_mean`: `128.0` -> `0.0` (eliminates warm-path JSON parsing)
  - `record_count`: `128.0` -> `128.0` (behavior preserved for the probe workload)

## Known Gaps
- Linux-only local verification for this Python slice is complete.
- I did not run full-repository `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, or `make integration-test` because this cron slice was intentionally scoped to a Linux-verifiable Python optimization path.
- Because `infra/perf/pr_scoped_probes.json` changed, the hosted `pr-scoped-performance` workflow will run the full scoped-probe matrix before merge; auto-merge should only be enabled after that workflow is green.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (Not applicable: no protocol/schema changes.)
- [x] Dependency changes include updated lockfiles. (Not applicable: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
