### PR TITLE
perf: avoid splitlines for MLX structured results

### DIFF
--- a/docs/plans/2026-05-03-mlx-lm-structured-result-tail-parse.md
+++ b/docs/plans/2026-05-03-mlx-lm-structured-result-tail-parse.md
@@ -1,0 +1,46 @@
+# MLX-LM structured result tail parsing optimization
+
+## Goal
+
+Reduce redundant stdout parsing work in `MLXLMRunner._run_subprocess()` when extracting the final structured MLX result from large subprocess output, without changing error handling or parsed payload semantics.
+
+## Scope
+
+This slice is limited to:
+
+- `services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py`
+- `services/mlx-worker-python/tests/test_lora_model_ops_unit.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/mlx_lm_result_tail_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux constraint
+
+This is a Python-only optimization slice. Verification must stay Linux-local via focused pytest, changed-scope coverage, and a PR-scoped performance probe that compares `origin/main` to the branch implementation.
+
+## Performance probe
+
+Register a dedicated PR-scoped performance probe for the hot path that:
+
+- synthesizes a large `stdout` payload with many noise lines and one terminal `__MELIX_MLX_RESULT__=` JSON line
+- measures `elapsed_ms_mean` for repeated structured-result extraction
+- measures `peak_bytes_mean` with `tracemalloc`
+- preserves an explicit correctness signal such as `payload_id`, `line_count`, and `sample_count`
+
+## Implementation plan
+
+1. Add a small helper that extracts the last structured result line from `stdout` by searching backward for the last line-start-prefixed result marker instead of materializing `stdout.splitlines()`.
+2. Preserve current semantics for:
+   - subprocess error propagation
+   - accepting a terminal structured result with or without a trailing newline
+   - rejecting outputs that never expose a line starting with `__MELIX_MLX_RESULT__=`
+3. Add focused regression tests covering the optimized helper through `_run_subprocess()`.
+4. Register the dedicated `command_json` PR-scoped probe and add focused probe-registry tests.
+5. Validate with focused pytest, changed-scope coverage >=95%, `git diff --check`, and a local `origin/main` vs head probe run.
+
+## Success criteria
+
+- `_run_subprocess()` still returns the same parsed JSON payload for valid structured-result output.
+- Missing structured-result output still raises the same `ModelOperationError` code/message class.
+- Changed-scope coverage for the touched executable Python files remains at least 95%.
+- The dedicated probe shows lower `elapsed_ms_mean` and lower `peak_bytes_mean` than `origin/main` for the same synthetic workload.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -509,6 +509,37 @@
     ]
   },
   {
+    "id": "mlx-lm-structured-result-tail-parse",
+    "name": "MLX-LM structured result tail parse",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py",
+      "services/mlx-worker-python/tests/test_lora_model_ops_unit.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/mlx_lm_result_tail_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_extracts_terminal_structured_result_without_splitlines services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_rejects_missing_structured_result services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_accepts_carriage_return_line_end services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_skips_embedded_prefix_and_finds_prior_line services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_lm_runner_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_main_covers_checked_in_file",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_extracts_terminal_structured_result_without_splitlines services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_rejects_missing_structured_result services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_accepts_carriage_return_line_end services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_skips_embedded_prefix_and_finds_prior_line services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_lm_runner_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_main_covers_checked_in_file && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_lm_result_tail_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -lc 'if [ -f scripts/mlx_lm_result_tail_probe.py ]; then python3 scripts/mlx_lm_result_tail_probe.py; else python3 - <<\"PY\"\nimport json\nimport statistics\nimport sys\nimport time\nimport tracemalloc\nfrom pathlib import Path\n\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.model_ops import mlx_lm_runner as mlx_lm_runner_module\n\nprefix = mlx_lm_runner_module._RESULT_PREFIX\npayload = {\"value\": 42, \"weights_path\": \"/tmp/adapters.safetensors\"}\nnoise_line_count = 50000\niteration_count = 12\nsample_count = 5\n\ndef legacy_extract(stdout):\n    for line in reversed(stdout.splitlines()):\n        if line.startswith(prefix):\n            return json.loads(line.removeprefix(prefix))\n    return None\n\ndef extract(stdout):\n    helper = getattr(mlx_lm_runner_module, \"_extract_structured_result_payload\", None)\n    if helper is not None:\n        return helper(stdout)\n    return legacy_extract(stdout)\n\nstdout = \"progress log mentioning __MELIX_MLX_RESULT__=not-a-result-line\\n\" + \"\".join(f\"worker log {index}\\n\" for index in range(noise_line_count)) + f\"{prefix}{json.dumps(payload, sort_keys=True)}\\n\"\nelapsed_samples = []\npeak_samples = []\nfor _ in range(sample_count):\n    tracemalloc.start()\n    started = time.perf_counter()\n    parsed = None\n    for _ in range(iteration_count):\n        parsed = extract(stdout)\n    elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n    _, peak_bytes = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    if parsed != payload:\n        raise SystemExit(\"unexpected structured result payload\")\n    peak_samples.append(float(peak_bytes))\nprint(json.dumps({\n    \"elapsed_ms_mean\": round(statistics.fmean(elapsed_samples), 6),\n    \"iteration_count\": float(iteration_count),\n    \"line_count\": float(noise_line_count + 2),\n    \"peak_bytes_mean\": round(statistics.fmean(peak_samples), 3),\n    \"payload_value\": float(payload[\"value\"]),\n    \"sample_count\": float(sample_count),\n}, sort_keys=True))\nPY\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "deterministic-rerank-query-context-reuse",
     "name": "Deterministic rerank query-context reuse",
     "runner": "ubuntu-latest",

--- a/scripts/mlx_lm_result_tail_probe.py
+++ b/scripts/mlx_lm_result_tail_probe.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.model_ops import mlx_lm_runner as mlx_lm_runner_module  # noqa: E402
+
+PREFIX = mlx_lm_runner_module._RESULT_PREFIX
+PAYLOAD = {"value": 42, "weights_path": "/tmp/adapters.safetensors"}
+NOISE_LINE_COUNT = 50000
+ITERATION_COUNT = 12
+SAMPLE_COUNT = 5
+
+
+def _legacy_extract(stdout: str) -> dict[str, object] | None:
+    for line in reversed(stdout.splitlines()):
+        if line.startswith(PREFIX):
+            return json.loads(line.removeprefix(PREFIX))
+    return None
+
+
+def _extract(stdout: str) -> dict[str, object] | None:
+    extractor = getattr(mlx_lm_runner_module, "_extract_structured_result_payload", None)
+    if extractor is not None:
+        return extractor(stdout)
+    return _legacy_extract(stdout)
+
+
+def main() -> int:
+    stdout = (
+        "progress log mentioning __MELIX_MLX_RESULT__=not-a-result-line\n"
+        + "".join(f"worker log {index}\n" for index in range(NOISE_LINE_COUNT))
+        + f"{PREFIX}{json.dumps(PAYLOAD, sort_keys=True)}\n"
+    )
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    for _ in range(SAMPLE_COUNT):
+        tracemalloc.start()
+        started = time.perf_counter()
+        payload = None
+        for _ in range(ITERATION_COUNT):
+            payload = _extract(stdout)
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        if payload != PAYLOAD:
+            raise SystemExit("unexpected structured result payload")
+        peak_samples.append(float(peak_bytes))
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+                "iteration_count": float(ITERATION_COUNT),
+                "line_count": float(NOISE_LINE_COUNT + 2),
+                "peak_bytes_mean": round(statistics.fmean(peak_samples), 3),
+                "payload_value": float(PAYLOAD["value"]),
+                "sample_count": float(SAMPLE_COUNT),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import subprocess
 import sys
 import types
 
@@ -105,6 +106,72 @@ def test_checkpoint_summary_handles_empty_or_missing_directories(tmp_path: Path)
 
     assert mlx_lm_runner_module._checkpoint_summary(adapter_dir) == (0, "")
     assert mlx_lm_runner_module._checkpoint_summary(tmp_path / "missing") == (0, "")
+
+
+def test_run_subprocess_extracts_terminal_structured_result_without_splitlines(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text("{}\n", encoding="utf-8")
+    runner = MLXLMRunner()
+    structured_payload = {"weights_path": "/tmp/adapters.safetensors", "metrics": {"loss_final": 0.1}}
+    class NoSplitlinesStr(str):
+        def splitlines(self, *args: object, **kwargs: object) -> list[str]:  # pragma: no cover - defensive guard
+            del args, kwargs
+            raise AssertionError("_run_subprocess should avoid stdout.splitlines()")
+
+    stdout = NoSplitlinesStr(
+        "noisy prefix mentioning __MELIX_MLX_RESULT__=not-a-line\n"
+        "worker log\n"
+        f"{mlx_lm_runner_module._RESULT_PREFIX}{json.dumps({'ignored': True})}\n"
+        f"{mlx_lm_runner_module._RESULT_PREFIX}{json.dumps(structured_payload)}"
+    )
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        del args, kwargs
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(mlx_lm_runner_module.subprocess, "run", fake_run)
+
+    assert runner._run_subprocess("train", payload_path, error_code="backend_training_failure") == structured_payload
+
+
+def test_run_subprocess_rejects_missing_structured_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text("{}\n", encoding="utf-8")
+    runner = MLXLMRunner()
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        del args, kwargs
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="worker log only\n", stderr="")
+
+    monkeypatch.setattr(mlx_lm_runner_module.subprocess, "run", fake_run)
+
+    with pytest.raises(ModelOperationError, match="structured result"):
+        runner._run_subprocess("train", payload_path, error_code="backend_training_failure")
+
+
+def test_extract_structured_result_payload_accepts_carriage_return_line_end() -> None:
+    payload = {"manifest_path": "/tmp/manifest.json"}
+    stdout = (
+        "leading noise\r\n"
+        f"{mlx_lm_runner_module._RESULT_PREFIX}{json.dumps(payload)}\r\n"
+        "tail noise"
+    )
+
+    assert mlx_lm_runner_module._extract_structured_result_payload(stdout) == payload
+
+
+
+def test_extract_structured_result_payload_skips_embedded_prefix_and_finds_prior_line() -> None:
+    payload = {"value": 7}
+    stdout = (
+        f"{mlx_lm_runner_module._RESULT_PREFIX}{json.dumps(payload)}\n"
+        "trailing log __MELIX_MLX_RESULT__=not-a-result-line"
+    )
+
+    assert mlx_lm_runner_module._extract_structured_result_payload(stdout) == payload
 
 
 class _UnexpectedActivationRunner(MLXLMRunner):

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 from pathlib import Path
@@ -156,6 +157,16 @@ def test_scope_report_selects_job_registry_probe() -> None:
 
     assert scope["selected_count"] == 1
     assert scope["selected_probes"][0]["id"] == "job-registry-derived-model-single-pass"
+
+
+def test_scope_report_selects_mlx_lm_runner_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "mlx-lm-structured-result-tail-parse"
 
 
 def test_scope_report_selects_model_registry_catalog_probe() -> None:
@@ -437,6 +448,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "evaluation-store-compare-summary-csv-streaming",
         "evaluation-store-samples-csv-streaming",
         "job-registry-derived-model-single-pass",
+        "mlx-lm-structured-result-tail-parse",
         "model-registry-plain-local-manifest-stat-elision",
         "package-macos-resolve-fallback-scandir",
         "pr-scoped-performance-scope-json-read-bytes",
@@ -1427,6 +1439,42 @@ def test_model_registry_catalog_probe_command_emits_metrics() -> None:
     assert metrics["manifest_parse_calls_mean"] == 0.0
     assert metrics["discovered_model_count_mean"] == metrics["model_count"] == 800.0
     assert metrics["sample_count"] == 3.0
+
+
+def test_mlx_lm_result_tail_probe_script_emits_metrics() -> None:
+    probe = next(
+        probe
+        for probe in load_probe_registry(REGISTRY_PATH)
+        if probe.probe_id == "mlx-lm-structured-result-tail-parse"
+    )
+
+    metrics = _probe_command_json(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["payload_value"] == 42.0
+    assert metrics["line_count"] == 50002.0
+    assert metrics["sample_count"] == 5.0
+
+
+
+def test_mlx_lm_result_tail_probe_script_main_covers_checked_in_file(capsys: pytest.CaptureFixture[str]) -> None:
+    script_path = REPO_ROOT / "scripts" / "mlx_lm_result_tail_probe.py"
+    spec = importlib.util.spec_from_file_location("mlx_lm_result_tail_probe_test", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.NOISE_LINE_COUNT = 32
+    module.ITERATION_COUNT = 2
+    module.SAMPLE_COUNT = 2
+
+    assert module.main() == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+
+    assert payload["payload_value"] == 42.0
+    assert payload["sample_count"] == 2.0
+    assert payload["line_count"] == 34.0
+
 
 
 def test_command_json_probe_rejects_missing_command_and_non_numeric_metrics(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -306,14 +306,35 @@ class MLXLMRunner:
                 message=(process.stderr or process.stdout or "MLX subprocess failed.").strip(),
             )
 
-        for line in reversed(process.stdout.splitlines()):
-            if line.startswith(_RESULT_PREFIX):
-                return json.loads(line.removeprefix(_RESULT_PREFIX))
+        payload = _extract_structured_result_payload(process.stdout)
+        if payload is not None:
+            return payload
 
         raise ModelOperationError(
             code=error_code,
             message="MLX subprocess completed without returning a structured result.",
         )
+
+
+def _extract_structured_result_payload(stdout: str) -> dict[str, object] | None:
+    search_end = len(stdout)
+    prefix = _RESULT_PREFIX
+    prefix_length = len(prefix)
+    while True:
+        prefix_index = stdout.rfind(prefix, 0, search_end)
+        if prefix_index < 0:
+            return None
+        if prefix_index > 0 and stdout[prefix_index - 1] not in {"\n", "\r"}:
+            search_end = prefix_index
+            continue
+        line_end = len(stdout)
+        newline_index = stdout.find("\n", prefix_index)
+        carriage_index = stdout.find("\r", prefix_index)
+        if newline_index >= 0:
+            line_end = min(line_end, newline_index)
+        if carriage_index >= 0:
+            line_end = min(line_end, carriage_index)
+        return json.loads(stdout[prefix_index + prefix_length:line_end])
 
 
 def _mlx_lora_namespace(request: TrainingRequest):


### PR DESCRIPTION
## Summary
- Reduce redundant stdout parsing in `MLXLMRunner._run_subprocess()` by extracting the last structured `__MELIX_MLX_RESULT__=` line with a backward marker search instead of materializing `stdout.splitlines()`.
- Add focused regression tests for terminal structured-result parsing semantics.
- Register a dedicated PR-scoped performance probe for the MLX structured-result tail parse hot path and add probe-registry coverage/tests.

## Plan or Spec
- `docs/plans/2026-05-03-mlx-lm-structured-result-tail-parse.md`

## Commands Run
```text
# Focused pytest
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_extracts_terminal_structured_result_without_splitlines \
  services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_rejects_missing_structured_result \
  services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_accepts_carriage_return_line_end \
  services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_skips_embedded_prefix_and_finds_prior_line \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_lm_runner_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_emits_metrics \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_main_covers_checked_in_file
