### PR TITLE
perf: reuse evaluation latency percentile vectors

### DIFF
--- a/docs/plans/2026-05-03-evaluation-latency-percentile-vector-reuse.md
+++ b/docs/plans/2026-05-03-evaluation-latency-percentile-vector-reuse.md
@@ -1,0 +1,43 @@
+# Evaluation Latency Percentile Vector Reuse
+
+## Goal
+
+Eliminate duplicate sorting in `EvaluationCore._latency_stats()` by reusing one ordered latency vector for both `p50` and `p95` calculations, while preserving the current percentile interpolation semantics exactly.
+
+## Linux-Only Constraint
+
+This slice is confined to the Python worker and the PR-scoped performance harness, so it can be fully verified on Linux without macOS or Swift execution.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/engine/evaluation_core.py`
+- `services/mlx-worker-python/tests/test_evaluation_core.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Probe Definition
+
+Update the evaluation-scoped PR performance probe set with a dedicated `command_json` probe that exercises `_latency_stats()` on a large synthetic latency vector and records:
+
+- `elapsed_ms_mean`
+- `sorted_calls_mean`
+- `sample_count`
+
+The probe must be base-compatible so `origin/main` still runs successfully during base-vs-head comparison.
+
+## Success Metrics
+
+- `_latency_stats()` performs one sort per invocation instead of two.
+- Latency summary outputs (`mean`, `p50`, `p95`, `max`) remain unchanged.
+- Focused changed-scope coverage for touched executable files is at least 95%.
+- Local probe shows lower elapsed time and fewer sort calls versus `origin/main`.
+
+## Verification Commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <focused tests>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <focused tests>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --probe-id evaluation-latency-percentile-vector-reuse --base-ref origin/main --samples 3 --warmup 1 --output <json>
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -265,6 +265,37 @@
     ]
   },
   {
+    "id": "evaluation-latency-percentile-vector-reuse",
+    "name": "Evaluation latency percentile vector reuse",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/engine/evaluation_core.py",
+      "services/mlx-worker-python/tests/test_evaluation_core.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_percentile_preserves_interpolated_results services/mlx-worker-python/tests/test_evaluation_core.py::test_latency_stats_reuse_single_sorted_vector services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_latency_percentile_probe_command_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_percentile_preserves_interpolated_results services/mlx-worker-python/tests/test_evaluation_core.py::test_latency_stats_reuse_single_sorted_vector services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_latency_percentile_probe_command_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 - <<'PY'\nimport builtins\nimport json\nimport random\nimport sys\nimport time\nfrom pathlib import Path\n\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / 'services/mlx-worker-python'))\nfrom worker.engine.evaluation_core import EvaluationCore\n\nseed = 7\nlatency_count = 12000\niteration_count = 160\nrng = random.Random(seed)\nvalues = [rng.random() * 1000.0 for _ in range(latency_count)]\noriginal_sorted = builtins.sorted\n\nelapsed_samples = []\nsorted_calls = []\nfor _ in range(3):\n    call_counter = [0]\n\n    def counting_sorted(*args, **kwargs):\n        call_counter[0] += 1\n        return original_sorted(*args, **kwargs)\n\n    builtins.sorted = counting_sorted\n    try:\n        started = time.perf_counter()\n        stats = None\n        for _ in range(iteration_count):\n            stats = EvaluationCore._latency_stats(values)\n        elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n        sorted_calls.append(call_counter[0] / iteration_count)\n    finally:\n        builtins.sorted = original_sorted\n\nassert stats is not None\nprint(json.dumps({\n    'elapsed_ms_mean': round(sum(elapsed_samples) / len(elapsed_samples), 6),\n    'sorted_calls_mean': round(sum(sorted_calls) / len(sorted_calls), 6),\n    'sample_count': float(latency_count),\n    'iteration_count': float(iteration_count),\n    'p50': float(stats['p50']),\n    'p95': float(stats['p95']),\n}, sort_keys=True))\nPY",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "sorted_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "evaluation-store-compare-summary-csv-streaming",
     "name": "Evaluation store compare summary CSV streaming",
     "runner": "ubuntu-latest",

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -647,6 +647,29 @@ def test_sample_probe_means_aggregate_multiple_fields_in_one_pass() -> None:
     }
 
 
