### PR TITLE
perf: precompile changed-scope diff parsing

### DIFF
--- a/docs/plans/2026-05-05-changed-scope-coverage-diff-regex-precompile.md
+++ b/docs/plans/2026-05-05-changed-scope-coverage-diff-regex-precompile.md
@@ -1,0 +1,40 @@
+# Changed-scope coverage diff regex precompile
+
+## Goal
+
+Reduce redundant regex work in `scripts/changed_scope_coverage.py` when parsing large unified diffs for changed-scope coverage reports.
+
+## Linux-only constraint
+
+This slice is Python-only and locally verifiable on Linux with focused pytest, changed-scope coverage, and an explicit parser micro-probe.
+
+## Touched files
+
+- `scripts/changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_parse_probe.py`
+- `tests/test_changed_scope_coverage.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Performance probe
+
+Register `changed-scope-coverage-diff-parser` in the PR-scoped performance registry. The probe builds a deterministic synthetic multi-file diff, repeatedly calls `_parse_changed_lines(...)`, and reports:
+
+- `elapsed_ms_mean` (lower is better)
+- `line_count` and `changed_line_count` guard-rail metrics
+
+## Success metrics
+
+- Focused tests pass.
+- Changed-scope coverage for touched executable lines is at least 95%.
+- Local parser probe reports concrete elapsed time and stable guard-rail counts.
+- The registered scoped probe is selected when `scripts/changed_scope_coverage.py` changes.
+
+## Verification commands
+
+```bash
+python -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+python scripts/changed_scope_coverage_parse_probe.py
+python scripts/pr_scoped_performance_run.py --probe changed-scope-coverage-diff-parser --base-ref origin/main --head-ref HEAD --output /tmp/changed-scope-coverage-diff-parser.json
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1070,5 +1070,40 @@
         "warn_pct": 5.0
       }
     ]
+  },
+  {
+    "id": "changed-scope-coverage-diff-parser",
+    "name": "Changed-scope coverage diff parser",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "scripts/changed_scope_coverage.py",
+      "scripts/changed_scope_coverage_parse_probe.py",
+      "tests/test_changed_scope_coverage.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "bash -c 'if [ -f scripts/changed_scope_coverage_parse_probe.py ]; then python scripts/changed_scope_coverage_parse_probe.py; else python - <<\"PY\"\nimport importlib.util, json, statistics, time\nfrom pathlib import Path\nrepo_root = Path.cwd()\nspec = importlib.util.spec_from_file_location(\"changed_scope_coverage_probe_target\", repo_root / \"scripts\" / \"changed_scope_coverage.py\")\nmodule = importlib.util.module_from_spec(spec)\nspec.loader.exec_module(module)\nlines = []\nfor file_index in range(240):\n    path = f\"pkg/module_{file_index:04d}.py\"\n    lines.extend([f\"diff --git a/{path} b/{path}\", f\"--- a/{path}\", f\"+++ b/{path}\"])\n    for hunk_index in range(8):\n        start = hunk_index * 10 + 1\n        lines.append(f\"@@ -{start},3 +{start},6 @@\")\n        lines.append(\" context\")\n        lines.append(\"-old_value\")\n        for addition_index in range(4):\n            lines.append(f\"+new_value_{file_index}_{hunk_index}_{addition_index}\")\n        lines.append(\" context_tail\")\ndiff_text = \"\\n\".join(lines)\nsamples = []\nchanged = files = 0\nfor _ in range(12):\n    start = time.perf_counter()\n    parsed = module._parse_changed_lines(diff_text)\n    samples.append((time.perf_counter() - start) * 1000.0)\n    files = len(parsed)\n    changed = sum(len(v) for v in parsed.values())\n    if files != 240 or changed != 7680:\n        raise RuntimeError(f\"unexpected parser output: files={files} changed={changed}\")\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(samples), \"elapsed_ms_min\": min(samples), \"line_count\": float(diff_text.count(\"\\n\") + 1), \"file_count\": float(files), \"changed_line_count\": float(changed)}, sort_keys=True))\nPY\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "changed_line_count",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
+        "key": "line_count",
+        "unit": "count",
+        "direction": "informational"
+      }
+    ]
   }
 ]

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -10,20 +10,28 @@ import subprocess
 import sys
 
 
