### PR TITLE
Record quantization runtime smoke evidence

### DIFF
--- a/docs/plans/2026-05-05-issue-365-quantization-runtime-evidence.md
+++ b/docs/plans/2026-05-05-issue-365-quantization-runtime-evidence.md
@@ -1,0 +1,88 @@
+# Issue 365 Quantization Runtime Evidence Slice
+
+## Goal
+
+Continue the implementation path for
+https://github.com/Keith-CY/melix/issues/365 by replacing the quantized bundle
+smoke-test boolean with typed local smoke evidence in
+`melix.quantized_bundle.v1` manifests.
+
+Issue 365 is still not complete after this slice. This work makes release-gate
+evidence auditable and adds an opt-in local runtime generate probe, but it does
+not implement real PTQ/QAT weight conversion or final local-runtime acceptance.
+
+## Scope
+
+### Included
+
+- Add a `local_inference_smoke` manifest block for quantized bundles.
+- Keep `release_gate.local_inference_smoke_result` derived from typed smoke
+  evidence instead of a loose boolean.
+- Preserve the current default structural bundle smoke mode for fast unit and
+  deterministic release-gate checks.
+- Add an opt-in `runtime_generate` smoke mode that loads the produced bundle
+  through the worker runtime, renders a short prompt, requests one generated
+  token, records latency and token-count evidence, and unloads the model.
+- Record failure evidence for missing structural files and runtime smoke
+  failures.
+- Do not add or preserve screenshot artifacts as evidence for this slice.
+
+### Excluded
+
+- Real PTQ over merged model weights.
+- Real QAT optimizer or fake-quant training execution.
+- Final local-runtime quantization acceptance.
+- Window UI screenshot evidence.
+- Closing issue 365.
+
+## Performance And Metrics
+
+The default `structural` smoke mode keeps the existing cheap artifact check.
+The opt-in `runtime_generate` mode intentionally adds one model load, one short
+prompt render, one-token generation, and unload when operators request runtime
+evidence.
+
+Success metrics:
+
+- Quantized bundle manifests include typed smoke evidence for requested and
+  non-requested paths.
+- Runtime-generate smoke evidence records status, evidence kind, latency, prompt
+  hash, generated token count, runtime, and checked artifact files.
+- Failure paths preserve structured evidence instead of only flipping a boolean.
+- Changed-scope coverage remains at least 95 percent.
+
+## Verification
+
+Targeted commands:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_training_dataset_builder.py
+git diff --check
+```
+
+Coverage and metrics:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_training_dataset_builder.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-quantization-runtime-evidence-coverage.json
+python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-quantization-runtime-evidence-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py docs/plans/2026-05-05-issue-365-quantization-runtime-evidence.md
+```
+
+Results on 2026-05-05:
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_training_dataset_builder.py`: 87 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_training_dataset_builder.py`: 87 passed.
+- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-quantization-runtime-evidence-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py docs/plans/2026-05-05-issue-365-quantization-runtime-evidence.md`: 99.50% total changed-line coverage (198/199).
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python python -m compileall -q services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py`: passed.
+- `git diff --check`: passed.
+- Screenshot artifacts: none added or retained for this slice; only existing tracked product resources and evaluation fixtures were present.
+
+## Remaining Issue 365 Gaps
+
+- GRPO candidate generation, scoring, and policy updates.
+- RLHF reward-model-backed policy optimization from issue 366.
+- Real PTQ/QAT local inference release evidence.
+- Full CLI chain tests for every business line.
+- Window UI runnable and inspectable acceptance for every business line.
+- Final release evidence separating deterministic/unit evidence from real local
+  runtime evidence.

--- a/services/mlx-worker-python/tests/test_quantization_pipeline.py
+++ b/services/mlx-worker-python/tests/test_quantization_pipeline.py
@@ -16,10 +16,24 @@ from worker.model_ops.quantization_profiles import (
 )
 from worker.model_registry.catalog import WorkerModelCatalog
 from worker.registry import WorkerRegistry
+from worker.runtime.deterministic_backend import DeterministicTextBackend
+from worker.runtime.mlx_text_runtime import MLXTextRuntime
 
 
 def build_service(tmp_path: Path) -> WorkerMaintenanceService:
     registry = WorkerRegistry(model_catalog=WorkerModelCatalog())
