### PR TITLE
perf: cache multimodal signature key ordering

### DIFF
--- a/docs/plans/2026-05-05-multimodal-fast-path-signature-top-level-key-cache.md
+++ b/docs/plans/2026-05-05-multimodal-fast-path-signature-top-level-key-cache.md
@@ -1,0 +1,32 @@
+# Multimodal Fast-Path Signature Top-Level Key Cache
+
+## Goal
+
+Avoid per-call sorting of the fixed top-level model metadata keys used by `fast_path_probe_signature(...)` while preserving the existing stable signature representation.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py`
+- `services/mlx-worker-python/tests/test_multimodal_fast_paths.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/multimodal_fast_path_signature_probe.py`
+
+## Linux-only constraint
+
+This is a Python runtime helper slice and can be verified on Linux with focused pytest, changed-scope coverage, and a local performance probe.
+
+## Performance probe
+
+Register `multimodal-fast-path-signature-top-level-key-cache` in the PR-scoped performance registry. The probe repeatedly calls `fast_path_probe_signature(...)` against a representative loaded VLM model dictionary and prepared vision request, recording:
+
+- `elapsed_ms_mean` (lower is better)
+- `peak_bytes_mean` (lower is better)
+- `sample_count`
+
+## Success metrics
+
+- Focused tests pass.
+- Changed executable line coverage for the touched Python scope is at least 95%.
+- Local probe shows behavior-preserving concrete timing/allocation metrics against `origin/main`.
+- `git diff --check` passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "multimodal-fast-path-signature-top-level-key-cache",
+    "name": "Multimodal fast-path signature top-level key cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py",
+      "services/mlx-worker-python/tests/test_multimodal_fast_paths.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/multimodal_fast_path_signature_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_fast_path_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_fast_path_signature_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_fast_path_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_fast_path_signature_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/multimodal_fast_path_signature_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/multimodal_fast_path_signature_probe.py ]; then python scripts/multimodal_fast_path_signature_probe.py; else python - <<\"PY\"\nimport json\nimport statistics\nimport sys\nimport time\nimport tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.runtime.multimodal_fast_paths import fast_path_probe_signature\nfrom worker.runtime.multimodal_preprocessing import PreparedImageInput, PreparedVisionRequest\nimage = PreparedImageInput(bytes_data=b\"synthetic-image-payload\", source_kind=\"inline\", reference=\"inline:sample.jpg\", mime_type=\"image/jpeg\", format=\"jpg\", filename=\"sample.jpg\", sha256_hex=\"f\" * 64)\nrequest = PreparedVisionRequest(prompt_text=\"Describe the image in detail.\", images=[image], videos=[], video_frame_policies=[], preprocess_latency_ms=1.0, preprocess_input_bytes=image.byte_length, preprocess_peak_memory_bytes=image.byte_length, prompt_hash_hex=\"p\" * 64, multimodal_hash_hex=\"m\" * 64)\nloaded_model = {\"model_id\": \"melix-dev-vlm\", \"revision\": \"main\", \"tokenizer_hash\": \"tok-abcdef\", \"quant_profile_id\": \"q8\", \"metadata\": {\"melix.vlm.execution_mode\": \"multimodal\", \"vision_family_id\": \"gemma4-v1\", \"vision_prompt_profile_id\": \"gemma4-chatml-v1\", \"vision_tokenization_mode\": \"interleaved\", \"vision_max_images_per_prompt\": \"8\", \"melix.multimodal_adapter_hash\": \"adapter-a\"}}\nexpected_signature = fast_path_probe_signature(loaded_model, request)\niterations = 120000\nsample_count = 5\nelapsed_samples = []\npeak_samples = []\nsignature_count = 0\nfor _ in range(sample_count):\n    tracemalloc.start()\n    start = time.perf_counter()\n    for _index in range(iterations):\n        signature = fast_path_probe_signature(loaded_model, request)\n        if signature != expected_signature:\n            raise AssertionError(\"fast-path probe signature changed during probe\")\n        signature_count += 1\n    elapsed_samples.append((time.perf_counter() - start) * 1000.0)\n    _current, peak = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    peak_samples.append(float(peak))\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed_samples), \"peak_bytes_mean\": statistics.fmean(peak_samples), \"sample_count\": float(sample_count), \"iterations_per_sample\": float(iterations), \"signature_count\": float(signature_count), \"top_level_item_count\": 4.0}, sort_keys=True))\nPY\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "benchmark-evaluation-report-running-aggregates",
     "name": "Benchmark evaluation report running aggregates",
     "runner": "ubuntu-latest",

--- a/scripts/multimodal_fast_path_signature_probe.py
+++ b/scripts/multimodal_fast_path_signature_probe.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+
+def _prepare_imports() -> None:
+    repo_root = Path.cwd()
+    sys.path.insert(0, str(repo_root))
+    sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
+
+
+def _build_request():
+    from worker.runtime.multimodal_preprocessing import PreparedImageInput, PreparedVisionRequest
+
+    image = PreparedImageInput(
+        bytes_data=b"synthetic-image-payload",
+        source_kind="inline",
+        reference="inline:sample.jpg",
+        mime_type="image/jpeg",
+        format="jpg",
+        filename="sample.jpg",
+        sha256_hex="f" * 64,
+    )
+    return PreparedVisionRequest(
+        prompt_text="Describe the image in detail.",
+        images=[image],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=1.0,
+        preprocess_input_bytes=image.byte_length,
+        preprocess_peak_memory_bytes=image.byte_length,
+        prompt_hash_hex="p" * 64,
+        multimodal_hash_hex="m" * 64,
+    )
+
+
+def _build_loaded_model() -> dict[str, object]:
+    return {
+        "model_id": "melix-dev-vlm",
+        "revision": "main",
+        "tokenizer_hash": "tok-abcdef",
+        "quant_profile_id": "q8",
+        "metadata": {
+            "melix.vlm.execution_mode": "multimodal",
+            "vision_family_id": "gemma4-v1",
+            "vision_prompt_profile_id": "gemma4-chatml-v1",
+            "vision_tokenization_mode": "interleaved",
+            "vision_max_images_per_prompt": "8",
+            "melix.multimodal_adapter_hash": "adapter-a",
+        },
+    }
+
+
+def main() -> int:
+    _prepare_imports()
+    from worker.runtime.multimodal_fast_paths import fast_path_probe_signature
+
+    loaded_model = _build_loaded_model()
+    request = _build_request()
+    expected_signature = fast_path_probe_signature(loaded_model, request)
+
+    iterations = int(os.environ.get("MELIX_MULTIMODAL_SIGNATURE_PROBE_ITERATIONS", "120000"))
+    sample_count = int(os.environ.get("MELIX_MULTIMODAL_SIGNATURE_PROBE_SAMPLES", "5"))
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    signature_count = 0
+
+    for _ in range(sample_count):
+        tracemalloc.start()
+        start = time.perf_counter()
+        for _index in range(iterations):
+            signature = fast_path_probe_signature(loaded_model, request)
+            if signature != expected_signature:
+                raise AssertionError("fast-path probe signature changed during probe")
+            signature_count += 1
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        _current, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        elapsed_samples.append(elapsed_ms)
+        peak_samples.append(float(peak))
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+                "peak_bytes_mean": statistics.fmean(peak_samples),
+                "sample_count": float(sample_count),
+                "iterations_per_sample": float(iterations),
+                "signature_count": float(signature_count),
+                "top_level_item_count": float(expected_signature[1].count("(")) - 1.0,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_multimodal_fast_paths.py
+++ b/services/mlx-worker-python/tests/test_multimodal_fast_paths.py
@@ -12,6 +12,7 @@ from worker.runtime.multimodal_fast_paths import (
     MULTIMODAL_LOAD_NATIVE_QUANTIZED,
     MultimodalFastPathController,
     _preprocessing_fingerprint,
+    _FAST_PATH_SIGNATURE_TOP_LEVEL_KEYS_SORTED,
     fast_path_probe_signature,
 )
 from worker.runtime.multimodal_preprocessing import PreparedImageInput, PreparedVisionRequest
@@ -426,3 +427,27 @@ def test_fast_path_probe_signature_ignores_non_dict_loaded_models() -> None:
     signature = fast_path_probe_signature(object(), _request([_image(b"image")]))
 
     assert signature == ("multi", "()", "()")
+
+
+def test_fast_path_probe_signature_reuses_pre_sorted_top_level_keys() -> None:
+    loaded_model = {
+        "quant_profile_id": "q8",
+        "tokenizer_hash": "tok",
+        "revision": "main",
+        "model_id": "melix-dev-vlm",
+        "metadata": {
+            "vision_family_id": "gemma4-v1",
+        },
+    }
+
+    signature = fast_path_probe_signature(loaded_model, _request([_image(b"image")]))
+
+    expected_top_level_items = tuple(
+        (key, str(loaded_model.get(key, "")))
+        for key in _FAST_PATH_SIGNATURE_TOP_LEVEL_KEYS_SORTED
+    )
+    assert signature[1] == repr(expected_top_level_items)
+    assert signature[1] == (
+        "(('model_id', 'melix-dev-vlm'), ('quant_profile_id', 'q8'), "
+        "('revision', 'main'), ('tokenizer_hash', 'tok'))"
+    )

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -155,6 +155,16 @@ def test_dispatch_probe_impl_supports_evaluation_final_result_probe() -> None:
 
 
 
+def test_scope_report_selects_multimodal_fast_path_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "multimodal-fast-path-signature-top-level-key-cache"
+
+
 def test_scope_report_selects_worker_registry_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -519,6 +529,26 @@ def test_compiled_glob_pattern_reuses_cached_regex(monkeypatch: pytest.MonkeyPat
     pr_scoped_performance_module._force_all_wildcard_matchers.cache_clear()
 
 
+def test_multimodal_fast_path_signature_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_MULTIMODAL_SIGNATURE_PROBE_ITERATIONS", "3")
+    monkeypatch.setenv("MELIX_MULTIMODAL_SIGNATURE_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(REPO_ROOT / "scripts/multimodal_fast_path_signature_probe.py"), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["iterations_per_sample"] == 3.0
+    assert metrics["signature_count"] == 3.0
+    assert metrics["top_level_item_count"] == 4.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
         "benchmark-evaluation-report-running-aggregates",
@@ -539,6 +569,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "mlx-lm-structured-result-tail-parse",
         "mlx-vlm-family-config-cache",
         "model-registry-plain-local-manifest-stat-elision",
+        "multimodal-fast-path-signature-top-level-key-cache",
         "package-macos-resolve-fallback-scandir",
         "pr-scoped-performance-scope-json-read-bytes",
         "pr-scoped-performance-scope-matcher",

--- a/services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py
+++ b/services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py
@@ -35,6 +35,7 @@ _FAST_PATH_SIGNATURE_METADATA_KEYS = frozenset(
     }
 )
 _FAST_PATH_SIGNATURE_TOP_LEVEL_KEYS = ("model_id", "revision", "tokenizer_hash", "quant_profile_id")
+_FAST_PATH_SIGNATURE_TOP_LEVEL_KEYS_SORTED = tuple(sorted(_FAST_PATH_SIGNATURE_TOP_LEVEL_KEYS))
 
 
 @dataclass(frozen=True)
@@ -284,10 +285,8 @@ def fast_path_probe_signature(
     top_level_items: tuple[tuple[str, str], ...] = ()
     if isinstance(loaded_model, dict):
         top_level_items = tuple(
-            sorted(
-                (key, str(loaded_model.get(key, "")))
-                for key in _FAST_PATH_SIGNATURE_TOP_LEVEL_KEYS
-            )
+            (key, str(loaded_model.get(key, "")))
+            for key in _FAST_PATH_SIGNATURE_TOP_LEVEL_KEYS_SORTED
         )
     return (
         prepared_request.multimodal_hash_hex,


### PR DESCRIPTION
## Summary
- Cache the sorted top-level key order used by `fast_path_probe_signature(...)` so the fixed model metadata keys are not re-sorted on every signature call.
- Add focused regression coverage for the preserved stable signature representation.
- Register a Linux PR-scoped performance probe for the multimodal fast-path signature hot path.

## Plan or Spec
- Plan: `docs/plans/2026-05-05-multimodal-fast-path-signature-top-level-key-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_fast_path_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_fast_path_signature_probe_script_emits_metrics
# 23 passed in 0.34s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_fast_path_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_fast_path_signature_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/multimodal_fast_path_signature_probe.py
# 23 passed; TOTAL 24 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/multimodal_fast_path_signature_probe.py
# elapsed_ms_mean=9493.312606611289; peak_bytes_mean=30282.8; sample_count=5; iterations_per_sample=120000

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id multimodal-fast-path-signature-top-level-key-cache --base-repo /tmp/melix-cron-opt-20260505001326-base-1777940545 --head-repo "$PWD" --output /tmp/multimodal-fast-path-probe-result-2.json
# head verification passed; base elapsed_ms_mean=9716.23043678701; head elapsed_ms_mean=9518.210083211306

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes_json_check.out
# passed

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 24 0 100%` for touched executable lines.
- Registered scoped CI probe: `multimodal-fast-path-signature-top-level-key-cache`.
- Local base-vs-head probe: `elapsed_ms_mean` improved from `9716.23043678701 ms` to `9518.210083211306 ms` over 5 samples of 120,000 signature calls each (~2.04% lower).
- The probe script also reports peak traced bytes for observability, but the registered gate tracks elapsed time because the code change is a CPU/allocation-work elision of a fixed-key sort and the base-compatible inline fallback has a different script shape from the checked-in head script.

## Known Gaps
- Linux-only verification was run. macOS/Swift checks were not run because this slice only touches Python runtime/perf-harness files.
- Hosted PR-scoped performance and broader branch checks still need to complete on GitHub before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
