### PR TITLE
perf: batch changed-scope diff parsing

### DIFF
--- a/docs/plans/2026-05-02-changed-scope-coverage-batched-diff.md
+++ b/docs/plans/2026-05-02-changed-scope-coverage-batched-diff.md
@@ -1,0 +1,44 @@
+# Changed-Scope Coverage Batched Diff Optimization Plan
+
+## Goal
+
+Reduce redundant subprocess work in `scripts/changed_scope_coverage.py` by parsing one batched `git diff --unified=0` output for the requested files instead of spawning a separate `git diff` process for each path.
+
+## Linux-Only Constraint
+
+This change is limited to a repository Python helper script plus focused tests, so it can be fully verified on Linux without relying on macOS or Swift-only execution paths.
+
+## Touched Files
+
+- `scripts/changed_scope_coverage.py`
+- `tests/test_changed_scope_coverage.py`
+
+## Optimization Slice
+
+- Replace the per-path `_changed_lines(...)` subprocess pattern with one batched diff collection step for the requested paths.
+- Parse the combined unified diff into a `{rel_path -> changed_line_set}` mapping while preserving current changed-line semantics for additions, deletions, and context lines.
+- Keep output format and pass/fail behavior unchanged.
+- Add focused regression tests that lock the combined-diff parser behavior and prove the implementation only invokes `git diff` once for multiple paths.
+
+## Performance Probe
+
+Run a local synthetic probe that:
+
+- creates a temporary git repository with many changed Python files,
+- executes the current baseline implementation and the branch implementation on the same workload,
+- reports mean elapsed milliseconds and subprocess call count.
+
+The success signal is identical coverage semantics with one `git diff` subprocess instead of one per file and lower elapsed time on the synthetic workload.
+
+## Success Metrics
+
+- Script output remains behaviorally identical for the covered test cases.
+- Changed executable scope coverage is at least 95%.
+- The local synthetic probe shows materially lower elapsed time and reduces diff subprocess count from `N` to `1` for an `N`-file workload.
+
+## Verification Commands
+
+- `pytest -q tests/test_changed_scope_coverage.py`
+- `coverage run -m pytest -q tests/test_changed_scope_coverage.py && coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py`
+- `git diff --check`
+- Local synthetic batched-diff timing probe comparing the current branch implementation against an inline baseline implementation on the same temporary repository workload

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -10,42 +10,63 @@ import subprocess
 import sys
 
 
-def _changed_lines(repo_root: Path, rel_path: str) -> set[int]:
-    proc = subprocess.run(
-        ["git", "diff", "--unified=0", "--", rel_path],
-        cwd=repo_root,
-        text=True,
-        capture_output=True,
-        check=True,
-    )
-    changed: set[int] = set()
+def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
+    changed_by_path: dict[str, set[int]] = {}
+    current_path: str | None = None
     new_line: int | None = None
-    for line in proc.stdout.splitlines():
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git "):
+            match = re.match(r"diff --git a/(.+) b/(.+)", line)
+            current_path = None if match is None else match.group(2)
+            if current_path is not None:
+                changed_by_path.setdefault(current_path, set())
+            new_line = None
+            continue
         if line.startswith("@@"):
             match = re.search(r"\+(\d+)(?:,(\d+))?", line)
             if match is None:
                 continue
             new_line = int(match.group(1))
             continue
-        if new_line is None or line.startswith("+++") or line.startswith("---"):
+        if current_path is None or new_line is None:
+            continue
+        if line.startswith("\\ "):
+            continue
+        if re.match(r"\+\+\+ (?:b/|/dev/null)", line) or re.match(r"--- (?:a/|/dev/null)", line):
             continue
         if line.startswith("+"):
-            changed.add(new_line)
+            changed_by_path[current_path].add(new_line)
             new_line += 1
         elif line.startswith("-"):
             continue
         else:
             new_line += 1
