### PR TITLE
perf: cache stream assembler parser mode state

### DIFF
--- a/docs/plans/2026-05-04-stream-assembler-parser-mode-cache.md
+++ b/docs/plans/2026-05-04-stream-assembler-parser-mode-cache.md
@@ -1,0 +1,27 @@
+# Stream Assembler Parser Mode Cache Plan
+
+## Goal
+
+Reduce repeated parser-mode and structural-prefix derivation in `RequestStreamAssembler` by computing immutable request-mode values once during assembler initialization.
+
+## Linux-only constraint
+
+This slice is Python-only and can be verified locally on Linux with focused pytest, changed-scope coverage, and an explicit synthetic stream assembly probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/stream_assembler.py`
+- `services/mlx-worker-python/tests/test_stream_assembler.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Performance probe
+
+Register `stream-assembler-parser-mode-cache` in the PR-scoped performance registry. The probe feeds many cumulative fragments through a tool-enabled assembler, including partial structural tag suffixes and tool-call parsing, and reports elapsed time plus emitted tool-call count.
+
+## Success metrics
+
+- Focused stream assembler tests pass.
+- Changed-scope coverage for touched executable Python lines is at least 95%.
+- Local synthetic probe shows lower mean elapsed time on head than `origin/main` while preserving the same tool-call count.
+- `git diff --check` passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -25,6 +25,30 @@
     ]
   },
   {
+    "id": "stream-assembler-parser-mode-cache",
+    "name": "Stream assembler parser-mode cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/stream_assembler.py",
+      "services/mlx-worker-python/tests/test_stream_assembler.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 - <<'PY'\nimport json\nimport statistics\nimport time\nfrom worker.runtime.stream_assembler import RequestStreamAssembler, StreamFragment\n\nchunks = []\nraw = ''\nfor index in range(1200):\n    if index % 120 == 0:\n        piece = '<think>plan</think><tool_call>{\\\"id\\\":\\\"call-%d\\\",\\\"name\\\":\\\"search\\\",\\\"arguments\\\":{\\\"q\\\":\\\"alpha\\\"}}</tool_call>' % index\n    elif index % 17 == 0:\n        piece = 'alpha<tool_ca'\n    else:\n        piece = ' token-%d ' % index\n    raw += piece\n    chunks.append(raw)\n\nelapsed = []\ntool_counts = []\nfor _ in range(8):\n    assembler = RequestStreamAssembler('probe', True, '', 'qwen')\n    started = time.perf_counter()\n    tool_count = 0\n    for chunk in chunks:\n        tool_count += sum(1 for delta in assembler.accept(StreamFragment(raw_text=chunk)) if delta.tool_call is not None)\n    completed = assembler.completed()\n    elapsed.append((time.perf_counter() - started) * 1000.0)\n    tool_counts.append(tool_count)\n    if completed.metrics['tool_call_markup_leak_count'] != 0:\n        raise SystemExit('tool markup leaked')\nif len(set(tool_counts)) != 1 or tool_counts[0] != 10:\n    raise SystemExit(f'unexpected tool counts: {tool_counts!r}')\nprint(json.dumps({'elapsed_ms_mean': statistics.fmean(elapsed), 'raw_char_count': float(len(raw)), 'tool_call_count': float(tool_counts[0])}, sort_keys=True))\nPY",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "deterministic-embedding-duplicate-input-cache",
     "name": "Deterministic embedding duplicate input cache",
     "runner": "ubuntu-latest",

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -79,6 +79,16 @@ def benchmark_scope() -> dict[str, object]:
     )
 
 
+def test_scope_report_selects_stream_assembler_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/stream_assembler.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "stream-assembler-parser-mode-cache"
+
+
 def test_scope_report_selects_only_matching_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -666,6 +676,7 @@ def test_deterministic_embedding_duplicate_probe_script_emits_metrics(
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
         "benchmark-evaluation-report-running-aggregates",
+        "stream-assembler-parser-mode-cache",
         "benchmark-export-run-scan-single-pass",
         "benchmark-queue-decoded-record-cache",
         "benchmark-store-matrix-streaming",

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -30,6 +30,23 @@ def test_structural_tag_prefixes_are_cached_per_parser_mode() -> None:
 
     assert tool_enabled._structural_tag_prefixes == think_prefixes + tool_prefixes
     assert tool_disabled._structural_tag_prefixes == think_prefixes
+    assert tool_enabled._structural_tag_prefixes is tool_enabled._structural_tag_prefixes
+    assert tool_disabled._structural_tag_prefixes is tool_disabled._structural_tag_prefixes
+
+
+def test_parser_mode_flags_are_computed_once_at_initialization() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-cached-parser-mode-flags",
+        reasoning_enabled=False,
+        structured_output_mode=" json_schema ",
+        tool_parser_mode=" qwen ",
+    )
+
+    assert assembler._is_json_structured_output is True
+    assert assembler._is_json_only_structured_output is False
+    assert assembler._tool_parsing_enabled is True
+    assert assembler._request_context_mode == "tool_parser"
+    assert assembler._structural_tag_prefixes is assembler._structural_tag_prefixes_value
 
 
 def test_next_structural_tag_prefers_the_earliest_tool_tag() -> None:

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -58,6 +58,24 @@ class RequestStreamAssembler:
         self._reasoning_enabled = reasoning_enabled
         self._structured_output_mode = structured_output_mode.strip().lower()
         self._tool_parser_mode = tool_parser_mode.strip().lower()