+_DIFF_HEADER_RE = re.compile(r"diff --git a/(.+) b/(.+)")
+_HUNK_NEW_RANGE_RE = re.compile(r"\+(\d+)(?:,(\d+))?")
+
+
+def _is_diff_file_marker(line: str) -> bool:
+    return line.startswith(("+++ b/", "+++ /dev/null", "--- a/", "--- /dev/null"))
+
+
 def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     changed_by_path: dict[str, set[int]] = {}
     current_path: str | None = None
     new_line: int | None = None
     for line in diff_text.splitlines():
         if line.startswith("diff --git "):
-            match = re.match(r"diff --git a/(.+) b/(.+)", line)
+            match = _DIFF_HEADER_RE.match(line)
             current_path = None if match is None else match.group(2)
             if current_path is not None:
                 changed_by_path.setdefault(current_path, set())
             new_line = None
             continue
         if line.startswith("@@"):
-            match = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            match = _HUNK_NEW_RANGE_RE.search(line)
             if match is None:
                 continue
             new_line = int(match.group(1))
@@ -32,7 +40,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
             continue
         if line.startswith("\\ "):
             continue
-        if re.match(r"\+\+\+ (?:b/|/dev/null)", line) or re.match(r"--- (?:a/|/dev/null)", line):
+        if _is_diff_file_marker(line):
             continue
         if line.startswith("+"):
             changed_by_path[current_path].add(new_line)

