### PR TITLE
perf: lazy-serialize restored model-ops manifests

### DIFF
--- a/docs/plans/2026-05-03-job-registry-lazy-restored-manifest-json.md
+++ b/docs/plans/2026-05-03-job-registry-lazy-restored-manifest-json.md
@@ -1,0 +1,91 @@
+# Job Registry Lazy Restored Manifest JSON Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Avoid redundant JSON re-serialization when restoring completed model-ops jobs from manifest files.
+
+**Architecture:** Keep restored `ModelOpsJob` instances manifest-cache-first: preserve the parsed `manifest` dict and `manifest_cached=True`, but stop eagerly rebuilding `manifest_json` during `_restore_manifest_jobs`. Update manifest readers/snapshot builders so cached manifests remain visible even when `manifest_json` is empty. Reuse the existing `job-registry-restore-sort-elision` PR-scoped probe rather than introducing a new registry entry.
+
+**Tech Stack:** Python 3.11, pytest, coverage.py, Melix PR-scoped performance probe `scripts/job_registry_restore_probe.py`.
+
+---
+
+### Task 1: Add a written plan for the restore optimization slice
+
+**Objective:** Record the governing plan/spec and verification contract before code changes.
+
+**Files:**
+- Create: `docs/plans/2026-05-03-job-registry-lazy-restored-manifest-json.md`
+
+**Verification:**
+- Plan exists and names the touched files, probe, and success metric.
+
+### Task 2: Make restored jobs lazy about `manifest_json`
+
+**Objective:** Remove eager `json.dumps(payload)` work in `_restore_manifest_jobs` while preserving snapshot and derived-model behavior.
+
+**Files:**
+- Modify: `services/mlx-worker-python/worker/model_ops/job_registry.py`
+
+**Implementation notes:**
+- In `_restore_manifest_jobs`, keep `manifest=payload` and `manifest_cached=True`, but do not eagerly serialize `manifest_json`.
+- Update `_job_manifest(...)` to prefer `manifest_cached` before checking `manifest_json`, so restored jobs still expose their cached manifest.
+- Update `_snapshot_job(...)` similarly so snapshots include restored manifests even when `manifest_json` is empty.
+- Do not change behavior for uncached jobs or `registry_snapshot` jobs.
+
+**Success metric:**
+- Existing restore probe reports lower `restore_elapsed_ms_mean` than the current baseline.
+
+### Task 3: Add focused regression tests for lazy restored manifests
+
+**Objective:** Prove restored jobs still expose manifests without requiring serialized `manifest_json`.
+
+**Files:**
+- Modify: `services/mlx-worker-python/tests/test_model_ops_job_registry.py`
+
+**Test coverage goals:**
+- Restored jobs preserve manifest ordering and keep `manifest_json == ""` while `manifest_cached is True`.
+- `_job_manifest(...)` returns the cached manifest even when `manifest_json` is empty.
+- `_snapshot_job(...)` emits the cached manifest for restored jobs with empty `manifest_json`.
+- Existing restore-focused tests still pass.
+
+### Task 4: Verify locally on Linux
+
+**Objective:** Satisfy the Python-slice verification contract before commit.
+
+**Files:**
+- Verify only
+
+**Commands:**
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_restore_probe_script_emits_metrics`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_restore_probe_script_emits_metrics`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_restore_probe.py`
+- `git diff --check`
+
+**Acceptance:**
+- Focused pytest passes.
+- Changed-scope coverage is >=95% for touched executable lines.
+- Probe prints concrete elapsed metrics and improves over baseline.
+- `git diff --check` is clean.
+
+### Task 5: Commit, push, PR, and CI wait
+
+**Objective:** Publish the slice with evidence-complete PR metadata and wait for hosted scoped-performance validation.
+
+**Files:**
+- Modify: `/tmp/pr-body-*.md` (temporary only, outside repo)
+
+**Requirements:**
+- Commit message: `perf: lazy-serialize restored model-ops manifests`
+- PR body must keep headings exactly:
+  - `## Summary`
+  - `## Plan or Spec`
+  - `## Commands Run`
+  - `## Coverage and Metrics`
+  - `## Known Gaps`
+  - `## Evidence Checklist`
+- Wait for the relevant `pr-scoped-performance` run to complete before enabling auto-merge.
+- Probe to cite in the PR: `job-registry-restore-sort-elision`.

