### PR TITLE
perf: reduce benchmark queue sort clone overhead

### DIFF
--- a/docs/plans/2026-05-02-benchmark-queue-sorted-clone-fastpath.md
+++ b/docs/plans/2026-05-02-benchmark-queue-sorted-clone-fastpath.md
@@ -1,0 +1,65 @@
+# BenchmarkQueue sorted clone fast path performance slice
+
+## Goal
+
+Reduce warm `BenchmarkQueueStore.list_records()` Python overhead by avoiding the generator-based clone-sort path, while preserving JSON filtering, regular-file filtering, record ordering, cache invalidation semantics, and returned-record defensive copies.
+
+## Linux-only constraint
+
+This slice is Python-only under `services/mlx-worker-python`, so it can be fully verified from this Linux host without touching macOS/Swift surfaces.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/productization/benchmark_queue.py`
+
+## Optimization hypothesis
+
+`list_records()` already materializes decoded records into a local list. Sorting clones through `sorted((clone(record) for record in records), key=...)` adds generator and sorted-list construction overhead before returning the defensive copies.
+
+This slice sorts the local cached-record list in place, then returns a list comprehension of defensive clones. The returned values remain independent copies, and ordering remains `(created_at_unix_ms, queue_item_id)`.
+
+A rejected trial in this worktree attempted to reuse `DirEntry.stat()` metadata for the cache key. Local registered probe samples were worse than the current baseline, so that approach was reverted before this accepted slice.
+
+## Registered probe
+
+The affected path is covered by `benchmark-queue-decoded-record-cache` in `infra/perf/pr_scoped_probes.json`. The entry includes focused `test_command`, `coverage_command`, and `probe_command` values and measures:
+
+- `warm_elapsed_ms_mean` (lower is better)
+- `warm_json_loads_mean` (lower is better; should remain zero for cached warm reads)
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_benchmark_queue.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_benchmark_queue.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/productization/benchmark_queue.py \
+  services/mlx-worker-python/worker/productization/pr_scoped_performance.py \
+  services/mlx-worker-python/tests/test_benchmark_queue.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_benchmark_queue_probe.py
+
+git diff --check
+```
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope automated coverage is at least 95%.
+- Local registered probe reports concrete metrics and keeps `warm_json_loads_mean` at `0.0`.
+- PR-scoped CI probe `benchmark-queue-decoded-record-cache` validates the same path before merge.

--- a/services/mlx-worker-python/worker/productization/benchmark_queue.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_queue.py
@@ -95,10 +95,8 @@ class BenchmarkQueueStore:
                     records.append(self._load_record(path, metadata_key=self._metadata_key(path)))
         except OSError:
             return []
-        return sorted(
-            (self._clone_record(record) for record in records),
-            key=lambda record: (record.created_at_unix_ms, record.queue_item_id),
-        )
+        records.sort(key=lambda record: (record.created_at_unix_ms, record.queue_item_id))
+        return [self._clone_record(record) for record in records]
 
     def transition(
         self,


### PR DESCRIPTION
## Summary
- Sort cached benchmark queue records in place before cloning returned records.
- Avoid the generator-based clone/sort path in `BenchmarkQueueStore.list_records()` while preserving defensive copies and stable ordering.
- Add a focused plan for the registered BenchmarkQueue performance slice.

## Plan or Spec
- `docs/plans/2026-05-02-benchmark-queue-sorted-clone-fastpath.md`
- Registered PR-scoped probe: `benchmark-queue-decoded-record-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe on origin/main worktree, three runs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_benchmark_queue_probe.py
=> warm_elapsed_ms_mean: 1.729095, 1.716802, 1.664313; warm_json_loads_mean: 0.0 each

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
=> 22 passed in 10.96s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
=> 22 passed in 33.25s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_queue.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
=> TOTAL 2 0 100%

# Head probe, three runs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_benchmark_queue_probe.py
=> warm_elapsed_ms_mean: 1.600972, 1.605553, 1.629389; warm_json_loads_mean: 0.0 each

git diff --check
=> passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Registered local probe: `benchmark-queue-decoded-record-cache`.
- Baseline `warm_elapsed_ms_mean` mean: `1.703403 ms`.
- Head `warm_elapsed_ms_mean` mean: `1.611971 ms`.
- Delta: `-0.091432 ms` (`5.37%` faster).
- `warm_json_loads_mean`: `0.0` baseline and head.
- CI must run the registered PR-scoped performance workflow and report for merge validation.

## Known Gaps
- Local validation is Linux/Python only; no Swift/macOS runtime effect is claimed.
- A rejected trial that reused `DirEntry.stat()` metadata was locally slower and was reverted before this PR.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
