### PR TITLE
[codex] Preserve explicit tool parsing for structured streams

### DIFF
--- a/.github/workflows/package-self-contained-app.yml
+++ b/.github/workflows/package-self-contained-app.yml
@@ -50,33 +50,35 @@ jobs:
       - uses: astral-sh/setup-uv@v7
 
       - name: Bootstrap Python worker environment
-        run: make bootstrap
+        run: bash scripts/ci_progress.sh "Package app bootstrap" make bootstrap
 
       - name: Build CLI executable
-        run: swift build --product melix --disable-automatic-resolution
+        run: bash scripts/ci_progress.sh "Package app CLI build" swift build --product melix --disable-automatic-resolution
 
       - name: Build Swift text worker
-        run: swift build --package-path services/mlx-text-worker-swift --disable-automatic-resolution
+        run: bash scripts/ci_progress.sh "Package app Swift text worker build" swift build --package-path services/mlx-text-worker-swift --disable-automatic-resolution
 
       - name: Build menu bar app executable
-        run: swift build --package-path apps/macos-menubar --disable-automatic-resolution
+        run: bash scripts/ci_progress.sh "Package app menubar build" swift build --package-path apps/macos-menubar --disable-automatic-resolution
 
       - name: Packaging smoke checks
-        run: make package-smoke
+        run: bash scripts/ci_progress.sh "Package app smoke checks" make package-smoke
 
       - name: Prepare packaging Python runtime
         run: |
-          UV_PROJECT_ENVIRONMENT="$GITHUB_WORKSPACE/.venv-package" \
-          UV_CACHE_DIR="$GITHUB_WORKSPACE/.uv-cache" \
-          uv sync --project services/mlx-worker-python --extra mlx --no-dev --frozen
+          bash scripts/ci_progress.sh "Package app Python runtime sync" \
+            env UV_PROJECT_ENVIRONMENT="$GITHUB_WORKSPACE/.venv-package" \
+            UV_CACHE_DIR="$GITHUB_WORKSPACE/.uv-cache" \
+            uv sync --project services/mlx-worker-python --extra mlx --no-dev --frozen
 
       - name: Compute build metadata
         id: compute-build-metadata
         run: |
-          PYTHONPATH="$GITHUB_WORKSPACE:$GITHUB_WORKSPACE/services/mlx-worker-python" \
-          UV_CACHE_DIR="$GITHUB_WORKSPACE/.uv-cache" \
-          uv run --project services/mlx-worker-python \
-          python scripts/compute_build_metadata.py \
+          bash scripts/ci_progress.sh "Package app build metadata" \
+            env PYTHONPATH="$GITHUB_WORKSPACE:$GITHUB_WORKSPACE/services/mlx-worker-python" \
+            UV_CACHE_DIR="$GITHUB_WORKSPACE/.uv-cache" \
+            uv run --project services/mlx-worker-python \
+            python scripts/compute_build_metadata.py \
             --repo-root "$GITHUB_WORKSPACE" \
             --ref-type "${GITHUB_REF_TYPE:-branch}" \
             --ref-name "${GITHUB_REF_NAME:-}" \
@@ -90,8 +92,9 @@ jobs:
           PACKAGE_PYTHON="$GITHUB_WORKSPACE/.venv-package/bin/python"
           PYTHON_RUNTIME_ROOT="$(dirname "$(dirname "$(realpath "$PACKAGE_PYTHON")")")"
           PYTHON_SITE_PACKAGES="$("$PACKAGE_PYTHON" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
-          PYTHONPATH="$GITHUB_WORKSPACE:$GITHUB_WORKSPACE/services/mlx-worker-python" \
-          "$PACKAGE_PYTHON" scripts/package_macos_menubar_app.py \
+          bash scripts/ci_progress.sh "Package app bundle assembly" \
+            env PYTHONPATH="$GITHUB_WORKSPACE:$GITHUB_WORKSPACE/services/mlx-worker-python" \
+            "$PACKAGE_PYTHON" scripts/package_macos_menubar_app.py \
             --repo-root "$GITHUB_WORKSPACE" \
             --output-path "$RUNNER_TEMP/Melix.app" \
             --archive-path "$RUNNER_TEMP/${{ steps.compute-build-metadata.outputs.artifact_name }}.zip" \