--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -147,12 +147,12 @@ def test_restore_manifest_jobs_preserves_collected_manifest_order_without_resort
     assert list(registry._jobs) == ["model-ops-0002", "model-ops-0001"]
     restored_job = registry._jobs["model-ops-0002"]
     assert restored_job.manifest_cached is True
+    assert restored_job.manifest_json == ""
     assert restored_job.manifest == {
         "job_id": "model-ops-0002",
         "operation": "train_lora",
         "source_model": "src-2",
     }
-    assert json.loads(restored_job.manifest_json) == restored_job.manifest
 
 
 
@@ -205,7 +205,7 @@ def test_json_safe_reuses_clean_containers_and_copies_only_changed_branch() -> N
     assert safe["other"] is unsafe["other"]
 
 
-def test_job_manifest_handles_empty_registry_snapshot_and_uncached_json() -> None:
+def test_job_manifest_handles_empty_registry_snapshot_and_uncached_empty_manifest_json() -> None:
     registry_snapshot_job = ModelOpsJobRegistry._job_manifest(
         ModelOpsJob(
             job_id="model-ops-0001",
@@ -220,13 +220,78 @@ def test_job_manifest_handles_empty_registry_snapshot_and_uncached_json() -> Non
             operation="activate_adapter",
             source_model="melix-dev-text",
             output_dir="/runtime/activate",
-            manifest_json=json.dumps({"derived_model_id": "melix-dev-active"}),
+            manifest_json="",
             manifest_cached=False,
         )
     )
 
     assert registry_snapshot_job == {}
-    assert uncached_manifest == {"derived_model_id": "melix-dev-active"}
+    assert uncached_manifest == {}
+
+
+def test_job_manifest_returns_cached_manifest_for_restored_job_with_empty_manifest_json() -> None:
+    restored_manifest = {
+        "job_id": "model-ops-0007",
+        "operation": "activate_adapter",
+        "derived_model_id": "melix-dev-active",
+    }
+
+    manifest = ModelOpsJobRegistry._job_manifest(
+        ModelOpsJob(
+            job_id="model-ops-0007",
+            operation="activate_adapter",
+            source_model="melix-dev-text",
+            output_dir="/runtime/activate",
+            manifest_json="",
+            manifest=restored_manifest,
+            manifest_cached=True,
+        )
+    )
+
+    assert manifest == restored_manifest
+
+
+def test_snapshot_job_handles_empty_manifest_for_uncached_non_snapshot_job() -> None:
+    snapshot = ModelOpsJobRegistry._snapshot_job(
+        ModelOpsJob(
+            job_id="model-ops-0008",
+            operation="train_lora",
+            source_model="melix-dev-text",
+            output_dir="/runtime/train",
+            manifest_json="",
+            manifest_cached=False,
+            stage_history=[("write_manifest", 0.97)],
+            output_path="/runtime/train/model-ops-0008/train_lora.adapter.json",
+            status="completed",
+        )
+    )
+
+    assert snapshot["manifest"] == {}
+
+
+def test_snapshot_job_returns_cached_manifest_for_restored_job_with_empty_manifest_json() -> None:
+    restored_manifest = {
+        "job_id": "model-ops-0009",
+        "operation": "train_lora",
+        "adapter_name": "adapter-a",
+    }
+
+    snapshot = ModelOpsJobRegistry._snapshot_job(
+        ModelOpsJob(
+            job_id="model-ops-0009",
+            operation="train_lora",
+            source_model="melix-dev-text",
+            output_dir="/runtime/train",
+            manifest_json="",
+            manifest=restored_manifest,
+            manifest_cached=True,
+            stage_history=[("write_manifest", 0.97)],
+            output_path="/runtime/train/model-ops-0009/train_lora.adapter.json",
+            status="completed",
+        )
+    )
+
+    assert snapshot["manifest"] == restored_manifest
 
 
 def test_active_derived_model_manifests_avoids_full_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -277,7 +277,6 @@ class ModelOpsJobRegistry:
                 source_model=str(payload.get("source_model", "")),
                 output_dir=str(output_dir),
                 stage_history=[("write_manifest", pct)],
