### PR TITLE
Propagate operator reasoning template flags

### DIFF
--- a/docs/plans/2026-04-26-issue-41-structured-streaming-reasoning-continuity.md
+++ b/docs/plans/2026-04-26-issue-41-structured-streaming-reasoning-continuity.md
@@ -7,7 +7,7 @@ Make shipped text streaming deterministic, request-scoped, reasoning-aware, tool
 ## Scope
 
 - preserve raw generation text separately from display-cleaned text
-- resolve reasoning controls through one shared policy path across shipped text endpoints
+- resolve reasoning controls through one shared policy path across shipped text endpoints and operator-driven chat dispatch
 - assemble content, reasoning, and tool-call fragments with request-local parser state
 - suppress incompatible tool parsing for JSON-only structured-output requests without explicit tools
 - preserve hidden reasoning continuity for session follow-up turns without exposing hidden channels in operator-visible output
@@ -23,7 +23,7 @@ Out of scope:
 
 1. Add regression tests for reasoning policy parity, structured-output gating, stream assembler isolation, replay-safe tool-call deltas, JSON reasoning-prefix cleanup, and hidden continuity sanitization.
 2. Extend worker protobuf schema with raw text and parser observability fields, then regenerate Swift and Python protocol artifacts.
-3. Add a Swift `ReasoningPolicyResolver` used by all shipped text request normalizers. Preserve top-level `enable_thinking`, `reasoning_effort`, Messages `thinking`, template kwargs, model/operator defaults, auto-detected family capability, and suppressions in deterministic precedence order.
+3. Add a Swift `ReasoningPolicyResolver` used by all shipped text request normalizers and the operator `startChat` path. Preserve top-level `enable_thinking`, `reasoning_effort`, Messages `thinking`, template kwargs, model/operator defaults, auto-detected family capability, and suppressions in deterministic precedence order.
 4. Add request-scoped Python stream assembly that parses `raw_text || text`, emits unseen deltas only, separates content/reasoning/tool fragments, and skips recoverable malformed tool fragments.
 5. Add session reasoning-continuity metadata in the control plane keyed by session/branch/request. Rehydrate supported follow-up turns through execution metadata/template kwargs while keeping raw hidden content out of SSE and public session state.
 6. Add cache-scope/fingerprint metadata for reasoning mode, reasoning effort, parser mode, template kwargs, and continuity presence.
@@ -44,6 +44,9 @@ Out of scope:
 - `stream_parser_request_context_mode`, `tool_call_markup_leak_count`, and
   `reasoning_channel_recovery_count` make parser context, visible markup leaks,
   and recovered malformed reasoning channels observable.
+- `resolved_stop_token_count`, `reasoning_flag_source`, and
+  `turn_boundary_stop_reason` make the pre-decode turn-boundary stop contract
+  observable in streaming completion evidence.
 
 ## Verification
 
@@ -60,4 +63,6 @@ Out of scope:
 - short visible streaming replies are not swallowed by marker-prefix buffering
 - JSON-only structured-output streams are not contaminated by hidden reasoning prefixes or generic tool parsing
 - repeated session turns preserve supported hidden reasoning continuity while public output remains sanitized
+- turn-boundary stop sequences are resolved before decode from request stop lists,
+  tokenizer EOS metadata, and model/registry stop overrides
 - metrics and docs explain how to reproduce the stream-pipeline evidence

--- a/docs/runbooks/structured-streaming-reasoning-continuity.md
+++ b/docs/runbooks/structured-streaming-reasoning-continuity.md
@@ -1,12 +1,13 @@
 # Structured Streaming And Reasoning Continuity Runbook
 
-Use this runbook when debugging Chat Completions, Completions, Responses, or Messages streaming behavior involving reasoning, tool calls, structured JSON output, or repeated-turn session continuity.
+Use this runbook when debugging Chat Completions, Completions, Responses, Messages, or operator `startChat` streaming behavior involving reasoning, tool calls, structured JSON output, or repeated-turn session continuity.
 
 ## Scope
 
 Covered:
 
 - shipped stream-capable text endpoints
+- operator-driven chat dispatch through the shared text translator
 - Swift request normalization and reasoning policy resolution
 - Python request-local stream assembly
 - JSON-only structured-output parser suppression
@@ -34,6 +35,10 @@ For a reasoning-enabled request, inspect the worker `GenerateRequest.execution` 
 - `ReasoningConfig.effort`
 - `ReasoningConfig.continuity_rehydrated`
 
+Operator `startChat` requests that provide explicit reasoning or template
+flags must produce the same metadata before worker dispatch as equivalent Chat
+Completions requests.
+
 Cache compatibility must include:
 
 - `melix.cache.fingerprint.reasoning_mode`
