### PR TITLE
perf: decode benchmark queue records from bytes

### DIFF
--- a/docs/plans/2026-05-02-benchmark-queue-record-cache.md
+++ b/docs/plans/2026-05-02-benchmark-queue-record-cache.md
@@ -18,6 +18,7 @@ Probe ID: `benchmark-queue-decoded-record-cache`
 Measure repeated `BenchmarkQueueStore.list_records()` scans across a synthetic queue directory with many stable JSON records.
 
 Success metrics:
+- lower `cold_elapsed_ms` for uncached queue record loads in Task 2
 - lower `warm_elapsed_ms_mean`
 - lower `warm_json_loads_mean`
 - preserve `record_count`
@@ -42,6 +43,17 @@ Requirements:
 - preserve current sort order and failure behavior when files disappear or become unreadable
 - add focused tests proving unchanged files avoid redundant JSON loads while changed files still reload
 - register a PR-scoped performance probe for the touched path with focused test and changed-scope coverage commands
+
+## Task 2
+
+Decode uncached queue records from bytes instead of text.
+
+Requirements:
+- keep the persisted JSON format unchanged
+- use `Path.read_bytes()` for uncached queue record payloads so JSON parsing can consume bytes directly without an intermediate Unicode decode in Python code
+- preserve metadata-keyed cache behavior from Task 1
+- extend the registered probe to report cold read elapsed time for this slice while keeping the warm cache metrics
+- add focused regression coverage proving uncached loads avoid `Path.read_text()`
 
 ## Verification Commands
 

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -83,6 +83,12 @@
     "coverage_replays_tests": true,
     "metrics": [
       {
+        "key": "cold_elapsed_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
         "key": "warm_elapsed_ms_mean",
         "unit": "ms",
         "direction": "lower_is_better",

--- a/services/mlx-worker-python/tests/test_benchmark_queue.py
+++ b/services/mlx-worker-python/tests/test_benchmark_queue.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -408,6 +409,46 @@ def test_list_records_reuses_cached_decoded_records_for_unchanged_files(
     assert [record.queue_item_id for record in first] == ["queue-1"]
     assert [record.queue_item_id for record in second] == ["queue-1"]
     assert loads == 1
+
+
+def test_list_records_decodes_uncached_records_from_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    queue_root = tmp_path / "queue"
+    queue_root.mkdir()
+    payload = BenchmarkQueueRecord(
+        queue_item_id="queue-1",
+        job_kind="benchmark",
+        model_id="melix-dev-text",
+        suite_ids=("smoke",),
+        parameters={"sample_size": "32"},
+        status="queued",
+        created_at_unix_ms=100,
+        updated_at_unix_ms=100,
+    ).to_dict()
+    path = queue_root / "queue-1.json"
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    store = BenchmarkQueueStore()
+    read_bytes_calls = 0
+    original_read_bytes = Path.read_bytes
+
+    def tracked_read_bytes(self: Path) -> bytes:
+        nonlocal read_bytes_calls
+        if self == path:
+            read_bytes_calls += 1
+        return original_read_bytes(self)
+
+    read_text_mock = Mock(side_effect=AssertionError("uncached queue records should be decoded from bytes"))
+
+    monkeypatch.setattr(Path, "read_bytes", tracked_read_bytes)
+    monkeypatch.setattr(Path, "read_text", read_text_mock)
+
+    records = store.list_records(queue_root=queue_root)
+
+    assert [record.queue_item_id for record in records] == ["queue-1"]
+    assert read_bytes_calls == 1
+    read_text_mock.assert_not_called()
 
 
 def test_list_records_reload_changed_files_and_transition_refreshes_cache(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -924,6 +924,7 @@ def test_dispatch_probe_impl_supports_benchmark_queue_probe() -> None:
 
     metrics = _dispatch_probe_impl(probe=probe, repo_root=REPO_ROOT)
 
+    assert metrics["cold_elapsed_ms"] >= 0
     assert metrics["cold_json_loads"] == 128.0
     assert metrics["record_count"] == 128.0
     assert metrics["warm_json_loads_mean"] == 0.0

--- a/services/mlx-worker-python/worker/productization/benchmark_queue.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_queue.py
@@ -150,7 +150,7 @@ class BenchmarkQueueStore:
         cached = self._decoded_record_cache.get(path)
         if cached is not None and cached.metadata_key == current_metadata_key:
             return cached.record
-        record = BenchmarkQueueRecord.from_dict(json.loads(path.read_text(encoding="utf-8")))
+        record = BenchmarkQueueRecord.from_dict(json.loads(path.read_bytes()))
         cached_record = self._clone_record(record)
         self._decoded_record_cache[path] = _RecordCacheEntry(
             metadata_key=current_metadata_key,

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -678,14 +678,16 @@ def _probe_benchmark_queue_cache(repo_root: Path) -> dict[str, float]:
         tracked_loads = 0
         original_loads = module.json.loads
 
-        def counting_loads(raw: str, *args: object, **kwargs: object) -> object:
+        def counting_loads(raw: str | bytes, *args: object, **kwargs: object) -> object:
             nonlocal tracked_loads
             tracked_loads += 1
             return original_loads(raw, *args, **kwargs)
 
         module.json.loads = counting_loads
         try:
+            cold_started = time.perf_counter()
             cold_records = store.list_records(queue_root=queue_root)
+            cold_elapsed_ms = (time.perf_counter() - cold_started) * 1000.0
             if len(cold_records) != record_count:
                 raise ValueError("benchmark queue probe produced an unexpected benchmark queue record count")
             cold_json_loads = tracked_loads
@@ -702,6 +704,7 @@ def _probe_benchmark_queue_cache(repo_root: Path) -> dict[str, float]:
         finally:
             module.json.loads = original_loads
     return {
+        "cold_elapsed_ms": round(cold_elapsed_ms, 6),
         "cold_json_loads": float(cold_json_loads),
         "record_count": float(record_count),
         "warm_elapsed_ms_mean": round(sum(warm_elapsed_samples) / len(warm_elapsed_samples), 6),


### PR DESCRIPTION
## Summary
- Decode uncached benchmark queue JSON records with `Path.read_bytes()` so `json.loads` can consume bytes directly.
- Extend the registered PR-scoped benchmark queue probe with a cold-read elapsed metric while preserving warm cache metrics.
- Add focused regression coverage that proves uncached loads use `Path.read_bytes()` and do not call `Path.read_text()`.

## Plan or Spec
- `docs/plans/2026-05-02-benchmark-queue-record-cache.md` (Task 2: decode uncached queue records from bytes).

## Commands Run
```text
# Focused smoke
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py::test_list_records_decodes_uncached_records_from_bytes services/mlx-worker-python/tests/test_benchmark_queue.py::test_list_records_reuses_cached_decoded_records_for_unchanged_files services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe
# exit 0; 3 passed in 0.12s

# Registered focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
# exit 0; 23 passed in 10.63s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_queue.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; TOTAL 26 0 100%

# Registered probe, repeated locally on Linux
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .tmp_probe_benchmark_queue.py
# exit 0; cold_elapsed_ms samples: 6.319431, 6.797878, 6.059563; warm_elapsed_ms_mean samples: 1.571497, 1.634479, 1.603146; warm_json_loads_mean=0.0

# Old/new cold-read comparison, 512 synthetic records, 7 samples each
# origin/main mean_ms=30.346784; this branch mean_ms=27.276148; delta_ms=-3.070636; speedup=1.112576x; improvement=10.12%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 26 0 100%`.
- Registered probe is present as `benchmark-queue-decoded-record-cache` with `test_command`, `coverage_command`, and `probe_command`.
- Local Linux registered-probe samples:
  - `cold_elapsed_ms`: 6.319431, 6.797878, 6.059563
  - `warm_elapsed_ms_mean`: 1.571497, 1.634479, 1.603146
  - `warm_json_loads_mean`: 0.0
- Local old/new cold-read comparison (512 synthetic records, 7 samples): old_mean=30.346784 ms, new_mean=27.276148 ms, delta_ms=-3.070636, speedup=1.112576x, improvement=10.12%.
- CI is still required for the registered PR-scoped performance report before merge.

## Known Gaps
- None for the Python/Linux slice. No Swift runtime behavior is touched.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