-                manifest_json=json.dumps(payload),
                 manifest=payload,
                 manifest_cached=True,
                 output_path=str(manifest_path),
@@ -398,10 +397,12 @@ class ModelOpsJobRegistry:
 
     @classmethod
     def _job_manifest(cls, job: ModelOpsJob) -> dict[str, Any]:
-        if job.operation == "registry_snapshot" or not job.manifest_json:
+        if job.operation == "registry_snapshot":
             return {}
         if job.manifest_cached:
             return job.manifest
+        if not job.manifest_json:
+            return {}
         return cls._decode_manifest_json(job.manifest_json)
 
     @classmethod
@@ -559,10 +560,10 @@ class ModelOpsJobRegistry:
             stage, pct = job.stage_history[-1]
 
         manifest: dict[str, Any] = {}
-        if job.operation != "registry_snapshot" and job.manifest_json:
+        if job.operation != "registry_snapshot":
             if job.manifest_cached:
                 manifest = job.manifest
-            else:
+            elif job.manifest_json:
                 manifest = ModelOpsJobRegistry._decode_manifest_json(job.manifest_json)
 
         return {


### PR DESCRIPTION
## Summary
- Stop eagerly re-serializing restored model-ops manifests in `ModelOpsJobRegistry._restore_manifest_jobs(...)`.
- Keep restored manifests visible by making `_job_manifest(...)` and `_snapshot_job(...)` prefer the cached manifest dict even when `manifest_json == ""`.
- Add focused regression tests plus a plan doc for this Linux-verifiable optimization slice.

## Plan or Spec
- `docs/plans/2026-05-03-job-registry-lazy-restored-manifest-json.md`

## Commands Run
```text
# Focused pytest
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_restore_probe_script_emits_metrics
# Result: 23 passed in 1.35s

# Coverage + changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_restore_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py
# Result: TOTAL 19 0 100%

# Local probe on branch
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_restore_probe.py
# Result: {"restore_elapsed_ms_mean": 125.31088, "per_manifest_ms_mean": 0.008354059, "job_count": 15000.0, ...}

# Detached origin/main baseline probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_restore_probe.py
# Result on detached origin/main worktree: {"restore_elapsed_ms_mean": 190.254547, "per_manifest_ms_mean": 0.012683636, "job_count": 15000.0, ...}

# Diff hygiene
git diff --check
# Result: clean
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 19 0 100%`
- Focused file coverage:
  - `services/mlx-worker-python/tests/test_model_ops_job_registry.py`: `99%`
  - `services/mlx-worker-python/worker/model_ops/job_registry.py`: broad file report `62%` (not the gate for this narrow slice)
- Registered scoped CI probe reused for this path: `job-registry-restore-sort-elision`
- Local probe comparison (`scripts/job_registry_restore_probe.py`, 15,000 restored manifests, 8 samples):
  - `origin/main` baseline: `restore_elapsed_ms_mean=190.254547 ms`, `per_manifest_ms_mean=0.012683636 ms`
  - branch head: `restore_elapsed_ms_mean=125.31088 ms`, `per_manifest_ms_mean=0.008354059 ms`
  - improvement: about `34.13%` lower mean restore elapsed time
- Slice type: Python-only optimization, locally verified on Linux

## Known Gaps
- I did not run the full repository verification suite (`make proto`, `make swift-test`, `make py-test`, `make integration-test`) from this Linux cron run; this slice only ran targeted Python verification for the touched path.
- macOS/Swift surfaces were not locally exercised on this Linux host.
- Final merge should wait for the hosted `pr-scoped-performance` run (including `job-registry-restore-sort-elision`) plus the repo’s normal PR checks.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] No protocol changes; regenerated generated artifacts were not required.
- [x] No dependency changes; lockfile updates were not required.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
