### PR TITLE
[codex] Build CLI before packaging Melix.app

### DIFF
--- a/.github/workflows/package-self-contained-app.yml
+++ b/.github/workflows/package-self-contained-app.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Bootstrap Python worker environment
         run: make bootstrap
 
+      - name: Build CLI executable
+        run: swift build --product melix --disable-automatic-resolution
+
       - name: Build Swift text worker
         run: swift build --package-path services/mlx-text-worker-swift --disable-automatic-resolution
 

--- a/docs/plans/2026-04-15-ci-failure-remediation.md
+++ b/docs/plans/2026-04-15-ci-failure-remediation.md
@@ -39,6 +39,9 @@ This slice does not add:
   provision Python or `uv`, so worker-client bridge tests fail even when the Swift code is valid.
 - `package-app` fails under Xcode 16.4 concurrency checks because a cached `NSImage` static
   property is not isolated to the main actor.
+- `package-app` builds the menu bar executable and Swift text worker before bundle packaging, but
+  does not build the root `melix` CLI product that `scripts/package_macos_menubar_app.py` bundles
+  into `Melix.app`.
 - `swift-tests` expose a timing-sensitive request coordinator test that assumes disconnect-grace
   expiry has already completed after a fixed sleep.
 - `validate_pr_evidence.py` currently accepts empty fenced code blocks and loose placeholder text
@@ -73,6 +76,8 @@ This slice does not add:
 - Provision Python, `uv`, and the locked worker environment before running `make swift-test`.
 - Move protocol generation to repository-pinned toolchains so `proto-drift` is deterministic across
   runs.
+- Build the root `melix` CLI product before the self-contained app packaging step resolves bundled
+  Swift executables.
 - Reduce packaging workflow permissions to `contents: read` by default and isolate release-asset
   publication in a tag-only write-scoped job.
 - Separate scheduled and push-triggered release-gate workflow concurrency keys on `main`.
@@ -124,6 +129,8 @@ Measurement points for this remediation:
   gate during the transition period, and the deterministic smoke fixture remains green.
 - Protocol generation determinism: the same repository-locked protobuf toolchain is used in CI and
   local regeneration paths.
+- Packaging workflow prerequisites: `melix`, `melix-menubar`, and `melix-text-worker-swift` build
+  products exist before the bundle writer resolves inputs.
 - Packaging workflow permissions: pull request execution paths stay read-only.
 - Workflow scheduling isolation: scheduled and push-triggered release-gate runs do not cancel each
   other on `main`.
