### PR TITLE
perf: reuse embedded closure audit in phase8 metrics report

### DIFF
--- a/docs/plans/2026-05-02-phase8-metrics-closure-audit-reuse.md
+++ b/docs/plans/2026-05-02-phase8-metrics-closure-audit-reuse.md
@@ -1,0 +1,29 @@
+# Phase8 Metrics Closure Audit Reuse Plan
+
+## Goal
+Avoid duplicate closure-audit work in `scripts/phase8_metrics_report.py` by reusing the closure-audit evidence already embedded in the release-gate report, while preserving current report output and adding PR-scoped proof.
+
+## Linux-only constraint
+This slice targets Python-only reporting and PR-scoped performance wiring that can be verified locally on Linux. No macOS runtime execution is required for the implementation proof.
+
+## Touched files
+- `scripts/phase8_metrics_report.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_phase8_runtime_probes.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Implementation task
+1. Update `scripts/phase8_metrics_report.py` to reuse `release_gate_report["m9"]["closure_audit"]` when present and only fall back to `build_closure_audit(repo_root).to_dict()` if that nested evidence is absent.
+2. Add/adjust focused tests to prove the report reuses the embedded closure audit and does not call the fallback builder when the release-gate payload already contains the evidence.
+3. Register a PR-scoped performance probe that measures the phase8 metrics path and reports at least `elapsed_ms_mean`, `closure_audit_calls_mean`, and `sample_count`, with a base-compatible `command_json` probe command.
+
+## Success metrics
+- Functional: `phase8_metrics_report.main()` still emits the same closure-audit metrics payload.
+- Redundant-work reduction: local explicit probe reports `closure_audit_calls_mean` dropping from 2.0 on `origin/main` to 1.0 on the branch.
+- Coverage: changed executable scope remains at or above 95%.
+
+## Verification commands
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_phase8_runtime_probes.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_phase8_metrics_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_phase8_runtime_probes.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_phase8_metrics_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/phase8_metrics_report.py services/mlx-worker-python/tests/test_phase8_runtime_probes.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- Explicit local probe command from the registered PR-scoped probe entry to compare `origin/main` vs head.
+- `git diff --check`

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -153,6 +153,43 @@
     ]
   },
   {
+    "id": "phase8-metrics-closure-audit-reuse",
+    "name": "Phase8 metrics closure-audit reuse",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "scripts/phase8_metrics_report.py",
+      "services/mlx-worker-python/tests/test_phase8_runtime_probes.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_phase8_runtime_probes.py::test_phase8_metrics_report_main_emits_split_bootstrap_metrics services/mlx-worker-python/tests/test_phase8_runtime_probes.py::test_phase8_metrics_report_main_reuses_embedded_closure_audit services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_phase8_metrics_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_phase8_runtime_probes.py::test_phase8_metrics_report_main_emits_split_bootstrap_metrics services/mlx-worker-python/tests/test_phase8_runtime_probes.py::test_phase8_metrics_report_main_reuses_embedded_closure_audit services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_phase8_metrics_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/phase8_metrics_report.py services/mlx-worker-python/tests/test_phase8_runtime_probes.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python:$PWD/scripts\" uv run --project services/mlx-worker-python python3 - <<'PY'\nimport contextlib\nimport io\nimport json\nimport statistics\nimport sys\nimport time\nfrom pathlib import Path\n\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / 'services/mlx-worker-python'))\nsys.path.insert(0, str(repo_root / 'scripts'))\n\nimport phase8_metrics_report\n\nembedded_closure_audit = {\n    'metrics': {\n        'closure_audit.blocker_count': 0.0,\n        'closure_audit.accepted_risk_count': 1.0,\n        'closure_audit.evidence_gap_count': 0.0,\n        'closure_audit.deferred_work_count': 1.0,\n    },\n    'summary': {\n        'top_unresolved_findings': ['Synthetic embedded closure-audit evidence'],\n    },\n}\n\nelapsed_samples = []\nclosure_audit_call_samples = []\nsample_count = 5\n\nfor _ in range(sample_count):\n    calls = {'closure_audit': 0}\n\n    phase8_metrics_report.measure_cold_boot_to_ready = lambda repo_root: {'cold_boot_to_ready_ms': 801.2}\n    phase8_metrics_report.collect_restart_recovery_evidence = lambda repo_root: {'restart_recovery_ms': 710.7, 'restart_recovery_success_rate': 100.0}\n    phase8_metrics_report.collect_runtime_core_evidence = lambda repo_root: {'multi_model_ready_count': 3, 'multi_model_request_success_rate': 100.0}\n    phase8_metrics_report.load_release_gate_policy = lambda path: {}\n    phase8_metrics_report.collect_operator_action_evidence = lambda jobs_root: {'operator_action_latency_ms': 0.5, 'registry_job_count': 2, 'registry_adapter_count': 1}\n    phase8_metrics_report.build_release_gate_report = lambda repo_root, policy, recovery, runtime_core: {\n        'install': {'checks': {'manifest_exists': True, 'environment_script_exists': True, 'all_plists_exist': True}},\n        'benchmarks': {'report_exists': True, 'metrics': {}},\n        'training': {'training_duration_ms': 1420.0, 'adapter_publish_ms': 118.0},\n        'recovery': recovery,\n        'runtime_core': runtime_core,\n        'm9': {\n            'summary': {\n                'required_probe_count': 23.0,\n                'missing_probe_count': 0.0,\n                'failed_threshold_count': 0.0,\n            },\n            'closure_audit': phase8_metrics_report.build_closure_audit(repo_root).to_dict(),\n        },\n        'passed': True,\n        'failures': [],\n    }\n\n    class FakeClosureAudit:\n        def to_dict(self):\n            return embedded_closure_audit\n\n    def tracked_build_closure_audit(repo_root):\n        calls['closure_audit'] += 1\n        return FakeClosureAudit()\n\n    phase8_metrics_report.build_closure_audit = tracked_build_closure_audit\n\n    started = time.perf_counter()\n    original_argv = sys.argv\n    try:\n        sys.argv = ['phase8_metrics_report.py', '--repo-root', str(repo_root), '--json']\n        with contextlib.redirect_stdout(io.StringIO()) as buffer:\n            exit_code = phase8_metrics_report.main()\n        payload = json.loads(buffer.getvalue())\n    finally:\n        sys.argv = original_argv\n\n    elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n    closure_audit_call_samples.append(float(calls['closure_audit']))\n    if exit_code != 0:\n        raise SystemExit(f'expected zero exit code, got {exit_code}')\n    if payload['closure_audit'] != embedded_closure_audit:\n        raise SystemExit('phase8 metrics report did not reuse embedded closure audit payload')\n\nprint(json.dumps({\n    'elapsed_ms_mean': round(statistics.fmean(elapsed_samples), 6),\n    'closure_audit_calls_mean': round(statistics.fmean(closure_audit_call_samples), 6),\n    'sample_count': float(sample_count),\n}, sort_keys=True))\nPY",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "closure_audit_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "sample_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "evaluation-job-id-high-water-mark",
     "name": "Evaluation job-id high-water mark",
     "runner": "ubuntu-latest",

--- a/scripts/phase8_metrics_report.py
+++ b/scripts/phase8_metrics_report.py
@@ -48,7 +48,9 @@ def main() -> int:
         recovery=recovery,
         runtime_core=runtime_core,
     )
-    closure_audit = build_closure_audit(repo_root).to_dict()
+    closure_audit = dict(release_gate_report.get("m9", {})).get("closure_audit")
+    if closure_audit is None:
+        closure_audit = build_closure_audit(repo_root).to_dict()
     operator = collect_operator_action_evidence(repo_root / ".runtime" / "phase8-metrics")
     report = build_phase8_metrics_report(
         cold_boot=cold_boot,

--- a/services/mlx-worker-python/tests/test_phase8_runtime_probes.py
+++ b/services/mlx-worker-python/tests/test_phase8_runtime_probes.py
@@ -1509,6 +1509,94 @@ def test_phase8_metrics_report_main_emits_split_bootstrap_metrics(
     assert metrics["release_gate.m9_failed_threshold_count"] == 0.0
 
 
+def test_phase8_metrics_report_main_reuses_embedded_closure_audit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    embedded_closure_audit = {
+        "metrics": {
+            "closure_audit.blocker_count": 0.0,
+            "closure_audit.accepted_risk_count": 2.0,
+            "closure_audit.evidence_gap_count": 1.0,
+            "closure_audit.deferred_work_count": 3.0,
+        },
+        "summary": {
+            "top_unresolved_findings": [
+                "Embedded closure-audit evidence should be reused."
+            ]
+        },
+    }
+
+    monkeypatch.setattr(
+        phase8_metrics_report,
+        "measure_cold_boot_to_ready",
+        lambda repo_root: {"cold_boot_to_ready_ms": 801.2},
+    )
+    monkeypatch.setattr(
+        phase8_metrics_report,
+        "collect_restart_recovery_evidence",
+        lambda repo_root: {"restart_recovery_ms": 710.7, "restart_recovery_success_rate": 100.0},
+    )
+    monkeypatch.setattr(
+        phase8_metrics_report,
+        "collect_runtime_core_evidence",
+        lambda repo_root: {"multi_model_ready_count": 3, "multi_model_request_success_rate": 100.0},
+    )
+    monkeypatch.setattr(phase8_metrics_report, "load_release_gate_policy", lambda path: {})
+    monkeypatch.setattr(
+        phase8_metrics_report,
+        "build_release_gate_report",
+        lambda repo_root, policy, recovery, runtime_core: {
+            "install": {"checks": {"manifest_exists": True, "environment_script_exists": True, "all_plists_exist": True}},
+            "benchmarks": {"report_exists": True, "metrics": {}},
+            "training": {"training_duration_ms": 1420.0, "adapter_publish_ms": 118.0},
+            "recovery": recovery,
+            "runtime_core": runtime_core,
+            "m9": {
+                "summary": {
+                    "required_probe_count": 23.0,
+                    "missing_probe_count": 0.0,
+                    "failed_threshold_count": 0.0,
+                },
+                "closure_audit": embedded_closure_audit,
+            },
+            "passed": True,
+            "failures": [],
+        },
+    )
+
+    def fail_build_closure_audit(repo_root: Path) -> object:
+        raise AssertionError("build_closure_audit should not be called when release gate embeds closure_audit")
+
+    monkeypatch.setattr(phase8_metrics_report, "build_closure_audit", fail_build_closure_audit)
+    monkeypatch.setattr(
+        phase8_metrics_report,
+        "collect_operator_action_evidence",
+        lambda jobs_root: {
+            "operator_action_latency_ms": 0.5,
+            "registry_job_count": 2,
+            "registry_adapter_count": 1,
+        },
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["phase8_metrics_report.py", "--repo-root", str(tmp_path), "--json"],
+    )
+
+    assert phase8_metrics_report.main() == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    metrics = payload["metrics"]
+    assert metrics["closure_audit.blocker_count"] == 0.0
+    assert metrics["closure_audit.accepted_risk_count"] == 2.0
+    assert metrics["closure_audit.evidence_gap_count"] == 1.0
+    assert metrics["closure_audit.deferred_work_count"] == 3.0
+    assert payload["closure_audit"] == embedded_closure_audit
+
+
+
 def test_phase8_metrics_report_main_returns_nonzero_when_release_gate_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -196,6 +196,16 @@ def test_scope_report_selects_model_ops_bundle_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "model-ops-bundle-artifact-byte-accounting"
 
 
+def test_scope_report_selects_phase8_metrics_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["scripts/phase8_metrics_report.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "phase8-metrics-closure-audit-reuse"
+
+
 def test_scope_report_selects_bench_report_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -399,6 +409,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "pr-scoped-performance-scope-matcher",
         "training-dataset-token-percentiles-single-sort",
         "maintenance-bench-report-readback",
+        "phase8-metrics-closure-audit-reuse",
         "swift-cli-json-envelope-encoding",
         "upload-receipt-published-files-scandir",
         "download-pipeline-directory-size-single-stat",


### PR DESCRIPTION
## Summary
- Reuse the closure-audit evidence already embedded in `release_gate_report["m9"]["closure_audit"]` when building `scripts/phase8_metrics_report.py`.
- Keep the existing fallback to `build_closure_audit(repo_root).to_dict()` only when the embedded evidence is absent.
- Add focused regression coverage plus a dedicated PR-scoped performance probe for this path.

## Plan or Spec
- `docs/plans/2026-05-02-phase8-metrics-closure-audit-reuse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_phase8_runtime_probes.py::test_phase8_metrics_report_main_emits_split_bootstrap_metrics services/mlx-worker-python/tests/test_phase8_runtime_probes.py::test_phase8_metrics_report_main_reuses_embedded_closure_audit services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_phase8_metrics_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
-> 4 passed in 0.27s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_phase8_runtime_probes.py::test_phase8_metrics_report_main_emits_split_bootstrap_metrics services/mlx-worker-python/tests/test_phase8_runtime_probes.py::test_phase8_metrics_report_main_reuses_embedded_closure_audit services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_phase8_metrics_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
-> 4 passed in 0.67s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/phase8_metrics_report.py services/mlx-worker-python/tests/test_phase8_runtime_probes.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
-> TOTAL 27 1 96%

Registered scoped probe `phase8-metrics-closure-audit-reuse`
-> origin/main: {"closure_audit_calls_mean": 2.0, "elapsed_ms_mean": 1.067248, "sample_count": 5.0}
-> branch:      {"closure_audit_calls_mean": 1.0, "elapsed_ms_mean": 1.066682, "sample_count": 5.0}

git diff --check
-> clean
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 27 1 96%`
- Registered scoped CI probe: `phase8-metrics-closure-audit-reuse`
- Probe interpretation:
  - `closure_audit_calls_mean` dropped from `2.0` on `origin/main` to `1.0` on this branch.
  - `sample_count` stayed at `5.0` for both runs.
  - `elapsed_ms_mean` stayed effectively flat in the synthetic local run while the redundant closure-audit rebuild was removed.

## Known Gaps
- Local verification is Linux-only. I did not run the full macOS/Swift runtime stack locally on this host.
- Because `infra/perf/pr_scoped_probes.json` changed, the hosted `pr-scoped-performance` workflow will force the full scoped-probe matrix; merge should wait for that workflow to pass.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
