### PR TITLE
[codex] Expand LoRA training mode contracts

### DIFF
--- a/docs/plans/2026-05-03-issue-15-lora-training-mode-expansion.md
+++ b/docs/plans/2026-05-03-issue-15-lora-training-mode-expansion.md
@@ -1,0 +1,85 @@
+# Issue 15 LoRA Training Mode Expansion
+
+## Goal
+
+Expand the Melix LoRA training contract beyond LoRA and QLoRA SFT by adding
+product-owned boundaries for DoRA, preference-tuning datasets and modes, and
+continual-pretraining datasets and mode behavior.
+
+## Source
+
+- GitHub issue: https://github.com/Keith-CY/melix/issues/15
+- Governing roadmap: `docs/plans/2026-04-16-lora-capability-modules-and-commit-plan.md`
+- Operator runbook: `docs/runbooks/phase-8-lora-adapter-workflow.md`
+
+## Scope
+
+- Treat `training_mode=dora` as a first-class adapter training contract with
+  validation and manifest evidence.
+- Add preference-pair dataset contracts for preference-style modes.
+- Add `training_mode=dpo` and `training_mode=orpo` as preference-mode
+  boundaries that validate preference-pair datasets and preserve manifest
+  evidence without claiming full trainer execution breadth beyond the current
+  local runner.
+- Add `training_mode=cpt` as a continual-pretraining boundary that requires
+  text-only datasets and disables response-only SFT assumptions.
+- Keep existing `lora` and `qlora` SFT behavior unchanged.
+
+## Non-Goals
+
+- Implement full DPO, ORPO, or CPT optimizer loops in MLX-LM.
+- Add UI or CLI surface changes outside the worker-owned operation contract.
+- Add QAT forward hooks from the later issue comments; those comments define a
+  follow-up direction but are larger than Module 4's requested contract slice.
+
+## Implementation Plan
+
+- [x] Sync `main` to `origin/main` and create an isolated worktree.
+- [x] Verify baseline targeted LoRA tests on the synced branch.
+- [x] Extend `LoRATrainingConfig` with training objective and adapter algorithm
+  metadata.
+- [x] Add DoRA mode normalization and persist DoRA manifest fields.
+- [x] Add preference-pair dataset format validation and normalization.
+- [x] Add DPO/ORPO mode validation against preference-pair datasets.
+- [x] Add CPT mode validation against text-completion datasets.
+- [x] Update LoRA runbook examples and operator expectations.
+- [x] Run targeted pytest and `git diff --check`.
+
+## Performance And Metrics
+
+- No new long-running trainer loop is introduced in this slice.
+- Dataset validation remains pre-runner and bounded by existing package sample
+  normalization.
+- Success metrics:
+  - DoRA manifests expose `adapter_algorithm=dora`.
+  - DPO and ORPO requests require `preference_pair` datasets and record
+    `training_objective=preference`.
+  - CPT requests require `text_completion` datasets and record
+    `training_objective=continual_pretraining`.
+  - Existing LoRA/QLoRA SFT regression tests continue to pass.
+
+## Verification
+
+- `make bootstrap`
+- `PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_lora_model_ops.py -q`
+- `make py-coverage`
+- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue15-python-coverage.json services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py`
+- `git diff --check`
+
+## Baseline Evidence
+
+- `make bootstrap`: passed on the isolated worktree.
+- Targeted pytest before changes: `66 passed in 2.46s`.
+
+## Implementation Evidence
+
+- Targeted pytest after changes:
+  `78 passed in 7.05s`.
+- Related runner/config regression tests:
+  `81 passed in 0.55s`.
+- `make py-coverage`:
+  `1537 passed, 5 skipped, 2 warnings in 171.48s`; repository Python
+  coverage remained `95%`.
+- Python changed-line coverage for touched worker files:
+  `100.00% (58/58)`.
+- `git diff --check`: passed.

--- a/docs/runbooks/phase-8-lora-adapter-workflow.md
+++ b/docs/runbooks/phase-8-lora-adapter-workflow.md
@@ -19,7 +19,7 @@ surfaces:
 
 - choose a base text model
 - choose a local dataset package or a Hugging Face dataset source
-- choose `LoRA` or `QLoRA` training mode
+- choose `LoRA`, `QLoRA`, `DoRA`, preference, or continual-pretraining training mode
 - set LoRA hyperparameters, adapter name, target repo, optional validation split, and optional derived-model alias
 - choose `fused_derived_model` or `adapter_backed_runtime` activation mode
 - start training, inspect persisted adapter history, activate an adapter into a derived model, publish the adapter package, and remove an activated derived model
@@ -77,6 +77,7 @@ Supported package formats:
 - `chat_messages`
 - `prompt_completion`
 - `text_completion`
+- `preference_pair`
 
 Example `manifest.json`:
 
@@ -95,6 +96,13 @@ Example `samples.jsonl` for `chat_messages`:
 ```jsonl
 {"messages":[{"role":"system","content":"You are helpful."},{"role":"user","content":"Say hi."},{"role":"assistant","content":"Hi there."}]}
 {"messages":[{"role":"user","content":"Say bye."},{"role":"assistant","content":"Bye."}]}
