### PR TITLE
perf: remove redundant job registry restore sorting

### DIFF
--- a/docs/plans/2026-05-03-job-registry-restore-sort-elision.md
+++ b/docs/plans/2026-05-03-job-registry-restore-sort-elision.md
@@ -1,0 +1,40 @@
+# Job Registry Restore Sort Elision
+
+## Scope
+
+- Affected path: `services/mlx-worker-python/worker/model_ops/job_registry.py`
+- Supporting tests: `services/mlx-worker-python/tests/test_model_ops_job_registry.py`
+- Existing PR-scoped probe: `job-registry-derived-model-single-pass` in `infra/perf/pr_scoped_probes.json`
+- Probe support path: `scripts/job_registry_derived_model_probe.py`
+- Constraint: Linux-only local verification; no macOS/Swift validation is available in this cron run.
+
+## Goal
+
+Remove redundant restore-time sorting in `ModelOpsJobRegistry` while preserving manifest restore ordering and behavior.
+
+## Why this slice
+
+`_collect_restore_manifest_paths()` already sorts each operation-specific manifest path list before returning it. `_restore_manifest_jobs()` then calls `sorted(manifest_paths)` again, repeating work on already ordered inputs during cold restore from disk.
+
+## Implementation
+
+1. Keep `_collect_restore_manifest_paths()` as the single owner of restore manifest ordering.
+2. Remove the duplicate sort inside `_restore_manifest_jobs()`.
+3. Add a focused regression test that fails if `_restore_manifest_jobs()` falls back to `sorted(...)` for already ordered inputs.
+4. Preserve all restore semantics and job ordering.
+
+## Verification Plan
+
+Run the registered probe's Linux-safe local verification path:
+
+1. Focused tests covering `job_registry.py` plus the probe-registration smoke tests.
+2. Changed-scope coverage via `coverage run`, `coverage json`, and `scripts/changed_scope_coverage.py`.
+3. Explicit base-vs-head probe through `scripts/pr_scoped_performance_run.py` for `job-registry-derived-model-single-pass`.
+4. `git diff --check` before commit.
+
+## Success Criteria
+
+- Focused tests pass.
+- Changed executable scope coverage is at least 95%.
+- The registered probe shows equal or better restore-path performance versus `origin/main`.
+- No behavior regressions in restored job ordering or manifest handling.

--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import json
 import math
 from pathlib import Path
@@ -90,6 +91,61 @@ def test_job_registry_restore_scans_manifest_directories_once(monkeypatch: pytes
     assert any(str(jobs_root / "activate_adapter") == call for call in scan_calls)
     assert any(str(jobs_root / "remove_derived_model") == call for call in scan_calls)
     assert len(scan_calls) <= 9
+
+
+def test_restore_manifest_jobs_preserves_collected_manifest_order_without_resorting(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry = ModelOpsJobRegistry()
+    first_manifest = tmp_path / "train_lora" / "model-ops-0002" / "train_lora.adapter.json"
+    second_manifest = tmp_path / "train_lora" / "model-ops-0001" / "train_lora.adapter.json"
+    first_manifest.parent.mkdir(parents=True)
+    second_manifest.parent.mkdir(parents=True)
+    first_manifest.write_bytes(
+        json.dumps(
+            {
+                "job_id": "model-ops-0002",
+                "operation": "train_lora",
+                "source_model": "src-2",
+            }
+        ).encode("utf-8")
+    )
+    second_manifest.write_bytes(
+        json.dumps(
+            {
+                "job_id": "model-ops-0001",
+                "operation": "train_lora",
+                "source_model": "src-1",
+            }
+        ).encode("utf-8")
+    )
+    ordered_manifest_paths = (first_manifest, second_manifest)
+    original_sorted = builtins.sorted
+
+    class RestoreResortDetected(Exception):
+        pass
+
+    def fail_on_restore_resort(iterable, *args, **kwargs):
+        iterated_values = tuple(iterable)
+        if iterated_values == ordered_manifest_paths:
+            raise RestoreResortDetected(
+                "_restore_manifest_jobs should not resort ordered manifest paths"
+            )
+        return original_sorted(iterated_values, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "sorted", fail_on_restore_resort)
+
+    with pytest.raises(RestoreResortDetected):
+        sorted(list(ordered_manifest_paths))
+
+    registry._restore_manifest_jobs(
+        operation="train_lora",
+        manifest_paths=ordered_manifest_paths,
+        pct=0.97,
+    )
+
+    assert list(registry._jobs) == ["model-ops-0002", "model-ops-0001"]
+
 
 
 def test_job_registry_restore_reads_manifest_bytes_without_text_decode(

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -261,7 +261,7 @@ class ModelOpsJobRegistry:
         manifest_paths,
         pct: float,
     ) -> None:
-        for manifest_path in sorted(manifest_paths):
+        for manifest_path in manifest_paths:
             payload = self._read_manifest_dict(manifest_path)
             if not payload or str(payload.get("operation", "")).strip() != operation:
                 continue


### PR DESCRIPTION
## Summary
- remove the redundant `sorted(manifest_paths)` call inside `ModelOpsJobRegistry._restore_manifest_jobs()`
- keep `_collect_restore_manifest_paths()` as the single owner of restore manifest ordering
- add a focused regression test that fails if restore-time re-sorting is reintroduced for already ordered manifest paths

## Plan or Spec
- `docs/plans/2026-05-03-job-registry-restore-sort-elision.md`

## Commands Run
```text
git diff --check
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id job-registry-derived-model-single-pass --base-repo /tmp/melix-base-20260503-073143 --head-repo "$PWD" --output /tmp/job_registry_restore_sort_elision_probe.json
```

## Coverage and Metrics
- changed-scope coverage: `TOTAL 24 1 96%`
  - `services/mlx-worker-python/worker/model_ops/job_registry.py`: `100.00%`
  - `services/mlx-worker-python/tests/test_model_ops_job_registry.py`: `95.65%`
- focused pytest: `20 passed`
- registered scoped CI probe: `job-registry-derived-model-single-pass` (existing probe; no registry change needed for this path)
- local base-vs-head probe metrics:
  - `restore_elapsed_ms_mean`: `52.849133 ms` -> `47.585431 ms` (~`9.96%` lower)
  - `elapsed_ms_mean`: `52.895217 ms` -> `47.651032 ms` (~`9.91%` lower)
  - `active_manifest_count`: `960` on both base and head
  - `restored_job_count`: `880` on both base and head

## Known Gaps
- Local verification is Linux-only. I did not run the repository-wide macOS/Swift checks from this host.
- Hosted `pr-scoped-performance` and branch protection remain the final merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
