### PR TITLE
perf: read PR scope changed files as bytes

### DIFF
--- a/docs/plans/2026-05-02-pr-scope-json-read-bytes.md
+++ b/docs/plans/2026-05-02-pr-scope-json-read-bytes.md
@@ -1,0 +1,47 @@
+# PR-scoped Scope Changed-files JSON Read Bytes Slice
+
+## Goal
+
+Reduce JSON input loading overhead in `scripts/pr_scoped_performance_scope.py`, the script that reads the changed-files payload before selecting PR-scoped performance probes.
+
+## Scope
+
+- `scripts/pr_scoped_performance_scope.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Linux Constraint
+
+This slice is Python-only and locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered PR-scoped performance probe. It does not validate Swift runtime effects locally.
+
+## Optimization Hypothesis
+
+The scope CLI currently loads the changed-files JSON via `Path.read_text(encoding="utf-8")` before `json.loads`. Switching to `Path.read_bytes()` lets Python's JSON decoder consume bytes directly and avoids an intermediate text decode/allocation on large changed-file payloads while preserving the same JSON-list validation and string coercion in `main()`.
+
+## Registered Probe
+
+- Probe ID: `pr-scoped-performance-scope-json-read-bytes`
+- Workload: create a synthetic changed-files JSON payload with 5,000 file paths and repeatedly call `load_changed_files()`.
+- Metrics:
+  - `elapsed_ms_mean` lower is better
+  - `elapsed_ms_min` lower is better
+  - `changed_file_count` and `sample_count` informational
+
+## Success Metrics
+
+- Focused tests prove the scope CLI loader uses binary JSON reads and the registry selects the new probe for `scripts/pr_scoped_performance_scope.py`.
+- Changed-scope coverage for the touched script/test scope remains at or above 95%.
+- Local registered probe improves versus the pre-change baseline.
+- PR-scoped performance CI completes successfully before merge.
+
+## Verification Commands
+
+```text
+python3 -m json.tool infra/perf/pr_scoped_probes.json >/dev/null
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_pr_scoped_scope_script_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_cli_loads_changed_files_with_binary_json_read services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_cli_scripts_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_pr_scoped_scope_script_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_cli_loads_changed_files_with_binary_json_read services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_cli_scripts_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/pr_scoped_performance_scope.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id pr-scoped-performance-scope-json-read-bytes --base-repo <baseline-worktree> --head-repo "$PWD" --output /tmp/pr_scope_json_read_bytes_probe.json
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -577,6 +577,36 @@
     ]
   },
   {
+    "id": "pr-scoped-performance-scope-json-read-bytes",
+    "name": "PR-scoped performance scope changed-files JSON read bytes",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "scripts/pr_scoped_performance_scope.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_pr_scoped_scope_script_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_cli_loads_changed_files_with_binary_json_read services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_cli_scripts_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_pr_scoped_scope_script_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_cli_loads_changed_files_with_binary_json_read services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_cli_scripts_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/pr_scoped_performance_scope.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 - <<'PY'\nimport importlib.util\nimport json\nimport statistics\nimport tempfile\nimport time\nfrom pathlib import Path\nrepo_root = Path.cwd()\nmodule_path = repo_root / \"scripts\" / \"pr_scoped_performance_scope.py\"\nspec = importlib.util.spec_from_file_location(\"melix_pr_scope_probe\", module_path)\nif spec is None or spec.loader is None:\n    raise RuntimeError(f\"Unable to load {module_path}\")\nmodule = importlib.util.module_from_spec(spec)\nspec.loader.exec_module(module)\nload_changed_files = getattr(module, \"load_changed_files\", None)\nif load_changed_files is None:\n    load_changed_files = lambda path: json.loads(Path(path).read_text(encoding=\"utf-8\"))\nchanged_count = 5000\nsample_count = 9\nelapsed_samples = []\nloaded_count = 0\nwith tempfile.TemporaryDirectory(prefix=\"melix-pr-perf-scope-json-\") as temp_dir:\n    changed_files_path = Path(temp_dir) / \"changed-files.json\"\n    changed_files = [f\"services/mlx-worker-python/worker/productization/synthetic_{index:05d}.py\" for index in range(changed_count)]\n    changed_files_path.write_bytes(json.dumps(changed_files).encode(\"utf-8\"))\n    for _ in range(sample_count):\n        started = time.perf_counter()\n        loaded = load_changed_files(changed_files_path)\n        elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n        loaded_count = len(loaded)\nif loaded_count != changed_count:\n    raise AssertionError(f\"expected {changed_count}, got {loaded_count}\")\nprint(json.dumps({\"changed_file_count\": float(changed_count), \"elapsed_ms_mean\": round(statistics.fmean(elapsed_samples), 6), \"elapsed_ms_min\": round(min(elapsed_samples), 6), \"sample_count\": float(sample_count)}, sort_keys=True))\nPY",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "pr-scoped-performance-scope-matcher",
     "name": "PR-scoped performance scope matcher",
     "runner": "ubuntu-latest",

--- a/scripts/pr_scoped_performance_scope.py
+++ b/scripts/pr_scoped_performance_scope.py
@@ -14,6 +14,13 @@ sys.path.insert(0, str(ROOT / "services/mlx-worker-python"))
 from worker.productization.pr_scoped_performance import build_scope_report  # noqa: E402
 
 
+def load_changed_files(path: str | Path) -> list[object]:
+    changed_files = json.loads(Path(path).read_bytes())
+    if not isinstance(changed_files, list):
+        raise ValueError("changed files payload must be a JSON list")
+    return changed_files
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--registry", required=True)
@@ -21,9 +28,7 @@ def main() -> int:
     parser.add_argument("--output", default="")
     args = parser.parse_args()
 
-    changed_files = json.loads(Path(args.changed_files_json).read_text(encoding="utf-8"))
-    if not isinstance(changed_files, list):
-        raise ValueError("changed files payload must be a JSON list")
+    changed_files = load_changed_files(args.changed_files_json)
     scope = build_scope_report(registry_path=args.registry, changed_files=[str(path) for path in changed_files])
     rendered = json.dumps(scope, indent=2, sort_keys=True) + "\n"
     if args.output:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -137,6 +137,17 @@ def test_scope_report_selects_worker_registry_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "worker-registry-resident-bytes-accumulator"
 
 
+def test_scope_report_selects_pr_scoped_scope_script_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["scripts/pr_scoped_performance_scope.py"],
+    )
+
+    selected_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert scope["force_all"] is True
+    assert "pr-scoped-performance-scope-json-read-bytes" in selected_ids
+
+
 def test_scope_report_selects_job_registry_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -428,6 +439,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "job-registry-derived-model-single-pass",
         "model-registry-plain-local-manifest-stat-elision",
         "package-macos-resolve-fallback-scandir",