+```
+
+Example `samples.jsonl` for `preference_pair`:
+
+```jsonl
+{"prompt":"Choose the more helpful answer.","chosen":"Give a direct answer with the relevant command.","rejected":"Add unrelated background before answering."}
+{"prompt":"Pick the safer response.","chosen":"Explain the limitation and offer a supported path.","rejected":"Pretend an unsupported feature exists."}
 ```
 
 ## Train Adapter
@@ -127,6 +135,15 @@ Use the following `ext` keys as the stable operator-facing inputs:
   "max_seq_length": "2048"
 }
 ```
+
+Supported `training_mode` values:
+
+- `lora`: supervised fine-tuning with LoRA adapters
+- `qlora`: supervised fine-tuning against a quantized base model
+- `dora`: supervised fine-tuning contract with DoRA adapter metadata
+- `dpo`: preference-mode contract requiring `preference_pair` samples
+- `orpo`: preference-mode contract requiring `preference_pair` samples
+- `cpt`: continual-pretraining contract requiring `text_completion` samples
 
 Equivalent CLI examples:
 
@@ -163,7 +180,11 @@ Expected training behavior:
 
 - dataset validation runs before backend execution
 - Hugging Face dataset materialization is cached under `<jobs_root>/datasets/<cache-key>`
-- Melix supports both `lora` and `qlora` through the same `train_lora` surface
+- Melix supports `lora`, `qlora`, `dora`, `dpo`, `orpo`, and `cpt` through the same `train_lora` surface
+- `dora` records `adapter_algorithm=dora` and `dora_enabled=true` in the adapter manifest
+- `dpo` and `orpo` require `preference_pair` datasets and record `training_objective=preference`
+- `cpt` requires `text_completion` datasets and records `training_objective=continual_pretraining`
+- this slice defines worker-owned mode and dataset contracts; DPO, ORPO, and CPT optimizer-loop breadth remains bounded by the active local runner implementation
 - if `hf_valid_split` is provided, the normalized dataset snapshot persists the explicit validation source
 - Melix expands compact target modules or preset groups into family-specific module paths
 - supported preset groups currently include `attention`, `mlp`, `attention_mlp`, and `full`; `qwen` plus `kimi` also accept `qkv`, `gemma` also accepts `gated_mlp`, experimental `mixtral` accepts `experts`, and experimental `qwen3moe` accepts `qkv`, `experts`, and `attention_experts` (`full` is an alias for `attention_experts`)

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -726,6 +726,154 @@ def test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alia
     ]
 
 