@@ -59,6 +64,9 @@ The worker stream assembler reports parser metrics on completed events:
 - `stream_parser_request_context_mode`
 - `tool_call_markup_leak_count`
 - `reasoning_channel_recovery_count`
+- `resolved_stop_token_count`
+- `reasoning_flag_source`
+- `turn_boundary_stop_reason`
 
 Expected healthy values:
 
@@ -80,6 +88,22 @@ Expected healthy values:
   `tool_parser` and keep `tool_call_markup_leak_count == 0`
 - malformed reasoning-open boundaries should increment
   `reasoning_channel_recovery_count` without emitting hidden text
+- completed stream evidence should report the pre-decode turn-boundary stop
+  contract through `resolved_stop_token_count`, `reasoning_flag_source`, and
+  `turn_boundary_stop_reason`
+
+## Turn-Boundary Stop Checks
+
+Before decode starts, the worker must resolve one request-scoped stop contract
+from explicit request stop sequences, tokenizer EOS metadata, and model or
+registry stop overrides. Inspect completed stream evidence for:
+
+1. `resolved_stop_token_count` greater than zero when any source contributes
+   a stop sequence or EOS token.
+2. `reasoning_flag_source` matching the Swift-resolved request metadata source,
+   such as `request`, `template`, `family_auto_detect`, or `unspecified`.
+3. `turn_boundary_stop_reason` set to `stop_sequence` when generation ends on a
+   resolved turn-boundary marker.
 
 ## JSON Structured Output Checks
 

--- a/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
+++ b/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
@@ -712,6 +712,13 @@ public actor RequestCoordinator {
         }
         await hub.testingDetachAllConsumersWithoutLifecycleCallback()
     }