+def test_percentile_preserves_interpolated_results() -> None:
+    assert EvaluationCore._percentile([42.0], 95.0) == 42.0
+    assert EvaluationCore._percentile([10.0, 20.0, 30.0, 40.0], 50.0) == 25.0
+    assert EvaluationCore._percentile([10.0, 20.0, 30.0, 40.0], 95.0) == 38.5
+
+
+def test_latency_stats_reuse_single_sorted_vector(monkeypatch: pytest.MonkeyPatch) -> None:
+    sorted_call_count = 0
+    original_sorted = builtins.sorted
+
+    def counting_sorted(*args, **kwargs):
+        nonlocal sorted_call_count
+        sorted_call_count += 1
+        return original_sorted(*args, **kwargs)
+
+    monkeypatch.setattr(builtins, "sorted", counting_sorted)
+
+    stats = EvaluationCore._latency_stats([40.0, 10.0, 30.0, 20.0])
+
+    assert stats == {"mean": 25.0, "p50": 25.0, "p95": 38.5, "max": 40.0}
+    assert sorted_call_count == 1
+
+
 def test_run_local_suite_executes_packaged_dataset_and_persists_result(tmp_path: Path) -> None:
     dataset_root = _write_dataset_package(
         tmp_path=tmp_path,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -968,7 +968,7 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     assert evaluation_store_metrics["csv_line_count"] == 10001.0
     assert scope_matcher_metrics["build_scope_report_ms_mean"] > 0
     assert scope_matcher_metrics["changed_file_count"] == float(len(_build_large_scope_probe_changed_files()))
-    assert scope_matcher_metrics["selected_probe_count_mean"] == 4.0
+    assert scope_matcher_metrics["selected_probe_count_mean"] == 5.0
     assert scope_matcher_metrics["force_all_selected_mean"] == 0.0
     assert training_dataset_metrics["elapsed_ms_mean"] > 0
     assert training_dataset_metrics["peak_bytes_mean"] > 0
@@ -1274,7 +1274,7 @@ def test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe() -> None:
 
     assert metrics["build_scope_report_ms_mean"] > 0
     assert metrics["changed_file_count"] == float(len(_build_large_scope_probe_changed_files()))
-    assert metrics["selected_probe_count_mean"] == 4.0
+    assert metrics["selected_probe_count_mean"] == 5.0
     assert metrics["force_all_selected_mean"] == 0.0
 
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -389,9 +389,10 @@ def test_scope_report_large_changed_set_preserves_exact_selection_semantics() ->
         "benchmark-export-run-scan-single-pass",
         "evaluation-job-id-high-water-mark",
         "evaluation-sample-probe-aggregation",
+        "evaluation-latency-percentile-vector-reuse",
         "download-pipeline-directory-size-single-stat",
     ]
-    assert scope["selected_count"] == 4
+    assert scope["selected_count"] == 5
 
 
 def test_match_probe_indexes_deduplicates_repeated_watch_globs() -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -108,9 +108,10 @@ def test_scope_report_selects_evaluation_probes() -> None:
     )
 
     probe_ids = {probe["id"] for probe in scope["selected_probes"]}
-    assert scope["selected_count"] == 2
+    assert scope["selected_count"] == 3
     assert probe_ids == {
         "evaluation-job-id-high-water-mark",
+        "evaluation-latency-percentile-vector-reuse",
         "evaluation-sample-probe-aggregation",
     }
 
@@ -528,6 +529,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "dev-up-mlx-metal-dist-info-scandir",
         "evaluation-job-id-high-water-mark",
         "evaluation-final-result-materialization-streaming",
+        "evaluation-latency-percentile-vector-reuse",
         "evaluation-sample-probe-aggregation",
         "evaluation-store-compare-summary-csv-streaming",
         "evaluation-store-samples-csv-streaming",
