### PR TITLE
perf: read job registry restore manifests as bytes

### DIFF
--- a/docs/plans/2026-05-02-job-registry-manifest-read-bytes.md
+++ b/docs/plans/2026-05-02-job-registry-manifest-read-bytes.md
@@ -1,0 +1,43 @@
+# Job registry restore manifest byte reads
+
+## Scope
+
+This slice targets `services/mlx-worker-python/worker/model_ops/job_registry.py`
+restore manifest decoding only. The restore path loads many small JSON manifest
+files from the model-ops jobs root when rebuilding registry state, so it should
+avoid an intermediate UTF-8 text decode before handing the payload to
+`json.loads`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`job-registry-derived-model-single-pass` in `infra/perf/pr_scoped_probes.json`.
+This slice extends the existing probe payload with restore-from-disk metrics:
+
+- `restore_elapsed_ms_mean`
+- `restore_elapsed_ms_min`
+- `restored_job_count`
+
+The registry entry keeps focused `test_command`, `coverage_command`, and
+`probe_command` entries for the job registry, its probe script, PR-scoped probe
+selection, and changed-scope coverage.
+
+## Verification plan
+
+This slice is Python-only and locally verifiable on Linux:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id job-registry-derived-model-single-pass --base-repo <baseline-worktree> --head-repo "$PWD" --output /tmp/job_registry_manifest_read_bytes_probe.json
+```
+
+## Success criteria
+
+- Restore manifest parsing continues to reject invalid/missing JSON as before.
+- Regression coverage proves restore manifests are read with `Path.read_bytes()`
+  and do not call `Path.read_text()` for manifest payloads.
+- The registered probe reports a nonzero `restore_elapsed_ms_mean` and does not
+  regress relative to the synced `origin/main` baseline.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -493,6 +493,12 @@
         "unit": "ms",
         "direction": "lower_is_better",
         "warn_pct": 5.0
+      },
+      {
+        "key": "restore_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
       }
     ]
   },

--- a/scripts/job_registry_derived_model_probe.py
+++ b/scripts/job_registry_derived_model_probe.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import statistics
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -23,7 +24,7 @@ def _seed_registry(job_count: int):
         train_job = registry.start("train_lora", "melix-dev-text", f"/runtime/train/{model_id}")
         registry.attach_manifest(
             train_job.job_id,
-            json.dumps({"adapter_name": f"adapter-{index:04d}", "adapter_set_hash": f"hash-{index:04d}"}),
+            json.dumps(_train_manifest(index, adapter_manifest_path)),
         )
         registry.complete(train_job.job_id, adapter_manifest_path)
 
@@ -31,18 +32,7 @@ def _seed_registry(job_count: int):
         activation_manifest_path = f"/runtime/activate/{model_id}/manifest.json"
         registry.attach_manifest(
             activation_job.job_id,
-            json.dumps(
-                {
-                    "adapter_manifest_path": adapter_manifest_path,
-                    "adapter_weights_path": f"/runtime/train/{model_id}/adapters.safetensors",
-                    "adapter_set_hash": f"hash-{index:04d}",
-                    "derived_model_id": model_id,
-                    "derived_model_path": f"/runtime/activate/{model_id}",
-                    "derived_model_alias": f"alias-{index:04d}",
-                    "source_model": "melix-dev-text",
-                    "activation_mode": "fused_derived_model",
-                }
-            ),
+            json.dumps(_activation_manifest(index, adapter_manifest_path)),
         )
         registry.complete(activation_job.job_id, activation_manifest_path)
 
@@ -50,18 +40,101 @@ def _seed_registry(job_count: int):
             removal_job = registry.start("remove_derived_model", "melix-dev-text", f"/runtime/remove/{model_id}")
             registry.attach_manifest(
                 removal_job.job_id,
-                json.dumps(
-                    {
-                        "derived_model_id": model_id,
-                        "activation_job_id": activation_job.job_id,
-                        "activation_manifest_path": activation_manifest_path,
-                        "adapter_manifest_path": adapter_manifest_path,
-                    }
-                ),
+                json.dumps(_removal_manifest(index, activation_job.job_id, activation_manifest_path, adapter_manifest_path)),
             )
             registry.complete(removal_job.job_id, f"/runtime/remove/{model_id}/remove_derived_model.lifecycle.json")
             removed_count += 1
     return registry, job_count - removed_count
+
+
+def _train_manifest(index: int, adapter_manifest_path: str) -> dict[str, str]:
+    return {
+        "job_id": f"model-ops-train-{index:04d}",
+        "operation": "train_lora",
+        "source_model": "melix-dev-text",
+        "adapter_name": f"adapter-{index:04d}",
+        "adapter_set_hash": f"hash-{index:04d}",
+        "output_path": adapter_manifest_path,
+    }
+
+
+def _activation_manifest(index: int, adapter_manifest_path: str) -> dict[str, str]:
+    model_id = f"melix-dev-derived-{index:04d}"
+    return {
+        "job_id": f"model-ops-activate-{index:04d}",
+        "operation": "activate_adapter",
+        "adapter_manifest_path": adapter_manifest_path,
+        "adapter_weights_path": f"/runtime/train/{model_id}/adapters.safetensors",
+        "adapter_set_hash": f"hash-{index:04d}",
+        "derived_model_id": model_id,
+        "derived_model_path": f"/runtime/activate/{model_id}",
+        "derived_model_alias": f"alias-{index:04d}",
+        "source_model": "melix-dev-text",
+        "activation_mode": "fused_derived_model",
+    }
+
+
+def _removal_manifest(
+    index: int,
+    activation_job_id: str,
+    activation_manifest_path: str,
+    adapter_manifest_path: str,
+) -> dict[str, str]:
+    model_id = f"melix-dev-derived-{index:04d}"
+    return {
+        "job_id": f"model-ops-remove-{index:04d}",
+        "operation": "remove_derived_model",
+        "source_model": "melix-dev-text",
+        "derived_model_id": model_id,
+        "activation_job_id": activation_job_id,
+        "activation_manifest_path": activation_manifest_path,
+        "adapter_manifest_path": adapter_manifest_path,
+    }
+
+
+def _write_restore_jobs_root(root: Path, job_count: int) -> int:
+    removed_count = 0
+    for index in range(job_count):
+        model_id = f"melix-dev-derived-{index:04d}"
+        adapter_manifest_path = f"/runtime/train/{model_id}/train_lora.adapter.json"
+        train_path = root / "train_lora" / f"model-ops-train-{index:04d}" / "train_lora.adapter.json"
+        train_path.parent.mkdir(parents=True, exist_ok=True)
+        train_path.write_bytes(json.dumps(_train_manifest(index, adapter_manifest_path), sort_keys=True).encode("utf-8"))
+
+        activation_job_id = f"model-ops-activate-{index:04d}"
+        activation_path = root / "activate_adapter" / activation_job_id / model_id / "manifest.json"
+        activation_path.parent.mkdir(parents=True, exist_ok=True)
+        activation_path.write_bytes(json.dumps(_activation_manifest(index, adapter_manifest_path), sort_keys=True).encode("utf-8"))
+
+        if index % 5 == 0:
+            removal_path = root / "remove_derived_model" / f"model-ops-remove-{index:04d}" / "remove_derived_model.lifecycle.json"
+            removal_path.parent.mkdir(parents=True, exist_ok=True)
+            removal_path.write_bytes(
+                json.dumps(
+                    _removal_manifest(index, activation_job_id, f"/runtime/activate/{model_id}/manifest.json", adapter_manifest_path),
+                    sort_keys=True,
+                ).encode("utf-8")
+            )
+            removed_count += 1
+    return job_count * 2 + removed_count
+
+
+def _measure_restore(job_count: int, sample_count: int) -> tuple[list[float], int]:
+    from worker.model_ops.job_registry import ModelOpsJobRegistry
+
+    elapsed_samples: list[float] = []
+    restored_count = 0
+    with tempfile.TemporaryDirectory(prefix="melix-job-registry-restore-probe-") as temp_dir:
+        jobs_root = Path(temp_dir) / "jobs"
+        expected_count = _write_restore_jobs_root(jobs_root, job_count)
+        for _ in range(sample_count):
+            started = time.perf_counter()
+            registry = ModelOpsJobRegistry(jobs_root=jobs_root)
+            elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+            restored_count = len(registry._jobs)
+            if restored_count != expected_count:  # pragma: no cover - defensive probe guard
+                raise RuntimeError(f"expected {expected_count} restored jobs, got {restored_count}")
+    return elapsed_samples, restored_count
 
 
 def main() -> int:
@@ -99,19 +172,25 @@ def main() -> int:
         if not manifest_path_target or manifest_path_target.get("derived_model_id") != target_model_id:
             raise RuntimeError("manifest-path lookup returned the wrong target")  # pragma: no cover
 
+    restore_elapsed_ms, restored_job_count = _measure_restore(job_count=400, sample_count=3)
+
     payload = {
         "active_manifest_count": float(active_count),
         "active_manifest_elapsed_ms_mean": round(statistics.fmean(active_elapsed_ms), 6),
         "elapsed_ms_mean": round(
             statistics.fmean(active_elapsed_ms)
             + statistics.fmean(resolve_elapsed_ms)
-            + statistics.fmean(manifest_path_elapsed_ms),
+            + statistics.fmean(manifest_path_elapsed_ms)
+            + statistics.fmean(restore_elapsed_ms),
             6,
         ),
         "job_count": float(job_count),
         "manifest_path_elapsed_ms_mean": round(statistics.fmean(manifest_path_elapsed_ms), 6),
         "removed_count": float(job_count - active_count),
         "resolve_target_elapsed_ms_mean": round(statistics.fmean(resolve_elapsed_ms), 6),
+        "restore_elapsed_ms_mean": round(statistics.fmean(restore_elapsed_ms), 6),
+        "restore_elapsed_ms_min": round(min(restore_elapsed_ms), 6),
+        "restored_job_count": float(restored_job_count),
         "sample_count": float(sample_count),
     }
     print(json.dumps(payload, sort_keys=True))

--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -92,6 +92,41 @@ def test_job_registry_restore_scans_manifest_directories_once(monkeypatch: pytes
     assert len(scan_calls) <= 9
 
 
+def test_job_registry_restore_reads_manifest_bytes_without_text_decode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    jobs_root = tmp_path / "jobs"
+    manifest_path = jobs_root / "train_lora" / "model-ops-0001" / "train_lora.adapter.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_bytes(
+        json.dumps(
+            {
+                "job_id": "model-ops-0001",
+                "operation": "train_lora",
+                "source_model": "melix-dev-text",
+            }
+        ).encode("utf-8")
+    )
+
+    read_bytes_calls: list[Path] = []
+    original_read_bytes = Path.read_bytes
+
+    def tracked_read_bytes(self: Path) -> bytes:
+        read_bytes_calls.append(self)
+        return original_read_bytes(self)
+
+    def forbidden_read_text(self: Path, *args: Any, **kwargs: Any) -> str:
+        raise AssertionError(f"restore manifests should be read as bytes: {self}")  # pragma: no cover
+
+    monkeypatch.setattr(Path, "read_bytes", tracked_read_bytes)
+    monkeypatch.setattr(Path, "read_text", forbidden_read_text)
+
+    registry = ModelOpsJobRegistry(jobs_root=jobs_root)
+
+    assert "model-ops-0001" in registry._jobs
+    assert read_bytes_calls == [manifest_path]
+
+
 def test_json_safe_reuses_clean_containers_and_copies_only_changed_branch() -> None:
     clean = {"rows": [{"pct": 1.0, "label": "ready"}]}
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -948,8 +948,11 @@ def test_job_registry_probe_script_emits_metrics(capsys: pytest.CaptureFixture[s
     payload = json.loads(capsys.readouterr().out)
     assert payload["active_manifest_elapsed_ms_mean"] > 0
     assert payload["resolve_target_elapsed_ms_mean"] > 0
+    assert payload["restore_elapsed_ms_mean"] > 0
+    assert payload["restore_elapsed_ms_min"] > 0
     assert payload["active_manifest_count"] == 960.0
     assert payload["removed_count"] == 240.0
+    assert payload["restored_job_count"] == 880.0
     assert payload["sample_count"] == 6.0
 
 

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -295,7 +295,7 @@ class ModelOpsJobRegistry:
     @staticmethod
     def _read_manifest_dict(path: Path) -> dict[str, Any]:
         try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
+            payload = json.loads(path.read_bytes())
         except (OSError, json.JSONDecodeError):
             return {}
         return payload if isinstance(payload, dict) else {}


### PR DESCRIPTION
## Summary
- Read model-ops job registry restore manifests with `Path.read_bytes()` instead of `Path.read_text()` before `json.loads`.
- Extend the registered `job-registry-derived-model-single-pass` probe to include restore-from-disk metrics.
- Add regression coverage proving restore manifests do not use text decoding.

## Plan or Spec
- `docs/plans/2026-05-02-job-registry-manifest-read-bytes.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/dev/null -> exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics -> 19 passed
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics -> 19 passed
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json -> exit 0
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py -> TOTAL 61 0 100%
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id job-registry-derived-model-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-job-registry-manifest-read-bytes-20260502224807 --head-repo "$PWD" --output /tmp/job_registry_manifest_read_bytes_probe.json -> exit 0
python3 standalone restore compare script, base vs head -> exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 61 0 100%`.
- Registered probe smoke: `job-registry-derived-model-single-pass` completed for base/head and reports new head restore metrics: `restore_elapsed_ms_mean=48.687286`, `restore_elapsed_ms_min=42.062624`, `restored_job_count=880.0`.
- Like-for-like restore microbenchmark using the same 400-job restore workload across base/head:
  - base mean `39.949429 ms`, min `37.759739 ms`
  - head mean `36.503103 ms`, min `32.488067 ms`
  - delta `-3.446326 ms`, speedup `1.094x` (about `8.63%` faster by mean)

## Known Gaps
- CI is required for the authoritative registered PR-scoped performance workflow result after PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
