### PR TITLE
perf: read benchmark export json as bytes

### DIFF
--- a/docs/plans/2026-05-03-benchmark-export-json-read-bytes.md
+++ b/docs/plans/2026-05-03-benchmark-export-json-read-bytes.md
@@ -1,0 +1,27 @@
+# Benchmark Export JSON Read-Bytes Slice
+
+## Summary
+
+This performance slice keeps benchmark export artifact collection behavior unchanged while reducing per-file overhead for small JSON artifact reads.
+
+## Scope
+
+- Affected path: `services/mlx-worker-python/worker/productization/benchmark_export.py`
+- Registered PR-scoped probe: `benchmark-export-run-scan-single-pass`
+- Supporting tests: `services/mlx-worker-python/tests/test_benchmark_export.py`
+
+## Optimization
+
+`_load_json_object` now reads JSON artifacts with `Path.read_bytes()` and parses the bytes payload with `json.loads()`. This avoids constructing a text file wrapper for each small JSON artifact while preserving object-type validation and error behavior for missing or invalid files.
+
+## Validation Plan
+
+Run the registered probe's focused tests, changed-scope coverage command, and probe command locally on Linux before opening the PR. The CI PR-scoped performance workflow remains the merge gate for registered probe validation.
+
+## Metrics
+
+Primary registered metrics from `benchmark-export-run-scan-single-pass`:
+
+- `elapsed_ms_mean` lower is better
+- `per_run_ms_mean` lower is better
+- `csv_elapsed_ms_mean` lower is better

--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -34,6 +34,27 @@ from worker.productization.benchmark_export import (
 )
 
 
+def test_load_json_object_reads_bytes_without_text_file_wrapper(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_bytes(json.dumps({"job_id": "bench-1", "value": 1.25}).encode("utf-8"))
+
+    original_open = Path.open
+    binary_open_count = 0
+
+    def tracking_open(self: Path, mode: str = "r", *args: object, **kwargs: object):
+        nonlocal binary_open_count
+        if self == payload_path:
+            if "b" not in mode:
+                raise AssertionError("expected benchmark JSON object loading to use read_bytes")  # pragma: no cover
+            binary_open_count += 1
+        return original_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", tracking_open)
+
+    assert _load_json_object(payload_path) == {"job_id": "bench-1", "value": 1.25}
+    assert binary_open_count == 1
+
+
 class _CountingMetricList(list[dict[str, float | str]]):
     def __init__(self, items: list[dict[str, float | str]]) -> None:
         super().__init__(items)

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -460,8 +460,7 @@ def _iter_sorted_matching_files(parent: Path, *, prefix: str, suffix: str) -> tu
 
 
 def _load_json_object(path: Path) -> dict[str, object]:
-    with path.open("r", encoding="utf-8") as handle:
-        payload = json.load(handle)
+    payload = json.loads(path.read_bytes())
     if not isinstance(payload, dict):
         raise TypeError(f"expected JSON object in {path}")
     return payload


### PR DESCRIPTION
## Summary
- Read benchmark export JSON artifact objects via `Path.read_bytes()` + `json.loads()` to avoid per-file text wrapper overhead.
- Add a focused regression test that fails if `_load_json_object` falls back to text-mode file opening.
- Add a governing plan for this small registered performance slice.

## Plan or Spec
- `docs/plans/2026-05-03-benchmark-export-json-read-bytes.md`
- Registered probe: `benchmark-export-run-scan-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# focused tests, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_export.py::test_load_json_object_reads_bytes_without_text_file_wrapper services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_job_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_result_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_summary_csv_count
59 passed in 12.54s

# changed-scope coverage, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_export.py::test_load_json_object_reads_bytes_without_text_file_wrapper services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_export_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_job_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_result_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_export_run_scan_rejects_unexpected_summary_csv_count
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_export.py services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
TOTAL 14 0 100%

# registered local probe baseline on origin/main, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/run_benchmark_export_probe.py
{"csv_bytes": 41518.0, "csv_elapsed_ms_mean": 2.157661, "elapsed_ms_mean": 59.454441, "per_run_ms_mean": 0.247727, "result_file_count": 720.0, "run_directory_count": 240.0, "sample_count": 5.0}

# registered local probe on this branch, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/run_benchmark_export_probe.py
{"csv_bytes": 41518.0, "csv_elapsed_ms_mean": 1.939052, "elapsed_ms_mean": 50.616052, "per_run_ms_mean": 0.2109, "result_file_count": 720.0, "run_directory_count": 240.0, "sample_count": 5.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 14 0 100%`.
- Local registered probe (`benchmark-export-run-scan-single-pass`, Linux):
  - `elapsed_ms_mean`: 59.454441 -> 50.616052 ms (`delta=-8.838389 ms`, ~14.87% faster)
  - `per_run_ms_mean`: 0.247727 -> 0.210900 ms (`delta=-0.036827 ms`, ~14.87% faster)
  - `csv_elapsed_ms_mean`: 2.157661 -> 1.939052 ms (`delta=-0.218609 ms`, ~10.13% faster)
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation is Linux-only. This slice touches Python benchmark export code; no Swift runtime effect is claimed.
- Probe timings are synthetic and may vary; merge is gated on the registered CI probe completing successfully.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
