### PR TITLE
Implement Issue 365 offline preference trainer routing

### DIFF
--- a/docs/plans/2026-05-05-issue-365-offline-preference-trainers.md
+++ b/docs/plans/2026-05-05-issue-365-offline-preference-trainers.md
@@ -21,10 +21,10 @@ returns objective-specific metrics that the alignment manifest records.
 
 ## Completion Boundary
 
-This plan does not close #365. It covers only Slice 2: offline DPO, ORPO, and
-CPO trainer execution. GRPO, RLHF/#366, PTQ/QAT real local inference evidence,
-full CLI chain acceptance, and Window real-runtime acceptance remain separate
-Issue 365 slices.
+This plan does not complete all #365 acceptance criteria. It covers only Slice
+2: offline DPO, ORPO, and CPO trainer execution. GRPO, RLHF/#366, PTQ/QAT real
+local inference evidence, full CLI chain acceptance, and Window real-runtime
+acceptance remain separate Issue 365 slices.
 
 ## Files
 
@@ -463,11 +463,12 @@ section in this plan.
 - Native preference trainer wiring test with patched MLX-LM trainer:
   `1 passed, 2 warnings in 0.86s`.
 - Focused Python regression after native preference trainer routing:
-  `134 passed, 2 warnings in 2.91s`.
+  `139 passed, 2 warnings in 3.13s`.
 - Coverage run after native preference trainer routing:
-  `134 passed, 2 warnings in 3.44s`.
+  `139 passed, 2 warnings in 3.44s`.
 - Python changed-line coverage after native preference trainer routing:
-  `96.22% (764/794)`.
+  `97.21% (557/573)` after refreshing `origin/main` to include merged
+  PR #368.
 - `git diff --check` after native preference trainer routing: passed.
 
 ## Remaining Issue 365 Gaps After This Plan

--- a/docs/plans/2026-05-05-issue-365-offline-preference-trainers.md
+++ b/docs/plans/2026-05-05-issue-365-offline-preference-trainers.md
@@ -1,0 +1,465 @@
+# Issue 365 Offline Preference Trainers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the first real local DPO, ORPO, and CPO trainer execution
+paths for Issue 365 instead of manifest-only alignment placeholders.
+
+**Architecture:** Keep supervised LoRA/QLoRA/DoRA execution in
+`MLXLMRunner.train_native` through `mlx_lm.lora.train_model`, and add a
+separate worker-side preference trainer module for `preference_pair` datasets.
+The preference trainer uses MLX-LM's lower-level tuner primitives with
+algorithm-specific loss functions, writes normal adapter weights/config, and
+returns objective-specific metrics that the alignment manifest records.
+
+**Tech Stack:** Python worker, MLX/MLX-LM 0.31.x tuner primitives,
+`pytest`, `coverage`, `scripts/python_changed_line_coverage.py`.
+
+---
+
+## Completion Boundary
+
+This plan does not close #365. It covers only Slice 2: offline DPO, ORPO, and
+CPO trainer execution. GRPO, RLHF/#366, PTQ/QAT real local inference evidence,
+full CLI chain acceptance, and Window real-runtime acceptance remain separate
+Issue 365 slices.
+
+## Files
+
+- Create: `services/mlx-worker-python/worker/model_ops/preference_training.py`
+  - Owns preference-pair tokenization, batching, losses, MLX-LM trainer wiring,
+    adapter config writing, and preference metrics.
+- Modify: `services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py`
+  - Routes `training_objective=preference` to the new preference trainer and
+    keeps `alignment_rl` guarded until GRPO/RLHF are implemented.
+- Modify: `services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py`
+  - Copies preference trainer metrics into `melix.alignment_run.v1`.
+- Modify: `services/mlx-worker-python/worker/model_ops/deterministic_lora_runner.py`
+  - Keeps deterministic contract behavior explicit for tests.
+- Modify: `services/mlx-worker-python/tests/test_lora_model_ops_unit.py`
+  - Adds pure unit coverage for preference dataset parsing, serialization, and
+    runner routing.
+- Modify: `services/mlx-worker-python/tests/test_lora_model_ops.py`
+  - Adds worker pipeline assertions for real preference metrics in manifests.
+- Modify: `docs/plans/2026-05-05-issue-365-offline-preference-trainers.md`
+  - Records implementation evidence and remaining gaps.
+
+## Algorithm Contracts
+
+- DPO loss:
+  `-log_sigmoid(beta * ((logp_chosen - logp_rejected) - (logp_ref_chosen - logp_ref_rejected)))`
+- ORPO loss:
+  `chosen_nll + beta * -log_sigmoid(logp_chosen - logp_rejected)`
+- CPO loss:
+  `-log_sigmoid(beta * ((logp_chosen - logp_rejected) - margin_target))`
+
+Use `alignment.kl_penalty` as `beta` when it is greater than zero; otherwise use
+`0.1`. Use `preference_margin_target` from request ext when present; otherwise
+use `0.0` for CPO. DPO loads `reference_model_path` when provided, otherwise it
+uses a frozen base-model reference loaded from the same source model path.
+
+## Task 1: Preference Metrics Shape
+
+**Files:**
+
+- Modify: `services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py`
+- Test: `services/mlx-worker-python/tests/test_lora_model_ops_unit.py`
+
+- [x] **Step 1: Write the failing metrics serialization test**
+
+Add this test near the existing training request serialization tests:
+
+```python
+def test_training_metrics_serializes_preference_fields(tmp_path: Path) -> None:
+    metrics = mlx_lm_runner_module.TrainingMetrics(
+        job_duration_ms=10.0,
+        tokens_seen=4,
+        examples_seen=2,
+        loss_final=0.4,
+        loss_best=0.3,
+        learning_rate_final=1e-4,
+        preference_loss_final=0.2,
+        chosen_logprob_mean=-1.5,
+        rejected_logprob_mean=-2.0,
+        chosen_rejected_margin=0.5,
+        win_rate_proxy=1.0,
+    )
+    result = mlx_lm_runner_module.TrainingResult(
+        weights_path=tmp_path / "adapters.safetensors",
+        adapter_config_path=tmp_path / "adapter_config.json",
+        metrics=metrics,
+        execution_backend="native",
+    )
+
+    restored = mlx_lm_runner_module._deserialize_training_result(
+        mlx_lm_runner_module._serialize_training_result(result)
+    )
+
+    assert restored.metrics.preference_loss_final == pytest.approx(0.2)
+    assert restored.metrics.chosen_logprob_mean == pytest.approx(-1.5)
+    assert restored.metrics.rejected_logprob_mean == pytest.approx(-2.0)
+    assert restored.metrics.chosen_rejected_margin == pytest.approx(0.5)
+    assert restored.metrics.win_rate_proxy == pytest.approx(1.0)
+```
+
+- [x] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_training_metrics_serializes_preference_fields
+```
+
+Expected: fails with `TypeError` for unknown `TrainingMetrics` keyword.
+
+- [x] **Step 3: Add metrics fields**
+
+Add these defaulted fields to `TrainingMetrics`:
+
+```python
+    preference_loss_final: float = 0.0
+    chosen_logprob_mean: float = 0.0
+    rejected_logprob_mean: float = 0.0
+    chosen_rejected_margin: float = 0.0
+    win_rate_proxy: float = 0.0
+```
+
+- [x] **Step 4: Verify the test passes**
+
+Run the same pytest command. Expected: `1 passed`.
+
+## Task 2: Preference Trainer Module
+
+**Files:**
+
+- Create: `services/mlx-worker-python/worker/model_ops/preference_training.py`
+- Test: `services/mlx-worker-python/tests/test_lora_model_ops_unit.py`
+
+- [x] **Step 1: Write failing unit tests for dataset loading and objective config**
+
+Add tests that create `train.jsonl` with `prompt/chosen/rejected`, call
+`load_preference_pairs(...)`, and assert:
+
+```python
+assert pairs[0].prompt == "Choose."
+assert pairs[0].chosen == "Helpful."
+assert pairs[0].rejected == "Unsafe."
+assert resolve_preference_beta(config) == pytest.approx(0.1)
+```
+
+Also add a CPO request with `preference_margin_target="0.25"` and assert the
+resolved margin is `0.25`.
+
+- [x] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'preference_pairs or preference_beta'
+```
+
+Expected: import failure because `preference_training.py` does not exist.
+
+- [x] **Step 3: Implement the module skeleton**
+
+Create:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+
+from worker.model_ops.errors import ModelOperationError
+from worker.model_ops.training_config import LoRATrainingConfig
+
+
+@dataclass(frozen=True)
+class PreferencePair:
+    prompt: str
+    chosen: str
+    rejected: str
+
+
+@dataclass(frozen=True)
+class PreferenceObjectiveConfig:
+    algorithm: str
+    beta: float
+    margin_target: float = 0.0
+
+
+def load_preference_pairs(dataset_dir: Path) -> list[PreferencePair]:
+    path = dataset_dir / "train.jsonl"
+    pairs: list[PreferencePair] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            sample = json.loads(line)
+            try:
+                pairs.append(
+                    PreferencePair(
+                        prompt=str(sample["prompt"]),
+                        chosen=str(sample["chosen"]),
+                        rejected=str(sample["rejected"]),
+                    )
+                )
+            except KeyError as exc:
+                raise ModelOperationError(
+                    code="invalid_dataset_package",
+                    message="preference_pair training rows must include prompt, chosen, and rejected.",
+                    details={"line_number": str(line_number), "missing_field": str(exc.args[0])},
+                ) from exc
+    if not pairs:
+        raise ModelOperationError(
+            code="invalid_dataset_package",
+            message="preference_pair training requires at least one training pair.",
+        )
+    return pairs
+
+
+def resolve_preference_objective(config: LoRATrainingConfig) -> PreferenceObjectiveConfig:
+    if config.alignment is None:
+        raise ModelOperationError(
+            code="invalid_alignment_config",
+            message="preference training requires alignment config.",
+        )
+    beta = config.alignment.kl_penalty if config.alignment.kl_penalty > 0 else 0.1
+    return PreferenceObjectiveConfig(
+        algorithm=config.alignment.alignment_algorithm,
+        beta=beta,
+        margin_target=0.0,
+    )
+```
+
+- [x] **Step 4: Verify skeleton tests pass**
+
+Run the same pytest command. Expected: targeted tests pass.
+
+## Task 3: Native Preference Trainer Routing
+
+**Files:**
+
+- Modify: `services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py`
+- Modify: `services/mlx-worker-python/worker/model_ops/preference_training.py`
+- Test: `services/mlx-worker-python/tests/test_lora_model_ops_unit.py`
+
+- [ ] **Step 1: Write failing routing test**
+
+Add a test that monkeypatches `preference_training.train_preference_native` to
+write adapter files and return metrics. Assert `MLXLMRunner().train(...)` for
+`training_mode=dpo` returns `execution_backend="native"` and does not raise
+`unsupported_alignment_trainer`.
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_mlx_lm_runner_routes_preference_training_to_preference_backend
+```
+
+Expected: fails with `unsupported_alignment_trainer`.
+
+- [ ] **Step 3: Implement routing**
+
+In `MLXLMRunner.supports_alignment_training`, return true only for
+`training_objective == "preference"`. Keep `alignment_rl` guarded.
+
+In `MLXLMRunner.train_native`, before supervised MLX-LM dataset loading:
+
+```python
+if request.config.training_objective == "preference":
+    from worker.model_ops.preference_training import train_preference_native
+
+    return train_preference_native(request)
+```
+
+- [ ] **Step 4: Verify routing test passes**
+
+Run the same pytest command. Expected: `1 passed`.
+
+## Task 4: MLX Preference Loss Implementation
+
+**Files:**
+
+- Modify: `services/mlx-worker-python/worker/model_ops/preference_training.py`
+- Test: `services/mlx-worker-python/tests/test_lora_model_ops_unit.py`
+
+- [x] **Step 1: Add pure loss tests with fake arrays**
+
+Add tests for `dpo_loss_values`, `orpo_loss_values`, and `cpo_loss_values`
+using small numeric margins. Assert chosen margins lower the loss and rejected
+margins raise it.
+
+- [x] **Step 2: Run failing loss tests**
+
+Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'dpo_loss_values or orpo_loss_values or cpo_loss_values'
+```
+
+Expected: fails because loss helpers do not exist.
+
+- [x] **Step 3: Implement stable scalar helpers**
+
+Implement scalar helpers first so behavior is testable without MLX:
+
+```python
+import math
+
+
+def _log_sigmoid(value: float) -> float:
+    if value >= 0:
+        return -math.log1p(math.exp(-value))
+    return value - math.log1p(math.exp(value))
+
+
+def dpo_loss_value(policy_margin: float, reference_margin: float, beta: float) -> float:
+    return -_log_sigmoid(beta * (policy_margin - reference_margin))
+
+
+def orpo_loss_value(chosen_nll: float, policy_margin: float, beta: float) -> float:
+    return chosen_nll - beta * _log_sigmoid(policy_margin)
+
+
+def cpo_loss_value(policy_margin: float, beta: float, margin_target: float) -> float:
+    return -_log_sigmoid(beta * (policy_margin - margin_target))
+```
+
+- [ ] **Step 4: Implement MLX loss closure**
+
+Add MLX equivalents that compute chosen/rejected sequence logprobs from model
+logits and select DPO/ORPO/CPO based on `PreferenceObjectiveConfig.algorithm`.
+The loss closure must return `(loss, token_count)` in the shape expected by
+`mlx_lm.tuner.trainer.train`.
+
+- [ ] **Step 5: Verify tests pass**
+
+Run the same pytest command. Expected: loss tests pass.
+
+## Task 5: Adapter Output And Metrics
+
+**Files:**
+
+- Modify: `services/mlx-worker-python/worker/model_ops/preference_training.py`
+- Modify: `services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py`
+- Test: `services/mlx-worker-python/tests/test_lora_model_ops.py`
+
+- [x] **Step 1: Write failing manifest metrics test**
+
+Extend the existing DPO/ORPO/CPO parametrized pipeline test to assert:
+
+```python
+assert alignment_payload["metrics"]["preference_loss_final"] == pytest.approx(0.2)
+assert alignment_payload["metrics"]["chosen_logprob_mean"] == pytest.approx(-1.5)
+assert alignment_payload["metrics"]["rejected_logprob_mean"] == pytest.approx(-2.0)
+assert alignment_payload["metrics"]["chosen_rejected_margin"] == pytest.approx(0.5)
+assert alignment_payload["metrics"]["win_rate_proxy"] == pytest.approx(1.0)
+```
+
+- [x] **Step 2: Run failing pipeline test**
+
+Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_preference_mode_contracts
+```
+
+Expected: fails because metrics are not copied into alignment manifest.
+
+- [x] **Step 3: Copy metrics into alignment manifest**
+
+In `_alignment_manifest_payload`, when `dataset_contract == "preference_pair"`,
+populate preference metrics from `training_result.metrics` instead of static
+zero defaults.
+
+- [x] **Step 4: Verify pipeline test passes**
+
+Run the same pytest command. Expected: `3 passed`.
+
+## Task 6: Verification And Evidence
+
+**Files:**
+
+- Modify: `docs/plans/2026-05-05-issue-365-offline-preference-trainers.md`
+
+- [ ] **Step 1: Run focused regression**
+
+Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_lora_model_ops.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run coverage**
+
+Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_lora_model_ops.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-offline-preference-trainers-coverage.json
+python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-offline-preference-trainers-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/preference_training.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+```
+
+Expected: changed-line coverage is at least `95.00%`.
+
+- [ ] **Step 3: Run diff check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Update implementation evidence**
+
+Append the exact command outcomes under a new `## Implementation Evidence`
+section in this plan.
+
+## Implementation Evidence
+
+- Baseline in isolated worktree before this slice:
+  `119 passed in 4.01s`.
+- Failing metrics serialization test:
+  failed with `TrainingMetrics.__init__() got an unexpected keyword argument
+  'preference_loss_final'`.
+- Targeted metrics serialization test after implementation:
+  `1 passed in 0.05s`.
+- Failing manifest metrics test:
+  failed with missing `preference_loss_final` in alignment manifest metrics.
+- Targeted metrics and manifest tests after implementation:
+  `4 passed in 0.38s`.
+- Failing preference module tests:
+  failed with `ModuleNotFoundError: No module named
+  'worker.model_ops.preference_training'`.
+- Targeted preference module tests after implementation:
+  `6 passed, 55 deselected in 0.11s`.
+- CPO margin-target config test:
+  `2 passed in 0.10s`.
+- Focused Python regression:
+  `128 passed in 2.49s`.
+- Coverage run:
+  `128 passed in 2.39s`.
+- Python changed-line coverage:
+  `100.00% (464/464)`.
+- `git diff --check`: passed.
+
+## Remaining Issue 365 Gaps After This Plan
+
+- GRPO candidate generation, scoring, and policy updates.
+- RLHF reward-model-backed policy optimization from #366.
+- PTQ/QAT real local inference and quality/latency/size gate evidence.
+- Complete CLI chain tests with real local runtime evidence for every business
+  line.
+- Window UI runnable/inspectable acceptance with real local runtime evidence
+  for every business line.

