### PR TITLE
[codex] Implement Issue 77 non-text auth and audio diagnostics

### DIFF
--- a/docs/plans/2026-05-03-issue-77-non-text-auth-and-audio-diagnostics.md
+++ b/docs/plans/2026-05-03-issue-77-non-text-auth-and-audio-diagnostics.md
@@ -1,0 +1,71 @@
+# Issue 77 Non-Text Auth and Audio Diagnostics
+
+## Goal
+
+Make non-text and tool/control gateway requests fail safely by enforcing the shared gateway
+authorization boundary on every operator-facing route, rejecting endpoint/model mismatches before
+worker execution, and surfacing actionable audio processor asset diagnostics during first load.
+
+## Scope
+
+- Add an operator route admission fixture matrix that covers text, non-text, image, audio,
+  tool/control, cache, model, and unknown routes under shared API-key mode.
+- Centralize endpoint-family validation for text generation, embeddings, rerank, transcription,
+  speech, and image endpoints before request execution reaches the worker.
+- Validate required `mlx_audio` processor assets at first load for speech and transcription models.
+- Expose operator-visible metrics for blocked auth, wrong-endpoint validation, and audio processor
+  validation failures.
+
+## Non-Goals
+
+- Redesign the gateway auth product surface.
+- Change model download, packaging, or scheduler behavior outside the endpoint admission contract.
+- Add new audio model families.
+
+## Implementation Plan
+
+- [x] Add focused Swift HTTP gateway tests proving every operator-facing route except `/health`
+  inherits the configured shared API-key policy.
+- [x] Add a shared endpoint contract helper in `OpenAIHandler` that resolves selected model
+  metadata and rejects mismatches with a structured 400 error before worker dispatch.
+- [x] Record `route_auth_policy` and `endpoint_type_validation_result` metrics on the changed
+  gateway paths.
+- [x] Add Python audio runtime validation for required processor assets and return
+  `audio_processor_validation_failed` with missing asset class and `load_model` stage details.
+- [x] Add regression fixtures for missing audio processor configs, wrong endpoint selection, and
+  auth-blocked non-text/tool requests.
+- [x] Update runbook evidence for the new diagnostics.
+
+## Performance And Metrics
+
+- `route_auth_policy`: numeric auth mode projection recorded for every non-health request.
+- `endpoint_type_validation_result`: `1` for accepted endpoint/model pair, `0` for rejected pair.
+- `audio_processor_validation_result`: worker error detail set to `0` when required real
+  `mlx_audio` processor assets are missing. Successful validation continues into the existing load
+  path and is represented by successful load evidence rather than a separate success receipt.
+- Existing latency probes remain unchanged: the validation runs before worker execution and should
+  avoid creating new request latency on successful deterministic routes beyond metadata lookup.
+
+## Verification
+
+- `swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests'`
+- `PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_audio_runtime.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_runtime_service.py -q`
+- `git diff --check`
+
+## Metrics Report
+
+- Swift gateway regression: `OpenAIHandlerTests` passed with 122 tests. The auth parity fixture
+  covers 16 operator-facing non-health routes, with 14 shared-policy failures returning
+  `missing_api_key`, 2 session-token failures returning `missing_session`, and `/health` remaining
+  open.
+- Endpoint validation regression: 7 wrong-endpoint fixtures returned structured
+  `wrong_endpoint_for_model` 400 responses, recorded
+  `endpoint_type_validation_rejection_count = 7`, and did not dispatch to worker clients.
+- Python audio regression: 39 targeted audio/runtime tests passed. The missing processor fixture
+  covers both `mlx_audio.stt` and `mlx_audio.tts`; worker first-load errors return
+  `audio_processor_validation_failed` with `missing_asset_class`,
+  `load_stage = load_model:processor_asset_preflight`, and
+  `audio_processor_validation_result = 0`.
+- Coverage percentage: N/A for this handoff because the touched-scope verification commands do not
+  emit line coverage. The regression counts above are the measured automated evidence for this
+  slice.

--- a/docs/runbooks/shared-access.md
+++ b/docs/runbooks/shared-access.md
@@ -90,6 +90,15 @@ Expected failure probes:
 - unknown shared key returns `401` with `invalid_api_key`
 - explicit shared headers in configured-but-disabled mode return `403` with `shared_access_disabled`
 
+### Route Parity
+
+The same shared-access policy applies to every operator-facing route except `/health`, including
+text generation, embeddings, rerank, audio transcription, audio speech, image generation/editing,
+cache stats, auth session creation, and unknown routes. Missing credentials in shared-enabled mode
+must return `401 missing_api_key` before request body decoding or worker dispatch. Session inspect
+and revoke routes require `X-Melix-Session`; missing session credentials return
+`401 missing_session` and do not fall through to the route handler.
+
 ### Desktop State
 
 After the menu bar app hydrates from handshake:
@@ -129,3 +138,14 @@ Supporting snapshot and bootstrap probes also expose:
 - `shared_access.ready`
 
 These values are projected into the control-plane snapshot and desktop operator state so backend truth, smoke evidence, and menu bar rendering stay aligned.
+
+Issue 77 also records:
+
+- `route_auth_policy`
+- `endpoint_type_validation_result`
+- `endpoint_type_validation_rejection_count`
+
+`route_auth_policy` is emitted for non-health requests after the gateway selects the effective
+access policy. `endpoint_type_validation_result = 0` with an incremented rejection count means the
+request selected a model that belongs to a different endpoint family; the JSON error body includes
+the requested endpoint, model endpoint family, and suggested retry endpoint.

--- a/docs/runbooks/speech-runtime-operator-evidence.md
+++ b/docs/runbooks/speech-runtime-operator-evidence.md
@@ -95,6 +95,16 @@ If transcription requests fail with `audio_model_download_required`:
 - inspect `.melix-managed-audio-models.json`
 - confirm the managed model root still contains a `managed-model.json` entry for the failing model
 
+If transcription or synthesis first-load requests fail with `audio_processor_validation_failed`:
+
+- inspect the HTTP error `details`
+- confirm `missing_asset_class` is `processor_config`
+- confirm `load_stage` identifies `load_model:processor_asset_preflight`
+- confirm `audio_processor_validation_result` is `0`
+- inspect the managed model directory and verify it contains one of `processor_config.json`,
+  `preprocessor_config.json`, or `feature_extractor_config.json`
+- redownload or reinstall the managed audio model before retrying the request
+
 If synthesis locale evidence regresses:
 
 - inspect `requested_locale`