--- a/Makefile
+++ b/Makefile
@@ -104,35 +104,18 @@ swift-build-integration-prereqs:
 
 swift-test:
 	/bin/zsh -lc 'set -e; \
-	run_swift_stage() { \
-		local label="$$1"; \
-		shift; \
-		local started_at; \
-		started_at="$$(date +%s)"; \
-		printf "[melix-ci] swift-test stage started: %s\n" "$$label" >&2; \
-		set +e; \
-		"$$@"; \
-		local status="$$?"; \
-		set -e; \
-		local finished_at; \
-		finished_at="$$(date +%s)"; \
-		local elapsed; \
-		elapsed=$$((finished_at - started_at)); \
-		printf "[melix-ci] swift-test stage completed: %s rc=%s elapsed=%ss\n" "$$label" "$$status" "$$elapsed" >&2; \
-		return "$$status"; \
-	}; \
 	mkdir -p "$(PROTOCOL_SWIFT_HOME)" "$(TEXT_WORKER_SWIFT_HOME)" "$(CONTROL_PLANE_SWIFT_HOME)" "$(MENUBAR_SWIFT_HOME)"; \
 	mkdir -p "$(PROTOCOL_MODULE_CACHE_PATH)" "$(TEXT_WORKER_MODULE_CACHE_PATH)" "$(CONTROL_PLANE_MODULE_CACHE_PATH)" "$(MENUBAR_MODULE_CACHE_PATH)"; \
-	run_swift_stage "protocol package" env HOME="$(PROTOCOL_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(PROTOCOL_MODULE_CACHE_PATH)" xcrun swift test --package-path packages/protocol/swift; \
-	run_swift_stage "text worker package" env HOME="$(TEXT_WORKER_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(TEXT_WORKER_MODULE_CACHE_PATH)" xcrun swift test --package-path services/mlx-text-worker-swift; \
-	run_swift_stage "control-plane core groups" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_CONTROL)"; \
+	bash scripts/ci_progress.sh "swift-test stage: protocol package" env HOME="$(PROTOCOL_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(PROTOCOL_MODULE_CACHE_PATH)" xcrun swift test --package-path packages/protocol/swift; \
+	bash scripts/ci_progress.sh "swift-test stage: text worker package" env HOME="$(TEXT_WORKER_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(TEXT_WORKER_MODULE_CACHE_PATH)" xcrun swift test --package-path services/mlx-text-worker-swift; \
+	bash scripts/ci_progress.sh "swift-test stage: control-plane core groups" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_CONTROL)"; \
 	for specifier in $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_A) $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_B) $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_C) $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_D) $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_E); do \
-		run_swift_stage "control-plane request coordinator $$specifier" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$$specifier"; \
+		bash scripts/ci_progress.sh "swift-test stage: control-plane request coordinator $$specifier" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$$specifier"; \
 	done; \
-	run_swift_stage "control-plane OpenAI handler" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_OPENAI)"; \
-	run_swift_stage "control-plane REST compatibility" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_HTTP_REST)"; \
-	run_swift_stage "control-plane worker clients" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_WORKER)"; \
-	run_swift_stage "macOS menubar package" env HOME="$(MENUBAR_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(MENUBAR_MODULE_CACHE_PATH)" xcrun swift test --package-path apps/macos-menubar'
+	bash scripts/ci_progress.sh "swift-test stage: control-plane OpenAI handler" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_OPENAI)"; \
+	bash scripts/ci_progress.sh "swift-test stage: control-plane REST compatibility" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_HTTP_REST)"; \
+	bash scripts/ci_progress.sh "swift-test stage: control-plane worker clients" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_WORKER)"; \
+	bash scripts/ci_progress.sh "swift-test stage: macOS menubar package" env HOME="$(MENUBAR_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(MENUBAR_MODULE_CACHE_PATH)" xcrun swift test --package-path apps/macos-menubar'
 
 py-test:
 	mkdir -p "$(UV_CACHE_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -104,18 +104,35 @@ swift-build-integration-prereqs:
 
 swift-test:
 	/bin/zsh -lc 'set -e; \
+	run_swift_stage() { \
+		local label="$$1"; \
+		shift; \
+		local started_at; \
+		started_at="$$(date +%s)"; \
+		printf "[melix-ci] swift-test stage started: %s\n" "$$label" >&2; \
+		set +e; \
+		"$$@"; \
+		local status="$$?"; \
+		set -e; \
+		local finished_at; \
+		finished_at="$$(date +%s)"; \
+		local elapsed; \
+		elapsed=$$((finished_at - started_at)); \
+		printf "[melix-ci] swift-test stage completed: %s rc=%s elapsed=%ss\n" "$$label" "$$status" "$$elapsed" >&2; \
+		return "$$status"; \
+	}; \
 	mkdir -p "$(PROTOCOL_SWIFT_HOME)" "$(TEXT_WORKER_SWIFT_HOME)" "$(CONTROL_PLANE_SWIFT_HOME)" "$(MENUBAR_SWIFT_HOME)"; \
 	mkdir -p "$(PROTOCOL_MODULE_CACHE_PATH)" "$(TEXT_WORKER_MODULE_CACHE_PATH)" "$(CONTROL_PLANE_MODULE_CACHE_PATH)" "$(MENUBAR_MODULE_CACHE_PATH)"; \
-	HOME="$(PROTOCOL_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(PROTOCOL_MODULE_CACHE_PATH)" xcrun swift test --package-path packages/protocol/swift; \
-	HOME="$(TEXT_WORKER_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(TEXT_WORKER_MODULE_CACHE_PATH)" xcrun swift test --package-path services/mlx-text-worker-swift; \
-	HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_CONTROL)"; \
+	run_swift_stage "protocol package" env HOME="$(PROTOCOL_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(PROTOCOL_MODULE_CACHE_PATH)" xcrun swift test --package-path packages/protocol/swift; \
+	run_swift_stage "text worker package" env HOME="$(TEXT_WORKER_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(TEXT_WORKER_MODULE_CACHE_PATH)" xcrun swift test --package-path services/mlx-text-worker-swift; \
+	run_swift_stage "control-plane core groups" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_CONTROL)"; \
 	for specifier in $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_A) $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_B) $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_C) $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_D) $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_E); do \
-		HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$$specifier"; \
+		run_swift_stage "control-plane request coordinator $$specifier" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$$specifier"; \
 	done; \
-	HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_OPENAI)"; \
-	HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_HTTP_REST)"; \
-	HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_WORKER)"; \
-	HOME="$(MENUBAR_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(MENUBAR_MODULE_CACHE_PATH)" xcrun swift test --package-path apps/macos-menubar'
+	run_swift_stage "control-plane OpenAI handler" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_OPENAI)"; \
+	run_swift_stage "control-plane REST compatibility" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_HTTP_REST)"; \
+	run_swift_stage "control-plane worker clients" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_WORKER)"; \
+	run_swift_stage "macOS menubar package" env HOME="$(MENUBAR_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(MENUBAR_MODULE_CACHE_PATH)" xcrun swift test --package-path apps/macos-menubar'
 
 py-test:
 	mkdir -p "$(UV_CACHE_DIR)"

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -10890,6 +10890,9 @@ public final class RuntimeViewModel {
                 )
             )
         }
