### PR TITLE
perf: bind evaluation JSONL writer hot loop

### DIFF
--- a/docs/plans/2026-05-03-evaluation-final-jsonl-writer-local-bindings.md
+++ b/docs/plans/2026-05-03-evaluation-final-jsonl-writer-local-bindings.md
@@ -1,0 +1,42 @@
+# Evaluation Final-Result JSONL Writer Local Bindings
+
+## Goal
+
+Reduce final-result evaluation dataset materialization overhead by avoiding repeated attribute lookups inside the per-row JSONL writer loop, while preserving the exact JSONL bytes emitted today.
+
+## Linux-Only Constraint
+
+This slice only touches the Python worker final-result materialization path and its PR-scoped performance probe, so it can be locally verified on Linux.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/productization/evaluation_final_result.py`
+- `docs/plans/2026-05-03-evaluation-final-jsonl-writer-local-bindings.md`
+
+## Existing Probe Coverage
+
+The affected path is already covered by registered PR-scoped probe `evaluation-final-result-materialization-streaming` in `infra/perf/pr_scoped_probes.json`. The registered probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and measures:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- `sample_count`
+
+## Optimization Slice
+
+`_write_jsonl_rows()` now binds `json.dumps` and `handle.write` to local variables before the row loop. This keeps the wire-format and empty-input newline contract unchanged while reducing repeated global and attribute lookups across large materialized evaluation datasets.
+
+## Success Metrics
+
+- Focused tests for `evaluation_final_result.py` pass.
+- Changed-scope coverage for `evaluation_final_result.py` and its tests is at least 95%.
+- Registered local probe reports lower `elapsed_ms_mean` or an explainable neutral variance, with no semantic regression.
+
+## Verification Commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/eval_final_probe.py
+```

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -579,14 +579,16 @@ def _iter_serialized_samples(
 
 def _write_jsonl_rows(path: Path, rows: Iterable[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    json_dumps = json.dumps
     with path.open("w", encoding="utf-8") as handle:
+        handle_write = handle.write
         wrote_row = False
         for row in rows:
             wrote_row = True
-            handle.write(json.dumps(row))
-            handle.write("\n")
+            handle_write(json_dumps(row))
+            handle_write("\n")
         if not wrote_row:
-            handle.write("\n")
+            handle_write("\n")
 
 
 def _validate_field_mapping(field_mapping: EvaluationFieldMapping) -> None:


### PR DESCRIPTION
## Summary
- Bound `json.dumps` and `handle.write` once before the final-result JSONL sample writer loop.
- Preserved the existing JSONL bytes and empty-input newline contract while reducing repeated global/attribute lookups on large materialization runs.

## Plan or Spec
- `docs/plans/2026-05-03-evaluation-final-jsonl-writer-local-bindings.md`
- Registered PR-scoped probe: `evaluation-final-result-materialization-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
git fetch origin && git reset --hard origin/main
# exit 0; synced slice base to c49437575fe1704f83af1a4311949fdabb2cdf06

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 20 passed in 5.14s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 20 passed in 5.21s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# exit 0; Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; TOTAL 5 0 100%

git diff --check
# exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/eval_final_probe.py
# origin/main worktree: exit 0; {"elapsed_ms_mean": 868.5153, "peak_bytes_mean": 21543554.2, "sample_count": 15000.0}
# head worktree: exit 0; {"elapsed_ms_mean": 795.5087, "peak_bytes_mean": 21543554.2, "sample_count": 15000.0}
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Local Linux probe (`evaluation-final-result-materialization-streaming` equivalent): `old_mean=868.5153ms`, `new_mean=795.5087ms`, `delta_ms=-73.0066ms`, `speedup=1.092x`; `peak_bytes_mean` unchanged at `21543554.2`.
- CI PR-scoped performance workflow is still required as the registered probe validation source before merge.

## Known Gaps
- Local metrics were collected on Linux only; no Swift/macOS path is touched.
- The probe has normal timing variance, so the registered CI comparison remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
