### PR TITLE
Fix assistant history sanitization across parts

### DIFF
--- a/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
+++ b/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
@@ -451,7 +451,6 @@ public struct TextRequestShaper: Sendable {
                     parts[index].text = stripped.text
                     stripCount += stripped.count
                 }
-                break
             }
 
             return NormalizedTextMessage(

--- a/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
@@ -199,6 +199,33 @@ struct TextEndpointContractTests {
         )
     }
 
+    @Test("prior assistant hidden-thought prefixes are stripped from every text part")
+    func priorAssistantHiddenThoughtPrefixesAreStrippedFromEveryTextPart() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "reasoning-history-strip-parts" })
+        let translated = try translator.translate(
+            MelixMessagesRequest(
+                model: "melix-dev-text",
+                messages: [
+                    .init(
+                        role: "assistant",
+                        contentBlocks: [
+                            .init(type: .text, text: "<think>hidden first part</think>Visible first part."),
+                            .init(type: .text, text: "\n<think>hidden second part</think>Visible second part."),
+                        ]
+                    ),
+                    .init(role: "user", content: "Continue.")
+                ]
+            ),
+            modelHandle: "worker-text"
+        )
+
+        let assistant = try #require(translated.workerRequest.messages.first)
+
+        #expect(assistant.role == "assistant")
+        #expect(assistant.parts.map(\.text) == ["Visible first part.", "Visible second part."])
+        #expect(translated.workerRequest.execution.ext["melix.reasoning.history_strip_count"] == "2")
+    }
+
     @Test("inline hidden-thought literals in assistant history are preserved")
     func inlineHiddenThoughtLiteralsInAssistantHistoryArePreserved() throws {
         let translator = ChatRequestTranslator(requestIDGenerator: { "reasoning-history-literal" })


### PR DESCRIPTION
## Summary
- Sanitize leading hidden-thought blocks from every assistant text part instead of stopping after the first non-empty part.
- Add a regression test for `/v1/messages` assistant content blocks with multiple text parts.

## Plan or Spec
- `docs/plans/2026-04-26-issue-41-structured-streaming-reasoning-continuity.md`
- `docs/runbooks/structured-streaming-reasoning-continuity.md`

## Commands Run
```text
HOME="$(pwd)/.runtime/swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" xcrun swift test --package-path services/control-plane-swift --filter TextEndpointContractTests
Result: passed, 47 tests.

HOME="$(pwd)/.runtime/swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" xcrun swift test --package-path services/control-plane-swift --enable-code-coverage --filter TextEndpointContractTests
Result: passed, 47 tests.

python3 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/Requests/TextRequestShaper.swift services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
Result: TOTAL 100.00% (25/25).
```

## Coverage and Metrics
- Changed-line coverage: `100.00%` (`25/25`).
- Performance metrics: N/A: deterministic request-shaping bug fix; no new hot-path probe needed beyond preserving existing `melix.reasoning.history_strip_count` behavior.

## Known Gaps
- Full baseline commands `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run locally for this narrow review-comment follow-up.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