+        if chatPresentationTask == nil {
+            _ = flushNextChatPresentationChunk(forceComplete: false)
+        }
         startChatPresentationLoopIfNeeded()
     }
 

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -9751,13 +9751,14 @@ struct RuntimeViewModelTests {
     @MainActor
     func chatPromptSmoothsBurstyDeltasWhilePreservingFinalTranscriptFidelity() async throws {
         let client = FakeControlPlaneXPCClient()
+        let assistantText = String(repeating: "Assistant response chunk. ", count: 80)
         await client.configureScheduledChatEvents([
             .init(delay: .zero, event: .queued(lane: "text.decode.interactive", queuePosition: 0, backpressure: 0)),
             .init(delay: .zero, event: .admitted(lane: "text.decode.interactive", workerID: "swift-text-worker", queueDelayMs: 0.5)),
-            .init(delay: .zero, event: .tokenDelta("Assistant response")),
-            .init(delay: .milliseconds(80), event: .completed(
+            .init(delay: .zero, event: .tokenDelta(assistantText)),
+            .init(delay: .seconds(3), event: .completed(
                 finishReason: "stop",
-                assistantText: "Assistant response",
+                assistantText: assistantText,
                 reasoningText: ""
             )),
         ])
@@ -9774,20 +9775,20 @@ struct RuntimeViewModelTests {
 
         try await waitForRuntimeViewModelCondition("chat smoothing should present a partial assistant row") {
             viewModel.chatTranscript.contains { entry in
-                entry.kind == .assistant && entry.body.isEmpty == false && entry.body != "Assistant response"
+                entry.kind == .assistant && entry.body.isEmpty == false && entry.body != assistantText
             }
         }
 
         let partialAssistantEntry = try #require(viewModel.chatTranscript.first { $0.kind == .assistant })
         #expect(partialAssistantEntry.body.isEmpty == false)
-        #expect(partialAssistantEntry.body != "Assistant response")
+        #expect(partialAssistantEntry.body != assistantText)
         #expect(viewModel.isChatStreaming)
 
         await submitTask.value
 
         let finalAssistantEntry = try #require(viewModel.chatTranscript.first { $0.kind == .assistant })
         let metricsSnapshot = await metrics.snapshot()
-        #expect(finalAssistantEntry.body == "Assistant response")
+        #expect(finalAssistantEntry.body == assistantText)
         #expect(metricsSnapshot["menu.chat_presentation_lag_ms"] != nil)
         #expect((metricsSnapshot["menu.chat_presentation_flush_count"] ?? 0) > 1)
     }

--- a/docs/plans/2026-04-26-issue-41-structured-streaming-reasoning-continuity.md
+++ b/docs/plans/2026-04-26-issue-41-structured-streaming-reasoning-continuity.md
@@ -62,6 +62,9 @@ Out of scope:
 - no malformed or duplicated streamed tool-call payloads in repository-owned fixtures
 - short visible streaming replies are not swallowed by marker-prefix buffering
 - JSON-only structured-output streams are not contaminated by hidden reasoning prefixes or generic tool parsing
+- structured-output streams with an explicit tool parser keep request-local
+  tool-call assembly enabled instead of falling through the JSON-only display
+  cleanup path
 - repeated session turns preserve supported hidden reasoning continuity while public output remains sanitized
 - turn-boundary stop sequences are resolved before decode from request stop lists,
   tokenizer EOS metadata, and model/registry stop overrides

--- a/docs/plans/2026-04-26-issue-41-structured-streaming-reasoning-continuity.md
+++ b/docs/plans/2026-04-26-issue-41-structured-streaming-reasoning-continuity.md
@@ -12,6 +12,8 @@ Make shipped text streaming deterministic, request-scoped, reasoning-aware, tool
 - suppress incompatible tool parsing for JSON-only structured-output requests without explicit tools
 - preserve hidden reasoning continuity for session follow-up turns without exposing hidden channels in operator-visible output
 - expose stream-pipeline metrics and regression evidence
+- keep operator chat presentation responsive for bursty stream deltas and make
+  long Swift CI runs report their current test stage
 
 Out of scope:
 
@@ -65,6 +67,10 @@ Out of scope:
 - structured-output streams with an explicit tool parser keep request-local
   tool-call assembly enabled instead of falling through the JSON-only display
   cleanup path
+- macOS operator chat surfaces the first bursty visible delta promptly while
+  preserving final transcript fidelity
+- Swift CI emits package/specifier stage start and completion lines during the
+  long `make swift-test` run
 - repeated session turns preserve supported hidden reasoning continuity while public output remains sanitized
 - turn-boundary stop sequences are resolved before decode from request stop lists,
   tokenizer EOS metadata, and model/registry stop overrides

--- a/docs/runbooks/structured-streaming-reasoning-continuity.md
+++ b/docs/runbooks/structured-streaming-reasoning-continuity.md
@@ -115,6 +115,9 @@ For JSON-only requests without explicit tools:
 4. Confirm completed assistant text starts at the first JSON delimiter and has no reasoning preamble.
 
 If an explicit tool parser was requested, the parser must remain enabled.
+Completed stream metrics should report `stream_parser_request_context_mode` as
+`tool_parser`, and `tool_call_markup_leak_count` should stay `0`, even when
+`melix.structured_output.mode` is `json_object` or `json_schema`.
 
 ## Continuity Checks
 

--- a/services/mlx-worker-python/tests/test_generate_stream.py
+++ b/services/mlx-worker-python/tests/test_generate_stream.py
@@ -221,6 +221,56 @@ def test_generate_streams_reasoning_tool_and_content_channels_from_raw_text() ->
     assert completed.parser_metrics["duplicate_tool_delta_count"] == "0"
 
 
+def test_generate_stream_preserves_explicit_tool_parser_with_structured_json_mode() -> None:
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=StructuredStreamingBackend()),
+        model_catalog=WorkerModelCatalog(),
+    )
+    runtime_service = WorkerRuntimeService(registry)
+    inference_service = WorkerInferenceService(registry)
+    load_response = runtime_service.LoadModel(
+        runtime_pb2.LoadModelRequest(model=WorkerModelCatalog.dev_text_model()),
+        context=None,
+    )
+    request = inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(request_id="req-structured-tools"),
+            model_handle=load_response.model_handle,
+            ext={
+                "melix.reasoning.mode": "enabled",
+                "melix.structured_output.mode": "json_schema",
+                "melix.tool_parser.mode": "qwen",
+            },
+            reasoning=common_pb2.ReasoningConfig(
+                enabled=True,
+                mode_source="request_enable_thinking",
+                effort="low",
+            ),
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(text="Use a tool")],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=16),
+        stream=True,
+    )
+
+    events = list(inference_service.Generate(request, context=None))
+    tool_call = next(event.tool_call_delta for event in events if event.HasField("tool_call_delta"))
+    token = next(event.token_delta for event in events if event.HasField("token_delta"))
+    completed = next(event.completed for event in events if event.HasField("completed"))
+
+    assert tool_call.tool_name == "search"
+    assert tool_call.arguments_json_fragment == '{"q":"one"}'
+    assert token.text == "visible"
+    assert completed.assistant_text == "visible"
+    assert completed.parser_metrics["stream_parser_request_context_mode"] == "tool_parser"
+    assert completed.parser_metrics["tool_call_markup_leak_count"] == "0"
+    assert completed.parser_metrics["reasoning_leak_count"] == "0"
+
+
 def test_generate_stream_flushes_short_visible_prefix_before_marker_hold() -> None:
     registry = WorkerRegistry(
         runtime=MLXTextRuntime(backend=ShortPrefixStreamingBackend()),

--- a/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
+++ b/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
@@ -27,11 +27,14 @@ def find_named_workflow_step(workflow: str, name: str) -> re.Match[str]:
 def find_run_workflow_step(workflow: str, name: str, command: str) -> re.Match[str]:
     match = re.search(
         rf"^[ \t]*-[ \t]+name:[ \t]+{re.escape(name)}[ \t]*\n"
-        rf"^[ \t]*run:[ \t]+{re.escape(command)}[ \t]*$",
+        r"(?P<body>.*?)(?=^[ \t]*-[ \t]+name:|\Z)",
         workflow,
-        flags=re.MULTILINE,
+        flags=re.MULTILINE | re.DOTALL,
     )
     assert match is not None, f"Workflow run step not found: {name}"
+    step = match.group(0)
+    assert re.search(r"^[ \t]*run:", step, flags=re.MULTILINE), f"Workflow run step missing run: {name}"
+    assert command in step, f"Workflow run step missing command: {name}"
     return match
 
 
@@ -218,9 +221,28 @@ def test_package_workflow_builds_required_swift_products_before_packaging_app() 
 
     previous_step_end = 0
     for build_step in build_steps:
-        assert previous_step_end < build_step.start()
+        assert previous_step_end <= build_step.start()
         assert build_step.end() < package_step.start()
+        assert "scripts/ci_progress.sh" in build_step.group(0)
         previous_step_end = build_step.end()
+
+
+def test_package_workflow_wraps_long_packaging_steps_with_ci_progress() -> None:
+    workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    progress_labels = [
+        "Package app bootstrap",
+        "Package app CLI build",
+        "Package app Swift text worker build",
+        "Package app menubar build",
+        "Package app smoke checks",
+        "Package app Python runtime sync",
+        "Package app build metadata",
+        "Package app bundle assembly",
+    ]
+
+    for label in progress_labels:
+        assert f'bash scripts/ci_progress.sh "{label}"' in workflow
 
 
 def test_main_resolves_default_build_outputs_and_prints_app_path(

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -152,6 +152,35 @@ def test_json_structured_output_strips_reasoning_prefix_before_first_json_delimi
     assert completed.metrics["reasoning_leak_count"] == 0
 
 
+def test_explicit_tool_parser_survives_structured_json_mode() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-json-tools",
+        reasoning_enabled=True,
+        structured_output_mode="json_schema",
+        tool_parser_mode="qwen",
+    )
+
+    deltas = assembler.accept(
+        StreamFragment(
+            raw_text=(
+                '<think>plan</think>'
+                '<tool_call>{"name":"search","arguments":{"q":"json"}}</tool_call>'
+                '{"answer":"done"}'
+            )
+        )
+    )
+    completed = assembler.completed()
+
+    assert [delta.reasoning_text for delta in deltas if delta.reasoning_text] == ["plan"]
+    calls = [delta.tool_call for delta in deltas if delta.tool_call]
+    assert [call.tool_name for call in calls] == ["search"]
+    assert [delta.content_text for delta in deltas if delta.content_text] == ['{"answer":"done"}']
+    assert completed.assistant_text == '{"answer":"done"}'
+    assert completed.metrics["stream_parser_request_context_mode"] == "tool_parser"
+    assert completed.metrics["tool_call_markup_leak_count"] == 0
+    assert completed.metrics["reasoning_leak_count"] == 0
+
+
 def test_bare_json_structured_output_mode_is_not_treated_as_json_only() -> None:
     assembler = RequestStreamAssembler(
         request_id="req-bare-json-mode",
@@ -220,7 +249,7 @@ def test_json_structured_output_without_json_delimiter_drops_hidden_prefix_on_co
         request_id="req-json-prefix",
         reasoning_enabled=False,
         structured_output_mode="json_schema",
-        tool_parser_mode="qwen",
+        tool_parser_mode="",
     )
 
     assert assembler.accept(StreamFragment(raw_text="<think>hidden preamble")) == []
@@ -433,6 +462,12 @@ def test_request_context_mode_marks_structured_json_and_plain_streams() -> None:
         request_id="req-structured-context",
         reasoning_enabled=False,
         structured_output_mode="json_schema",
+        tool_parser_mode="",
+    )
+    structured_with_tools = RequestStreamAssembler(
+        request_id="req-structured-tool-context",
+        reasoning_enabled=False,
+        structured_output_mode="json_schema",
         tool_parser_mode="qwen",
     )
     plain = RequestStreamAssembler(
@@ -443,4 +478,5 @@ def test_request_context_mode_marks_structured_json_and_plain_streams() -> None:
     )
 
     assert structured.completed().metrics["stream_parser_request_context_mode"] == "structured_json"
