### PR TITLE
perf: remove redundant benchmark result sort

### DIFF
--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -689,7 +689,7 @@ def _collect_benchmark_run(
     job_path = scan.file_path("bench-job.json")
     context_path = scan.file_path("bench-context-rows.jsonl")
     batch_path = scan.file_path("bench-batch-rows.jsonl")
-    result_paths = list(scan.matching_file_paths(prefix="bench-result-", suffix=".json"))
+    result_paths = scan.matching_file_paths(prefix="bench-result-", suffix=".json")
 
     if summary_path is not None:
         summary_row = _try_load_json_object(summary_path)
@@ -710,7 +710,7 @@ def _collect_benchmark_run(
     if batch_path is not None:
         batch_rows.extend(_try_iter_jsonl_dict_rows(batch_path))
 
-    for result_path in sorted(result_paths):
+    for result_path in result_paths:
         result_row = _try_load_json_object(result_path)
         if result_row is not None:
             results.append(result_row)


### PR DESCRIPTION
## Summary
- Remove a redundant sort in benchmark export result collection by iterating `bench-result-*.json` files in the already-sorted scan order returned by `_ScannedDirectoryEntries.matching_file_paths`.
- This is a micro-optimization that avoids an extra O(m log m) sort pass per benchmark run without changing output ordering.

## Plan or Spec
- Governing spec: one-path optimization slice to remove redundant sorting overhead in `services/mlx-worker-python/worker/productization/benchmark_export.py::_collect_benchmark_run`.
- Candidate selected from scout review: remove redundant sorting in `_collect_benchmark_run` with real verification path via existing `benchmark_export` tests and `benchmark-export-run-scan-single-pass` probe.

## Commands Run
```text
cd /tmp/melix-cron-opt-20260504-202902
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_export.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_export.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_export.py services/mlx-worker-python/tests/test_benchmark_export.py
cd /tmp/melix-cron-opt-20260504-202902 && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python /tmp/measure_benchmark_export_scan.py
```

## Coverage and Metrics
- Focused test results: `54 passed` in `services/mlx-worker-python/tests/test_benchmark_export.py`.
- Changed-scope coverage (measurable changed lines: `2`, covered: `2`, missed: `0`): **100.00%**.
- Probe metrics (`_probe_benchmark_export_run_scan`):
  - `benchmark_job_count`: 241.0
  - `evaluation_job_count`: 241.0
  - `evaluation_result_count`: 241.0
  - `evaluation_sample_count`: 241.0
  - `result_file_count`: 723.0
  - `run_directory_count`: 240.0
  - `elapsed_ms_mean`: 83.547986
  - `per_run_ms_mean`: 0.348117
  - `csv_elapsed_ms_mean`: 2.285101

## Known Gaps
- `make bootstrap`, `make proto`, `make swift-test`, and `make integration-test` were not run locally in this cron-only optimization pass.
- Full project-level CI validation remains to be confirmed on GitHub.

## Evidence Checklist
- [x] Relevant plan/spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (`N/A`: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (`N/A`: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, and changed-scope coverage is above threshold.
- [x] Deferred work and known gaps are stated explicitly.
