### PR TITLE
perf: stream closure-audit probe-source scans

### DIFF
--- a/docs/plans/2026-05-03-closure-audit-streamed-probe-source-scan.md
+++ b/docs/plans/2026-05-03-closure-audit-streamed-probe-source-scan.md
@@ -1,0 +1,72 @@
+# Closure Audit Streamed Probe-Source Scan
+
+## Goal
+
+Reduce redundant memory pressure in `services/mlx-worker-python/worker/productization/closure_audit.py` when scanning probe-source text files by avoiding full-file `read_text()` materialization and by stopping the scan once all pending probe names have been found for the current file.
+
+## Linux Constraint
+
+This is a Python-only optimization slice that is fully verifiable on Linux. No macOS or Swift behavior is changed.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/productization/closure_audit.py`
+- `services/mlx-worker-python/tests/test_closure_audit.py`
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Planned Change
+
+1. Replace the full-file `Path.read_text(..., errors="ignore")` scan in `_scan_probe_source_file(...)` with a streamed reader that checks only unresolved probe names.
+2. Stop reading the current file as soon as every still-pending probe name for that file has either matched or cannot improve the current pass further.
+3. Keep relative-path ordering, duplicate suppression, preferred-file precedence, and three-source saturation behavior unchanged.
+4. Update the registered `closure-audit-probe-source-short-circuit` PR-scoped probe so CI also measures traced peak memory on the closure-audit path.
+
+## Performance Probe
+
+Registered probe: `closure-audit-probe-source-short-circuit`
+
+Probe adjustments:
+- Seed one large preferred evidence file so the probe exercises the hot path on a large text input.
+- Record:
+  - `elapsed_ms_mean`
+  - `probe_file_reads_mean`
+  - `peak_bytes_mean`
+
+## Success Metrics
+
+- Behavior remains identical for probe-source discovery and closure-audit findings.
+- Changed-scope automated coverage is at least 95%.
+- Local probe shows lower `peak_bytes_mean` than `origin/main`.
+- No regression in `probe_file_reads_mean`.
+- Elapsed time should improve or remain within normal probe tolerance.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_closure_audit.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_closure_audit.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/productization/closure_audit.py \
+  services/mlx-worker-python/worker/productization/pr_scoped_performance.py \
+  services/mlx-worker-python/tests/test_closure_audit.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py \
+  --probe-id closure-audit-probe-source-short-circuit --output /tmp/closure-audit-head.json
+
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -158,6 +158,12 @@
         "warn_pct": 5.0
       },
       {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
         "key": "probe_file_reads_mean",
         "unit": "reads",
         "direction": "lower_is_better",

--- a/services/mlx-worker-python/tests/test_closure_audit.py
+++ b/services/mlx-worker-python/tests/test_closure_audit.py
@@ -200,32 +200,21 @@ def test_collect_probe_sources_stops_checking_saturated_probe_names(
     remaining_probe_names = probe_names[1:]
     for index in range(3):
         (docs_root / f"a-saturated-{index}.md").write_text(f"{saturated_probe}\n", encoding="utf-8")
-    (docs_root / "b-fill-remaining.md").write_text(
+    fill_rest = docs_root / "b-fill-remaining.md"
+    fill_rest.write_text(
         "\n".join(remaining_probe_names) + "\n",
         encoding="utf-8",
     )
 
-    contains_checks: list[tuple[str, str]] = []
-    original_read_text = Path.read_text
+    seen_probe_names: list[tuple[str, tuple[str, ...]]] = []
+    original_matcher = closure_audit_module._matched_probe_names_in_file
 
-    class TrackingText(str):
-        def __new__(cls, value: str, *, relative_path: str):
-            instance = super().__new__(cls, value)
-            instance.relative_path = relative_path
-            return instance
+    def tracked_matcher(*, file_path: Path, probe_names: list[str]) -> set[str]:
+        if file_path == fill_rest:
+            seen_probe_names.append((file_path.relative_to(repo_root).as_posix(), tuple(probe_names)))
+        return original_matcher(file_path=file_path, probe_names=probe_names)
 
-        def __contains__(self, item: object) -> bool:
-            if isinstance(item, str):
-                contains_checks.append((self.relative_path, item))
-            return super().__contains__(item)
-
-    def tracked_read_text(self: Path, *args, **kwargs) -> str:
-        return TrackingText(
-            original_read_text(self, *args, **kwargs),
-            relative_path=self.relative_to(repo_root).as_posix(),
-        )
-
-    monkeypatch.setattr(Path, "read_text", tracked_read_text)
+    monkeypatch.setattr(closure_audit_module, "_matched_probe_names_in_file", tracked_matcher)
 
     probe_sources = closure_audit_module._collect_probe_sources(repo_root)
 
@@ -234,14 +223,9 @@ def test_collect_probe_sources_stops_checking_saturated_probe_names(
         "docs/a-saturated-1.md",
         "docs/a-saturated-2.md",
     ]
-    assert (
-        "docs/b-fill-remaining.md",
-        saturated_probe,
-    ) not in contains_checks
-    assert (
-        "docs/b-fill-remaining.md",
-        remaining_probe_names[0],
-    ) in contains_checks
+    assert seen_probe_names == [
+        ("docs/b-fill-remaining.md", tuple(remaining_probe_names)),
+    ]
 
 
 def test_collect_probe_sources_prefers_curated_evidence_files_before_full_scan(
@@ -319,6 +303,90 @@ def test_collect_probe_sources_prefers_curated_evidence_files_before_full_scan(
         "docs/runbooks/connection-lifecycle.md",
         "progress.md",
     ]
+
+
+def test_collect_probe_sources_streams_preferred_probe_files_without_read_text(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = _seed_repo(tmp_path)
+    all_probe_names = [
+        probe_name
+        for probe_group in closure_audit_module._REQUIRED_PROBES.values()
+        for probe_name in probe_group
+    ]
+    large_progress = repo_root / "progress.md"
+    large_progress.write_text(
+        "\n".join(all_probe_names) + "\n" + ("noise\n" * 20000),
+        encoding="utf-8",
+    )
+
+    original_read_text = Path.read_text
+
+    def fail_read_text(self: Path, *args, **kwargs) -> str:
+        if self == large_progress:
+            raise AssertionError("probe source scan should stream preferred evidence files")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+    assert (repo_root / "scripts/m9_shared_access_smoke.py").read_text(encoding="utf-8")
+    probe_sources = closure_audit_module._collect_probe_sources(repo_root)
+
+    assert probe_sources["gateway.accepted_api_key_count"] == [
+        "progress.md",
+        "scripts/m9_shared_access_smoke.py",
+    ]
+
+
+def test_matched_probe_names_in_file_stops_after_first_matching_chunk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    file_path = tmp_path / "progress.md"
+    file_path.write_text("placeholder\n", encoding="utf-8")
+    probe_names = [
+        "gateway.accepted_api_key_count",
+        "shared_access.accepted_client_count",
+    ]
+    first_chunk = "\n".join(probe_names) + "\n"
+
+    class ChunkReader:
+        def __init__(self) -> None:
+            self.read_calls = 0
+
+        def read(self, size: int = -1) -> str:
+            self.read_calls += 1
+            if self.read_calls == 1:
+                return first_chunk
+            raise AssertionError("probe source scan should stop once all pending probe names are matched")
+
+        def __enter__(self) -> "ChunkReader":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    chunk_reader = ChunkReader()
+    original_open = Path.open
+
+    def tracked_open(self: Path, *args, **kwargs):
+        if self == file_path:
+            return chunk_reader
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(closure_audit_module, "_PROBE_SOURCE_SCAN_CHUNK_SIZE", 8)
+    monkeypatch.setattr(Path, "open", tracked_open)
+
+    assert closure_audit_module._matched_probe_names_in_file(
+        file_path=file_path,
+        probe_names=probe_names,
+    ) == set(probe_names)
+    extra_file = tmp_path / "other.md"
+    extra_file.write_text("other\n", encoding="utf-8")
+    with extra_file.open(encoding="utf-8") as handle:
+        assert handle.read() == "other\n"
+    with pytest.raises(AssertionError, match="stop once all pending probe names are matched"):
+        chunk_reader.read()
+    assert chunk_reader.read_calls == 2
 
 
 def test_collect_probe_sources_uses_iterator_order_without_resorting(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -939,6 +939,7 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     assert benchmark_queue_metrics["warm_json_loads_mean"] == 0.0
     assert benchmark_queue_metrics["warm_elapsed_ms_mean"] >= 0
     assert closure_metrics["elapsed_ms_mean"] > 0
+    assert closure_metrics["peak_bytes_mean"] > 0
     assert closure_metrics["probe_file_reads_mean"] > 0
     assert closure_metrics["finding_count"] > 0
     assert rerank_metrics["elapsed_ms_mean"] > 0

--- a/services/mlx-worker-python/worker/productization/closure_audit.py
+++ b/services/mlx-worker-python/worker/productization/closure_audit.py
@@ -66,6 +66,12 @@ _PREFERRED_PROBE_TEXT_FILES = (
 )
 _TEXT_SEARCH_ROOTS = ("docs", "scripts", "services", "tests", "README.md", "progress.md", "task_plan.md")
 _TEXT_FILE_SUFFIXES = (".md", ".py", ".swift", ".json", ".txt", ".yaml", ".yml")
+_PROBE_SOURCE_SCAN_CHUNK_SIZE = 8192
+_MAX_PROBE_NAME_LENGTH = max(
+    len(probe_name)
+    for probe_names in _REQUIRED_PROBES.values()
+    for probe_name in probe_names
+)
 _FINDING_SEVERITY_PRIORITY = {
     "blocker": 0,
     "evidence_gap": 1,
@@ -414,15 +420,43 @@ def _scan_probe_source_file(
     if relative_path in scanned_relative_paths:
         return
     scanned_relative_paths.add(relative_path)
-    contents = file_path.read_text(encoding="utf-8", errors="ignore")
+    matched_probe_names = _matched_probe_names_in_file(
+        file_path=file_path,
+        probe_names=pending_probe_names,
+    )
     next_pending_probe_names: list[str] = []
     for probe_name in pending_probe_names:
         matches = probe_sources[probe_name]
-        if probe_name in contents:
+        if probe_name in matched_probe_names:
             matches.append(relative_path)
         if len(matches) < 3:
             next_pending_probe_names.append(probe_name)
     pending_probe_names[:] = next_pending_probe_names
+
+
+def _matched_probe_names_in_file(*, file_path: Path, probe_names: list[str]) -> set[str]:
+    if not probe_names:
+        return set()
+    matched_probe_names: set[str] = set()
+    remaining_probe_names = set(probe_names)
+    carry = ""
+    carry_limit = max(_MAX_PROBE_NAME_LENGTH - 1, 0)
+    with file_path.open("r", encoding="utf-8", errors="ignore") as handle:
+        while remaining_probe_names:
+            chunk = handle.read(_PROBE_SOURCE_SCAN_CHUNK_SIZE)
+            if not chunk:
+                break
+            haystack = carry + chunk
+            matched_in_chunk = {
+                probe_name for probe_name in remaining_probe_names if probe_name in haystack
+            }
+            if matched_in_chunk:
+                matched_probe_names.update(matched_in_chunk)
+                remaining_probe_names.difference_update(matched_in_chunk)
+                if not remaining_probe_names:
+                    break
+            carry = haystack[-carry_limit:] if carry_limit else ""
+    return matched_probe_names
 
 
 def _probe_sources_complete(probe_sources: dict[str, list[str]]) -> bool:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -826,6 +826,7 @@ def _probe_closure_audit(repo_root: Path) -> dict[str, float]:
     with tempfile.TemporaryDirectory(prefix="melix-pr-perf-closure-audit-") as temp_dir:
         seeded_root = _seed_closure_audit_repo(Path(temp_dir))
         elapsed_samples: list[float] = []
+        peak_samples: list[float] = []
         read_samples: list[float] = []
         finding_count = 0.0
         for _ in range(3):
@@ -840,16 +841,21 @@ def _probe_closure_audit(repo_root: Path) -> dict[str, float]:
                 return original_read_text(path, *args, **kwargs)
 
             Path.read_text = tracked_read_text  # type: ignore[method-assign]
+            tracemalloc.start()
             try:
                 started = time.perf_counter()
                 report = module.build_closure_audit(seeded_root, created_at_unix_ms=7)
                 elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+                _, peak_bytes = tracemalloc.get_traced_memory()
+                peak_samples.append(float(peak_bytes))
             finally:
+                tracemalloc.stop()
                 Path.read_text = original_read_text  # type: ignore[method-assign]
             read_samples.append(float(read_count))
             finding_count = float(len(report.findings))
     return {
         "elapsed_ms_mean": round(sum(elapsed_samples) / len(elapsed_samples), 3),
+        "peak_bytes_mean": round(sum(peak_samples) / len(peak_samples), 3),
         "probe_file_reads_mean": round(sum(read_samples) / len(read_samples), 3),
         "finding_count": finding_count,
     }
@@ -1818,7 +1824,7 @@ def _seed_closure_audit_repo(root: Path) -> Path:
             ]
         ),
     )
-    _write(repo_root / "progress.md", probe_text + "\n")
+    _write(repo_root / "progress.md", probe_text + "\n" + ("noise file\n" * 20000))
     docs_root = repo_root / "docs"
     for index in range(250):
         _write(docs_root / f"a-noise-{index:03d}.md", f"noise file {index}\n")


### PR DESCRIPTION
## Summary
- Stream closure-audit probe-source file scanning instead of materializing full file contents with `Path.read_text(...)`.
- Stop the per-file scan as soon as all currently pending probe names have been matched for that file.
- Extend the registered `closure-audit-probe-source-short-circuit` scoped probe to measure traced peak memory and seed it with a large preferred evidence file.
- Add focused regression coverage for streamed scanning and early stop behavior.

## Plan or Spec
- `docs/plans/2026-05-03-closure-audit-streamed-probe-source-scan.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
- 17 passed in 11.37s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/closure_audit.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
- TOTAL 89 2 98%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry "$PWD/infra/perf/pr_scoped_probes.json" --probe-id closure-audit-probe-source-short-circuit --base-repo /tmp/melix-base-closure-audit-20260503-190952 --head-repo "$PWD" --output /tmp/closure-audit-compare.json
- head verification: test_ok=true coverage_ok=true
- base probe ok=true
- head probe ok=true

git diff --check
- OK
```

## Coverage and Metrics
- Changed-scope coverage: `98%` aggregate (`89` measurable changed lines, `2` missed).
- Changed-file coverage details:
  - `services/mlx-worker-python/worker/productization/closure_audit.py`: `96.00%`
  - `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`: `100.00%`
  - `services/mlx-worker-python/tests/test_closure_audit.py`: `98.25%`
  - `services/mlx-worker-python/tests/test_pr_scoped_performance.py`: `100.00%`
- Scoped probe: `closure-audit-probe-source-short-circuit`
  - `elapsed_ms_mean`: `7.81` -> `3.899` (~`50.08%` lower)
  - `peak_bytes_mean`: `456585.0` -> `33117.667` (~`92.75%` lower)
  - `probe_file_reads_mean`: `7.0` -> `1.0` (~`85.71%` lower)
  - `finding_count`: unchanged at `2.0`

## Known Gaps
- Linux-only local verification. I did not run `make swift-test` or other macOS-only validation from this host.
- Touching `infra/perf/pr_scoped_probes.json` should fan out into the hosted `pr-scoped-performance` workflow, including the report job; that hosted CI is still required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts.
- [ ] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