@@ -1663,6 +1665,22 @@ def test_command_json_probe_executes_probe_command_and_parses_metrics(tmp_path: 
     metrics = _probe_command_json(probe=probe, repo_root=tmp_path)
 
     assert metrics == {"elapsed_ms_mean": 12.5, "iteration_count": 3.0}
+
+
+def test_evaluation_latency_percentile_probe_command_emits_metrics() -> None:
+    probe = next(
+        probe
+        for probe in load_probe_registry(REGISTRY_PATH)
+        if probe.probe_id == "evaluation-latency-percentile-vector-reuse"
+    )
+
+    metrics = _probe_command_json(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["sorted_calls_mean"] == 1.0
+    assert metrics["sample_count"] == 12000.0
+    assert metrics["iteration_count"] == 160.0
+    assert metrics["p95"] >= metrics["p50"]
 
 
 def test_model_registry_catalog_probe_command_emits_metrics() -> None:

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -1277,16 +1277,20 @@ class EvaluationCore:
     def _latency_stats(cls, values: list[float]) -> dict[str, float]:
         if not values:
             return {"mean": 0.0, "p50": 0.0, "p95": 0.0, "max": 0.0}
+        sorted_values = sorted(values)
         return {
             "mean": cls._round_ms(sum(values) / len(values)),
-            "p50": cls._round_ms(cls._percentile(values, 50.0)),
-            "p95": cls._round_ms(cls._percentile(values, 95.0)),
+            "p50": cls._round_ms(cls._ordered_percentile(sorted_values, 50.0)),
+            "p95": cls._round_ms(cls._ordered_percentile(sorted_values, 95.0)),
             "max": cls._round_ms(max(values)),
         }
 
     @staticmethod
     def _percentile(values: list[float], percentile: float) -> float:
-        sorted_values = sorted(values)
+        return EvaluationCore._ordered_percentile(sorted(values), percentile)
+
+    @staticmethod
+    def _ordered_percentile(sorted_values: list[float], percentile: float) -> float:
         if len(sorted_values) == 1:
             return sorted_values[0]
         index = (len(sorted_values) - 1) * (percentile / 100.0)


### PR DESCRIPTION
## Summary
- Reuse one sorted latency vector inside `EvaluationCore._latency_stats()` instead of sorting twice for `p50` and `p95`.
- Add focused regression tests for percentile interpolation and single-sort latency stats behavior.
- Register a dedicated PR-scoped performance probe for this evaluation latency percentile path.

## Plan or Spec
- `docs/plans/2026-05-03-evaluation-latency-percentile-vector-reuse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_percentile_preserves_interpolated_results services/mlx-worker-python/tests/test_evaluation_core.py::test_latency_stats_reuse_single_sorted_vector services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_latency_percentile_probe_command_emits_metrics
# 4 passed in 2.85s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_percentile_preserves_interpolated_results services/mlx-worker-python/tests/test_evaluation_core.py::test_latency_stats_reuse_single_sorted_vector services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_latency_percentile_probe_command_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 4 passed in 1.53s
# TOTAL 27 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-latency-percentile-vector-reuse --base-repo /tmp/melix-base-20260503-153101 --head-repo /tmp/melix-20260503-153101 --output /tmp/evaluation-latency-percentile-vector-reuse.json
# base elapsed_ms_mean=486.617791 sorted_calls_mean=2.0
# head elapsed_ms_mean=266.485834 sorted_calls_mean=1.0

git diff --check
# clean
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 27 0 100%`
- Probe: `evaluation-latency-percentile-vector-reuse`
  - `elapsed_ms_mean`: `486.617791` -> `266.485834` (~45.23% lower)
  - `sorted_calls_mean`: `2.0` -> `1.0` (50% fewer sorts)
  - `sample_count`: `12000`
  - `iteration_count`: `160`
  - `p50`: unchanged at `495.0611`
  - `p95`: unchanged at `950.5231`

## Known Gaps
- Linux-only local verification; no macOS/Swift checks were run locally because this slice only touches Python worker code and PR-scoped performance configuration.
- Touching `infra/perf/pr_scoped_probes.json` triggers the full hosted `pr-scoped-performance` matrix; auto-merge should wait for that workflow to complete green.
- Repository-wide `make swift-test` / `make integration-test` were not run in this Linux cron slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
