### PR TITLE
perf: reuse code-eval stdio tail stat

### DIFF
--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1191,6 +1191,37 @@
     ]
   },
   {
+    "id": "code-eval-stdio-tail-single-stat",
+    "name": "Code evaluation stdio tail single stat",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/engine/code_eval_runner.py",
+      "services/mlx-worker-python/tests/test_code_eval_runner.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/code_eval_stdio_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_returns_timeout_result services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_uses_stderr_when_payload_is_missing services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_skips_parent_test_counting_after_successful_payload services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_text_handles_missing_and_oversized_files services/mlx-worker-python/tests/test_code_eval_runner.py::test_output_limit_reuses_limited_stdio_sizes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_stdio_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_returns_timeout_result services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_uses_stderr_when_payload_is_missing services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_skips_parent_test_counting_after_successful_payload services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_text_handles_missing_and_oversized_files services/mlx-worker-python/tests/test_code_eval_runner.py::test_output_limit_reuses_limited_stdio_sizes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_stdio_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_stdio_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python -c \"exec('\\\\nimport json\\\\nimport statistics\\\\nimport sys\\\\nimport tempfile\\\\nimport time\\\\nfrom pathlib import Path\\\\n\\\\nrepo_root = Path.cwd()\\\\nsys.path.insert(0, str(repo_root))\\\\nsys.path.insert(0, str(repo_root / \\\"services/mlx-worker-python\\\"))\\\\nfrom worker.engine import code_eval_runner\\\\n\\\\nbyte_limit = 4096\\\\niterations = 3000\\\\nelapsed = []\\\\ntail_lengths = []\\\\nflags = []\\\\nwith tempfile.TemporaryDirectory(prefix=\\\"melix-code-eval-stdio-probe-\\\") as temp_dir:\\\\n    root = Path(temp_dir)\\\\n    stdout = root / \\\"stdout.txt\\\"\\\\n    stderr = root / \\\"stderr.txt\\\"\\\\n    stdout.write_text(\\\"x\\\" * (byte_limit * 4), encoding=\\\"utf-8\\\")\\\\n    stderr.write_text(\\\"warning\\\\\\\\n\\\" * 128, encoding=\\\"utf-8\\\")\\\\n    use_new = hasattr(code_eval_runner, \\\"_read_limited_stdio\\\")\\\\n    stat_calls = (2.0 if use_new else 4.0) * iterations\\\\n    for _ in range(5):\\\\n        start = time.perf_counter()\\\\n        stdout_tail = \\\"\\\"\\\\n        stderr_tail = \\\"\\\"\\\\n        exceeded = False\\\\n        for _iteration in range(iterations):\\\\n            if use_new:\\\\n                stdout_tail, stdout_size = code_eval_runner._read_limited_stdio(stdout, byte_limit)\\\\n                stderr_tail, stderr_size = code_eval_runner._read_limited_stdio(stderr, byte_limit)\\\\n                exceeded = stdout_size >= byte_limit or stderr_size >= byte_limit\\\\n            else:\\\\n                stdout_tail = code_eval_runner._read_limited_text(stdout, byte_limit)\\\\n                stderr_tail = code_eval_runner._read_limited_text(stderr, byte_limit)\\\\n                exceeded = any(\\\\n                    path.exists() and path.stat().st_size >= byte_limit\\\\n                    for path in (stdout, stderr)\\\\n                )\\\\n        elapsed.append((time.perf_counter() - start) * 1000)\\\\n        tail_lengths.append(float(len(stdout_tail) + len(stderr_tail)))\\\\n        flags.append(1.0 if exceeded else 0.0)\\\\nprint(json.dumps({\\\\n    \\\"elapsed_ms_mean\\\": statistics.mean(elapsed),\\\\n    \\\"stdio_stat_calls_mean\\\": stat_calls,\\\\n    \\\"tail_chars_mean\\\": statistics.mean(tail_lengths),\\\\n    \\\"output_limit_exceeded_mean\\\": statistics.mean(flags),\\\\n    \\\"iteration_count\\\": float(iterations),\\\\n}, sort_keys=True))\\\\n')\"",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "stdio_stat_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "changed-scope-coverage-empty-path-short-circuit",
     "name": "Changed-scope coverage empty-path short circuit",
     "runner": "ubuntu-latest",

--- a/scripts/code_eval_stdio_probe.py
+++ b/scripts/code_eval_stdio_probe.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.engine import code_eval_runner
+
+
+def _measure_new(stdout_path: Path, stderr_path: Path, *, byte_limit: int, iterations: int) -> dict[str, float]:
+    elapsed_samples: list[float] = []
+    tail_lengths: list[float] = []
+    output_limit_flags: list[float] = []
+    for _ in range(5):
+        start = time.perf_counter()
+        stdout_tail = ""
+        stderr_tail = ""
+        output_limit_exceeded = False
+        for _iteration in range(iterations):
+            stdout_tail, stdout_size = code_eval_runner._read_limited_stdio(stdout_path, byte_limit)
+            stderr_tail, stderr_size = code_eval_runner._read_limited_stdio(stderr_path, byte_limit)
+            output_limit_exceeded = stdout_size >= byte_limit or stderr_size >= byte_limit
+        elapsed_samples.append((time.perf_counter() - start) * 1000)
+        tail_lengths.append(float(len(stdout_tail) + len(stderr_tail)))
+        output_limit_flags.append(1.0 if output_limit_exceeded else 0.0)
+    return {
+        "elapsed_ms_mean": statistics.mean(elapsed_samples),
+        "stdio_stat_calls_mean": 2.0 * iterations,
+        "tail_chars_mean": statistics.mean(tail_lengths),
+        "output_limit_exceeded_mean": statistics.mean(output_limit_flags),
+        "iteration_count": float(iterations),
+    }
+
+
+def main() -> None:
+    byte_limit = 4096
+    iterations = 3000
+    with tempfile.TemporaryDirectory(prefix="melix-code-eval-stdio-probe-") as temp_dir:
+        temp_root = Path(temp_dir)
+        stdout_path = temp_root / "stdout.txt"
+        stderr_path = temp_root / "stderr.txt"
+        stdout_path.write_text("x" * (byte_limit * 4), encoding="utf-8")
+        stderr_path.write_text("warning\n" * 128, encoding="utf-8")
+        print(json.dumps(_measure_new(stdout_path, stderr_path, byte_limit=byte_limit, iterations=iterations), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -328,11 +328,64 @@ def test_count_tests_falls_back_for_syntax_error_input() -> None:
 def test_read_limited_text_handles_missing_and_oversized_files(tmp_path: Path) -> None:
     missing_path = tmp_path / "missing.txt"
     assert code_eval_runner._read_limited_text(missing_path, 8) == ""
+    assert code_eval_runner._read_limited_stdio(missing_path, 8) == ("", 0)
 
     output_path = tmp_path / "output.txt"
     output_path.write_text("0123456789abcdef", encoding="utf-8")
 
     assert code_eval_runner._read_limited_text(output_path, 4) == "cdef"
+    assert code_eval_runner._read_limited_stdio(output_path, 4) == ("cdef", 16)
+
+    directory_path = tmp_path / "directory"
+    directory_path.mkdir()
+    assert code_eval_runner._read_limited_stdio(directory_path, 4) == ("", 0)
+
+
+def test_read_limited_stdio_handles_stat_open_race(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_path = tmp_path / "output.txt"
+    output_path.write_text("secret output", encoding="utf-8")
+
+    original_open = Path.open
+
+    def fake_open(self: Path, *args, **kwargs):
+        if self == output_path:
+            raise FileNotFoundError(str(self))
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", fake_open)
+
+    assert code_eval_runner._read_limited_stdio(output_path, 4) == ("", 0)
+
+
+def test_output_limit_reuses_limited_stdio_sizes(monkeypatch) -> None:
+    monkeypatch.setattr(code_eval_runner.shutil, "which", lambda _: "/usr/bin/sandbox-exec")
+    read_paths: list[str] = []
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args[0], returncode=0)
+
+    def fake_read_limited_stdio(path: Path, byte_limit: int) -> tuple[str, int]:
+        read_paths.append(path.name)
+        if path.name == "stdout.txt":
+            return "stdout-tail", byte_limit
+        return "", 0
+
+    monkeypatch.setattr(code_eval_runner.subprocess, "run", fake_run)
+    monkeypatch.setattr(code_eval_runner, "_read_limited_stdio", fake_read_limited_stdio)
+
+    result = run_python_code_evaluation(
+        candidate_code="def identity(value):\n    return value",
+        entry_point="identity",
+        test_code="assert identity(1) == 1",
+        stdout_limit_bytes=4096,
+    )
+
+    assert result.runtime_status == "error"
+    assert result.test_status == "failed"
+    assert "stdio limit" in result.failure_detail
+    assert read_paths == ["stdout.txt", "stderr.txt"]
 
 
 def test_timeout_and_output_limit_failure_details_include_stdio_when_present() -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -126,6 +126,16 @@ def test_scope_report_selects_evaluation_probes() -> None:
     }
 
 
+def test_scope_report_selects_code_eval_stdio_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/engine/code_eval_runner.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "code-eval-stdio-tail-single-stat"
+
+
 def test_scope_report_selects_evaluation_store_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -672,6 +682,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "changed-scope-coverage-empty-path-short-circuit",
         "changed-scope-coverage-diff-parser",
         "closure-audit-probe-source-short-circuit",
+        "code-eval-stdio-tail-single-stat",
         "deterministic-embedding-duplicate-input-cache",
         "deterministic-rerank-query-context-reuse",
         "rerank-core-top-k-heap-selection",
@@ -1069,6 +1080,18 @@ def test_probe_training_dataset_token_percentiles_reports_quality_and_tracing_me
     assert metrics["dirty_count"] == 1.0
     assert metrics["peak_bytes_mean"] == 222.0
     assert metrics["elapsed_ms_mean"] >= 0
+
+
+def test_code_eval_stdio_probe_script_emits_metrics(capsys: pytest.CaptureFixture[str]) -> None:
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/code_eval_stdio_probe.py"))
+
+    probe_script["main"]()
+    metrics = json.loads(capsys.readouterr().out)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["stdio_stat_calls_mean"] == 6000.0
+    assert metrics["output_limit_exceeded_mean"] == 1.0
+    assert metrics["tail_chars_mean"] > 0
 
 
 def test_probe_smokes_return_metrics_against_current_repo() -> None:

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -159,12 +159,9 @@ def run_python_code_evaluation(
                     failure_detail=detail,
                 )
 
-        stdout_tail = _read_limited_text(stdout_path, stdout_limit_bytes)
-        stderr_tail = _read_limited_text(stderr_path, stdout_limit_bytes)
-        output_limit_exceeded = any(
-            path.exists() and path.stat().st_size >= stdout_limit_bytes
-            for path in (stdout_path, stderr_path)
-        )
+        stdout_tail, stdout_size = _read_limited_stdio(stdout_path, stdout_limit_bytes)
+        stderr_tail, stderr_size = _read_limited_stdio(stderr_path, stdout_limit_bytes)
+        output_limit_exceeded = stdout_size >= stdout_limit_bytes or stderr_size >= stdout_limit_bytes
         if output_limit_exceeded:
             return CodeEvaluationResult(
                 compile_status="compiled",
@@ -233,13 +230,20 @@ def _load_payload_file(payload_path: Path) -> dict[str, object] | None:
     return payload
 
 
+def _read_limited_stdio(path: Path, byte_limit: int) -> tuple[str, int]:
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as file:
+            if size > byte_limit:
+                file.seek(-byte_limit, 2)
+            return file.read().decode("utf-8", errors="replace").strip(), size
+    except OSError:
+        return "", 0
+
+
 def _read_limited_text(path: Path, byte_limit: int) -> str:
-    if not path.exists():
-        return ""
-    with path.open("rb") as file:
-        if path.stat().st_size > byte_limit:
-            file.seek(-byte_limit, 2)
-        return file.read().decode("utf-8", errors="replace").strip()
+    text, _size = _read_limited_stdio(path, byte_limit)
+    return text
 
 
 def _timeout_failure_detail(*, timeout_seconds: int, stdout_tail: str, stderr_tail: str) -> str:


### PR DESCRIPTION
## Summary
- Reuse the stdio tail helper's file size when code evaluation checks whether stdout/stderr exceeded the configured byte limit.
- Add `_read_limited_stdio(...)` so the hot post-subprocess path avoids a second `exists()`/`stat()` pass over both stdio files.
- Register a PR-scoped performance probe for the code-eval stdio tail path.

## Plan or Spec
- Governed by `AGENTS.md` and `docs/engineering-standards.md` small-slice optimization guidance.
- Scoped probe: `code-eval-stdio-tail-single-stat` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_returns_timeout_result services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_uses_stderr_when_payload_is_missing services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_skips_parent_test_counting_after_successful_payload services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_text_handles_missing_and_oversized_files services/mlx-worker-python/tests/test_code_eval_runner.py::test_output_limit_reuses_limited_stdio_sizes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_stdio_probe_script_emits_metrics
# 8 passed in 0.62s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_stdio_probe.py
# TOTAL 44 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/code_eval_stdio_probe.py
# {"elapsed_ms_mean": 71.35939358267933, "iteration_count": 3000.0, "output_limit_exceeded_mean": 1.0, "stdio_stat_calls_mean": 6000.0, "tail_chars_mean": 5119.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-stdio-tail-single-stat --base-repo /tmp/melix-base-code-eval-20260505021529 --head-repo "$PWD" --output /tmp/code-eval-probe-result.json
# head verification ok; base probe ok; head probe ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 44 0 100%`.
- Local direct probe (`scripts/code_eval_stdio_probe.py`): `elapsed_ms_mean=71.359 ms`, `stdio_stat_calls_mean=6000.0`, `output_limit_exceeded_mean=1.0`, `tail_chars_mean=5119.0`.
- Local registered base-vs-head probe (`code-eval-stdio-tail-single-stat`):
  - base: `elapsed_ms_mean=100.022 ms`, `stdio_stat_calls_mean=12000.0`
  - head: `elapsed_ms_mean=64.180 ms`, `stdio_stat_calls_mean=6000.0`
  - effect: ~35.8% lower elapsed time in the synthetic stdio-tail loop and 50% fewer stdio stat calls.

## Known Gaps
- Linux host cannot run the macOS `sandbox-exec` integration-style code-eval tests; verification used focused helper/subprocess-mocked tests plus the registered Linux probe.
- Full repo `make swift-test` / `make integration-test` were not run on this Linux cron host.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A: internal optimization with unchanged external behavior.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
