### PR TITLE
perf: finalize evaluation sample means directly

### DIFF
--- a/docs/plans/2026-05-03-benchmark-eval-sample-direct-mean.md
+++ b/docs/plans/2026-05-03-benchmark-eval-sample-direct-mean.md
@@ -1,0 +1,29 @@
+# Benchmark evaluation sample direct-mean aggregation
+
+## Goal
+
+Reduce per-report overhead in `benchmark_evaluation_report` when finalizing evaluation sample probe metrics without changing metric names, values, or report status semantics.
+
+## Scope
+
+This slice is limited to:
+
+- `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`
+- `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`
+
+## Registered probe coverage
+
+The affected path is covered by the registered PR-scoped probe `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json`. The probe has focused `test_command`, `coverage_command`, and `probe_command` entries and reports `elapsed_ms_mean`, `peak_bytes_mean`, and row-count correctness for the synthetic benchmark/evaluation report workload.
+
+## Implementation plan
+
+1. Add regression coverage proving evaluation sample metrics are finalized as direct means without routing through the generic aggregate finalizer.
+2. Replace the generic finalizer call in `_collect_evaluation_sample_probe_metrics()` with direct `total / count` mean emission. Evaluation sample metrics always use the `_mean` suffix, unlike benchmark probe metrics that may emit rates or sums.
+3. Run focused pytest, changed-scope coverage, `git diff --check`, and the registered probe locally on Linux against both `origin/main` and the branch.
+
+## Success criteria
+
+- Evaluation sample metric keys and values remain unchanged.
+- Focused tests and changed-scope coverage pass.
+- The registered local probe shows a lower `elapsed_ms_mean` without changing `row_count`.
+- CI PR-scoped performance completes successfully before merge.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -459,6 +459,34 @@ def test_probe_collectors_fast_path_exact_numeric_values(monkeypatch: pytest.Mon
     assert evaluation_metrics["eval.sample.smoke.validation_ms_mean"] == 0.0
 
 
+def test_evaluation_sample_collector_finalizes_mean_metrics_directly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_finalize_numeric_aggregate(
+        key: str,
+        aggregate: tuple[float, int] | None,
+    ) -> tuple[str, float]:
+        del aggregate
+        raise AssertionError(f"unexpected generic aggregate finalizer for {key}")
+
+    monkeypatch.setattr(
+        benchmark_evaluation_report,
+        "_finalize_numeric_aggregate",
+        fail_finalize_numeric_aggregate,
+    )
+
+    metrics: dict[str, object] = {}
+    _collect_evaluation_sample_probe_metrics(
+        metrics,
+        [
+            {"suite_id": "smoke", "sample_render_ms": 3.0},
+            {"suite_id": "smoke", "sample_render_ms": 5.0},
+        ],
+    )
+
+    assert metrics == {"eval.sample.smoke.sample_render_ms_mean": 4.0}
+
+
 def test_probe_collectors_use_registered_probe_key_order_without_items_scan() -> None:
     class NoItemsDict(dict[str, object]):
         def items(self):  # type: ignore[override]

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -518,8 +518,8 @@ def _collect_evaluation_sample_probe_metrics(
                 failure_stage_counts.get((suite_id, failure_stage), 0) + 1
             )
     for (suite_id, key), aggregate in aggregates_by_suite_and_key.items():
-        _, value = _finalize_numeric_aggregate(key, aggregate)
-        metrics[f"eval.sample.{suite_id}.{key}_mean"] = value
+        total, count = aggregate
+        metrics[f"eval.sample.{suite_id}.{key}_mean"] = total / count
     for (suite_id, failure_stage), count in failure_stage_counts.items():
         metrics[f"eval.sample.{suite_id}.failure_stage.{failure_stage}.failure_count"] = float(count)
 


### PR DESCRIPTION
## Summary
- Finalize evaluation sample probe metrics with direct `total / count` mean emission instead of routing through the generic aggregate finalizer.
- Add a focused regression test that locks the direct-mean path while preserving current metric keys and values.
- Document the slice plan and registered PR-scoped probe coverage.

## Plan or Spec
- `docs/plans/2026-05-03-benchmark-eval-sample-direct-mean.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py::test_evaluation_sample_collector_finalizes_mean_metrics_directly
# expected RED before implementation; failed with AssertionError from the generic finalizer

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# 37 passed in 0.06s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# TOTAL 684 stmts, 7 miss, 99% coverage

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_benchmark_eval_probe.py
# {"elapsed_ms_mean": 145.513, "peak_bytes_mean": 3895477.7, "row_count": 5990.0}

git diff --check
# passed
```

## Coverage and Metrics
- Registered probe: `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json` (focused test, coverage, and probe commands are present).
- Changed-scope coverage: 99% total for `benchmark_evaluation_report.py` and `test_benchmark_evaluation_report.py`.
- Local Linux probe comparison using the registered probe implementation:
  - `origin/main` samples: `151.565`, `186.047`, `146.194` ms; mean `161.269` ms.
  - branch samples: `146.544`, `144.569`, `149.555` ms; mean `146.889` ms.
  - delta: `-14.379` ms (`8.916%` faster); `row_count` unchanged at `5990.0`; `peak_bytes_mean` unchanged at `3895477.7` bytes.
- CI PR-scoped performance remains the merge gate for the registered probe report.

## Known Gaps
- Local validation is Linux-only; no Swift runtime effect is claimed or required for this Python-only slice.
- Local timing samples are noisy, so CI must complete the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
