### PR TITLE
perf: elide plain-local manifest stats in model registry

### DIFF
--- a/docs/plans/2026-05-02-model-registry-manifest-stat-elision.md
+++ b/docs/plans/2026-05-02-model-registry-manifest-stat-elision.md
@@ -1,0 +1,53 @@
+# Model registry plain-local manifest stat elision
+
+## Goal
+
+Remove redundant `manifest.json` filesystem checks from the plain-local model scan path in `services/mlx-worker-python/worker/model_registry/catalog.py` while preserving model discovery behavior.
+
+## Why this slice
+
+The registry root tree scanner already classifies directories with `manifest.json` into the manifest path list before `_scan_raw_model_directories(...)` processes plain-local model directories. The later `Path.is_file()` check for `resolved_path / "manifest.json"` repeats work that the earlier scan already resolved.
+
+## Linux-only constraint
+
+This cron run is on Linux, so the slice must stay inside Python paths that can be verified locally with focused pytest, changed-scope coverage, and a local performance probe. No macOS-only validation is required for the implementation itself.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/model_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_model_registry_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Implementation tasks
+
+1. Add a focused regression test that proves `registry_snapshot()` no longer calls `Path.is_file()` on `plain-model/manifest.json` for directories already classified by the root tree scanner.
+2. Remove the redundant `manifest.json` check from `_scan_raw_model_directories(...)`.
+3. Register a PR-scoped performance probe for the model-registry catalog path so CI can re-measure the slice on future changes.
+4. Add focused PR-scoped-performance tests that select and validate the new probe registration.
+
+## Performance probe
+
+### Probe name
+
+`model-registry-plain-local-manifest-stat-elision`
+
+### Probe workload
+
+- Build a synthetic registry root with many plain-local model directories.
+- Run `WorkerModelCatalog.registry_snapshot(rescan=True)` multiple times.
+- Track how many `manifest.json` `Path.is_file()` checks occur on the plain-local directories.
+- Record elapsed milliseconds.
+
+### Success metrics
+
+- `manifest_is_file_calls_mean` should drop materially versus `origin/main`.
+- `elapsed_ms_mean` should not regress meaningfully and ideally improves.
+- Model IDs discovered by the probe workload must remain identical.
+
+## Verification commands
+
+- Focused pytest for the model-registry catalog and PR-scoped-performance tests.
+- Changed-scope coverage report from `coverage.json` using `scripts/changed_scope_coverage.py`.
+- Local explicit probe run for the model-registry catalog workload.
+- `git diff --check`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -725,6 +725,36 @@
     ]
   },
   {
+    "id": "model-registry-plain-local-manifest-stat-elision",
+    "name": "Model registry plain-local manifest stat elision",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_registry/catalog.py",
+      "services/mlx-worker-python/tests/test_model_registry_catalog.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_root_tree_records_plain_local_weight_presence_during_single_scandir_pass services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_reuses_plain_local_tree_scan_and_config_payload services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_does_not_stat_plain_local_manifest_after_tree_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_registry_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_registry_catalog_probe_command_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_root_tree_records_plain_local_weight_presence_during_single_scandir_pass services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_reuses_plain_local_tree_scan_and_config_payload services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_does_not_stat_plain_local_manifest_after_tree_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_registry_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_registry_catalog_probe_command_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_registry/catalog.py services/mlx-worker-python/tests/test_model_registry_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -lc 'python3 - <<\"PY\"\nimport json\nimport statistics\nimport tempfile\nimport time\nfrom pathlib import Path\n\nfrom worker.model_registry.catalog import WorkerModelCatalog\n\noriginal_is_file = Path.is_file\nmodel_count = 800\nsample_count = 3\nelapsed_samples = []\nmanifest_stat_samples = []\ndiscovered_counts = []\n\nwith tempfile.TemporaryDirectory() as tmpdir:\n    root = Path(tmpdir) / \"registry\"\n    root.mkdir()\n    probe_paths = set()\n    for index in range(model_count):\n        model_dir = root / f\"model-{index:04d}\"\n        model_dir.mkdir(parents=True, exist_ok=True)\n        (model_dir / \"config.json\").write_text(\n            json.dumps({\"model_type\": \"qwen3\", \"architectures\": [\"Qwen3ForCausalLM\"], \"library_name\": \"mlx\"}) + \"\\n\",\n            encoding=\"utf-8\",\n        )\n        (model_dir / \"weights.safetensors\").write_bytes(b\"0\")\n        probe_paths.add((model_dir / \"manifest.json\").resolve())\n\n    env = {\"MELIX_MODEL_ROOTS\": str(root), \"HOME\": str(Path(tmpdir) / \"home\")}\n    catalog = WorkerModelCatalog(environment=env)\n\n    for _ in range(sample_count):\n        counter = {\"count\": 0}\n\n        def tracked_is_file(self):\n            if self.resolve() in probe_paths:\n                counter[\"count\"] += 1\n            return original_is_file(self)\n\n        Path.is_file = tracked_is_file\n        try:\n            started = time.perf_counter()\n            snapshot = catalog.registry_snapshot(rescan=True)\n            elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n            manifest_stat_samples.append(float(counter[\"count\"]))\n            discovered_counts.append(float(len(snapshot.models)))\n        finally:\n            Path.is_file = original_is_file\n\nprint(json.dumps({\n    \"elapsed_ms_mean\": round(statistics.fmean(elapsed_samples), 6),\n    \"manifest_is_file_calls_mean\": round(statistics.fmean(manifest_stat_samples), 6),\n    \"model_count\": float(model_count),\n    \"sample_count\": float(sample_count),\n    \"discovered_model_count_mean\": round(statistics.fmean(discovered_counts), 6),\n}, sort_keys=True))\nPY'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "manifest_is_file_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "swift-cli-json-envelope-encoding",
     "name": "Swift CLI JSON envelope encoding",
     "runner": "macos-15",

--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -879,6 +879,44 @@ def test_registry_snapshot_reuses_plain_local_tree_scan_and_config_payload(
 
 
 
+def test_registry_snapshot_does_not_stat_plain_local_manifest_after_tree_scan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    model_dir = root / "plain-model"
+    manifest_probe = (model_dir / "manifest.json").resolve()
+    _write_model_config(
+        model_dir,
+        {
+            "model_type": "qwen3",
+            "architectures": ["Qwen3ForCausalLM"],
+            "library_name": "mlx",
+        },
+    )
+    _write_weights(model_dir)
+
+    original_is_file = Path.is_file
+    manifest_probe_calls = 0
+
+    def tracking_is_file(self: Path) -> bool:
+        nonlocal manifest_probe_calls
+        if self.resolve() == manifest_probe:
+            manifest_probe_calls += 1
+        return original_is_file(self)
+
+    assert tracking_is_file(manifest_probe) is False
+    manifest_probe_calls = 0
+    monkeypatch.setattr(Path, "is_file", tracking_is_file)
+
+    catalog = WorkerModelCatalog(environment={"MELIX_MODEL_ROOTS": str(root), "HOME": str(tmp_path / "home")})
+    snapshot = catalog.registry_snapshot()
+
+    assert [model.model_id for model in snapshot.models] == ["plain-model"]
+    assert manifest_probe_calls == 0
+
+
+
 def test_registry_snapshot_skips_plain_local_config_dirs_without_weights(tmp_path: Path) -> None:
     root = tmp_path / "root"
     model_dir = root / "plain-model"

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -147,6 +147,16 @@ def test_scope_report_selects_job_registry_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "job-registry-derived-model-single-pass"
 
 
+def test_scope_report_selects_model_registry_catalog_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/model_registry/catalog.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "model-registry-plain-local-manifest-stat-elision"
+
+
 def test_scope_report_selects_deterministic_rerank_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -416,6 +426,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "evaluation-store-compare-summary-csv-streaming",
         "evaluation-store-samples-csv-streaming",
         "job-registry-derived-model-single-pass",
+        "model-registry-plain-local-manifest-stat-elision",
         "package-macos-resolve-fallback-scandir",
         "pr-scoped-performance-scope-matcher",
         "training-dataset-token-percentiles-single-sort",
@@ -1331,6 +1342,21 @@ def test_command_json_probe_executes_probe_command_and_parses_metrics(tmp_path: 
     metrics = _probe_command_json(probe=probe, repo_root=tmp_path)
 
     assert metrics == {"elapsed_ms_mean": 12.5, "iteration_count": 3.0}
+
+
+def test_model_registry_catalog_probe_command_emits_metrics() -> None:
+    probe = next(
+        probe
+        for probe in load_probe_registry(REGISTRY_PATH)
+        if probe.probe_id == "model-registry-plain-local-manifest-stat-elision"
+    )
+
+    metrics = _probe_command_json(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["manifest_is_file_calls_mean"] == 0.0
+    assert metrics["discovered_model_count_mean"] == metrics["model_count"] == 800.0
+    assert metrics["sample_count"] == 3.0
 
 
 def test_command_json_probe_rejects_missing_command_and_non_numeric_metrics(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -1170,8 +1170,6 @@ class WorkerModelCatalog:
             resolved_path = plain_local_model.model_dir
             if resolved_path in seen_paths or _is_hf_cache_snapshot_dir(root_resolved, resolved_path):
                 continue
-            if (resolved_path / "manifest.json").is_file():
-                continue
             model_id = _local_model_id(root_resolved, resolved_path)
             if model_id in discovered_models or model_id in self._seed_models:
                 continue


### PR DESCRIPTION
## Summary
- remove the redundant plain-local `manifest.json` stat from `WorkerModelCatalog._scan_raw_model_directories(...)`
- add focused regression coverage proving plain-local discovery still works and the manifest stat is no longer called after the root tree scan
- register a dedicated `model-registry-plain-local-manifest-stat-elision` PR-scoped performance probe for this path

## Plan or Spec
- `docs/plans/2026-05-02-model-registry-manifest-stat-elision.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_root_tree_records_plain_local_weight_presence_during_single_scandir_pass services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_reuses_plain_local_tree_scan_and_config_payload services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_does_not_stat_plain_local_manifest_after_tree_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_registry_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_registry_catalog_probe_command_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_root_tree_records_plain_local_weight_presence_during_single_scandir_pass services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_reuses_plain_local_tree_scan_and_config_payload services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_does_not_stat_plain_local_manifest_after_tree_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_registry_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_registry_catalog_probe_command_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_registry/catalog.py services/mlx-worker-python/tests/test_model_registry_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `python3 -m json.tool infra/perf/pr_scoped_probes.json >/dev/null`
- `git diff --check`
- local base/head probe runs on detached `origin/main` worktree and this branch using the same synthetic workload

## Coverage and Metrics
- Focused pytest: `6 passed`
- Changed-scope coverage: `TOTAL 30 0 100%`
- Registered scoped probe: `model-registry-plain-local-manifest-stat-elision`
- Local explicit probe (same synthetic workload, 800 plain-local models, 5 samples):
  - `origin/main`: `manifest_is_file_calls_mean=800.0`, `elapsed_ms_mean=277.894825`, `discovered_model_count_mean=800.0`
  - `this branch`: `manifest_is_file_calls_mean=0.0`, `elapsed_ms_mean=244.909087`, `discovered_model_count_mean=800.0`
- Interpretation:
  - removed the redundant plain-local manifest stat entirely on the synthetic workload
  - preserved discovered model count
  - improved the measured rescan latency by ~`11.87%` (`277.894825 ms -> 244.909087 ms`)

## Known Gaps
- Linux-only local verification was completed for the Python slice.
- Hosted `pr-scoped-performance` / `pr-evidence` / branch protection checks still need to run on GitHub after PR creation.
- Because `infra/perf/pr_scoped_probes.json` changes, the hosted `pr-scoped-performance` workflow is expected to run the full scoped-probe matrix, including non-Linux probes managed by CI.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs/plan.
- [x] Relevant focused tests were run.
- [x] The affected path has a defined performance probe and target metrics.
- [x] A coverage and metrics report is included.
- [x] Command outcomes are recorded.
- [x] Known gaps and pending hosted checks are stated explicitly.
