### PR TITLE
perf: reduce training dataset token summary allocations

### DIFF
--- a/docs/plans/2026-05-02-training-dataset-inplace-token-sort.md
+++ b/docs/plans/2026-05-02-training-dataset-inplace-token-sort.md
@@ -1,0 +1,53 @@
+# Training dataset in-place token summary sort
+
+## Goal
+
+Reduce avoidable allocations in `services/mlx-worker-python/worker/model_ops/training_dataset.py` when building token summaries from temporary token-count lists.
+
+## Constraints
+
+- This slice is Linux-verifiable Python-only work under `services/mlx-worker-python`.
+- The change must preserve the existing token-stat output schema and percentile semantics exactly.
+- The affected path is already covered by the registered PR-scoped probe `training-dataset-token-percentiles-single-sort` in `infra/perf/pr_scoped_probes.json`.
+- Keep the change limited to one coherent optimization slice plus focused regression tests.
+
+## Proposed change
+
+1. Extend `_summarize_token_values(...)` with an internal opt-in path that can sort the provided list in place.
+2. Use that opt-in only from callers that pass freshly built temporary token-count lists inside:
+   - `_build_quality_and_token_stats(...)`
+   - `_collect_token_stats(...)`
+3. Leave the default helper behavior non-mutating for any other direct callers.
+4. Add focused tests that prove:
+   - the default helper behavior still preserves caller ordering
+   - the in-place fast path preserves summary values while sorting the temporary list
+
+## Probe and success metrics
+
+### Scoped CI probe
+
+`training-dataset-token-percentiles-single-sort`
+
+### Measurement path
+
+The registered probe repeatedly calls `_build_quality_and_token_stats(samples, "prompt_completion")` on a large synthetic dataset and records:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- unchanged semantic guard rails such as `sample_count`, `duplicate_count`, and percentile fields
+
+### Success metric
+
+- Primary: lower `peak_bytes_mean` and/or `elapsed_ms_mean` versus `origin/main`
+- Guard rails: unchanged semantic metrics from the existing probe output
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_training_dataset_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_training_dataset_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-token-percentiles-single-sort --base-repo /tmp/melix-training-dataset-base --head-repo "$PWD" --output /tmp/melix-training-dataset-probe.json
+git diff --check
+```

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -938,6 +938,24 @@ def test_build_quality_and_token_stats_falls_back_to_generic_digest_for_non_norm
     assert token_stats["sample_count"] == 2
 
 
+def test_summarize_token_values_preserves_input_order_by_default() -> None:
+    values = [4, 1, 3, 2]
+
+    summary = training_dataset_module._summarize_token_values(values, total=10)
+
+    assert summary == {"mean": 2.5, "p50": 2, "p95": 3, "max": 4}
+    assert values == [4, 1, 3, 2]
+
+
+def test_summarize_token_values_can_sort_temporary_lists_in_place() -> None:
+    values = [4, 1, 3, 2]
+
+    summary = training_dataset_module._summarize_token_values(values, total=10, sort_in_place=True)
+
+    assert summary == {"mean": 2.5, "p50": 2, "p95": 3, "max": 4}
+    assert values == [1, 2, 3, 4]
+
+
 def test_resolve_dataset_build_source_reuses_existing_package_sample_lists(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1345,9 +1345,9 @@ def _build_quality_and_token_stats(
         completion_tokens_append(completion_count)
         total_tokens_append(prompt_count + completion_count)
 
-    finalized_prompt_summary = _summarize_token_values(prompt_tokens)
-    finalized_completion_summary = _summarize_token_values(completion_tokens)
-    finalized_total_summary = _summarize_token_values(total_tokens)
+    finalized_prompt_summary = _summarize_token_values(prompt_tokens, sort_in_place=True)
+    finalized_completion_summary = _summarize_token_values(completion_tokens, sort_in_place=True)
+    finalized_total_summary = _summarize_token_values(total_tokens, sort_in_place=True)
 
     return (
         {
@@ -1409,9 +1409,9 @@ def _collect_token_stats(samples: Iterable[dict[str, Any]], format_name: str) ->
             completion_tokens_append(completion_count)
             total_tokens_append(prompt_count + completion_count)
 
-    prompt_summary = _summarize_token_values(prompt_tokens, total=prompt_token_sum)
-    completion_summary = _summarize_token_values(completion_tokens, total=completion_token_sum)
-    total_summary = _summarize_token_values(total_tokens, total=total_token_sum)
+    prompt_summary = _summarize_token_values(prompt_tokens, total=prompt_token_sum, sort_in_place=True)
+    completion_summary = _summarize_token_values(completion_tokens, total=completion_token_sum, sort_in_place=True)
+    total_summary = _summarize_token_values(total_tokens, total=total_token_sum, sort_in_place=True)
 
     return {
         "estimator": "whitespace_v1",
@@ -1586,8 +1586,11 @@ def _mean_value(values: list[int]) -> float:
     return round(sum(values) / len(values), 3)
 
 
-def _summarize_token_values(values: list[int], *, total: int | None = None) -> dict[str, float | int]:
-    ordered = sorted(values)
+def _summarize_token_values(
+    values: list[int], *, total: int | None = None, sort_in_place: bool = False
+) -> dict[str, float | int]:
+    ordered = values if sort_in_place else list(values)
+    ordered.sort()
     return {
         "mean": _mean_value_from_total(total if total is not None else sum(values), len(values)),
         "p50": _sorted_percentile_value(ordered, 0.50),


### PR DESCRIPTION
## Summary
- reduce temporary allocations when summarizing training-dataset token counts
- add an internal opt-in in-place sort path for `_summarize_token_values(...)`
- use that fast path only for temporary token-count lists built inside `training_dataset.py`
- add focused regression tests that preserve the default non-mutating helper behavior

## Plan or Spec
- `docs/plans/2026-05-02-training-dataset-inplace-token-sort.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
- PASS (106 passed)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
- PASS (TOTAL 19 0 100%)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-token-percentiles-single-sort --base-repo /tmp/melix-training-dataset-base --head-repo "$PWD" --output /tmp/melix-training-dataset-probe.json
- PASS

git diff --check
- PASS
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`19/19` measurable changed lines covered)
- Registered scoped probe: `training-dataset-token-percentiles-single-sort`
- Probe guard rails preserved:
  - `sample_count`: `20000.0` → `20000.0`
  - `duplicate_count`: `784.0` → `784.0`
  - `dirty_count`: `393.0` → `393.0`
- Probe metrics:
  - `peak_bytes_mean`: `2362556.0` → `2202484.0` (~`6.78%` lower, `160072` fewer bytes)
  - `elapsed_ms_mean`: `361.381` → `377.947` (~`4.58%` higher)
- Interpretation: this slice reduces temporary allocation pressure in the measured path while staying within the probe's configured elapsed-time warning threshold.

## Known Gaps
- Linux-only local verification was run for this Python slice; no macOS/Swift verification was applicable.
- The local probe showed a small elapsed-time regression while materially reducing peak traced allocation. Hosted `pr-scoped-performance` remains the final merge gate for this tradeoff.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