+    assert structured_with_tools.completed().metrics["stream_parser_request_context_mode"] == "tool_parser"
     assert plain.completed().metrics["stream_parser_request_context_mode"] == "plain"

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -89,14 +89,14 @@ class RequestStreamAssembler:
         if not delta:
             return []
 
-        if self._is_json_structured_output:
+        if self._is_json_only_structured_output:
             return self._accept_json_structured_output(delta)
 
         self._buffer += delta
         return self._drain_buffer(final=False)
 
     def completed(self) -> AssemblyCompletion:
-        if self._is_json_structured_output:
+        if self._is_json_only_structured_output:
             if not self._json_started:
                 self._metrics["reasoning_leak_count"] += int("<think" in self._buffer)
                 self._buffer = ""
@@ -114,15 +114,19 @@ class RequestStreamAssembler:
         return self._structured_output_mode in {"json_object", "json_schema"}
 
     @property
+    def _is_json_only_structured_output(self) -> bool:
+        return self._is_json_structured_output and not self._tool_parser_mode
+
+    @property
     def _tool_parsing_enabled(self) -> bool:
-        return bool(self._tool_parser_mode) and not self._is_json_structured_output
+        return bool(self._tool_parser_mode)
 
     @property
     def _request_context_mode(self) -> str:
-        if self._is_json_structured_output:
-            return "structured_json"
         if self._tool_parsing_enabled:
             return "tool_parser"