# Result: 8 passed

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
  services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_extracts_terminal_structured_result_without_splitlines \
  services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_rejects_missing_structured_result \
  services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_accepts_carriage_return_line_end \
  services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_skips_embedded_prefix_and_finds_prior_line \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_lm_runner_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_emits_metrics \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_main_covers_checked_in_file && \
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && \
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py \
  services/mlx-worker-python/tests/test_lora_model_ops_unit.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/mlx_lm_result_tail_probe.py
# Result: TOTAL 80 0 100%

# Direct head probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_lm_result_tail_probe.py
# Result: elapsed_ms_mean=0.160791, peak_bytes_mean=1781.4, line_count=50002, sample_count=5

# Base-vs-head registered probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py \
  --registry infra/perf/pr_scoped_probes.json \
  --probe-id mlx-lm-structured-result-tail-parse \
  --base-repo /tmp/melix-base-mlx-lm-tail-parse-20260503-044601 \
  --head-repo /tmp/melix-cron-opt-20260503-044601 \
  --output /tmp/melix-mlx-lm-tail-probe-result.json
# Result: base/head probe + head verification OK

# Diff hygiene
git diff --check
# Result: clean
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 80 0 100%`
- Registered scoped probe: `mlx-lm-structured-result-tail-parse`
- Head probe metrics:
  - `elapsed_ms_mean=0.160791`
  - `peak_bytes_mean=1781.4`
  - `line_count=50002`
  - `sample_count=5`
  - `payload_value=42`
- Local base-vs-head comparison from `scripts/pr_scoped_performance_run.py`:
  - `elapsed_ms_mean`: `251.879686` -> `0.204237` (~99.92% lower)
  - `peak_bytes_mean`: `3285164.0` -> `1781.4` (~99.95% lower)
  - correctness signals preserved: `payload_value=42`, `line_count=50002`, `sample_count=5`

## Known Gaps
- Linux-only local verification ran for this Python slice; no macOS/Swift checks were run because the change only touches Python + PR-scoped performance metadata.
- Touching `infra/perf/pr_scoped_probes.json` may trigger the broader hosted `pr-scoped-performance` matrix; merge should wait for the hosted scoped run to finish green.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
