### PR TITLE
perf: reuse sorted bootstrap replicates

### DIFF
--- a/docs/plans/2026-05-05-statistical-evidence-bootstrap-single-sort.md
+++ b/docs/plans/2026-05-05-statistical-evidence-bootstrap-single-sort.md
@@ -1,0 +1,39 @@
+# Statistical Evidence Bootstrap Single-Sort Optimization
+
+## Goal
+Reduce redundant work in the paired bootstrap confidence interval path by sorting the bootstrap replicate vector once and reusing it for the lower and upper percentile bounds.
+
+## Touched Files
+- `services/mlx-worker-python/worker/productization/statistical_evidence.py`
+- `services/mlx-worker-python/tests/test_statistical_evidence.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux-Only Constraint
+This is a pure Python worker/productization slice and can be verified locally on Linux with focused pytest, changed-scope coverage, and an explicit PR-scoped performance probe.
+
+## Performance Probe
+Register `statistical-evidence-bootstrap-single-sort` in the PR-scoped performance registry. The probe runs a deterministic synthetic paired-outcome workload through `build_paired_statistical_evidence(...)` and reports:
+- `elapsed_ms_mean` (lower is better)
+- `peak_bytes_mean` (lower is better)
+- `sample_size`
+- `bootstrap_iterations`
+- `delta_accuracy`
+
+## Success Metrics
+- Focused statistical evidence tests pass.
+- Changed executable line coverage is at least 95% for the touched scope.
+- Local base-vs-head scoped probe shows lower elapsed time and lower or acceptable peak traced memory while preserving deterministic output fields.
+- `git diff --check` passes.
+
+## Verification Commands
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+
+python scripts/pr_scoped_performance_scope.py --base origin/main --head HEAD --registry infra/perf/pr_scoped_probes.json --output /tmp/statistical-scope.json
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --scope /tmp/statistical-scope.json --probe-id statistical-evidence-bootstrap-single-sort --base-ref origin/main --head-ref HEAD --output /tmp/statistical-probe.json
+
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1409,5 +1409,36 @@
         "warn_pct": 5.0
       }
     ]
+  },
+  {
+    "id": "statistical-evidence-bootstrap-single-sort",
+    "name": "Statistical evidence bootstrap single sort",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/statistical_evidence.py",
+      "services/mlx-worker-python/tests/test_statistical_evidence.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python - <<'PY'\nimport json\nimport statistics\nimport sys\nimport time\nimport tracemalloc\nfrom pathlib import Path\n\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\n\nfrom worker.productization.statistical_evidence import build_paired_statistical_evidence\n\nsample_size = 64\nbootstrap_iterations = 8000\nsamples = 5\noutcomes = tuple(1.0 if index % 7 in (0, 1, 2) else (-1.0 if index % 11 == 0 else 0.0) for index in range(sample_size))\nelapsed_ms = []\npeak_bytes = []\nlast = None\nfor sample_index in range(samples):\n    tracemalloc.start()\n    started = time.perf_counter()\n    result = build_paired_statistical_evidence(\n        paired_outcomes=outcomes,\n        confidence_level=0.95,\n        bootstrap_iterations=bootstrap_iterations,\n        bootstrap_seed=100 + sample_index,\n    )\n    elapsed_ms.append((time.perf_counter() - started) * 1000.0)\n    _, peak = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    peak_bytes.append(float(peak))\n    last = result\n\nif last is None:\n    raise RuntimeError(\"statistical evidence probe did not run\")\n\nprint(json.dumps({\n    \"elapsed_ms_mean\": statistics.fmean(elapsed_ms),\n    \"peak_bytes_mean\": statistics.fmean(peak_bytes),\n    \"sample_size\": float(last[\"sample_size\"]),\n    \"bootstrap_iterations\": float(last[\"bootstrap\"][\"iterations\"]),\n    \"delta_accuracy\": float(last[\"delta_accuracy\"]),\n}, sort_keys=True))\nPY",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
   }
 ]

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -217,6 +217,16 @@ def test_scope_report_selects_lora_reward_summary_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "lora-reward-summary-candidate-minmax"
 
 
+def test_scope_report_selects_statistical_evidence_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/statistical_evidence.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "statistical-evidence-bootstrap-single-sort"
+
+
 def test_scope_report_selects_pr_scoped_scope_script_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -757,6 +767,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "worker-registry-resident-bytes-accumulator",
         "pr-scoped-performance-report-results-scandir",
         "model-ops-bundle-artifact-byte-accounting",
+        "statistical-evidence-bootstrap-single-sort",
     }
     registry_probe = None
     maintenance_probe = None

--- a/services/mlx-worker-python/tests/test_statistical_evidence.py
+++ b/services/mlx-worker-python/tests/test_statistical_evidence.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import builtins
 import math
 
+import pytest
+
+from worker.productization import statistical_evidence as statistical_evidence_module
 from worker.productization.statistical_evidence import (
     _interval_sign,
     _percentile,
+    _percentile_ordered,
     build_category_breakdown,
     build_paired_statistical_evidence,
     classify_release_verdict,
@@ -87,6 +92,36 @@ def test_build_paired_statistical_evidence_keeps_full_confidence_intervals_finit
     assert evidence["analytical"]["lower_bound"] <= evidence["analytical"]["upper_bound"]
 
 
+def test_bootstrap_interval_reuses_one_sorted_replicate_vector(monkeypatch: pytest.MonkeyPatch) -> None:
+    sorted_call_lengths: list[int] = []
+    original_sorted = builtins.sorted
+
+    def tracking_sorted(values: object, *args: object, **kwargs: object) -> list[object]:
+        materialized = list(values)  # type: ignore[arg-type]
+        sorted_call_lengths.append(len(materialized))
+        return original_sorted(materialized, *args, **kwargs)
+
+    monkeypatch.setattr(statistical_evidence_module, "sorted", tracking_sorted, raising=False)
+
+    evidence = build_paired_statistical_evidence(
+        paired_outcomes=(1, 0, 1, 1, -1, 0, 1, 1),
+        confidence_level=0.9,
+        bootstrap_iterations=64,
+        bootstrap_seed=13,
+    )
+
+    assert sorted_call_lengths == [64]
+    assert evidence["bootstrap"] == {
+        "method": "paired_bootstrap_percentile",
+        "confidence_level": 0.9,
+        "lower_bound": 0.125,
+        "upper_bound": 1.0,
+        "crosses_zero": False,
+        "iterations": 64,
+        "seed": 13,
+    }
+
+
 def test_classify_release_verdict_returns_inconclusive_when_any_interval_crosses_zero() -> None:
     verdict = classify_release_verdict(
         delta_accuracy=0.2,
@@ -133,6 +168,7 @@ def test_statistical_helper_edges_cover_percentiles_and_interval_sign_fallbacks(
     assert _percentile([], 0.5) == 0.0
     assert _percentile([0.25], 0.5) == 0.25
     assert _percentile([0.25, 0.5, 0.75], 0.5) == 0.5
+    assert _percentile_ordered([], 0.5) == 0.0
     assert _interval_sign({"lower_bound": -0.2, "upper_bound": 0.3, "crosses_zero": False}) == 0
 
 

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -127,11 +127,12 @@ def _paired_bootstrap_interval(
         replicates.append(_mean(replicate))
 
     alpha = (1.0 - confidence_level) / 2.0
+    ordered_replicates = sorted(replicates)
     return _interval_payload(
         method="paired_bootstrap_percentile",
         confidence_level=confidence_level,
-        lower_bound=_percentile(replicates, alpha),
-        upper_bound=_percentile(replicates, 1.0 - alpha),
+        lower_bound=_percentile_ordered(ordered_replicates, alpha),
+        upper_bound=_percentile_ordered(ordered_replicates, 1.0 - alpha),
         iterations=int(bootstrap_iterations),
         seed=int(bootstrap_seed),
     )
@@ -218,8 +219,13 @@ def _mean(values: list[float] | tuple[float, ...]) -> float:
 def _percentile(values: list[float], percentile: float) -> float:
     if not values:
         return 0.0
+    return _percentile_ordered(sorted(values), percentile)
+
+
+def _percentile_ordered(ordered: list[float], percentile: float) -> float:
+    if not ordered:
+        return 0.0
     bounded_percentile = min(max(percentile, 0.0), 1.0)
-    ordered = sorted(values)
     if len(ordered) == 1:
         return ordered[0]
     position = bounded_percentile * (len(ordered) - 1)


### PR DESCRIPTION
## Summary
- Reuse one sorted bootstrap replicate vector for paired statistical evidence confidence interval bounds instead of sorting separately for lower and upper percentiles.
- Keep the public `_percentile(...)` behavior unchanged by adding an internal `_percentile_ordered(...)` helper.
- Register a dedicated PR-scoped performance probe for the statistical evidence bootstrap path.

## Plan or Spec
- Plan: `docs/plans/2026-05-05-statistical-evidence-bootstrap-single-sort.md`
- Scope: Python-only optimization in `services/mlx-worker-python/worker/productization/statistical_evidence.py` plus focused tests and PR-scoped performance registry coverage.
- Goal: remove redundant percentile sorting in the bootstrap confidence interval path while preserving result payload shape and deterministic bootstrap behavior.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py && rm -f coverage.json && git diff --check`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json /tmp/statistical-changed-files.json --output /tmp/statistical-scope.json`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id statistical-evidence-bootstrap-single-sort --base-repo /tmp/melix-stat-base-20260505052845 --head-repo "$PWD" --output /tmp/statistical-probe-rerun.json`

