### PR TITLE
perf: single-scan benchmark export matrix run discovery

### DIFF
--- a/docs/plans/2026-05-03-benchmark-export-matrix-run-single-scan.md
+++ b/docs/plans/2026-05-03-benchmark-export-matrix-run-single-scan.md
@@ -1,0 +1,52 @@
+# Benchmark Export Matrix-Run Single Scan
+
+## Context
+
+This slice is Python-only and Linux-verifiable from the worker workspace. The current `benchmark_export.py` implementation already uses a single `os.scandir()` pass for serving benchmark run discovery, but `_collect_benchmark_matrix_run(...)` still probes `bench-matrix-job.json`, `bench-matrix-summary.jsonl`, and `bench-matrix-requests.jsonl` with three separate `Path.is_file()` calls per run directory.
+
+The repository already registers the scoped CI probe `benchmark-export-run-scan-single-pass`, so this slice should stay inside that measurable path instead of introducing a new probe family.
+
+## Chosen Slice
+
+- update `services/mlx-worker-python/worker/productization/benchmark_export.py`
+- update `services/mlx-worker-python/tests/test_benchmark_export.py`
+- update `infra/perf/pr_scoped_probes.json` only if the existing focused test or coverage command needs tightening for the touched matrix-run behavior
+
+Goal: make `_collect_benchmark_matrix_run(...)` discover its three artifact files with one directory scan while preserving output ordering, fallback behavior, and JSON/JSONL loading semantics.
+
+## Linux Constraint
+
+This work is limited to the Python worker/export path and can be verified locally on Linux. No macOS or Swift validation is required for correctness, but the existing PR-scoped performance CI must still validate the registered scoped probe after push.
+
+## Probe Definition
+
+Registered scoped CI probe: `benchmark-export-run-scan-single-pass` in `infra/perf/pr_scoped_probes.json`.
+
+Local measurement path before commit:
+
+- run the focused benchmark export pytest slice
+- run changed-scope coverage for the touched executable lines
+- run the existing benchmark export scoped probe and record concrete metrics such as:
+  - `elapsed_ms_mean`
+  - `per_run_ms_mean`
+  - `csv_elapsed_ms_mean`
+
+Success criteria:
+
+1. matrix-run artifact collection remains behavior-identical
+2. changed executable line coverage for the touched scope is at least 95%
+3. the local probe does not regress versus the current baseline and ideally improves `elapsed_ms_mean` and `per_run_ms_mean`
+
+## Verification Commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_job_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_result_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_summary_csv_count
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_job_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_result_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_summary_csv_count
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_export.py services/mlx-worker-python/tests/test_benchmark_export.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_benchmark_export_run_scan as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
+
+git diff --check
+```

--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from worker.productization.benchmark_export import (
+    _collect_benchmark_matrix_run,
     _collect_benchmark_run,
     _collect_evaluation_run,
     _iter_jsonl_dict_rows,
@@ -730,6 +731,84 @@ def test_collect_benchmark_artifacts_reads_matrix_run_history_from_matrix_runs_d
     assert [job["job_id"] for job in result["benchmark_matrix_jobs"]] == ["bench-matrix-1", "bench-matrix-2"]
     assert [row["job_id"] for row in result["benchmark_matrix_summary_rows"]] == ["bench-matrix-1", "bench-matrix-2"]
     assert [row["job_id"] for row in result["benchmark_matrix_request_rows"]] == ["bench-matrix-1", "bench-matrix-2"]
+
+
+def test_collect_benchmark_matrix_run_uses_direntry_checks_without_path_is_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _write_bench_matrix_run_fixture(tmp_path, job_id="bench-matrix-1")
+    run_root = tmp_path / "matrix-runs" / "bench-matrix-1"
+
+    monkeypatch.setattr(
+        Path,
+        "is_file",
+        lambda self: (_ for _ in ()).throw(AssertionError("_collect_benchmark_matrix_run should not use Path.is_file")),
+    )
+
+    jobs: list[dict[str, object]] = []
+    summary_rows: list[dict[str, object]] = []
+    request_rows: list[dict[str, object]] = []
+
+    _collect_benchmark_matrix_run(
+        run_root,
+        jobs=jobs,
+        summary_rows=summary_rows,
+        request_rows=request_rows,
+    )
+
+    assert [job["job_id"] for job in jobs] == ["bench-matrix-1"]
+    assert [row["job_id"] for row in summary_rows] == ["bench-matrix-1"]
+    assert [row["job_id"] for row in request_rows] == ["bench-matrix-1"]
+
+
+def test_collect_benchmark_matrix_run_skips_entries_with_stat_failures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    run_root = tmp_path / "matrix-runs" / "bench-matrix-1"
+    run_root.mkdir(parents=True)
+    payloads = {
+        "bench-matrix-job.json": json.dumps({"job_id": "bench-matrix-1"}) + "\n",
+        "bench-matrix-summary.jsonl": json.dumps({"job_id": "bench-matrix-1", "row_kind": "summary"}) + "\n",
+        "bench-matrix-requests.jsonl": json.dumps({"job_id": "bench-matrix-1", "row_kind": "request"}) + "\n",
+    }
+    for name, payload in payloads.items():
+        (run_root / name).write_text(payload)
+
+    class _BrokenEntry:
+        name = "bench-matrix-broken.json"
+
+        def is_file(self) -> bool:
+            raise OSError("stat failed")
+
+    class _GoodEntry:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def is_file(self) -> bool:
+            return True
+
+    class _Scandir:
+        def __enter__(self):
+            return iter((_BrokenEntry(), _GoodEntry("bench-matrix-job.json"), _GoodEntry("bench-matrix-summary.jsonl"), _GoodEntry("bench-matrix-requests.jsonl")))
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    monkeypatch.setattr("worker.productization.benchmark_export.os.scandir", lambda path: _Scandir())
+
+    jobs: list[dict[str, object]] = []
+    summary_rows: list[dict[str, object]] = []
+    request_rows: list[dict[str, object]] = []
+
+    _collect_benchmark_matrix_run(
+        run_root,
+        jobs=jobs,
+        summary_rows=summary_rows,
+        request_rows=request_rows,
+    )
+
+    assert jobs == [{"job_id": "bench-matrix-1"}]
+    assert summary_rows == [{"job_id": "bench-matrix-1", "row_kind": "summary"}]
+    assert request_rows == [{"job_id": "bench-matrix-1", "row_kind": "request"}]
 
 
 def test_iter_sorted_child_directories_returns_sorted_directories(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -532,16 +532,36 @@ def _collect_benchmark_matrix_run(
     summary_rows: list[dict[str, object]],
     request_rows: list[dict[str, object]],
 ) -> None:
-    job_path = run_root / "bench-matrix-job.json"
-    if job_path.is_file():
+    job_path: Path | None = None
+    summary_path: Path | None = None
+    requests_path: Path | None = None
+
+    try:
+        with os.scandir(run_root) as entries:
+            for entry in entries:
+                name = entry.name
+                try:
+                    if not entry.is_file():
+                        continue
+                except OSError:
+                    continue
+                path = run_root / name
+                if name == "bench-matrix-job.json":
+                    job_path = path
+                elif name == "bench-matrix-summary.jsonl":
+                    summary_path = path
+                elif name == "bench-matrix-requests.jsonl":
+                    requests_path = path
+    except OSError:
+        return
+
+    if job_path is not None:
         jobs.append(_load_json_object(job_path))
 
-    summary_path = run_root / "bench-matrix-summary.jsonl"
-    if summary_path.is_file():
+    if summary_path is not None:
         summary_rows.extend(_iter_jsonl_dict_rows(summary_path))
 
-    requests_path = run_root / "bench-matrix-requests.jsonl"
-    if requests_path.is_file():
+    if requests_path is not None:
         request_rows.extend(_iter_jsonl_dict_rows(requests_path))
 
 


### PR DESCRIPTION
## Summary
- replace `_collect_benchmark_matrix_run(...)`'s three per-file `Path.is_file()` probes with one `os.scandir()` directory scan
- preserve matrix-run artifact loading order and JSON/JSONL parsing semantics
- add focused regression tests for the matrix-run helper's `DirEntry.is_file()` path and stat-failure skip behavior

## Plan or Spec
- `docs/plans/2026-05-03-benchmark-export-matrix-run-single-scan.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_job_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_result_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_summary_csv_count
- PASS: 57 passed in 11.83s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_job_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_result_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_summary_csv_count
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_export.py services/mlx-worker-python/tests/test_benchmark_export.py
- PASS: aggregate changed-scope coverage 100% (63/63 measurable changed lines covered)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-export-run-scan-single-pass --base-repo /tmp/melix-origin-main-20260503-010316 --head-repo /tmp/melix-cron-opt-20260503-010316 --output /tmp/benchmark-export-run-scan-single-pass.json
- PASS: base-vs-head scoped probe completed successfully

git diff --check
- PASS
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 63 0 100%`
- Registered scoped CI probe: `benchmark-export-run-scan-single-pass` (existing probe reused; no registry change required)
- Local base vs head probe metrics:
  - `elapsed_ms_mean`: `56.963941` -> `54.929920` (~3.57% lower)
  - `per_run_ms_mean`: `0.237350` -> `0.228875` (~3.57% lower)
  - `csv_elapsed_ms_mean`: `2.160942` -> `2.275174` (~5.29% higher)
  - invariant metrics unchanged: `csv_bytes=41518`, `run_directory_count=240`, `result_file_count=720`, `sample_count=5`
- Interpretation:
  - the matrix-run scan path improved on the probe's primary run-scan metrics (`elapsed_ms_mean`, `per_run_ms_mean`)
  - CSV rendering showed a small regression in this sample, but the touched optimization path preserved output size and improved the targeted directory-scan metrics

## Known Gaps
- Linux-only local verification was performed for the Python worker scope; full Swift/macOS validation was not run locally on this host.
- Full repository baseline commands (`make swift-test`, `make integration-test`) were not rerun for this narrow Python-only slice.
- Hosted `pr-scoped-performance` and `pr-evidence` CI remain the final merge gates.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
