### PR TITLE
perf: reuse sorted maintenance percentile vectors

### DIFF
--- a/docs/plans/2026-05-03-maintenance-percentile-reuse.md
+++ b/docs/plans/2026-05-03-maintenance-percentile-reuse.md
@@ -1,0 +1,75 @@
+# Maintenance percentile reuse optimization plan
+
+## Goal
+
+Reduce redundant sorting work in `services/mlx-worker-python/worker/engine/maintenance_core.py` by reusing one sorted latency vector when the code needs multiple percentiles from the same sample set.
+
+## Linux-only constraint
+
+This slice is limited to the Python worker and PR-scoped performance configuration so it can be verified locally on Linux without macOS or Swift execution.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/engine/maintenance_core.py`
+- `services/mlx-worker-python/tests/test_maintenance_service.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Implementation sketch
+
+1. Add a helper that computes multiple percentiles from one sorted sample vector while preserving existing rounding and interpolation semantics.
+2. Route the repeated p50/p95 maintenance paths through that helper:
+   - top-level `RunBench` request latency summary
+   - matrix summary `ttft` and request latency summaries
+   - latency-suite metric emission
+3. Add focused regression tests that prove these paths no longer fall back to repeated percentile helper calls.
+4. Register a dedicated PR-scoped performance probe for the maintenance percentile path.
+
+## Performance probe
+
+Register `maintenance-percentile-vector-reuse` in `infra/perf/pr_scoped_probes.json`.
+
+Probe definition:
+- build a synthetic list of request latencies
+- compare the hot path that needs p50 and p95 from the same vector
+- report concrete elapsed metrics for repeated samples
+- keep the probe command base-compatible by embedding it inline in the registry command
+
+## Success metrics
+
+- No behavior change in percentile outputs.
+- Changed-scope automated coverage >= 95%.
+- Local probe shows lower mean elapsed time for the repeated percentile workload.
+- `git diff --check` passes.
+
+## Verification commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_latency_and_summary_reuse_single_sorted_request_latency_vector \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_reuses_single_sorted_latency_vectors \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_percentiles_reuse_one_sorted_vector_and_preserve_interpolation \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_measures_runtime_behavior_from_loaded_backend \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_returns_summary_rows_and_persists_matrix_artifacts \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_percentile_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_latency_and_summary_reuse_single_sorted_request_latency_vector \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_reuses_single_sorted_latency_vectors \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_percentiles_reuse_one_sorted_vector_and_preserve_interpolation \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_measures_runtime_behavior_from_loaded_backend \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_returns_summary_rows_and_persists_matrix_artifacts \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_percentile_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/engine/maintenance_core.py \
+  services/mlx-worker-python/tests/test_maintenance_service.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -lc '<maintenance percentile probe command from registry>'
+
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -373,6 +373,36 @@
     ]
   },
   {
+    "id": "maintenance-percentile-vector-reuse",
+    "name": "Maintenance percentile vector reuse",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/engine/maintenance_core.py",
+      "services/mlx-worker-python/tests/test_maintenance_service.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_percentiles_reuse_one_sorted_vector_and_preserve_interpolation services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_latency_and_summary_reuse_single_sorted_request_latency_vector services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_reuses_single_sorted_latency_vectors services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_measures_runtime_behavior_from_loaded_backend services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_returns_summary_rows_and_persists_matrix_artifacts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_percentile_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_percentiles_reuse_one_sorted_vector_and_preserve_interpolation services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_latency_and_summary_reuse_single_sorted_request_latency_vector services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_reuses_single_sorted_latency_vectors services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_measures_runtime_behavior_from_loaded_backend services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_returns_summary_rows_and_persists_matrix_artifacts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_percentile_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 - <<'PY'\nimport builtins\nimport json\nimport statistics\nimport sys\nimport time\nfrom pathlib import Path\n\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / 'services/mlx-worker-python'))\n\nfrom worker.engine.maintenance_core import MaintenanceCore\n\nvalues = [float((index * 37) % 1000) for index in range(20000)]\nelapsed_samples = []\nsort_call_samples = []\nsample_count = 5\niteration_count = 300\nlast_result = (0.0, 0.0)\nfor _ in range(sample_count):\n    original_sorted = builtins.sorted\n    sort_calls = {'count': 0}\n\n    def tracked_sorted(iterable, *args, **kwargs):\n        sort_calls['count'] += 1\n        return original_sorted(iterable, *args, **kwargs)\n\n    builtins.sorted = tracked_sorted\n    started = time.perf_counter()\n    try:\n        helper = getattr(MaintenanceCore, '_percentiles', None)\n        for _ in range(iteration_count):\n            if helper is None:\n                last_result = (\n                    MaintenanceCore._percentile(values, 50.0),\n                    MaintenanceCore._percentile(values, 95.0),\n                )\n            else:\n                last_result = helper(values, 50.0, 95.0)\n    finally:\n        builtins.sorted = original_sorted\n    elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n    sort_call_samples.append(float(sort_calls['count']))\n\nif last_result[1] < last_result[0]:\n    raise SystemExit('unexpected percentile ordering regression')\n\nprint(json.dumps({\n    'elapsed_ms_mean': round(statistics.fmean(elapsed_samples), 6),\n    'iteration_count': float(iteration_count),\n    'p50_ms': float(last_result[0]),\n    'p95_ms': float(last_result[1]),\n    'sample_count': float(sample_count),\n    'sort_calls_mean': round(statistics.fmean(sort_call_samples), 6),\n    'value_count': float(len(values)),\n}, sort_keys=True))\nPY",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "sort_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "upload-receipt-published-files-scandir",
     "name": "Upload receipt published-files scandir",
     "runner": "ubuntu-latest",

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import csv
 import hashlib
 import json
@@ -4136,6 +4137,109 @@ def test_run_bench_persists_report_without_reading_report_file(tmp_path: Path, m
     assert report_path.name == "bench-report.md"
     assert "# Melix Bench" in report
     assert "runtime_name: fast-benchmark" in report
+
+
+def test_percentiles_reuse_one_sorted_vector_and_preserve_interpolation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_sorted = builtins.sorted
+    sorted_calls: list[list[float]] = []
+
+    def tracked_sorted(values: list[float], *args: object, **kwargs: object) -> list[float]:
+        ordered = original_sorted(values, *args, **kwargs)
+        sorted_calls.append(list(ordered))
+        return ordered
+
+    monkeypatch.setattr(builtins, "sorted", tracked_sorted)
+
+    values = [5.0, 1.0, 7.0, 9.0]
+
+    assert MaintenanceCore._percentiles(values) == ()
+    assert MaintenanceCore._percentiles([], 50.0, 95.0) == (0.0, 0.0)
+    assert MaintenanceCore._percentiles(values, 50.0, 95.0) == (6.0, 8.7)
+    assert MaintenanceCore._percentile(values, 95.0) == 8.7
+    assert sorted_calls == [[1.0, 5.0, 7.0, 9.0], [1.0, 5.0, 7.0, 9.0]]
+
+
+def test_run_bench_latency_and_summary_reuse_single_sorted_request_latency_vector(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=FastBenchmarkBackend()),
+        model_catalog=WorkerModelCatalog(),
+    )
+    loaded = registry.load_model(WorkerModelCatalog.dev_text_model())
+    service = build_service(tmp_path, registry=registry)
+    service._core._benchmark_suite_catalog = BenchmarkSuiteCatalog(
+        hf_dataset_fetcher=FakeBenchmarkHFDatasetFetcher()
+    )
+
+    monkeypatch.setattr(
+        MaintenanceCore,
+        "_percentile",
+        staticmethod(lambda values, percentile: (_ for _ in ()).throw(AssertionError("legacy percentile helper should not run"))),
+    )
+
+    events = list(
+        service.RunBench(
+            maintenance_pb2.RunBenchRequest(
+                model_handle=loaded.handle,
+                suites=["latency"],
+                parameters={"require_live_model": "true"},
+            ),
+            context=None,
+        )
+    )
+
+    metrics = {
+        event.metric.name: event.metric.value
+        for event in events
+        if event.HasField("metric")
+    }
+
+    assert metrics["bench.latency.p95_ms"] >= metrics["bench.latency.p50_ms"] >= 0.0
+
+
+def test_run_bench_matrix_reuses_single_sorted_latency_vectors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=RecordingBenchmarkBackend()),
+        model_catalog=WorkerModelCatalog(),
+    )
+    service = build_service(tmp_path, registry=registry)
+
+    monkeypatch.setattr(
+        MaintenanceCore,
+        "_percentile",
+        staticmethod(
+            lambda values, percentile: 9.2
+            if percentile == 95.0
+            else (_ for _ in ()).throw(AssertionError("matrix percentile reuse should only leave the queue-wait p95 path"))
+        ),
+    )
+
+    response = service.RunBenchMatrix(
+        maintenance_pb2.RunBenchMatrixRequest(
+            model_handle="melix-dev-text::1",
+            task_kind="text-generation",
+            suite_ids=["smoke"],
+            context_lengths=[1024, 256],
+            generation_lengths=[128],
+            batch_sizes=[2],
+            cache_profiles=["cold"],
+            reasoning_modes=["enabled"],
+            structured_output_modes=["plain_text"],
+            concurrency_levels=[1],
+            repeats=2,
+            requests=4,
+        ),
+        context=None,
+    )
+
+    assert len(response.summary_rows) == 2
 
 
 def test_run_bench_require_live_model_rejects_deterministic_runtime(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -238,6 +238,16 @@ def test_scope_report_selects_bench_report_probe() -> None:
     assert "maintenance-bench-report-readback" in probe_ids
 
 
+def test_scope_report_selects_maintenance_percentile_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/engine/maintenance_core.py"],
+    )
+
+    probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert "maintenance-percentile-vector-reuse" in probe_ids
+
+
 def test_scope_report_selects_upload_receipt_published_files_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -443,6 +453,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "pr-scoped-performance-scope-matcher",
         "training-dataset-token-percentiles-single-sort",
         "maintenance-bench-report-readback",