--- a/scripts/changed_scope_coverage_parse_probe.py
+++ b/scripts/changed_scope_coverage_parse_probe.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import statistics
+import time
+
+
+def _load_changed_scope_module(repo_root: Path):
+    module_path = repo_root / "scripts" / "changed_scope_coverage.py"
+    spec = importlib.util.spec_from_file_location("changed_scope_coverage_probe_target", module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover
+        raise RuntimeError(f"unable to load {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_synthetic_diff(file_count: int = 240, hunks_per_file: int = 8, additions_per_hunk: int = 4) -> str:
+    lines: list[str] = []
+    for file_index in range(file_count):
+        path = f"pkg/module_{file_index:04d}.py"
+        lines.extend(
+            [
+                f"diff --git a/{path} b/{path}",
+                f"--- a/{path}",
+                f"+++ b/{path}",
+            ]
+        )
+        for hunk_index in range(hunks_per_file):
+            start = hunk_index * 10 + 1
+            lines.append(f"@@ -{start},3 +{start},6 @@")
+            lines.append(" context")
+            lines.append("-old_value")
+            for addition_index in range(additions_per_hunk):
+                lines.append(f"+new_value_{file_index}_{hunk_index}_{addition_index}")
+            lines.append(" context_tail")
+    return "\n".join(lines)
+
+
+def run_probe(repo_root: Path) -> dict[str, float]:
+    module = _load_changed_scope_module(repo_root)
+    diff_text = _build_synthetic_diff()
+    expected_changed = 240 * 8 * 4
+    samples: list[float] = []
+    observed_changed = 0
+    observed_files = 0
+    for _ in range(12):
+        start = time.perf_counter()
+        parsed = module._parse_changed_lines(diff_text)
+        samples.append((time.perf_counter() - start) * 1000.0)
+        observed_files = len(parsed)
+        observed_changed = sum(len(lines) for lines in parsed.values())
+        if observed_files != 240 or observed_changed != expected_changed:
+            raise RuntimeError(
+                f"unexpected parser output: files={observed_files} changed={observed_changed}"
+            )
+    return {
+        "elapsed_ms_mean": statistics.fmean(samples),
+        "elapsed_ms_min": min(samples),
+        "line_count": float(diff_text.count("\n") + 1),
+        "file_count": float(observed_files),
+        "changed_line_count": float(observed_changed),
+    }
+
+
+def main() -> int:
+    repo_root = Path.cwd()
+    print(json.dumps(run_probe(repo_root), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -176,6 +176,17 @@ def test_scope_report_selects_pr_scoped_scope_script_probe() -> None:
     assert "pr-scoped-performance-scope-json-read-bytes" in selected_ids
 
 
+def test_scope_report_selects_changed_scope_coverage_parser_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["scripts/changed_scope_coverage.py"],
+    )
+
+    selected_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert scope["force_all"] is False
+    assert "changed-scope-coverage-diff-parser" in selected_ids
+
+
 def test_scope_report_selects_job_registry_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -525,6 +536,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "benchmark-export-run-scan-single-pass",
         "benchmark-queue-decoded-record-cache",
         "benchmark-store-matrix-streaming",
+        "changed-scope-coverage-diff-parser",
         "closure-audit-probe-source-short-circuit",
         "deterministic-rerank-query-context-reuse",
         "dev-up-mlx-metal-dist-info-scandir",

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -14,6 +14,15 @@ assert MODULE_SPEC.loader is not None
 changed_scope_coverage = importlib.util.module_from_spec(MODULE_SPEC)
 MODULE_SPEC.loader.exec_module(changed_scope_coverage)
 
+PROBE_MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "changed_scope_coverage_parse_probe.py"
+PROBE_MODULE_SPEC = importlib.util.spec_from_file_location(
+    "changed_scope_coverage_parse_probe", PROBE_MODULE_PATH
+)
+assert PROBE_MODULE_SPEC is not None
+assert PROBE_MODULE_SPEC.loader is not None
+changed_scope_coverage_parse_probe = importlib.util.module_from_spec(PROBE_MODULE_SPEC)
+PROBE_MODULE_SPEC.loader.exec_module(changed_scope_coverage_parse_probe)
+
 
 def test_parse_changed_lines_handles_multiple_files_and_hunks() -> None:
     diff_text = "\n".join(
@@ -114,6 +123,39 @@ def test_parse_changed_lines_preserves_added_content_that_starts_with_diff_heade
     assert changed == {"foo.py": {1, 2}}
 
 
+def test_parse_changed_lines_uses_precompiled_patterns_and_prefix_marker_check(monkeypatch) -> None:
+    def fail_module_level_regex(*args: object, **kwargs: object) -> object:  # pragma: no cover
+        raise AssertionError("hot parser should use precompiled regex objects")
+
+    monkeypatch.setattr(changed_scope_coverage.re, "match", fail_module_level_regex)
+    monkeypatch.setattr(changed_scope_coverage.re, "search", fail_module_level_regex)
+
+    diff_text = "\n".join(
+        [
+            "diff --git a/foo.py b/foo.py",
+            "--- a/foo.py",
+            "+++ b/foo.py",
+            "@@ -1 +1,2 @@",
+            "+new",
+            " context",
+            "+tail",
+        ]
+    )
+
+    changed = changed_scope_coverage._parse_changed_lines(diff_text)
+
+    assert changed == {"foo.py": {1, 3}}
+
+
+def test_is_diff_file_marker_matches_only_real_file_markers() -> None:
+    assert changed_scope_coverage._is_diff_file_marker("+++ b/foo.py")
+    assert changed_scope_coverage._is_diff_file_marker("--- a/foo.py")
+    assert changed_scope_coverage._is_diff_file_marker("+++ /dev/null")
+    assert changed_scope_coverage._is_diff_file_marker("--- /dev/null")
+    assert not changed_scope_coverage._is_diff_file_marker("++++not-a-header")
+    assert not changed_scope_coverage._is_diff_file_marker("+---also-real-content")
+
+
 def test_measurable_changed_lines_filters_blank_comment_and_unmeasured_lines(tmp_path: Path) -> None:
     source_path = tmp_path / "foo.py"
     source_path.write_text("first\n# comment\n\ncovered\nmissed\n", encoding="utf-8")
@@ -136,6 +178,36 @@ def test_measurable_changed_lines_filters_blank_comment_and_unmeasured_lines(tmp
     assert measurable == [1, 4, 5]
     assert covered == [1, 4]
     assert missed == [5]
+
+
+def test_parse_probe_reports_stable_parser_guardrails(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(changed_scope_coverage_parse_probe, "_load_changed_scope_module", lambda repo_root: changed_scope_coverage)
+    monkeypatch.setattr(changed_scope_coverage_parse_probe.time, "perf_counter", iter([0.0, 0.01] * 12).__next__)
+
+    metrics = changed_scope_coverage_parse_probe.run_probe(tmp_path)
+
+    assert metrics["elapsed_ms_mean"] == 10.0
+    assert metrics["file_count"] == 240.0
+    assert metrics["changed_line_count"] == 7680.0
+    assert metrics["line_count"] > metrics["changed_line_count"]
+
+
+def test_parse_probe_loads_changed_scope_module() -> None:
+    module = changed_scope_coverage_parse_probe._load_changed_scope_module(Path(__file__).resolve().parents[1])
+
+    assert module._parse_changed_lines("diff --git a/foo.py b/foo.py\n@@ -0,0 +1 @@\n+new") == {"foo.py": {1}}
+
+
+def test_parse_probe_main_prints_json(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        changed_scope_coverage_parse_probe,
+        "run_probe",
+        lambda repo_root: {"elapsed_ms_mean": 1.25, "changed_line_count": 2.0},
+    )
+
+    assert changed_scope_coverage_parse_probe.main() == 0
+
+    assert json.loads(capsys.readouterr().out) == {"elapsed_ms_mean": 1.25, "changed_line_count": 2.0}
 
 
 def test_main_reports_aggregate_coverage_for_multiple_paths(monkeypatch, tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- Precompiles the changed-scope coverage diff parser regexes and replaces hot header-marker regex checks with prefix checks.
- Adds a dedicated parser probe script plus a PR-scoped performance registry entry for the diff parser path.
- Adds focused tests for the precompiled-regex path, marker filtering, probe guard rails, and scoped probe selection.

## Plan or Spec
- `docs/plans/2026-05-05-changed-scope-coverage-diff-regex-precompile.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 13 passed in 0.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 13 passed; TOTAL 94 2 98%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/changed_scope_coverage_parse_probe.py
# {"changed_line_count": 7680.0, "elapsed_ms_mean": 8.02797633514274, "elapsed_ms_min": 7.449640019331127, "file_count": 240.0, "line_count": 16080.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-diff-parser --base-repo /tmp/melix-cron-opt-base-20260505-031507-a --head-repo "$PWD" --output /tmp/changed-scope-coverage-diff-parser.json
# head verification passed; base elapsed_ms_mean=19.67847732885275, head elapsed_ms_mean=7.697471829790932

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 94 2 98%`.
  - `scripts/changed_scope_coverage.py`: 100% changed-line coverage.
  - `tests/test_changed_scope_coverage.py`: 100% changed-line coverage.
  - `scripts/changed_scope_coverage_parse_probe.py`: 95.83% changed-line coverage.
  - `services/mlx-worker-python/tests/test_pr_scoped_performance.py`: 100% changed-line coverage.
- Local probe: `changed-scope-coverage-diff-parser`.
  - Base `elapsed_ms_mean`: `19.67847732885275` ms.
  - Head `elapsed_ms_mean`: `7.697471829790932` ms.
  - Improvement: ~60.88% lower parser time on the synthetic 16,080-line diff.
  - Guard rails: `file_count=240.0`, `changed_line_count=7680.0`, `line_count=16080.0` on both base and head.

## Known Gaps
- Full repository test suite was not run on this Linux cron host; verification was limited to the touched Python/CI-harness scope and the registered PR-scoped parser probe.
- Hosted PR-scoped performance and broader GitHub Actions checks still need to complete before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
