### PR TITLE
perf: reduce deterministic embedding projection allocation

### DIFF
--- a/docs/plans/2026-05-05-deterministic-embedding-projection-allocation.md
+++ b/docs/plans/2026-05-05-deterministic-embedding-projection-allocation.md
@@ -1,0 +1,42 @@
+# Deterministic Embedding Projection Allocation Probe
+
+## Goal
+
+Reduce avoidable temporary list allocation in the deterministic embedding projection helper while preserving the exact emitted embedding values.
+
+## Linux-only constraint
+
+This slice is Python-only under `services/mlx-worker-python` and is verifiable on Linux with focused pytest, changed-scope coverage, and an explicit local performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/embedding_backends.py`
+- `services/mlx-worker-python/tests/test_embedding_runtime.py`
+- `scripts/deterministic_embedding_project_digest_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Optimization
+
+`DeterministicEmbeddingBackend._project_digest(...)` currently builds a full repeated `values` list and then builds the final normalized output list. For larger deterministic embedding dimensions, the repeated intermediate list duplicates the final output size.
+
+Compute the repeated-pattern L2 norm from the eight digest-derived base values, then emit the normalized output directly from the base pattern. This preserves ordering and rounding semantics while avoiding the full pre-normalization vector materialization.
+
+## Performance probe
+
+Register `deterministic-embedding-project-digest-allocation` as a `command_json` PR-scoped probe.
+
+Metrics:
+
+- `elapsed_ms_mean` — lower is better, warned on >5% regression.
+- `peak_bytes_mean` — lower is better, warned on >5% regression.
+- `vector_count` and `dimensions` — workload guard metrics.
+
+Success means equivalent vector shape/output semantics with materially lower peak traced memory for a large deterministic projection workload.
+
+## Verification commands
+
+- Focused pytest for embedding runtime tests and probe registry coverage.
+- Changed-scope coverage via `scripts/changed_scope_coverage.py`, requiring >=95% changed executable coverage.
+- Local base-vs-head probe through `scripts/pr_scoped_performance_run.py` for `deterministic-embedding-project-digest-allocation`.
+- `git diff --check`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1286,5 +1286,36 @@
         "warn_pct": 0.0
       }
     ]
+  },
+  {
+    "id": "deterministic-embedding-project-digest-allocation",
+    "name": "Deterministic embedding projection allocation",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/embedding_backends.py",
+      "services/mlx-worker-python/tests/test_embedding_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/deterministic_embedding_project_digest_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py",
+    "probe_command": "if [ -f scripts/deterministic_embedding_project_digest_probe.py ]; then PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py; else PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c 'import gc,json,time,tracemalloc; from worker.runtime.embedding_backends import BERTEmbeddingBackend; b=BERTEmbeddingBackend(); d=4096; n=500; s=3; texts=[f\"bert::synthetic projection row {i % 251}::{i}\" for i in range(n)]; es=[]; ps=[]; c=0.0\nfor _ in range(s):\n gc.collect(); tracemalloc.start(); t=time.perf_counter()\n for text in texts:\n  v=b._project_digest(text,d)\n  if len(v)!=d: raise AssertionError(f\"unexpected vector length: {len(v)}\")\n  c += v[0] + v[-1]\n es.append((time.perf_counter()-t)*1000.0); ps.append(float(tracemalloc.get_traced_memory()[1])); tracemalloc.stop()\nprint(json.dumps({\"elapsed_ms_mean\":round(sum(es)/len(es),6),\"peak_bytes_mean\":round(sum(ps)/len(ps),6),\"sample_count\":float(s),\"vector_count\":float(n),\"dimensions\":float(d),\"checksum\":round(c,6)}, sort_keys=True))'; fi",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
   }
 ]

--- a/scripts/deterministic_embedding_project_digest_probe.py
+++ b/scripts/deterministic_embedding_project_digest_probe.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import gc
+import json
+from pathlib import Path
+import sys
+import time
+import tracemalloc
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    repo_root = _repo_root()
+    sys.path.insert(0, str(repo_root))
+    sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
+
+    from worker.runtime.embedding_backends import BERTEmbeddingBackend
+
+    backend = BERTEmbeddingBackend()
+    dimensions = 4096
+    vector_count = 500
+    sample_count = 3
+    seed_texts = [f"bert::synthetic projection row {index % 251}::{index}" for index in range(vector_count)]
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    checksum = 0.0
+
+    for _ in range(sample_count):
+        gc.collect()
+        tracemalloc.start()
+        started = time.perf_counter()
+        for seed_text in seed_texts:
+            vector = backend._project_digest(seed_text, dimensions)
+            if len(vector) != dimensions:
+                raise AssertionError(f"unexpected vector length: {len(vector)}")
+            checksum += vector[0] + vector[-1]
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        elapsed_samples.append(elapsed_ms)
+        peak_samples.append(float(peak_bytes))
+
+    payload = {
+        "elapsed_ms_mean": round(sum(elapsed_samples) / len(elapsed_samples), 6),
+        "peak_bytes_mean": round(sum(peak_samples) / len(peak_samples), 6),
+        "sample_count": float(sample_count),
+        "vector_count": float(vector_count),
+        "dimensions": float(dimensions),
+        "checksum": round(checksum, 6),
+    }
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_embedding_runtime.py
+++ b/services/mlx-worker-python/tests/test_embedding_runtime.py
@@ -104,7 +104,7 @@ def _legacy_project_digest(seed_text: str, dimensions: int) -> list[float]:
 def test_project_digest_preserves_legacy_projection_values() -> None:
     backend = BERTEmbeddingBackend()
 