+        "maintenance-percentile-vector-reuse",
         "phase8-metrics-closure-audit-reuse",
         "pr-scoped-performance-registry-cache",
         "swift-cli-json-envelope-encoding",

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -1224,8 +1224,7 @@ class MaintenanceCore:
                     }
                 )
             )
-            request_p50_ms = self._percentile(text_request_latencies, 50.0)
-            request_p95_ms = self._percentile(text_request_latencies, 95.0)
+            request_p50_ms, request_p95_ms = self._percentiles(text_request_latencies, 50.0, 95.0)
             generation_length = self._benchmark_generation_length(parameters)
             repeats = self._benchmark_repeats(parameters)
             cache_profile = self._benchmark_cache_profile(parameters)
@@ -1544,6 +1543,13 @@ class MaintenanceCore:
                                                 else 0.0
                                             )
                                             decode_mean = self._mean(decode_values)
+                                            ttft_p50_ms, ttft_p95_ms = self._percentiles(ttft_values, 50.0, 95.0)
+                                            request_latency_p50_ms, request_latency_p95_ms = self._percentiles(
+                                                request_latencies,
+                                                50.0,
+                                                95.0,
+                                            )
+
                                             summary_rows.append(
                                                 build_benchmark_matrix_summary_row(
                                                     job_id=job.job_id,
@@ -1585,10 +1591,10 @@ class MaintenanceCore:
                                                     cell_wall_ms=round((time.perf_counter() - cell_started_at) * 1_000.0, 2),
                                                     completed_count=len(completed_rows),
                                                     failed_count=len(cell_rows) - len(completed_rows),
-                                                    ttft_p50_ms=self._percentile(ttft_values, 50.0),
-                                                    ttft_p95_ms=self._percentile(ttft_values, 95.0),
-                                                    request_latency_p50_ms=self._percentile(request_latencies, 50.0),
-                                                    request_latency_p95_ms=self._percentile(request_latencies, 95.0),
+                                                    ttft_p50_ms=ttft_p50_ms,
+                                                    ttft_p95_ms=ttft_p95_ms,
+                                                    request_latency_p50_ms=request_latency_p50_ms,
+                                                    request_latency_p95_ms=request_latency_p95_ms,
                                                     created_at_unix_ms=queued_at,
                                                 )
                                             )