+    return WorkerMaintenanceService(registry, jobs_root=tmp_path / "model-ops")
+
+
+def build_deterministic_service(tmp_path: Path) -> WorkerMaintenanceService:
+    return build_service_with_text_backend(tmp_path, DeterministicTextBackend())
+
+
+def build_service_with_text_backend(tmp_path: Path, backend: object) -> WorkerMaintenanceService:
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=backend),
+        model_catalog=WorkerModelCatalog(),
+    )
     return WorkerMaintenanceService(registry, jobs_root=tmp_path / "model-ops")
 
 
@@ -101,6 +115,19 @@ def test_quantize_job_writes_bundle_directory_and_versioned_manifest(tmp_path: P
         "latency_delta": 0.0,
         "local_inference_smoke_result": "not_requested",
     }
+    assert manifest_payload["local_inference_smoke"] == {
+        "status": "not_requested",
+        "evidence_kind": "not_requested",
+        "smoke_mode": "structural",
+        "runtime": "mlx_text",
+        "runtime_backend": "not_requested",
+        "artifact_path": str(bundle_path),
+        "checked_files": [],
+        "latency_ms": 0.0,
+        "prompt_sha256": "",
+        "generated_token_count": 0,
+        "failure_reason": "",
+    }
     assert manifest_payload["quant_profile"] == {
         "algorithm": "oq",
         "schema_version": "melix.quant_profile.v1",
@@ -153,12 +180,246 @@ def test_quantize_job_records_successful_smoke_validation(tmp_path: Path) -> Non
     assert manifest_payload["compatibility"]["smoke_test_requested"] is True
     assert manifest_payload["compatibility"]["smoke_test_passed"] is True
     assert manifest_payload["release_gate"]["local_inference_smoke_result"] == "passed"
+    assert manifest_payload["local_inference_smoke"]["status"] == "passed"
+    assert manifest_payload["local_inference_smoke"]["evidence_kind"] == "bundle_structural"
+    assert manifest_payload["local_inference_smoke"]["smoke_mode"] == "structural"
+    assert manifest_payload["local_inference_smoke"]["runtime"] == "mlx_text"
+    assert manifest_payload["local_inference_smoke"]["runtime_backend"] == "structural"
+    assert manifest_payload["local_inference_smoke"]["checked_files"] == [
+        "config.json",
+        "tokenizer.json",
+        "weights.safetensors",
+    ]
+    assert manifest_payload["local_inference_smoke"]["latency_ms"] >= 0.0
+    assert manifest_payload["local_inference_smoke"]["prompt_sha256"] == ""
+    assert manifest_payload["local_inference_smoke"]["generated_token_count"] == 0
+    assert manifest_payload["local_inference_smoke"]["failure_reason"] == ""
     assert manifest_payload["artifact_bytes"] > 0
     assert manifest_payload["manifest_bytes"] > 0
     assert manifest_event.artifact.smoke_test_requested is True
     assert manifest_event.artifact.smoke_test_passed is True
     assert completed_event.artifact.smoke_test_requested is True
     assert completed_event.artifact.smoke_test_passed is True
+
+
+def test_structural_smoke_wrapper_reports_invalid_json(tmp_path: Path) -> None:
+    bundle_path = tmp_path / "bad-json-bundle"
+    bundle_path.mkdir()
+    (bundle_path / "config.json").write_text("{not-json\n", encoding="utf-8")
+    (bundle_path / "tokenizer.json").write_text("{}\n", encoding="utf-8")
+    (bundle_path / "weights.safetensors").write_bytes(b"weights")
+
+    evidence = OQQuantizationPipeline._run_structural_smoke_evidence(bundle_path)
+
+    assert OQQuantizationPipeline._run_structural_smoke_test(bundle_path) is False
+    assert evidence.status == "failed"
+    assert evidence.evidence_kind == "bundle_structural"
+    assert "config.json is not readable JSON" in evidence.failure_reason
+
+
+def test_quantize_job_records_structured_smoke_failure_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = build_service(tmp_path)
+    original_write_bytes_file = OQQuantizationPipeline._write_bytes_file
+
+    def write_and_remove_weights(path: Path, payload: bytes) -> int:
+        written = original_write_bytes_file(path, payload)
+        if path.name == "weights.safetensors":
+            path.unlink()
+        return written
+
+    monkeypatch.setattr(
+        OQQuantizationPipeline,
+        "_write_bytes_file",
+        staticmethod(write_and_remove_weights),
+    )
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                run_smoke_test=True,
+                ext={"operation": "quantize"},
+            ),
+            context=None,
+        )
+    )
+
+    manifest_payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+
+    assert events[-1].HasField("completed")
+    assert manifest_payload["compatibility"]["smoke_test_passed"] is False
+    assert manifest_payload["release_gate"]["local_inference_smoke_result"] == "failed"
+    assert manifest_payload["local_inference_smoke"]["status"] == "failed"
+    assert manifest_payload["local_inference_smoke"]["evidence_kind"] == "bundle_structural"
+    assert manifest_payload["local_inference_smoke"]["runtime_backend"] == "structural"
+    assert manifest_payload["local_inference_smoke"]["checked_files"] == [
+        "config.json",
+        "tokenizer.json",
+        "weights.safetensors",
+    ]
+    assert "weights.safetensors is missing" in manifest_payload["local_inference_smoke"]["failure_reason"]
+
+
+def test_quantize_job_records_runtime_generate_preflight_failure_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = build_deterministic_service(tmp_path)
+    original_write_bytes_file = OQQuantizationPipeline._write_bytes_file
+
+    def write_and_remove_weights(path: Path, payload: bytes) -> int:
+        written = original_write_bytes_file(path, payload)
+        if path.name == "weights.safetensors":
+            path.unlink()
+        return written
+
+    monkeypatch.setattr(
+        OQQuantizationPipeline,
+        "_write_bytes_file",
+        staticmethod(write_and_remove_weights),
+    )
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                run_smoke_test=True,
+                ext={
+                    "operation": "quantize",
+                    "local_inference_smoke_mode": "runtime_generate",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    manifest_payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+    smoke = manifest_payload["local_inference_smoke"]
+
+    assert events[-1].HasField("completed")
+    assert smoke["status"] == "failed"
+    assert smoke["evidence_kind"] == "local_runtime_generate"
+    assert smoke["runtime_backend"] == "preflight"
+    assert "structural preflight failed" in smoke["failure_reason"]
+
+
+def test_quantize_job_records_runtime_generate_smoke_evidence(tmp_path: Path) -> None:
+    service = build_deterministic_service(tmp_path)
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                run_smoke_test=True,
+                ext={
+                    "operation": "quantize",
+                    "local_inference_smoke_mode": "runtime_generate",
+                    "local_inference_smoke_prompt": "Summarize the quantized runtime gate.",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    manifest_payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+    smoke = manifest_payload["local_inference_smoke"]
+
+    assert events[-1].HasField("completed")
+    assert manifest_payload["compatibility"]["smoke_test_passed"] is True
+    assert manifest_payload["release_gate"]["local_inference_smoke_result"] == "passed"
+    assert smoke["status"] == "passed"
+    assert smoke["evidence_kind"] == "local_runtime_generate"
+    assert smoke["smoke_mode"] == "runtime_generate"
+    assert smoke["runtime"] == "mlx_text"
+    assert smoke["runtime_backend"] == "deterministic-text"
+    assert smoke["checked_files"] == [
+        "config.json",
+        "tokenizer.json",
+        "weights.safetensors",
+    ]
+    assert smoke["latency_ms"] >= 0.0
+    assert len(smoke["prompt_sha256"]) == 64
+    assert smoke["generated_token_count"] == 1
+    assert smoke["failure_reason"] == ""
+
+
+def test_quantize_job_records_runtime_generate_empty_token_failure(tmp_path: Path) -> None:
+    class EmptyTokenBackend(DeterministicTextBackend):
+        runtime_name = "empty-token"
+
+        def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event):
+            return []
+
+    service = build_service_with_text_backend(tmp_path, EmptyTokenBackend())
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                run_smoke_test=True,
+                ext={
+                    "operation": "quantize",
+                    "local_inference_smoke_mode": "runtime_generate",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    manifest_payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+    smoke = manifest_payload["local_inference_smoke"]
+
+    assert events[-1].HasField("completed")
+    assert manifest_payload["release_gate"]["local_inference_smoke_result"] == "failed"
+    assert smoke["status"] == "failed"
+    assert smoke["runtime_backend"] == "empty-token"
+    assert smoke["generated_token_count"] == 0
+    assert smoke["failure_reason"] == "Runtime smoke generated no token events."
+
+
+def test_quantize_job_rejects_unknown_local_inference_smoke_mode(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                run_smoke_test=True,
+                ext={
+                    "operation": "quantize",
+                    "local_inference_smoke_mode": "screenshot",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].HasField("failed")
+    assert events[-1].failed.error.code == "unsupported_local_inference_smoke_mode"
+    assert events[-1].failed.error.details["local_inference_smoke_mode"] == "screenshot"
 
 
 def test_quantize_job_writes_manifest_once_after_in_memory_byte_convergence(

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
+from threading import Event
+import time
 from typing import Any
 
 from packages.protocol.python.worker.v1 import common_pb2, maintenance_pb2
@@ -23,6 +26,41 @@ from worker.model_ops.errors import ModelOperationError
 from worker.registry import WorkerRegistry
 
 _BUNDLE_SCHEMA_VERSION = "melix.quantized_bundle.v1"
+_SMOKE_REQUIRED_FILES = ("config.json", "tokenizer.json", "weights.safetensors")
+
+
+@dataclass(frozen=True)
+class LocalInferenceSmokeEvidence:
+    status: str
+    evidence_kind: str
+    smoke_mode: str
+    runtime: str
+    runtime_backend: str
+    artifact_path: str
+    checked_files: tuple[str, ...]
+    latency_ms: float
+    prompt_sha256: str = ""
+    generated_token_count: int = 0
+    failure_reason: str = ""
+
+    @property
+    def passed(self) -> bool:
+        return self.status == "passed"
+
+    def to_manifest_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "evidence_kind": self.evidence_kind,
+            "smoke_mode": self.smoke_mode,
+            "runtime": self.runtime,
+            "runtime_backend": self.runtime_backend,
+            "artifact_path": self.artifact_path,
+            "checked_files": list(self.checked_files),
+            "latency_ms": self.latency_ms,
+            "prompt_sha256": self.prompt_sha256,
+            "generated_token_count": self.generated_token_count,
+            "failure_reason": self.failure_reason,
+        }
 
 
 @dataclass(frozen=True)
@@ -35,6 +73,7 @@ class QuantizationPipelineResult:
     artifact_bytes: int
     manifest_bytes: int
     smoke_test_passed: bool
+    smoke_evidence: LocalInferenceSmokeEvidence
 
 
 class OQQuantizationPipeline:
@@ -62,6 +101,7 @@ class OQQuantizationPipeline:
             source_artifact_kind=source_artifact_kind,
             source_artifact_path=source_artifact_path,
         )
+        smoke_mode = _local_inference_smoke_mode_for_request(request)
         calibration_evidence = _calibration_evidence_for_request(request)
         calibration = calibration_plan_for_profile(
             profile,
@@ -103,9 +143,20 @@ class OQQuantizationPipeline:
             ).encode("utf-8"),
         )
 
-        smoke_test_passed = False
+        smoke_evidence = _not_requested_smoke_evidence(
+            bundle_path=bundle_path,
+            smoke_mode=smoke_mode,
+        )
         if request.run_smoke_test:
-            smoke_test_passed = self._run_structural_smoke_test(bundle_path)
+            smoke_evidence = self._run_local_inference_smoke_test(
+                request=request,
+                job_id=job_id,
+                source_model=source_model,
+                profile=profile,
+                bundle_path=bundle_path,
+                smoke_mode=smoke_mode,
+            )
+        smoke_test_passed = smoke_evidence.passed
 
         manifest_path = bundle_path / "manifest.json"
         manifest_payload = self._manifest_payload(
@@ -126,7 +177,7 @@ class OQQuantizationPipeline:
             bundle_path=bundle_path,
             manifest_path=manifest_path,
             artifact_bytes=artifact_bytes,
-            smoke_test_passed=smoke_test_passed,
+            smoke_evidence=smoke_evidence,
         )
         manifest_bytes = 0
         encoded_manifest = b""
@@ -149,6 +200,7 @@ class OQQuantizationPipeline:
             artifact_bytes=artifact_bytes,
             manifest_bytes=manifest_payload["manifest_bytes"],
             smoke_test_passed=smoke_test_passed,
+            smoke_evidence=smoke_evidence,
         )
 
     def _resolve_source_model(self, source_model: str) -> common_pb2.ModelSpec:
@@ -168,19 +220,194 @@ class OQQuantizationPipeline:
             max_context=0,
         )
 
+    def _run_local_inference_smoke_test(
+        self,
+        *,
+        request: maintenance_pb2.ConvertModelRequest,
+        job_id: str,
+        source_model: common_pb2.ModelSpec,
+        profile: QuantizationProfile,
+        bundle_path: Path,
+        smoke_mode: str,
+    ) -> LocalInferenceSmokeEvidence:
+        if smoke_mode == "structural":
+            return self._run_structural_smoke_evidence(bundle_path)
+        if smoke_mode == "runtime_generate":
+            return self._run_runtime_generate_smoke_evidence(
+                request=request,
+                job_id=job_id,
+                source_model=source_model,
+                profile=profile,
+                bundle_path=bundle_path,
+            )
+        raise AssertionError(f"Unexpected local inference smoke mode: {smoke_mode}")
+
     @staticmethod
     def _run_structural_smoke_test(bundle_path: Path) -> bool:
-        required_files = (
-            bundle_path / "config.json",
-            bundle_path / "tokenizer.json",
-            bundle_path / "weights.safetensors",
-        )
-        for path in required_files:
+        return OQQuantizationPipeline._run_structural_smoke_evidence(bundle_path).passed
+
+    @staticmethod
+    def _run_structural_smoke_evidence(bundle_path: Path) -> LocalInferenceSmokeEvidence:
+        started_at = time.perf_counter()
+        checked_files = _SMOKE_REQUIRED_FILES
+        for file_name in checked_files:
+            path = bundle_path / file_name
             if not path.exists():