--- a/docs/plans/2026-05-05-issue-365-offline-preference-trainers.md
+++ b/docs/plans/2026-05-05-issue-365-offline-preference-trainers.md
@@ -119,11 +119,11 @@ Expected: fails with `TypeError` for unknown `TrainingMetrics` keyword.
 Add these defaulted fields to `TrainingMetrics`:
 
 ```python
-    preference_loss_final: float = 0.0
-    chosen_logprob_mean: float = 0.0
-    rejected_logprob_mean: float = 0.0
-    chosen_rejected_margin: float = 0.0
-    win_rate_proxy: float = 0.0
+    preference_loss_final: float | None = None
+    chosen_logprob_mean: float | None = None
+    rejected_logprob_mean: float | None = None
+    chosen_rejected_margin: float | None = None
+    win_rate_proxy: float | None = None
 ```
 
 - [x] **Step 4: Verify the test passes**
@@ -377,7 +377,9 @@ Expected: fails because metrics are not copied into alignment manifest.
 
 In `_alignment_manifest_payload`, when `dataset_contract == "preference_pair"`,
 populate preference metrics from `training_result.metrics` instead of static
-zero defaults.
+zero defaults. Keep the config-time loss selector under
+`preference_loss_config` so manifest consumers can distinguish the requested
+objective from the observed `preference_loss_final` scalar.
 
 - [x] **Step 4: Verify pipeline test passes**
 
@@ -470,6 +472,15 @@ section in this plan.
   `97.21% (557/573)` after refreshing `origin/main` to include merged
   PR #368.
 - `git diff --check` after native preference trainer routing: passed.
+- PR #369 review follow-up targeted tests:
+  `8 passed, 2 warnings in 1.18s`.
+- Focused Python regression after PR #369 review follow-up:
+  `142 passed, 2 warnings in 3.49s`.
+- Coverage run after PR #369 review follow-up:
+  `142 passed, 2 warnings in 4.03s`.
+- Python changed-line coverage after PR #369 review follow-up:
+  `97.88% (600/613)`.
+- `git diff --check` after PR #369 review follow-up: passed.
 
 ## Remaining Issue 365 Gaps After This Plan
 

--- a/docs/plans/2026-05-05-issue-365-offline-preference-trainers.md
+++ b/docs/plans/2026-05-05-issue-365-offline-preference-trainers.md
@@ -248,14 +248,14 @@ Run the same pytest command. Expected: targeted tests pass.
 - Modify: `services/mlx-worker-python/worker/model_ops/preference_training.py`
 - Test: `services/mlx-worker-python/tests/test_lora_model_ops_unit.py`
 
-- [ ] **Step 1: Write failing routing test**
+- [x] **Step 1: Write failing routing test**
 
 Add a test that monkeypatches `preference_training.train_preference_native` to
 write adapter files and return metrics. Assert `MLXLMRunner().train(...)` for
 `training_mode=dpo` returns `execution_backend="native"` and does not raise
 `unsupported_alignment_trainer`.
 
-- [ ] **Step 2: Run the failing test**
+- [x] **Step 2: Run the failing test**
 
 Run:
 
@@ -265,7 +265,7 @@ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" 
 
 Expected: fails with `unsupported_alignment_trainer`.
 
-- [ ] **Step 3: Implement routing**
+- [x] **Step 3: Implement routing**
 
 In `MLXLMRunner.supports_alignment_training`, return true only for
 `training_objective == "preference"`. Keep `alignment_rl` guarded.
@@ -279,7 +279,7 @@ if request.config.training_objective == "preference":
     return train_preference_native(request)
 ```
 
-- [ ] **Step 4: Verify routing test passes**
+- [x] **Step 4: Verify routing test passes**
 
 Run the same pytest command. Expected: `1 passed`.
 
@@ -332,14 +332,14 @@ def cpo_loss_value(policy_margin: float, beta: float, margin_target: float) -> f
     return -_log_sigmoid(beta * (policy_margin - margin_target))
 ```
 
-- [ ] **Step 4: Implement MLX loss closure**
+- [x] **Step 4: Implement MLX loss closure**
 
 Add MLX equivalents that compute chosen/rejected sequence logprobs from model
 logits and select DPO/ORPO/CPO based on `PreferenceObjectiveConfig.algorithm`.
 The loss closure must return `(loss, token_count)` in the shape expected by
 `mlx_lm.tuner.trainer.train`.
 
-- [ ] **Step 5: Verify tests pass**
+- [x] **Step 5: Verify tests pass**
 
 Run the same pytest command. Expected: loss tests pass.
 
@@ -389,7 +389,7 @@ Run the same pytest command. Expected: `3 passed`.
 
 - Modify: `docs/plans/2026-05-05-issue-365-offline-preference-trainers.md`
 
-- [ ] **Step 1: Run focused regression**
+- [x] **Step 1: Run focused regression**
 
 Run:
 
@@ -399,7 +399,7 @@ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" 
 
 Expected: all tests pass.
 
-- [ ] **Step 2: Run coverage**
+- [x] **Step 2: Run coverage**
 
 Run:
 
@@ -411,7 +411,7 @@ python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-of
 
 Expected: changed-line coverage is at least `95.00%`.
 
-- [ ] **Step 3: Run diff check**
+- [x] **Step 3: Run diff check**
 
 Run:
 
@@ -421,7 +421,7 @@ git diff --check
 
 Expected: no output.
 
-- [ ] **Step 4: Update implementation evidence**
+- [x] **Step 4: Update implementation evidence**
 
 Append the exact command outcomes under a new `## Implementation Evidence`
 section in this plan.
@@ -453,6 +453,22 @@ section in this plan.
 - Python changed-line coverage:
   `100.00% (464/464)`.
 - `git diff --check`: passed.
