### PR TITLE
perf: elide benchmark queue cold cache clone

### DIFF
--- a/docs/plans/2026-05-03-benchmark-queue-cold-cache-clone-elision.md
+++ b/docs/plans/2026-05-03-benchmark-queue-cold-cache-clone-elision.md
@@ -1,0 +1,60 @@
+# Benchmark queue cold cache clone elision
+
+## Goal
+
+Reduce the uncached `BenchmarkQueueStore.list_records()` path in `services/mlx-worker-python/worker/productization/benchmark_queue.py` by removing a redundant clone during cache-miss decode, while preserving returned-record defensive copies, stable ordering, cache invalidation semantics, and the existing PR-scoped performance evidence path.
+
+## Linux-only constraint
+
+This slice is Python-only under `services/mlx-worker-python`, so it can be fully verified from this Linux host without touching macOS or Swift surfaces.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/productization/benchmark_queue.py`
+- `services/mlx-worker-python/tests/test_benchmark_queue.py`
+
+## Optimization hypothesis
+
+`list_records()` already clones each returned record at the public API boundary. On a cache miss, `_load_record()` currently decodes a `BenchmarkQueueRecord`, clones it once to populate `_decoded_record_cache`, and returns that cloned copy. `list_records()` then clones the same record again before returning it to the caller.
+
+This slice stores the decoded record itself in the cache on cache misses and keeps the defensive clone at the public return boundary. That should reduce cold-path object copying without weakening mutation isolation for callers.
+
+## Verification path
+
+Use the existing `benchmark-queue-decoded-record-cache` PR-scoped performance probe in `infra/perf/pr_scoped_probes.json`.
+
+### Focused checks
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_benchmark_queue.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_benchmark_queue.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/productization/benchmark_queue.py \
+  services/mlx-worker-python/tests/test_benchmark_queue.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_benchmark_queue_cache as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
+
+git diff --check
+```
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope automated coverage is at least 95%.
+- Local probe reports concrete cold/warm metrics and keeps `warm_json_loads_mean` at `0.0`.
+- Hosted `benchmark-queue-decoded-record-cache` PR-scoped CI validates the same path before merge.

--- a/services/mlx-worker-python/tests/test_benchmark_queue.py
+++ b/services/mlx-worker-python/tests/test_benchmark_queue.py
@@ -451,6 +451,40 @@ def test_list_records_decodes_uncached_records_from_bytes(
     read_text_mock.assert_not_called()
 
 
+def test_list_records_cold_cache_miss_clones_only_at_public_return_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    queue_root = tmp_path / "queue"
+    queue_root.mkdir()
+    payload = BenchmarkQueueRecord(
+        queue_item_id="queue-1",
+        job_kind="benchmark",
+        model_id="melix-dev-text",
+        suite_ids=("smoke",),
+        parameters={"sample_size": "32"},
+        status="queued",
+        created_at_unix_ms=100,
+        updated_at_unix_ms=100,
+    ).to_dict()
+    (queue_root / "queue-1.json").write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    store = BenchmarkQueueStore()
+    clone_calls = 0
+    original_clone = BenchmarkQueueStore._clone_record
+
+    def tracked_clone(record: BenchmarkQueueRecord) -> BenchmarkQueueRecord:
+        nonlocal clone_calls
+        clone_calls += 1
+        return original_clone(record)
+
+    monkeypatch.setattr(BenchmarkQueueStore, "_clone_record", staticmethod(tracked_clone))
+
+    records = store.list_records(queue_root=queue_root)
+
+    assert [record.queue_item_id for record in records] == ["queue-1"]
+    assert clone_calls == 1
+
+
 def test_list_records_reload_changed_files_and_transition_refreshes_cache(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/services/mlx-worker-python/worker/productization/benchmark_queue.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_queue.py
@@ -151,12 +151,11 @@ class BenchmarkQueueStore:
         if cached is not None and cached.metadata_key == current_metadata_key:
             return cached.record
         record = BenchmarkQueueRecord.from_dict(json.loads(path.read_bytes()))
-        cached_record = self._clone_record(record)
         self._decoded_record_cache[path] = _RecordCacheEntry(
             metadata_key=current_metadata_key,
-            record=cached_record,
+            record=record,
         )
-        return cached_record
+        return record
 
     def queue_snapshot(self, *, queue_root: Path) -> dict[str, object]:
         records = self.list_records(queue_root=queue_root)


### PR DESCRIPTION
## Summary
- eliminate a redundant cache-miss clone in `BenchmarkQueueStore._load_record()` so uncached queue reads store the decoded record directly and keep defensive cloning only at the public return boundary
- add a focused regression test proving cold `list_records()` cache misses clone exactly once at the API boundary while preserving caller mutation isolation
- document the slice and reuse the existing `benchmark-queue-decoded-record-cache` PR-scoped performance probe for CI validation

## Plan or Spec
- `docs/plans/2026-05-03-benchmark-queue-cold-cache-clone-elision.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py::test_list_records_cold_cache_miss_clones_only_at_public_return_boundary
- PASS (1 passed)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
- PASS (24 passed)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_queue.py services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
- PASS (TOTAL 16 0 100%)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-queue-decoded-record-cache --base-repo /tmp/melix-base-20260503-080906 --head-repo /tmp/melix-20260503-080906 --output /tmp/benchmark-queue-decoded-record-cache-20260503-080906-rerun.json
- PASS

git diff --check
- PASS
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 16 0 100%`
- Registered scoped CI probe reused without registry changes: `benchmark-queue-decoded-record-cache`
- Local base vs head probe (`origin/main` detached worktree vs this branch):
  - `cold_elapsed_ms`: `11.957335` -> `5.705905` (`-52.28%`)
  - `warm_elapsed_ms_mean`: `2.267853` -> `1.584938` (`-30.11%`)
  - `warm_json_loads_mean`: `0.0` -> `0.0` (unchanged)
  - `record_count`: `128` -> `128` (unchanged)

## Known Gaps
- Hosted GitHub Actions validation is still required for the registered `pr-scoped-performance` workflow and has not run yet at PR creation time.
- This Linux cron run did not execute macOS or Swift verification because the slice is limited to the Python worker path.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
