### PR TITLE
[codex] Redesign Command Center

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationState.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationState.swift
@@ -71,6 +71,35 @@ public struct DesktopLogEntry: Identifiable, Equatable, Sendable {
     }
 }
 
+public enum DesktopFoundationHealthState: String, Equatable, Sendable {
+    case runtimeReady
+    case runtimeWarning
+    case recoveryAvailable
+    case needsAttention
+    case runtimeState
+
+    static func resolve(
+        serverState: Melix_Controlplane_V1_ServerState,
+        hasErrors: Bool
+    ) -> DesktopFoundationHealthState {
+        if hasErrors {
+            return .needsAttention
+        }
+        switch serverState {
+        case .serverReady:
+            return .runtimeReady
+        case .serverDegraded, .serverDraining:
+            return .runtimeWarning
+        case .serverStopped:
+            return .recoveryAvailable
+        case .serverFailed:
+            return .needsAttention
+        default:
+            return .runtimeState
+        }
+    }
+}
+
 public struct DesktopMetricRow: Identifiable, Equatable, Sendable {
     public let id: String
     public let name: String
@@ -144,6 +173,7 @@ public struct DesktopFoundationState: Equatable, Sendable {
     public let serverStateText: String
     public let connectionStateText: String
     public let connectionDetailText: String
+    public let healthState: DesktopFoundationHealthState
     public let dashboardCards: [DesktopDashboardCard]
     public let queueLanes: [DesktopQueueLaneRow]
     public let models: [RuntimeModelRow]
@@ -212,6 +242,11 @@ public struct DesktopFoundationState: Equatable, Sendable {
         let guardDetail = recentGuardAlerts.first?.message
             ?? modelGuardAlerts.first.map { formatTransitionReason($0.residency.transitionReason) }
             ?? "No active memory guard failures"
+
+        let healthState = DesktopFoundationHealthState.resolve(
+            serverState: snapshot.serverState,
+            hasErrors: (lastError?.isEmpty == false) || snapshot.recentErrors.isEmpty == false
+        )
 
         let dashboardCards = [
             DesktopDashboardCard(
@@ -414,6 +449,7 @@ public struct DesktopFoundationState: Equatable, Sendable {
             serverStateText: serverStateText,
             connectionStateText: connectionStateText,
             connectionDetailText: connectionDetailText,
+            healthState: healthState,
             dashboardCards: dashboardCards,
             queueLanes: queueLanes,
             models: snapshot.models

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -272,237 +272,58 @@ struct DesktopCommandCenterView: View {
         let serverSessions = liveServerSessions
 
         ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                Text("Command Center")
-                    .font(.largeTitle.weight(.semibold))
+            VStack(alignment: .leading, spacing: DesktopCommandCenterVisuals.sectionSpacing) {
+                DesktopCommandCenterHeaderView(
+                    foundation: foundation,
+                    lastError: viewModel?.lastError
+                )
 
-                LazyVGrid(columns: [GridItem(.adaptive(minimum: 260), spacing: 12)], spacing: 12) {
-                    GroupBox("Runtime Health") {
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text(foundation.serverStateText)
-                                .font(.headline)
-                            Text(foundation.connectionStateText)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text(foundation.connectionDetailText)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(2)
+                ViewThatFits(in: .horizontal) {
+                    HStack(alignment: .top, spacing: DesktopCommandCenterVisuals.columnSpacing) {
+                        VStack(alignment: .leading, spacing: DesktopCommandCenterVisuals.sectionSpacing) {
+                            DesktopCommandCenterRuntimePanel(foundation: foundation)
+                            DesktopCommandCenterPressurePanel(foundation: foundation)
+                            DesktopCommandCenterActivityPanel(foundation: foundation)
                         }
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .frame(minWidth: DesktopCommandCenterVisuals.primaryColumnMinimumWidth)
+
+                        VStack(alignment: .leading, spacing: DesktopCommandCenterVisuals.sectionSpacing) {
+                            DesktopCommandCenterRecoveryPanel(
+                                viewModel: viewModel,
+                                serverSessions: serverSessions
+                            )
+                            DesktopCommandCenterWorkflowPanel(viewModel: viewModel)
+                            DesktopCommandCenterSessionSummaryPanel(
+                                chatSessions: chatSessions,
+                                serverSessions: serverSessions
+                            )
+                        }
+                        .frame(width: DesktopCommandCenterVisuals.secondaryColumnWidth)
                     }
 
-                    GroupBox("Primary Model") {
-                        VStack(alignment: .leading, spacing: 6) {
-                            if let model = foundation.models.first {
-                                Text(model.displayName)
-                                    .font(.headline)
-                                    .lineLimit(1)
-                                Text("\(model.modelID) • \(model.stateText) • \(model.memoryPolicyText)")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                Text(model.memoryText)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(2)
-                            } else {
-                                Text("No model discovered.")
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    VStack(alignment: .leading, spacing: DesktopCommandCenterVisuals.sectionSpacing) {
+                        DesktopCommandCenterRuntimePanel(foundation: foundation)
+                        DesktopCommandCenterRecoveryPanel(
+                            viewModel: viewModel,
+                            serverSessions: serverSessions
+                        )
+                        DesktopCommandCenterPressurePanel(foundation: foundation)
+                        DesktopCommandCenterWorkflowPanel(viewModel: viewModel)
+                        DesktopCommandCenterActivityPanel(foundation: foundation)
+                        DesktopCommandCenterSessionSummaryPanel(
+                            chatSessions: chatSessions,
+                            serverSessions: serverSessions
+                        )
                     }
-
-                    if let viewModel, viewModel.recoverableDownloads.isEmpty == false {
-                        GroupBox("Download Recovery") {
-                            VStack(alignment: .leading, spacing: 8) {
-                                ForEach(viewModel.recoverableDownloads.prefix(2)) { entry in
-                                    VStack(alignment: .leading, spacing: 4) {
-                                        Text(entry.sourceModel)
-                                            .font(.headline)
-                                            .lineLimit(1)
-                                        Text(entry.progressText)
-                                            .font(.caption.monospacedDigit())
-                                            .foregroundStyle(.secondary)
-                                        Button("Resume Download") {
-                                            Task { await viewModel.resumeDownload(jobID: entry.jobID) }
-                                        }
-                                        .buttonStyle(.borderedProminent)
-                                        .controlSize(.small)
-                                    }
-                                }
-                                if let overflowText = Self.downloadRecoveryOverflowText(
-                                    totalCount: viewModel.recoverableDownloads.count
-                                ) {
-                                    HStack {
-                                        Text(overflowText)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                        Spacer()
-                                        Button(Self.downloadRecoveryOverflowActionTitle) {
-                                            viewModel.selectSurface(.tools)
-                                            viewModel.selectToolSection(.downloads)
-                                        }
-                                        .buttonStyle(.bordered)
-                                        .controlSize(.small)
-                                    }
-                                }
-                            }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                    }
-
-                    if let operation = viewModel?.lastModelOperation {
-                        GroupBox("Last Operation") {
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text(operation.operation)
-                                    .font(.headline)
-                                Text(operation.modelID)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                Text(operation.outputPath)
-                                    .font(.caption2.monospaced())
-                                    .foregroundStyle(.tertiary)
-                                    .lineLimit(2)
-                            }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                    }
-
-                    if let lastError = viewModel?.lastError {
-                        GroupBox("Latest Error") {
-                            Text(lastError)
-                                .foregroundStyle(MelixDesignTokens.StatusColor.error)
-                                .lineLimit(3)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                    }
-                }
-
-                LazyVGrid(columns: [GridItem(.adaptive(minimum: 220), spacing: 12)], spacing: 12) {
-                    ForEach(foundation.dashboardCards.filter { ["server", "connection", "backpressure", "memory"].contains($0.id) }) { card in
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text(card.title)
-                                .font(.headline)
-                            Text(card.value)
-                                .font(.title3.weight(.semibold))
-                            Text(card.detail)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding()
-                        .background(.quaternary.opacity(0.6), in: RoundedRectangle(cornerRadius: 14))
-                    }
-                }
-
-                HStack(alignment: .top, spacing: 16) {
-                    GroupBox("Resource And Queue Pressure") {
-                        VStack(alignment: .leading, spacing: 10) {
-                            ForEach(foundation.queueLanes) { lane in
-                                VStack(alignment: .leading, spacing: 4) {
-                                    HStack {
-                                        Text(lane.id)
-                                            .font(.headline)
-                                        Spacer()
-                                        Text("bp \(String(format: "%.2f", lane.backpressure))")
-                                            .font(.caption.monospacedDigit())
-                                            .foregroundStyle(.secondary)
-                                    }
-                                    Text("\(lane.laneClass) • active \(lane.activeRequests) • queued \(lane.queuedRequests)")
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                }
-                            }
-                            if foundation.queueLanes.isEmpty {
-                                Text("No active queue pressure.")
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-
-                    GroupBox("Recovery Items") {
-                        VStack(alignment: .leading, spacing: 10) {
-                            ForEach(serverSessions.filter { $0.lifecycle == .error || $0.lifecycle == .stopped || $0.lifecycle == .unavailable }) { session in
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text(session.title)
-                                        .font(.headline)
-                                    Text("\(session.lifecycle.rawValue) • \(session.effectiveBaseURL)")
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                    if !session.lastError.isEmpty {
-                                        Text(session.lastError)
-                                            .font(.caption)
-                                            .foregroundStyle(MelixDesignTokens.StatusColor.error)
-                                    }
-                                }
-                            }
-                            if serverSessions.contains(where: { $0.lifecycle == .error || $0.lifecycle == .stopped || $0.lifecycle == .unavailable }) == false {
-                                Text("No recovery items.")
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                }
-
-                GroupBox("Recent Activity") {
-                    VStack(alignment: .leading, spacing: 10) {
-                        ForEach(foundation.logs.prefix(8)) { entry in
-                            VStack(alignment: .leading, spacing: 2) {
-                                HStack {
-                                    Text(entry.kind)
-                                        .font(.caption2)
-                                        .padding(.horizontal, 6)
-                                        .padding(.vertical, 2)
-                                        .background(.quaternary, in: Capsule())
-                                    Spacer()
-                                    Text(entry.level.uppercased())
-                                        .font(.caption2)
-                                        .foregroundStyle(entry.level == "error" ? MelixDesignTokens.StatusColor.error : .secondary)
-                                }
-                                Text(entry.message)
-                                    .font(.body)
-                                Text(entry.detail)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        if foundation.logs.isEmpty {
-                            Text("No recent activity.")
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-
-                GroupBox("Session Summary") {
-                    HStack(alignment: .top, spacing: 24) {
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text("Chat Sessions")
-                                .font(.headline)
-                            Text("\(chatSessions.count)")
-                                .font(.title3.weight(.semibold))
-                            Text(chatSessions.first?.summaryText ?? "No chat sessions")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text("Server Sessions")
-                                .font(.headline)
-                            Text("\(serverSessions.count)")
-                                .font(.title3.weight(.semibold))
-                            Text(serverSessions.first?.effectiveListenerLabel ?? "No listener configured")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
-            .padding(20)
+            .padding(DesktopCommandCenterVisuals.contentPadding)
+            .frame(
+                maxWidth: DesktopCommandCenterVisuals.maxContentWidth,
+                alignment: .leading
+            )
         }
+        .background(MelixDesignTokens.Palette.backgroundBase.color)
     }
 
     private var liveFoundation: DesktopFoundationState {
@@ -515,6 +336,561 @@ struct DesktopCommandCenterView: View {
 
     private var liveServerSessions: [DesktopServerSessionState] {
         viewModel?.serverSessions ?? serverSessions
+    }
+}
+
+enum DesktopCommandCenterVisuals {
+    static let repositoryDesignSystemPath = "docs/design-system/README.md"
+    static let appleLayoutGuidanceURL = "https://developer.apple.com/design/human-interface-guidelines/layout"
+    static let visualDirection = "Digital Broadsheet Command Center"
+    static let operatorLabel = "Melix Operator"
+    static let windowTitle = "Command Center"
+    static let runtimeSectionTitle = "Runtime"
+    static let pressureSectionTitle = "Resource And Queue Pressure"
+    static let recoverySectionTitle = "Recovery"
+    static let workflowSectionTitle = "Workflow"
+    static let activitySectionTitle = "Recent Activity"
+    static let sessionSummarySectionTitle = "Session Summary"
+    static let primaryModelTitle = "Primary Model"
+    static let maxContentWidth: CGFloat = 1120
+    static let primaryColumnMinimumWidth: CGFloat = 520
+    static let secondaryColumnWidth: CGFloat = 320
+    static let contentPadding = MelixDesignTokens.Spacing.huge
+    static let sectionSpacing = MelixDesignTokens.Spacing.xl
+    static let columnSpacing = MelixDesignTokens.Spacing.huge
+    static let panelCornerRadius = MelixDesignTokens.Radius.xl
+    static let statusSymbolName = "command.circle"
+    static let recoverySymbolName = "arrow.clockwise.circle"
+}
+
+private struct DesktopCommandCenterHeaderView: View {
+    let foundation: DesktopFoundationState
+    let lastError: String?
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: MelixDesignTokens.Spacing.lg) {
+            VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.sm) {
+                Text(DesktopCommandCenterVisuals.operatorLabel).melixSectionLabel()
+                Text(DesktopCommandCenterVisuals.windowTitle)
+                    .font(MelixDesignTokens.Typography.largeTitle)
+                Text(foundation.title)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: MelixDesignTokens.Spacing.lg)
+
+            HStack(alignment: .center, spacing: MelixDesignTokens.Spacing.sm) {
+                Image(systemName: healthSymbolName)
+                    .foregroundStyle(healthTint)
+                Text(healthLabel)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(healthTint)
+            }
+            .padding(.horizontal, MelixDesignTokens.Spacing.md)
+            .padding(.vertical, MelixDesignTokens.Spacing.sm)
+            .background(
+                healthTint.opacity(MelixDesignTokens.AccentOpacity.weak),
+                in: Capsule()
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var healthLabel: String {
+        switch resolvedHealthState {
+        case .runtimeReady:
+            return "Runtime Ready"
+        case .runtimeWarning:
+            return "Runtime Warning"
+        case .recoveryAvailable:
+            return "Recovery Available"
+        case .needsAttention:
+            return "Needs Attention"
+        case .runtimeState:
+            return "Runtime State"
+        }
+    }
+
+    private var healthSymbolName: String {
+        switch resolvedHealthState {
+        case .needsAttention:
+            return "exclamationmark.triangle.fill"
+        case .runtimeWarning:
+            return "exclamationmark.triangle"
+        case .recoveryAvailable:
+            return "pause.circle.fill"
+        case .runtimeReady, .runtimeState:
+            return DesktopCommandCenterVisuals.statusSymbolName
+        }
+    }
+
+    private var healthTint: Color {
+        switch resolvedHealthState {
+        case .needsAttention:
+            return MelixDesignTokens.StatusColor.error
+        case .runtimeWarning, .recoveryAvailable:
+            return MelixDesignTokens.StatusColor.warning
+        case .runtimeReady:
+            return MelixDesignTokens.StatusColor.success
+        case .runtimeState:
+            return MelixDesignTokens.StatusColor.info
+        }
+    }
+
+    private var resolvedHealthState: DesktopFoundationHealthState {
+        if let lastError, !lastError.isEmpty {
+            return .needsAttention
+        }
+        return foundation.healthState
+    }
+}
+
+private struct DesktopCommandCenterPanel<Content: View>: View {
+    let title: String
+    let symbolName: String
+    @ViewBuilder let content: () -> Content
+
+    init(_ title: String, symbolName: String, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.symbolName = symbolName
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.md) {
+            HStack(alignment: .center, spacing: MelixDesignTokens.Spacing.sm) {
+                Image(systemName: symbolName)
+                    .font(.caption)
+                    .foregroundStyle(MelixDesignTokens.accent)
+                Text(title).melixSectionLabel()
+            }
+
+            content()
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(MelixDesignTokens.Spacing.panelInset)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .melixCard(radius: DesktopCommandCenterVisuals.panelCornerRadius)
+    }
+}
+
+private struct DesktopCommandCenterRuntimePanel: View {
+    let foundation: DesktopFoundationState
+
+    var body: some View {
+        DesktopCommandCenterPanel(
+            DesktopCommandCenterVisuals.runtimeSectionTitle,
+            symbolName: "gauge.with.dots.needle.67percent"
+        ) {
+            VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.lg) {
+                HStack(alignment: .top, spacing: MelixDesignTokens.Spacing.xxl) {
+                    VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
+                        Text(foundation.serverStateText)
+                            .font(.title3.weight(.semibold))
+                        Text(foundation.connectionStateText)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(foundation.connectionDetailText)
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(2)
+                    }
+
+                    Spacer(minLength: MelixDesignTokens.Spacing.md)
+
+                    DesktopCommandCenterPrimaryModelView(model: foundation.models.first)
+                        .frame(maxWidth: 300, alignment: .leading)
+                }
+
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 118), spacing: MelixDesignTokens.Spacing.md)],
+                    spacing: MelixDesignTokens.Spacing.md
+                ) {
+                    ForEach(foundation.dashboardCards.filter { commandCenterMetricIDs.contains($0.id) }) { card in
+                        DesktopCommandCenterMetricView(card: card)
+                    }
+                }
+            }
+        }
+    }
+
+    private var commandCenterMetricIDs: Set<String> {
+        ["server", "connection", "backpressure", "memory"]
+    }
+}
+
+private struct DesktopCommandCenterPrimaryModelView: View {
+    let model: RuntimeModelRow?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
+            Text(DesktopCommandCenterVisuals.primaryModelTitle).melixSectionLabel()
+            if let model {
+                Text(model.displayName)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text("\(model.modelID) • \(model.stateText)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text("\(model.memoryPolicyText) • \(model.memoryText)")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(2)
+            } else {
+                Text("No model discovered.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+private struct DesktopCommandCenterMetricView: View {
+    let card: DesktopDashboardCard
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
+            Text(card.title).melixSectionLabel()
+            Text(card.value)
+                .font(.headline.monospacedDigit())
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Text(card.detail)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct DesktopCommandCenterPressurePanel: View {
+    let foundation: DesktopFoundationState
+
+    var body: some View {
+        DesktopCommandCenterPanel(
+            DesktopCommandCenterVisuals.pressureSectionTitle,
+            symbolName: "waveform.path.ecg"
+        ) {
+            VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.md) {
+                ForEach(foundation.queueLanes) { lane in
+                    DesktopCommandCenterQueueLaneView(lane: lane)
+                }
+                if foundation.queueLanes.isEmpty {
+                    Text("No active queue pressure.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+private struct DesktopCommandCenterQueueLaneView: View {
+    let lane: DesktopQueueLaneRow
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(lane.id)
+                    .font(.headline)
+                    .lineLimit(1)
+                Spacer()
+                Text("bp \(String(format: "%.2f", lane.backpressure))")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            Text("\(lane.laneClass) • active \(lane.activeRequests) • queued \(lane.queuedRequests)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+private struct DesktopCommandCenterRecoveryPanel: View {
+    let viewModel: RuntimeViewModel?
+    let serverSessions: [DesktopServerSessionState]
+
+    var body: some View {
+        let recoverySessions = serverSessions.filter {
+            $0.lifecycle == .error || $0.lifecycle == .stopped || $0.lifecycle == .unavailable
+        }
+        let recoverableDownloads = viewModel?.recoverableDownloads ?? []
+        let hasLatestError = (viewModel?.lastError ?? "").isEmpty == false
+        let hasRecovery = recoverableDownloads.isEmpty == false
+            || recoverySessions.isEmpty == false
+            || hasLatestError
+
+        DesktopCommandCenterPanel(
+            DesktopCommandCenterVisuals.recoverySectionTitle,
+            symbolName: DesktopCommandCenterVisuals.recoverySymbolName
+        ) {
+            VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.md) {
+                if let lastError = viewModel?.lastError, !lastError.isEmpty {
+                    DesktopCommandCenterAlertRow(
+                        title: "Latest Error",
+                        detail: lastError,
+                        tint: MelixDesignTokens.StatusColor.error
+                    )
+                }
+
+                ForEach(recoverableDownloads.prefix(2)) { entry in
+                    DesktopCommandCenterDownloadRecoveryRow(
+                        entry: entry,
+                        resume: {
+                            Task { await viewModel?.resumeDownload(jobID: entry.jobID) }
+                        }
+                    )
+                }
+
+                if let viewModel,
+                   let overflowText = DesktopCommandCenterView.downloadRecoveryOverflowText(
+                    totalCount: recoverableDownloads.count
+                   ) {
+                    HStack(alignment: .firstTextBaseline) {
+                        Text(overflowText)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button(DesktopCommandCenterView.downloadRecoveryOverflowActionTitle) {
+                            viewModel.selectSurface(.tools)
+                            viewModel.selectToolSection(.downloads)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .fixedSize(horizontal: true, vertical: false)
+                    }
+                }
+
+                ForEach(recoverySessions) { session in
+                    DesktopCommandCenterServerRecoveryRow(session: session)
+                }
+
+                if !hasRecovery {
+                    Text("No recovery items.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+private struct DesktopCommandCenterAlertRow: View {
+    let title: String
+    let detail: String
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
+            HStack(alignment: .firstTextBaseline, spacing: MelixDesignTokens.Spacing.xs) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(tint)
+                Text(title)
+                    .font(.headline)
+            }
+            Text(detail)
+                .font(.caption)
+                .foregroundStyle(tint)
+                .lineLimit(3)
+        }
+    }
+}
+
+private struct DesktopCommandCenterDownloadRecoveryRow: View {
+    let entry: RuntimeDownloadQueueEntryState
+    let resume: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.sm) {
+            HStack(alignment: .firstTextBaseline, spacing: MelixDesignTokens.Spacing.sm) {
+                VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
+                    Text(entry.sourceModel)
+                        .font(.headline)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Text(entry.progressText)
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: MelixDesignTokens.Spacing.sm)
+
+                Button(action: resume) {
+                    Label(entry.resumeActionTitle, systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .fixedSize(horizontal: true, vertical: false)
+            }
+
+            if !entry.transferDetailText.isEmpty {
+                Text(entry.transferDetailText)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(2)
+            }
+        }
+    }
+}
+
+private struct DesktopCommandCenterServerRecoveryRow: View {
+    let session: DesktopServerSessionState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
+            Text(session.title)
+                .font(.headline)
+                .lineLimit(1)
+            Text("\(session.lifecycle.rawValue) • \(session.effectiveBaseURL)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            if !session.lastError.isEmpty {
+                Text(session.lastError)
+                    .font(.caption2)
+                    .foregroundStyle(MelixDesignTokens.StatusColor.error)
+                    .lineLimit(2)
+            }
+        }
+    }
+}
+
+private struct DesktopCommandCenterWorkflowPanel: View {
+    let viewModel: RuntimeViewModel?
+
+    var body: some View {
+        DesktopCommandCenterPanel(
+            DesktopCommandCenterVisuals.workflowSectionTitle,
+            symbolName: "point.3.connected.trianglepath.dotted"
+        ) {
+            VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.md) {
+                if let operation = viewModel?.lastModelOperation {
+                    VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
+                        Text(operation.operation)
+                            .font(.headline)
+                            .lineLimit(1)
+                        Text("\(operation.modelID) • \(operation.stage)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Text(operation.outputPath)
+                            .font(.caption2.monospaced())
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(2)
+                            .truncationMode(.middle)
+                    }
+                } else {
+                    Text("No model operation recorded.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+private struct DesktopCommandCenterActivityPanel: View {
+    let foundation: DesktopFoundationState
+
+    var body: some View {
+        DesktopCommandCenterPanel(
+            DesktopCommandCenterVisuals.activitySectionTitle,
+            symbolName: "list.bullet.rectangle"
+        ) {
+            VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.md) {
+                ForEach(foundation.logs.prefix(8)) { entry in
+                    DesktopCommandCenterActivityRow(entry: entry)
+                }
+                if foundation.logs.isEmpty {
+                    Text("No recent activity.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+private struct DesktopCommandCenterActivityRow: View {
+    let entry: DesktopLogEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
+            HStack(alignment: .firstTextBaseline, spacing: MelixDesignTokens.Spacing.sm) {
+                Text(entry.kind)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(entry.level)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(
+                        entry.level == "error"
+                            ? MelixDesignTokens.StatusColor.error
+                            : MelixDesignTokens.Palette.foregroundTertiary.color
+                    )
+            }
+            Text(entry.message)
+                .font(.body)
+                .lineLimit(2)
+            Text(entry.detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+    }
+}
+
+private struct DesktopCommandCenterSessionSummaryPanel: View {
+    let chatSessions: [DesktopChatSessionState]
+    let serverSessions: [DesktopServerSessionState]
+
+    var body: some View {
+        DesktopCommandCenterPanel(
+            DesktopCommandCenterVisuals.sessionSummarySectionTitle,
+            symbolName: "rectangle.stack"
+        ) {
+            HStack(alignment: .top, spacing: MelixDesignTokens.Spacing.xxl) {
+                DesktopCommandCenterSessionMetricView(
+                    title: "Chat Sessions",
+                    value: "\(chatSessions.count)",
+                    detail: chatSessions.first?.summaryText ?? "No chat sessions"
+                )
+                DesktopCommandCenterSessionMetricView(
+                    title: "Server Sessions",
+                    value: "\(serverSessions.count)",
+                    detail: serverSessions.first?.effectiveListenerLabel ?? "No listener configured"
+                )
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+private struct DesktopCommandCenterSessionMetricView: View {
+    let title: String
+    let value: String
+    let detail: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
+            Text(title).melixSectionLabel()
+            Text(value)
+                .font(.title3.weight(.semibold).monospacedDigit())
+            Text(detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -111,6 +111,60 @@ struct DesktopFoundationViewTests {
         #expect(DesktopLoRAVisualPolish.chartFillOpacity == 0.24)
     }
 
+    @Test("command center visuals track design-system and Apple-style inputs")
+    func commandCenterVisualsTrackDesignInputs() {
+        #expect(DesktopCommandCenterVisuals.visualDirection == "Digital Broadsheet Command Center")
+        #expect(DesktopCommandCenterVisuals.operatorLabel == "Melix Operator")
+        #expect(DesktopCommandCenterVisuals.windowTitle == "Command Center")
+        #expect(DesktopCommandCenterVisuals.runtimeSectionTitle == "Runtime")
+        #expect(DesktopCommandCenterVisuals.pressureSectionTitle == "Resource And Queue Pressure")
+        #expect(DesktopCommandCenterVisuals.recoverySectionTitle == "Recovery")
+        #expect(DesktopCommandCenterVisuals.workflowSectionTitle == "Workflow")
+        #expect(DesktopCommandCenterVisuals.activitySectionTitle == "Recent Activity")
+        #expect(DesktopCommandCenterVisuals.sessionSummarySectionTitle == "Session Summary")
+        #expect(DesktopCommandCenterVisuals.primaryModelTitle == "Primary Model")
+        #expect(DesktopCommandCenterVisuals.repositoryDesignSystemPath == "docs/design-system/README.md")
+        #expect(DesktopCommandCenterVisuals.appleLayoutGuidanceURL.contains("human-interface-guidelines/layout"))
+        #expect(DesktopCommandCenterVisuals.maxContentWidth == 1120)
+        #expect(DesktopCommandCenterVisuals.primaryColumnMinimumWidth > DesktopCommandCenterVisuals.secondaryColumnWidth)
+        #expect(DesktopCommandCenterVisuals.panelCornerRadius == MelixDesignTokens.Radius.xl)
+        #expect(DesktopCommandCenterVisuals.statusSymbolName == "command.circle")
+        #expect(DesktopCommandCenterVisuals.recoverySymbolName == "arrow.clockwise.circle")
+    }
+
+    @Test("command center health is derived from foundation state semantics")
+    func commandCenterHealthUsesSemanticFoundationState() {
+        func foundation(
+            serverState: Melix_Controlplane_V1_ServerState,
+            lastError: String? = nil
+        ) -> DesktopFoundationState {
+            var snapshot = Melix_Controlplane_V1_ServerSnapshot()
+            snapshot.serverState = serverState
+            return DesktopFoundationState.build(
+                statusTitle: "Melix Ready",
+                serverStateText: "Localized server copy",
+                connectionStateText: "Localized connection copy",
+                connectionDetailText: "Snapshot hydrated",
+                snapshot: snapshot,
+                protocolVersion: "melix.controlplane.v1",
+                serverVersion: "0.1.0",
+                daemonInstanceID: "daemon-command-center-health",
+                features: ["xpc"],
+                productUpdateSummary: nil,
+                productUpdateDetail: nil,
+                lastError: lastError,
+                recentEvents: []
+            )
+        }
+
+        #expect(foundation(serverState: .serverReady).healthState == .runtimeReady)
+        #expect(foundation(serverState: .serverDegraded).healthState == .runtimeWarning)
+        #expect(foundation(serverState: .serverDraining).healthState == .runtimeWarning)
+        #expect(foundation(serverState: .serverStopped).healthState == .recoveryAvailable)
+        #expect(foundation(serverState: .serverFailed).healthState == .needsAttention)
+        #expect(foundation(serverState: .serverReady, lastError: "Handshake failed").healthState == .needsAttention)
+    }
+
     @Test("logo svg resource mirrors the design system asset")
     func logoSVGResourceMirrorsDesignSystemAsset() throws {
         let root = try repositoryRootForDesktopFoundationTests()
@@ -527,6 +581,13 @@ struct DesktopFoundationViewTests {
         )
 
         #expect(view.subviews.isEmpty == false)
+        #expect(DesktopCommandCenterVisuals.operatorLabel == "Melix Operator")
+        #expect(DesktopCommandCenterVisuals.windowTitle == "Command Center")
+        #expect(DesktopCommandCenterVisuals.runtimeSectionTitle == "Runtime")
+        #expect(DesktopCommandCenterVisuals.pressureSectionTitle == "Resource And Queue Pressure")
+        #expect(DesktopCommandCenterVisuals.recoverySectionTitle == "Recovery")
+        #expect(DesktopCommandCenterVisuals.activitySectionTitle == "Recent Activity")
+        #expect(DesktopCommandCenterVisuals.sessionSummarySectionTitle == "Session Summary")
     }
 
     @Test("command center renders state-first recovery and workflow summaries")
@@ -600,6 +661,10 @@ struct DesktopFoundationViewTests {
         #expect(viewModel.desktopFoundationState.models.isEmpty == false)
         #expect(viewModel.recoverableDownloads.count == 3)
         #expect(viewModel.desktopSignalStates.contains { $0.title == "Download Recovery Available" })
+        #expect(DesktopCommandCenterVisuals.recoverySectionTitle == "Recovery")
+        #expect(viewModel.recoverableDownloads.first?.resumeActionTitle == "Resume Download")
+        #expect(DesktopCommandCenterView.downloadRecoveryOverflowActionTitle == "View All Downloads")
+        #expect(DesktopCommandCenterVisuals.workflowSectionTitle == "Workflow")
         #expect(DesktopCommandCenterView.downloadRecoveryOverflowText(totalCount: 2) == nil)
         #expect(DesktopCommandCenterView.downloadRecoveryOverflowText(totalCount: 3) == "+1 more stalled download")
         #expect(DesktopCommandCenterView.downloadRecoveryOverflowActionTitle == "View All Downloads")
@@ -2074,6 +2139,7 @@ struct DesktopFoundationViewTests {
             serverStateText: "Ready",
             connectionStateText: "Connected",
             connectionDetailText: "Snapshot hydrated",
+            healthState: .runtimeReady,
             dashboardCards: [],
             queueLanes: [],
             models: [],

--- a/docs/plans/2026-04-21-macos-uiux-follow-up.md
+++ b/docs/plans/2026-04-21-macos-uiux-follow-up.md
@@ -9,7 +9,7 @@ repository design system while preserving the existing control-plane and worker 
 
 ## Design Inputs
 
-- `/Users/ChenYu/Downloads/Melix Design System.pdf`
+- Uploaded `Melix Design System.pdf` design reference
 - `docs/design-system/README.md`
 - `docs/design-system/ui_kits/macos-app/`
 - `docs/plans/2026-04-18-window-menubar-ui-optimization.md`
@@ -25,6 +25,13 @@ repository design system while preserving the existing control-plane and worker 
   a sheet before invoking install or download remediation.
 - [ ] Derive one runtime endpoint/model projection from the selected server session and use it for
   callable API, Chat, Command Center, and agent integration output.
+- [x] Redesign Command Center as a standalone Apple-style utility window using the uploaded PDF,
+  repository design system, and existing state-first operator plan:
+  - replace default `GroupBox`-heavy layout with lightweight broadsheet sections and quiet tiles;
+  - keep global health, pressure, recovery, workflow, error, activity, and session summaries visible
+    without moving object-local editing into the window;
+  - preserve the existing `RuntimeViewModel` data and recovery actions while improving scan order,
+    spacing, typography, SF Symbol usage, and compact/wide adaptability.
 - [ ] Replace nested API quick-start and agent integration `GroupBox` layouts with lightweight
   section cards so accessibility exposes one logical copy of each group/control.
 - [ ] Polish Server, Tools, API, Downloads, Diagnostics, and Image so primary actions stay visible
@@ -81,6 +88,20 @@ swift test --package-path apps/macos-menubar --filter 'RuntimeViewModelTests|Des
 python3 scripts/m15_desktop_polish_smoke.py --json
 ```
 
+Latest Command Center redesign evidence:
+
+- `swift test --package-path apps/macos-menubar --filter DesktopFoundationViewTests`: passed,
+  173 Swift Testing cases.
+- `swift test --package-path apps/macos-menubar --filter DesktopPolishSmokeTests`: passed, 1
+  Swift Testing case; emitted canonical M15 desktop polish metrics.
+- `python3 scripts/m15_desktop_polish_smoke.py --json`: passed with `ok: true`,
+  `grounded_surface_count: 5`, `grounded_tool_section_count: 6`,
+  `top_banner_title: "Download Recovery Available"`.
+- `git diff --check`: passed.
+- Review follow-up: removed production references to the local PDF path, moved Command Center
+  health presentation onto `DesktopFoundationHealthState` semantics, and reused the shared
+  `melixCard()` modifier for broadsheet panel surfaces.
+
 Manual evidence:
 
 - Rebuild/open the macOS app and review Chat, Server, Tools, Downloads, Image, and API with
@@ -90,6 +111,9 @@ Manual evidence:
 - Confirm collapsed side panes do not leave restore rails in the content area.
 - Confirm API quick starts and copy controls are no longer duplicated in the accessibility tree.
 - Confirm callable API/agent export URLs use the same effective listener URL.
+- Confirm Command Center opens as a standalone utility-style window, shows state-first global
+  health/recovery/workflow summaries, uses design-system broadsheet sections instead of default
+  `GroupBox` chrome, and keeps recovery/download actions reachable.
 - Confirm Chat opens without the empty transcript copy, the default branch chip, transcript-side
   model/request IDs, runtime request metadata, or a highlighted new chat button; new sessions must
   choose a server/provider before Send is enabled, and the inspector should show capability readiness
@@ -118,3 +142,6 @@ Manual evidence:
   registry sync. The text-route correction reuses existing scheduler/HTTP route metrics and adds no
   new inference hot-path metrics.
 - UI evidence: focused Swift tests, desktop polish smoke JSON, and Computer Use visual/AX review.
+- Command Center redesign metrics: runtime probes N/A because the change is a SwiftUI layout and
+  composition update over existing read models and actions; UI evidence is the focused Swift view
+  suite plus desktop polish smoke checks listed above.


### PR DESCRIPTION
## Summary
- Redesign Command Center as an Apple-style standalone utility surface using the Melix design system, uploaded PDF direction, and the state-first operator plan.
- Replace the default GroupBox-heavy layout with quiet broadsheet panels for runtime health, pressure, recovery, workflow, recent activity, and session summary.
- Preserve existing RuntimeViewModel data flow and recovery actions while improving scan order, spacing, typography, SF Symbol usage, and wide/compact adaptability.
- Address review follow-up by removing local PDF path metadata from repo files, deriving header health from `DesktopFoundationHealthState`, and reusing the shared `melixCard()` surface modifier.

## Plan or Spec
- `docs/plans/2026-04-21-macos-uiux-follow-up.md`
- `docs/design-system/README.md`
- `docs/architecture/2026-04-01-server-session-desktop-shell.md`

## Commands Run
```text
swift test --package-path apps/macos-menubar --filter DesktopFoundationViewTests
Result: passed, 173 Swift Testing cases.

swift test --package-path apps/macos-menubar --filter DesktopPolishSmokeTests
Result: passed, 1 Swift Testing case; emitted M15 desktop polish metrics.

python3 scripts/m15_desktop_polish_smoke.py --json
Result: passed with ok: true, grounded_surface_count: 5, grounded_tool_section_count: 6, top_banner_title: Download Recovery Available.

git diff --check
Result: passed.
```

## Coverage and Metrics
- Changed-scope coverage: focused Swift view coverage for Command Center state and recovery behavior is covered by `DesktopFoundationViewTests` and `DesktopPolishSmokeTests`; numeric line coverage for this SwiftUI view scope is not currently emitted by the local command.
- Metrics: runtime performance probes are N/A because this is a SwiftUI layout and composition update over existing read models and actions. UI evidence is the focused Swift view suite plus `scripts/m15_desktop_polish_smoke.py --json` with `grounded_surface_count: 5`, `grounded_tool_section_count: 6`, and `top_banner_title: Download Recovery Available`.

## Known Gaps
- Full baseline gates from `docs/contributing.md` were not rerun for this scoped macOS UI change: `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test`.
- Manual app visual review is still listed in the active plan as follow-up evidence.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.