### PR TITLE
perf: reuse force-all wildcard matchers

### DIFF
--- a/docs/plans/2026-05-02-pr-scoped-performance-scope-matcher-optimization.md
+++ b/docs/plans/2026-05-02-pr-scoped-performance-scope-matcher-optimization.md
@@ -31,6 +31,11 @@ This slice keeps the existing registry and probe shape intact. The affected path
 - Cache the derived watch-glob index and the scope-report registry load by path, mtime, and size for repeated scope computations in the same process.
 - Keep the public `load_probe_registry(...)` parser uncached so direct validation callers still observe file contents immediately.
 
+## Slice update: force-all wildcard matcher reuse
+- Cache the compiled force-all wildcard matcher table once per process instead of re-deriving the literal prefix and regex lookup on every changed path.
+- Keep exact-path force-all matching first so common exact infra/script paths still return without invoking wildcard matching.
+- Keep selection semantics unchanged; this only changes matcher setup reuse in the scope-report hot path.
+
 ## Performance probe
 - Probe target: `build_scope_report(...)` on a synthetic large changed-file set and current probe registry.
 - Primary metrics:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -359,8 +359,26 @@ def test_match_probe_indexes_skips_prefix_misses_before_regex(monkeypatch: pytes
     assert match_calls == []
 
 
-def test_compiled_glob_pattern_reuses_cached_regex() -> None:
+def test_compiled_glob_pattern_reuses_cached_regex(monkeypatch: pytest.MonkeyPatch) -> None:
     assert _compiled_glob_pattern("services/*.py") is _compiled_glob_pattern("services/*.py")
+
+    pr_scoped_performance_module._force_all_wildcard_matchers.cache_clear()
+    compile_calls: list[str] = []
+    original_compile = pr_scoped_performance_module._compiled_glob_pattern
+
+    def tracked_compile(glob: str):
+        compile_calls.append(glob)
+        return original_compile(glob)
+
+    monkeypatch.setattr(pr_scoped_performance_module, "_compiled_glob_pattern", tracked_compile)
+
+    assert pr_scoped_performance_module._path_matches_force_all("scripts/pr_scoped_performance_run.py") is True
+    assert pr_scoped_performance_module._path_matches_force_all("docs/plans/scope.md") is False
+    assert compile_calls == ["scripts/pr_scoped_performance_*.py"]
+    assert pr_scoped_performance_module._path_matches_force_all("scripts/pr_scoped_performance_report.py") is True
+    assert compile_calls == ["scripts/pr_scoped_performance_*.py"]
+
+    pr_scoped_performance_module._force_all_wildcard_matchers.cache_clear()
 
 
 def test_registered_probes_expose_focused_commands() -> None:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -1933,14 +1933,14 @@ def _compiled_glob_pattern(glob: str) -> re.Pattern[str]:
 
 @lru_cache(maxsize=None)
 def _glob_literal_prefix(glob: str) -> str:
-    special_indexes = [
-        index
-        for token in ("*", "?", "[")
-        if (index := glob.find(token)) != -1
-    ]
-    if not special_indexes:
+    first_special_index = len(glob)
+    for token in "*?[":
+        index = glob.find(token)
+        if index != -1 and index < first_special_index:
+            first_special_index = index
+    if first_special_index == len(glob):
         return glob
-    return glob[: min(special_indexes)]
+    return glob[:first_special_index]
 
 
 def _glob_matches_path(path: str, glob: str) -> bool:
@@ -1950,12 +1950,30 @@ def _glob_matches_path(path: str, glob: str) -> bool:
     return _compiled_glob_pattern(glob).match(path) is not None
 
 
+@lru_cache(maxsize=1)
+def _force_all_wildcard_matchers() -> tuple[tuple[str, re.Pattern[str]], ...]:
+    return tuple(
+        (_glob_literal_prefix(glob), _compiled_glob_pattern(glob))
+        for glob in _FORCE_ALL_WILDCARD_GLOBS
+    )
+
+
 def _path_matches_force_all(path: str) -> bool:
-    return path in _FORCE_ALL_EXACT_PATHS or _matches_any_glob(path, _FORCE_ALL_WILDCARD_GLOBS)
+    return path in _FORCE_ALL_EXACT_PATHS or _matches_any_compiled_glob(
+        path,
+        _force_all_wildcard_matchers(),
+    )
 
 
 def _matches_any_glob(path: str, globs: tuple[str, ...]) -> bool:
     return any(_glob_matches_path(path, glob) for glob in globs)
+
+
+def _matches_any_compiled_glob(path: str, matchers: tuple[tuple[str, re.Pattern[str]], ...]) -> bool:
+    return any(
+        (not prefix or path.startswith(prefix)) and pattern.match(path) is not None
+        for prefix, pattern in matchers
+    )
 
 
 def _is_relative_to(path: Path, root: Path) -> bool:


### PR DESCRIPTION
## Summary
- Reuse a cached compiled matcher table for force-all wildcard path checks in the PR-scoped performance scope matcher.
- Keep exact force-all path checks first and preserve selected probe semantics.
- Add regression coverage proving the wildcard matcher is compiled once and reused across force-all checks.

## Plan or Spec
- `docs/plans/2026-05-02-pr-scoped-performance-scope-matcher-optimization.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo
# 7 passed in 33.55s (via coverage replay) / 8 passed in 10.82s before folding the new assertion into the registered node

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 27 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id pr-scoped-performance-scope-matcher --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo . --output /tmp/pr-scope-prefix-head2
# ok; base build_scope_report_ms_mean=3.275991, head=2.951931

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 27 0 100%` for `services/mlx-worker-python/worker/productization/pr_scoped_performance.py` and `services/mlx-worker-python/tests/test_pr_scoped_performance.py`.
- Registered probe: `pr-scoped-performance-scope-matcher`.
- Local Linux probe delta: `build_scope_report_ms_mean` 3.275991 ms -> 2.951931 ms (`-0.324060 ms`, ~9.89% faster).
- Selection metrics unchanged: `selected_probe_count_mean=4.0`, `force_all_selected_mean=0.0`.

## Known Gaps
- Local validation is Linux-only; GitHub Actions remains the source of truth for the registered PR-scoped performance workflow.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