+
+    func testingExecutionHubHasConsumers(requestID: String) async -> Bool {
+        guard let hub = executionHubs[requestID] else {
+            return false
+        }
+        return await hub.hasConsumers()
+    }
 #endif
 
     public func startChatCompletion(
@@ -1116,9 +1123,7 @@ public actor RequestCoordinator {
             forKey: "disconnect.resume_success_rate"
         )
         await metricsStore.increment("disconnect.terminal_failure_count")
-        if let workerClient = activeWorkerClients[requestID] {
-            _ = try? await workerClient.abort(requestID: requestID)
-        }
+        let workerClient = activeWorkerClients[requestID]
         let errorEvent = makeLifecycleFailureEvent(
             requestID: requestID,
             code: "stream_disconnect_timeout",
@@ -1128,6 +1133,7 @@ public actor RequestCoordinator {
         await hub.emitLifecycle(.terminalFailure(code: "stream_disconnect_timeout", message: "The client disconnected and the resume grace period expired."))
         await hub.finish()
         await finishRequestTracking(requestID: requestID, phase: .requestFailed)
+        _ = try? await workerClient?.abort(requestID: requestID)
     }
 
     private func makeLifecycleFailureEvent(

--- a/services/control-plane-swift/Sources/XPCService/ControlPlaneChatExecution.swift
+++ b/services/control-plane-swift/Sources/XPCService/ControlPlaneChatExecution.swift
@@ -63,6 +63,9 @@ public struct ControlPlaneChatRequest: Sendable, Equatable {
 
     public let modelID: String
     public let messages: [Message]
+    public let enableThinking: Bool?
+    public let reasoningEffort: String?
+    public let chatTemplateKwargs: ChatTemplateRequestConfiguration?
     public let resumeRequestID: String?
     public let temperature: Double?
     public let topP: Double?
@@ -72,6 +75,9 @@ public struct ControlPlaneChatRequest: Sendable, Equatable {
     public init(
         modelID: String,
         messages: [Message],
+        enableThinking: Bool? = nil,
+        reasoningEffort: String? = nil,
+        chatTemplateKwargs: ChatTemplateRequestConfiguration? = nil,
         resumeRequestID: String? = nil,
         temperature: Double? = nil,
         topP: Double? = nil,
@@ -80,6 +86,9 @@ public struct ControlPlaneChatRequest: Sendable, Equatable {
     ) {
         self.modelID = modelID
         self.messages = messages
+        self.enableThinking = enableThinking
+        self.reasoningEffort = reasoningEffort
+        self.chatTemplateKwargs = chatTemplateKwargs
         self.resumeRequestID = resumeRequestID
         self.temperature = temperature
         self.topP = topP

--- a/services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift
+++ b/services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift
@@ -358,10 +358,13 @@ public actor ControlPlaneService {
                 messages: request.messages.map {
                     OpenAIChatCompletionsRequest.Message(role: $0.role, content: $0.content)
                 },
+                enableThinking: request.enableThinking,
+                reasoningEffort: request.reasoningEffort,
                 stream: true,
                 temperature: request.temperature,
                 topP: request.topP,
-                maxTokens: request.maxTokens
+                maxTokens: request.maxTokens,
+                chatTemplateKwargs: request.chatTemplateKwargs
             )
         )
         let modelHandle: String

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift
@@ -7908,6 +7908,58 @@ struct ControlPlaneServiceTests {
         #expect(generated.execution.ext["melix.gateway.completion_batch_size"] == "3")
     }
 
+    @Test("startChat propagates explicit reasoning and template flags before worker dispatch")
+    func startChatPropagatesExplicitReasoningAndTemplateFlagsBeforeWorkerDispatch() async throws {
+        let modelCatalog = ModelCatalog()
+        _ = await modelCatalog.loadModel(id: "melix-dev-text")
+        let textClient = ScriptedChatWorkerClient(events: [
+            makeQueuedExecuteEvent(requestID: "chat-reasoning-template"),
+            makeCompletedExecuteEvent(
+                requestID: "chat-reasoning-template",
+                finishReason: "stop",
+                assistant: "done",
+                reasoning: ""
+            ),
+        ])
+        let service = ControlPlaneService(
+            modelCatalog: modelCatalog,
+            workerRegistry: WorkerRegistry(defaultTextClient: textClient),
+            chatTranslator: ChatRequestTranslator(requestIDGenerator: { "chat-reasoning-template" })
+        )
+
+        let execution = try await service.startChat(
+            ControlPlaneChatRequest(
+                modelID: "melix-dev-text",
+                messages: [.init(role: "user", content: "Use explicit prompt policy.")],
+                enableThinking: true,
+                reasoningEffort: " high ",
+                chatTemplateKwargs: ChatTemplateRequestConfiguration(values: [
+                    "enable_thinking": .bool(false),
+                    "chat_template": .string("operator-template"),
+                ])
+            )
+        )
+
+        _ = try await Array(execution.stream)
+        let generated = try #require(await textClient.lastGenerateRequest)
+
+        #expect(generated.execution.reasoning.enabled)
+        #expect(generated.execution.reasoning.mode == "enabled")
+        #expect(generated.execution.reasoning.modeSource == "request")
+        #expect(generated.execution.reasoning.effort == "high")
+        #expect(generated.execution.ext["melix.reasoning.mode_source"] == "request")
+        #expect(generated.execution.ext["melix.reasoning.effort"] == "high")
+        #expect(generated.execution.ext["melix.chat_template_kwargs.source"] == "request")
+        #expect(
+            generated.execution.ext["melix.chat_template_kwargs.effective_json"]
+                == "{\"chat_template\":\"operator-template\",\"enable_thinking\":false}"
+        )
+        #expect(generated.execution.scope.reasoningMode == "enabled")
+        #expect(generated.execution.scope.reasoningEffort == "high")
+        #expect(generated.execution.scope.chatTemplateKwargsHash ==
+            generated.execution.ext["melix.cache.fingerprint.chat_template_kwargs"])
+    }
+
     @Test("startChat auto injects MCP tool metadata into worker requests")
     func startChatAutoInjectsMCPToolMetadataIntoWorkerRequests() async throws {
         let modelCatalog = ModelCatalog()

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -218,6 +218,7 @@ struct RequestCoordinatorTests {
                 disconnectGracePeriod: 0.2
             )
         )
+        #expect(await coordinator.testingExecutionHubHasConsumers(requestID: "missing") == false)
 
         let execution = try await coordinator.startChatCompletion(
             makeTranslatedChatRequest(requestID: "req-resume-timeout")
@@ -229,9 +230,14 @@ struct RequestCoordinatorTests {
             } catch {
             }
         }
-        await Task.yield()
+        for _ in 0..<100 where !(await coordinator.testingExecutionHubHasConsumers(requestID: "req-resume-timeout")) {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
         initialConsumer.cancel()
         _ = await initialConsumer.result
+        for _ in 0..<100 where await coordinator.testingExecutionHubHasConsumers(requestID: "req-resume-timeout") {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
 
         var disconnectMetrics = await metricsStore.snapshot()
         for _ in 0..<100 where disconnectMetrics.values["http.stream_disconnect_count", default: 0] < 1 {


### PR DESCRIPTION
## Summary
- Add explicit operator `startChat` fields for reasoning controls and chat template kwargs.
- Route those operator flags into the shared text request translator before worker dispatch so operator chat matches HTTP endpoint reasoning/template precedence.
- Stabilize disconnect grace timeout handling so the terminal `.requestFailed` state wins before worker abort can complete the upstream stream.
- Update the issue #41 plan and runbook with operator dispatch scope and turn-boundary stop-contract evidence fields.

## Plan or Spec
- `docs/plans/2026-04-26-issue-41-structured-streaming-reasoning-continuity.md`
- `docs/runbooks/structured-streaming-reasoning-continuity.md`
- Related milestone: https://github.com/Keith-CY/melix/issues/41

## Commands Run
```text
make proto
# Passed before final rebase and again after rebase to origin/main@6031f13fd; no generated protocol diff.

xcrun swift test --no-parallel --package-path services/control-plane-swift --filter 'ControlPlaneServiceTests/startChatPropagatesExplicitReasoningAndTemplateFlagsBeforeWorkerDispatch|TextEndpointContractTests/reasoningResolverEmitsSharedExecutionMetadataAcrossEndpointVariants'
# Passed after final rebase: 2 tests in 2 suites.

xcrun swift test --enable-code-coverage --no-parallel --package-path services/control-plane-swift --filter 'ControlPlaneServiceTests/startChatPropagatesExplicitReasoningAndTemplateFlagsBeforeWorkerDispatch|TextEndpointContractTests/reasoningResolverEmitsSharedExecutionMetadataAcrossEndpointVariants'
# Passed after final rebase: 2 tests in 2 suites.

python3 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/XPCService/ControlPlaneChatExecution.swift services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift
# Passed after final rebase: TOTAL 100.00% 57/57.

CI=true xcrun swift test --no-parallel --package-path services/control-plane-swift --filter 'RequestCoordinatorTests/disconnectGraceExpiryAbortsTheWorkerAndRecordsATerminalLifecycleFailure'
# Reproduced the CI failure before the fix, then passed after the disconnect terminal-order fix.

CI=true xcrun swift test --no-parallel --package-path services/control-plane-swift --filter 'RequestCoordinatorTests/disconnectGraceExpiryAbortsTheWorkerAndRecordsATerminalLifecycleFailure|RequestCoordinatorTests/disconnectGraceKeepsRequestResumeEligibleUntilANewConsumerAttaches|RequestCoordinatorTests/streamDisconnectHandlerRecordsDisconnectMetricsAndOpensAResumeGraceWindow'
# Passed after the CI fix: 3 tests in 1 suite.

make swift-test
# Passed after the CI fix.

HOME="/private/tmp/melix-issue41-turn-boundary/.swift-home/control-plane-swift" CLANG_MODULE_CACHE_PATH="/private/tmp/melix-issue41-turn-boundary/.build/ModuleCache.noindex/control-plane-swift" xcrun swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'RequestCoordinatorTests'
# Passed after the CI fix: 61 tests in 1 suite.

python3 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/Requests/RequestCoordinator.swift services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
# Passed after the CI fix: TOTAL 100.00% 15/15.

git diff --check
# Passed after the CI fix.

bash -n scripts/ci_progress.sh
# Passed after the CI fix.

xcrun swift test --no-parallel --package-path services/control-plane-swift --filter 'TextEndpointContractTests|StructuredOutputValidationTests|RequestCoordinatorTests|OpenAIHandlerTests|ControlPlaneServiceTests/startChatPropagatesExplicitReasoningAndTemplateFlagsBeforeWorkerDispatch'
# Passed before final rebase: 237 tests in 5 suites.

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_mlx_backend.py -q
# Passed before final rebase: 60 passed.

make py-test
# Passed before final rebase: 1616 passed, 5 skipped, 2 warnings.

make integration-test
# Passed before final rebase: 86 passed, 1 skipped.
```

## Coverage and Metrics
- Changed-line Swift coverage after final rebase for operator dispatch scope: `TOTAL 100.00% 57/57`.
- Changed-line Swift coverage after CI fix for disconnect timeout scope: `TOTAL 100.00% 15/15`.
- Metrics report: N/A for runtime performance measurement; this slice propagates existing operator request fields through the shared translator, updates issue #41 observability docs, and fixes a disconnect-timeout lifecycle race. The changed-scope metrics are the coverage reports above.
- CI progress evidence: `ci-pr.yml` wraps long bootstrap, Swift, Python, and integration steps with `scripts/ci_progress.sh`, which emits started, periodic `still running`, and completed lines with elapsed seconds and exit code. Failed run `25288077231` showed `[melix-ci] Swift tests still running after 901s` and `[melix-ci] Swift tests completed rc=2 elapsed=954s`.

## Known Gaps
- Issue #41 remains open for the broader structured streaming and reasoning continuity milestone.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
