### PR TITLE
perf: short-circuit scope glob prefix misses

### DIFF
--- a/docs/plans/2026-05-02-pr-scoped-performance-scope-matcher-optimization.md
+++ b/docs/plans/2026-05-02-pr-scoped-performance-scope-matcher-optimization.md
@@ -15,13 +15,16 @@ This cron run executes on Linux and cannot validate the macOS/Swift app directly
 - `infra/perf/pr_scoped_probes.json`
 
 ## Proposed implementation
-1. Introduce a small internal fast path for scope selection that avoids repeating equivalent glob translation/matching work across every path × glob comparison.
+1. Introduce a small internal literal-prefix fast path for glob matching so paths that cannot match a probe glob avoid regex lookup/matching entirely.
 2. Preserve existing scope-selection semantics exactly, including:
    - force-all behavior
    - watch glob matching behavior
    - selected probe IDs and ordering
 3. Add focused regression tests for the optimized matcher path and the dedicated probe selection.
-4. Register/update a dedicated PR-scoped performance probe for the harness so CI measures the optimized scope-selection path directly.
+4. Use the registered `pr-scoped-performance-scope-matcher` probe so CI measures the optimized scope-selection path directly.
+
+## Slice update: literal-prefix miss short-circuit
+This slice keeps the existing registry and probe shape intact. The affected path already has the registered `pr-scoped-performance-scope-matcher` probe with focused `test_command`, `coverage_command`, and `probe_command` entries. The code change is limited to `_glob_matches_path(...)`: derive and cache the literal prefix before the first glob metacharacter (`*`, `?`, or `[`) and return `False` without touching the compiled regex cache when the changed path does not start with that prefix. Globs without metacharacters still use the full literal path as their prefix, preserving exact-match semantics through the existing regex matcher.
 
 ## Implemented slice
 - Split force-all and watch-glob matching into exact-path and wildcard paths so exact changed files avoid regex glob checks.

--- a/docs/plans/2026-05-02-pr-scoped-performance-scope-matcher-optimization.md
+++ b/docs/plans/2026-05-02-pr-scoped-performance-scope-matcher-optimization.md
@@ -24,7 +24,7 @@ This cron run executes on Linux and cannot validate the macOS/Swift app directly
 4. Use the registered `pr-scoped-performance-scope-matcher` probe so CI measures the optimized scope-selection path directly.
 
 ## Slice update: literal-prefix miss short-circuit
-This slice keeps the existing registry and probe shape intact. The affected path already has the registered `pr-scoped-performance-scope-matcher` probe with focused `test_command`, `coverage_command`, and `probe_command` entries. The code change is limited to `_glob_matches_path(...)`: derive and cache the literal prefix before the first glob metacharacter (`*`, `?`, or `[`) and return `False` without touching the compiled regex cache when the changed path does not start with that prefix. Globs without metacharacters still use the full literal path as their prefix, preserving exact-match semantics through the existing regex matcher.
+This slice keeps the existing registry and probe shape intact. The affected path already has the registered `pr-scoped-performance-scope-matcher` probe with focused `test_command`, `coverage_command`, and `probe_command` entries. The code change derives and caches the literal prefix before the first glob metacharacter (`*`, `?`, or `[`) and uses that prefix to skip impossible path/glob pairs before regex matching. `_match_probe_indexes(...)` also builds the `(prefix, compiled regex, probe indexes)` matcher table once per scope report so the hot path avoids repeated cache lookups while preserving exact-match semantics through the existing regex matcher.
 
 ## Implemented slice
 - Split force-all and watch-glob matching into exact-path and wildcard paths so exact changed files avoid regex glob checks.

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -280,9 +280,7 @@ def test_scope_report_large_changed_set_preserves_exact_selection_semantics() ->
     assert scope["selected_count"] == 4
 
 
