### PR TITLE
perf: cache duplicate deterministic embeddings

### DIFF
--- a/docs/plans/2026-05-05-deterministic-embedding-duplicate-input-cache.md
+++ b/docs/plans/2026-05-05-deterministic-embedding-duplicate-input-cache.md
@@ -1,0 +1,41 @@
+# Deterministic Embedding Duplicate Input Cache
+
+## Goal
+
+Reduce redundant deterministic embedding work when a single embedding request contains repeated input strings.
+
+## Linux-only constraint
+
+This is a Python worker-runtime slice. It can be validated on Linux with focused pytest, changed-scope coverage, and a local PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py`
+- `services/mlx-worker-python/tests/test_embedding_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Optimization hypothesis
+
+`DeterministicEmbeddingRuntime.embed_inputs()` currently embeds every input position independently. For duplicate strings inside the same request, it repeats the same family/backend embedding work even though backend, family, and dimensions are fixed for that call.
+
+Add a request-local cache keyed by the raw input text so duplicate positions reuse the already-computed vector while preserving input ordering and output values.
+
+## Performance probe
+
+Register `deterministic-embedding-duplicate-input-cache` in the PR-scoped performance registry.
+
+The probe will run a synthetic request with many duplicate input strings, measure:
+
+- `elapsed_ms_mean` — lower is better
+- `embed_text_calls_mean` — lower is better
+- `unique_input_count` / `input_count` — behavior context
+
+Success means the branch keeps identical output cardinality/checksum while reducing repeated embed calls to the unique input count and improving elapsed time on the duplicate-heavy workload.
+
+## Verification commands
+
+- Focused pytest for embedding runtime and PR-scoped probe selection/smoke tests
+- Changed-scope coverage for touched Python/tests with at least 95% automated coverage
+- Local registered probe run through `scripts/pr_scoped_performance_run.py`
+- `git diff --check`

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -25,6 +25,37 @@
     ]
   },
   {
+    "id": "deterministic-embedding-duplicate-input-cache",
+    "name": "Deterministic embedding duplicate input cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py",
+      "services/mlx-worker-python/tests/test_embedding_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/deterministic_embedding_duplicate_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_duplicate_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/deterministic_embedding_duplicate_probe.py ]; then python scripts/deterministic_embedding_duplicate_probe.py; else python - <<PY\nimport json\nimport statistics\nimport sys\nimport time\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.runtime.deterministic_embedding_runtime import DeterministicEmbeddingRuntime\nfrom worker.runtime.embedding_backends import DeterministicEmbeddingBackend, DeterministicEmbeddingFamilyAdapter, EmbeddingBackendDescriptor, EmbeddingFamilyDescriptor\nclass CountingEmbeddingBackend(DeterministicEmbeddingBackend):\n    descriptor = EmbeddingBackendDescriptor(backend_id=\"counting-v1\", family_id=\"counting\", pooling_mode=\"mean\", normalization=\"none\", estimated_resident_bytes=1)\n    def __init__(self):\n        self.calls = 0\n    def embed_text(self, text, dimensions):\n        self.calls += 1\n        seed = (len(text) % 17) / 17.0\n        return [seed + (index / 1000.0) for index in range(dimensions)]\nclass CountingEmbeddingFamilyAdapter(DeterministicEmbeddingFamilyAdapter):\n    descriptor = EmbeddingFamilyDescriptor(family_id=\"counting\", pooling_mode=\"mean\", normalization=\"none\", default_dimensions=32)\n    def embed_text(self, backend, text, dimensions):\n        return backend.embed_text(text, dimensions)\ndimensions = 32\nunique_inputs = [f\"document-{index % 160}-payload-{index % 13}\" for index in range(512)]\ninputs = [unique_inputs[index % len(unique_inputs)] for index in range(8192)]\nexpected_unique_count = len(set(inputs))\nelapsed_samples = []\ncall_samples = []\nchecksum = 0.0\nfor _ in range(5):\n    backend = CountingEmbeddingBackend()\n    runtime = DeterministicEmbeddingRuntime(dimensions=dimensions)\n    loaded_model = {\"model_id\": \"melix-dev-embed-counting\", \"dimensions\": dimensions, \"embedding_backend\": backend, \"embedding_family_adapter\": CountingEmbeddingFamilyAdapter()}\n    started = time.perf_counter()\n    vectors = runtime.embed_inputs(loaded_model, inputs)\n    elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n    call_samples.append(float(backend.calls))\n    checksum = sum(vector[0] for vector in vectors)\nif len(vectors) != len(inputs):\n    raise AssertionError(f\"unexpected vector count: {len(vectors)} != {len(inputs)}\")\nprint(json.dumps({\"elapsed_ms_mean\": round(statistics.fmean(elapsed_samples), 6), \"embed_text_calls_mean\": round(statistics.fmean(call_samples), 6), \"input_count\": float(len(inputs)), \"unique_input_count\": float(expected_unique_count), \"checksum\": round(checksum, 6)}, sort_keys=True))\nPY\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "embed_text_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "benchmark-evaluation-report-running-aggregates",
     "name": "Benchmark evaluation report running aggregates",
     "runner": "ubuntu-latest",

--- a/scripts/deterministic_embedding_duplicate_probe.py
+++ b/scripts/deterministic_embedding_duplicate_probe.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+repo_root = Path.cwd()
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
+
+from worker.runtime.deterministic_embedding_runtime import DeterministicEmbeddingRuntime
+from worker.runtime.embedding_backends import (
+    DeterministicEmbeddingBackend,
+    DeterministicEmbeddingFamilyAdapter,
+    EmbeddingBackendDescriptor,
+    EmbeddingFamilyDescriptor,
+)
+
+
+class CountingEmbeddingBackend(DeterministicEmbeddingBackend):
+    descriptor = EmbeddingBackendDescriptor(
+        backend_id="counting-v1",
+        family_id="counting",
+        pooling_mode="mean",
+        normalization="none",
+        estimated_resident_bytes=1,
+    )
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def embed_text(self, text: str, dimensions: int) -> list[float]:
+        self.calls += 1
+        seed = (len(text) % 17) / 17.0
+        return [seed + (index / 1000.0) for index in range(dimensions)]
+
+
+class CountingEmbeddingFamilyAdapter(DeterministicEmbeddingFamilyAdapter):
+    descriptor = EmbeddingFamilyDescriptor(
+        family_id="counting",
+        pooling_mode="mean",
+        normalization="none",
+        default_dimensions=32,
+    )
+
+    def embed_text(
+        self,
+        backend: DeterministicEmbeddingBackend,
+        text: str,
+        dimensions: int,
+    ) -> list[float]:
+        return backend.embed_text(text, dimensions)
+
+
+def run_probe() -> dict[str, float]:
+    dimensions = 32
+    unique_inputs = [f"document-{index % 160}-payload-{index % 13}" for index in range(512)]
+    inputs = [unique_inputs[index % len(unique_inputs)] for index in range(8192)]
+    expected_unique_count = len(set(inputs))
+    sample_count = 5
+    elapsed_samples: list[float] = []
+    call_samples: list[float] = []
+    checksum = 0.0
+
+    for _ in range(sample_count):
+        backend = CountingEmbeddingBackend()
+        runtime = DeterministicEmbeddingRuntime(dimensions=dimensions)
+        loaded_model = {
+            "model_id": "melix-dev-embed-counting",
+            "dimensions": dimensions,
+            "embedding_backend": backend,
+            "embedding_family_adapter": CountingEmbeddingFamilyAdapter(),
+        }
+        started = time.perf_counter()
+        vectors = runtime.embed_inputs(loaded_model, inputs)
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        call_samples.append(float(backend.calls))
+        checksum = sum(vector[0] for vector in vectors)
+
+    if len(vectors) != len(inputs):
+        raise AssertionError(f"unexpected vector count: {len(vectors)} != {len(inputs)}")
+    return {
+        "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+        "embed_text_calls_mean": round(statistics.fmean(call_samples), 6),
+        "input_count": float(len(inputs)),
+        "unique_input_count": float(expected_unique_count),
+        "checksum": round(checksum, 6),
+    }
+
+
+def main() -> None:
+    print(json.dumps(run_probe(), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_embedding_runtime.py
+++ b/services/mlx-worker-python/tests/test_embedding_runtime.py
@@ -9,7 +9,13 @@ from worker.grpc_server import WorkerInferenceService, WorkerRuntimeService
 from worker.model_registry.catalog import WorkerModelCatalog
 from worker.registry import WorkerRegistry
 from worker.runtime.deterministic_embedding_runtime import DeterministicEmbeddingRuntime
-from worker.runtime.embedding_backends import BERTEmbeddingBackend
+from worker.runtime.embedding_backends import (
+    BERTEmbeddingBackend,
+    DeterministicEmbeddingBackend,
+    DeterministicEmbeddingFamilyAdapter,
+    EmbeddingBackendDescriptor,
+    EmbeddingFamilyDescriptor,
+)
 from worker.runtime.mlx_text_runtime import MLXTextRuntime
 
 
@@ -21,6 +27,40 @@ class PassiveTextBackend:
 
     def estimate_resident_bytes(self, model_spec):
         return 1024
+
+
+class CountingEmbeddingBackend(DeterministicEmbeddingBackend):
+    descriptor = EmbeddingBackendDescriptor(
+        backend_id="counting-v1",
+        family_id="counting",
+        pooling_mode="mean",
+        normalization="none",
+        estimated_resident_bytes=1,
+    )
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int]] = []
+
+    def embed_text(self, text: str, dimensions: int) -> list[float]:
+        self.calls.append((text, dimensions))
+        return [float(len(self.calls))] * dimensions
+
+
+class CountingEmbeddingFamilyAdapter(DeterministicEmbeddingFamilyAdapter):
+    descriptor = EmbeddingFamilyDescriptor(
+        family_id="counting",
+        pooling_mode="mean",
+        normalization="none",
+        default_dimensions=4,
+    )
+
+    def embed_text(
+        self,
+        backend: DeterministicEmbeddingBackend,
+        text: str,
+        dimensions: int,
+    ) -> list[float]:
+        return backend.embed_text(text, dimensions)
 
 
 def build_services(model_catalog: WorkerModelCatalog | None = None):
@@ -289,6 +329,32 @@ def test_embed_runtime_resolves_backend_from_loaded_model_metadata() -> None:
 
     assert len(vectors) == 1
     assert len(vectors[0]) == 8
+
+
+def test_embed_runtime_reuses_duplicate_inputs_within_one_request() -> None:
+    runtime = DeterministicEmbeddingRuntime()
+    backend = CountingEmbeddingBackend()
+    family = CountingEmbeddingFamilyAdapter()
+
+    vectors = runtime.embed_inputs(
+        {
+            "model_id": "melix-dev-embed-counting",
+            "dimensions": 4,
+            "embedding_backend": backend,
+            "embedding_family_adapter": family,
+        },
+        ["alpha", "beta", "alpha", "gamma", "beta"],
+    )
+
+    assert backend.calls == [("alpha", 4), ("beta", 4), ("gamma", 4)]
+    assert vectors == [
+        [1.0, 1.0, 1.0, 1.0],
+        [2.0, 2.0, 2.0, 2.0],
+        [1.0, 1.0, 1.0, 1.0],
+        [3.0, 3.0, 3.0, 3.0],
+        [2.0, 2.0, 2.0, 2.0],
+    ]
+    assert vectors[0] is not vectors[2]
 
 
 def test_load_model_rejects_unsupported_embedding_backend() -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -260,6 +260,16 @@ def test_scope_report_selects_deterministic_rerank_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "deterministic-rerank-query-context-reuse"
 
 
+def test_scope_report_selects_deterministic_embedding_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "deterministic-embedding-duplicate-input-cache"
+
+
 def test_scope_report_selects_benchmark_export_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -605,6 +615,22 @@ def test_multimodal_fast_path_signature_probe_script_emits_metrics(
     assert metrics["peak_bytes_mean"] > 0
 
 
+def test_deterministic_embedding_duplicate_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runpy.run_path(
+        str(REPO_ROOT / "scripts/deterministic_embedding_duplicate_probe.py"),
+        run_name="__main__",
+    )
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["input_count"] == 8192.0
+    assert 0 < metrics["unique_input_count"] < metrics["input_count"]
+    assert metrics["embed_text_calls_mean"] == metrics["unique_input_count"]
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["checksum"] > 0
+
+
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
         "benchmark-evaluation-report-running-aggregates",
@@ -613,6 +639,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "benchmark-store-matrix-streaming",
         "changed-scope-coverage-diff-parser",
         "closure-audit-probe-source-short-circuit",
+        "deterministic-embedding-duplicate-input-cache",
         "deterministic-rerank-query-context-reuse",
         "dev-up-mlx-metal-dist-info-scandir",
         "evaluation-job-id-high-water-mark",

--- a/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
@@ -35,4 +35,13 @@ class DeterministicEmbeddingRuntime:
         family = loaded_model.get("embedding_family_adapter")
         if family is None:
             family = resolve_embedding_family(loaded_model.get("embedding_family_id", ""), backend)
-        return [family.embed_text(backend, text, dimensions) for text in inputs]
+
+        vector_cache: dict[str, tuple[float, ...]] = {}
+        vectors: list[list[float]] = []
+        for text in inputs:
+            vector = vector_cache.get(text)
+            if vector is None:
+                vector = tuple(family.embed_text(backend, text, dimensions))
+                vector_cache[text] = vector
+            vectors.append(list(vector))
+        return vectors


### PR DESCRIPTION
## Summary
- Adds a request-local duplicate-input cache to `DeterministicEmbeddingRuntime.embed_inputs()` so repeated strings in one embedding request reuse the same deterministic backend/family computation.
- Preserves output ordering and returns distinct list objects for duplicate positions while avoiding repeated digest/projection work.
- Registers a dedicated PR-scoped performance probe for the duplicate-heavy deterministic embedding path.

## Plan or Spec
- Plan: `docs/plans/2026-05-05-deterministic-embedding-duplicate-input-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics
# 16 passed in 0.94s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_duplicate_probe.py
# 16 passed; TOTAL 41 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-duplicate-input-cache --base-repo /tmp/melix-cron-opt-20260505055830-base-060523 --head-repo "$PWD" --output /tmp/deterministic-embedding-probe.json
# base/head probe succeeded

git diff --check
git diff --cached --check
# no whitespace errors
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 41 0 100%`.
- Registered scoped CI probe: `deterministic-embedding-duplicate-input-cache`.
- Local base-vs-head probe metrics:
  - `elapsed_ms_mean`: base `27.258067 ms` → head `5.632871 ms` (~79.34% lower).
  - `embed_text_calls_mean`: base `8192.0` → head `512.0` (93.75% fewer calls; equals `unique_input_count`).
  - `input_count`: `8192.0`; `unique_input_count`: `512.0`.
  - `checksum`: unchanged at `2169.411765`.

## Known Gaps
- Linux-only local verification was run for this Python slice.
- Full repository `make py-test`, Swift, macOS, and integration suites were not run locally from this Linux host.
- Updating `infra/perf/pr_scoped_probes.json` may force the full hosted `pr-scoped-performance` matrix.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
