### PR TITLE
perf: reuse converged model-ops manifest bytes

### DIFF
--- a/docs/plans/2026-05-03-model-ops-manifest-final-encode-reuse.md
+++ b/docs/plans/2026-05-03-model-ops-manifest-final-encode-reuse.md
@@ -1,0 +1,59 @@
+# Model-ops manifest final-encode reuse
+
+## Scope
+
+This Python-only optimization slice targets the model-ops bundle manifest path in:
+
+- `services/mlx-worker-python/worker/model_ops/conversion_pipeline.py`
+- `services/mlx-worker-python/worker/model_ops/quantization_pipeline.py`
+
+Both pipelines currently iterate in memory until `manifest_bytes` converges, then call
+`_write_manifest(...)`, which re-encodes the same final manifest payload one more time just to write
+identical bytes to disk. The manifest encoding is deterministic, so the final converged bytes can be
+reused for the disk write instead of paying for one extra JSON encode per pipeline run.
+
+## Linux-only constraint
+
+The touched path is entirely inside the Python worker workspace, so Linux local verification is the
+primary correctness gate. Hosted `pr-scoped-performance` remains the merge gate for the registered
+probe.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe
+`model-ops-bundle-artifact-byte-accounting` in `infra/perf/pr_scoped_probes.json`.
+
+Relevant metrics:
+
+- `elapsed_ms_mean`
+- `bundle_scandir_calls_mean`
+
+## Success metrics
+
+1. Conversion and quantization manifests still converge to the same `manifest_bytes` value and the
+   same persisted JSON payload.
+2. The final write path reuses the converged encoded bytes instead of re-encoding the same manifest
+   payload inside `_write_manifest(...)`.
+3. Focused changed-scope coverage for the touched executable files remains at least `95%`.
+4. The local registered probe shows a non-regressive `elapsed_ms_mean` and preserves
+   `bundle_scandir_calls_mean`.
+
+## Task list
+
+1. Add or update focused tests that prove the final encoded manifest bytes are reused for the last
+   write in both pipelines.
+2. Implement a small helper path in both pipelines so the final convergence loop returns reusable
+   encoded bytes while preserving manifest payload shape and file contents.
+3. Run the registered focused pytest selection, changed-scope coverage, `git diff --check`, and the
+   registered probe locally on Linux before commit.
+
+## Validation commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_bundle_directory_and_versioned_manifest services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_manifest_once_after_in_memory_byte_convergence services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_model_writes_manifest_once_after_in_memory_byte_convergence services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_ops_bundle_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_model_ops_bundle_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_bundle_directory_and_versioned_manifest services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_manifest_once_after_in_memory_byte_convergence services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_model_writes_manifest_once_after_in_memory_byte_convergence services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_ops_bundle_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_model_ops_bundle_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/conversion_pipeline.py services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id model-ops-bundle-artifact-byte-accounting --base-repo /tmp/melix-cron-20260503131814-base --head-repo "$PWD" --output /tmp/model_ops_bundle_probe.json
+git diff --check
+```

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -652,14 +652,21 @@ def test_convert_model_writes_manifest_once_after_in_memory_byte_convergence(
 ) -> None:
     service = build_service(tmp_path)
     write_calls = 0
+    encode_manifest_bytes: list[int] = []
     original_write_manifest = ModelConversionPipeline._write_manifest
+    original_encode_manifest = ModelConversionPipeline._encode_manifest
 
-    def counting_write_manifest(path: Path, payload: dict[str, object]) -> int:
+    def counting_write_manifest(path: Path, payload: dict[str, object], encoded: bytes | None = None) -> int:
         nonlocal write_calls
         write_calls += 1
-        return original_write_manifest(path, payload)
+        return original_write_manifest(path, payload, encoded)
+
+    def tracking_encode_manifest(payload: dict[str, object]) -> bytes:
+        encode_manifest_bytes.append(int(payload["manifest_bytes"]))
+        return original_encode_manifest(payload)
 
     monkeypatch.setattr(ModelConversionPipeline, "_write_manifest", staticmethod(counting_write_manifest))
+    monkeypatch.setattr(ModelConversionPipeline, "_encode_manifest", staticmethod(tracking_encode_manifest))
 
     convert_events = list(
         service.ConvertModel(
@@ -674,10 +681,16 @@ def test_convert_model_writes_manifest_once_after_in_memory_byte_convergence(
     convert_manifest = next(event.manifest for event in convert_events if event.HasField("manifest"))
     convert_payload = json.loads(convert_manifest.manifest_json)
     manifest_path = Path(convert_events[-1].completed.output_path) / "manifest.json"
+    final_manifest_bytes = convert_payload["manifest_bytes"]
 
     assert write_calls == 1
+    assert encode_manifest_bytes.count(final_manifest_bytes) == 1
     assert convert_payload["manifest_bytes"] == manifest_path.stat().st_size
     assert json.loads(manifest_path.read_text(encoding="utf-8")) == convert_payload
+
+    rewrite_path = manifest_path.with_name("manifest.rewrite.json")
+    assert original_write_manifest(rewrite_path, convert_payload) == final_manifest_bytes
+    assert rewrite_path.read_bytes() == manifest_path.read_bytes()
 
 
 def test_convert_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory(

--- a/services/mlx-worker-python/tests/test_quantization_pipeline.py
+++ b/services/mlx-worker-python/tests/test_quantization_pipeline.py
@@ -130,14 +130,21 @@ def test_quantize_job_writes_manifest_once_after_in_memory_byte_convergence(
 ) -> None:
     service = build_service(tmp_path)
     write_calls = 0
+    encode_manifest_bytes: list[int] = []
     original_write_manifest = OQQuantizationPipeline._write_manifest
+    original_encode_manifest = OQQuantizationPipeline._encode_manifest
 
-    def counting_write_manifest(path: Path, payload: dict[str, object]) -> int:
+    def counting_write_manifest(path: Path, payload: dict[str, object], encoded: bytes | None = None) -> int:
         nonlocal write_calls
         write_calls += 1
-        return original_write_manifest(path, payload)
+        return original_write_manifest(path, payload, encoded)
+
+    def tracking_encode_manifest(payload: dict[str, object]) -> bytes:
+        encode_manifest_bytes.append(int(payload["manifest_bytes"]))
+        return original_encode_manifest(payload)
 
     monkeypatch.setattr(OQQuantizationPipeline, "_write_manifest", staticmethod(counting_write_manifest))
+    monkeypatch.setattr(OQQuantizationPipeline, "_encode_manifest", staticmethod(tracking_encode_manifest))
 
     events = list(
         service.ConvertModel(
@@ -156,10 +163,16 @@ def test_quantize_job_writes_manifest_once_after_in_memory_byte_convergence(
     manifest_event = next(event.manifest for event in events if event.HasField("manifest"))
     manifest_path = Path(events[-1].completed.output_path) / "manifest.json"
     manifest_payload = json.loads(manifest_event.manifest_json)
+    final_manifest_bytes = manifest_payload["manifest_bytes"]
 
     assert write_calls == 1
+    assert encode_manifest_bytes.count(final_manifest_bytes) == 1
     assert manifest_payload["manifest_bytes"] == manifest_path.stat().st_size
     assert json.loads(manifest_path.read_text(encoding="utf-8")) == manifest_payload
+
+    rewrite_path = manifest_path.with_name("manifest.rewrite.json")
+    assert original_write_manifest(rewrite_path, manifest_payload) == final_manifest_bytes
+    assert rewrite_path.read_bytes() == manifest_path.read_bytes()
 
 
 def test_quantize_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory(

--- a/services/mlx-worker-python/worker/model_ops/conversion_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/conversion_pipeline.py
@@ -95,14 +95,16 @@ class ModelConversionPipeline:
             smoke_test_passed=smoke_test_passed,
         )
         manifest_bytes = 0
+        encoded_manifest = b""
         while True:
             manifest_payload["manifest_bytes"] = manifest_bytes
-            next_manifest_bytes = self._manifest_size(manifest_payload)
+            encoded_manifest = self._encode_manifest(manifest_payload)
+            next_manifest_bytes = len(encoded_manifest)
             if next_manifest_bytes == manifest_bytes:
                 break
             manifest_bytes = next_manifest_bytes
         manifest_payload["manifest_bytes"] = manifest_bytes
-        self._write_manifest(manifest_path, manifest_payload)
+        self._write_manifest(manifest_path, manifest_payload, encoded_manifest)
 
         return ConversionPipelineResult(
             bundle_path=bundle_path,
@@ -226,7 +228,8 @@ class ModelConversionPipeline:
         return len(payload)
 
     @staticmethod
-    def _write_manifest(path: Path, payload: dict[str, Any]) -> int:
-        encoded = ModelConversionPipeline._encode_manifest(payload)
+    def _write_manifest(path: Path, payload: dict[str, Any], encoded: bytes | None = None) -> int:
+        if encoded is None:
+            encoded = ModelConversionPipeline._encode_manifest(payload)
         path.write_bytes(encoded)
         return len(encoded)

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -111,14 +111,16 @@ class OQQuantizationPipeline:
             smoke_test_passed=smoke_test_passed,
         )
         manifest_bytes = 0
+        encoded_manifest = b""
         while True:
             manifest_payload["manifest_bytes"] = manifest_bytes
-            next_manifest_bytes = self._manifest_size(manifest_payload)
+            encoded_manifest = self._encode_manifest(manifest_payload)
+            next_manifest_bytes = len(encoded_manifest)
             if next_manifest_bytes == manifest_bytes:
                 break
             manifest_bytes = next_manifest_bytes
         manifest_payload["manifest_bytes"] = manifest_bytes
-        self._write_manifest(manifest_path, manifest_payload)
+        self._write_manifest(manifest_path, manifest_payload, encoded_manifest)
 
         return QuantizationPipelineResult(
             bundle_path=bundle_path,
@@ -244,7 +246,8 @@ class OQQuantizationPipeline:
         return len(payload)
 
     @staticmethod
-    def _write_manifest(path: Path, payload: dict[str, Any]) -> int:
-        encoded = OQQuantizationPipeline._encode_manifest(payload)
+    def _write_manifest(path: Path, payload: dict[str, Any], encoded: bytes | None = None) -> int:
+        if encoded is None:
+            encoded = OQQuantizationPipeline._encode_manifest(payload)
         path.write_bytes(encoded)
         return len(encoded)


### PR DESCRIPTION
## Summary
- reuse the converged final encoded manifest bytes when writing model-ops bundle manifests
- keep conversion and quantization manifest payloads, `manifest_bytes`, and artifact-byte accounting unchanged
- tighten focused regression tests so both pipelines prove the final manifest size is encoded once and then reused for the final write
- record the scoped plan for this Linux-verified optimization slice

## Plan or Spec
- Plan: `docs/plans/2026-05-03-model-ops-manifest-final-encode-reuse.md`
- Scope:
  - `services/mlx-worker-python/worker/model_ops/conversion_pipeline.py`
  - `services/mlx-worker-python/worker/model_ops/quantization_pipeline.py`
  - focused regression tests in `test_maintenance_service.py` and `test_quantization_pipeline.py`
- Goal: after `manifest_bytes` convergence, reuse the final deterministic encoded manifest bytes for the final write instead of re-encoding inside `_write_manifest(...)`, while preserving manifest shape and file contents.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_bundle_directory_and_versioned_manifest services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_writes_manifest_once_after_in_memory_byte_convergence services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_model_writes_manifest_once_after_in_memory_byte_convergence services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_ops_bundle_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_model_ops_bundle_probe`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/conversion_pipeline.py services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id model-ops-bundle-artifact-byte-accounting --base-repo /tmp/melix-cron-20260503131814-base --head-repo "$PWD" --output .runtime/model-ops-bundle-probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused verification: `9 passed in 38.25s`
- Changed-scope coverage: `TOTAL 40 0 100%`
  - `conversion_pipeline.py`: `100%`
  - `quantization_pipeline.py`: `100%`
- Registered scoped probe: `model-ops-bundle-artifact-byte-accounting`
- Local base vs head probe results:
  - `elapsed_ms_mean`: `3.902` -> `2.352` (~39.7% lower)
  - `bundle_scandir_calls_mean`: `0.0` -> `0.0` (unchanged)
  - `sample_count`: `14.0`
- Head verification inside the scoped probe passed:
  - focused test gate: `ok`
  - changed-scope coverage gate: `100%`

## Known Gaps
- Local verification covered only the Linux-safe Python worker scope, not the full macOS/Swift surfaces.
- Hosted `pr-scoped-performance` remains the final merge gate for this slice.
- Repository guidance references `.github/pull_request_template.md`, but that file does not currently exist in this checkout; this PR body still preserves the required evidence headings.

## Evidence Checklist
- [x] Relevant plan or spec identified
- [x] Focused tests run and passing
- [x] Changed-scope coverage >= 95%
- [x] Explicit scoped performance probe run with concrete metrics
- [x] Verification commands recorded
- [x] Known gaps stated explicitly
