### PR TITLE
perf: avoid sorting HF cache snapshots

### DIFF
--- a/docs/plans/2026-05-04-real-model-support-hf-cache-latest-snapshot.md
+++ b/docs/plans/2026-05-04-real-model-support-hf-cache-latest-snapshot.md
@@ -1,0 +1,37 @@
+# Real model support HF cache latest snapshot optimization
+
+## Goal
+
+Reduce redundant work in the Linux-verifiable real-model support helper that falls back to the Hugging Face cache when `refs/main` is unavailable.
+
+## Scope
+
+- `scripts/real_model_support.py`
+- `tests/test_real_model_support.py`
+- `scripts/real_model_support_hf_cache_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Linux-only constraint
+
+This slice touches Python helper and CI probe code only. It does not require macOS or Swift validation.
+
+## Optimization hypothesis
+
+`_huggingface_cache_model_path(...)` currently materializes every snapshot directory name and sorts the full list to pick the lexicographically latest fallback. The fallback only needs the maximum name, so the helper can track the latest directory during the existing `os.scandir(...)` pass and avoid the `O(n log n)` sort and list allocation.
+
+## Performance probe
+
+Register `real-model-support-hf-cache-latest-snapshot` in the PR-scoped performance registry. The probe creates a synthetic Hugging Face cache with thousands of snapshot directories and repeatedly resolves the fallback path, reporting:
+
+- `elapsed_ms_mean` (lower is better)
+- `peak_bytes_mean` (lower is better)
+- `snapshot_count` (guardrail)
+- `selected_latest_snapshot` (guardrail)
+
+## Success metrics
+
+- Focused pytest for the real-model support fallback and PR-scoped probe registration passes.
+- Changed-scope coverage for touched executable Python lines is at least 95%.
+- Local head probe reports concrete elapsed and memory metrics.
+- Detached `origin/main` vs head PR-scoped probe comparison shows lower elapsed time and/or peak memory for the same synthetic cache workload.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1050,6 +1050,37 @@
     ]
   },
   {
+    "id": "real-model-support-hf-cache-latest-snapshot",
+    "name": "Real model support HF cache latest snapshot",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "scripts/real_model_support.py",
+      "tests/test_real_model_support.py",
+      "scripts/real_model_support_hf_cache_probe.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/real_model_support.py tests/test_real_model_support.py scripts/real_model_support_hf_cache_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/real_model_support_hf_cache_probe.py ]; then python scripts/real_model_support_hf_cache_probe.py; else python - <<\"PY\"\nimport json\nimport statistics\nimport sys\nimport tempfile\nimport time\nimport tracemalloc\nfrom pathlib import Path\n\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\n\nfrom scripts.real_model_support import resolve_real_small_text_model_source\n\nSNAPSHOT_COUNT = 6000\nSAMPLE_COUNT = 7\nLATEST_SNAPSHOT = f\"snapshot-{SNAPSHOT_COUNT - 1:05d}\"\n\nelapsed_samples = []\npeak_samples = []\nselected_snapshots = set()\nwith tempfile.TemporaryDirectory() as tmpdir:\n    home = Path(tmpdir) / \"home\"\n    snapshots_root = home / \".cache\" / \"huggingface\" / \"hub\" / \"models--mlx-community--Qwen3.5-0.8B-OptiQ-4bit\" / \"snapshots\"\n    snapshots_root.mkdir(parents=True)\n    for index in range(SNAPSHOT_COUNT):\n        (snapshots_root / f\"snapshot-{index:05d}\").mkdir()\n    (snapshots_root / \"not-a-directory\").write_text(\"ignored\\n\", encoding=\"utf-8\")\n    environment = {\"HOME\": str(home)}\n    for _ in range(SAMPLE_COUNT):\n        tracemalloc.start()\n        started = time.perf_counter()\n        source = resolve_real_small_text_model_source(environment=environment, allow_managed_root=False, allow_hf_cache=True)\n        elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n        _, peak = tracemalloc.get_traced_memory()\n        tracemalloc.stop()\n        peak_samples.append(float(peak))\n        selected_snapshots.add(Path(source.local_model_path).name)\nif selected_snapshots != {LATEST_SNAPSHOT}:\n    raise RuntimeError(f\"unexpected selected snapshots: {sorted(selected_snapshots)}\")\nprint(json.dumps({\n    \"elapsed_ms_mean\": round(statistics.fmean(elapsed_samples), 6),\n    \"peak_bytes_mean\": round(statistics.fmean(peak_samples), 1),\n    \"sample_count\": float(SAMPLE_COUNT),\n    \"snapshot_count\": float(SNAPSHOT_COUNT),\n    \"selected_latest_snapshot\": float(SNAPSHOT_COUNT - 1),\n}, sort_keys=True))\nPY\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "swift-cli-json-envelope-encoding",
     "name": "Swift CLI JSON envelope encoding",
     "runner": "macos-15",

--- a/scripts/real_model_support.py
+++ b/scripts/real_model_support.py
@@ -290,15 +290,16 @@ def _huggingface_cache_model_path(
     snapshots_root = repo_cache / "snapshots"
     if not snapshots_root.is_dir():
         return None
-    snapshot_names: list[str] = []
+    latest_snapshot_name: str | None = None
     with os.scandir(snapshots_root) as entries:
         for entry in entries:
             if not entry.is_dir():
                 continue
-            snapshot_names.append(entry.name)
-    if not snapshot_names:
+            if latest_snapshot_name is None or entry.name > latest_snapshot_name:
+                latest_snapshot_name = entry.name
+    if latest_snapshot_name is None:
         return None
-    fallback = (snapshots_root / sorted(snapshot_names)[-1]).resolve()
+    fallback = (snapshots_root / latest_snapshot_name).resolve()
     return _HuggingFaceCacheModelPath(
         path=fallback,
         warnings=(

--- a/scripts/real_model_support_hf_cache_probe.py
+++ b/scripts/real_model_support_hf_cache_probe.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+SNAPSHOT_COUNT = 6000
+SAMPLE_COUNT = 7
+MODEL_ID = "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"
+LATEST_SNAPSHOT = f"snapshot-{SNAPSHOT_COUNT - 1:05d}"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _build_cache(home: Path) -> Path:
+    snapshots_root = (
+        home
+        / ".cache"
+        / "huggingface"
+        / "hub"
+        / "models--mlx-community--Qwen3.5-0.8B-OptiQ-4bit"
+        / "snapshots"
+    )
+    snapshots_root.mkdir(parents=True)
+    for index in range(SNAPSHOT_COUNT):
+        (snapshots_root / f"snapshot-{index:05d}").mkdir()
+    (snapshots_root / "not-a-directory").write_text("ignored\n", encoding="utf-8")
+    return snapshots_root
+
+
+def _measure() -> dict[str, float]:
+    repo_root = _repo_root()
+    sys.path.insert(0, str(repo_root))
+    sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
+
+    from scripts.real_model_support import resolve_real_small_text_model_source
+
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    selected_snapshots: set[str] = set()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        home = Path(tmpdir) / "home"
+        snapshots_root = _build_cache(home)
+        environment = {"HOME": str(home)}
+
+        for _ in range(SAMPLE_COUNT):
+            tracemalloc.start()
+            started = time.perf_counter()
+            source = resolve_real_small_text_model_source(
+                environment=environment,
+                allow_managed_root=False,
+                allow_hf_cache=True,
+            )
+            elapsed_ms = (time.perf_counter() - started) * 1000.0
+            _, peak = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+
+            elapsed_samples.append(elapsed_ms)
+            peak_samples.append(float(peak))
+            selected_snapshots.add(Path(source.local_model_path).name)
+
+        if selected_snapshots != {LATEST_SNAPSHOT}:
+            raise RuntimeError(f"unexpected selected snapshots: {sorted(selected_snapshots)}")
+        if len(tuple(snapshots_root.iterdir())) != SNAPSHOT_COUNT + 1:
+            raise RuntimeError("synthetic cache was not built with the expected snapshot count")
+
+    return {
+        "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+        "peak_bytes_mean": round(statistics.fmean(peak_samples), 1),
+        "sample_count": float(SAMPLE_COUNT),
+        "snapshot_count": float(SNAPSHOT_COUNT),
+        "selected_latest_snapshot": float(SNAPSHOT_COUNT - 1),
+    }
+
+
+def main() -> int:
+    print(json.dumps(_measure(), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -101,6 +101,16 @@ def test_scope_report_selects_training_dataset_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "training-dataset-token-percentiles-single-sort"
 
 
+def test_scope_report_selects_real_model_support_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["scripts/real_model_support.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "real-model-support-hf-cache-latest-snapshot"
+
+
 def test_scope_report_selects_evaluation_probes() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -547,6 +557,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "maintenance-percentile-vector-reuse",
         "phase8-metrics-closure-audit-reuse",
         "pr-scoped-performance-registry-cache",
+        "real-model-support-hf-cache-latest-snapshot",
         "swift-cli-json-envelope-encoding",
         "upload-receipt-published-files-scandir",
         "download-pipeline-directory-size-single-stat",
@@ -1264,6 +1275,21 @@ def test_benchmark_store_probe_script_emits_metrics(capsys: pytest.CaptureFixtur
     assert payload["request_row_count"] == 6000.0
     assert payload["request_csv_line_count"] == 6001.0
     assert payload["sample_count"] == 3.0
+
+
+def test_real_model_support_hf_cache_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(REPO_ROOT / "scripts/real_model_support_hf_cache_probe.py"), run_name="__main__")
+
+    assert excinfo.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["elapsed_ms_mean"] > 0
+    assert payload["peak_bytes_mean"] > 0
+    assert payload["sample_count"] == 7.0
+    assert payload["snapshot_count"] == 6000.0
+    assert payload["selected_latest_snapshot"] == 5999.0
 
 
 def test_upload_receipt_probe_script_emits_metrics(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_real_model_support.py
+++ b/tests/test_real_model_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import json
 from pathlib import Path
 
@@ -238,6 +239,40 @@ def test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot(tmp_path
     assert source.local_model_path == str(latest_snapshot.resolve())
     assert source.source_resolution_mode == "hf_cache_snapshot"
     assert "refs/main was unavailable" in source.warnings[0]
+
+
+def test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home = tmp_path / "home"
+    snapshots_root = (
+        home
+        / ".cache"
+        / "huggingface"
+        / "hub"
+        / "models--mlx-community--Qwen3.5-0.8B-OptiQ-4bit"
+        / "snapshots"
+    )
+    for snapshot_name in ("bbb", "zzz", "aaa", "mno"):
+        (snapshots_root / snapshot_name).mkdir(parents=True)
+    (snapshots_root / "not-a-directory").write_text("ignored\n", encoding="utf-8")
+
+    def fail_sorted(*args, **kwargs):  # pragma: no cover - regression sentinel
+        raise AssertionError("HF cache fallback should not sort every snapshot name")
+
+    monkeypatch.setattr(builtins, "sorted", fail_sorted)
+
+    source = resolve_real_small_text_model_source(
+        environment={"HOME": str(home)},
+        allow_managed_root=False,
+        allow_hf_cache=True,
+    )
+
+    assert source.live is False
+    assert source.local_model_path == str((snapshots_root / "zzz").resolve())
+    assert source.source_resolution_mode == "hf_cache_snapshot"
+    assert "using lexicographically last snapshot directory" in source.warnings[0]
 
 
 def test_runtime_model_preflight_marks_real_local_weights(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Avoid sorting every Hugging Face cache snapshot directory when `scripts/real_model_support.py` falls back without `refs/main`.
- Track the lexicographically latest snapshot during the existing `os.scandir(...)` pass instead.
- Add a focused regression test and a registered PR-scoped performance probe for the fallback path.

## Plan or Spec
- `docs/plans/2026-05-04-real-model-support-hf-cache-latest-snapshot.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics
# 5 passed in 0.66s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/real_model_support.py tests/test_real_model_support.py scripts/real_model_support_hf_cache_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 5 passed in 1.45s; TOTAL 32 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/real_model_support_hf_cache_probe.py
# {"elapsed_ms_mean": 17.293187, "peak_bytes_mean": 4894.0, "sample_count": 7.0, "selected_latest_snapshot": 5999.0, "snapshot_count": 6000.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id real-model-support-hf-cache-latest-snapshot --base-repo /tmp/melix-cron-opt-20260504-223910-base --head-repo "$PWD" --output /tmp/real-model-support-hf-cache-probe.json
# head verification passed; base elapsed_ms_mean=19.727285 / peak_bytes_mean=457016.0; head elapsed_ms_mean=16.923846 / peak_bytes_mean=4894.0

git diff --check
# passed

python -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.check.json
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 32 0 100%`.
- Registered scoped probe: `real-model-support-hf-cache-latest-snapshot`.
- Local head probe: `elapsed_ms_mean=17.293187`, `peak_bytes_mean=4894.0`, `snapshot_count=6000.0`.
- Local base-vs-head scoped probe:
  - base: `elapsed_ms_mean=19.727285`, `peak_bytes_mean=457016.0`
  - head: `elapsed_ms_mean=16.923846`, `peak_bytes_mean=4894.0`
  - interpretation: ~14.21% lower elapsed time and ~98.93% lower traced peak memory on the synthetic 6000-snapshot fallback workload.

## Known Gaps
- Linux/Python-only verification. Swift/macOS checks were not run because this slice only touches Python helper, tests, docs, and PR-scoped performance registry/script code.
- Updating `infra/perf/pr_scoped_probes.json` may trigger the full `pr-scoped-performance` matrix; hosted CI remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
