### PR TITLE
perf: short-circuit empty changed-scope coverage paths

### DIFF
--- a/docs/plans/2026-05-05-changed-scope-coverage-empty-path-short-circuit.md
+++ b/docs/plans/2026-05-05-changed-scope-coverage-empty-path-short-circuit.md
@@ -1,0 +1,32 @@
+# Changed Scope Coverage Empty Path Short-Circuit
+
+## Goal
+
+Reduce redundant work in `scripts/changed_scope_coverage.py` when a requested path has no changed executable lines. The helper currently still reads source files and builds coverage sets before discovering that there is nothing to measure.
+
+## Scope
+
+- `scripts/changed_scope_coverage.py`
+- `tests/test_changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Linux-only verification path
+
+This is a Python/CI-helper slice and is locally verifiable on Linux.
+
+## Performance probe
+
+Register `changed-scope-coverage-empty-path-short-circuit` in the PR-scoped performance registry. The probe measures a synthetic workload with many requested paths whose `changed` set is empty and reports:
+
+- `elapsed_ms_mean` (lower is better)
+- `source_read_calls_mean` (lower is better; target is zero on the optimized branch)
+- `path_count`
+
+## Success metrics
+
+- Focused tests pass.
+- Changed executable line coverage is at least 95%.
+- Local probe shows fewer source reads and lower elapsed time than `origin/main` on the same synthetic workload.
+- `git diff --check` passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1,5 +1,36 @@
 [
   {
+    "id": "changed-scope-coverage-empty-path-short-circuit",
+    "name": "Changed-scope coverage empty-path short circuit",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "scripts/changed_scope_coverage.py",
+      "scripts/changed_scope_coverage_probe.py",
+      "tests/test_changed_scope_coverage.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "python3 -c \"exec(\\\"import importlib.util, json, statistics, tempfile, time\\\\nfrom pathlib import Path\\\\nrepo_root = Path.cwd()\\\\nspec = importlib.util.spec_from_file_location('changed_scope_coverage_probe_target', repo_root / 'scripts' / 'changed_scope_coverage.py')\\\\nmodule = importlib.util.module_from_spec(spec)\\\\nspec.loader.exec_module(module)\\\\npath_count = 300\\\\nsamples = 7\\\\nelapsed_samples = []\\\\nread_samples = []\\\\nwith tempfile.TemporaryDirectory(prefix='melix-changed-scope-probe-') as tmp:\\\\n    root = Path(tmp)\\\\n    rel_paths = [f'pkg/module_{index}.py' for index in range(path_count)]\\\\n    for rel_path in rel_paths:\\\\n        source_path = root / rel_path\\\\n        source_path.parent.mkdir(parents=True, exist_ok=True)\\\\n        source_path.write_text('covered = 1\\\\\\\\nmissed = 2\\\\\\\\n', encoding='utf-8')\\\\n    coverage_payload = {'files': {rel_path: {'executed_lines': [1], 'missing_lines': [2]} for rel_path in rel_paths}}\\\\n    original_read_text = module.Path.read_text\\\\n    try:\\\\n        for _ in range(samples):\\\\n            read_calls_box = [0]\\\\n            def counted_read_text(self, *args, **kwargs):\\\\n                read_calls_box[0] += 1\\\\n                return original_read_text(self, *args, **kwargs)\\\\n            module.Path.read_text = counted_read_text\\\\n            start = time.perf_counter()\\\\n            for rel_path in rel_paths:\\\\n                measurable, covered, missed = module._measurable_changed_lines(root, coverage_payload, rel_path, set())\\\\n                if measurable or covered or missed:\\\\n                    raise RuntimeError('empty changed sets must not produce measurable lines')\\\\n            elapsed_samples.append((time.perf_counter() - start) * 1000.0)\\\\n            read_samples.append(float(read_calls_box[0]))\\\\n    finally:\\\\n        module.Path.read_text = original_read_text\\\\nprint(json.dumps({'elapsed_ms_mean': statistics.fmean(elapsed_samples), 'source_read_calls_mean': statistics.fmean(read_samples), 'path_count': float(path_count), 'sample_count': float(samples)}, sort_keys=True))\\\")\"",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "source_read_calls_mean",
+        "unit": "reads",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "benchmark-evaluation-report-running-aggregates",
     "name": "Benchmark evaluation report running aggregates",
     "runner": "ubuntu-latest",

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -10,20 +10,25 @@ import subprocess
 import sys
 
 
+_DIFF_HEADER_RE = re.compile(r"diff --git a/(.+) b/(.+)")
+_HUNK_NEW_RANGE_RE = re.compile(r"\+(\d+)(?:,(\d+))?")
+_FILE_MARKER_RE = re.compile(r"(?:\+\+\+|---) (?:[ab]/|/dev/null)")
+
+
 def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     changed_by_path: dict[str, set[int]] = {}
     current_path: str | None = None
     new_line: int | None = None
     for line in diff_text.splitlines():
         if line.startswith("diff --git "):
-            match = re.match(r"diff --git a/(.+) b/(.+)", line)
+            match = _DIFF_HEADER_RE.match(line)
             current_path = None if match is None else match.group(2)
             if current_path is not None:
                 changed_by_path.setdefault(current_path, set())
             new_line = None
             continue
         if line.startswith("@@"):
-            match = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            match = _HUNK_NEW_RANGE_RE.search(line)
             if match is None:
                 continue
             new_line = int(match.group(1))
@@ -32,7 +37,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
             continue
         if line.startswith("\\ "):
             continue
-        if re.match(r"\+\+\+ (?:b/|/dev/null)", line) or re.match(r"--- (?:a/|/dev/null)", line):
+        if _FILE_MARKER_RE.match(line):
             continue
         if line.startswith("+"):
             changed_by_path[current_path].add(new_line)
@@ -62,18 +67,21 @@ def _measurable_changed_lines(
     rel_path: str,
     changed: set[int],
 ) -> tuple[list[int], list[int], list[int]]:
+    if not changed:
+        return [], [], []
+
     entry = coverage_payload["files"][rel_path]
     executed = set(entry["executed_lines"])
     missing = set(entry["missing_lines"])
     measured = executed | missing
     source_lines = (repo_root / rel_path).read_text(encoding="utf-8").splitlines()
-    measurable = [
-        line_no
-        for line_no in sorted(changed)
-        if line_no in measured
-        and source_lines[line_no - 1].strip()
-        and not source_lines[line_no - 1].strip().startswith("#")
-    ]
+    measurable: list[int] = []
+    for line_no in sorted(changed):
+        if line_no not in measured:
+            continue
+        stripped = source_lines[line_no - 1].strip()
+        if stripped and not stripped.startswith("#"):
+            measurable.append(line_no)
     covered = [line_no for line_no in measurable if line_no in executed]
     missed = [line_no for line_no in measurable if line_no in missing]
     return measurable, covered, missed

--- a/scripts/changed_scope_coverage_probe.py
+++ b/scripts/changed_scope_coverage_probe.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import statistics
+import tempfile
+import time
+
+
+def _load_changed_scope_coverage(repo_root: Path):
+    module_path = repo_root / "scripts" / "changed_scope_coverage.py"
+    spec = importlib.util.spec_from_file_location("changed_scope_coverage_probe_target", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_probe(repo_root: Path, *, path_count: int = 300, samples: int = 7) -> dict[str, float]:
+    module = _load_changed_scope_coverage(repo_root)
+    elapsed_samples: list[float] = []
+    read_samples: list[float] = []
+
+    with tempfile.TemporaryDirectory(prefix="melix-changed-scope-probe-") as tmp:
+        root = Path(tmp)
+        rel_paths = [f"pkg/module_{index}.py" for index in range(path_count)]
+        for rel_path in rel_paths:
+            source_path = root / rel_path
+            source_path.parent.mkdir(parents=True, exist_ok=True)
+            source_path.write_text("covered = 1\nmissed = 2\n", encoding="utf-8")
+
+        coverage_payload = {
+            "files": {
+                rel_path: {"executed_lines": [1], "missing_lines": [2]}
+                for rel_path in rel_paths
+            }
+        }
+
+        original_read_text = module.Path.read_text
+        try:
+            for _ in range(samples):
+                read_calls = 0
+
+                def counted_read_text(self: Path, *args: object, **kwargs: object) -> str:
+                    nonlocal read_calls
+                    read_calls += 1
+                    return original_read_text(self, *args, **kwargs)
+
+                module.Path.read_text = counted_read_text
+                start = time.perf_counter()
+                for rel_path in rel_paths:
+                    measurable, covered, missed = module._measurable_changed_lines(
+                        root,
+                        coverage_payload,
+                        rel_path,
+                        set(),
+                    )
+                    if measurable or covered or missed:
+                        raise RuntimeError("empty changed sets must not produce measurable lines")
+                elapsed_samples.append((time.perf_counter() - start) * 1000.0)
+                read_samples.append(float(read_calls))
+        finally:
+            module.Path.read_text = original_read_text
+
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "source_read_calls_mean": statistics.fmean(read_samples),
+        "path_count": float(path_count),
+        "sample_count": float(samples),
+    }
+
+
+def main() -> int:
+    print(json.dumps(run_probe(Path.cwd()), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -91,6 +91,16 @@ def test_scope_report_selects_only_matching_probe() -> None:
     assert scope["force_all"] is False
 
 
+def test_scope_report_selects_changed_scope_coverage_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["scripts/changed_scope_coverage.py"],
+    )
+
+    selected_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert "changed-scope-coverage-empty-path-short-circuit" in selected_ids
+
+
 def test_scope_report_selects_training_dataset_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -525,6 +535,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "benchmark-export-run-scan-single-pass",
         "benchmark-queue-decoded-record-cache",
         "benchmark-store-matrix-streaming",
+        "changed-scope-coverage-empty-path-short-circuit",
         "closure-audit-probe-source-short-circuit",
         "deterministic-rerank-query-context-reuse",
         "dev-up-mlx-metal-dist-info-scandir",

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -138,6 +138,52 @@ def test_measurable_changed_lines_filters_blank_comment_and_unmeasured_lines(tmp
     assert missed == [5]
 
 
+def test_measurable_changed_lines_skips_source_read_when_no_changed_lines(monkeypatch, tmp_path: Path) -> None:
+    coverage_payload = {
+        "files": {
+            "foo.py": {
+                "executed_lines": [1],
+                "missing_lines": [2],
+            }
+        }
+    }
+    read_calls: list[Path] = []
+
+    def fail_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        read_calls.append(self)
+        raise AssertionError("source file should not be read when the changed set is empty")
+
+    monkeypatch.setattr(changed_scope_coverage.Path, "read_text", fail_read_text)
+
+    measurable, covered, missed = changed_scope_coverage._measurable_changed_lines(
+        tmp_path,
+        coverage_payload,
+        "foo.py",
+        set(),
+    )
+
+    assert measurable == []
+    assert covered == []
+    assert missed == []
+    assert read_calls == []
+
+
+def test_changed_scope_coverage_probe_emits_empty_path_metrics() -> None:
+    probe_path = Path(__file__).resolve().parents[1] / "scripts" / "changed_scope_coverage_probe.py"
+    spec = importlib.util.spec_from_file_location("changed_scope_coverage_probe", probe_path)
+    assert spec is not None
+    assert spec.loader is not None
+    probe = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(probe)
+
+    metrics = probe.run_probe(Path(__file__).resolve().parents[1], path_count=5, samples=2)
+
+    assert metrics["path_count"] == 5.0
+    assert metrics["sample_count"] == 2.0
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["source_read_calls_mean"] == 0.0
+
+
 def test_main_reports_aggregate_coverage_for_multiple_paths(monkeypatch, tmp_path: Path, capsys) -> None:
     (tmp_path / "foo.py").write_text("covered\nmissed\n", encoding="utf-8")
     (tmp_path / "bar.py").write_text("covered\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- Short-circuit `scripts/changed_scope_coverage.py` when a requested file has no changed lines, avoiding coverage/source set construction and source file reads for empty changed scopes.
- Keep the latest `main` changed-scope diff parser improvements while registering a dedicated empty-path PR-scoped performance probe.
- Refresh conflict-resolution tests so the new probe, registry selection, and failure guardrails are covered.

## Plan or Spec
- Plan: `docs/plans/2026-05-05-changed-scope-coverage-empty-path-short-circuit.md`
- Scouted candidate: Python CI helper optimization for empty changed-scope coverage paths.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 21 passed in 0.09s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 21 passed in 0.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# Wrote JSON report to coverage.json

python3 scripts/python_changed_line_coverage.py --coverage-json coverage.json --diff-from origin/main scripts/changed_scope_coverage.py scripts/changed_scope_coverage_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 100.00% 109/109

python3 scripts/changed_scope_coverage_probe.py
# {"elapsed_ms_mean": 0.04238698498478958, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}

python3 -c "import json, subprocess; probes=json.load(open('infra/perf/pr_scoped_probes.json')); command=next(p['probe_command'] for p in probes if p['id']=='changed-scope-coverage-empty-path-short-circuit'); raise SystemExit(subprocess.run(command, shell=True).returncode)"
# {"elapsed_ms_mean": 0.07662496396473475, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}

python3 scripts/changed_scope_coverage_parse_probe.py
# {"changed_line_count": 7680.0, "elapsed_ms_mean": 3.2512535302278898, "elapsed_ms_min": 2.9351250268518925, "file_count": 240.0, "line_count": 16080.0}

python3 -m json.tool infra/perf/pr_scoped_probes.json
# passed

git diff --check
# passed
```

## Coverage and Metrics
- Changed executable line coverage against `origin/main`: `TOTAL 100.00% 109/109` for the touched Python/test scope.
- Registered probe: `changed-scope-coverage-empty-path-short-circuit`.
- Empty-path helper probe: `source_read_calls_mean=0.0`, `path_count=300.0`, `sample_count=7.0`.
- Parser compatibility probe retained from latest `main`: `changed_line_count=7680.0`, `file_count=240.0`, `line_count=16080.0`.

## Known Gaps
- Full local `make swift-test` / macOS checks were not run locally for this Python CI-helper conflict-resolution slice.
- Hosted GitHub Actions restarted after the conflict-resolution push and must pass before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
