### PR TITLE
[codex] Stabilize server model refresh test

### DIFF
--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -5908,7 +5908,13 @@ struct RuntimeViewModelTests {
         viewModel.beginServerCreation(kind: .localServer)
 
         #expect(viewModel.isRefreshingServerModelOptions)
-        try await Task.sleep(for: .milliseconds(80))
+        try await waitForRuntimeViewModelCondition("expected registry-backed server model options to refresh") {
+            viewModel.isRefreshingServerModelOptions == false
+                && viewModel.serverModelOptions.map(\.modelID) == [
+                    "unsloth/gemma-4-E4B-it-MLX-8bit",
+                ]
+                && viewModel.newLocalServerModelID == "unsloth/gemma-4-E4B-it-MLX-8bit"
+        }
 
         #expect(viewModel.isRefreshingServerModelOptions == false)
         #expect(viewModel.serverModelOptions.map(\.modelID) == [

--- a/docs/plans/2026-05-04-issue-347-lora-training-studio.md
+++ b/docs/plans/2026-05-04-issue-347-lora-training-studio.md
@@ -125,3 +125,15 @@ forward into existing activation and post-training surfaces.
 - Review follow-up changed-line coverage:
   - Root LoRA store scope: 100.00% (140/140).
   - macOS menubar review scope: 98.29% (115/117).
+- Post-review CI stabilization verification:
+  - `swift test --package-path apps/macos-menubar --enable-code-coverage
+    --filter localServerCreationRefreshesReadyModelOptionsFromRegistryWhenCatalogIsEmpty`
+    passed 1 test.
+  - `swift test --package-path apps/macos-menubar --enable-code-coverage
+    --filter "RuntimeViewModelTests|DesktopFoundationViewTests"`
+    passed 420 tests.
+  - `make swift-test` passed.
+  - `git diff --check` passed.
+- Post-review CI stabilization changed-line coverage:
+  - Follow-up scope: 100.00% (7/7 executable changed lines; plan document
+    lines are non-executable).


### PR DESCRIPTION
## Summary
- Follow up on #363 after it merged before the final CI-stabilization commit could land there.
- Replace the fixed sleep in the registry-backed local-server model refresh test with an explicit wait for async refresh completion and hydrated model selection state.
- Update the LoRA training studio plan with the follow-up verification evidence.

## Plan or Spec
- `docs/plans/2026-05-04-issue-347-lora-training-studio.md`

## Commands Run
```text
git diff --check
-> passed

HOME="$PWD/.swift-home/menubar" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/menubar" xcrun swift test --package-path apps/macos-menubar --enable-code-coverage --filter localServerCreationRefreshesReadyModelOptionsFromRegistryWhenCatalogIsEmpty
-> passed 1 test

HOME="$PWD/.swift-home/menubar" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/menubar" xcrun swift test --package-path apps/macos-menubar --enable-code-coverage --filter "RuntimeViewModelTests|DesktopFoundationViewTests"
-> passed 420 tests

python3 scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift docs/plans/2026-05-04-issue-347-lora-training-studio.md
-> TOTAL 100.00% (7/7)
```

## Coverage and Metrics
- Follow-up changed-line coverage: 100.00% (7/7 executable changed lines; plan document lines are non-executable).
- Metrics report: N/A for runtime metrics because this is a test-only stabilization plus plan evidence update; determinism is covered by the registry-backed local-server refresh test waiting for the async state transition and model selection result.

## Known Gaps
- #363 is already merged; this PR intentionally carries only the CI-stabilization follow-up.
- Existing dirty screenshot artifacts under `artifacts/lora-marketing-screenshots/2026-04-24-polish/` are not part of this PR.
- No runtime behavior, protocol schema, or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. (N/A: no runtime behavior change; verification evidence updated.)
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol schema changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
