### PR TITLE
perf: dispatch changed-scope diff parser by prefix

### DIFF
--- a/docs/plans/2026-05-05-changed-scope-coverage-line-dispatch.md
+++ b/docs/plans/2026-05-05-changed-scope-coverage-line-dispatch.md
@@ -1,0 +1,29 @@
+# Changed-scope coverage parser line dispatch
+
+## Goal
+
+Reduce hot-loop prefix checks in `scripts/changed_scope_coverage.py` by dispatching unified diff parser branches from the first character before falling back to full prefix matching.
+
+## Scope
+
+This slice is Python-only and limited to the changed-scope coverage diff parser path. It keeps parser output identical while reducing repeated `str.startswith(...)` work for ordinary context, deletion, addition, hunk, and file-marker lines.
+
+## Registered performance probe
+
+The affected path is already covered by the registered PR-scoped probe `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`, including focused `test_command`, `coverage_command`, and `probe_command` entries. The probe builds a deterministic synthetic multi-file diff and reports:
+
+- `elapsed_ms_mean` (lower is better)
+- `line_count` and `changed_line_count` guard-rail metrics
+
+## Verification plan
+
+- Run the focused parser and PR-scoped registry tests.
+- Run changed-scope coverage for the touched files and require at least 95% changed-line coverage.
+- Run the registered parser probe locally on Linux against both `origin/main` and this branch via `scripts/pr_scoped_performance_run.py`.
+- Use the GitHub PR-scoped performance workflow as the merge gate after opening the PR.
+
+## Success criteria
+
+- Parser tests preserve multi-file, hunk, marker, blank-context, and added-content semantics.
+- Changed-scope coverage is at least 95% for the touched executable lines.
+- Local and CI probe metrics show a clear non-regression or improvement for `elapsed_ms_mean` with unchanged guard-rail counts.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -23,14 +23,15 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     current_path: str | None = None
     new_line: int | None = None
     for line in diff_text.splitlines():
-        if line.startswith("diff --git "):
+        first_char = line[:1]
+        if first_char == "d" and line.startswith("diff --git "):
             match = _DIFF_HEADER_RE.match(line)
             current_path = None if match is None else match.group(2)
             if current_path is not None:
                 changed_by_path.setdefault(current_path, set())
             new_line = None
             continue
-        if line.startswith("@@"):
+        if first_char == "@" and line.startswith("@@"):
             match = _HUNK_NEW_RANGE_RE.search(line)
             if match is None:
                 continue
@@ -38,14 +39,14 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
             continue
         if current_path is None or new_line is None:
             continue
-        if line.startswith("\\ "):
+        if first_char == "\\" and line.startswith("\\ "):
             continue
-        if _is_diff_file_marker(line):
+        if first_char in {"+", "-"} and _is_diff_file_marker(line):
             continue
-        if line.startswith("+"):
+        if first_char == "+":
             changed_by_path[current_path].add(new_line)
             new_line += 1
-        elif line.startswith("-"):
+        elif first_char == "-":
             continue
         else:
             new_line += 1

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -123,6 +123,24 @@ def test_parse_changed_lines_preserves_added_content_that_starts_with_diff_heade
     assert changed == {"foo.py": {1, 2}}
 
 
+def test_parse_changed_lines_counts_blank_context_lines_with_prefix_dispatch() -> None:
+    diff_text = "\n".join(
+        [
+            "diff --git a/foo.py b/foo.py",
+            "--- a/foo.py",
+            "+++ b/foo.py",
+            "@@ -1,3 +1,4 @@",
+            " context",
+            "",
+            "+inserted_after_blank",
+        ]
+    )
+
+    changed = changed_scope_coverage._parse_changed_lines(diff_text)
+
+    assert changed == {"foo.py": {3}}
+
+
 def test_parse_changed_lines_uses_precompiled_patterns_and_prefix_marker_check(monkeypatch) -> None:
     def fail_module_level_regex(*args: object, **kwargs: object) -> object:  # pragma: no cover
         raise AssertionError("hot parser should use precompiled regex objects")


### PR DESCRIPTION
## Summary
- Dispatch changed-scope coverage diff parsing from the line's first character before running full prefix checks.
- Add a parser regression test for blank context lines so the new dispatch path preserves line-number accounting.
- Document the slice and its registered PR-scoped probe gate.

## Plan or Spec
- `docs/plans/2026-05-05-changed-scope-coverage-line-dispatch.md`

## Commands Run
```text
# Baseline probe on origin/main worktree, 5 samples
python3 scripts/changed_scope_coverage_parse_probe.py
old elapsed_ms_mean samples: 7.782320, 7.492670, 7.403102, 7.413995, 7.360339

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
Result: 14 passed in 0.38s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
Result: TOTAL 11 0 100%

# Head probe, 5 samples
python3 scripts/changed_scope_coverage_parse_probe.py
new elapsed_ms_mean samples: 6.242444, 4.760307, 5.008554, 4.710262, 4.677435

# Registered local probe run
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-diff-parser --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output .runtime/changed-scope-coverage-line-dispatch-probe.json
Result: base elapsed_ms_mean=7.481535086602283, head elapsed_ms_mean=5.210047088136586, changed_line_count=7680.0, line_count=16080.0, head verification ok

git diff --check
Result: pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Direct 5-run probe means: old_mean=`7.490485 ms`, new_mean=`5.079800 ms`, delta=`-2.410685 ms`, speedup=`1.474563x` (`32.18%` lower).
- Registered local probe: base `elapsed_ms_mean=7.481535086602283`, head `elapsed_ms_mean=5.210047088136586`, guard rails unchanged (`changed_line_count=7680.0`, `line_count=16080.0`).
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Full repository test suite was not run locally; this is a focused Python performance slice.
- CI is the source of truth for the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