-    return changed
+    return changed_by_path
 
 
-def _measurable_changed_lines(repo_root: Path, coverage_payload: dict[str, object], rel_path: str) -> tuple[list[int], list[int], list[int]]:
+def _changed_lines_by_path(repo_root: Path, rel_paths: list[str]) -> dict[str, set[int]]:
+    proc = subprocess.run(
+        ["git", "diff", "--unified=0", "--", *rel_paths],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    changed_by_path = _parse_changed_lines(proc.stdout)
+    return {rel_path: changed_by_path.get(rel_path, set()) for rel_path in rel_paths}
+
+
+def _measurable_changed_lines(
+    repo_root: Path,
+    coverage_payload: dict[str, object],
+    rel_path: str,
+    changed: set[int],
+) -> tuple[list[int], list[int], list[int]]:
     entry = coverage_payload["files"][rel_path]
     executed = set(entry["executed_lines"])
     missing = set(entry["missing_lines"])
     measured = executed | missing
     source_lines = (repo_root / rel_path).read_text(encoding="utf-8").splitlines()
-    changed = _changed_lines(repo_root, rel_path)
     measurable = [
         line_no
         for line_no in sorted(changed)
@@ -66,12 +87,18 @@ def main() -> int:
 
     repo_root = Path.cwd()
     coverage_payload = json.loads(Path(args.coverage_json).read_text(encoding="utf-8"))
+    changed_lines_by_path = _changed_lines_by_path(repo_root, args.paths)
 
     total_measurable = 0
     total_covered = 0
     total_missed = 0
     for rel_path in args.paths:
-        measurable, covered, missed = _measurable_changed_lines(repo_root, coverage_payload, rel_path)
+        measurable, covered, missed = _measurable_changed_lines(
+            repo_root,
+            coverage_payload,
+            rel_path,
+            changed_lines_by_path.get(rel_path, set()),
+        )
         total_measurable += len(measurable)
         total_covered += len(covered)
         total_missed += len(missed)

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "changed_scope_coverage.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("changed_scope_coverage", MODULE_PATH)
+assert MODULE_SPEC is not None
+assert MODULE_SPEC.loader is not None
+changed_scope_coverage = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(changed_scope_coverage)
+
+
+def test_parse_changed_lines_handles_multiple_files_and_hunks() -> None:
+    diff_text = "\n".join(
+        [
+            "diff --git a/foo.py b/foo.py",
+            "--- a/foo.py",
+            "+++ b/foo.py",
+            "@@ -0,0 +3,2 @@",
+            "+alpha",
+            "+beta",
+            "@@ -10 +12 @@",
+            "+gamma",
+            "diff --git a/bar.py b/bar.py",
+            "--- a/bar.py",
+            "+++ b/bar.py",
+            "@@ -5,2 +5,3 @@",
+            " keep",
+            "-old",
+            "+new",
+            "+extra",
+        ]
+    )
+
+    changed = changed_scope_coverage._parse_changed_lines(diff_text)
+
+    assert changed == {
+        "foo.py": {3, 4, 12},
+        "bar.py": {6, 7},
+    }
+
+
+def test_changed_lines_by_path_uses_one_batched_git_diff(monkeypatch, tmp_path: Path) -> None:
+    observed_commands: list[list[str]] = []
+    diff_text = "\n".join(
+        [
+            "diff --git a/foo.py b/foo.py",
+            "--- a/foo.py",
+            "+++ b/foo.py",
+            "@@ -0,0 +2 @@",
+            "+alpha",
+            "diff --git a/bar.py b/bar.py",
+            "--- a/bar.py",
+            "+++ b/bar.py",
+            "@@ -0,0 +5 @@",
+            "+beta",
+        ]
+    )
+
+    def fake_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+        observed_commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout=diff_text, stderr="")
+
+    monkeypatch.setattr(changed_scope_coverage.subprocess, "run", fake_run)
+
+    changed = changed_scope_coverage._changed_lines_by_path(tmp_path, ["foo.py", "bar.py", "baz.py"])
+
+    assert observed_commands == [["git", "diff", "--unified=0", "--", "foo.py", "bar.py", "baz.py"]]
+    assert changed == {
+        "foo.py": {2},
+        "bar.py": {5},
+        "baz.py": set(),
+    }
+
+
+def test_parse_changed_lines_ignores_no_newline_marker_and_keeps_line_numbers() -> None:
+    diff_text = "\n".join(
+        [
+            "diff --git a/foo.py b/foo.py",
+            "--- a/foo.py",
+            "+++ b/foo.py",
+            "@@ -1 +1,2 @@",
+            "-old",
+            "+new",
+            "\\ No newline at end of file",
+            "+tail",
+        ]
+    )
+
+    changed = changed_scope_coverage._parse_changed_lines(diff_text)
+
+    assert changed == {"foo.py": {1, 2}}
+
+
+def test_parse_changed_lines_preserves_added_content_that_starts_with_diff_header_prefix() -> None:
+    diff_text = "\n".join(
+        [
+            "diff --git a/foo.py b/foo.py",
+            "--- a/foo.py",
+            "+++ b/foo.py",
+            "@@ -0,0 +1,2 @@",
+            "++++not-a-header",
+            "+---also-real-content",
+        ]
+    )
+
+    changed = changed_scope_coverage._parse_changed_lines(diff_text)
+
+    assert changed == {"foo.py": {1, 2}}
+
+
+def test_measurable_changed_lines_filters_blank_comment_and_unmeasured_lines(tmp_path: Path) -> None:
+    source_path = tmp_path / "foo.py"
+    source_path.write_text("first\n# comment\n\ncovered\nmissed\n", encoding="utf-8")
+    coverage_payload = {
+        "files": {
+            "foo.py": {
+                "executed_lines": [1, 4],
+                "missing_lines": [5],
+            }
+        }
+    }
+
+    measurable, covered, missed = changed_scope_coverage._measurable_changed_lines(
+        tmp_path,
+        coverage_payload,
+        "foo.py",
+        {1, 2, 3, 4, 5},
+    )
+
+    assert measurable == [1, 4, 5]
+    assert covered == [1, 4]
+    assert missed == [5]
+
+
+def test_main_reports_aggregate_coverage_for_multiple_paths(monkeypatch, tmp_path: Path, capsys) -> None:
+    (tmp_path / "foo.py").write_text("covered\nmissed\n", encoding="utf-8")
+    (tmp_path / "bar.py").write_text("covered\n", encoding="utf-8")
+    coverage_json = tmp_path / "coverage.json"
+    coverage_json.write_text(
+        json.dumps(
+            {
+                "files": {
+                    "foo.py": {"executed_lines": [1], "missing_lines": [2]},
+                    "bar.py": {"executed_lines": [1], "missing_lines": []},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(sys, "argv", ["changed_scope_coverage.py", "--coverage-json", str(coverage_json), "foo.py", "bar.py"])
+    monkeypatch.setattr(changed_scope_coverage.Path, "cwd", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(
+        changed_scope_coverage,
+        "_changed_lines_by_path",
+        lambda repo_root, rel_paths: {"foo.py": {1, 2}, "bar.py": {1}},
+    )
+
+    assert changed_scope_coverage.main() == 1
+
+    output = capsys.readouterr().out
+    assert "foo.py" in output
+    assert "covered_changed_lines=[1]" in output
+    assert "missed_changed_lines=[2]" in output
+    assert "bar.py" in output
+    assert "aggregate_measurable_changed_lines=3" in output
+    assert "aggregate_covered_changed_lines=2" in output
+    assert "aggregate_missed_changed_lines=1" in output
+    assert "TOTAL 3 1 67%" in output


### PR DESCRIPTION
## Summary
- batch `scripts/changed_scope_coverage.py` into one `git diff --unified=0 -- <paths...>` call for the requested file set instead of spawning one diff subprocess per path
- preserve the helper's output format and pass/fail contract while parsing the combined diff into per-path changed-line sets
- add focused regression tests for multi-file hunks, batched subprocess behavior, `\ No newline at end of file` metadata, and added content that starts with diff-header-like prefixes
- record the optimization plan under `docs/plans/2026-05-02-changed-scope-coverage-batched-diff.md`

## Plan or Spec
- `docs/plans/2026-05-02-changed-scope-coverage-batched-diff.md`

## Commands Run
```text
pytest -q tests/test_changed_scope_coverage.py
- PASS (6 passed)

coverage run -m pytest -q tests/test_changed_scope_coverage.py
coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py
- PASS
- aggregate changed-scope coverage: TOTAL 25 0 100%

git diff --check
- PASS

python3 - <<'PY' ... local synthetic probe ... PY
- PASS
- HEAD commit matched origin/main before the change baseline probe
- baseline_mean_ms=428.218
- head_mean_ms=24.042
- speedup_x=17.81
- baseline_subprocess_calls=1250
- head_subprocess_calls=5
```

## Coverage and Metrics
- Changed-scope coverage:
  - `scripts/changed_scope_coverage.py`: `25/25` measurable changed lines covered (`100%`)
  - aggregate gate: `TOTAL 25 0 100%`
- Local synthetic performance probe on a 250-file temporary git workload:
  - baseline mean: `428.218 ms`
  - branch mean: `24.042 ms`
  - speedup: `17.81x`
  - diff subprocess calls: `1250` baseline vs `5` branch across 5 samples (`250 -> 1` per sample)
- Interpretation:
  - the optimization keeps changed-line semantics while removing per-path diff subprocess fan-out
  - the primary win is much lower subprocess overhead for multi-file changed-scope coverage checks

## Known Gaps
- This is a Linux-verified Python helper slice only; I did not run the repository-wide `make proto`, `make swift-test`, or `make integration-test` baselines in this cron run.
- Hosted `pr-scoped-performance` and `pr-evidence` GitHub Actions remain the merge gate for the pushed PR.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [ ] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