+def test_train_lora_supports_dora_mode_contract_and_manifest(tmp_path: Path) -> None:
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset-dora",
+        samples=[
+            {
+                "messages": [
+                    {"role": "user", "content": "Say hi."},
+                    {"role": "assistant", "content": "Hi there."},
+                ]
+            }
+        ],
+    )
+    runner = SuccessfulRunner()
+    service = _build_service(tmp_path, runner)
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "train-dora"),
+                generate_manifest=True,
+                ext={
+                    "operation": "train_lora",
+                    "training_mode": "dora",
+                    "adapter_name": "melix-dora-adapter",
+                    "dataset_uri": str(dataset_dir),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+
+    assert payload["training_mode"] == "dora"
+    assert payload["training_objective"] == "supervised_finetuning"
+    assert payload["adapter_algorithm"] == "dora"
+    assert payload["preference_loss"] == ""
+    assert payload["dataset_contract"] == "sft"
+    assert payload["dora_enabled"] is True
+    assert runner.last_train_request is not None
+    assert runner.last_train_request.config.training_mode == "dora"
+    assert runner.last_train_request.config.adapter_algorithm == "dora"
+    assert runner.last_train_request.config.training_objective == "supervised_finetuning"
+
+
+@pytest.mark.parametrize("training_mode", ["dpo", "orpo"])
+def test_train_lora_supports_preference_mode_contracts(
+    tmp_path: Path,
+    training_mode: str,
+) -> None:
+    dataset_dir = _write_dataset_package(
+        tmp_path / f"dataset-{training_mode}",
+        format="preference_pair",
+        samples=[
+            {
+                "prompt": "Choose a response.",
+                "chosen": "The concise response.",
+                "rejected": "The unrelated response.",
+            },
+            {
+                "prompt": "Choose a safer answer.",
+                "chosen": "Follow the guide.",
+                "rejected": "Make a guess.",
+            },
+        ],
+    )
+    runner = SuccessfulRunner()
+    service = _build_service(tmp_path, runner)
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / f"train-{training_mode}"),
+                generate_manifest=True,
+                ext={
+                    "operation": "train_lora",
+                    "training_mode": training_mode,
+                    "adapter_name": f"melix-{training_mode}-adapter",
+                    "dataset_uri": str(dataset_dir),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+    normalized_dataset_path = Path(payload["normalized_dataset_manifest_path"])
+    normalized_dataset_payload = json.loads(normalized_dataset_path.read_text(encoding="utf-8"))
+
+    assert payload["training_mode"] == training_mode
+    assert payload["dataset_format"] == "preference_pair"
+    assert payload["training_objective"] == "preference"
+    assert payload["adapter_algorithm"] == "lora"
+    assert payload["preference_loss"] == training_mode
+    assert payload["dataset_contract"] == "preference_pair"
+    assert payload["dora_enabled"] is False
+    assert normalized_dataset_payload["format"] == "preference_pair"
+    assert runner.last_train_request is not None
+    assert runner.last_train_request.dataset_format == "preference_pair"
+    assert runner.last_train_request.config.preference_loss == training_mode
+    assert runner.last_train_request.config.training_objective == "preference"
+
+
+def test_train_lora_supports_continual_pretraining_contract(tmp_path: Path) -> None:
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset-cpt",
+        format="text_completion",
+        samples=[
+            {"text": "Long-form domain text for local continual pretraining."},
+            {"text": "A second document keeps the contract sample based."},
+        ],
+    )
+    runner = SuccessfulRunner()
+    service = _build_service(tmp_path, runner)
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "train-cpt"),
+                generate_manifest=True,
+                ext={
+                    "operation": "train_lora",
+                    "training_mode": "cpt",
+                    "adapter_name": "melix-cpt-adapter",
+                    "dataset_uri": str(dataset_dir),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+
+    assert payload["training_mode"] == "cpt"
+    assert payload["dataset_format"] == "text_completion"
+    assert payload["training_objective"] == "continual_pretraining"
+    assert payload["adapter_algorithm"] == "lora"
+    assert payload["preference_loss"] == ""
+    assert payload["dataset_contract"] == "text_completion"
+    assert payload["response_only"] is False
+    assert runner.last_train_request is not None
+    assert runner.last_train_request.config.mask_prompt is False
+    assert runner.last_train_request.config.training_objective == "continual_pretraining"
+
+
 def test_train_lora_rejects_qlora_for_non_quantized_base_model(tmp_path: Path) -> None:
     dataset_dir = _write_dataset_package(
         tmp_path / "dataset",
@@ -761,6 +909,120 @@ def test_train_lora_rejects_qlora_for_non_quantized_base_model(tmp_path: Path) -
     )
 
     assert events[-1].failed.error.code == "unsupported_training_mode"
+
+
+@pytest.mark.parametrize("training_mode", ["dpo", "orpo"])
+def test_train_lora_rejects_preference_modes_without_preference_pair_dataset(
+    tmp_path: Path,
+    training_mode: str,
+) -> None:
+    dataset_dir = _write_dataset_package(
+        tmp_path / f"dataset-invalid-{training_mode}",
+        samples=[
+            {
+                "messages": [
+                    {"role": "user", "content": "Say hi."},
+                    {"role": "assistant", "content": "Hi there."},
+                ]
+            }
+        ],
+    )
+    service = _build_service(tmp_path, SuccessfulRunner())
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / f"train-invalid-{training_mode}"),
+                ext={
+                    "operation": "train_lora",
+                    "training_mode": training_mode,
+                    "adapter_name": f"melix-invalid-{training_mode}",
+                    "dataset_uri": str(dataset_dir),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "invalid_dataset_package"
+    assert events[-1].failed.error.details["training_mode"] == training_mode
+    assert events[-1].failed.error.details["required_format"] == "preference_pair"
+    assert events[-1].failed.error.details["actual_format"] == "chat_messages"
+
+
+def test_train_lora_rejects_cpt_without_text_completion_dataset(tmp_path: Path) -> None:
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset-invalid-cpt",
+        samples=[
+            {
+                "messages": [
+                    {"role": "user", "content": "Say hi."},
+                    {"role": "assistant", "content": "Hi there."},
+                ]
+            }
+        ],
+    )
+    service = _build_service(tmp_path, SuccessfulRunner())
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "train-invalid-cpt"),
+                ext={
+                    "operation": "train_lora",
+                    "training_mode": "cpt",
+                    "adapter_name": "melix-invalid-cpt",
+                    "dataset_uri": str(dataset_dir),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "invalid_dataset_package"
+    assert events[-1].failed.error.details["training_mode"] == "cpt"
+    assert events[-1].failed.error.details["required_format"] == "text_completion"
+    assert events[-1].failed.error.details["actual_format"] == "chat_messages"
+
+
+def test_train_lora_rejects_sft_mode_with_preference_pair_dataset(tmp_path: Path) -> None:
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset-invalid-sft",
+        format="preference_pair",
+        samples=[
+            {
+                "prompt": "Choose.",
+                "chosen": "A.",
+                "rejected": "B.",
+            }
+        ],
+    )
+    service = _build_service(tmp_path, SuccessfulRunner())
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "train-invalid-sft"),
+                ext={
+                    "operation": "train_lora",
+                    "training_mode": "lora",
+                    "adapter_name": "melix-invalid-sft",
+                    "dataset_uri": str(dataset_dir),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "invalid_dataset_package"
+    assert events[-1].failed.error.details["training_mode"] == "lora"
+    assert events[-1].failed.error.details["required_format"] == (
+        "chat_messages,prompt_completion,text_completion"
+    )
+    assert events[-1].failed.error.details["actual_format"] == "preference_pair"
 
 
 def test_train_lora_resolves_qwen_attention_preset_and_catalog_support_metadata(tmp_path: Path) -> None:
@@ -1261,12 +1523,23 @@ def test_training_config_validates_direct_error_paths() -> None:
     with pytest.raises(Exception) as bad_mode_error:
         training_config_module.normalize_training_config(
             source_model=text_model,
-            ext={"training_mode": "dora"},
+            ext={"training_mode": "ppo"},
             dataset_format="text_completion",
             response_only_supported=True,
             sample_count=1,
         )
     assert bad_mode_error.value.code == "unsupported_training_mode"
+
+    dora_config = training_config_module.normalize_training_config(
+        source_model=text_model,
+        ext={"training_mode": "dora"},
+        dataset_format="text_completion",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    assert dora_config.training_mode == "dora"
+    assert dora_config.adapter_algorithm == "dora"
+    assert dora_config.training_objective == "supervised_finetuning"
 
     with pytest.raises(Exception) as preset_error:
         training_config_module.normalize_training_config(

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -222,6 +222,78 @@ def test_load_training_dataset_package_stops_reading_after_sample_limit(
     assert package.normalized_samples == [{"text": "alpha"}]
 
 
+def test_load_training_dataset_package_supports_preference_pair_samples(
+    tmp_path: Path,
+) -> None:
+    package_path = tmp_path / "preference-package"
+    package_path.mkdir(parents=True, exist_ok=True)
+    (package_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "preference-package",
+                "format": "preference_pair",
+                "sample_count": 2,
+                "version": "1",
+                "validation_sample_count": 1,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (package_path / "samples.jsonl").write_text(
+        '{"prompt": "Choose a greeting.", "chosen": "Hello.", "rejected": "Goodbye."}\n'
+        '{"prompt": "Pick the safer answer.", "chosen": "Use the guide.", "rejected": "Guess."}\n',
+        encoding="utf-8",
+    )
+    (package_path / "valid.jsonl").write_text(
+        '{"prompt": "Holdout?", "chosen": "Yes.", "rejected": "No."}\n',
+        encoding="utf-8",
+    )
+
+    package = load_training_dataset_package(str(package_path))
+
+    assert package.format == "preference_pair"
+    assert package.response_only_supported is False
+    assert package.normalized_samples == [
+        {"prompt": "Choose a greeting.", "chosen": "Hello.", "rejected": "Goodbye."},
+        {"prompt": "Pick the safer answer.", "chosen": "Use the guide.", "rejected": "Guess."},
+    ]
+    assert package.normalized_validation_samples == [
+        {"prompt": "Holdout?", "chosen": "Yes.", "rejected": "No."}
+    ]
+
+
+def test_load_training_dataset_package_rejects_incomplete_preference_pair_samples(
+    tmp_path: Path,
+) -> None:
+    package_path = tmp_path / "invalid-preference-package"
+    package_path.mkdir(parents=True, exist_ok=True)
+    (package_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "invalid-preference-package",
+                "format": "preference_pair",
+                "sample_count": 1,
+                "version": "1",
+                "validation_sample_count": 0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (package_path / "samples.jsonl").write_text(
+        '{"prompt": "Choose.", "chosen": "A"}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ModelOperationError) as exc:
+        load_training_dataset_package(str(package_path))
+
+    assert exc.value.code == "invalid_dataset_package"
+
+
 
 def test_iter_dataset_package_jsonl_rows_enforces_sample_limit_before_invalid_tail(
     tmp_path: Path,
@@ -349,6 +421,60 @@ def test_build_training_dataset_artifact_converts_alpaca_rows_and_records_qualit
     assert package.validation_sample_count == 1
 
 
+def test_build_training_dataset_artifact_converts_preference_pair_rows(
+    tmp_path: Path,
+) -> None:
+    dataset_path = _write_jsonl(
+        tmp_path / "preferences.jsonl",
+        [
+            {
+                "prompt": "Choose the concise answer.",
+                "chosen": "Use the short answer.",
+                "rejected": "Add unrelated details.",
+            },
+            {
+                "prompt": "Choose the concise answer.",
+                "chosen": "Use the short answer.",
+                "rejected": "Add unrelated details.",
+            },
+            {
+                "prompt": "Pick the better answer.",
+                "chosen": "same",
+                "rejected": "same",
+            },
+        ],
+    )
+
+    result = build_training_dataset_artifact(
+        {
+            "dataset_uri": str(dataset_path),
+            "template": "auto",
+            "dataset_id": "melix-preference-demo",
+            "validation_ratio": "0.34",
+        },
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "built-preference-dataset",
+        source_model_id="melix-dev-text",
+    )
+
+    payload = result.manifest_payload
+    package = load_training_dataset_package(str(result.package_path))
+
+    assert payload["schema_version"] == "melix.training_dataset_package.v1"
+    assert payload["format"] == "preference_pair"
+    assert payload["conversion_template"] == "preference_pair"
+    assert payload["response_only_supported"] is False
+    assert payload["quality"]["duplicate_count"] == 1
+    assert payload["quality"]["dirty_count"] == 1
+    assert payload["quality"]["dirty_samples"] == [
+        {"index": 2, "reasons": ["duplicate_preference_pair"]}
+    ]
+    assert payload["token_stats"]["prompt_tokens_max"] >= 4
+    assert payload["token_stats"]["completion_tokens_max"] >= 6
+    assert package.format == "preference_pair"
+    assert package.validation_sample_count == 1
+
+
 def test_build_training_dataset_artifact_inspects_sharegpt_rows_without_writing_a_package(
     tmp_path: Path,
 ) -> None:
@@ -465,6 +591,70 @@ def test_build_training_dataset_artifact_materializes_hf_source_and_clears_stale
     assert stale_valid.exists() is False
 
 
+def test_hf_preference_pair_schema_inference_and_mapping() -> None:
+    default_reference = HFDatasetReference(
+        dataset_path="melix/preferences",
+        dataset_name="default",
+        dataset_revision="main",
+        train_split="train",
+        chat_feature="",
+        prompt_feature="",
+        completion_feature="",
+        text_feature="",
+    )
+    default_rows = [
+        {
+            "prompt": "Choose.",
+            "chosen": "A.",
+            "rejected": "B.",
+        }
+    ]
+    assert training_dataset_module._infer_hf_dataset_format(
+        default_reference,
+        default_rows,
+    ) == "preference_pair"
+    assert training_dataset_module._map_hf_row_to_training_sample(
+        default_rows[0],
+        "preference_pair",
+        default_reference,
+    ) == {"prompt": "Choose.", "chosen": "A.", "rejected": "B."}
+
+    configured_reference = HFDatasetReference(
+        dataset_path="melix/preferences",
+        dataset_name="default",
+        dataset_revision="main",
+        train_split="train",
+        chat_feature="",
+        prompt_feature="question",
+        completion_feature="",
+        text_feature="",
+        chosen_feature="accepted",
+        rejected_feature="rejected_answer",
+    )
+    configured_row = {
+        "question": "Pick.",
+        "accepted": "Use this.",
+        "rejected_answer": "Avoid this.",
+    }
+    assert training_dataset_module._infer_hf_dataset_format(
+        configured_reference,
+        [configured_row],
+    ) == "preference_pair"
+    assert training_dataset_module._map_hf_row_to_training_sample(
+        configured_row,
+        "preference_pair",
+        configured_reference,
+    ) == {"prompt": "Pick.", "chosen": "Use this.", "rejected": "Avoid this."}
+
+    with pytest.raises(ModelOperationError) as missing_column:
+        training_dataset_module._map_hf_row_to_training_sample(
+            {"question": "Pick.", "accepted": "Use this."},
+            "preference_pair",
+            configured_reference,
+        )
+    assert missing_column.value.code == "hf_dataset_fetch_failed"
+
+
 def test_build_training_dataset_artifact_loads_existing_package_and_helper_branches(
     tmp_path: Path,
 ) -> None:
@@ -550,6 +740,10 @@ def test_build_training_dataset_artifact_loads_existing_package_and_helper_branc
     ) == "alpaca"
     assert training_dataset_module._resolve_local_conversion_template(
         "auto",
+        {"prompt": "Choose", "chosen": "A", "rejected": "B"},
+    ) == "preference_pair"
+    assert training_dataset_module._resolve_local_conversion_template(
+        "auto",
         {"conversation": []},
     ) == "sharegpt"
     with pytest.raises(ModelOperationError) as invalid_template:
@@ -563,6 +757,10 @@ def test_build_training_dataset_artifact_loads_existing_package_and_helper_branc
         [{"text": "hello world"}],
         "text_completion",
     ) == ("text_completion", [{"text": "hello world"}])
+    assert training_dataset_module._convert_local_rows(
+        [{"prompt": "Choose", "chosen": "A", "rejected": "B"}],
+        "preference_pair",
+    ) == ("preference_pair", [{"prompt": "Choose", "chosen": "A", "rejected": "B"}])
     with pytest.raises(ModelOperationError) as bad_sharegpt_shape:
         training_dataset_module._convert_local_rows(
             [{"conversations": "bad"}],

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -156,6 +156,11 @@ class LoRATrainingPipeline:
             "dataset_cache_key": dataset.cache_key,
             "dataset_cache_hit": dataset.cache_hit,
             "training_mode": config.training_mode,
+            "training_objective": config.training_objective,
+            "adapter_algorithm": config.adapter_algorithm,
+            "preference_loss": config.preference_loss,
+            "dataset_contract": config.dataset_contract,
+            "dora_enabled": config.adapter_algorithm == "dora",
             "quantization_mode": config.quantization_mode,
             "training_backend": training_result.execution_backend,
             "adapter_set_hash": adapter_set_hash,
@@ -245,6 +250,8 @@ class LoRATrainingPipeline:
                     "prompt_feature": dataset.hf_reference.prompt_feature,
                     "completion_feature": dataset.hf_reference.completion_feature,
                     "text_feature": dataset.hf_reference.text_feature,
+                    "chosen_feature": dataset.hf_reference.chosen_feature,
+                    "rejected_feature": dataset.hf_reference.rejected_feature,
                 }
             )
         manifest_path = output_dir / "train_lora.adapter.json"

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -47,6 +47,10 @@ class LoRATrainingConfig:
     target_repo: str
     chunked_training: bool
     chunk_size: int
+    training_objective: str = "supervised_finetuning"
+    adapter_algorithm: str = "lora"
+    preference_loss: str = ""
+    dataset_contract: str = "sft"
 
 
 _DENSE_ATTENTION_TARGETS = ["q_proj", "k_proj", "v_proj", "o_proj"]
@@ -71,6 +75,14 @@ _UNSAFE_QUANTIZED_LORA_TARGETS = {
 }
 _CONFIRMED_EXPERT_COUNT_SOURCES = {"config"}
 _QUANTIZED_MODEL_PATTERN = re.compile(r"(?<![a-z0-9])(?:4bit|8bit|q4|q8|optiq)(?![a-z0-9])")
+_SFT_TRAINING_MODES = {"lora", "qlora", "dora"}
+_PREFERENCE_TRAINING_MODES = {"dpo", "orpo"}
+_CPT_TRAINING_MODES = {"cpt"}
+_SUPPORTED_TRAINING_MODES = (
+    _SFT_TRAINING_MODES
+    | _PREFERENCE_TRAINING_MODES
+    | _CPT_TRAINING_MODES
+)
 
 _FAMILY_PROFILES: dict[str, dict[str, object]] = {
     "llama": {
@@ -305,11 +317,12 @@ def normalize_training_config(
         )
 
     training_mode = ext.get("training_mode", "lora").strip().lower() or "lora"
-    if training_mode not in {"lora", "qlora"}:
+    if training_mode not in _SUPPORTED_TRAINING_MODES:
         raise ModelOperationError(
             code="unsupported_training_mode",
             message=f"Unsupported training_mode: {training_mode}",
         )
+    mode_contract = _resolve_training_mode_contract(training_mode, dataset_format)
     quantized_base_model = _is_quantized_base_model(source_model)
     if training_mode == "qlora" and quantized_base_model is False:
         raise ModelOperationError(
@@ -531,7 +544,66 @@ def normalize_training_config(
         target_repo=ext.get("target_repo", "").strip(),
         chunked_training=chunked_training,
         chunk_size=chunk_size,
+        training_objective=mode_contract["training_objective"],
+        adapter_algorithm=mode_contract["adapter_algorithm"],
+        preference_loss=mode_contract["preference_loss"],
+        dataset_contract=mode_contract["dataset_contract"],
     )
+
+
+def _resolve_training_mode_contract(training_mode: str, dataset_format: str) -> dict[str, str]:
+    if training_mode in _SFT_TRAINING_MODES:
+        if dataset_format == "preference_pair":
+            raise ModelOperationError(
+                code="invalid_dataset_package",
+                message="SFT training modes require supervised training datasets.",
+                details={
+                    "training_mode": training_mode,
+                    "required_format": "chat_messages,prompt_completion,text_completion",
+                    "actual_format": dataset_format,
+                },
+            )
+        return {
+            "training_objective": "supervised_finetuning",
+            "adapter_algorithm": "dora" if training_mode == "dora" else "lora",
+            "preference_loss": "",
+            "dataset_contract": "sft",
+        }
+
+    if training_mode in _PREFERENCE_TRAINING_MODES:
+        if dataset_format != "preference_pair":
+            raise ModelOperationError(
+                code="invalid_dataset_package",
+                message="Preference training modes require preference_pair datasets.",
+                details={
+                    "training_mode": training_mode,
+                    "required_format": "preference_pair",
+                    "actual_format": dataset_format,
+                },
+            )
+        return {
+            "training_objective": "preference",
+            "adapter_algorithm": "lora",
+            "preference_loss": training_mode,
+            "dataset_contract": "preference_pair",
+        }
+
+    if dataset_format != "text_completion":
+        raise ModelOperationError(
+            code="invalid_dataset_package",
+            message="Continual pretraining requires text_completion datasets.",
+            details={
+                "training_mode": training_mode,
+                "required_format": "text_completion",
+                "actual_format": dataset_format,
+            },
+        )
+    return {
+        "training_objective": "continual_pretraining",
+        "adapter_algorithm": "lora",
+        "preference_loss": "",
+        "dataset_contract": "text_completion",
+    }
 
 
 def _resolve_training_preset(preset_id: str) -> dict[str, object]:

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -15,7 +15,7 @@ from urllib.request import Request, urlopen
 
 from worker.model_ops.errors import ModelOperationError
 
-_SUPPORTED_FORMATS = {"chat_messages", "prompt_completion", "text_completion"}
+_SUPPORTED_FORMATS = {"chat_messages", "prompt_completion", "text_completion", "preference_pair"}
 _SUPPORTED_ROLES = {"system", "user", "assistant", "tool"}
 _HF_DATASETS_SERVER_URL = "https://datasets-server.huggingface.co"
 _QUALITY_REPORT_SAMPLE_LIMIT = 10
@@ -63,6 +63,8 @@ class HFDatasetReference:
     completion_feature: str
     text_feature: str
     valid_split: str = ""
+    chosen_feature: str = ""
+    rejected_feature: str = ""
 
 
 @dataclass(frozen=True)
@@ -336,6 +338,8 @@ def resolve_training_dataset_package(
         completion_feature=request_ext.get("completion_feature", "").strip(),
         text_feature=request_ext.get("text_feature", "").strip(),
         valid_split=request_ext.get("hf_valid_split", "").strip(),
+        chosen_feature=request_ext.get("chosen_feature", "").strip(),
+        rejected_feature=request_ext.get("rejected_feature", "").strip(),
     )
     if not reference.dataset_path:
         raise ModelOperationError(
@@ -634,6 +638,8 @@ def materialize_hf_training_dataset_package(
         "prompt_feature": resolved_reference.prompt_feature,
         "completion_feature": resolved_reference.completion_feature,
         "text_feature": resolved_reference.text_feature,
+        "chosen_feature": resolved_reference.chosen_feature,
+        "rejected_feature": resolved_reference.rejected_feature,
     }
     manifest_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
     _write_jsonl_rows(samples_path, serialized_samples)
@@ -729,6 +735,21 @@ def _normalize_sample(
             "completion": _truncate_text(completion, max_characters_per_sample),
         }
 
+    if format_name == "preference_pair":
+        prompt = str(sample.get("prompt", "")).strip()
+        chosen = str(sample.get("chosen", "")).strip()
+        rejected = str(sample.get("rejected", "")).strip()
+        if not prompt or not chosen or not rejected:
+            raise ModelOperationError(
+                code="invalid_dataset_package",
+                message="preference_pair samples must include prompt, chosen, and rejected text.",
+            )
+        return {
+            "prompt": _truncate_text(prompt, max_characters_per_sample),
+            "chosen": _truncate_text(chosen, max_characters_per_sample),
+            "rejected": _truncate_text(rejected, max_characters_per_sample),
+        }
+
     text = str(sample.get("text", "")).strip()
     if not text:
         raise ModelOperationError(
@@ -792,6 +813,8 @@ def _reference_from_cached_manifest(
         completion_feature=str(payload.get("completion_feature", reference.completion_feature)),
         text_feature=str(payload.get("text_feature", reference.text_feature)),
         valid_split=str(payload.get("hf_valid_split", reference.valid_split)),
+        chosen_feature=str(payload.get("chosen_feature", reference.chosen_feature)),
+        rejected_feature=str(payload.get("rejected_feature", reference.rejected_feature)),
     )
 
 
@@ -878,6 +901,8 @@ def _fetch_hf_dataset_rows(
 def _infer_hf_dataset_format(reference: HFDatasetReference, rows: list[dict[str, Any]]) -> str:
     if reference.chat_feature:
         return "chat_messages"
+    if reference.chosen_feature or reference.rejected_feature:
+        return "preference_pair"
     if reference.prompt_feature or reference.completion_feature:
         return "prompt_completion"
     if reference.text_feature:
@@ -886,6 +911,8 @@ def _infer_hf_dataset_format(reference: HFDatasetReference, rows: list[dict[str,
     sample = rows[0]
     if isinstance(sample.get("messages"), list):
         return "chat_messages"
+    if "prompt" in sample and "chosen" in sample and "rejected" in sample:
+        return "preference_pair"
     if "prompt" in sample and "completion" in sample:
         return "prompt_completion"
     if "text" in sample:
@@ -931,6 +958,27 @@ def _map_hf_row_to_training_sample(
             "completion": row[completion_field],
         }
 
+    if format_name == "preference_pair":
+        prompt_field = reference.prompt_feature or "prompt"
+        chosen_field = reference.chosen_feature or "chosen"
+        rejected_field = reference.rejected_feature or "rejected"
+        if prompt_field not in row or chosen_field not in row or rejected_field not in row:
+            raise ModelOperationError(
+                code="hf_dataset_fetch_failed",
+                message="Hugging Face dataset preference_pair rows are missing configured columns.",
+                details={
+                    "hf_dataset_path": reference.dataset_path,
+                    "prompt_feature": prompt_field,
+                    "chosen_feature": chosen_field,
+                    "rejected_feature": rejected_field,
+                },
+            )
+        return {
+            "prompt": row[prompt_field],
+            "chosen": row[chosen_field],
+            "rejected": row[rejected_field],
+        }
+
     text_field = reference.text_feature or "text"
     if text_field not in row:
         raise ModelOperationError(
@@ -965,6 +1013,8 @@ def _hf_materialization_cache_key(reference: HFDatasetReference) -> str:
                 "prompt_feature": reference.prompt_feature,
                 "completion_feature": reference.completion_feature,
                 "text_feature": reference.text_feature,
+                "chosen_feature": reference.chosen_feature,
+                "rejected_feature": reference.rejected_feature,
                 "valid_split": reference.valid_split,
             },
             sort_keys=True,
@@ -1020,6 +1070,8 @@ def _resolve_dataset_build_source(
                 "hf_dataset_revision": resolved.hf_reference.dataset_revision if resolved.hf_reference else "",
                 "hf_train_split": resolved.hf_reference.train_split if resolved.hf_reference else "",
                 "hf_valid_split": resolved.hf_reference.valid_split if resolved.hf_reference else "",
+                "chosen_feature": resolved.hf_reference.chosen_feature if resolved.hf_reference else "",
+                "rejected_feature": resolved.hf_reference.rejected_feature if resolved.hf_reference else "",
             },
         }
 
@@ -1127,6 +1179,7 @@ def _resolve_local_conversion_template(template: str, sample_row: dict[str, Any]
             "chat_messages",
             "prompt_completion",
             "text_completion",
+            "preference_pair",
             "alpaca",
             "sharegpt",
         }:
@@ -1138,6 +1191,8 @@ def _resolve_local_conversion_template(template: str, sample_row: dict[str, Any]
 
     if isinstance(sample_row.get("messages"), list):
         return "chat_messages"
+    if "prompt" in sample_row and "chosen" in sample_row and "rejected" in sample_row:
+        return "preference_pair"
     if "prompt" in sample_row and "completion" in sample_row:
         return "prompt_completion"
     if "text" in sample_row:
@@ -1159,6 +1214,8 @@ def _local_conversion_format(template: str) -> str:
         return "prompt_completion"
     if template == "text_completion":
         return "text_completion"
+    if template == "preference_pair":
+        return "preference_pair"
     raise ModelOperationError(
         code="invalid_dataset_source",
         message=f"Unsupported dataset conversion template: {template}",
@@ -1178,6 +1235,12 @@ def _convert_local_row(
         }
     if template == "text_completion":
         return {"text": row.get("text")}
+    if template == "preference_pair":
+        return {
+            "prompt": row.get("prompt"),
+            "chosen": row.get("chosen"),
+            "rejected": row.get("rejected"),
+        }
     if template == "alpaca":
         instruction = str(row.get("instruction", "")).strip()
         input_text = str(row.get("input", "")).strip()
@@ -1488,6 +1551,14 @@ def _sample_token_counts(sample: dict[str, Any], format_name: str) -> tuple[int,
             _whitespace_token_count(str(sample.get("completion", ""))),
         )
 
+    if format_name == "preference_pair":
+        return (
+            _whitespace_token_count(str(sample.get("prompt", ""))),
+            _whitespace_token_count(
+                f"{sample.get('chosen', '')} {sample.get('rejected', '')}"
+            ),
+        )
+
     return 0, _whitespace_token_count(str(sample.get("text", "")))
 
 
@@ -1503,6 +1574,11 @@ def _dirty_sample_reasons(sample: dict[str, Any]) -> list[str]:
         completion = str(sample.get("completion", "")).strip()
         if prompt and completion and prompt == completion:
             reasons.append("duplicate_prompt_completion")
+    if "prompt" in sample and "chosen" in sample and "rejected" in sample:
+        chosen = str(sample.get("chosen", "")).strip()
+        rejected = str(sample.get("rejected", "")).strip()
+        if chosen and rejected and chosen == rejected:
+            reasons.append("duplicate_preference_pair")
 
     if "messages" in sample:
         messages = sample.get("messages")
@@ -1550,6 +1626,12 @@ def _sample_text_segments(sample: dict[str, Any]) -> list[str]:
                 for message in messages
                 if isinstance(message, dict)
             ]
+    if "prompt" in sample and ("chosen" in sample or "rejected" in sample):
+        return [
+            str(sample.get("prompt", "")),
+            str(sample.get("chosen", "")),
+            str(sample.get("rejected", "")),
+        ]
     if "prompt" in sample or "completion" in sample:
         return [str(sample.get("prompt", "")), str(sample.get("completion", ""))]
     return [str(sample.get("text", ""))]


### PR DESCRIPTION
## Summary
- Expands the LoRA worker contract beyond LoRA/QLoRA SFT with DoRA, DPO, ORPO, and CPT mode boundaries.
- Adds `preference_pair` dataset validation, local/HF mapping support, and manifest evidence for mode objective/adapter metadata.
- Updates the Phase 8 LoRA runbook and records the Issue 15 execution plan.
- Closes #15.

## Plan or Spec
- `docs/plans/2026-05-03-issue-15-lora-training-mode-expansion.md`
- Governing roadmap: `docs/plans/2026-04-16-lora-capability-modules-and-commit-plan.md`
- Operator runbook: `docs/runbooks/phase-8-lora-adapter-workflow.md`

## Commands Run
```text
make bootstrap: passed
PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_lora_model_ops.py -q: 78 passed in 7.05s
PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_runtime_edges.py -q: 81 passed in 0.55s
make py-coverage: 1537 passed, 5 skipped, 2 warnings in 171.48s; repository Python coverage 95%
python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue15-python-coverage.json services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py: TOTAL 100.00% (58/58)
git diff --check: passed
```

## Coverage and Metrics
- Changed-line coverage for touched worker files: `100.00% (58/58)`.
- Repository Python coverage: `95%`.
- No new long-running trainer loop or performance-sensitive hot path was introduced; dataset validation remains pre-runner and bounded by existing package normalization.

## Known Gaps
- Full DPO, ORPO, and CPT optimizer-loop implementations are intentionally deferred.
- QAT forward-hook work from later issue comments is intentionally out of scope.
- No protocol or dependency changes; no generated artifacts or lockfiles changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
