### PR TITLE
perf: flatten benchmark evaluation probe aggregates

### DIFF
--- a/docs/plans/2026-05-02-benchmark-evaluation-flat-aggregate-map.md
+++ b/docs/plans/2026-05-02-benchmark-evaluation-flat-aggregate-map.md
@@ -1,0 +1,41 @@
+# Benchmark Evaluation Flat Aggregate Map
+
+## Goal
+
+Reduce hot-path dictionary churn in `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py` by replacing nested per-label aggregate maps with a flatter aggregate structure while preserving report metric names, values, and warning semantics.
+
+## Scope
+
+This Linux-verifiable Python optimization slice is limited to:
+
+- `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`
+- `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`
+
+No Swift, protobuf, workflow, dependency, or generated-artifact changes are in scope.
+
+## Performance Probe
+
+Use the already-registered PR-scoped performance probe `benchmark-evaluation-report-running-aggregates` from `infra/perf/pr_scoped_probes.json`.
+
+Tracked metrics:
+
+- `elapsed_ms_mean` — lower is better
+- `peak_bytes_mean` — lower is better
+- `row_count` — parity guard
+
+## Success Metrics
+
+- Focused pytest for `test_benchmark_evaluation_report.py` passes.
+- Changed-scope automated coverage for the touched executable Python file is at least 95%.
+- The local probe reports identical `row_count` and non-regressing `elapsed_ms_mean` and `peak_bytes_mean` versus the pre-change baseline.
+
+## Implementation Plan
+
+1. Add a focused regression test that locks the flat aggregate helper behavior and preserves exported metric names and values.
+2. Replace nested `label -> key -> aggregate` updates in `_collect_benchmark_probe_metrics(...)` with a flat aggregate map keyed by `(label, key)`.
+3. Finalize the flat aggregate map back into the existing `metrics[f"{prefix}.{label}.{key}_{suffix}"]` contract.
+4. Run focused pytest, changed-scope coverage, `git diff --check`, and the registered local performance probe before commit.
+
+## Validation Boundary
+
+This is a Python-only Linux-local optimization slice. The existing PR-scoped performance CI probe for this path remains the CI merge gate after the PR is opened.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -16,12 +16,14 @@ from worker.productization.benchmark_evaluation_report import (
     _collect_runtime_metadata,
     _dict_rows,
     _finalize_numeric_aggregate,
+    _finalize_probe_aggregates,
     _label_part,
     _markdown_cell,
     _metric_direction,
     _metric_key_direction,
     _report_rows,
     _update_numeric_aggregate,
+    _update_probe_aggregate_pairs,
     _update_probe_aggregates_by_label,
     build_benchmark_evaluation_report,
     build_sticky_comment_body,
@@ -349,6 +351,28 @@ def test_collect_benchmark_probe_metrics_groups_aggregates_by_label_and_preserve
             "prefill_ms": (24.0, 2),
             "decode_ms": (20.0, 1),
         }
+    }
+
+    aggregate_pairs: dict[tuple[str, str], tuple[float, int]] = {}
+    _update_probe_aggregate_pairs(aggregate_pairs, label="shared", key="prefill_ms", value=10.0)
+    _update_probe_aggregate_pairs(aggregate_pairs, label="shared", key="prefill_ms", value=14.0)
+    _update_probe_aggregate_pairs(aggregate_pairs, label="shared", key="decode_ms", value=20.0)
+    _update_probe_aggregate_pairs(
+        aggregate_pairs,
+        label="shared",
+        key="speculative_fallback_count",
+        value=4.0,
+    )
+
+    assert aggregate_pairs == {
+        ("shared", "prefill_ms"): (24.0, 2),
+        ("shared", "decode_ms"): (20.0, 1),
+        ("shared", "speculative_fallback_count"): (4.0, 1),
+    }
+    assert _finalize_probe_aggregates(aggregate_pairs, prefix="bench") == {
+        "bench.shared.prefill_ms_mean": 12.0,
+        "bench.shared.decode_ms_mean": 20.0,
+        "bench.shared.speculative_fallback_count_sum": 4.0,
     }
 
     metrics: dict[str, object] = {}

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -125,6 +125,7 @@ _METRIC_DIRECTION_BY_KEY = {
 }
 
 _NumericAggregate = tuple[float, int]
+_ProbeAggregateKey = tuple[str, str]
 _BenchmarkLabelCacheKey = tuple[str, str, str, str, str, str]
 
 
@@ -453,7 +454,7 @@ def _collect_benchmark_probe_metrics(
     prefix: str,
     label_cache: dict[_BenchmarkLabelCacheKey, str] | None = None,
 ) -> None:
