### PR TITLE
perf: reuse rerank order checks

### DIFF
--- a/docs/plans/2026-05-05-rerank-order-check-reuse.md
+++ b/docs/plans/2026-05-05-rerank-order-check-reuse.md
@@ -1,0 +1,35 @@
+# Rerank Order Check Reuse Optimization
+
+## Goal
+
+Reduce redundant query-order scans in the deterministic rerank scoring path on Linux-verifiable Python code.
+
+## Scope
+
+Touched files:
+
+- `services/mlx-worker-python/worker/runtime/rerank_backends.py`
+- `services/mlx-worker-python/tests/test_rerank_runtime.py`
+
+## Linux-only constraint
+
+This slice is Python-only and can be verified locally on Linux with focused pytest, changed-scope coverage, and the existing PR-scoped performance probe.
+
+## Performance probe
+
+Probe ID: `deterministic-rerank-query-context-reuse`
+
+The existing probe watches `rerank_backends.py` and exercises 2,048 deterministic rerank documents over repeated samples. Success means preserving the existing `query_context_builds_mean=1.0` and `tokenize_calls_mean=2049.0` metrics while improving or not regressing `elapsed_ms_mean` compared with `origin/main`.
+
+## Implementation plan
+
+1. Route Jina v3 exact-order and prefix checks through `_query_order_matches(...)` once when all query terms overlap.
+2. Route CausalLM exact-order and prefix checks through the same helper once under the same condition.
+3. Add focused regression tests that fail if full-overlap scoring bypasses the combined order helper and separately calls the lower-level contiguous/prefix helpers.
+4. Run focused tests, changed-scope coverage, `git diff --check`, and the existing scoped probe locally.
+
+## Success metrics
+
+- Focused rerank tests pass.
+- Changed executable line coverage is at least 95%.
+- Local probe reports concrete numbers and preserves score output shape/metrics.

--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -602,6 +602,47 @@ def test_order_aware_query_context_preserves_exact_order_and_prefix_bonuses(
         abs=1e-6,
     )
 
+
+@pytest.mark.parametrize(
+    "family",
+    [JinaV3RerankFamilyAdapter(), CausalLMRerankFamilyAdapter()],
+)
+def test_order_aware_rerank_families_use_combined_order_match_once_for_full_overlap(
+    monkeypatch,
+    family: RerankFamilyAdapter,
+) -> None:
+    backend = DeterministicRerankBackend()
+    query_order_matches = Mock(return_value=(True, True))
+    contains = Mock(side_effect=AssertionError("score should use the combined order matcher"))
+    has_prefix = Mock(side_effect=AssertionError("score should use the combined order matcher"))
+
+    monkeypatch.setattr(
+        JinaV3RerankFamilyAdapter,
+        "_query_order_matches",
+        staticmethod(query_order_matches),
+    )
+    monkeypatch.setattr(
+        JinaV3RerankFamilyAdapter,
+        "_contains_contiguous_query",
+        staticmethod(contains),
+    )
+    monkeypatch.setattr(
+        JinaV3RerankFamilyAdapter,
+        "_has_query_prefix",
+        staticmethod(has_prefix),
+    )
+
+    score = family.score(backend, "swift runtime", "swift runtime is available")
+
+    assert score > 0.0
+    query_order_matches.assert_called_once_with(
+        ["swift", "runtime", "is", "available"],
+        ("swift", "runtime"),
+    )
+    contains.assert_not_called()
+    has_prefix.assert_not_called()
+
+
 def test_rerank_rejects_missing_and_wrong_model_kinds() -> None:
     runtime_service, inference_service = build_services()
     text_handle = load_model(runtime_service, WorkerModelCatalog.dev_text_model())

--- a/services/mlx-worker-python/worker/runtime/rerank_backends.py
+++ b/services/mlx-worker-python/worker/runtime/rerank_backends.py
@@ -219,10 +219,13 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
                 query_pairs=query_context.ordered_pairs,
             )
         has_all_query_terms = overlap_count >= len(reusable_query_token_set)
-        exact_order_bonus = (
-            0.1 if has_all_query_terms and self._contains_contiguous_query(document_tokens, reusable_query_tokens) else 0.0
-        )
-        prefix_bonus = 0.05 if has_all_query_terms and self._has_query_prefix(document_tokens, reusable_query_tokens) else 0.0
+        if has_all_query_terms:
+            exact_order, prefix_match = self._query_order_matches(document_tokens, reusable_query_tokens)
+        else:
+            exact_order = False
+            prefix_match = False
+        exact_order_bonus = 0.1 if exact_order else 0.0
+        prefix_bonus = 0.05 if prefix_match else 0.0
 
         return round(
             overlap_score
@@ -330,15 +333,14 @@ class CausalLMRerankFamilyAdapter(RerankFamilyAdapter):
                 document_tokens,
                 query_pairs=query_context.ordered_pairs,
             )
-        exact_order = (
-            JinaV3RerankFamilyAdapter._contains_contiguous_query(document_tokens, reusable_query_tokens)
-            if overlap_count >= len(reusable_query_token_set)
-            else False
-        )
-        prefix_match = (
-            overlap_count >= len(reusable_query_token_set)
-            and JinaV3RerankFamilyAdapter._has_query_prefix(document_tokens, reusable_query_tokens)
-        )
+        if overlap_count >= len(reusable_query_token_set):
+            exact_order, prefix_match = JinaV3RerankFamilyAdapter._query_order_matches(
+                document_tokens,
+                reusable_query_tokens,
+            )
+        else:
+            exact_order = False
+            prefix_match = False
 
         yes_logit = overlap * 6.0
         yes_logit += pair_bonus * 3.0


### PR DESCRIPTION
## Summary
- Reuses the combined deterministic rerank order matcher for both Jina v3 and CausalLM full-overlap scoring paths.
- Avoids scanning the same document tokens separately for contiguous-query and prefix checks while preserving scoring semantics.
- Adds focused regression coverage that fails if full-overlap scoring bypasses the combined matcher.

## Plan or Spec
- `docs/plans/2026-05-05-rerank-order-check-reuse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py
# 31 passed in 0.69s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o /tmp/melix-rerank-coverage.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/melix-rerank-coverage.json services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/tests/test_rerank_runtime.py
# TOTAL 24 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-rerank-query-context-reuse --base-repo /tmp/melix-base-rerank-20260505040707b --head-repo "$PWD" --output /tmp/melix-rerank-probe.json
# head verification: 35 passed in 38.16s; changed-scope TOTAL 24 0 100%
# base probe elapsed_ms_mean=87.209963, query_context_builds_mean=1.0, tokenize_calls_mean=2049.0
# head probe elapsed_ms_mean=81.990012, query_context_builds_mean=1.0, tokenize_calls_mean=2049.0

git diff --check
# pass
```

## Coverage and Metrics
- Changed executable line coverage: `TOTAL 24 0 100%` across `rerank_backends.py` and the focused rerank tests.
- Registered scoped CI probe: `deterministic-rerank-query-context-reuse`.
- Local base-vs-head probe:
  - `elapsed_ms_mean`: `87.209963` → `81.990012` ms (~5.99% lower)
  - `query_context_builds_mean`: `1.0` → `1.0`
  - `tokenize_calls_mean`: `2049.0` → `2049.0`

## Known Gaps
- Linux-only local verification was run. macOS/Swift checks were not run locally on this Linux host.
- Hosted `pr-scoped-performance` remains the required CI validation before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