-    for dimensions in (0, 1, 8, 9, 17, 384):
+    for dimensions in (0, 1, 8, 9, 17, 384, 1536, 4096):
         actual = backend._project_digest("bert::projection parity", dimensions)
         expected = _legacy_project_digest("bert::projection parity", dimensions)
         assert actual == expected

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -282,6 +282,32 @@ def test_scope_report_selects_deterministic_rerank_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "deterministic-rerank-query-context-reuse"
 
 
+def test_scope_report_selects_embedding_project_digest_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/embedding_backends.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "deterministic-embedding-project-digest-allocation"
+
+
+def test_deterministic_embedding_project_digest_probe_script_smoke(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/deterministic_embedding_project_digest_probe.py"),
+            run_name="__main__",
+        )
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["sample_count"] == 3.0
+    assert metrics["vector_count"] == 500.0
+    assert metrics["dimensions"] == 4096.0
+
+
 def test_scope_report_selects_rerank_core_top_k_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -673,6 +699,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "changed-scope-coverage-diff-parser",
         "closure-audit-probe-source-short-circuit",
         "deterministic-embedding-duplicate-input-cache",
+        "deterministic-embedding-project-digest-allocation",
         "deterministic-rerank-query-context-reuse",
         "rerank-core-top-k-heap-selection",
         "dev-up-mlx-metal-dist-info-scandir",

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -47,13 +47,21 @@ class DeterministicEmbeddingBackend:
             - 1.0
             for start in range(0, len(digest), 4)
         ]
-        full_repeats, remainder = divmod(dimensions, len(base_values))
-        values = base_values * full_repeats + base_values[:remainder]
+        base_count = len(base_values)
+        full_repeats, remainder = divmod(dimensions, base_count)
+        squared_values = [value * value for value in base_values]
+        squared_sum = sum(squared_values) * full_repeats
+        squared_sum += sum(squared_values[:remainder])
 
-        l2_norm = math.sqrt(sum(value * value for value in values))
+        l2_norm = math.sqrt(squared_sum)
         if l2_norm == 0.0:
             return [0.0] * dimensions
-        return [round(value / l2_norm, 6) for value in values]
+        normalized_base = [round(value / l2_norm, 6) for value in base_values]
+        result: list[float] = []
+        for _ in range(full_repeats):
+            result.extend(normalized_base)
+        result.extend(normalized_base[:remainder])
+        return result
 
     @staticmethod
     def _collapse_whitespace(text: str) -> str:


### PR DESCRIPTION
## Summary
- Optimizes deterministic embedding projection by computing the repeated-pattern L2 norm from the digest-derived base vector and emitting the normalized output directly from the normalized base pattern.
- Avoids materializing the full pre-normalization repeated vector for large deterministic embedding dimensions.
- Registers a PR-scoped `command_json` probe for deterministic embedding projection allocation and keeps the probe command base-compatible for `origin/main`.

## Plan or Spec
- `docs/plans/2026-05-05-deterministic-embedding-projection-allocation.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
# 16 passed in 35.53s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
# 16 passed in 37.02s
# TOTAL 22 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
# {"checksum": 0.348915, "dimensions": 4096.0, "elapsed_ms_mean": 30.235711, "peak_bytes_mean": 99467.666667, "sample_count": 3.0, "vector_count": 500.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-project-digest-allocation --base-repo /tmp/melix-cron-opt-base-20260505011733 --head-repo /tmp/melix-cron-opt-20260505011733 --output /tmp/deterministic-embedding-project-digest-allocation.json
# head verification ok; base/head probe ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 22 0 100%`.
- Registered scoped CI probe: `deterministic-embedding-project-digest-allocation`.
- Local base-vs-head probe (`500` vectors x `4096` dimensions x `3` samples):
  - `elapsed_ms_mean`: `4823.294431` -> `35.228389` (~99.27% lower)
  - `peak_bytes_mean`: `296531.666667` -> `99467.666667` (~66.46% lower)
  - `checksum`: unchanged at `0.348915`

## Known Gaps
- Linux/Python slice only; macOS/Swift checks were not run locally on this Linux host.
- The new probe is registered in PR-scoped performance CI; hosted CI must validate before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