-def test_match_probe_indexes_deduplicates_repeated_watch_globs(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_match_probe_indexes_deduplicates_repeated_watch_globs() -> None:
     probes = (
         ProbeDefinition(
             probe_id="alpha",
@@ -318,22 +316,36 @@ def test_match_probe_indexes_deduplicates_repeated_watch_globs(
             metrics=(MetricDefinition(key="elapsed_ms_mean", unit="ms", direction="lower_is_better"),),
         ),
     )
-    calls: list[tuple[str, str]] = []
-
-    def fake_glob_matches_path(path: str, glob: str) -> bool:
-        calls.append((path, glob))
-        return path == "services/b.py" and glob == "services/*.py"
-
-    monkeypatch.setattr(pr_scoped_performance_module, "_glob_matches_path", fake_glob_matches_path)
-
     matched = _match_probe_indexes(changed_paths=("shared.py", "services/b.py", "unmatched.py"), probes=probes)
 
     assert matched == {0, 1, 2}
-    assert calls == [
-        ("shared.py", "services/*.py"),
-        ("services/b.py", "services/*.py"),
-        ("unmatched.py", "services/*.py"),
-    ]
+
+
+def test_match_probe_indexes_skips_prefix_misses_before_regex(monkeypatch: pytest.MonkeyPatch) -> None:
+    probes = (
+        ProbeDefinition(
+            probe_id="alpha",
+            name="Alpha",
+            runner="ubuntu-latest",
+            watch_globs=("services/*.py",),
+            test_command="true",
+            coverage_command="true",
+            probe_impl="benchmark_evaluation_report",
+            probe_command="",
+            metrics=(MetricDefinition(key="elapsed_ms_mean", unit="ms", direction="lower_is_better"),),
+        ),
+    )
+    match_calls: list[str] = []
+
+    class FailingPattern:
+        def match(self, path: str) -> None:  # pragma: no cover - sentinel
+            match_calls.append(path)
+            raise AssertionError("prefix misses should not invoke regex matching")
+
+    monkeypatch.setattr(pr_scoped_performance_module, "_compiled_glob_pattern", lambda glob: FailingPattern())
+
+    assert _match_probe_indexes(changed_paths=("docs/a.md", "README.md"), probes=probes) == set()
+    assert match_calls == []
 
 
 def test_compiled_glob_pattern_reuses_cached_regex() -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -25,6 +25,7 @@ from worker.productization.pr_scoped_performance import (
     _float_or_none,
     _format_delta,
     _format_value,
+    _glob_literal_prefix,
     _is_relative_to,
     _load_upload_receipt_pipeline_module,
     _load_repo_module,
@@ -1222,10 +1223,36 @@ def test_data_generation_and_formatting_helpers_cover_misc_branches(tmp_path: Pa
     assert _float_or_none(True) == 1.0
     assert _float_or_none(False) == 0.0
     assert _float_or_none("x") is None
+    assert _glob_literal_prefix("services/*.py") == "services/"
+    assert _glob_literal_prefix("docs/plans/file.md") == "docs/plans/file.md"
+    assert _glob_literal_prefix("tests/test_[ab].py") == "tests/test_"
     assert _matches_any_glob("services/a.py", ("services/*.py",)) is True
     assert _matches_any_glob("docs/a.md", ("services/*.py",)) is False
     assert _is_relative_to(nested_path, tmp_path) is True
     assert _is_relative_to(Path("/tmp/not-child"), tmp_path) is False
+
+
+def test_glob_matching_skips_regex_when_literal_prefix_misses(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_compile(glob: str):  # pragma: no cover - sentinel
+        raise AssertionError(f"regex should not be compiled for prefix miss: {glob}")
+
+    monkeypatch.setattr(pr_scoped_performance_module, "_compiled_glob_pattern", fail_compile)
+
+    assert pr_scoped_performance_module._glob_matches_path(
+        "docs/plans/scope.md",
+        "services/mlx-worker-python/*.py",
+    ) is False
+
+
+def test_glob_matching_preserves_wildcard_semantics() -> None:
+    assert pr_scoped_performance_module._glob_matches_path(
+        "services/mlx-worker-python/worker/productization/pr_scoped_performance.py",
+        "services/mlx-worker-python/worker/productization/*.py",
+    ) is True
+    assert pr_scoped_performance_module._glob_matches_path(
+        "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+        "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    ) is True
 
 
 def test_report_results_loader_uses_scandir_and_binary_json_reads(

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -1795,12 +1795,14 @@ def _float_or_none(value: object) -> float | None:
 
 
 def _match_probe_indexes(*, changed_paths: tuple[str, ...], probes: tuple[ProbeDefinition, ...]) -> set[int]:
-    exact_path_to_probe_indexes, wildcard_glob_to_probe_indexes = _probe_match_indexes(probes)
+    exact_path_to_probe_indexes, wildcard_glob_matchers = _probe_match_indexes(probes)
     matched_probe_indexes: set[int] = set()
     for path in changed_paths:
         matched_probe_indexes.update(exact_path_to_probe_indexes.get(path, ()))
-        for glob, probe_indexes in wildcard_glob_to_probe_indexes.items():
-            if _glob_matches_path(path, glob):
+        for prefix, pattern, probe_indexes in wildcard_glob_matchers:
+            if prefix and not path.startswith(prefix):
+                continue
+            if pattern.match(path) is not None:
                 matched_probe_indexes.update(probe_indexes)
     return matched_probe_indexes
 
@@ -1808,7 +1810,7 @@ def _match_probe_indexes(*, changed_paths: tuple[str, ...], probes: tuple[ProbeD
 @lru_cache(maxsize=None)
 def _probe_match_indexes(
     probes: tuple[ProbeDefinition, ...],
-) -> tuple[dict[str, tuple[int, ...]], dict[str, tuple[int, ...]]]:
+) -> tuple[dict[str, tuple[int, ...]], tuple[tuple[str, re.Pattern[str], tuple[int, ...]], ...]]:
     exact_path_to_probe_indexes: dict[str, list[int]] = {}
     wildcard_glob_to_probe_indexes: dict[str, list[int]] = {}
     for probe_index, probe in enumerate(probes):
@@ -1817,9 +1819,13 @@ def _probe_match_indexes(
                 wildcard_glob_to_probe_indexes.setdefault(glob, []).append(probe_index)
             else:
                 exact_path_to_probe_indexes.setdefault(glob, []).append(probe_index)
+    wildcard_glob_matchers = tuple(
+        (_glob_literal_prefix(glob), _compiled_glob_pattern(glob), tuple(probe_indexes))
+        for glob, probe_indexes in wildcard_glob_to_probe_indexes.items()
+    )
     return (
         {path: tuple(probe_indexes) for path, probe_indexes in exact_path_to_probe_indexes.items()},
-        {glob: tuple(probe_indexes) for glob, probe_indexes in wildcard_glob_to_probe_indexes.items()},
+        wildcard_glob_matchers,
     )
 
 

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -1828,7 +1828,22 @@ def _compiled_glob_pattern(glob: str) -> re.Pattern[str]:
     return re.compile(fnmatch.translate(glob))
 
 
+@lru_cache(maxsize=None)
+def _glob_literal_prefix(glob: str) -> str:
+    special_indexes = [
+        index
+        for token in ("*", "?", "[")
+        if (index := glob.find(token)) != -1
+    ]
+    if not special_indexes:
+        return glob
+    return glob[: min(special_indexes)]
+
+
 def _glob_matches_path(path: str, glob: str) -> bool:
+    prefix = _glob_literal_prefix(glob)
+    if prefix and not path.startswith(prefix):
+        return False
     return _compiled_glob_pattern(glob).match(path) is not None
 
 


### PR DESCRIPTION
## Summary
- Add a cached literal-prefix fast path before PR-scoped glob regex matching.
- Cover prefix-miss and wildcard-preservation behavior with focused tests.
- Update the scope matcher optimization plan with the accepted slice details.

## Plan or Spec
- `docs/plans/2026-05-02-pr-scoped-performance-scope-matcher-optimization.md`
- Registered probe: `pr-scoped-performance-scope-matcher` in `infra/perf/pr_scoped_probes.json` already covers `services/mlx-worker-python/worker/productization/pr_scoped_performance.py` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
# Baseline probe before code changes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_pr_scope_probe.py
exit 0; {"build_scope_report_ms_mean": 43.322359, "build_scope_report_ms_min": 41.390883, "changed_file_count": 3205.0, "force_all_selected_mean": 0.0, "sample_count": 6.0, "selected_probe_count_mean": 4.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_glob_matching_skips_regex_when_literal_prefix_misses services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_glob_matching_preserves_wildcard_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_data_generation_and_formatting_helpers_cover_misc_branches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo
exit 0; 8 passed in 10.68s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_data_generation_and_formatting_helpers_cover_misc_branches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_glob_matching_skips_regex_when_literal_prefix_misses services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_glob_matching_preserves_wildcard_semantics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
exit 0; 10 passed in 35.82s; TOTAL 18 0 100%

# Head probe after code changes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_pr_scope_probe.py
exit 0; {"build_scope_report_ms_mean": 29.660639, "build_scope_report_ms_min": 29.111348, "changed_file_count": 3205.0, "force_all_selected_mean": 0.0, "sample_count": 6.0, "selected_probe_count_mean": 4.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 18 0 100%`.
- Local registered probe equivalent (`pr-scoped-performance-scope-matcher`): baseline `build_scope_report_ms_mean=43.322359`; head `build_scope_report_ms_mean=29.660639`; delta `-13.661720 ms`; speedup `1.460601x`; improvement `31.54%`.
- Semantics metric stayed stable: `selected_probe_count_mean=4.0`, `force_all_selected_mean=0.0` before and after.
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime effect is claimed for this slice.
- Did not run the full repository suite; this PR is limited to the registered Python scope matcher probe and focused tests.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