+        self._tool_parsing_enabled_value = bool(self._tool_parser_mode)
+        self._is_json_structured_output_value = self._structured_output_mode in {
+            "json_object",
+            "json_schema",
+        }
+        self._is_json_only_structured_output_value = (
+            self._is_json_structured_output_value and not self._tool_parsing_enabled_value
+        )
+        self._structural_tag_prefixes_value = self._THINK_PREFIXES
+        if self._tool_parsing_enabled_value:
+            self._request_context_mode_value = "tool_parser"
+            self._structural_tag_prefixes_value = self._THINK_PREFIXES + self._TOOL_PREFIXES
+        elif self._is_json_structured_output_value:
+            self._request_context_mode_value = "structured_json"
+        elif self._reasoning_enabled:
+            self._request_context_mode_value = "reasoning_only"
+        else:
+            self._request_context_mode_value = "plain"
         self._raw_seen = ""
         self._buffer = ""
         self._json_started = False
@@ -111,31 +129,23 @@ class RequestStreamAssembler:
 
     @property
     def _is_json_structured_output(self) -> bool:
-        return self._structured_output_mode in {"json_object", "json_schema"}
+        return self._is_json_structured_output_value
 
     @property
     def _is_json_only_structured_output(self) -> bool:
-        return self._is_json_structured_output and not self._tool_parser_mode
+        return self._is_json_only_structured_output_value
 
     @property
     def _tool_parsing_enabled(self) -> bool:
-        return bool(self._tool_parser_mode)
+        return self._tool_parsing_enabled_value
 
     @property
     def _request_context_mode(self) -> str:
-        if self._tool_parsing_enabled:
-            return "tool_parser"
-        if self._is_json_structured_output:
-            return "structured_json"
-        if self._reasoning_enabled:
-            return "reasoning_only"
-        return "plain"
+        return self._request_context_mode_value
 
     @property
     def _structural_tag_prefixes(self) -> tuple[str, ...]:
-        if self._tool_parsing_enabled:
-            return self._THINK_PREFIXES + self._TOOL_PREFIXES
-        return self._THINK_PREFIXES
+        return self._structural_tag_prefixes_value
 
     def _unseen_delta(self, raw: str) -> str:
         if raw.startswith(self._raw_seen):


### PR DESCRIPTION
## Summary
- Cache immutable `RequestStreamAssembler` parser-mode booleans, request-context mode, and structural tag prefix tuples during initialization.
- Preserve existing private property accessors as compatibility shims while avoiding repeated mode-derived recomputation in stream hot paths.
- Register a PR-scoped performance probe for the stream assembler parser-mode cache path.

## Plan or Spec
- `docs/plans/2026-05-04-stream-assembler-parser-mode-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 26 passed in 0.32s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id stream-assembler-parser-mode-cache --base-repo /tmp/melix-cron-opt-base-20260504-231123 --head-repo "$PWD" --output /tmp/stream-assembler-probe-result.json
# head verification: 26 passed in 0.19s; changed-scope coverage TOTAL 32 0 100%
# base probe elapsed_ms_mean=8.056342863710597, tool_call_count=10.0
# head probe elapsed_ms_mean=5.423131748102605, tool_call_count=10.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 32 0 100%` from `scripts/changed_scope_coverage.py`.
- Registered scoped probe: `stream-assembler-parser-mode-cache`.
- Local base-vs-head probe: `elapsed_ms_mean` improved from `8.0563 ms` to `5.4231 ms` (~32.68% lower) on the synthetic cumulative stream workload.
- Probe semantic guard: `tool_call_count` stayed `10.0`; `raw_char_count` stayed `14323.0`; no tool-call markup leaked.

## Known Gaps
- Linux-only Python verification was run locally. macOS/Swift checks were not run because this PR does not touch Swift/macOS surfaces.
- Editing `infra/perf/pr_scoped_probes.json` force-selects the full PR-scoped performance matrix in hosted CI; merge should wait for the relevant hosted scoped performance workflow/report to pass.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