@@ -2429,18 +2435,19 @@ class MaintenanceCore:
                         )
 
         if suite.suite_id == "latency":
+            request_latency_p50_ms, request_latency_p95_ms = self._percentiles(request_latencies, 50.0, 95.0)
             return (
                 [
                     BenchMetricSpec(
                         suite=suite.suite_id,
                         name="bench.latency.p50_ms",
-                        value=self._percentile(request_latencies, 50.0),
+                        value=request_latency_p50_ms,
                         unit="ms",
                     ),
                     BenchMetricSpec(
                         suite=suite.suite_id,
                         name="bench.latency.p95_ms",
-                        value=self._percentile(request_latencies, 95.0),
+                        value=request_latency_p95_ms,
                         unit="ms",
                     ),
                 ],
@@ -3574,7 +3581,19 @@ class MaintenanceCore:
     def _percentile(values: list[float], percentile: float) -> float:
         if not values:
             return 0.0
+        return MaintenanceCore._ordered_percentile(sorted(values), percentile)
+
+    @staticmethod
+    def _percentiles(values: list[float], *percentiles: float) -> tuple[float, ...]:
+        if not percentiles:
+            return ()
+        if not values:
+            return tuple(0.0 for _ in percentiles)
         ordered = sorted(values)
+        return tuple(MaintenanceCore._ordered_percentile(ordered, percentile) for percentile in percentiles)
+
+    @staticmethod
+    def _ordered_percentile(ordered: list[float], percentile: float) -> float:
         if len(ordered) == 1:
             return round(ordered[0], 2)
         rank = (len(ordered) - 1) * max(0.0, min(percentile, 100.0)) / 100.0


### PR DESCRIPTION
## Summary
- reuse one sorted latency vector in `maintenance_core.py` when the same sample list needs multiple percentiles
- preserve existing percentile interpolation and rounding semantics while removing redundant `sorted(...)` work from `RunBench`, latency-suite metric emission, and matrix summary rows
- add focused regression tests plus a dedicated `maintenance-percentile-vector-reuse` PR-scoped performance probe

## Plan or Spec
- `docs/plans/2026-05-03-maintenance-percentile-reuse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_percentiles_reuse_one_sorted_vector_and_preserve_interpolation services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_latency_and_summary_reuse_single_sorted_request_latency_vector services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_reuses_single_sorted_latency_vectors services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_measures_runtime_behavior_from_loaded_backend services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_returns_summary_rows_and_persists_matrix_artifacts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_percentile_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
- result: 7 passed in 1.04s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_percentiles_reuse_one_sorted_vector_and_preserve_interpolation services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_latency_and_summary_reuse_single_sorted_request_latency_vector services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_reuses_single_sorted_latency_vectors services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_measures_runtime_behavior_from_loaded_backend services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_returns_summary_rows_and_persists_matrix_artifacts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_percentile_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
- result: 7 passed in 0.75s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
- result: TOTAL 48 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
... maintenance percentile probe ...
PY
- head result: {"elapsed_ms_mean": 304.772966, "iteration_count": 300.0, "p50_ms": 499.5, "p95_ms": 949.05, "sample_count": 5.0, "sort_calls_mean": 300.0, "value_count": 20000.0}
- origin/main result: {"elapsed_ms_mean": 624.414035, "iteration_count": 300.0, "p50_ms": 499.5, "p95_ms": 949.05, "sample_count": 5.0, "sort_calls_mean": 600.0, "value_count": 20000.0}

git diff --check
- result: passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 48 0 100%`
- `services/mlx-worker-python/worker/engine/maintenance_core.py`: `100%` changed-line coverage
- `services/mlx-worker-python/tests/test_maintenance_service.py`: `100%` changed-line coverage
- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`: `100%` changed-line coverage
- Local probe (`maintenance-percentile-vector-reuse` synthetic workload, 20,000 values × 300 iterations × 5 samples):
  - `origin/main` `elapsed_ms_mean=624.414035`, `sort_calls_mean=600.0`
  - `HEAD` `elapsed_ms_mean=304.772966`, `sort_calls_mean=300.0`
  - delta: `elapsed_ms_mean` improved by `51.19%`; sort calls reduced by `50.0%`
- Registered scoped CI probe: `maintenance-percentile-vector-reuse`

## Known Gaps
- Local verification covered the Linux-verifiable Python slice only.
- Because this change touches `infra/perf/pr_scoped_probes.json`, hosted `pr-scoped-performance` will force the wider probe matrix, including macOS-hosted probes that cannot be validated locally on this Linux host.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (Not applicable; no protocol change.)
- [x] Dependency changes include updated lockfiles. (Not applicable; no dependency change.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
