### PR TITLE
perf: iterate benchmark report probe row keys

### DIFF
--- a/docs/plans/2026-04-30-benchmark-evaluation-report-streaming-aggregation.md
+++ b/docs/plans/2026-04-30-benchmark-evaluation-report-streaming-aggregation.md
@@ -20,6 +20,10 @@ A second follow-up Linux-verifiable slice extends the exact-type numeric fast pa
 
 This Linux-verifiable slice keeps the report loader behavior unchanged while decoding benchmark/evaluation export JSON directly from `Path.read_bytes()`. The registered benchmark-evaluation report probe now records `load_input_ms_mean` around `load_report_input()` before report construction, so this removes the intermediate UTF-8 string decode and lets `json.loads` consume bytes directly. The regression test forbids `Path.read_text()` on the loader path while preserving malformed, missing, non-object, and directory fallback behavior.
 
+## 2026-05-03 benchmark probe key iteration slice
+
+This Linux-verifiable slice keeps benchmark/evaluation report output unchanged while iterating the actual keys present in each benchmark probe row and filtering them through a module-level probe-key set. The previous hot path checked every known probe key against every sparse row before reading values. The registered benchmark-evaluation report probe exercises the benchmark context and matrix request row collectors, so the slice removes avoidable fixed-key membership scans while preserving label construction, aggregate suffixes, and metric names. The sparse-row regression test now fails on fixed-key membership scans as well as fixed-key `get()` calls.
+
 ## Touched Files
 
 - `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -35,9 +35,21 @@ from worker.productization.benchmark_evaluation_report import (
 
 
 class _SparseProbeRow(dict[str, object]):
-    def __init__(self, *args: object, forbidden_keys: set[str], **kwargs: object) -> None:
+    def __init__(
+        self,
+        *args: object,
+        forbidden_keys: set[str],
+        forbid_contains: bool = False,
+        **kwargs: object,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self._forbidden_keys = forbidden_keys
+        self._forbid_contains = forbid_contains
+
+    def __contains__(self, key: object) -> bool:
+        if self._forbid_contains and key in self._forbidden_keys:
+            raise AssertionError(f"unexpected fixed-key membership scan for {key}")
+        return super().__contains__(key)
 
     def get(self, key: str, default: object = None) -> object:
         if key in self._forbidden_keys:
@@ -487,16 +499,22 @@ def test_evaluation_sample_collector_finalizes_mean_metrics_directly(
     assert metrics == {"eval.sample.smoke.sample_render_ms_mean": 4.0}
 
 
-def test_probe_collectors_use_registered_probe_key_order_without_items_scan() -> None:
+def test_probe_collectors_use_expected_sparse_row_scan_strategy() -> None:
+    class NoContainsDict(dict[str, object]):
+        def __contains__(self, key: object) -> bool:
+            if key in {"prefill_ms", "decode_ms", "tokens_in", "dflash_enabled"}:
+                raise AssertionError("benchmark collector should scan actual row items")
+            return super().__contains__(key)
+
     class NoItemsDict(dict[str, object]):
         def items(self):  # type: ignore[override]
-            raise AssertionError("collector should scan registered probe keys directly")
+            raise AssertionError("evaluation collector should scan registered probe keys directly")
 
     benchmark_metrics: dict[str, object] = {}
     _collect_benchmark_probe_metrics(
         benchmark_metrics,
         [
-            NoItemsDict(
+            NoContainsDict(
                 {
                     "suite_id": "smoke",
                     "context_length": 1024,
@@ -973,6 +991,7 @@ def test_report_builder_uses_sparse_benchmark_probe_rows_without_fixed_key_scans
             "prefill_ms_extra": 123,
         },
         forbidden_keys={"prefill_ms", "decode_ms", "tokens_in", "dflash_enabled"},
+        forbid_contains=True,
     )
 
     report = build_benchmark_evaluation_report(

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -42,6 +42,7 @@ _REQUEST_PROBE_KEYS = (
     "dflash_rollback_count",
     "dflash_target_hidden_layers",
 )
+_REQUEST_PROBE_KEY_SET = frozenset(_REQUEST_PROBE_KEYS)
 _COUNT_PROBE_KEYS = {
     "speculative_accepted_tokens",
     "speculative_rejected_tokens",
@@ -463,10 +464,9 @@ def _collect_benchmark_probe_metrics(
     matrix_label_cache: dict[tuple[object, object, object, object, object], str] = {}
     for row in _dict_rows(rows):
         label = ""
-        for key in _REQUEST_PROBE_KEYS:
-            if key not in row:
+        for key, raw_value in row.items():
+            if key not in _REQUEST_PROBE_KEY_SET:
                 continue
-            raw_value = row[key]
             raw_value_type = type(raw_value)
             if raw_value_type is float:
                 value = raw_value


### PR DESCRIPTION
## Summary
- Iterate actual benchmark probe row keys and filter through a module-level request probe key set.
- Preserve benchmark/evaluation report metric names, labels, aggregate suffixes, and output semantics.
- Extend sparse-row regression coverage so benchmark rows fail on fixed-key membership scans.

## Plan or Spec
- `docs/plans/2026-04-30-benchmark-evaluation-report-streaming-aggregation.md`

## Commands Run
```text
# Baseline probe on origin/main before edits
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_benchmark_eval_probe.py
exit 0; {"elapsed_ms_mean": 171.805849, "load_input_ms_mean": 6.657846, "peak_bytes_mean": 3888683.4, "row_count": 5990.0, "sample_count": 5.0}

# Regression-first focused test after making the test stricter, before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py::test_report_builder_uses_sparse_benchmark_probe_rows_without_fixed_key_scans
exit 1; failed with AssertionError: unexpected fixed-key membership scan for prefill_ms

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
exit 0; 38 passed in 0.13s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
exit 0; TOTAL 704 statements, 12 missed, 98% coverage

# Registered probe locally via equivalent /tmp wrapper because this CLI blocks python3 -c execution; CI runs the registered command exactly.
for i in 1 2 3 4 5; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_benchmark_eval_probe.py; done
exit 0; elapsed_ms_mean samples: 149.587224, 144.436530, 152.300928, 163.592155, 151.060034

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 98% total for `benchmark_evaluation_report.py` plus `test_benchmark_evaluation_report.py`.
- Registered probe: `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json`; includes focused `test_command`, `coverage_command`, and `probe_command`.
- Local Linux probe comparison:
  - baseline last-5 `elapsed_ms_mean`: 157.055837 ms
  - candidate last-5 `elapsed_ms_mean`: 152.195374 ms
  - delta: -4.860462 ms (-3.094735%)
  - baseline all recorded `elapsed_ms_mean`: 157.258253 ms
  - candidate all recorded `elapsed_ms_mean`: 153.870994 ms
  - delta: -3.387259 ms (-2.153947%)
  - row_count unchanged: 5990
  - peak_bytes_mean changed by +56 bytes (~0.0014%), below the 5% warning threshold.

## Known Gaps
- Local probe command used an equivalent file wrapper instead of the registry's `python3 -c` form because this scheduled CLI requires approval for `-c` execution. GitHub Actions will run the registered probe command exactly.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
