### PR TITLE
perf: stream evaluation final-result materialization

### DIFF
--- a/docs/plans/2026-05-03-evaluation-final-result-streaming-materialization.md
+++ b/docs/plans/2026-05-03-evaluation-final-result-streaming-materialization.md
@@ -1,0 +1,47 @@
+# Evaluation Final Result Streaming Materialization Plan
+
+## Goal
+
+Reduce redundant memory use in `services/mlx-worker-python/worker/productization/evaluation_final_result.py` by removing the intermediate fully materialized `serialized_samples` list from final-result dataset package construction while preserving package bytes, row ordering, cache semantics, and manifest fields.
+
+## Linux-only constraint
+
+This cron run is on Linux, so the slice must stay inside the Python worker and be fully verifiable with focused pytest, changed-scope coverage, and a local synthetic performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/productization/evaluation_final_result.py`
+- `services/mlx-worker-python/tests/test_evaluation_final_result.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Planned change
+
+1. Refactor final-result package materialization so `samples.jsonl` is written from a single-pass iterable instead of first building a full `serialized_samples: list[dict]` in memory.
+2. Keep the existing output schema and newline behavior unchanged.
+3. Add focused regression coverage proving the materialization path passes a streaming iterable into the JSONL writer instead of a prebuilt list.
+4. Register a PR-scoped performance probe for `evaluation_final_result.py` that measures the materialization path directly and reports elapsed time plus peak traced bytes.
+
+## Performance probe
+
+Probe ID: `evaluation-final-result-materialization-streaming`
+
+Synthetic workload:
+- Build a deterministic final-result source with many rows (target ~15,000 rows).
+- Materialize the package into a temporary cache directory.
+- Record `elapsed_ms_mean`, `peak_bytes_mean`, and `sample_count`.
+- Compare `origin/main` vs head through Melix PR-scoped performance CI.
+
+## Success metrics
+
+- Focused tests pass for the touched path.
+- Changed-scope automated coverage for touched executable files is at least 95%.
+- Local probe shows reduced `peak_bytes_mean` versus the current baseline while preserving `sample_count` and output behavior.
+- `git diff --check` passes.
+
+## Verification commands
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- Local probe command from the registered PR-scoped performance entry
+- `git diff --check`

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -314,6 +314,43 @@
     ]
   },
   {
+    "id": "evaluation-final-result-materialization-streaming",
+    "name": "Evaluation final-result materialization streaming",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/evaluation_final_result.py",
+      "services/mlx-worker-python/tests/test_evaluation_final_result.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c \"import json, statistics, tempfile, time, tracemalloc; from pathlib import Path; from worker.productization.evaluation_final_result import EvaluationFieldMapping, EvaluationMaterializationRequest, EvaluationProfileDefinition, materialize_local_evaluation_dataset; sample_count = 15000; elapsed_samples = []; peak_samples = []; profile = EvaluationProfileDefinition(profile_type='final_result', result_kind='text', extraction_mode='heuristic_final', scoring_mode='normalized_exact_match', threshold=1.0); field_mapping = EvaluationFieldMapping(system_path='meta.sys', input_text_path='payload.question', target_path='payload.target', sample_id_path='sample.id');\nwith tempfile.TemporaryDirectory() as tmpdir:\n    root = Path(tmpdir); source_path = root / 'source.jsonl'; source_path.write_text(''.join(json.dumps({'meta': {'sys': 'Return the final answer only.'}, 'payload': {'question': f'Question {index}?', 'target': f'Answer {index}'}, 'sample': {'id': f'sample-{index}'}}) + '\\\\n' for index in range(sample_count)), encoding='utf-8');\n    for iteration in range(5):\n        cache_root = root / f'cache-{iteration}'; tracemalloc.start(); started = time.perf_counter(); materialized = materialize_local_evaluation_dataset(request=EvaluationMaterializationRequest(source_kind='jsonl', source_path=source_path, profile=profile, field_mapping=field_mapping, dataset_id='synthetic.final-result.dev.v1', suite_id='synthetic-final-result'), cache_root=cache_root); elapsed_samples.append((time.perf_counter() - started) * 1000.0); peak_samples.append(tracemalloc.get_traced_memory()[1]); tracemalloc.stop(); manifest = json.loads((materialized.package_path / 'manifest.json').read_text(encoding='utf-8')); assert manifest['sample_count'] == sample_count;\nprint(json.dumps({'elapsed_ms_mean': round(statistics.fmean(elapsed_samples), 4), 'peak_bytes_mean': round(statistics.fmean(peak_samples), 4), 'sample_count': float(sample_count)}, sort_keys=True))\"",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "sample_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "training-dataset-token-percentiles-single-sort",
     "name": "Training dataset quality/token summary",
     "runner": "ubuntu-latest",

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -255,6 +255,155 @@ def test_materialize_local_evaluation_dataset_builds_final_result_package_from_j
     assert samples[1]["target"] == "Rome"
 
 
+def test_materialize_local_evaluation_dataset_streams_serialized_samples_into_jsonl_writer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_path = tmp_path / "source.jsonl"
+    source_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"meta": {"sys": "Return the final answer only."}, "payload": {"question": "Capital of France?", "target": "Paris"}, "sample": {"id": "capital-1"}}),
+                json.dumps({"meta": {"sys": "Return the final answer only."}, "payload": {"question": "Capital of Italy?", "target": "Rome"}, "sample": {"id": "capital-2"}}),
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    original_write_jsonl_rows = evaluation_final_result_module._write_jsonl_rows
+    captured_rows: list[dict[str, object]] = []
+
+    def _assert_streaming_rows(path: Path, rows: object) -> None:
+        assert "samples.jsonl" in path.name
+        assert not isinstance(rows, list)
+        assert iter(rows) is rows
+        captured_rows.extend(list(rows))
+        assert list(rows) == []
+        original_write_jsonl_rows(path, captured_rows)
+
+    monkeypatch.setattr(evaluation_final_result_module, "_write_jsonl_rows", _assert_streaming_rows)
+
+    materialized = materialize_local_evaluation_dataset(
+        request=EvaluationMaterializationRequest(
+            source_kind="jsonl",
+            source_path=source_path,
+            profile=EvaluationProfileDefinition(
+                profile_type="final_result",
+                result_kind="text",
+                extraction_mode="heuristic_final",
+                scoring_mode="normalized_exact_match",
+                threshold=1.0,
+            ),
+            field_mapping=EvaluationFieldMapping(
+                system_path="meta.sys",
+                input_text_path="payload.question",
+                target_path="payload.target",
+                sample_id_path="sample.id",
+            ),
+            dataset_id="capital.dev.v1",
+            suite_id="capital",
+        ),
+        cache_root=tmp_path / "cache",
+    )
+
+    manifest = json.loads((materialized.package_path / "manifest.json").read_text(encoding="utf-8"))
+    samples = [
+        json.loads(line)
+        for line in (materialized.package_path / "samples.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+    assert [row["id"] for row in captured_rows] == ["capital-1", "capital-2"]
+    assert manifest["sample_count"] == 2
+    assert [sample["id"] for sample in samples] == ["capital-1", "capital-2"]
+
+
+def test_materialize_local_evaluation_dataset_does_not_leave_partial_cache_after_streaming_failure(
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "source.jsonl"
+    source_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"meta": {"sys": "Return the final answer only."}, "payload": {"question": "Capital of France?", "target": "Paris"}, "sample": {"id": "capital-1"}}),
+                json.dumps({"meta": {"sys": "Return the final answer only."}, "payload": {"question": "Capital of Italy?"}, "sample": {"id": "capital-2"}}),
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    request = EvaluationMaterializationRequest(
+        source_kind="jsonl",
+        source_path=source_path,
+        profile=EvaluationProfileDefinition(
+            profile_type="final_result",
+            result_kind="text",
+            extraction_mode="heuristic_final",
+            scoring_mode="normalized_exact_match",
+            threshold=1.0,
+        ),
+        field_mapping=EvaluationFieldMapping(
+            system_path="meta.sys",
+            input_text_path="payload.question",
+            target_path="payload.target",
+            sample_id_path="sample.id",
+        ),
+        dataset_id="capital.dev.v1",
+        suite_id="capital",
+    )
+    cache_root = tmp_path / "cache"
+
+    with pytest.raises(ModelOperationError) as excinfo:
+        materialize_local_evaluation_dataset(request=request, cache_root=cache_root)
+
+    assert excinfo.value.code == "invalid_evaluation_source"
+    assert cache_root.exists() is False or list(cache_root.iterdir()) == []
+
+
+def test_write_materialized_package_preserves_existing_published_cache(tmp_path: Path) -> None:
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+    package_path = cache_root / "demo-cache-key"
+    package_path.mkdir()
+    manifest_path = package_path / "manifest.json"
+    samples_path = package_path / "samples.jsonl"
+    manifest_path.write_text(json.dumps({"sample_count": 1}, indent=2) + "\n", encoding="utf-8")
+    samples_path.write_text(json.dumps({"id": "existing-sample"}) + "\n", encoding="utf-8")
+
+    evaluation_final_result_module._write_materialized_package(
+        cache_root=cache_root,
+        package_path=package_path,
+        manifest_payload={"sample_count": 2},
+        serialized_samples=iter([{"id": "new-sample"}]),
+    )
+
+    assert json.loads(manifest_path.read_text(encoding="utf-8"))["sample_count"] == 1
+    assert samples_path.read_text(encoding="utf-8").strip() == json.dumps({"id": "existing-sample"})
+    assert list(cache_root.glob(".demo-cache-key.tmp-*")) == []
+
+
+
+def test_write_materialized_package_replaces_incomplete_existing_cache(tmp_path: Path) -> None:
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+    package_path = cache_root / "demo-cache-key"
+    package_path.mkdir()
+    (package_path / "samples.jsonl").write_text(json.dumps({"id": "stale-sample"}) + "\n", encoding="utf-8")
+
+    evaluation_final_result_module._write_materialized_package(
+        cache_root=cache_root,
+        package_path=package_path,
+        manifest_payload={"sample_count": 1},
+        serialized_samples=iter([{"id": "fresh-sample"}]),
+    )
+
+    assert json.loads((package_path / "manifest.json").read_text(encoding="utf-8"))["sample_count"] == 1
+    assert (package_path / "samples.jsonl").read_text(encoding="utf-8").strip() == json.dumps({"id": "fresh-sample"})
+    assert list(cache_root.glob(".demo-cache-key.tmp-*")) == []
+
+
+
 def test_local_source_metadata_reports_same_sha256_and_size_as_path_bytes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -127,6 +127,31 @@ def test_scope_report_selects_evaluation_store_probe() -> None:
     }
 
 