+- Failing preference routing test:
+  failed because `worker.model_ops.preference_training` had no
+  `train_preference_native` entry point.
+- Targeted preference routing and alignment-RL guard tests after implementation:
+  `2 passed in 0.05s`.
+- Targeted MLX preference loss and objective metrics tests:
+  `4 passed, 64 deselected in 1.60s`.
+- Native preference trainer wiring test with patched MLX-LM trainer:
+  `1 passed, 2 warnings in 0.86s`.
+- Focused Python regression after native preference trainer routing:
+  `134 passed, 2 warnings in 2.91s`.
+- Coverage run after native preference trainer routing:
+  `134 passed, 2 warnings in 3.44s`.
+- Python changed-line coverage after native preference trainer routing:
+  `96.22% (764/794)`.
+- `git diff --check` after native preference trainer routing: passed.
 
 ## Remaining Issue 365 Gaps After This Plan
 

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -855,6 +855,8 @@ def test_train_lora_supports_preference_mode_contracts(
     assert alignment_payload["alignment_algorithm"] == training_mode
     assert alignment_payload["dataset_contract"] == "preference_pair"
     assert alignment_payload["adapter_manifest_path"] == payload["artifact_path"]
+    assert "preference_loss" not in alignment_payload["metrics"]
+    assert alignment_payload["metrics"]["preference_loss_config"] == training_mode
     assert alignment_payload["metrics"]["preference_loss_final"] == pytest.approx(0.2)
     assert alignment_payload["metrics"]["chosen_logprob_mean"] == pytest.approx(-1.5)
     assert alignment_payload["metrics"]["rejected_logprob_mean"] == pytest.approx(-2.0)

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -202,6 +202,15 @@ class SuccessfulRunner(MLXLMRunner):
             + "\n",
             encoding="utf-8",
         )
+        preference_metrics = {}
+        if request.config.training_objective == "preference":
+            preference_metrics = {
+                "preference_loss_final": 0.2,
+                "chosen_logprob_mean": -1.5,
+                "rejected_logprob_mean": -2.0,
+                "chosen_rejected_margin": 0.5,
+                "win_rate_proxy": 1.0,
+            }
         return TrainingResult(
             weights_path=weights_path,
             adapter_config_path=adapter_config_path,
@@ -218,6 +227,7 @@ class SuccessfulRunner(MLXLMRunner):
                 resume_source_path=str(request.resume_source_path or ""),
                 tokens_per_second=128.5,
                 peak_memory_gb=5.25,
+                **preference_metrics,
             ),
             execution_backend="native",
         )
@@ -845,8 +855,11 @@ def test_train_lora_supports_preference_mode_contracts(
     assert alignment_payload["alignment_algorithm"] == training_mode
     assert alignment_payload["dataset_contract"] == "preference_pair"
     assert alignment_payload["adapter_manifest_path"] == payload["artifact_path"]
-    assert "chosen_rejected_margin" in alignment_payload["metrics"]
-    assert "win_rate_proxy" in alignment_payload["metrics"]
+    assert alignment_payload["metrics"]["preference_loss_final"] == pytest.approx(0.2)
+    assert alignment_payload["metrics"]["chosen_logprob_mean"] == pytest.approx(-1.5)
+    assert alignment_payload["metrics"]["rejected_logprob_mean"] == pytest.approx(-2.0)
+    assert alignment_payload["metrics"]["chosen_rejected_margin"] == pytest.approx(0.5)
+    assert alignment_payload["metrics"]["win_rate_proxy"] == pytest.approx(1.0)
     assert normalized_dataset_payload["format"] == "preference_pair"
     assert runner.last_train_request is not None
     assert runner.last_train_request.dataset_format == "preference_pair"

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -297,6 +297,31 @@ def test_training_metrics_serializes_preference_fields(tmp_path: Path) -> None:
     assert restored.metrics.win_rate_proxy == pytest.approx(1.0)
 
 
+def test_training_metrics_serializes_absent_preference_fields_as_null(tmp_path: Path) -> None:
+    metrics = mlx_lm_runner_module.TrainingMetrics(
+        job_duration_ms=10.0,
+        tokens_seen=4,
+        examples_seen=2,
+        loss_final=0.4,
+        loss_best=0.3,
+        learning_rate_final=1e-4,
+    )
+    result = mlx_lm_runner_module.TrainingResult(
+        weights_path=tmp_path / "adapters.safetensors",
+        adapter_config_path=tmp_path / "adapter_config.json",
+        metrics=metrics,
+        execution_backend="native",
+    )
+
+    payload = mlx_lm_runner_module._serialize_training_result(result)
+    restored = mlx_lm_runner_module._deserialize_training_result(payload)
+
+    assert payload["metrics"]["preference_loss_final"] is None
+    assert payload["metrics"]["win_rate_proxy"] is None
+    assert restored.metrics.preference_loss_final is None
+    assert restored.metrics.win_rate_proxy is None
+
+
 def test_preference_training_loads_preference_pairs(tmp_path: Path) -> None:
     from worker.model_ops.preference_training import load_preference_pairs
 
@@ -320,6 +345,28 @@ def test_preference_training_loads_preference_pairs(tmp_path: Path) -> None:
     assert pairs[0].prompt == "Choose."
     assert pairs[0].chosen == "Helpful."
     assert pairs[0].rejected == "Unsafe."
+
+
+def test_preference_examples_seen_prefers_callback_count(tmp_path: Path) -> None:
+    from worker.model_ops.preference_training import (
+        PreferenceMetricsCollector,
+        _preference_examples_seen,
+    )
+
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"training_mode": "orpo", "batch_size": "2", "iters": "3"},
+        dataset_format="preference_pair",
+        response_only_supported=False,
+        sample_count=6,
+    )
+    collector = PreferenceMetricsCollector()
+
+    assert _preference_examples_seen(collector=collector, config=config) == 6
+
+    collector.on_train_loss_report({"examples_seen": 5})
+
+    assert _preference_examples_seen(collector=collector, config=config) == 5
 
 
 def test_preference_training_rejects_missing_or_empty_train_file(tmp_path: Path) -> None:
@@ -645,6 +692,47 @@ def test_preference_training_iterate_batches_rejects_too_small_dataset() -> None
         next(iterate_preference_batches(dataset, batch_size=2, max_seq_length=16))
 
 
+def test_preference_training_iterate_batches_rejects_distributed_sharding() -> None:
+    pytest.importorskip("mlx.core")
+    from worker.model_ops.preference_training import (
+        PreferencePair,
+        PreferenceTokenDataset,
+        iterate_preference_batches,
+    )
+
+    class SimpleTokenizer:
+        eos_token_id = 4
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            del add_special_tokens
+            return {
+                "Prompt": [0],
+                "Good": [2],
+                "Bad": [3],
+            }[text]
+
+    class FakeCommGroup:
+        pass
+
+    dataset = PreferenceTokenDataset(
+        [
+            PreferencePair(prompt="Prompt", chosen="Good", rejected="Bad"),
+            PreferencePair(prompt="Prompt", chosen="Good", rejected="Bad"),
+        ],
+        SimpleTokenizer(),
+    )
+
+    with pytest.raises(NotImplementedError, match="Distributed preference batch sharding"):
+        next(
+            iterate_preference_batches(
+                dataset,
+                batch_size=2,
+                max_seq_length=16,
+                comm_group=FakeCommGroup(),
+            )
+        )
+
+
 def test_preference_training_tokenizes_chat_template_and_text_fallbacks() -> None:
     from worker.model_ops.preference_training import PreferencePair, PreferenceTokenDataset
 
@@ -760,6 +848,7 @@ def test_train_preference_native_wires_mlx_lm_trainer_and_metrics(
                 "train_loss": 0.31,
                 "learning_rate": 0.0002,
                 "trained_tokens": 12,
+                "trained_examples": 7,
                 "tokens_per_second": 34.0,
             }
         )
@@ -832,9 +921,11 @@ def test_train_preference_native_wires_mlx_lm_trainer_and_metrics(
     ]
     assert calls["lora_converted"] is True
     assert calls["trainer_args"].batch_size == 1
+    assert calls["trainer_args"].steps_per_eval == 0
     assert result.weights_path.read_bytes() == b"trained-preference-adapter"
     assert result.adapter_config_path.is_file()
     assert result.metrics.tokens_seen == 12
+    assert result.metrics.examples_seen == 7
     assert result.metrics.learning_rate_final == pytest.approx(0.0002)
     assert result.metrics.preference_loss_final == pytest.approx(0.2)
     assert result.metrics.chosen_rejected_margin == pytest.approx(0.5)

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -444,6 +444,16 @@ def test_orpo_and_cpo_loss_values_reward_positive_margins() -> None:
     )
 
 
+def test_preference_metrics_collector_records_validation_loss() -> None:
+    from worker.model_ops.preference_training import PreferenceMetricsCollector
+
+    collector = PreferenceMetricsCollector()
+
+    collector.on_val_loss_report({"val_loss": 0.27})
+
+    assert collector.losses == [pytest.approx(0.27)]
+
+
 def test_preference_training_mlx_loss_components_reward_chosen_sequence() -> None:
     mx = pytest.importorskip("mlx.core")
     np = pytest.importorskip("numpy")
@@ -499,6 +509,51 @@ def test_preference_training_mlx_loss_components_reward_chosen_sequence() -> Non
         float(np.array(loss_values).reshape(-1)[0])
     )
     assert float(np.array(loss_token_count).reshape(-1)[0]) == pytest.approx(4.0)
+
+
+def test_preference_training_mlx_loss_components_reject_missing_dpo_reference() -> None:
+    mx = pytest.importorskip("mlx.core")
+    np = pytest.importorskip("numpy")
+    from worker.model_ops.preference_training import PreferenceObjectiveConfig, preference_loss_components
+
+    class StaticLogitModel:
+        def __call__(self, inputs):  # noqa: ANN001
+            return mx.array(np.zeros((inputs.shape[0], inputs.shape[1], 5), dtype=np.float32))
+
+    with pytest.raises(ModelOperationError) as exc:
+        preference_loss_components(
+            model=StaticLogitModel(),
+            chosen_batch=mx.array([[0, 2, 2]], dtype=mx.int32),
+            chosen_lengths=mx.array([[1, 3]], dtype=mx.int32),
+            rejected_batch=mx.array([[0, 3, 3]], dtype=mx.int32),
+            rejected_lengths=mx.array([[1, 3]], dtype=mx.int32),
+            objective=PreferenceObjectiveConfig(algorithm="dpo", beta=0.1),
+            reference_model=None,
+        )
+
+    assert exc.value.code == "invalid_alignment_config"
+
+
+def test_preference_training_sequence_logprobs_accepts_tuple_logits() -> None:
+    mx = pytest.importorskip("mlx.core")
+    np = pytest.importorskip("numpy")
+    from worker.model_ops.preference_training import sequence_logprobs
+
+    class TupleLogitModel:
+        def __call__(self, inputs):  # noqa: ANN001
+            logits = np.zeros((inputs.shape[0], inputs.shape[1], 5), dtype=np.float32)
+            logits[:, :, 2] = 3.0
+            return mx.array(logits), {"ignored": True}
+
+    sequence_logprob, token_count, chosen_nll = sequence_logprobs(
+        TupleLogitModel(),
+        mx.array([[0, 2, 2]], dtype=mx.int32),
+        mx.array([[1, 3]], dtype=mx.int32),
+    )
+
+    assert float(np.array(sequence_logprob).reshape(-1)[0]) < 0.0
+    assert float(np.array(token_count).reshape(-1)[0]) == pytest.approx(2.0)
+    assert float(np.array(chosen_nll).reshape(-1)[0]) > 0.0
 
 
 @pytest.mark.parametrize("algorithm", ["dpo", "orpo", "cpo"])