--- a/scripts/m17_speech_runtime_smoke.py
+++ b/scripts/m17_speech_runtime_smoke.py
@@ -154,6 +154,7 @@ def _install_audio_assets(app_support_dir: Path) -> None:
             "localModelPath": str(local_model_path),
         }
         _write_json(local_model_path / "managed-model.json", record)
+        _write_json(local_model_path / "preprocessor_config.json", {"processor_class": "FakeMLXAudioProcessor"})
         managed_model_records[model_id] = record
 
     _write_json(

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -373,6 +373,7 @@ public struct OpenAIHandler: Sendable {
             return .success(.localTrusted)
         }
         let gatewayAccessPolicy = await gatewayAccessPolicyStore.currentPolicy()
+        await metricsStore.set(gatewayAccessPolicy.metricModeCode, forKey: "route_auth_policy")
         if
             route != .createSession,
             let sessionToken = header(named: PersistentAuthSessionStore.sessionHeaderName, in: request.headers),
@@ -722,6 +723,12 @@ public struct OpenAIHandler: Sendable {
 
     private func handleEmbeddings(_ request: HTTPRequest) async throws -> HTTPResponse {
         let embeddingsRequest = try decoder.decode(OpenAIEmbeddingsRequest.self, from: request.body)
+        if let validationFailure = await endpointCompatibilityFailureResponse(
+            modelID: embeddingsRequest.model,
+            endpoint: .embedding
+        ) {
+            return validationFailure
+        }
         let inputs = embeddingsRequest.normalizedInputs
 
         guard let modelHandle = await modelCatalog.dispatchHandle(for: embeddingsRequest.model) else {
@@ -770,6 +777,12 @@ public struct OpenAIHandler: Sendable {
 
     private func handleRerank(_ request: HTTPRequest) async throws -> HTTPResponse {
         let rerankRequest = try decoder.decode(OpenAIRerankRequest.self, from: request.body)
+        if let validationFailure = await endpointCompatibilityFailureResponse(
+            modelID: rerankRequest.model,
+            endpoint: .rerank
+        ) {
+            return validationFailure
+        }
 
         guard let modelHandle = await modelCatalog.dispatchHandle(for: rerankRequest.model) else {
             return httpErrorResponse(for: .modelNotReady)
@@ -817,6 +830,12 @@ public struct OpenAIHandler: Sendable {
 
     private func handleAudioTranscriptions(_ request: HTTPRequest) async throws -> HTTPResponse {
         let transcriptionRequest = try decoder.decode(OpenAIAudioTranscriptionsRequest.self, from: request.body)
+        if let validationFailure = await endpointCompatibilityFailureResponse(
+            modelID: transcriptionRequest.model,
+            endpoint: .transcription
+        ) {
+            return validationFailure
+        }
         let audioReference = transcriptionRequest.normalizedAudio
 
         if let preflightFailure = await audioReadinessFailureResponse(for: transcriptionRequest.model) {
@@ -834,6 +853,8 @@ public struct OpenAIHandler: Sendable {
             return httpErrorResponse(for: .modelRuntimeMissing)
         } catch OnDemandModelLoadError.modelNotReady {
             return httpErrorResponse(for: .modelNotReady)
+        } catch OnDemandModelLoadError.workerRejected(let error) {
+            return workerErrorResponse(error)
         } catch OnDemandModelLoadError.workerUnavailable {
             return workerUnavailableResponse()
         } catch {
@@ -922,6 +943,12 @@ public struct OpenAIHandler: Sendable {
 
     private func handleAudioSpeech(_ request: HTTPRequest) async throws -> HTTPResponse {
         let speechRequest = try decoder.decode(OpenAIAudioSpeechRequest.self, from: request.body)
+        if let validationFailure = await endpointCompatibilityFailureResponse(
+            modelID: speechRequest.model,
+            endpoint: .speech
+        ) {
+            return validationFailure
+        }
         let requestedFormat = (speechRequest.format ?? "wav").lowercased()
         if let selectedModel = await modelCatalog.model(id: speechRequest.model),
            !supportsSpeechFormat(requestedFormat, for: selectedModel) {
@@ -953,6 +980,8 @@ public struct OpenAIHandler: Sendable {
             return httpErrorResponse(for: .modelRuntimeMissing)
         } catch OnDemandModelLoadError.modelNotReady {
             return httpErrorResponse(for: .modelNotReady)
+        } catch OnDemandModelLoadError.workerRejected(let error) {
+            return workerErrorResponse(error)
         } catch OnDemandModelLoadError.workerUnavailable {
             return workerUnavailableResponse()
         } catch {
@@ -1039,6 +1068,12 @@ public struct OpenAIHandler: Sendable {
 
     private func handleImageGenerations(_ request: HTTPRequest) async throws -> HTTPResponse {
         let imageRequest = try decoder.decode(OpenAIImageGenerationsRequest.self, from: request.body)
+        if let validationFailure = await endpointCompatibilityFailureResponse(
+            modelID: imageRequest.model,
+            endpoint: .imageGeneration
+        ) {
+            return validationFailure
+        }
 
         guard let modelHandle = await modelCatalog.dispatchHandle(for: imageRequest.model) else {
             return httpErrorResponse(for: .modelNotReady)
@@ -1200,6 +1235,12 @@ public struct OpenAIHandler: Sendable {
 
     private func handleImageEdits(_ request: HTTPRequest) async throws -> HTTPResponse {
         let imageRequest = try decoder.decode(OpenAIImageEditsRequest.self, from: request.body)
+        if let validationFailure = await endpointCompatibilityFailureResponse(
+            modelID: imageRequest.model,
+            endpoint: .imageEdit
+        ) {
+            return validationFailure
+        }
         let resolvedEditMode = resolvedImageEditMode(imageRequest.editMode)
         let sourceArtifactID = imageRequest.sourceArtifactID?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let promptDelta = imageRequest.promptDelta?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -1438,6 +1479,12 @@ public struct OpenAIHandler: Sendable {
             metricsStore: metricsStore,
             rescan: true
         )
+        if let validationFailure = await endpointCompatibilityFailureResponse(
+            modelID: normalized.model,
+            endpoint: .textGeneration
+        ) {
+            throw HTTPRequestHandlingError.gatewayResponse(validationFailure)
+        }
         let modelHandle: String
         do {
             modelHandle = try await OnDemandModelLoader.ensureTextModelReady(
@@ -1450,6 +1497,8 @@ public struct OpenAIHandler: Sendable {
             throw HTTPRequestHandlingError.modelRuntimeMissing
         } catch OnDemandModelLoadError.modelNotReady {
             throw HTTPRequestHandlingError.modelNotReady
+        } catch OnDemandModelLoadError.workerRejected(let error) {
+            throw HTTPRequestHandlingError.workerRejected(error)
         } catch OnDemandModelLoadError.workerUnavailable {
             throw HTTPRequestHandlingError.workerUnavailable
         } catch {
@@ -1657,6 +1706,10 @@ public struct OpenAIHandler: Sendable {
             )
         case .workerUnavailable:
             return workerUnavailableResponse()
+        case .workerRejected(let error):
+            return workerErrorResponse(error)
+        case .gatewayResponse(let response):
+            return response
         }
     }
 
@@ -1683,6 +1736,8 @@ public struct OpenAIHandler: Sendable {
             statusCode = 404
         case "cancelled":
             statusCode = 409
+        case "audio_processor_validation_failed":
+            statusCode = 409
         case "resource_exhausted":
             statusCode = 503
         case "deadline_exceeded":
@@ -1693,10 +1748,206 @@ public struct OpenAIHandler: Sendable {
             statusCode = 500
         }
 
+        var payloadError: [String: Any] = ["code": error.code, "message": error.message]
+        if !error.details.isEmpty {
+            payloadError["details"] = Dictionary(uniqueKeysWithValues: error.details.map { ($0.key, $0.value) })
+        }
         return jsonResponse(
             statusCode: statusCode,
-            payload: ["error": ["code": error.code, "message": error.message]]
+            payload: ["error": payloadError]
         )
+    }
+
+    private func endpointCompatibilityFailureResponse(
+        modelID: String,
+        endpoint: HTTPGatewayEndpointFamily
+    ) async -> HTTPResponse? {
+        guard let model = await modelCatalog.model(id: modelID) else {
+            return nil
+        }
+        if endpointSupportsModel(model, endpoint: endpoint) {
+            await metricsStore.set(1, forKey: "endpoint_type_validation_result")
+            return nil
+        }
+
+        await metricsStore.set(0, forKey: "endpoint_type_validation_result")
+        await metricsStore.increment("endpoint_type_validation_rejection_count")
+
+        let modelEndpoint = endpointFamilyHint(for: model)
+        let correctEndpoint = modelEndpoint?.suggestedEndpoint ?? "/v1/models"
+        let routeKind = modelRouteKind(for: model)?.metadataIdentifier ?? ""
+        let supportedTasks = normalizedIdentifierList(
+            model.supportedTasks,
+            fallback: model.settings.ext["melix.capability.supported_tasks"]
+        )
+        let message = if let modelEndpoint {
+            "Model \(modelID) is registered for \(modelEndpoint.displayName) and cannot serve \(endpoint.displayName) requests at \(endpoint.path). Use \(correctEndpoint) for this model."
+        } else {
+            "Model \(modelID) does not advertise support for \(endpoint.displayName) requests at \(endpoint.path). Inspect /v1/models for supported tasks before retrying."
+        }
+
+        return jsonResponse(
+            statusCode: 400,
+            payload: [
+                "error": [
+                    "code": "wrong_endpoint_for_model",
+                    "message": message,
+                    "model_id": modelID,
+                    "requested_endpoint": endpoint.path,
+                    "requested_endpoint_family": endpoint.rawValue,
+                    "model_endpoint_family": modelEndpoint?.rawValue ?? "unknown",
+                    "correct_endpoint": correctEndpoint,
+                    "route_kind": routeKind,
+                    "supported_tasks": supportedTasks,
+                ],
+            ]
+        )
+    }
+
+    private func endpointSupportsModel(
+        _ model: Melix_Controlplane_V1_ModelSummary,
+        endpoint: HTTPGatewayEndpointFamily
+    ) -> Bool {
+        let kind = normalizedIdentifier(model.kind)
+        let capability = model.capabilityClass
+        let capabilityIdentifier = normalizedIdentifier(model.settings.ext["melix.capability.class"])
+        let routeKind = modelRouteKind(for: model)
+        let tasks = Set(normalizedIdentifierList(
+            model.supportedTasks,
+            fallback: model.settings.ext["melix.capability.supported_tasks"]
+        ))
+
+        switch endpoint {
+        case .textGeneration:
+            return tasks.contains("generate")
+                || tasks.contains("ocr")
+                || tasks.contains("vlm")
+                || kind == "text"
+                || kind == "ocr"
+                || kind == "vlm"
+                || capability == .modelCapabilityText
+                || capability == .modelCapabilityOcr
+                || capability == .modelCapabilityVlm
+                || capabilityIdentifier == "text"
+                || capabilityIdentifier == "ocr"
+                || capabilityIdentifier == "vlm"
+                || routeKind == .swiftText
+                || routeKind == .pythonCompatibility
+                || routeKind == .pythonOCR
+                || routeKind == .pythonVLM
+        case .embedding:
+            return tasks.contains("embed")
+                || kind == "embedding"
+                || capability == .modelCapabilityEmbedding
+                || capabilityIdentifier == "embedding"
+                || routeKind == .pythonEmbedding
+        case .rerank:
+            return tasks.contains("rerank")
+                || kind == "rerank"
+                || capability == .modelCapabilityRerank
+                || capabilityIdentifier == "rerank"
+                || routeKind == .pythonRerank
+        case .transcription:
+            return tasks.contains("transcribe")
+                || kind == "transcription"
+                || capability == .modelCapabilityTranscription
+                || capabilityIdentifier == "transcription"
+                || routeKind == .pythonTranscription
+        case .speech:
+            return tasks.contains("speak")
+                || kind == "speech"
+                || capability == .modelCapabilitySpeech
+                || capabilityIdentifier == "speech"
+                || routeKind == .pythonSpeech
+        case .imageGeneration:
+            if explicitBool(model.settings.ext["melix.image.supports_generation"]) == false {
+                return false
+            }
+            return tasks.contains("image_generate")
+                || kind == "image"
+                || kind == "image_generation"
+                || capability == .modelCapabilityImageGeneration
+                || capabilityIdentifier == "image_generation"
+                || routeKind == .pythonImage
+        case .imageEdit:
+            if explicitBool(model.settings.ext["melix.image.supports_edit"]) == false {
+                return false
+            }
+            return tasks.contains("image_edit")
+                || kind == "image"
+                || kind == "image_generation"
+                || capability == .modelCapabilityImageGeneration
+                || capabilityIdentifier == "image_generation"
+                || routeKind == .pythonImage
+        }
+    }
+
+    private func endpointFamilyHint(
+        for model: Melix_Controlplane_V1_ModelSummary
+    ) -> HTTPGatewayEndpointFamily? {
+        if endpointSupportsModel(model, endpoint: .embedding) {
+            return .embedding
+        }
+        if endpointSupportsModel(model, endpoint: .rerank) {
+            return .rerank
+        }
+        if endpointSupportsModel(model, endpoint: .transcription) {
+            return .transcription
+        }
+        if endpointSupportsModel(model, endpoint: .speech) {
+            return .speech
+        }
+        if endpointSupportsModel(model, endpoint: .imageGeneration) {
+            return .imageGeneration
+        }
+        if endpointSupportsModel(model, endpoint: .imageEdit) {
+            return .imageEdit
+        }
+        if endpointSupportsModel(model, endpoint: .textGeneration) {
+            return .textGeneration
+        }
+        return nil
+    }
+
+    private func modelRouteKind(
+        for model: Melix_Controlplane_V1_ModelSummary
+    ) -> WorkerRouteKind? {
+        if let route = WorkerRouteKind(routeClass: model.routeClass) {
+            return route
+        }
+        if let route = WorkerRouteKind(metadataIdentifier: model.settings.ext["melix.capability.route_kind"]) {
+            return route
+        }
+        return WorkerRouteKind(capabilityIdentifier: model.settings.ext["melix.capability.class"])
+    }
+
+    private func normalizedIdentifierList(
+        _ values: [String],
+        fallback: String?
+    ) -> [String] {
+        let identifiers = values.map(normalizedIdentifier).filter { !$0.isEmpty }
+        guard identifiers.isEmpty, let fallback else {
+            return identifiers
+        }
+        return fallback
+            .split(separator: ",")
+            .map { normalizedIdentifier(String($0)) }
+            .filter { !$0.isEmpty }
+    }
+
+    private func normalizedIdentifier(_ value: String?) -> String {
+        (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private func explicitBool(_ value: String?) -> Bool? {
+        switch normalizedIdentifier(value) {
+        case "true", "1", "yes", "on":
+            return true
+        case "false", "0", "no", "off":
+            return false
+        default:
+            return nil
+        }
     }
 
     private func audioReadinessFailureResponse(for modelID: String) async -> HTTPResponse? {
@@ -2560,6 +2811,60 @@ private enum HTTPRequestHandlingError: Error {
     case modelNotReady
     case modelRuntimeMissing
     case workerUnavailable
+    case workerRejected(Melix_Worker_V1_ErrorStatus)
+    case gatewayResponse(HTTPResponse)
+}
+
+private enum HTTPGatewayEndpointFamily: String {
+    case textGeneration = "text_generation"
+    case embedding
+    case rerank
+    case transcription
+    case speech
+    case imageGeneration = "image_generation"
+    case imageEdit = "image_edit"
+
+    var displayName: String {
+        switch self {
+        case .textGeneration:
+            return "text generation"
+        case .embedding:
+            return "embedding"
+        case .rerank:
+            return "rerank"
+        case .transcription:
+            return "audio transcription"
+        case .speech:
+            return "audio speech"
+        case .imageGeneration:
+            return "image generation"
+        case .imageEdit:
+            return "image edit"
+        }
+    }
+
+    var path: String {
+        switch self {
+        case .textGeneration:
+            return "/v1/chat/completions"
+        case .embedding:
+            return "/v1/embeddings"
+        case .rerank:
+            return "/v1/rerank"
+        case .transcription:
+            return "/v1/audio/transcriptions"
+        case .speech:
+            return "/v1/audio/speech"
+        case .imageGeneration:
+            return "/v1/images/generations"
+        case .imageEdit:
+            return "/v1/images/edits"
+        }
+    }
+
+    var suggestedEndpoint: String {
+        path
+    }
 }
 
 private struct HealthResponse: Codable {

--- a/services/control-plane-swift/Sources/WorkerClient/OnDemandModelLoader.swift
+++ b/services/control-plane-swift/Sources/WorkerClient/OnDemandModelLoader.swift
@@ -2,10 +2,26 @@ import Foundation
 import MelixControlPlaneProtocol
 import MelixWorkerProtocol
 
-enum OnDemandModelLoadError: Error {
+enum OnDemandModelLoadError: Error, Equatable {
     case modelNotReady
     case runtimeCacheMissing
+    case workerRejected(Melix_Worker_V1_ErrorStatus)
     case workerUnavailable
+
+    static func == (lhs: OnDemandModelLoadError, rhs: OnDemandModelLoadError) -> Bool {
+        switch (lhs, rhs) {
+        case (.modelNotReady, .modelNotReady),
+             (.runtimeCacheMissing, .runtimeCacheMissing),
+             (.workerUnavailable, .workerUnavailable):
+            return true
+        case (.workerRejected(let lhsError), .workerRejected(let rhsError)):
+            return lhsError.code == rhsError.code
+                && lhsError.message == rhsError.message
+                && lhsError.details == rhsError.details
+        default:
+            return false
+        }
+    }
 }
 
 enum OnDemandModelLoader {
@@ -112,6 +128,9 @@ enum OnDemandModelLoader {
                 reason: failureReason,
                 memoryBudgetEvidence: memoryBudgetEvidence
             )
+            if response.error.code == "audio_processor_validation_failed" {
+                throw OnDemandModelLoadError.workerRejected(response.error)
+            }
             throw OnDemandModelLoadError.workerUnavailable
         }
 

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -297,6 +297,62 @@ struct OpenAIHandlerTests {
         #expect(authorized.statusCode == 200)
     }
 
+    @Test("shared API-key policy gates every operator-facing route except health")
+    func sharedAPIKeyPolicyGatesEveryOperatorFacingRouteExceptHealth() async throws {
+        let metricsStore = MetricsStore()
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: ModelCatalog.phaseSevenContractSeedModels()),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
+                abortRegistry: AbortRegistry()
+            ),
+            metricsStore: metricsStore,
+            gatewayAccessPolicy: GatewayAccessPolicy(
+                mode: .apiKeys,
+                sharedAccessEnabled: true,
+                keys: [
+                    .init(keyID: "operator", label: "Operator", tokenHint: "operator", token: "sk-operator"),
+                ]
+            )
+        )
+        let operatorRoutes: [(HTTPMethod, String, String, Bool)] = [
+            (.get, "/v1/models", "missing_api_key", true),
+            (.get, "/v1/cache/stats", "missing_api_key", true),
+            (.post, "/v1/melix/auth/session", "missing_api_key", true),
+            (.get, "/v1/melix/auth/session", "missing_session", false),
+            (.delete, "/v1/melix/auth/session", "missing_session", false),
+            (.post, "/v1/chat/completions", "missing_api_key", true),
+            (.post, "/v1/completions", "missing_api_key", true),
+            (.post, "/v1/responses", "missing_api_key", true),
+            (.post, "/v1/messages", "missing_api_key", true),
+            (.post, "/v1/embeddings", "missing_api_key", true),
+            (.post, "/v1/rerank", "missing_api_key", true),
+            (.post, "/v1/audio/transcriptions", "missing_api_key", true),
+            (.post, "/v1/audio/speech", "missing_api_key", true),
+            (.post, "/v1/images/generations", "missing_api_key", true),
+            (.post, "/v1/images/edits", "missing_api_key", true),
+            (.get, "/v1/unknown", "missing_api_key", true),
+        ]
+
+        for (method, path, expectedErrorCode, _) in operatorRoutes {
+            let response = try await handler.handle(
+                HTTPRequest(method: method, path: path, headers: [:], body: Data("{}".utf8))
+            )
+            let payload = try await jsonObject(from: response.body)
+            #expect(response.statusCode == 401)
+            #expect(payload.errorCode == expectedErrorCode)
+        }
+
+        let health = try await handler.handle(
+            HTTPRequest(method: .get, path: "/health", headers: [:], body: Data())
+        )
+
+        let gatewayPolicyFailures = operatorRoutes.filter(\.3).count
+        #expect(health.statusCode == 200)
+        #expect(await metricsStore.value(forKey: "gateway.auth_validation_failures") == Double(gatewayPolicyFailures))
+        #expect(await metricsStore.value(forKey: "route_auth_policy") == 2)
+    }
+
     @Test("gateway auth sessions can be created reused and revoked")
     func gatewayAuthSessionsCanBeCreatedReusedAndRevoked() async throws {
         let metricsStore = MetricsStore()
@@ -2964,6 +3020,81 @@ struct OpenAIHandlerTests {
         #expect(body.contains("\"melix_state\":\"unknown\""))
     }
 
+    @Test("wrong endpoint requests return actionable 400 diagnostics before worker dispatch")
+    func wrongEndpointRequestsReturnActionableDiagnosticsBeforeWorkerDispatch() async throws {
+        let textClient = ScriptedWorkerClient(events: [])
+        let nonTextClient = ScriptedPhaseFiveWorkerClient()
+        let metricsStore = MetricsStore()
+        let catalog = ModelCatalog(seedModels: ModelCatalog.phaseSevenContractSeedModels())
+        let handler = OpenAIHandler(
+            modelCatalog: catalog,
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: textClient),
+                abortRegistry: AbortRegistry()
+            ),
+            workerRegistry: WorkerRegistry(
+                defaultTextClient: textClient,
+                pythonCompatibilityClient: nonTextClient,
+                embeddingClient: nonTextClient,
+                rerankClient: nonTextClient,
+                modelCatalog: catalog
+            ),
+            metricsStore: metricsStore
+        )
+        let cases: [(HTTPMethod, String, String, String)] = [
+            (
+                .post,
+                "/v1/chat/completions",
+                #"{"model":"melix-dev-transcribe","stream":true,"messages":[{"role":"user","content":"hello"}]}"#,
+                "/v1/audio/transcriptions"
+            ),
+            (.post, "/v1/embeddings", #"{"model":"melix-dev-speech","input":"hello"}"#, "/v1/audio/speech"),
+            (
+                .post,
+                "/v1/rerank",
+                #"{"model":"melix-dev-embed","query":"q","documents":["a"],"top_k":1}"#,
+                "/v1/embeddings"
+            ),
+            (
+                .post,
+                "/v1/audio/transcriptions",
+                #"{"model":"melix-dev-text","audio_base64":"aGVsbG8="}"#,
+                "/v1/chat/completions"
+            ),
+            (.post, "/v1/audio/speech", #"{"model":"melix-dev-transcribe","input":"hello"}"#, "/v1/audio/transcriptions"),
+            (.post, "/v1/images/generations", #"{"model":"melix-dev-rerank","prompt":"draw"}"#, "/v1/rerank"),
+            (.post, "/v1/images/edits", #"{"model":"melix-dev-text","prompt":"edit"}"#, "/v1/chat/completions"),
+        ]
+
+        for (method, path, rawBody, expectedEndpoint) in cases {
+            let response = try await handler.handle(
+                HTTPRequest(
+                    method: method,
+                    path: path,
+                    headers: [:],
+                    body: Data(rawBody.utf8)
+                )
+            )
+            let payload = try await jsonPayload(from: response.body)
+            let error = try #require(payload["error"] as? [String: Any])
+
+            #expect(response.statusCode == 400)
+            #expect(error["code"] as? String == "wrong_endpoint_for_model")
+            #expect(error["correct_endpoint"] as? String == expectedEndpoint)
+            #expect((error["message"] as? String ?? "").contains(expectedEndpoint))
+        }
+
+        #expect(await textClient.lastGenerateRequest == nil)
+        #expect(await nonTextClient.lastEmbedRequest == nil)
+        #expect(await nonTextClient.lastRerankRequest == nil)
+        #expect(await nonTextClient.lastTranscribeRequest == nil)
+        #expect(await nonTextClient.lastSpeakRequest == nil)
+        #expect(await nonTextClient.lastImageGenerateRequest == nil)
+        #expect(await nonTextClient.lastImageEditRequest == nil)
+        #expect(await metricsStore.value(forKey: "endpoint_type_validation_result") == 0)
+        #expect(await metricsStore.value(forKey: "endpoint_type_validation_rejection_count") == Double(cases.count))
+    }
+
     @Test("POST /v1/embeddings routes to the embedding worker and returns JSON")
     func postEmbeddingsRoutesAndReturnsJSON() async throws {
         let textClient = ScriptedWorkerClient(events: [])
@@ -4247,6 +4378,79 @@ struct OpenAIHandlerTests {
         #expect(response.statusCode == 409)
         #expect(payload.contains("\"code\":\"audio_model_download_required\""))
         #expect(payload.contains("\"model_id\":\"melix-kokoro-mlx\""))
+        #expect(await audioClient.lastSpeakRequest == nil)
+    }
+
+    @Test("POST /v1/audio/speech propagates missing processor asset diagnostics from first load")
+    func postAudioSpeechPropagatesMissingProcessorAssetDiagnosticsFromFirstLoad() async throws {
+        let textClient = ScriptedWorkerClient(events: [])
+        let audioClient = ScriptedPhaseFiveWorkerClient()
+        var loadFailure = Melix_Worker_V1_LoadModelResponse()
+        loadFailure.ok = false
+        loadFailure.error.code = "audio_processor_validation_failed"
+        loadFailure.error.message = "Audio model melix-kokoro-mlx is missing required processor_config processor assets before load_model:processor_asset_preflight."
+        loadFailure.error.details = [
+            "missing_asset_class": "processor_config",
+            "load_stage": "load_model:processor_asset_preflight",
+            "audio_processor_validation_result": "0",
+        ]
+        await audioClient.setLoadModelResponse(loadFailure)
+
+        let appSupportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-http-audio-processor-\(UUID().uuidString)", isDirectory: true)
+        let managedModelPath = appSupportDirectory
+            .appendingPathComponent("managed/kokoro", isDirectory: true)
+            .path
+        let assetManager = AudioAssetManager(appSupportDirectory: appSupportDirectory)
+        try assetManager.recordRuntimePackInstall(
+            packID: "melix-audio-runtime-pack",
+            version: "0.3.0",
+            profiles: ["audio-tts"]
+        )
+        try assetManager.recordManagedModel(
+            modelID: "melix-kokoro-mlx",
+            revision: "mlx-audio",
+            sourceModelPath: "mlx-community/Kokoro-82M-bf16",
+            localModelPath: managedModelPath
+        )
+
+        let catalog = ModelCatalog(seedModels: [ModelCatalog.mlxKokoroModel()])
+        let handler = OpenAIHandler(
+            modelCatalog: catalog,
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: textClient),
+                abortRegistry: AbortRegistry()
+            ),
+            workerRegistry: WorkerRegistry(
+                defaultTextClient: textClient,
+                pythonCompatibilityClient: audioClient,
+                modelCatalog: catalog
+            ),
+            audioAssetManager: assetManager
+        )
+        let body = try #require(
+            """
+            {
+              "model": "melix-kokoro-mlx",
+              "input": "hello speech",
+              "format": "wav"
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(method: .post, path: "/v1/audio/speech", headers: [:], body: body)
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let error = try #require(payload["error"] as? [String: Any])
+        let details = try #require(error["details"] as? [String: Any])
+
+        #expect(response.statusCode == 409)
+        #expect(error["code"] as? String == "audio_processor_validation_failed")
+        #expect(details["missing_asset_class"] as? String == "processor_config")
+        #expect(details["load_stage"] as? String == "load_model:processor_asset_preflight")
+        #expect(details["audio_processor_validation_result"] as? String == "0")
+        #expect(await audioClient.lastLoadModelRequest != nil)
         #expect(await audioClient.lastSpeakRequest == nil)
     }
 
@@ -6676,6 +6880,7 @@ private actor ScriptedPhaseFiveWorkerClient:
     private var imageGenerateResponse = Melix_Worker_V1_ImageGenerateResponse()
     private var imageEditResponse = Melix_Worker_V1_ImageEditResponse()
     private var runtimeStatsResponse = Melix_Worker_V1_GetRuntimeStatsResponse()
+    private var loadModelResponseOverride: Melix_Worker_V1_LoadModelResponse?
     private var thrownFailure: Error?
 
     func setEmbedResponse(_ response: Melix_Worker_V1_EmbedResponse) {
@@ -6706,6 +6911,10 @@ private actor ScriptedPhaseFiveWorkerClient:
         runtimeStatsResponse = response
     }
 
+    func setLoadModelResponse(_ response: Melix_Worker_V1_LoadModelResponse) {
+        loadModelResponseOverride = response
+    }
+
     func setThrownFailure(_ failure: Error?) {
         thrownFailure = failure
     }
@@ -6730,6 +6939,9 @@ private actor ScriptedPhaseFiveWorkerClient:
         request: Melix_Worker_V1_LoadModelRequest
     ) async throws -> Melix_Worker_V1_LoadModelResponse {
         lastLoadModelRequest = request
+        if let loadModelResponseOverride {
+            return loadModelResponseOverride
+        }
         var response = Melix_Worker_V1_LoadModelResponse()
         response.ok = true
         response.modelHandle = "\(request.model.modelID)::python"

--- a/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
@@ -6,8 +6,10 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
-from packages.protocol.python.worker.v1 import inference_pb2
+from packages.protocol.python.worker.v1 import inference_pb2, runtime_pb2
+from worker.grpc_server import WorkerRuntimeService
 from worker.model_registry.catalog import WorkerModelCatalog
+from worker.registry import WorkerRegistry
 
 
 def _install_fake_mlx_audio(
@@ -203,3 +205,85 @@ def test_mlx_audio_speech_runtime_falls_back_to_voice_descriptor_only_for_instru
         }
     ]
     assert probe.voice_fallback_count == 1
+
+
+@pytest.mark.parametrize(
+    ("builder", "runtime_class_name", "backend_id"),
+    [
+        (WorkerModelCatalog.mlx_whisper_model, "MLXAudioTranscriptionRuntime", "mlx_audio.stt"),
+        (WorkerModelCatalog.mlx_kokoro_model, "MLXAudioSpeechRuntime", "mlx_audio.tts"),
+    ],
+)
+def test_mlx_audio_runtimes_reject_local_models_missing_processor_assets(
+    tmp_path: Path,
+    builder,
+    runtime_class_name: str,
+    backend_id: str,
+) -> None:
+    import worker.runtime.mlx_audio_runtime as mlx_audio_runtime
+    from worker.runtime.audio_runtime_protocols import AudioProcessorValidationError
+
+    model_dir = tmp_path / "managed-audio-model"
+    model_dir.mkdir()
+    model_spec = builder()
+    model_spec.model_path = str(model_dir)
+    runtime = getattr(mlx_audio_runtime, runtime_class_name)()
+
+    with pytest.raises(AudioProcessorValidationError) as error:
+        runtime.load_model(model_spec)
+
+    assert error.value.details["backend_id"] == backend_id
+    assert error.value.details["missing_asset_class"] == "processor_config"
+    assert error.value.details["load_stage"] == "load_model:processor_asset_preflight"
+    assert error.value.details["audio_processor_validation_result"] == "0"
+    assert "processor_config.json" in error.value.details["required_files"]
+
+
+def test_mlx_audio_processor_validation_accepts_local_processor_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from worker.runtime.mlx_audio_runtime import MLXAudioTranscriptionRuntime
+
+    model_dir = tmp_path / "managed-whisper"
+    model_dir.mkdir()
+    (model_dir / "preprocessor_config.json").write_text("{}", encoding="utf-8")
+    captured_paths: list[str] = []
+
+    class FakeSTTModel:
+        def generate(self, audio_path: str, **kwargs):
+            _ = audio_path
+            _ = kwargs
+            return SimpleNamespace(text="ok", language="en", total_time=1.0)
+
+    def fake_load_model(model_path: str):
+        captured_paths.append(model_path)
+        return FakeSTTModel()
+
+    _install_fake_mlx_audio(monkeypatch, stt_loader=fake_load_model)
+    model_spec = WorkerModelCatalog.mlx_whisper_model()
+    model_spec.model_path = str(model_dir)
+
+    loaded = MLXAudioTranscriptionRuntime().load_model(model_spec)
+
+    assert loaded.backend_id == "mlx_audio.stt"
+    assert captured_paths == [str(model_dir)]
+
+
+def test_worker_load_model_returns_actionable_audio_processor_validation_error(tmp_path: Path) -> None:
+    model_dir = tmp_path / "managed-whisper"
+    model_dir.mkdir()
+    model_spec = WorkerModelCatalog.mlx_whisper_model()
+    model_spec.model_path = str(model_dir)
+    service = WorkerRuntimeService(WorkerRegistry(model_catalog=WorkerModelCatalog()))
+
+    response = service.LoadModel(
+        runtime_pb2.LoadModelRequest(model=model_spec),
+        context=None,
+    )
+
+    assert response.ok is False
+    assert response.error.code == "audio_processor_validation_failed"
+    assert response.error.details["missing_asset_class"] == "processor_config"
+    assert response.error.details["load_stage"] == "load_model:processor_asset_preflight"
+    assert response.error.details["audio_processor_validation_result"] == "0"

--- a/services/mlx-worker-python/worker/grpc_server.py
+++ b/services/mlx-worker-python/worker/grpc_server.py
@@ -47,7 +47,7 @@ from worker.productization.evaluation_final_result import (
     materialize_local_evaluation_dataset,
 )
 from worker.registry import DiskStreamingUnsupported, MemoryBudgetExceeded, WorkerRegistry
-from worker.runtime.audio_runtime_protocols import AudioBackendUnavailableError
+from worker.runtime.audio_runtime_protocols import AudioBackendUnavailableError, AudioProcessorValidationError
 from worker.runtime.deterministic_embedding_runtime import DeterministicEmbeddingRuntime
 from worker.runtime.deterministic_backend import DeterministicTextBackend
 from worker.runtime.deterministic_rerank_runtime import DeterministicRerankRuntime
@@ -147,6 +147,15 @@ class WorkerRuntimeService(runtime_pb2_grpc.RuntimeServiceServicer):
             return runtime_pb2.LoadModelResponse(
                 ok=False,
                 error=common_pb2.ErrorStatus(code="unavailable", message=str(exc)),
+            )
+        except AudioProcessorValidationError as exc:
+            return runtime_pb2.LoadModelResponse(
+                ok=False,
+                error=common_pb2.ErrorStatus(
+                    code="audio_processor_validation_failed",
+                    message=str(exc),
+                    details=exc.details,
+                ),
             )
         except Exception as exc:
             is_real_audio_backend = (

--- a/services/mlx-worker-python/worker/runtime/audio_runtime_protocols.py
+++ b/services/mlx-worker-python/worker/runtime/audio_runtime_protocols.py
@@ -9,6 +9,39 @@ class AudioBackendUnavailableError(RuntimeError):
 
 
 @dataclass(frozen=True)
+class AudioProcessorValidationError(RuntimeError):
+    model_id: str
+    model_path: str
+    backend_id: str
+    family_id: str
+    missing_asset_class: str
+    load_stage: str
+    required_files: tuple[str, ...]
+
+    def __str__(self) -> str:
+        required = ", ".join(self.required_files)
+        return (
+            f"Audio model {self.model_id} is missing required {self.missing_asset_class} "
+            f"processor assets before {self.load_stage}. Expected one of: {required}. "
+            "Reinstall or redownload the managed audio model before retrying."
+        )
+
+    @property
+    def details(self) -> dict[str, str]:
+        return {
+            "model_id": self.model_id,
+            "model_path": self.model_path,
+            "backend_id": self.backend_id,
+            "family_id": self.family_id,
+            "missing_asset_class": self.missing_asset_class,
+            "load_stage": self.load_stage,
+            "required_files": ",".join(self.required_files),
+            "required_action": "redownload_audio_model",
+            "audio_processor_validation_result": "0",
+        }
+
+
+@dataclass(frozen=True)
 class AudioRuntimeLoadedModel:
     backend_id: str
     family_id: str

--- a/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
@@ -12,9 +12,17 @@ import wave
 from worker.runtime.audio_preprocessing import prepare_audio_input
 from worker.runtime.audio_runtime_protocols import (
     AudioBackendUnavailableError,
+    AudioProcessorValidationError,
     AudioRuntimeLoadedModel,
     SpeechResult,
     TranscriptionResult,
+)
+
+
+_AUDIO_PROCESSOR_CONFIG_FILES = (
+    "processor_config.json",
+    "preprocessor_config.json",
+    "feature_extractor_config.json",
 )
 
 
@@ -68,6 +76,28 @@ def _voice_metadata_for_model(model) -> dict[str, object]:
     return {}
 
 
+def _validate_local_audio_processor_assets(model_spec, *, backend_id: str, load_stage: str) -> None:
+    model_path = str(getattr(model_spec, "model_path", "") or "").strip()
+    if not model_path:
+        return
+    model_dir = Path(model_path).expanduser()
+    if not model_dir.exists():
+        return
+    if model_dir.is_file():
+        model_dir = model_dir.parent
+    if any((model_dir / file_name).is_file() for file_name in _AUDIO_PROCESSOR_CONFIG_FILES):
+        return
+    raise AudioProcessorValidationError(
+        model_id=str(getattr(model_spec, "model_id", "") or ""),
+        model_path=str(model_dir),
+        backend_id=backend_id,
+        family_id=str(getattr(model_spec, "ext", {}).get("melix.audio.family_id", "unknown") or "unknown"),
+        missing_asset_class="processor_config",
+        load_stage=load_stage,
+        required_files=_AUDIO_PROCESSOR_CONFIG_FILES,
+    )
+
+
 @dataclass(frozen=True)
 class MLXAudioTranscriptionProbeSnapshot:
     preprocess_latency_ms: float
@@ -96,6 +126,12 @@ class MLXAudioTranscriptionRuntime:
 
     def load_model(self, model_spec) -> AudioRuntimeLoadedModel:
         started_at = perf_counter()
+        backend_id = model_spec.ext.get("melix.audio.backend_id", "mlx_audio.stt") or "mlx_audio.stt"
+        _validate_local_audio_processor_assets(
+            model_spec,
+            backend_id=backend_id,
+            load_stage="load_model:processor_asset_preflight",
+        )
         try:
             from mlx_audio.stt.utils import load_model
         except ImportError as exc:  # pragma: no cover - environment dependent
@@ -105,7 +141,7 @@ class MLXAudioTranscriptionRuntime:
 
         model = load_model(model_spec.model_path)
         return AudioRuntimeLoadedModel(
-            backend_id=model_spec.ext.get("melix.audio.backend_id", "mlx_audio.stt") or "mlx_audio.stt",
+            backend_id=backend_id,
             family_id=model_spec.ext.get("melix.audio.family_id", "unknown") or "unknown",
             runtime_name=self.runtime_name,
             model=model,
@@ -181,6 +217,12 @@ class MLXAudioSpeechRuntime:
 
     def load_model(self, model_spec) -> AudioRuntimeLoadedModel:
         started_at = perf_counter()
+        backend_id = model_spec.ext.get("melix.audio.backend_id", "mlx_audio.tts") or "mlx_audio.tts"
+        _validate_local_audio_processor_assets(
+            model_spec,
+            backend_id=backend_id,
+            load_stage="load_model:processor_asset_preflight",
+        )
         try:
             from mlx_audio.tts.utils import load_model
         except ImportError as exc:  # pragma: no cover - environment dependent
@@ -204,7 +246,7 @@ class MLXAudioSpeechRuntime:
             voice_mode = "named"
 
         return AudioRuntimeLoadedModel(
-            backend_id=model_spec.ext.get("melix.audio.backend_id", "mlx_audio.tts") or "mlx_audio.tts",
+            backend_id=backend_id,
             family_id=model_spec.ext.get("melix.audio.family_id", "unknown") or "unknown",
             runtime_name=self.runtime_name,
             model=model,

--- a/tests/integration/test_image_endpoints.py
+++ b/tests/integration/test_image_endpoints.py
@@ -216,4 +216,6 @@ def test_image_edit_endpoint_supports_fill_override_and_generation_rejects_edit_
 
     assert edit_payload["job"]["state"] == "completed"
     assert edit_payload["job"]["artifacts"][0]["role"] == "edit_source"
-    assert failure_payload["error"]["message"].startswith("Image model melix-dev-image does not support generation workflows")
+    assert failure_payload["error"]["message"].startswith(
+        "Model melix-dev-image is registered for image edit and cannot serve image generation requests"
+    )


### PR DESCRIPTION
## Summary
- Enforce shared-access auth on every operator-facing non-health gateway route.
- Reject endpoint/model family mismatches before worker dispatch with structured 400 diagnostics.
- Add first-load MLX audio processor asset validation and propagate missing-asset details through worker and gateway evidence.

## Plan or Spec
- `docs/plans/2026-05-03-issue-77-non-text-auth-and-audio-diagnostics.md`
- Closes #77

## Commands Run
```text
make bootstrap — passed
make proto — passed
make swift-test — failed twice in the aggregate command at the final macOS menu bar summary with 1 issue
/bin/zsh -lc 'HOME="/Users/ChenYu/Documents/Github/melix/.swift-home/macos-menubar" CLANG_MODULE_CACHE_PATH="/Users/ChenYu/Documents/Github/melix/.build/ModuleCache.noindex/macos-menubar" xcrun swift test --package-path apps/macos-menubar --filter AppMainBootstrapTests' — passed, 40 tests
/bin/zsh -lc 'HOME="/Users/ChenYu/Documents/Github/melix/.swift-home/macos-menubar" CLANG_MODULE_CACHE_PATH="/Users/ChenYu/Documents/Github/melix/.build/ModuleCache.noindex/macos-menubar" xcrun swift test --package-path apps/macos-menubar' — passed, 530 tests
make py-test — passed, 1518 passed, 5 skipped
make integration-test — failed first with 2 related integration assertions, then passed after fixes: 86 passed, 1 skipped
PYTHONPATH="/Users/ChenYu/Documents/Github/melix:/Users/ChenYu/Documents/Github/melix/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest tests/integration/test_image_endpoints.py::test_image_edit_endpoint_supports_fill_override_and_generation_rejects_edit_only_families tests/integration/test_m17_speech_runtime_smoke.py::test_m17_speech_runtime_smoke_records_live_audio_operator_evidence -q — passed, 2 tests
git diff --check — passed
git diff --cached --check — passed
```

## Coverage and Metrics
- Route auth parity fixture covers 16 non-health operator routes; `/health` remains open.
- Wrong-endpoint fixture covers 7 rejected endpoint/model pairs and confirms no worker dispatch.
- Audio processor fixture covers both `mlx_audio.stt` and `mlx_audio.tts` missing processor configs.
- M17 speech runtime smoke fixture now includes fake local `preprocessor_config.json` assets so the live-path smoke still exercises successful processor preflight.
- Coverage percentage: N/A because the changed-scope commands available in this workflow do not emit line coverage; regression counts above and the plan metrics report provide measured evidence.

## Known Gaps
- Aggregate `make swift-test` remains non-passing in this local environment when all Swift segments run before the macOS menu bar package. The isolated failing suite (`AppMainBootstrapTests`) passed with 40 tests, and the full menu bar package passed with 530 tests.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A because no protobuf schema changed.
- [x] Dependency changes include updated lockfiles, or N/A because no dependency changed.
- [x] Relevant tests were run.
- [x] A metrics report is included, or N/A is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