+        if self._is_json_structured_output:
+            return "structured_json"
         if self._reasoning_enabled:
             return "reasoning_only"
         return "plain"


### PR DESCRIPTION
## Summary
- Preserve explicit stream tool parsing when a request also carries `json_object` or `json_schema` structured-output metadata.
- Keep JSON-only cleanup scoped to requests that do not include `melix.tool_parser.mode`, so explicit tool-call streams still emit structured tool deltas instead of visible raw markup.
- Add assembler and worker Generate regressions, and update the issue #41 plan/runbook evidence.
- Stabilize the macOS menubar CI failures by waiting for the async local-server model refresh and flushing the first bursty chat presentation chunk immediately.
- Make long CI paths emit staged `[melix-ci] ... started/still running/completed` output, including Swift test sub-stages and package-app build/package stages.

Refs #41.

## Plan or Spec
- `docs/plans/2026-04-26-issue-41-structured-streaming-reasoning-continuity.md`
- `docs/runbooks/structured-streaming-reasoning-continuity.md`
- https://github.com/Keith-CY/melix/issues/41

## Commands Run
```text
git diff --check
# passed with no output

bash -n scripts/ci_progress.sh
# passed with no output

ruby -e "require 'yaml'; YAML.load_file('.github/workflows/package-self-contained-app.yml'); puts 'yaml ok'"
# yaml ok

bash scripts/ci_progress.sh "package workflow progress wrapper smoke" true
# [melix-ci] package workflow progress wrapper smoke started: true
# [melix-ci] package workflow progress wrapper smoke completed rc=0 elapsed=0s

make -n swift-test
# rendered the staged swift-test command successfully

bash scripts/ci_progress.sh "swift-test stage: smoke" true
# [melix-ci] swift-test stage: smoke started: true
# [melix-ci] swift-test stage: smoke completed rc=0 elapsed=0s

gh api repos/Keith-CY/melix/actions/jobs/74226417548/logs | rg "\[melix-ci\] swift-test stage: (protocol package|text worker package|control-plane core groups|control-plane request coordinator|macOS menubar package|control-plane OpenAI handler|control-plane REST compatibility|control-plane worker clients) (started|completed)|\[melix-ci\] Swift tests completed"
# confirmed staged Swift CI output, including protocol, text worker, control-plane, macOS menubar, and final Swift completion lines

gh pr view 362 --json headRefOid,mergeStateStatus,statusCheckRollup
# current head bc4c80d12403f555c95f71c79c4c6150be2f99b9; latest CI run is queued/in progress after rebasing onto origin/main

git fetch origin main
git rebase origin/main
# rebased onto origin/main at 6f07b896e; resolved the RuntimeViewModelTests conflict from the server model refresh test update

gh api repos/Keith-CY/melix/actions/jobs/74239506291/logs | rg "\[melix-ci\] Package app"
# confirmed package-app logs include started, still running, and completed progress lines for bootstrap, CLI build, Swift text worker build, menubar build, smoke checks, Python runtime sync, metadata, and bundle assembly

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py -q
# 10 passed in 0.04s

make py-test
# 1629 passed, 5 skipped, 2 warnings in 86.85s

HOME="$(pwd)/.swift-home/macos-menubar" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex/macos-menubar" xcrun swift test --package-path apps/macos-menubar --filter 'RuntimeViewModelTests/chatPromptSmoothsBurstyDeltasWhilePreservingFinalTranscriptFidelity'
# 1 test passed

HOME="$(pwd)/.swift-home/macos-menubar" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex/macos-menubar" xcrun swift test --package-path apps/macos-menubar --filter RuntimeViewModelTests
# 241 tests passed

HOME="$(pwd)/.swift-home/macos-menubar" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex/macos-menubar" xcrun swift test --package-path apps/macos-menubar --enable-code-coverage --filter RuntimeViewModelTests
python3 scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
# RuntimeViewModel.swift 100% (3/3), RuntimeViewModelTests.swift 100% (7/7), TOTAL 100% (10/10)

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python --extra mlx coverage erase
PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python --extra mlx coverage run --branch --source=worker -m pytest services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_generate_stream.py -q
PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python --extra mlx coverage report --include="*/worker/runtime/stream_assembler.py"
# 31 passed in 0.26s; stream_assembler.py 96% coverage

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_generate_stream.py -q
# 31 passed in 0.21s
```