@@ -149,6 +156,7 @@ uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-work
 xcrun swift test --package-path services/control-plane-swift --filter "HTTPGatewayTests.RequestCoordinatorTests/disconnectGraceExpiryAbortsTheWorkerAndRecordsATerminalLifecycleFailure()"
 xcrun swift test --package-path apps/macos-menubar
 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python python -m grpc_tools.protoc --version
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py::test_package_workflow_builds_cli_before_packaging_app -q
 HOME="$PWD/.swift-home/protocol" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/protocol" xcrun swift build --package-path packages/protocol/swift --product protoc-gen-swift --disable-automatic-resolution
 HOME="$PWD/.swift-home/protocol" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/protocol" xcrun swift build --package-path packages/protocol/swift --product protoc-gen-grpc-swift-2 --disable-automatic-resolution
 ```
@@ -177,4 +185,6 @@ This remediation is complete when:
 - swift test CI provisions the Python bridge runtime dependencies before worker-client tests launch
 - sandboxed Python code evaluation succeeds on runner-compatible interpreter paths
 - the menu bar app package builds under the current Xcode concurrency checks
+- the packaging workflow builds the root `melix` CLI product before invoking the bundle packaging
+  script
 - the request coordinator disconnect-grace test no longer depends on a fixed sleep race

--- a/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
+++ b/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
@@ -14,6 +14,27 @@ MODULE_PATH = REPO_ROOT / "scripts" / "package_macos_menubar_app.py"
 PACKAGE_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "package-self-contained-app.yml"
 
 
+def find_named_workflow_step(workflow: str, name: str) -> re.Match[str]:
+    match = re.search(
+        rf"^[ \t]*-[ \t]+name:[ \t]+{re.escape(name)}[ \t]*$",
+        workflow,
+        flags=re.MULTILINE,
+    )
+    assert match is not None, f"Workflow step not found: {name}"
+    return match
+
+
+def find_run_workflow_step(workflow: str, name: str, command: str) -> re.Match[str]:
+    match = re.search(
+        rf"^[ \t]*-[ \t]+name:[ \t]+{re.escape(name)}[ \t]*\n"
+        rf"^[ \t]*run:[ \t]+{re.escape(command)}[ \t]*$",
+        workflow,
+        flags=re.MULTILINE,
+    )
+    assert match is not None, f"Workflow run step not found: {name}"
+    return match
+
+
 def load_package_macos_app_module():
     assert MODULE_PATH.exists(), f"Expected package_macos_menubar_app entrypoint at {MODULE_PATH}"
     spec = importlib.util.spec_from_file_location("melix_package_macos_app", MODULE_PATH)
@@ -171,6 +192,35 @@ def test_package_workflow_uses_runtime_only_python_environment_for_bundle() -> N
     assert "$PYTHON_RUNTIME_ROOT" in workflow
     assert "--python-site-packages-path" in workflow
     assert "$PYTHON_SITE_PACKAGES" in workflow
+
+
+def test_package_workflow_builds_required_swift_products_before_packaging_app() -> None:
+    workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    build_steps = [
+        find_run_workflow_step(
+            workflow,
+            "Build CLI executable",
+            "swift build --product melix --disable-automatic-resolution",
+        ),
+        find_run_workflow_step(
+            workflow,
+            "Build Swift text worker",
+            "swift build --package-path services/mlx-text-worker-swift --disable-automatic-resolution",
+        ),
+        find_run_workflow_step(
+            workflow,
+            "Build menu bar app executable",
+            "swift build --package-path apps/macos-menubar --disable-automatic-resolution",
+        ),
+    ]
+    package_step = find_named_workflow_step(workflow, "Package self-contained Melix.app")
+
+    previous_step_end = 0
+    for build_step in build_steps:
+        assert previous_step_end < build_step.start()
+        assert build_step.end() < package_step.start()
+        previous_step_end = build_step.end()
 
 
 def test_main_resolves_default_build_outputs_and_prints_app_path(


### PR DESCRIPTION
## Summary
- Fix the `package-app` CI failure from PR #360 by building the root `melix` CLI before `scripts/package_macos_menubar_app.py` resolves bundled executables.
- Add a workflow regression test proving `package-self-contained-app.yml` builds all required Swift products before packaging `Melix.app`.
- Address review feedback by anchoring workflow step matching to YAML step lines instead of broad string searches.
- Update the CI remediation plan with the missing CLI build prerequisite and verification command.

## Plan or Spec
- `docs/plans/2026-04-15-ci-failure-remediation.md`

## Commands Run
```text
python3 /Users/ChenYu/.codex/skills/gh-fix-ci/scripts/inspect_pr_checks.py --repo . --pr 360 --json --max-lines 200 --context 50
Result: no failing checks detected on the already-merged PR, so the specific job URL was inspected directly.

gh run view 25312204405 --job 74201504098 --log
Result: package-app failed in `scripts/package_macos_menubar_app.py` with `FileNotFoundError: Unable to find built melix. Run swift build --product melix first.`

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py::test_package_workflow_builds_cli_before_packaging_app -q
Result: RED failed first because the workflow did not contain a `Build CLI executable` step before packaging.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py -q
Result: 9 tests passed.

python3 /Users/ChenYu/.codex/skills/gh-address-comments/scripts/fetch_comments.py
Result: confirmed 2 unresolved Gemini review threads on the workflow regression test.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py -q
Result: 9 tests passed after addressing review feedback.

make package-smoke
Result: 29 tests passed; packaging target smoke JSON reported all profile checks as 1.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py -q
Result: 9 tests passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx coverage json -o /tmp/melix_package_ci_review_coverage.json
Result: wrote JSON coverage report.

python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/melix_package_ci_review_coverage.json services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
Result: TOTAL 100.00% (16/16).

swift build --product melix --disable-automatic-resolution
Result: Build of product `melix` complete.

git diff --check
Result: passed.
```

## Coverage and Metrics
- Changed-line coverage: `100.00% (16/16)` for `services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py`.
- Workflow YAML coverage: `N/A`, GitHub Actions YAML is not executable under Python coverage; covered by the workflow regression test and `git diff --check`.
- Packaging smoke metric: `make package-smoke` reported `packaging_target_app_bundle_profile_ok = 1`, `packaging_target_homebrew_profile_ok = 1`, `packaging_target_launch_agents_profile_ok = 1`, and `packaging_target_shared_identity_ok = 1`.
- No dependency, protocol, or generated artifact changes.

## Known Gaps
- The full GitHub Actions `package-self-contained-app` artifact upload path cannot be fully reproduced locally; this PR relies on the updated workflow and the follow-up CI run for end-to-end Actions confirmation.
- Full baseline commands from `docs/contributing.md` (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not rerun for this narrow workflow prerequisite fix.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included.
- [x] Deferred work and known gaps are stated explicitly.