-    aggregates_by_label: dict[str, dict[str, _NumericAggregate]] = {}
+    aggregate_pairs: dict[_ProbeAggregateKey, _NumericAggregate] = {}
     matrix_label_cache: dict[tuple[object, object, object, object, object], str] = {}
     for row in _dict_rows(rows):
         label = ""
@@ -475,16 +476,13 @@ def _collect_benchmark_probe_metrics(
                         label_cache=label_cache,
                         matrix_label_cache=matrix_label_cache,
                     )
-                _update_probe_aggregates_by_label(
-                    aggregates_by_label,
+                _update_probe_aggregate_pairs(
+                    aggregate_pairs,
                     label=label,
                     key=key,
                     value=value,
                 )
-    for label, aggregates_by_key in aggregates_by_label.items():
-        for key, aggregate in aggregates_by_key.items():
-            suffix, value = _finalize_numeric_aggregate(key, aggregate)
-            metrics[f"{prefix}.{label}.{key}_{suffix}"] = value
+    metrics.update(_finalize_probe_aggregates(aggregate_pairs, prefix=prefix))
 
 
 def _collect_evaluation_sample_probe_metrics(
@@ -533,6 +531,17 @@ def _update_numeric_aggregate(
     return (aggregate[0] + value, aggregate[1] + 1)
 
 
+def _update_probe_aggregate_pairs(
+    aggregate_pairs: dict[_ProbeAggregateKey, _NumericAggregate],
+    *,
+    label: str,
+    key: str,
+    value: float,
+) -> None:
+    aggregate_key = (label, key)
+    aggregate_pairs[aggregate_key] = _update_numeric_aggregate(aggregate_pairs.get(aggregate_key), value)
+
+
 def _update_probe_aggregates_by_label(
     aggregates_by_label: dict[str, dict[str, _NumericAggregate]],
     *,
@@ -545,6 +554,18 @@ def _update_probe_aggregates_by_label(
         aggregates_by_key = {}
         aggregates_by_label[label] = aggregates_by_key
     aggregates_by_key[key] = _update_numeric_aggregate(aggregates_by_key.get(key), value)
+
+
+def _finalize_probe_aggregates(
+    aggregate_pairs: dict[_ProbeAggregateKey, _NumericAggregate],
+    *,
+    prefix: str,
+) -> dict[str, float]:
+    metrics: dict[str, float] = {}
+    for (label, key), aggregate in aggregate_pairs.items():
+        suffix, value = _finalize_numeric_aggregate(key, aggregate)
+        metrics[f"{prefix}.{label}.{key}_{suffix}"] = value
+    return metrics
 
 
 def _finalize_numeric_aggregate(


### PR DESCRIPTION
## Summary
- Flatten benchmark-evaluation probe aggregation in `benchmark_evaluation_report.py` from nested per-label maps to a flat `(label, key)` aggregate map.
- Preserve emitted metric names, values, and warning semantics while reducing hot-path dictionary churn in the registered report-building probe.
- Add focused regression coverage for the new flat aggregate helpers and keep the compatibility helper behavior covered.

## Plan or Spec
- `docs/plans/2026-05-02-benchmark-evaluation-flat-aggregate-map.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py::test_collect_benchmark_probe_metrics_groups_aggregates_by_label_and_preserves_metrics
- PASS (1 passed) after implementing the flat aggregate helpers; initial RED run failed during import because the new helpers did not exist yet.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
- PASS (36 passed)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
- PASS (TOTAL 20 0 100%)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-evaluation-report-running-aggregates --base-repo /tmp/melix-base-20260502-200438 --head-repo "$PWD" --output /tmp/benchmark-evaluation-report-probe-20260502-200438.json
- PASS (base/head probe comparison completed successfully)

git diff --check
- PASS
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 20 0 100%`
- Focused coverage report from the registered probe verification path:
  - `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`: `99%`
  - `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`: `99%`
- Registered scoped CI probe: `benchmark-evaluation-report-running-aggregates` (existing registry entry; no workflow/registry change needed because its `watch_globs` already cover this path)
- Local base-vs-head probe metrics:
  - `elapsed_ms_mean`: `185.585` → `150.59` (`-34.995 ms`, `-18.856589%`)
  - `peak_bytes_mean`: `3904837.7` → `3895477.7` (`-9360.0 bytes`, `-0.239703%`)
  - `row_count`: `5990.0` → `5990.0` (parity preserved)

## Known Gaps
- Full-repo `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run in this Linux cron slice; this PR uses the narrower Linux-verifiable worker test/probe path for the touched Python scope.
- Hosted `pr-scoped-performance` CI is still required before merge/auto-merge because this change relies on the registered PR-scoped performance gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. (No externally visible behavior change; the optimization plan documents the slice.)
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
