### PR TITLE
perf: hoist benchmark report metric key tuples

### DIFF
--- a/docs/plans/2026-05-03-benchmark-evaluation-summary-key-tuples.md
+++ b/docs/plans/2026-05-03-benchmark-evaluation-summary-key-tuples.md
@@ -1,0 +1,31 @@
+# Benchmark/evaluation report summary key tuple hoist
+
+## Scope
+
+This performance slice is limited to `worker.productization.benchmark_evaluation_report`.
+It keeps report semantics unchanged while reducing repeated tiny allocations in the
+registered benchmark/evaluation report aggregation path.
+
+## Optimization Hypothesis
+
+`_collect_metrics()` iterates the same benchmark matrix summary metric names and
+evaluation summary metric names for every report build. Those tuples were being
+constructed inside the function on every call. Hoisting them to module-level
+constants removes per-call tuple allocation while preserving the same iteration
+order, metric names, and output rows.
+
+## Registered Probe
+
+- Probe ID: `benchmark-evaluation-report-running-aggregates`
+- Registry: `infra/perf/pr_scoped_probes.json`
+- Local Linux validation source: the registered focused tests, changed-scope
+  coverage command, and the registered probe command.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_benchmark_evaluation_report as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
+git diff --check
+```

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -62,6 +62,16 @@ _EVALUATION_SAMPLE_PROBE_KEYS = (
     "raw_response_chars",
     "extracted_result_chars",
 )
+_MATRIX_SUMMARY_METRIC_KEYS = (
+    "request_latency_mean_ms",
+    "request_latency_p95_ms",
+    "ttft_mean_ms",
+    "ttft_p95_ms",
+    "throughput_tokens_per_second",
+    "success_rate",
+    "failed_count",
+)
+_EVALUATION_SUMMARY_METRIC_KEYS = ("failure_count", "duration_seconds")
 _LOWER_IS_BETTER_METRIC_FRAGMENTS = (
     "latency",
     "ttft",
@@ -308,15 +318,7 @@ def _collect_metrics(bundle: dict[str, object]) -> dict[str, object]:
     )
     for row in _dict_rows(bundle.get("benchmark_matrix_summary_rows", [])):
         label = _matrix_label(row, label_cache=label_cache)
-        for key in (
-            "request_latency_mean_ms",
-            "request_latency_p95_ms",
-            "ttft_mean_ms",
-            "ttft_p95_ms",
-            "throughput_tokens_per_second",
-            "success_rate",
-            "failed_count",
-        ):
+        for key in _MATRIX_SUMMARY_METRIC_KEYS:
             value = _float_or_none(row.get(key))
             if value is not None:
                 metrics[f"bench.matrix.{label}.{key}"] = value
@@ -332,7 +334,7 @@ def _collect_metrics(bundle: dict[str, object]) -> dict[str, object]:
         score_value = _float_or_none(row.get("primary_score_value"))
         if score_value is not None:
             metrics[f"eval.{suite_id}.{score_name}"] = score_value
-        for key in ("failure_count", "duration_seconds"):
+        for key in _EVALUATION_SUMMARY_METRIC_KEYS:
             value = _float_or_none(row.get(key))
             if value is not None:
                 metrics[f"eval.{suite_id}.{key}"] = value


### PR DESCRIPTION
## Summary
- Hoists benchmark/evaluation report summary metric key tuples to module-level constants.
- Removes repeated per-call tuple construction in `_collect_metrics()` while preserving metric order and output semantics.

## Plan or Spec
- `docs/plans/2026-05-03-benchmark-evaluation-summary-key-tuples.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# 36 passed in 0.13s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# 36 passed in 0.13s; TOTAL 99% coverage

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-evaluation-report-running-aggregates --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-benchmark-report-status-counts-20260503000048 --head-repo "$PWD" --output /tmp/benchmark_report_probe_20260503000207.json
# base/head probe ok; head verification ok

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 99% total (`benchmark_evaluation_report.py` 99%, `test_benchmark_evaluation_report.py` 99%).
- Registered probe: `benchmark-evaluation-report-running-aggregates`.
- Local Linux probe result (`/tmp/benchmark_report_probe_20260503000207.json`):
  - `elapsed_ms_mean`: base `148.531` ms → head `146.497` ms (`-2.034` ms, ~`1.37%` faster).
  - `peak_bytes_mean`: base `3895477.7` bytes → head `3895477.7` bytes (no change).
  - `row_count`: base/head `5990.0`.
- CI PR-scoped performance workflow is required as the final registered-probe validation source before merge.

## Known Gaps
- None. This is a small Python-only optimization and was locally verified on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