@@ -560,6 +615,66 @@ def test_preference_training_evaluates_mlx_metrics_for_objectives(algorithm: str
     assert metrics.chosen_logprob_mean > metrics.rejected_logprob_mean
     assert metrics.chosen_rejected_margin > 0.0
     assert metrics.win_rate_proxy == pytest.approx(1.0)
+
+
+def test_preference_training_iterate_batches_rejects_too_small_dataset() -> None:
+    pytest.importorskip("mlx.core")
+    from worker.model_ops.preference_training import (
+        PreferencePair,
+        PreferenceTokenDataset,
+        iterate_preference_batches,
+    )
+
+    class SimpleTokenizer:
+        eos_token_id = 4
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            del add_special_tokens
+            return {
+                "Prompt": [0],
+                "Good": [2],
+                "Bad": [3],
+            }[text]
+
+    dataset = PreferenceTokenDataset(
+        [PreferencePair(prompt="Prompt", chosen="Good", rejected="Bad")],
+        SimpleTokenizer(),
+    )
+
+    with pytest.raises(ValueError, match="batch_size=2"):
+        next(iterate_preference_batches(dataset, batch_size=2, max_seq_length=16))
+
+
+def test_preference_training_tokenizes_chat_template_and_text_fallbacks() -> None:
+    from worker.model_ops.preference_training import PreferencePair, PreferenceTokenDataset
+
+    class ChatTokenizer:
+        eos_token_id = 9
+
+        def apply_chat_template(self, messages, **kwargs):  # noqa: ANN001
+            if kwargs.get("add_generation_prompt"):
+                return [1, 2, 3]
+            return [1, 2, 3, len(messages[-1]["content"])]
+
+    class TextTokenizer:
+        eos_token_id = None
+
+        def encode(self, text: str) -> list[int]:
+            return [len(text)]
+
+    chat_dataset = PreferenceTokenDataset(
+        [PreferencePair(prompt="Prompt", chosen="Good", rejected="Bad")],
+        ChatTokenizer(),
+    )
+    text_dataset = PreferenceTokenDataset(
+        [PreferencePair(prompt="Prompt", chosen="Good", rejected="Bad")],
+        TextTokenizer(),
+    )
+
+    assert chat_dataset[0].chosen_tokens == [1, 2, 3, 4, 9]
+    assert chat_dataset[0].chosen_offset == 3
+    assert text_dataset[0].chosen_tokens == [6, 4]
+    assert text_dataset[0].chosen_offset == 1
 
 
 def test_train_preference_native_wires_mlx_lm_trainer_and_metrics(

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -131,7 +131,41 @@ def test_mlx_lora_namespace_uses_dora_fine_tune_type(tmp_path: Path) -> None:
     assert mlx_lm_runner_module._mlx_lora_namespace(request).fine_tune_type == "dora"
 
 
-def test_mlx_lm_runner_rejects_alignment_without_backend_before_mlx_execution(tmp_path: Path) -> None:
+def test_mlx_lm_runner_rejects_alignment_rl_without_backend_before_mlx_execution(tmp_path: Path) -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"training_mode": "grpo", "grpo_candidate_count": "4"},
+        dataset_format="prompt_candidate",
+        response_only_supported=False,
+        sample_count=2,
+    )
+    request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-grpo",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=tmp_path / "normalized",
+        config=config,
+        dataset_format="preference_pair",
+    )
+
+    with pytest.raises(ModelOperationError) as exc:
+        mlx_lm_runner_module.MLXLMRunner().train(request)
+
+    assert exc.value.code == "unsupported_alignment_trainer"
+    assert exc.value.details["training_mode"] == "grpo"
+    assert exc.value.details["alignment_algorithm"] == "grpo"
+    assert exc.value.details["available_backend"] == "mlx_lm_lora_supervised"
+    assert not request.adapter_output_dir.exists()
+
+
+def test_mlx_lm_runner_routes_preference_training_to_preference_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from worker.model_ops import preference_training
+
     config = training_config_module.normalize_training_config(
         source_model=_text_model(model_path=str(tmp_path / "base-model")),
         ext={"training_mode": "dpo"},
@@ -150,14 +184,45 @@ def test_mlx_lm_runner_rejects_alignment_without_backend_before_mlx_execution(tm
         dataset_format="preference_pair",
     )
 
-    with pytest.raises(ModelOperationError) as exc:
-        mlx_lm_runner_module.MLXLMRunner().train(request)
+    def fake_train_preference_native(
+        observed_request: mlx_lm_runner_module.TrainingRequest,
+    ) -> mlx_lm_runner_module.TrainingResult:
+        assert observed_request is request
+        observed_request.adapter_output_dir.mkdir(parents=True)
+        weights_path = observed_request.adapter_output_dir / "adapters.safetensors"
+        adapter_config_path = observed_request.adapter_output_dir / "adapter_config.json"
+        weights_path.write_bytes(b"preference-adapter")
+        adapter_config_path.write_text('{"fine_tune_type":"lora"}\n', encoding="utf-8")
+        return mlx_lm_runner_module.TrainingResult(
+            weights_path=weights_path,
+            adapter_config_path=adapter_config_path,
+            metrics=mlx_lm_runner_module.TrainingMetrics(
+                job_duration_ms=10.0,
+                tokens_seen=8,
+                examples_seen=2,
+                loss_final=0.2,
+                loss_best=0.2,
+                learning_rate_final=1e-4,
+                preference_loss_final=0.2,
+                chosen_logprob_mean=-1.5,
+                rejected_logprob_mean=-2.0,
+                chosen_rejected_margin=0.5,
+                win_rate_proxy=1.0,
+            ),
+            execution_backend="native",
+        )
 
-    assert exc.value.code == "unsupported_alignment_trainer"
-    assert exc.value.details["training_mode"] == "dpo"
-    assert exc.value.details["alignment_algorithm"] == "dpo"
-    assert exc.value.details["available_backend"] == "mlx_lm_lora_supervised"
-    assert not request.adapter_output_dir.exists()
+    monkeypatch.setattr(
+        preference_training,
+        "train_preference_native",
+        fake_train_preference_native,
+    )
+
+    result = mlx_lm_runner_module.MLXLMRunner().train(request)
+
+    assert result.execution_backend == "native"
+    assert result.weights_path.read_bytes() == b"preference-adapter"
+    assert result.metrics.chosen_rejected_margin == pytest.approx(0.5)
 
 
 def test_deterministic_lora_runner_declares_alignment_contract_support(tmp_path: Path) -> None:
@@ -377,6 +442,288 @@ def test_orpo_and_cpo_loss_values_reward_positive_margins() -> None:
         beta=0.1,
         margin_target=0.0,
     )