-                return False
+                return LocalInferenceSmokeEvidence(
+                    status="failed",
+                    evidence_kind="bundle_structural",
+                    smoke_mode="structural",
+                    runtime="mlx_text",
+                    runtime_backend="structural",
+                    artifact_path=str(bundle_path),
+                    checked_files=checked_files,
+                    latency_ms=_elapsed_ms(started_at),
+                    failure_reason=f"{file_name} is missing from quantized bundle.",
+                )
             if path.suffix == ".json":
-                json.loads(path.read_text(encoding="utf-8"))
-        return True
+                try:
+                    json.loads(path.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError) as exc:
+                    return LocalInferenceSmokeEvidence(
+                        status="failed",
+                        evidence_kind="bundle_structural",
+                        smoke_mode="structural",
+                        runtime="mlx_text",
+                        runtime_backend="structural",
+                        artifact_path=str(bundle_path),
+                        checked_files=checked_files,
+                        latency_ms=_elapsed_ms(started_at),
+                        failure_reason=f"{file_name} is not readable JSON: {exc}",
+                    )
+        return LocalInferenceSmokeEvidence(
+            status="passed",
+            evidence_kind="bundle_structural",
+            smoke_mode="structural",
+            runtime="mlx_text",
+            runtime_backend="structural",
+            artifact_path=str(bundle_path),
+            checked_files=checked_files,
+            latency_ms=_elapsed_ms(started_at),
+        )
+
+    def _run_runtime_generate_smoke_evidence(
+        self,
+        *,
+        request: maintenance_pb2.ConvertModelRequest,
+        job_id: str,
+        source_model: common_pb2.ModelSpec,
+        profile: QuantizationProfile,
+        bundle_path: Path,
+    ) -> LocalInferenceSmokeEvidence:
+        structural_evidence = self._run_structural_smoke_evidence(bundle_path)
+        prompt = (
+            request.ext.get("local_inference_smoke_prompt", "").strip()
+            or "Validate the Melix quantized bundle."
+        )
+        prompt_sha256 = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+        if not structural_evidence.passed:
+            return LocalInferenceSmokeEvidence(
+                status="failed",
+                evidence_kind="local_runtime_generate",
+                smoke_mode="runtime_generate",
+                runtime="mlx_text",
+                runtime_backend="preflight",
+                artifact_path=str(bundle_path),
+                checked_files=structural_evidence.checked_files,
+                latency_ms=structural_evidence.latency_ms,
+                prompt_sha256=prompt_sha256,
+                failure_reason=f"structural preflight failed: {structural_evidence.failure_reason}",
+            )
+
+        loaded_handle = ""
+        runtime_backend = ""
+        started_at = time.perf_counter()
+        try:
+            smoke_model = common_pb2.ModelSpec(
+                model_id=f"{source_model.model_id}-quantized-{profile.quant_profile_id}-{job_id}",
+                model_path=str(bundle_path),
+                model_kind=source_model.model_kind or "text",
+                revision=f"quantized:{job_id}",
+                tokenizer_hash=source_model.tokenizer_hash,
+                quant_profile_id=profile.quant_profile_id,
+                parser_mode=source_model.parser_mode,
+                reasoning_mode=source_model.reasoning_mode,
+                max_context=source_model.max_context,
+                ext=dict(source_model.ext),
+            )
+            smoke_model.ext["melix.quantized_bundle_path"] = str(bundle_path)
+            loaded = self._registry.load_model(smoke_model)
+            loaded_handle = loaded.handle
+            runtime = self._registry.runtime_for_loaded_model(loaded)
+            runtime_backend = str(getattr(runtime, "runtime_name", "") or loaded.runtime_kind)
+            messages = [
+                common_pb2.ChatMessage(
+                    role="user",
+                    parts=[common_pb2.MessagePart(text=prompt)],
+                )
+            ]
+            rendered_prompt = runtime.render_prompt(
+                messages,
+                loaded_model=loaded.runtime_model,
+                template_kwargs=None,
+                execution_ext={},
+            )
+            sampling = common_pb2.SamplingConfig(
+                temperature=0.0,
+                top_p=1.0,
+                top_k=1,
+                max_output_tokens=1,
+            )
+            cancel_event = Event()
+            token_stream = runtime.generate_tokens(
+                loaded.runtime_model,
+                rendered_prompt,
+                sampling,
+                cancel_event,
+                execution_ext={},
+            )
+            generated_token_count = 0
+            try:
+                for event in token_stream:
+                    text = getattr(event, "text", str(event))
+                    if text:
+                        generated_token_count += 1
+                    cancel_event.set()
+                    break
+            finally:
+                close = getattr(token_stream, "close", None)
+                if callable(close):
+                    close()
+            if generated_token_count <= 0:
+                raise RuntimeError("Runtime smoke generated no token events.")
+            return LocalInferenceSmokeEvidence(
+                status="passed",
+                evidence_kind="local_runtime_generate",
+                smoke_mode="runtime_generate",
+                runtime="mlx_text",
+                runtime_backend=runtime_backend,
+                artifact_path=str(bundle_path),
+                checked_files=_SMOKE_REQUIRED_FILES,
+                latency_ms=_elapsed_ms(started_at),
+                prompt_sha256=prompt_sha256,
+                generated_token_count=generated_token_count,
+            )
+        except Exception as exc:
+            return LocalInferenceSmokeEvidence(
+                status="failed",
+                evidence_kind="local_runtime_generate",
+                smoke_mode="runtime_generate",
+                runtime="mlx_text",
+                runtime_backend=runtime_backend or "unknown",
+                artifact_path=str(bundle_path),
+                checked_files=_SMOKE_REQUIRED_FILES,
+                latency_ms=_elapsed_ms(started_at),
+                prompt_sha256=prompt_sha256,
+                failure_reason=str(exc),
+            )
+        finally:
+            if loaded_handle:
+                self._registry.unload_model(loaded_handle)
 
     @staticmethod
     def _manifest_payload(
@@ -202,7 +429,7 @@ class OQQuantizationPipeline:
         bundle_path: Path,
         manifest_path: Path,
         artifact_bytes: int,
-        smoke_test_passed: bool,
+        smoke_evidence: LocalInferenceSmokeEvidence,
     ) -> dict[str, Any]:
         payload = {
             "schema_version": _BUNDLE_SCHEMA_VERSION,
@@ -233,15 +460,16 @@ class OQQuantizationPipeline:
             "calibration": calibration.to_dict(),
             "release_gate": _release_gate_for_request(
                 request,
-                smoke_test_passed=smoke_test_passed,
+                smoke_evidence=smoke_evidence,
             ),
+            "local_inference_smoke": smoke_evidence.to_manifest_dict(),
             "strategy": strategy,
             "source_format": source_format,
             "compatibility": {
-                "runtime": "mlx_text",
+                "runtime": smoke_evidence.runtime,
                 "serving_compatible": True,
                 "smoke_test_requested": request.run_smoke_test,
-                "smoke_test_passed": smoke_test_passed,
+                "smoke_test_passed": smoke_evidence.passed,
             },
             "protected_scope": protected_scope_for_request(
                 request,
@@ -312,6 +540,17 @@ def _source_artifact_kind_for_request(request: maintenance_pb2.ConvertModelReque
     return source_artifact_kind
 
 
+def _local_inference_smoke_mode_for_request(request: maintenance_pb2.ConvertModelRequest) -> str:
+    smoke_mode = request.ext.get("local_inference_smoke_mode", "").strip().lower() or "structural"
+    if smoke_mode not in {"structural", "runtime_generate"}:
+        raise ModelOperationError(
+            code="unsupported_local_inference_smoke_mode",
+            message=f"Unsupported local_inference_smoke_mode: {smoke_mode}",
+            details={"local_inference_smoke_mode": smoke_mode},
+        )
+    return smoke_mode
+
+
 def _source_artifact_path_for_request(
     request: maintenance_pb2.ConvertModelRequest,
     *,
@@ -348,6 +587,23 @@ def _validate_quantization_source(
                 "supported_source_artifact_kinds": "merged_adapter,adapter_export",
             },
         )
+
+
+def _not_requested_smoke_evidence(
+    *,
+    bundle_path: Path,
+    smoke_mode: str,
+) -> LocalInferenceSmokeEvidence:
+    return LocalInferenceSmokeEvidence(
+        status="not_requested",
+        evidence_kind="not_requested",
+        smoke_mode=smoke_mode,
+        runtime="mlx_text",
+        runtime_backend="not_requested",
+        artifact_path=str(bundle_path),
+        checked_files=(),
+        latency_ms=0.0,
+    )
 
 
 def _calibration_evidence_for_request(
@@ -429,10 +685,10 @@ def _calibration_evidence_for_request(
 def _release_gate_for_request(
     request: maintenance_pb2.ConvertModelRequest,
     *,
-    smoke_test_passed: bool,
+    smoke_evidence: LocalInferenceSmokeEvidence,
 ) -> dict[str, Any]:
     if request.run_smoke_test:
-        smoke_result = "passed" if smoke_test_passed else "failed"
+        smoke_result = smoke_evidence.status
     else:
         smoke_result = "not_requested"
     return {
@@ -440,6 +696,10 @@ def _release_gate_for_request(
         "latency_delta": _float_ext(request, "latency_delta"),
         "local_inference_smoke_result": smoke_result,
     }
+
+
+def _elapsed_ms(started_at: float) -> float:
+    return round(max(0.0, (time.perf_counter() - started_at) * 1000.0), 3)
 
 
 def _float_ext(request: maintenance_pb2.ConvertModelRequest, key: str) -> float:


### PR DESCRIPTION
## Summary
- Added typed `local_inference_smoke` evidence to `melix.quantized_bundle.v1` manifests.
- Kept the default fast structural smoke path and added opt-in `runtime_generate` evidence that loads the produced bundle, renders a prompt, requests one generated token, and records latency/token evidence.
- Documented this issue #365 slice and explicitly avoided retaining screenshot artifacts as evidence.

## Plan or Spec
- `docs/plans/2026-05-05-issue-365-quantization-runtime-evidence.md`
- Follow-up slice for issue #365: https://github.com/Keith-CY/melix/issues/365

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_training_dataset_builder.py
87 passed in 0.85s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_training_dataset_builder.py
87 passed in 0.98s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-quantization-runtime-evidence-coverage.json
Wrote JSON report to /tmp/issue365-quantization-runtime-evidence-coverage.json

python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-quantization-runtime-evidence-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py docs/plans/2026-05-05-issue-365-quantization-runtime-evidence.md
TOTAL 99.50% (198/199)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python python -m compileall -q services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py
passed

git diff --check
passed
```

## Coverage and Metrics
- Changed-line coverage: 99.50% (198/199) for `quantization_pipeline.py`, `test_quantization_pipeline.py`, and the new plan doc.
- Default smoke path remains structural and cheap.
- Opt-in `runtime_generate` adds one runtime load, prompt render, one-token generation request, and unload.
- Screenshot artifacts: none added or retained for this slice; only existing tracked product resources and evaluation fixtures were present.

## Known Gaps
- This does not close issue #365.
- Real PTQ/QAT weight conversion and final local-runtime release evidence remain deferred.
- GRPO candidate generation, RLHF reward-model optimization, full CLI chain coverage, and Window UI acceptance remain deferred.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A because no protocol schema changed.
- [x] Dependency changes include updated lockfiles, or N/A because no dependencies changed.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
