### PR TITLE
perf: cache MLX-VLM family config

### DIFF
--- a/docs/plans/2026-05-03-mlx-vlm-family-config-cache.md
+++ b/docs/plans/2026-05-03-mlx-vlm-family-config-cache.md
@@ -1,0 +1,44 @@
+# MLX-VLM family-config cache optimization
+
+## Goal
+
+Reduce repeated `resolve_vision_family_config(...)` work in the MLX-VLM runtime hot path by caching the resolved family config on the loaded-model payload, while preserving request shaping, prompt token counting, and capability metadata semantics.
+
+## Scope
+
+This slice is limited to:
+
+- `services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py`
+- `services/mlx-worker-python/tests/test_mlx_vlm_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/mlx_vlm_family_config_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux constraint
+
+This is a Python-only optimization slice. Verification must stay Linux-local via focused pytest, changed-scope coverage, and a PR-scoped performance probe that compares `origin/main` to the branch implementation.
+
+## Performance probe
+
+Register a dedicated PR-scoped performance probe for the MLX-VLM family-config path that:
+
+- exercises repeated `render_prompt(...)` plus `prompt_token_count(...)` calls on one loaded-model payload
+- measures `elapsed_ms_mean`
+- measures `resolve_calls_mean`
+- preserves explicit correctness signals such as `prompt_token_count`, `iteration_count`, and `sample_count`
+
+## Implementation plan
+
+1. Cache the resolved family config on the loaded-model payload during `load_model(...)`.
+2. Make `MLXVLMRuntime._family_config(...)` reuse that cached object and lazily populate it for compatibility when older/manual loaded-model payloads do not already contain the cache entry.
+3. Add focused regression tests that prove repeated prompt rendering and prompt token counting reuse the cached config instead of re-resolving it.
+4. Register the dedicated `command_json` PR-scoped probe and add focused probe-registry tests.
+5. Validate with focused pytest, changed-scope coverage >=95%, `git diff --check`, and a local `origin/main` vs head probe run.
+
+## Success criteria
+
+- `load_model(...)`, `render_prompt(...)`, and `prompt_token_count(...)` preserve existing shaping and token-count semantics.
+- Loaded-model payloads reuse one cached family config across repeated calls.
+- Compatibility behavior still works when `_family_config(...)` receives an older/manual payload without the cache entry.
+- Changed-scope coverage for the touched executable Python files remains at least 95%.
+- The dedicated probe shows lower `elapsed_ms_mean` and lower `resolve_calls_mean` than `origin/main` for the same synthetic workload.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -540,6 +540,37 @@
     ]
   },
   {
+    "id": "mlx-vlm-family-config-cache",
+    "name": "MLX-VLM family-config cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py",
+      "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/mlx_vlm_family_config_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_streams_backend_tokens_and_records_probe services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_caches_family_config_across_prompt_render_and_token_count services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_family_config_backfills_cache_for_legacy_loaded_model services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_vlm_runtime_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_family_config_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_family_config_probe_script_main_covers_checked_in_file",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_streams_backend_tokens_and_records_probe services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_caches_family_config_across_prompt_render_and_token_count services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_family_config_backfills_cache_for_legacy_loaded_model services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_vlm_runtime_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_family_config_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_family_config_probe_script_main_covers_checked_in_file && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_vlm_family_config_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -lc 'if [ -f scripts/mlx_vlm_family_config_probe.py ]; then python3 scripts/mlx_vlm_family_config_probe.py; else python3 - <<\"PY\"\nimport json\nimport statistics\nimport sys\nimport time\nfrom pathlib import Path\nfrom types import SimpleNamespace\n\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\n\nfrom packages.protocol.python.worker.v1 import common_pb2\nfrom worker.runtime import mlx_vlm_runtime as mlx_vlm_runtime_module\nfrom worker.runtime.mlx_vlm_runtime import AutoMLXVLMBackend, MLXVLMRuntime\n\niteration_count = 200\nsample_count = 5\nprompt_text = \"Describe the image\"\n\nclass ProbeFamilyConfig:\n    def capability_metadata(self):\n        return {\"vision_family_id\": \"gemma4-v1\", \"vision_prompt_profile_id\": \"gemma4-chatml-v1\"}\n    def shape_request(self, prepared):\n        return prepared\n    def prompt_token_count(self, prepared):\n        return len(prepared.prompt_text.split())\n\nclass ResolveCounter:\n    def __init__(self):\n        self.count = 0\n    def __call__(self, metadata):\n        self.count += 1\n        if metadata.get(\"vision_family_id\") != \"gemma4-v1\":\n            raise SystemExit(\"unexpected vision family metadata\")\n        return ProbeFamilyConfig()\n\ndef model_spec():\n    return common_pb2.ModelSpec(model_id=\"unsloth/gemma-4-E4B-it-MLX-8bit\", model_path=\"unsloth/gemma-4-E4B-it-MLX-8bit\", model_kind=\"vlm\", revision=\"main\", tokenizer_hash=\"hf.unsloth.gemma-4-E4B-it-MLX-8bit\", quant_profile_id=\"q8\", parser_mode=\"text\", reasoning_mode=\"off\", max_context=4096, ext={\"melix.vlm.backend_id\": \"mlx_vlm\", \"vision_family_id\": \"gemma4-v1\", \"vision_prompt_profile_id\": \"gemma4-chatml-v1\", \"vision_tokenization_mode\": \"interleaved\", \"vision_max_images_per_prompt\": \"8\", \"vision_supports_tool_calls\": \"true\", \"melix.multimodal_adapter_hash\": \"vision-family-gemma4-v1\"})\n\ndef messages():\n    return [common_pb2.ChatMessage(role=\"user\", parts=[common_pb2.MessagePart(text=prompt_text)])]\n\ndef build_runtime():\n    counter = ResolveCounter()\n    def fake_load(model_path, revision=\"main\"):\n        _ = model_path\n        _ = revision\n        model = SimpleNamespace(config=SimpleNamespace(model_type=\"gemma4\"))\n        processor = SimpleNamespace(image_processor=object())\n        return model, processor\n    mlx_vlm_runtime_module.resolve_vision_family_config = counter\n    mlx_vlm_runtime_module._installed_package_version = lambda name: f\"{name}-version\"\n    runtime = MLXVLMRuntime(backend=AutoMLXVLMBackend(load_fn=fake_load, stream_generate_fn=lambda *args, **kwargs: iter(()), apply_chat_template_fn=lambda *args, **kwargs: \"formatted::prompt\"))\n    return runtime, counter\n\nelapsed_samples = []\nresolve_samples = []\nprompt_token_count = 0\nfor _ in range(sample_count):\n    runtime, counter = build_runtime()\n    loaded_model = runtime.load_model(model_spec())\n    started = time.perf_counter()\n    for _ in range(iteration_count):\n        prepared = runtime.render_prompt(messages(), loaded_model=loaded_model)\n        prompt_token_count = runtime.prompt_token_count(prepared, loaded_model=loaded_model)\n    elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n    resolve_samples.append(float(counter.count))\n    if prompt_token_count != 3:\n        raise SystemExit(\"unexpected prompt token count\")\nprint(json.dumps({\n    \"elapsed_ms_mean\": round(statistics.fmean(elapsed_samples), 6),\n    \"iteration_count\": float(iteration_count),\n    \"prompt_token_count\": float(prompt_token_count),\n    \"resolve_calls_mean\": round(statistics.fmean(resolve_samples), 6),\n    \"sample_count\": float(sample_count),\n}, sort_keys=True))\nPY\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "resolve_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "deterministic-rerank-query-context-reuse",
     "name": "Deterministic rerank query-context reuse",
     "runner": "ubuntu-latest",

--- a/scripts/mlx_vlm_family_config_probe.py
+++ b/scripts/mlx_vlm_family_config_probe.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from packages.protocol.python.worker.v1 import common_pb2  # noqa: E402
+from worker.runtime import mlx_vlm_runtime as mlx_vlm_runtime_module  # noqa: E402
+from worker.runtime.mlx_vlm_runtime import AutoMLXVLMBackend, MLXVLMRuntime  # noqa: E402
+
+ITERATION_COUNT = 200
+SAMPLE_COUNT = 5
+PROMPT_TEXT = "Describe the image"
+
+
+class _ProbeFamilyConfig:
+    def capability_metadata(self) -> dict[str, str]:
+        return {
+            "vision_family_id": "gemma4-v1",
+            "vision_prompt_profile_id": "gemma4-chatml-v1",
+        }
+
+    def shape_request(self, prepared):
+        return prepared
+
+    def prompt_token_count(self, prepared) -> int:
+        return len(prepared.prompt_text.split())
+
+
+class _ResolveCounter:
+    def __init__(self) -> None:
+        self.count = 0
+
+    def __call__(self, metadata: dict[str, str]) -> _ProbeFamilyConfig:
+        self.count += 1
+        if metadata.get("vision_family_id") != "gemma4-v1":
+            raise SystemExit("unexpected vision family metadata")
+        return _ProbeFamilyConfig()
+
+
+def _model_spec() -> common_pb2.ModelSpec:
+    return common_pb2.ModelSpec(
+        model_id="unsloth/gemma-4-E4B-it-MLX-8bit",
+        model_path="unsloth/gemma-4-E4B-it-MLX-8bit",
+        model_kind="vlm",
+        revision="main",
+        tokenizer_hash="hf.unsloth.gemma-4-E4B-it-MLX-8bit",
+        quant_profile_id="q8",
+        parser_mode="text",
+        reasoning_mode="off",
+        max_context=4096,
+        ext={
+            "melix.vlm.backend_id": "mlx_vlm",
+            "vision_family_id": "gemma4-v1",
+            "vision_prompt_profile_id": "gemma4-chatml-v1",
+            "vision_tokenization_mode": "interleaved",
+            "vision_max_images_per_prompt": "8",
+            "vision_supports_tool_calls": "true",
+            "melix.multimodal_adapter_hash": "vision-family-gemma4-v1",
+        },
+    )
+
+
+def _messages() -> list[common_pb2.ChatMessage]:
+    return [common_pb2.ChatMessage(role="user", parts=[common_pb2.MessagePart(text=PROMPT_TEXT)])]
+
+
+def _build_runtime() -> tuple[MLXVLMRuntime, _ResolveCounter]:
+    counter = _ResolveCounter()
+
+    def fake_load(model_path: str, revision: str = "main"):
+        _ = model_path
+        _ = revision
+        model = SimpleNamespace(config=SimpleNamespace(model_type="gemma4"))
+        processor = SimpleNamespace(image_processor=object())
+        return model, processor
+
+    mlx_vlm_runtime_module.resolve_vision_family_config = counter
+    mlx_vlm_runtime_module._installed_package_version = lambda name: f"{name}-version"
+    runtime = MLXVLMRuntime(
+        backend=AutoMLXVLMBackend(
+            load_fn=fake_load,
+            stream_generate_fn=lambda *args, **kwargs: iter(()),
+            apply_chat_template_fn=lambda *args, **kwargs: "formatted::prompt",
+        )
+    )
+    return runtime, counter
+
+
+def main() -> int:
+    elapsed_samples: list[float] = []
+    resolve_samples: list[float] = []
+    prompt_token_count = 0
+    for _ in range(SAMPLE_COUNT):
+        runtime, counter = _build_runtime()
+        loaded_model = runtime.load_model(_model_spec())
+        started = time.perf_counter()
+        for _ in range(ITERATION_COUNT):
+            prepared = runtime.render_prompt(_messages(), loaded_model=loaded_model)
+            prompt_token_count = runtime.prompt_token_count(prepared, loaded_model=loaded_model)
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        resolve_samples.append(float(counter.count))
+        if prompt_token_count != 3:
+            raise SystemExit("unexpected prompt token count")
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+                "iteration_count": float(ITERATION_COUNT),
+                "prompt_token_count": float(prompt_token_count),
+                "resolve_calls_mean": round(statistics.fmean(resolve_samples), 6),
+                "sample_count": float(SAMPLE_COUNT),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -222,6 +222,105 @@ def test_mlx_vlm_runtime_records_installed_package_versions(monkeypatch: pytest.
     assert loaded_model["metadata"]["mlx_vlm_version"] == "0.4.4"
 
 
+def test_mlx_vlm_runtime_caches_family_config_across_prompt_render_and_token_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolve_call_count = 0
+
+    class FakeFamilyConfig:
+        def capability_metadata(self) -> dict[str, str]:
+            return {
+                "vision_family_id": "gemma4-v1",
+                "vision_prompt_profile_id": "gemma4-chatml-v1",
+            }
+
+        def shape_request(self, prepared: PreparedVisionRequest) -> PreparedVisionRequest:
+            return prepared
+
+        def prompt_token_count(self, prepared: PreparedVisionRequest) -> int:
+            return len(prepared.prompt_text.split())
+
+    def fake_resolve(metadata: dict[str, str]) -> FakeFamilyConfig:
+        nonlocal resolve_call_count
+        resolve_call_count += 1
+        assert metadata["vision_family_id"] == "gemma4-v1"
+        return FakeFamilyConfig()
+
+    def fake_load(model_path: str, revision: str = "main"):
+        _ = model_path
+        _ = revision
+        model = SimpleNamespace(config=SimpleNamespace(model_type="gemma4"))
+        processor = SimpleNamespace(image_processor=object())
+        return model, processor
+
+    monkeypatch.setattr(mlx_vlm_runtime_module, "resolve_vision_family_config", fake_resolve)
+    monkeypatch.setattr(mlx_vlm_runtime_module, "_installed_package_version", lambda name: f"{name}-version")
+
+    runtime = MLXVLMRuntime(
+        backend=AutoMLXVLMBackend(
+            load_fn=fake_load,
+            stream_generate_fn=lambda *args, **kwargs: iter(()),
+            apply_chat_template_fn=lambda *args, **kwargs: "formatted::prompt",
+        )
+    )
+    loaded_model = runtime.load_model(imported_gemma4_vlm_model())
+
+    assert resolve_call_count == 1
+    cached_config = loaded_model["_vision_family_config"]
+
+    prepared = runtime.render_prompt(
+        [common_pb2.ChatMessage(role="user", parts=[common_pb2.MessagePart(text="Describe the image")])],
+        loaded_model=loaded_model,
+    )
+
+    assert runtime.prompt_token_count(prepared, loaded_model=loaded_model) == 3
+    assert runtime.prompt_token_count(prepared, loaded_model=loaded_model) == 3
+    assert loaded_model["_vision_family_config"] is cached_config
+    assert resolve_call_count == 1
+
+
+def test_mlx_vlm_runtime_family_config_backfills_cache_for_legacy_loaded_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolve_call_count = 0
+
+    class FakeFamilyConfig:
+        def capability_metadata(self) -> dict[str, str]:
+            return {}
+
+        def shape_request(self, prepared: PreparedVisionRequest) -> PreparedVisionRequest:
+            return prepared
+
+        def prompt_token_count(self, prepared: PreparedVisionRequest) -> int:
+            return len(prepared.prompt_text)
+
+    def fake_resolve(metadata: dict[str, str]) -> FakeFamilyConfig:
+        nonlocal resolve_call_count
+        resolve_call_count += 1
+        assert metadata["vision_family_id"] == "gemma4-v1"
+        return FakeFamilyConfig()
+
+    monkeypatch.setattr(mlx_vlm_runtime_module, "resolve_vision_family_config", fake_resolve)
+
+    legacy_loaded_model = {
+        "metadata": {
+            "vision_family_id": "gemma4-v1",
+            "vision_prompt_profile_id": "gemma4-chatml-v1",
+            "melix.vlm.execution_mode": "multimodal",
+        }
+    }
+    runtime = MLXVLMRuntime()
+
+    prepared = runtime.render_prompt(
+        [common_pb2.ChatMessage(role="user", parts=[common_pb2.MessagePart(text="legacy cache path")])],
+        loaded_model=legacy_loaded_model,
+    )
+
+    assert runtime.prompt_token_count(prepared, loaded_model=legacy_loaded_model) == len("legacy cache path")
+    assert legacy_loaded_model["_vision_family_config"] is not None
+    assert resolve_call_count == 1
+
+
 def test_mlx_vlm_runtime_passes_video_when_backend_accepts_video_argument() -> None:
     stream_calls: list[dict[str, object]] = []
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -169,6 +169,16 @@ def test_scope_report_selects_mlx_lm_runner_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "mlx-lm-structured-result-tail-parse"
 
 
+def test_scope_report_selects_mlx_vlm_runtime_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "mlx-vlm-family-config-cache"
+
+
 def test_scope_report_selects_model_registry_catalog_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -449,6 +459,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "evaluation-store-samples-csv-streaming",
         "job-registry-derived-model-single-pass",
         "mlx-lm-structured-result-tail-parse",
+        "mlx-vlm-family-config-cache",
         "model-registry-plain-local-manifest-stat-elision",
         "package-macos-resolve-fallback-scandir",
         "pr-scoped-performance-scope-json-read-bytes",
@@ -1457,6 +1468,21 @@ def test_mlx_lm_result_tail_probe_script_emits_metrics() -> None:
     assert metrics["sample_count"] == 5.0
 
 
+def test_mlx_vlm_family_config_probe_script_emits_metrics() -> None:
+    probe = next(
+        probe
+        for probe in load_probe_registry(REGISTRY_PATH)
+        if probe.probe_id == "mlx-vlm-family-config-cache"
+    )
+
+    metrics = _probe_command_json(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["resolve_calls_mean"] >= 1.0
+    assert metrics["prompt_token_count"] == 3.0
+    assert metrics["iteration_count"] == 200.0
+    assert metrics["sample_count"] == 5.0
+
 
 def test_mlx_lm_result_tail_probe_script_main_covers_checked_in_file(capsys: pytest.CaptureFixture[str]) -> None:
     script_path = REPO_ROOT / "scripts" / "mlx_lm_result_tail_probe.py"
@@ -1475,6 +1501,25 @@ def test_mlx_lm_result_tail_probe_script_main_covers_checked_in_file(capsys: pyt
     assert payload["sample_count"] == 2.0
     assert payload["line_count"] == 34.0
 
+
+def test_mlx_vlm_family_config_probe_script_main_covers_checked_in_file(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    script_path = REPO_ROOT / "scripts" / "mlx_vlm_family_config_probe.py"
+    spec = importlib.util.spec_from_file_location("mlx_vlm_family_config_probe_test", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.ITERATION_COUNT = 8
+    module.SAMPLE_COUNT = 2
+
+    assert module.main() == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+
+    assert payload["prompt_token_count"] == 3.0
+    assert payload["iteration_count"] == 8.0
+    assert payload["sample_count"] == 2.0
+    assert payload["resolve_calls_mean"] >= 1.0
 
 
 def test_command_json_probe_rejects_missing_command_and_non_numeric_metrics(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -165,6 +165,7 @@ class AutoMLXVLMBackend:
                 original_error=exc,
             )
         metadata["melix.vlm.execution_mode"] = execution_mode
+        family_config = resolve_vision_family_config(dict(model_spec.ext))
         return {
             "model_id": model_spec.model_id,
             "model_kind": model_spec.model_kind,
@@ -177,7 +178,8 @@ class AutoMLXVLMBackend:
             "model": model,
             "processor": processor,
             "metadata": metadata,
-            **resolve_vision_family_config(dict(model_spec.ext)).capability_metadata(),
+            "_vision_family_config": family_config,
+            **family_config.capability_metadata(),
         }
 
     @staticmethod
@@ -593,13 +595,19 @@ class MLXVLMRuntime:
     def _family_config(loaded_model) -> Any:
         metadata: dict[str, str] = {}
         if isinstance(loaded_model, dict):
+            cached_config = loaded_model.get("_vision_family_config")
+            if cached_config is not None:
+                return cached_config
             raw_metadata = loaded_model.get("metadata")
             if isinstance(raw_metadata, dict):
                 metadata = {
                     str(key): str(value)
                     for key, value in raw_metadata.items()
                 }
-        return resolve_vision_family_config(metadata)
+        family_config = resolve_vision_family_config(metadata)
+        if isinstance(loaded_model, dict):
+            loaded_model["_vision_family_config"] = family_config
+        return family_config
 
     @staticmethod
     def _prompt_text_from_messages(messages) -> str:


### PR DESCRIPTION
## Summary
- cache the resolved MLX-VLM family config on the loaded-model payload during `load_model(...)`
- reuse that cached config from `render_prompt(...)` and `prompt_token_count(...)`, while still backfilling legacy/manual loaded-model payloads that do not already carry `_vision_family_config`
- add focused MLX-VLM cache regression tests plus a dedicated scoped performance probe (`mlx-vlm-family-config-cache`) and checked-in probe script

## Plan or Spec
- `docs/plans/2026-05-03-mlx-vlm-family-config-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_streams_backend_tokens_and_records_probe services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_caches_family_config_across_prompt_render_and_token_count services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_family_config_backfills_cache_for_legacy_loaded_model services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_vlm_runtime_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_family_config_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_family_config_probe_script_main_covers_checked_in_file
PASS (7 passed)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_streams_backend_tokens_and_records_probe services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_caches_family_config_across_prompt_render_and_token_count services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_family_config_backfills_cache_for_legacy_loaded_model services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_vlm_runtime_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_family_config_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_family_config_probe_script_main_covers_checked_in_file
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_vlm_family_config_probe.py
PASS (TOTAL 84 1 99%)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id mlx-vlm-family-config-cache --base-repo /tmp/melix-base-20260503-054442 --head-repo /tmp/melix-cron-opt-20260503-052929 --output /tmp/mlx-vlm-family-config-cache-result.json
PASS (base vs head probe comparison completed)

git diff --check
PASS
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 84 1 99%`
- Registered scoped CI probe: `mlx-vlm-family-config-cache`
- Local probe metrics (`origin/main` -> branch):
  - `elapsed_ms_mean`: `8.491669 ms` -> `7.497028 ms` (~11.71% lower)
  - `resolve_calls_mean`: `401.0` -> `1.0` (~99.75% lower)
  - `prompt_token_count`: `3.0` -> `3.0` (unchanged)
  - `iteration_count`: `200.0` -> `200.0` (same workload)
- Linux note: this is a Python-only slice; no local macOS/Swift verification was required for correctness

## Known Gaps
- Hosted `pr-scoped-performance` must still run after push because `infra/perf/pr_scoped_probes.json` changed and will fan out the scoped matrix
- I did not run full-repo `make py-test` / Swift / integration suites locally; this slice used focused Linux verification only

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