+        "pr-scoped-performance-scope-json-read-bytes",
         "pr-scoped-performance-scope-matcher",
         "training-dataset-token-percentiles-single-sort",
         "maintenance-bench-report-readback",
@@ -1834,6 +1846,27 @@ def test_report_script_preserves_exact_sticky_comment_body_on_markdown_stdout(
     assert (report_dir / "report.md").read_text(encoding="utf-8") == expected_markdown
     assert (report_dir / "pr-comment.md").read_text(encoding="utf-8") == expected_sticky
 
+
+
+def test_scope_cli_loads_changed_files_with_binary_json_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    changed_files_path = tmp_path / "changed-files.json"
+    changed_files_path.write_text(json.dumps(["scripts/pr_scoped_performance_scope.py"]), encoding="utf-8")
+    scope_script = runpy.run_path(str(REPO_ROOT / "scripts/pr_scoped_performance_scope.py"))
+    load_changed_files = scope_script["load_changed_files"]
+
+    def fail_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        raise AssertionError("scope changed-files loader should use read_bytes()")  # pragma: no cover
+
+    monkeypatch.setattr(scope_script["Path"], "read_text", fail_read_text)
+
+    assert load_changed_files(changed_files_path) == ["scripts/pr_scoped_performance_scope.py"]
+
+    changed_files_path.write_text(json.dumps({"not": "a list"}), encoding="utf-8")
+    with pytest.raises(ValueError, match="changed files payload must be a JSON list"):
+        load_changed_files(changed_files_path)
 
 
 def test_cli_scripts_smoke(tmp_path: Path, benchmark_scope: dict[str, object], monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary
- Read PR-scoped performance changed-files JSON with `Path.read_bytes()` before `json.loads`.
- Register the `pr-scoped-performance-scope-json-read-bytes` probe for the scope CLI path.
- Add focused coverage proving the loader keeps binary reads, validates JSON list payloads, and is selected by the registry.

## Plan or Spec
- `docs/plans/2026-05-02-pr-scope-json-read-bytes.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/dev/null -> exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_pr_scoped_scope_script_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_cli_loads_changed_files_with_binary_json_read services/mlx-worker-python/tests/test_cli_scripts_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands -> 4 passed
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_pr_scoped_scope_script_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_cli_loads_changed_files_with_binary_json_read services/mlx-worker-python/tests/test_cli_scripts_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands -> 4 passed
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json -> exit 0
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/pr_scoped_performance_scope.py services/mlx-worker-python/tests/test_pr_scoped_performance.py -> TOTAL 22 0 100%
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id pr-scoped-performance-scope-json-read-bytes --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-pr-scope-json-read-bytes-20260502232212 --head-repo "$PWD" --output /tmp/pr_scope_json_read_bytes_probe.json -> exit 0
git diff --check -> exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 22 0 100%`.
- Registered local probe `pr-scoped-performance-scope-json-read-bytes`:
  - base `elapsed_ms_mean=1.310265`, `elapsed_ms_min=0.848403`
  - head `elapsed_ms_mean=1.134272`, `elapsed_ms_min=0.829908`
  - mean delta `-0.175993 ms`, speedup `1.155x` (about `13.43%` faster by mean)
- CI is required for the authoritative registered PR-scoped performance workflow result after PR creation.

## Known Gaps
- PR-scoped performance registry changes force all registered probes to run in CI; local Linux verification covered the new probe directly.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