## Coverage and Metrics
- Targeted pytest / coverage: `10 passed in 0.12s`.
- Changed-scope coverage: `TOTAL 24 0 100%`.
  - `statistical_evidence.py`: 5/5 changed executable lines covered.
  - `test_statistical_evidence.py`: 15/15 changed executable lines covered.
  - `test_pr_scoped_performance.py`: 4/4 changed executable lines covered.
- Registered scoped probe: `statistical-evidence-bootstrap-single-sort`.
- Local base-vs-head scoped probe (`sample_size=64`, `bootstrap_iterations=8000`, `samples=5`):
  - `elapsed_ms_mean`: base `373.355165`, head `359.341095` (~3.75% lower).
  - `peak_bytes_mean`: base `356944.0`, head `356891.2` (slightly lower).
  - `delta_accuracy`: unchanged at `0.3906`.
- Scope selection noted `force_all=true` because `infra/perf/pr_scoped_probes.json` changed; the new probe was selected and verified locally.

## Known Gaps
- Linux-only local verification. No macOS/Swift checks were run locally.
- Since the PR-scoped probe registry changed, hosted `pr-scoped-performance` may fan out to the full matrix before merge readiness.

## Evidence Checklist
- [x] Focused tests added/updated for the changed behavior.
- [x] Changed-scope coverage is at least 95% for touched executable Python scope.
- [x] Explicit local performance probe produced concrete base-vs-head metrics.
- [x] PR-scoped performance probe registered for the optimized path.
- [x] `git diff --check` passed.
- [ ] Hosted CI / PR-scoped performance completed after PR creation.
