### PR TITLE
perf: skip sorted json dumps during job restore

### DIFF
--- a/docs/plans/2026-05-03-job-registry-restore-manifest-json-dump.md
+++ b/docs/plans/2026-05-03-job-registry-restore-manifest-json-dump.md
@@ -1,0 +1,46 @@
+# Job registry restore manifest JSON dump fast path
+
+## Scope
+
+This Python-only performance slice targets the model-ops job registry restore path in
+`services/mlx-worker-python/worker/model_ops/job_registry.py`.
+
+When restoring thousands of persisted model-ops manifests, `_restore_manifest_jobs()`
+keeps the decoded manifest dict cached on `ModelOpsJob`. The companion
+`manifest_json` field only needs to preserve a JSON representation of the same
+payload for compatibility; it does not need deterministic key ordering during
+restore. Sorting every restored manifest's keys adds avoidable CPU work in the
+registered restore probe.
+
+## Registered probe
+
+The affected path is covered by registered PR-scoped probe
+`job-registry-restore-sort-elision` in `infra/perf/pr_scoped_probes.json`.
+The probe has focused `test_command`, `coverage_command`, and `probe_command`
+entries and reports:
+
+- `restore_elapsed_ms_mean`
+- `per_manifest_ms_mean`
+- `job_count`
+
+## Implementation plan
+
+1. Add a regression assertion that restored jobs still cache the decoded manifest
+   and keep a JSON `manifest_json` payload equivalent to the manifest dict.
+2. Remove deterministic key sorting from the restore-only `json.dumps()` call.
+3. Keep all snapshot and active-derived-model behavior unchanged; the cached
+   manifest dict remains the authoritative restore payload.
+4. Run the registered focused tests, changed-scope coverage, and registered probe
+   locally on Linux.
+
+## Validation commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_restore_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_restore_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_restore_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_restore_probe.py
+```
+
+CI remains the merge gate for the registered PR-scoped performance report.

--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -145,6 +145,14 @@ def test_restore_manifest_jobs_preserves_collected_manifest_order_without_resort
     )
 
     assert list(registry._jobs) == ["model-ops-0002", "model-ops-0001"]
+    restored_job = registry._jobs["model-ops-0002"]
+    assert restored_job.manifest_cached is True
+    assert restored_job.manifest == {
+        "job_id": "model-ops-0002",
+        "operation": "train_lora",
+        "source_model": "src-2",
+    }
+    assert json.loads(restored_job.manifest_json) == restored_job.manifest
 
 
 

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -277,7 +277,7 @@ class ModelOpsJobRegistry:
                 source_model=str(payload.get("source_model", "")),
                 output_dir=str(output_dir),
                 stage_history=[("write_manifest", pct)],
-                manifest_json=json.dumps(payload, sort_keys=True),
+                manifest_json=json.dumps(payload),
                 manifest=payload,
                 manifest_cached=True,
                 output_path=str(manifest_path),


### PR DESCRIPTION
## Summary
- Remove deterministic key sorting from the restore-only `manifest_json` serialization in `ModelOpsJobRegistry._restore_manifest_jobs()`.
- Keep the decoded manifest dict cached as before and add regression coverage that the JSON payload remains equivalent to the cached manifest.

## Plan or Spec
- `docs/plans/2026-05-03-job-registry-restore-manifest-json-dump.md`
- Registered probe: `job-registry-restore-sort-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline local probe before the code change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_restore_probe.py
exit 0; restore_elapsed_ms_mean=220.943080, per_manifest_ms_mean=0.014729539

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_restore_probe_script_emits_metrics
exit 0; 20 passed in 2.05s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_restore_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_restore_probe.py
exit 0; 20 passed; TOTAL 4 0 100%

# Head local standalone probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_restore_probe.py
exit 0; restore_elapsed_ms_mean=187.406244, per_manifest_ms_mean=0.012493750

# Registered local base/head probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id job-registry-restore-sort-elision --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-restore-json-dump-20260503084027 --head-repo "$PWD" --output /tmp/job_registry_restore_json_dump_probe.json
exit 0; base/head comparison written to /tmp/job_registry_restore_json_dump_probe.json

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 4 0 100%`).
- Registered local base/head probe (`job-registry-restore-sort-elision`):
  - `restore_elapsed_ms_mean`: base `208.778094 ms`, head `192.754964 ms`, delta `-16.023130 ms` (`7.67%` lower, `1.0831x` speedup).
  - `per_manifest_ms_mean`: base `0.013918540 ms`, head `0.012850331 ms`, delta `-0.001068209 ms` (`7.67%` lower, `1.0831x` speedup).
- CI is still required as the merge gate for the registered PR-scoped performance report.

## Known Gaps
- None for the Python/Linux slice. No Swift runtime path is changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