+
+
+def test_preference_training_mlx_loss_components_reward_chosen_sequence() -> None:
+    mx = pytest.importorskip("mlx.core")
+    np = pytest.importorskip("numpy")
+    from worker.model_ops.preference_training import (
+        PreferenceObjectiveConfig,
+        make_preference_loss,
+        preference_loss_components,
+    )
+
+    class StaticLogitModel:
+        def __call__(self, inputs):  # noqa: ANN001
+            logits = np.zeros((inputs.shape[0], inputs.shape[1], 5), dtype=np.float32)
+            logits[:, :, 2] = 4.0
+            logits[:, :, 3] = -4.0
+            return mx.array(logits)
+
+    class NeutralReferenceModel:
+        def __call__(self, inputs):  # noqa: ANN001
+            return mx.zeros((inputs.shape[0], inputs.shape[1], 5))
+
+    chosen_batch = mx.array([[0, 2, 2]], dtype=mx.int32)
+    chosen_lengths = mx.array([[1, 3]], dtype=mx.int32)
+    rejected_batch = mx.array([[0, 3, 3]], dtype=mx.int32)
+    rejected_lengths = mx.array([[1, 3]], dtype=mx.int32)
+    objective = PreferenceObjectiveConfig(algorithm="dpo", beta=0.1)
+
+    loss_values, token_count, chosen_logprob, rejected_logprob = preference_loss_components(
+        model=StaticLogitModel(),
+        chosen_batch=chosen_batch,
+        chosen_lengths=chosen_lengths,
+        rejected_batch=rejected_batch,
+        rejected_lengths=rejected_lengths,
+        objective=objective,
+        reference_model=NeutralReferenceModel(),
+    )
+    loss, loss_token_count = make_preference_loss(
+        objective,
+        reference_model=NeutralReferenceModel(),
+    )(
+        StaticLogitModel(),
+        chosen_batch,
+        chosen_lengths,
+        rejected_batch,
+        rejected_lengths,
+    )
+
+    assert float(np.array(chosen_logprob).reshape(-1)[0]) > float(
+        np.array(rejected_logprob).reshape(-1)[0]
+    )
+    assert float(np.array(loss_values).reshape(-1)[0]) > 0.0
+    assert float(np.array(token_count).reshape(-1)[0]) == pytest.approx(4.0)
+    assert float(np.array(loss).reshape(-1)[0]) == pytest.approx(
+        float(np.array(loss_values).reshape(-1)[0])
+    )
+    assert float(np.array(loss_token_count).reshape(-1)[0]) == pytest.approx(4.0)
+
+
+@pytest.mark.parametrize("algorithm", ["dpo", "orpo", "cpo"])
+def test_preference_training_evaluates_mlx_metrics_for_objectives(algorithm: str) -> None:
+    mx = pytest.importorskip("mlx.core")
+    np = pytest.importorskip("numpy")
+    from worker.model_ops.preference_training import (
+        PreferenceObjectiveConfig,
+        PreferencePair,
+        PreferenceTokenDataset,
+        evaluate_preference_metrics,
+        iterate_preference_batches,
+    )
+
+    class SimpleTokenizer:
+        eos_token_id = 4
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            del add_special_tokens
+            return {
+                "Prompt": [0],
+                "Good": [2, 2],
+                "Bad": [3, 3],
+            }[text]
+
+    class StaticLogitModel:
+        def __call__(self, inputs):  # noqa: ANN001
+            logits = np.zeros((inputs.shape[0], inputs.shape[1], 5), dtype=np.float32)
+            logits[:, :, 2] = 4.0
+            logits[:, :, 3] = -4.0
+            return mx.array(logits)
+
+    class NeutralReferenceModel:
+        def __call__(self, inputs):  # noqa: ANN001
+            return mx.zeros((inputs.shape[0], inputs.shape[1], 5))
+
+    dataset = PreferenceTokenDataset(
+        [
+            PreferencePair(prompt="Prompt", chosen="Good", rejected="Bad"),
+            PreferencePair(prompt="Prompt", chosen="Good", rejected="Bad"),
+        ],
+        SimpleTokenizer(),
+    )
+    batch = next(
+        iterate_preference_batches(dataset, batch_size=2, max_seq_length=16)
+    )
+    reference_model = NeutralReferenceModel() if algorithm == "dpo" else None
+    metrics = evaluate_preference_metrics(
+        model=StaticLogitModel(),
+        dataset=dataset,
+        objective=PreferenceObjectiveConfig(algorithm=algorithm, beta=0.1),
+        batch_size=2,
+        max_seq_length=16,
+        reference_model=reference_model,
+    )
+
+    assert batch[0].shape == batch[2].shape
+    assert metrics.preference_loss_final > 0.0
+    assert metrics.chosen_logprob_mean > metrics.rejected_logprob_mean
+    assert metrics.chosen_rejected_margin > 0.0
+    assert metrics.win_rate_proxy == pytest.approx(1.0)
+
+
+def test_train_preference_native_wires_mlx_lm_trainer_and_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("mlx.core")
+    from worker.model_ops import preference_training
+    import mlx.optimizers as mlx_optimizers
+    import mlx_lm.tuner.trainer as trainer_module
+    import mlx_lm.tuner.utils as tuner_utils_module
+    import mlx_lm.utils as mlx_utils_module
+
+    class FakeModel:
+        def __init__(self) -> None:
+            self.layers = [object(), object()]
+            self.freeze_count = 0
+            self.eval_count = 0
+            self.loaded_weights = ""
+
+        def freeze(self) -> None:
+            self.freeze_count += 1
+
+        def eval(self) -> None:
+            self.eval_count += 1
+
+        def load_weights(self, path: str, strict: bool = False) -> None:
+            assert strict is False
+            self.loaded_weights = path
+
+    class FakeTokenizer:
+        eos_token_id = 4
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            del add_special_tokens
+            return {
+                "Prompt": [0],
+                "Good": [2, 2],
+                "Bad": [3, 3],
+            }[text]
+
+    class FakeAdam:
+        def __init__(self, learning_rate: float) -> None:
+            self.learning_rate = learning_rate
+
+    calls: dict[str, object] = {"load_paths": []}
+
+    def fake_load(path: str, lazy: bool = False):  # noqa: ANN001
+        assert lazy is False
+        calls["load_paths"].append(path)
+        return FakeModel(), FakeTokenizer()
+
+    def fake_save_config(payload: dict[str, object], path: Path) -> None:
+        path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+    def fake_linear_to_lora_layers(
+        model: FakeModel,
+        num_layers: int,
+        lora_parameters: dict[str, object],
+        use_dora: bool = False,
+    ) -> None:
+        assert model.freeze_count == 1
+        assert num_layers == 2
+        assert lora_parameters["rank"] == 8
+        assert use_dora is False
+        calls["lora_converted"] = True
+
+    def fake_train(
+        *,
+        model: FakeModel,
+        args,
+        optimizer: FakeAdam,
+        train_dataset,
+        val_dataset,
+        loss,
+        iterate_batches,
+        training_callback,
+    ) -> None:
+        del model, optimizer, train_dataset, val_dataset, loss, iterate_batches
+        Path(args.adapter_file).write_bytes(b"trained-preference-adapter")
+        training_callback.on_train_loss_report(
+            {
+                "train_loss": 0.31,
+                "learning_rate": 0.0002,
+                "trained_tokens": 12,
+                "tokens_per_second": 34.0,
+            }
+        )
+        calls["trainer_args"] = args
+
+    monkeypatch.setattr(mlx_utils_module, "load", fake_load)
+    monkeypatch.setattr(mlx_utils_module, "save_config", fake_save_config)
+    monkeypatch.setattr(
+        tuner_utils_module,
+        "linear_to_lora_layers",
+        fake_linear_to_lora_layers,
+    )
+    monkeypatch.setattr(
+        tuner_utils_module,
+        "print_trainable_parameters",
+        lambda model: None,
+    )
+    monkeypatch.setattr(trainer_module, "train", fake_train)
+    monkeypatch.setattr(mlx_optimizers, "Adam", FakeAdam)
+    monkeypatch.setattr(
+        preference_training,
+        "evaluate_preference_metrics",
+        lambda **kwargs: preference_training.PreferenceMetricSnapshot(
+            preference_loss_final=0.2,
+            chosen_logprob_mean=-1.5,
+            rejected_logprob_mean=-2.0,
+            chosen_rejected_margin=0.5,
+            win_rate_proxy=1.0,
+        ),
+    )
+
+    dataset_dir = tmp_path / "normalized"
+    dataset_dir.mkdir()
+    (dataset_dir / "train.jsonl").write_text(
+        json.dumps({"prompt": "Prompt", "chosen": "Good", "rejected": "Bad"}) + "\n",
+        encoding="utf-8",
+    )
+    resume_path = tmp_path / "resume.safetensors"
+    resume_path.write_bytes(b"resume")
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={
+            "training_mode": "dpo",
+            "batch_size": "1",
+            "iters": "1",
+            "learning_rate": "0.0002",
+            "reference_model_path": str(tmp_path / "reference-model"),
+        },
+        dataset_format="preference_pair",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-dpo-native",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=dataset_dir,
+        config=config,
+        dataset_format="preference_pair",
+        resume_source_path=resume_path,
+    )
+
+    result = preference_training.train_preference_native(request)
+
+    assert calls["load_paths"] == [
+        str(tmp_path / "base-model"),
+        str(tmp_path / "reference-model"),
+    ]
+    assert calls["lora_converted"] is True
+    assert calls["trainer_args"].batch_size == 1
+    assert result.weights_path.read_bytes() == b"trained-preference-adapter"
+    assert result.adapter_config_path.is_file()
+    assert result.metrics.tokens_seen == 12
+    assert result.metrics.learning_rate_final == pytest.approx(0.0002)
+    assert result.metrics.preference_loss_final == pytest.approx(0.2)
+    assert result.metrics.chosen_rejected_margin == pytest.approx(0.5)
+    assert result.metrics.resume_source_path == str(resume_path)
 
 
 def test_run_subprocess_extracts_terminal_structured_result_without_splitlines(

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -200,6 +200,185 @@ def test_training_request_deserialization_restores_alignment_config(tmp_path: Pa
     assert restored.config.alignment.dataset_contract == "preference_pair"
 
 
+def test_training_metrics_serializes_preference_fields(tmp_path: Path) -> None:
+    metrics = mlx_lm_runner_module.TrainingMetrics(
+        job_duration_ms=10.0,
+        tokens_seen=4,
+        examples_seen=2,
+        loss_final=0.4,
+        loss_best=0.3,
+        learning_rate_final=1e-4,
+        preference_loss_final=0.2,
+        chosen_logprob_mean=-1.5,
+        rejected_logprob_mean=-2.0,
+        chosen_rejected_margin=0.5,
+        win_rate_proxy=1.0,
+    )
+    result = mlx_lm_runner_module.TrainingResult(
+        weights_path=tmp_path / "adapters.safetensors",
+        adapter_config_path=tmp_path / "adapter_config.json",
+        metrics=metrics,
+        execution_backend="native",
+    )
+
+    restored = mlx_lm_runner_module._deserialize_training_result(
+        mlx_lm_runner_module._serialize_training_result(result)
+    )
+
+    assert restored.metrics.preference_loss_final == pytest.approx(0.2)
+    assert restored.metrics.chosen_logprob_mean == pytest.approx(-1.5)
+    assert restored.metrics.rejected_logprob_mean == pytest.approx(-2.0)
+    assert restored.metrics.chosen_rejected_margin == pytest.approx(0.5)
+    assert restored.metrics.win_rate_proxy == pytest.approx(1.0)
+
+
+def test_preference_training_loads_preference_pairs(tmp_path: Path) -> None:
+    from worker.model_ops.preference_training import load_preference_pairs
+
+    dataset_dir = tmp_path / "normalized"
+    dataset_dir.mkdir()
+    (dataset_dir / "train.jsonl").write_text(
+        "\n" + json.dumps(
+            {
+                "prompt": "Choose.",
+                "chosen": "Helpful.",
+                "rejected": "Unsafe.",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    pairs = load_preference_pairs(dataset_dir)
+
+    assert len(pairs) == 1
+    assert pairs[0].prompt == "Choose."
+    assert pairs[0].chosen == "Helpful."
+    assert pairs[0].rejected == "Unsafe."
+
+
+def test_preference_training_rejects_missing_or_empty_train_file(tmp_path: Path) -> None:
+    from worker.model_ops.preference_training import load_preference_pairs
+
+    missing_dir = tmp_path / "missing"
+    missing_dir.mkdir()
+    with pytest.raises(ModelOperationError) as missing_exc:
+        load_preference_pairs(missing_dir)
+
+    assert missing_exc.value.code == "invalid_dataset_package"
+    assert missing_exc.value.details["path"].endswith("train.jsonl")
+
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    (empty_dir / "train.jsonl").write_text("\n", encoding="utf-8")
+    with pytest.raises(ModelOperationError) as empty_exc:
+        load_preference_pairs(empty_dir)
+
+    assert empty_exc.value.code == "invalid_dataset_package"
+    assert "at least one" in empty_exc.value.message
+
+
+def test_preference_training_rejects_missing_pair_fields(tmp_path: Path) -> None:
+    from worker.model_ops.preference_training import load_preference_pairs
+
+    dataset_dir = tmp_path / "normalized"
+    dataset_dir.mkdir()
+    (dataset_dir / "train.jsonl").write_text(
+        json.dumps({"prompt": "Choose.", "chosen": "Helpful."}) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ModelOperationError) as exc:
+        load_preference_pairs(dataset_dir)
+
+    assert exc.value.code == "invalid_dataset_package"
+    assert exc.value.details["missing_field"] == "rejected"
+
+
+def test_preference_training_resolves_default_and_configured_beta(tmp_path: Path) -> None:
+    from worker.model_ops.preference_training import resolve_preference_objective
+
+    default_config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"training_mode": "dpo"},
+        dataset_format="preference_pair",
+        response_only_supported=False,
+        sample_count=2,
+    )
+    configured_config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={
+            "training_mode": "cpo",
+            "kl_penalty": "0.35",
+            "preference_margin_target": "0.25",
+        },
+        dataset_format="preference_pair",
+        response_only_supported=False,
+        sample_count=2,
+    )
+
+    assert resolve_preference_objective(default_config).beta == pytest.approx(0.1)
+    configured = resolve_preference_objective(configured_config)
+    assert configured.algorithm == "cpo"
+    assert configured.beta == pytest.approx(0.35)
+    assert configured.margin_target == pytest.approx(0.25)
+
+
+def test_preference_training_rejects_objective_without_alignment(tmp_path: Path) -> None:
+    from worker.model_ops.preference_training import resolve_preference_objective
+
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"training_mode": "lora"},
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+    )
+
+    with pytest.raises(ModelOperationError) as exc:
+        resolve_preference_objective(config)
+
+    assert exc.value.code == "invalid_alignment_config"
+
+
+@pytest.mark.parametrize(
+    ("policy_margin", "reference_margin", "expected_order"),
+    [
+        (2.0, 0.0, "lower"),
+        (-2.0, 0.0, "higher"),
+    ],
+)
+def test_dpo_loss_value_prefers_policy_margin(
+    policy_margin: float,
+    reference_margin: float,
+    expected_order: str,
+) -> None:
+    from worker.model_ops.preference_training import dpo_loss_value
+
+    neutral = dpo_loss_value(0.0, reference_margin, beta=0.1)
+    observed = dpo_loss_value(policy_margin, reference_margin, beta=0.1)
+
+    if expected_order == "lower":
+        assert observed < neutral
+    else:
+        assert observed > neutral
+
+
+def test_orpo_and_cpo_loss_values_reward_positive_margins() -> None:
+    from worker.model_ops.preference_training import cpo_loss_value, orpo_loss_value
+
+    assert orpo_loss_value(chosen_nll=0.5, policy_margin=2.0, beta=0.1) < orpo_loss_value(
+        chosen_nll=0.5,
+        policy_margin=-2.0,
+        beta=0.1,
+    )
+    assert cpo_loss_value(policy_margin=2.0, beta=0.1, margin_target=0.0) < cpo_loss_value(
+        policy_margin=-2.0,
+        beta=0.1,
+        margin_target=0.0,
+    )
+
+
 def test_run_subprocess_extracts_terminal_structured_result_without_splitlines(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -379,7 +379,7 @@ def _alignment_manifest_payload(
     if alignment.dataset_contract == "preference_pair":
         metrics.update(
             {
-                "preference_loss": config.preference_loss,
+                "preference_loss_config": config.preference_loss,
                 "preference_loss_final": training_result.metrics.preference_loss_final,
                 "chosen_logprob_mean": training_result.metrics.chosen_logprob_mean,
                 "rejected_logprob_mean": training_result.metrics.rejected_logprob_mean,

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -380,8 +380,11 @@ def _alignment_manifest_payload(
         metrics.update(
             {
                 "preference_loss": config.preference_loss,
-                "chosen_rejected_margin": 0.0,
-                "win_rate_proxy": 0.0,
+                "preference_loss_final": training_result.metrics.preference_loss_final,
+                "chosen_logprob_mean": training_result.metrics.chosen_logprob_mean,
+                "rejected_logprob_mean": training_result.metrics.rejected_logprob_mean,
+                "chosen_rejected_margin": training_result.metrics.chosen_rejected_margin,
+                "win_rate_proxy": training_result.metrics.win_rate_proxy,
             }
         )
     reward_summary = _reward_summary(dataset.package.normalized_samples)

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -58,6 +58,11 @@ class TrainingMetrics:
     chunked_enabled: bool = False
     chunk_count: int = 0
     source_sample_count: int = 0
+    preference_loss_final: float = 0.0
+    chosen_logprob_mean: float = 0.0
+    rejected_logprob_mean: float = 0.0
+    chosen_rejected_margin: float = 0.0
+    win_rate_proxy: float = 0.0
 
 
 @dataclass(frozen=True)

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -58,11 +58,11 @@ class TrainingMetrics:
     chunked_enabled: bool = False
     chunk_count: int = 0
     source_sample_count: int = 0
-    preference_loss_final: float = 0.0
-    chosen_logprob_mean: float = 0.0
-    rejected_logprob_mean: float = 0.0
-    chosen_rejected_margin: float = 0.0
-    win_rate_proxy: float = 0.0
+    preference_loss_final: float | None = None
+    chosen_logprob_mean: float | None = None
+    rejected_logprob_mean: float | None = None
+    chosen_rejected_margin: float | None = None
+    win_rate_proxy: float | None = None
 
 
 @dataclass(frozen=True)

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -159,8 +159,7 @@ class MLXLMRunner:
             return replace(result, execution_backend="subprocess")
 
     def supports_alignment_training(self, config: LoRATrainingConfig) -> bool:
-        del config
-        return False
+        return config.training_objective == "preference"
 
     def activate(self, request: ActivationRequest) -> ActivationResult:
         try:
@@ -171,6 +170,11 @@ class MLXLMRunner:
             return replace(result, execution_backend="subprocess")
 
     def train_native(self, request: TrainingRequest) -> TrainingResult:
+        if request.config.training_objective == "preference":
+            from worker.model_ops.preference_training import train_preference_native
+
+            return train_preference_native(request)
+
         try:
             from mlx_lm.lora import train_model
             from mlx_lm.tuner.callbacks import TrainingCallback

--- a/services/mlx-worker-python/worker/model_ops/preference_training.py
+++ b/services/mlx-worker-python/worker/model_ops/preference_training.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 import json
 import math
 from pathlib import Path
+import time
+from typing import Any
 
 from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.training_config import LoRATrainingConfig
@@ -23,8 +26,437 @@ class PreferenceObjectiveConfig:
     margin_target: float = 0.0
 
 
+@dataclass(frozen=True)
+class PreferenceTokenSample:
+    chosen_tokens: list[int]
+    chosen_offset: int
+    rejected_tokens: list[int]
+    rejected_offset: int
+
+
+@dataclass(frozen=True)
+class PreferenceMetricSnapshot:
+    preference_loss_final: float
+    chosen_logprob_mean: float
+    rejected_logprob_mean: float
+    chosen_rejected_margin: float
+    win_rate_proxy: float
+
+
+class PreferenceTokenDataset:
+    def __init__(self, pairs: list[PreferencePair], tokenizer: Any) -> None:
+        self._samples = [_tokenize_preference_pair(pair, tokenizer) for pair in pairs]
+
+    def __getitem__(self, idx: int) -> PreferenceTokenSample:
+        return self._samples[idx]
+
+    def __len__(self) -> int:
+        return len(self._samples)
+
+    def itemlen(self, idx: int) -> int:
+        sample = self._samples[idx]
+        return max(len(sample.chosen_tokens), len(sample.rejected_tokens))
+
+
+class PreferenceMetricsCollector:
+    def __init__(self) -> None:
+        self.losses: list[float] = []
+        self.learning_rates: list[float] = []
+        self.tokens_seen = 0
+        self.tokens_per_second = 0.0
+
+    def on_train_loss_report(self, train_info: dict) -> None:
+        if "train_loss" in train_info:
+            self.losses.append(float(train_info["train_loss"]))
+        if "learning_rate" in train_info:
+            self.learning_rates.append(float(train_info["learning_rate"]))
+        if "trained_tokens" in train_info:
+            self.tokens_seen = int(train_info["trained_tokens"])
+        if "tokens_per_second" in train_info:
+            self.tokens_per_second = float(train_info["tokens_per_second"])
+
+    def on_val_loss_report(self, val_info: dict) -> None:
+        if "val_loss" in val_info:
+            self.losses.append(float(val_info["val_loss"]))
+
+
 def load_preference_pairs(dataset_dir: Path) -> list[PreferencePair]:
     path = dataset_dir / "train.jsonl"
+    return _load_preference_pairs_file(path)
+
+
+def train_preference_native(request: Any) -> Any:
+    try:
+        import mlx.core as mx
+        import mlx.optimizers as optim
+        from mlx_lm.tuner.trainer import TrainingArgs, train
+        from mlx_lm.tuner.utils import (
+            build_schedule,
+            linear_to_lora_layers,
+            print_trainable_parameters,
+        )
+        from mlx_lm.utils import load, save_config
+    except ModuleNotFoundError as exc:
+        from worker.model_ops.mlx_lm_runner import NativeExecutionUnavailable
+
+        raise NativeExecutionUnavailable("MLX-LM is not available in the current runtime.") from exc
+
+    from worker.model_ops.mlx_lm_runner import (
+        TrainingMetrics,
+        TrainingResult,
+        _checkpoint_summary,
+        _mlx_lora_namespace,
+        _mlx_peak_memory_gb,
+        _reset_mlx_peak_memory_probe,
+    )
+
+    objective = resolve_preference_objective(request.config)
+    pairs = load_preference_pairs(request.normalized_dataset_dir)
+    args = _mlx_lora_namespace(request)
+    args.fine_tune_type = "lora"
+
+    started_at = time.perf_counter()
+    request.adapter_output_dir.mkdir(parents=True, exist_ok=True)
+    _reset_mlx_peak_memory_probe()
+    try:
+        mx.random.seed(args.seed)
+        model, tokenizer = load(str(request.model_path), lazy=False)
+        model.freeze()
+        if args.num_layers > len(model.layers):
+            raise ValueError(
+                f"Requested to train {args.num_layers} layers "
+                f"but the model only has {len(model.layers)} layers."
+            )
+        linear_to_lora_layers(
+            model,
+            args.num_layers,
+            args.lora_parameters,
+            use_dora=False,
+        )
+        if args.resume_adapter_file is not None:
+            model.load_weights(args.resume_adapter_file, strict=False)
+        print_trainable_parameters(model)
+
+        reference_model = None
+        if objective.algorithm == "dpo":
+            reference_model_path = (
+                request.config.alignment.reference_model_path
+                if request.config.alignment is not None
+                and request.config.alignment.reference_model_path
+                else str(request.model_path)
+            )
+            reference_model, _ = load(str(reference_model_path), lazy=False)
+            reference_model.freeze()
+            reference_model.eval()
+
+        adapter_file = request.adapter_output_dir / "adapters.safetensors"
+        save_config(vars(args), request.adapter_output_dir / "adapter_config.json")
+        dataset = PreferenceTokenDataset(pairs, tokenizer)
+        training_args = TrainingArgs(
+            batch_size=args.batch_size,
+            iters=args.iters,
+            val_batches=0,
+            steps_per_report=args.steps_per_report,
+            steps_per_eval=args.steps_per_eval,
+            steps_per_save=args.save_every,
+            adapter_file=adapter_file,
+            max_seq_length=args.max_seq_length,
+            grad_checkpoint=args.grad_checkpoint,
+            grad_accumulation_steps=args.grad_accumulation_steps,
+        )
+        learning_rate = (
+            build_schedule(args.lr_schedule)
+            if args.lr_schedule
+            else args.learning_rate
+        )
+        optimizer = optim.Adam(learning_rate=learning_rate)
+        collector = PreferenceMetricsCollector()
+        preference_loss = make_preference_loss(objective, reference_model=reference_model)
+        train(
+            model=model,
+            args=training_args,
+            optimizer=optimizer,
+            train_dataset=dataset,
+            val_dataset=None,
+            loss=preference_loss,
+            iterate_batches=iterate_preference_batches,
+            training_callback=collector,
+        )
+        metrics_snapshot = evaluate_preference_metrics(
+            model=model,
+            dataset=dataset,
+            objective=objective,
+            batch_size=args.batch_size,
+            max_seq_length=args.max_seq_length,
+            reference_model=reference_model,
+        )
+    except ModelOperationError:
+        raise
+    except Exception as exc:
+        raise ModelOperationError(
+            code="backend_training_failure",
+            message=f"MLX-LM preference training failed: {exc}",
+        ) from exc
+
+    duration_ms = (time.perf_counter() - started_at) * 1000.0
+    losses = collector.losses or [metrics_snapshot.preference_loss_final]
+    learning_rates = collector.learning_rates or [request.config.learning_rate]
+    checkpoint_count, latest_checkpoint_path = _checkpoint_summary(request.adapter_output_dir)
+    return TrainingResult(
+        weights_path=adapter_file,
+        adapter_config_path=request.adapter_output_dir / "adapter_config.json",
+        metrics=TrainingMetrics(
+            job_duration_ms=duration_ms,
+            tokens_seen=collector.tokens_seen,
+            examples_seen=request.config.batch_size * request.config.iters,
+            loss_final=losses[-1],
+            loss_best=min(losses),
+            learning_rate_final=learning_rates[-1],
+            checkpoint_count=checkpoint_count,
+            resume_ready=latest_checkpoint_path != "",
+            latest_checkpoint_path=latest_checkpoint_path,
+            resume_source_path=(
+                str(request.resume_source_path)
+                if request.resume_source_path is not None
+                else ""
+            ),
+            tokens_per_second=collector.tokens_per_second,
+            peak_memory_gb=_mlx_peak_memory_gb(),
+            preference_loss_final=metrics_snapshot.preference_loss_final,
+            chosen_logprob_mean=metrics_snapshot.chosen_logprob_mean,
+            rejected_logprob_mean=metrics_snapshot.rejected_logprob_mean,
+            chosen_rejected_margin=metrics_snapshot.chosen_rejected_margin,
+            win_rate_proxy=metrics_snapshot.win_rate_proxy,
+        ),
+        execution_backend="native",
+    )
+
+
+def make_preference_loss(
+    objective: PreferenceObjectiveConfig,
+    *,
+    reference_model: Any = None,
+) -> Any:
+    def preference_loss(
+        model: Any,
+        chosen_batch: Any,
+        chosen_lengths: Any,
+        rejected_batch: Any,
+        rejected_lengths: Any,
+    ) -> tuple[Any, Any]:
+        loss_values, token_count, _, _ = preference_loss_components(
+            model=model,
+            chosen_batch=chosen_batch,
+            chosen_lengths=chosen_lengths,
+            rejected_batch=rejected_batch,
+            rejected_lengths=rejected_lengths,
+            objective=objective,
+            reference_model=reference_model,
+        )
+        return loss_values.astype(_mx().float32).mean(), token_count
+
+    return preference_loss
+
+
+def preference_loss_components(
+    *,
+    model: Any,
+    chosen_batch: Any,
+    chosen_lengths: Any,
+    rejected_batch: Any,
+    rejected_lengths: Any,
+    objective: PreferenceObjectiveConfig,
+    reference_model: Any = None,
+) -> tuple[Any, Any, Any, Any]:
+    mx = _mx()
+    chosen_logprob, chosen_token_count, chosen_nll = sequence_logprobs(
+        model,
+        chosen_batch,
+        chosen_lengths,
+    )
+    rejected_logprob, rejected_token_count, _ = sequence_logprobs(
+        model,
+        rejected_batch,
+        rejected_lengths,
+    )
+    policy_margin = chosen_logprob - rejected_logprob
+    token_count = chosen_token_count.sum() + rejected_token_count.sum()
+    if objective.algorithm == "dpo":
+        if reference_model is None:
+            raise ModelOperationError(
+                code="invalid_alignment_config",
+                message="DPO preference training requires a reference model.",
+            )
+        reference_chosen_logprob, _, _ = sequence_logprobs(
+            reference_model,
+            chosen_batch,
+            chosen_lengths,
+        )
+        reference_rejected_logprob, _, _ = sequence_logprobs(
+            reference_model,
+            rejected_batch,
+            rejected_lengths,
+        )
+        reference_margin = reference_chosen_logprob - reference_rejected_logprob
+        loss_values = -_mlx_log_sigmoid(
+            objective.beta * (policy_margin - reference_margin)
+        )
+    elif objective.algorithm == "orpo":
+        loss_values = chosen_nll - objective.beta * _mlx_log_sigmoid(policy_margin)
+    elif objective.algorithm == "cpo":
+        loss_values = -_mlx_log_sigmoid(
+            objective.beta * (policy_margin - objective.margin_target)
+        )
+    else:
+        raise ModelOperationError(
+            code="unsupported_alignment_trainer",
+            message=f"Unsupported offline preference algorithm: {objective.algorithm}",
+            details={"alignment_algorithm": objective.algorithm},
+        )
+    return loss_values, token_count.astype(mx.float32), chosen_logprob, rejected_logprob
+
+
+def sequence_logprobs(model: Any, batch: Any, lengths: Any) -> tuple[Any, Any, Any]:
+    mx = _mx()
+    inputs = batch[:, :-1]
+    targets = batch[:, 1:]
+    logits = model(inputs)
+    if isinstance(logits, tuple):
+        logits = logits[0]
+    logits = logits.astype(mx.float32)
+    log_probs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+    token_logprobs = mx.take_along_axis(
+        log_probs,
+        targets[..., None],
+        axis=-1,
+    ).squeeze(-1)
+    steps = mx.arange(1, targets.shape[1] + 1)
+    mask = mx.logical_and(steps >= lengths[:, 0:1], steps <= lengths[:, 1:])
+    mask = mask.astype(mx.float32)
+    token_count = mask.sum(axis=1)
+    safe_token_count = mx.maximum(token_count, mx.ones_like(token_count))
+    sequence_logprob = (token_logprobs * mask).sum(axis=1)
+    chosen_nll = -sequence_logprob / safe_token_count
+    return sequence_logprob, safe_token_count, chosen_nll
+
+
+def evaluate_preference_metrics(
+    *,
+    model: Any,
+    dataset: PreferenceTokenDataset,
+    objective: PreferenceObjectiveConfig,
+    batch_size: int,
+    max_seq_length: int,
+    reference_model: Any = None,
+) -> PreferenceMetricSnapshot:
+    losses: list[float] = []
+    chosen_logprobs: list[float] = []
+    rejected_logprobs: list[float] = []
+    for batch in iterate_preference_batches(
+        dataset=dataset,
+        batch_size=batch_size,
+        max_seq_length=max_seq_length,
+        loop=False,
+    ):
+        loss_values, _, chosen_logprob, rejected_logprob = preference_loss_components(
+            model=model,
+            chosen_batch=batch[0],
+            chosen_lengths=batch[1],
+            rejected_batch=batch[2],
+            rejected_lengths=batch[3],
+            objective=objective,
+            reference_model=reference_model,
+        )
+        losses.extend(_array_to_float_list(loss_values))
+        chosen_logprobs.extend(_array_to_float_list(chosen_logprob))
+        rejected_logprobs.extend(_array_to_float_list(rejected_logprob))
+    if not losses:
+        raise ModelOperationError(
+            code="invalid_dataset_package",
+            message="preference_pair training requires at least one full batch.",
+            details={
+                "batch_size": str(batch_size),
+                "sample_count": str(len(dataset)),
+            },
+        )
+    margins = [
+        chosen - rejected
+        for chosen, rejected in zip(chosen_logprobs, rejected_logprobs)
+    ]
+    wins = [1.0 if margin > 0.0 else 0.0 for margin in margins]
+    return PreferenceMetricSnapshot(
+        preference_loss_final=sum(losses) / len(losses),
+        chosen_logprob_mean=sum(chosen_logprobs) / len(chosen_logprobs),
+        rejected_logprob_mean=sum(rejected_logprobs) / len(rejected_logprobs),
+        chosen_rejected_margin=sum(margins) / len(margins),
+        win_rate_proxy=sum(wins) / len(wins),
+    )
+
+
+def iterate_preference_batches(
+    dataset: PreferenceTokenDataset,
+    batch_size: int,
+    max_seq_length: int,
+    loop: bool = False,
+    seed: int | None = None,
+    comm_group: Any = None,
+) -> Iterator[tuple[Any, Any, Any, Any]]:
+    import numpy as np
+
+    mx = _mx()
+    if len(dataset) < batch_size:
+        raise ValueError(
+            f"Dataset must have at least batch_size={batch_size} examples "
+            f"but only has {len(dataset)}."
+        )
+    idx = sorted(range(len(dataset)), key=dataset.itemlen)
+    if comm_group is not None:
+        offset = comm_group.rank()
+        step = comm_group.size()
+    else:
+        offset = 0
+        step = 1
+    if batch_size % step != 0:
+        raise ValueError("The batch size must be divisible by the number of workers")
+
+    batch_idx = [
+        idx[i + offset: i + offset + batch_size: step]
+        for i in range(0, len(idx) - batch_size + 1, batch_size)
+    ]
+    if seed is not None:
+        np.random.seed(seed)
+    while True:
+        indices = np.random.permutation(len(batch_idx))
+        for batch_index in indices:
+            samples = [dataset[j] for j in batch_idx[batch_index]]
+            max_length = max(
+                max(len(sample.chosen_tokens), len(sample.rejected_tokens))
+                for sample in samples
+            )
+            pad_to = 32
+            max_length_in_batch = 1 + pad_to * ((max_length + pad_to - 1) // pad_to)
+            max_length_in_batch = min(max_length_in_batch, max_seq_length)
+            chosen_batch, chosen_lengths = _pad_preference_side(
+                samples,
+                side="chosen",
+                max_length=max_length_in_batch,
+            )
+            rejected_batch, rejected_lengths = _pad_preference_side(
+                samples,
+                side="rejected",
+                max_length=max_length_in_batch,
+            )
+            yield (
+                mx.array(chosen_batch),
+                mx.array(chosen_lengths),
+                mx.array(rejected_batch),
+                mx.array(rejected_lengths),
+            )
+        if not loop:
+            break
+
+
+def _load_preference_pairs_file(path: Path) -> list[PreferencePair]:
     pairs: list[PreferencePair] = []
     try:
         with path.open("r", encoding="utf-8") as handle:
@@ -95,3 +527,105 @@ def _log_sigmoid(value: float) -> float:
     if value >= 0:
         return -math.log1p(math.exp(-value))
     return value - math.log1p(math.exp(value))
+
+
+def _tokenize_preference_pair(pair: PreferencePair, tokenizer: Any) -> PreferenceTokenSample:
+    chosen_tokens, chosen_offset = _tokenize_prompt_response(
+        tokenizer,
+        prompt=pair.prompt,
+        response=pair.chosen,
+    )
+    rejected_tokens, rejected_offset = _tokenize_prompt_response(
+        tokenizer,
+        prompt=pair.prompt,
+        response=pair.rejected,
+    )
+    return PreferenceTokenSample(
+        chosen_tokens=chosen_tokens,
+        chosen_offset=chosen_offset,
+        rejected_tokens=rejected_tokens,
+        rejected_offset=rejected_offset,
+    )
+
+
+def _tokenize_prompt_response(
+    tokenizer: Any,
+    *,
+    prompt: str,
+    response: str,
+) -> tuple[list[int], int]:
+    apply_chat_template = getattr(tokenizer, "apply_chat_template", None)
+    if callable(apply_chat_template):
+        messages = [
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": response},
+        ]
+        try:
+            tokens = list(apply_chat_template(messages, return_dict=False))
+            prefix_tokens = list(
+                apply_chat_template(
+                    messages[:-1],
+                    add_generation_prompt=True,
+                    return_dict=False,
+                )
+            )
+            tokens = _append_eos_if_needed(tokens, tokenizer)
+            return tokens, min(len(prefix_tokens), max(len(tokens) - 1, 0))
+        except (TypeError, ValueError, AttributeError):
+            pass
+
+    prompt_tokens = _encode_text(tokenizer, prompt)
+    response_tokens = _encode_text(tokenizer, response)
+    tokens = _append_eos_if_needed([*prompt_tokens, *response_tokens], tokenizer)
+    return tokens, min(len(prompt_tokens), max(len(tokens) - 1, 0))
+
+
+def _encode_text(tokenizer: Any, text: str) -> list[int]:
+    try:
+        return list(tokenizer.encode(text, add_special_tokens=False))
+    except TypeError:
+        return list(tokenizer.encode(text))
+
+
+def _append_eos_if_needed(tokens: list[int], tokenizer: Any) -> list[int]:
+    eos_token_id = getattr(tokenizer, "eos_token_id", None)
+    if eos_token_id is None or (tokens and tokens[-1] == eos_token_id):
+        return tokens
+    return [*tokens, int(eos_token_id)]
+
+
+def _pad_preference_side(
+    samples: list[PreferenceTokenSample],
+    *,
+    side: str,
+    max_length: int,
+) -> tuple[Any, list[tuple[int, int]]]:
+    import numpy as np
+
+    batch = np.zeros((len(samples), max_length), np.int32)
+    lengths: list[tuple[int, int]] = []
+    for row, sample in enumerate(samples):
+        tokens = sample.chosen_tokens if side == "chosen" else sample.rejected_tokens
+        offset = sample.chosen_offset if side == "chosen" else sample.rejected_offset
+        truncated_length = min(len(tokens), max_length)
+        batch[row, :truncated_length] = tokens[:truncated_length]
+        safe_offset = min(offset, max(truncated_length - 1, 0))
+        lengths.append((safe_offset, truncated_length))
+    return batch, lengths
+
+
+def _mlx_log_sigmoid(value: Any) -> Any:
+    mx = _mx()
+    return -mx.logaddexp(mx.zeros_like(value), -value)
+
+
+def _array_to_float_list(value: Any) -> list[float]:
+    import numpy as np
+
+    return [float(item) for item in np.array(value).reshape(-1).tolist()]
+
+
+def _mx() -> Any:
+    import mlx.core as mx
+
+    return mx

--- a/services/mlx-worker-python/worker/model_ops/preference_training.py
+++ b/services/mlx-worker-python/worker/model_ops/preference_training.py
@@ -6,10 +6,15 @@ import json
 import math
 from pathlib import Path
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.training_config import LoRATrainingConfig
+
+if TYPE_CHECKING:
+    from worker.model_ops.mlx_lm_runner import TrainingRequest, TrainingResult
+
+_mlx_core: Any | None = None
 
 
 @dataclass(frozen=True)
@@ -63,6 +68,7 @@ class PreferenceMetricsCollector:
         self.losses: list[float] = []
         self.learning_rates: list[float] = []
         self.tokens_seen = 0
+        self.examples_seen: int | None = None
         self.tokens_per_second = 0.0
 
     def on_train_loss_report(self, train_info: dict) -> None:
@@ -72,6 +78,10 @@ class PreferenceMetricsCollector:
             self.learning_rates.append(float(train_info["learning_rate"]))
         if "trained_tokens" in train_info:
             self.tokens_seen = int(train_info["trained_tokens"])
+        if "trained_examples" in train_info:
+            self.examples_seen = int(train_info["trained_examples"])
+        elif "examples_seen" in train_info:
+            self.examples_seen = int(train_info["examples_seen"])
         if "tokens_per_second" in train_info:
             self.tokens_per_second = float(train_info["tokens_per_second"])
 
@@ -85,7 +95,7 @@ def load_preference_pairs(dataset_dir: Path) -> list[PreferencePair]:
     return _load_preference_pairs_file(path)
 
 
-def train_preference_native(request: Any) -> Any:
+def train_preference_native(request: TrainingRequest) -> TrainingResult:
     try:
         import mlx.core as mx
         import mlx.optimizers as optim
@@ -157,7 +167,7 @@ def train_preference_native(request: Any) -> Any:
             iters=args.iters,
             val_batches=0,
             steps_per_report=args.steps_per_report,
-            steps_per_eval=args.steps_per_eval,
+            steps_per_eval=0,
             steps_per_save=args.save_every,
             adapter_file=adapter_file,
             max_seq_length=args.max_seq_length,
@@ -208,7 +218,10 @@ def train_preference_native(request: Any) -> Any:
         metrics=TrainingMetrics(
             job_duration_ms=duration_ms,
             tokens_seen=collector.tokens_seen,
-            examples_seen=request.config.batch_size * request.config.iters,
+            examples_seen=_preference_examples_seen(
+                collector=collector,
+                config=request.config,
+            ),
             loss_final=losses[-1],
             loss_best=min(losses),
             learning_rate_final=learning_rates[-1],
@@ -409,18 +422,13 @@ def iterate_preference_batches(
             f"Dataset must have at least batch_size={batch_size} examples "
             f"but only has {len(dataset)}."
         )
-    idx = sorted(range(len(dataset)), key=dataset.itemlen)
     if comm_group is not None:
-        offset = comm_group.rank()
-        step = comm_group.size()
-    else:
-        offset = 0
-        step = 1
-    if batch_size % step != 0:
-        raise ValueError("The batch size must be divisible by the number of workers")
-
+        raise NotImplementedError(
+            "Distributed preference batch sharding is deferred until GRPO support lands."
+        )
+    idx = sorted(range(len(dataset)), key=dataset.itemlen)
     batch_idx = [
-        idx[i + offset: i + offset + batch_size: step]
+        idx[i: i + batch_size]
         for i in range(0, len(idx) - batch_size + 1, batch_size)
     ]
     if seed is not None:
@@ -626,6 +634,22 @@ def _array_to_float_list(value: Any) -> list[float]:
 
 
 def _mx() -> Any:
-    import mlx.core as mx
+    global _mlx_core
+    if _mlx_core is None:
+        import mlx.core as mx
 
-    return mx
+        _mlx_core = mx
+    return _mlx_core
+
+
+def _preference_examples_seen(
+    *,
+    collector: PreferenceMetricsCollector,
+    config: LoRATrainingConfig,
+) -> int:
+    if collector.examples_seen is not None:
+        return collector.examples_seen
+    # MLX-LM preference callbacks reliably expose trained_tokens, but not row
+    # counts. Keep examples_seen as configured sample-visits until that callback
+    # adds an actual examples counter.
+    return config.batch_size * config.iters

--- a/services/mlx-worker-python/worker/model_ops/preference_training.py
+++ b/services/mlx-worker-python/worker/model_ops/preference_training.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import math
+from pathlib import Path
+
+from worker.model_ops.errors import ModelOperationError
+from worker.model_ops.training_config import LoRATrainingConfig
+
+
+@dataclass(frozen=True)
+class PreferencePair:
+    prompt: str
+    chosen: str
+    rejected: str
+
+
+@dataclass(frozen=True)
+class PreferenceObjectiveConfig:
+    algorithm: str
+    beta: float
+    margin_target: float = 0.0
+
+
+def load_preference_pairs(dataset_dir: Path) -> list[PreferencePair]:
+    path = dataset_dir / "train.jsonl"
+    pairs: list[PreferencePair] = []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                sample = json.loads(line)
+                try:
+                    pairs.append(
+                        PreferencePair(
+                            prompt=str(sample["prompt"]),
+                            chosen=str(sample["chosen"]),
+                            rejected=str(sample["rejected"]),
+                        )
+                    )
+                except KeyError as exc:
+                    raise ModelOperationError(
+                        code="invalid_dataset_package",
+                        message="preference_pair training rows must include prompt, chosen, and rejected.",
+                        details={
+                            "line_number": str(line_number),
+                            "missing_field": str(exc.args[0]),
+                        },
+                    ) from exc
+    except FileNotFoundError as exc:
+        raise ModelOperationError(
+            code="invalid_dataset_package",
+            message="preference_pair training requires train.jsonl.",
+            details={"path": str(path)},
+        ) from exc
+
+    if not pairs:
+        raise ModelOperationError(
+            code="invalid_dataset_package",
+            message="preference_pair training requires at least one training pair.",
+        )
+    return pairs
+
+
+def resolve_preference_objective(config: LoRATrainingConfig) -> PreferenceObjectiveConfig:
+    if config.alignment is None:
+        raise ModelOperationError(
+            code="invalid_alignment_config",
+            message="preference training requires alignment config.",
+        )
+    beta = config.alignment.kl_penalty if config.alignment.kl_penalty > 0 else 0.1
+    return PreferenceObjectiveConfig(
+        algorithm=config.alignment.alignment_algorithm,
+        beta=beta,
+        margin_target=config.alignment.preference_margin_target,
+    )
+
+
+def dpo_loss_value(policy_margin: float, reference_margin: float, beta: float) -> float:
+    return -_log_sigmoid(beta * (policy_margin - reference_margin))
+
+
+def orpo_loss_value(chosen_nll: float, policy_margin: float, beta: float) -> float:
+    return chosen_nll - beta * _log_sigmoid(policy_margin)
+
+
+def cpo_loss_value(policy_margin: float, beta: float, margin_target: float) -> float:
+    return -_log_sigmoid(beta * (policy_margin - margin_target))
+
+
+def _log_sigmoid(value: float) -> float:
+    if value >= 0:
+        return -math.log1p(math.exp(-value))
+    return value - math.log1p(math.exp(value))

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -18,6 +18,7 @@ class AlignmentTrainingConfig:
     reward_model_manifest_path: str = ""
     grpo_candidate_count: int = 0
     kl_penalty: float = 0.0
+    preference_margin_target: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -711,6 +712,12 @@ def _resolve_alignment_config(
             default=0.0,
             minimum=0.0,
             field_name="kl_penalty",
+        ),
+        preference_margin_target=_float_value(
+            ext.get("preference_margin_target", ""),
+            default=0.0,
+            minimum=0.0,
+            field_name="preference_margin_target",
         ),
     )
 


### PR DESCRIPTION
## Summary
- Continues the Issue 365 offline preference trainer slice after merged PR #368.
- Adds native worker routing for `training_objective=preference` so DPO/ORPO/CPO no longer fail fast through the alignment guard.
- Implements `train_preference_native(...)` with preference-pair tokenization, MLX-LM tuner wiring, LoRA adapter output, DPO reference-model loading, DPO/ORPO/CPO MLX loss components, and final preference metrics.
- Addresses PR #369 review feedback: absent preference metrics now serialize as JSON `null`, the alignment manifest uses `preference_loss_config` for the config-time selector, the preference trainer keeps static request/result types, disables eval when no validation dataset exists, records callback-provided example counts when present, rejects deferred distributed sharding explicitly, and caches the optional MLX import.
- Keeps GRPO/RLHF under the existing `unsupported_alignment_trainer` guard until their real alignment-RL backends exist.

## Plan or Spec
- Refs #365.
- Builds on merged PR #368 / branch `codex/issue365-alignment-quantization-contracts`.
- Governing plan: `docs/plans/2026-05-05-issue-365-offline-preference-trainers.md`.
- Prior guard plan: `docs/plans/2026-05-05-issue-365-offline-preference-trainer-guard.md`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_training_metrics_serializes_preference_fields services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_training_metrics_serializes_absent_preference_fields_as_null services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_preference_examples_seen_prefers_callback_count services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_preference_training_iterate_batches_rejects_distributed_sharding services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_train_preference_native_wires_mlx_lm_trainer_and_metrics services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_preference_mode_contracts
# 8 passed, 2 warnings in 1.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_lora_model_ops.py
# 142 passed, 2 warnings in 3.49s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_lora_model_ops.py
# 142 passed, 2 warnings in 4.03s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-offline-preference-trainers-review-coverage.json
# Wrote JSON report to /tmp/issue365-offline-preference-trainers-review-coverage.json

python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-offline-preference-trainers-review-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/preference_training.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py
# TOTAL 97.88% 600/613

git diff --check
# passed

python3 -m compileall -q services/mlx-worker-python/worker/model_ops/preference_training.py services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py
# passed

python3 scripts/validate_pr_evidence.py --body-file /private/tmp/pr-369-review-fix.md
# PR evidence looks valid.
```

## Coverage and Metrics
- Python changed-line coverage for touched worker/test scope, measured against `origin/main`: `97.88% (600/613)`.
- Native preference trainer metrics: `train_preference_native(...)` returns `preference_loss_final`, `chosen_logprob_mean`, `rejected_logprob_mean`, `chosen_rejected_margin`, and `win_rate_proxy` from final policy scoring.
- Non-preference `TrainingMetrics` now serializes preference-only metrics as JSON `null`, so manifest consumers can distinguish "not applicable" from a zero-valued preference run.
- Alignment manifests carry `preference_loss_config` for the requested preference objective and `preference_loss_final` for the observed post-training scalar.
- Runtime performance metrics preserve `tokens_seen`, callback-provided `examples_seen` when available, `tokens_per_second`, `learning_rate_final`, checkpoint summary, resume source, and peak memory fields in `TrainingMetrics`.
- Objective coverage: DPO reference-margin loss, ORPO chosen-NLL plus odds loss, and CPO margin-target loss are covered by MLX array tests; trainer wiring is covered with patched MLX-LM `load/train/save_config` calls.

## Known Gaps
- This PR does not by itself satisfy all #365 acceptance criteria.
- The new DPO/ORPO/CPO path is covered by deterministic and patched local tests; a full real local model training run remains part of later Issue 365 runtime evidence.
- Distributed preference batch sharding now fails explicitly until GRPO/distributed trainer support lands.
- GRPO candidate generation/scoring/policy updates remain deferred.
- RLHF remains blocked on the reward-model artifact from #366.
- Real PTQ/QAT local inference evidence, full CLI chain acceptance, and Window real-runtime acceptance remain deferred.
- Full repository `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not rerun locally for this focused slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or no protocol changes were made.
- [x] Dependency changes include updated lockfiles, or no dependency changes were made.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