+def test_scope_report_selects_evaluation_final_result_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/evaluation_final_result.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "evaluation-final-result-materialization-streaming"
+
+
+def test_dispatch_probe_impl_supports_evaluation_final_result_probe() -> None:
+    probe = next(
+        probe
+        for probe in load_probe_registry(REGISTRY_PATH)
+        if probe.probe_id == "evaluation-final-result-materialization-streaming"
+    )
+
+    metrics = _dispatch_probe_impl(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["sample_count"] == 15000.0
+
+
+
 def test_scope_report_selects_worker_registry_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -433,6 +458,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "deterministic-rerank-query-context-reuse",
         "dev-up-mlx-metal-dist-info-scandir",
         "evaluation-job-id-high-water-mark",
+        "evaluation-final-result-materialization-streaming",
         "evaluation-sample-probe-aggregation",
         "evaluation-store-compare-summary-csv-streaming",
         "evaluation-store-samples-csv-streaming",

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -7,6 +7,9 @@ import json
 import os
 from pathlib import Path
 import re
+import shutil
+import tempfile
+from collections.abc import Iterable, Iterator
 from typing import Any, Callable
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
@@ -504,26 +507,12 @@ def _materialize_evaluation_rows(
             details={key: str(value) for key, value in source_metadata.items()},
         )
 
-    serialized_samples: list[dict[str, Any]] = []
-    for index, row in enumerate(rows, start=1):
-        serialized_samples.append(
-            {
-                "id": _string_field(row, field_mapping.sample_id_path) or f"sample-{index}",
-                "system": _string_field(row, field_mapping.system_path),
-                "input": {
-                    "text": _required_string_field(row, field_mapping.input_text_path, "input_text_path"),
-                },
-                "target": _required_value(row, field_mapping.target_path, "target_path"),
-            }
-        )
-
-    package_path.mkdir(parents=True, exist_ok=True)
     manifest_payload = {
         "schema_version": "melix.evaluation_dataset_package.v2",
         "dataset_id": dataset_id,
         "suite_id": suite_id,
         "version": "2026-04-14",
-        "sample_count": len(serialized_samples),
+        "sample_count": len(rows),
         "split": "validation",
         "task_kind": "text-generation",
         "input_modalities": ["text"],
@@ -542,19 +531,61 @@ def _materialize_evaluation_rows(
         },
         **source_metadata,
     }
-    manifest_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
-    _write_jsonl_rows(samples_path, serialized_samples)
+    _write_materialized_package(
+        cache_root=cache_root,
+        package_path=package_path,
+        manifest_payload=manifest_payload,
+        serialized_samples=_iter_serialized_samples(rows, field_mapping),
+    )
     return MaterializedEvaluationDataset(package_path=package_path, cache_key=cache_key, cache_hit=False)
 
 
-def _write_jsonl_rows(path: Path, rows: list[dict[str, Any]]) -> None:
+def _write_materialized_package(
+    *,
+    cache_root: Path,
+    package_path: Path,
+    manifest_payload: dict[str, Any],
+    serialized_samples: Iterable[dict[str, Any]],
+) -> None:
+    staging_path = Path(tempfile.mkdtemp(prefix=f".{package_path.name}.tmp-", dir=cache_root))
+    try:
+        _write_jsonl_rows(staging_path / "samples.jsonl", serialized_samples)
+        (staging_path / "manifest.json").write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
+        if package_path.exists():
+            manifest_path = package_path / "manifest.json"
+            samples_path = package_path / "samples.jsonl"
+            if manifest_path.is_file() and samples_path.is_file():
+                return
+            shutil.rmtree(package_path)
+        staging_path.replace(package_path)
+    finally:
+        shutil.rmtree(staging_path, ignore_errors=True)
+
+
+def _iter_serialized_samples(
+    rows: list[dict[str, Any]],
+    field_mapping: EvaluationFieldMapping,
+) -> Iterator[dict[str, Any]]:
+    for index, row in enumerate(rows, start=1):
+        yield {
+            "id": _string_field(row, field_mapping.sample_id_path) or f"sample-{index}",
+            "system": _string_field(row, field_mapping.system_path),
+            "input": {
+                "text": _required_string_field(row, field_mapping.input_text_path, "input_text_path"),
+            },
+            "target": _required_value(row, field_mapping.target_path, "target_path"),
+        }
+
+
+def _write_jsonl_rows(path: Path, rows: Iterable[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as handle:
-        if not rows:
-            handle.write("\n")
-            return
+        wrote_row = False
         for row in rows:
+            wrote_row = True
             handle.write(json.dumps(row))
+            handle.write("\n")
+        if not wrote_row:
             handle.write("\n")
 
 


### PR DESCRIPTION
## Summary
- stream final-result package serialization into `samples.jsonl` instead of prebuilding a second `serialized_samples` list
- publish evaluation dataset packages through a staged directory so serialization failures do not leave partial cache artifacts
- register a focused `evaluation-final-result-materialization-streaming` PR-scoped performance probe with focused verification commands

## Plan or Spec
- `docs/plans/2026-05-03-evaluation-final-result-streaming-materialization.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-final-result-materialization-streaming --base-repo /root/.openclaw/workspace/melix --head-repo /tmp/melix-cron-opt-20260503-035048 --output /tmp/evaluation-final-result-probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `20 passed`
- Changed-scope coverage: `TOTAL 86 0 100%`
- Registered probe: `evaluation-final-result-materialization-streaming`
- Local base vs head probe (`sample_count=15000`):
  - `elapsed_ms_mean`: `805.8364` -> `769.0557` (~`4.56%` lower)
  - `peak_bytes_mean`: `29642388.6` -> `21543554.2` (~`27.32%` lower; `8098834.4` fewer traced bytes)
  - `sample_count`: `15000.0` -> `15000.0` (unchanged)
- Interpretation: the slice preserves output cardinality while materially reducing peak traced allocation and slightly improving elapsed time on the synthetic local materialization probe.

## Known Gaps
- Linux-only local verification. I did not run macOS/Swift verification from this host.
- Because `infra/perf/pr_scoped_probes.json` changed, hosted `pr-scoped-performance` will run its force-all matrix before merge.

## Evidence Checklist
- [x] Relevant plan identified and updated in-repo
- [x] Behavior change covered by focused tests
- [x] Verification commands run and recorded
- [x] Changed-scope coverage >= 95%
- [x] Performance probe defined and measured locally
- [x] Known gaps stated explicitly