## Coverage and Metrics
- Changed executable scope: `services/mlx-worker-python/worker/runtime/stream_assembler.py`, `apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift`
- Python coverage: 96% line/branch coverage for `stream_assembler.py` from the focused coverage command.
- Swift changed-line coverage: 100% for the macOS menubar source/test lines touched by the CI fix.
- Workflow progress metrics:
  - `make swift-test` emits `[melix-ci] swift-test stage: ... started/completed` lines for Swift package and RequestCoordinator specifier progress.
  - `package-self-contained-app` now emits `[melix-ci] Package app ... started/still running/completed` lines around bootstrap, Swift builds, smoke checks, Python runtime sync, metadata, and bundle assembly.
- Regression metrics asserted:
  - explicit structured-output tool streams report `stream_parser_request_context_mode=tool_parser`
  - `tool_call_markup_leak_count=0`
  - `reasoning_leak_count=0`

## Known Gaps
- `make bootstrap`, `make proto`, full `make swift-test`, and `make integration-test` were not rerun locally after the CI hardening patch. The Swift failure was reproduced through the failing tests and covered by the full `RuntimeViewModelTests` suite plus changed-line coverage.
- The latest GitHub Actions run for head `bc4c80d12403f555c95f71c79c4c6150be2f99b9` is queued/in progress after rebasing onto latest `origin/main`.
- The only expected non-success status is `WIP`, which remains in progress while the pull request is draft.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
