### PR TITLE
perf: cache stream assembler structural prefixes

### DIFF
--- a/docs/plans/2026-05-05-stream-assembler-structural-prefix-cache.md
+++ b/docs/plans/2026-05-05-stream-assembler-structural-prefix-cache.md
@@ -1,0 +1,53 @@
+# Stream Assembler Structural Prefix Cache Plan
+
+## Goal
+
+Reduce repeated tuple concatenation in the Python request stream assembler hot path by caching the active structural tag prefix tuple once per assembler instance.
+
+## Linux-only Constraint
+
+This is a Python worker/runtime slice and can be verified on Linux with focused pytest, changed-scope coverage, and a synthetic local performance probe.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/runtime/stream_assembler.py`
+- `services/mlx-worker-python/tests/test_stream_assembler.py`
+- `scripts/stream_assembler_structural_prefix_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Probe Definition
+
+Register `stream-assembler-structural-prefix-cache` in the PR-scoped performance registry.
+
+The probe repeatedly checks a partial structural tag suffix on a tool-enabled `RequestStreamAssembler` and records:
+
+- `elapsed_ms_mean`
+- `elapsed_ms_min`
+- `peak_bytes_mean`
+- `prefix_identity_hits`
+- `held_suffix_hits`
+
+## Success Metrics
+
+- Focused stream assembler tests pass.
+- Changed-scope coverage for touched Python executable lines is at least 95%.
+- The local probe emits stable metrics and confirms the active prefix tuple identity remains stable for every hot-path access.
+- A detached `origin/main` vs head probe comparison shows lower or equal hot-path elapsed time without changing suffix-hit counts.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_stream_assembler.py::test_structural_tag_prefixes_are_cached_per_parser_mode \
+  services/mlx-worker-python/tests/test_stream_assembler.py::test_partial_structural_tag_suffix_checks_all_prefixes_in_one_endswith_call \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same tests>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python scripts/changed_scope_coverage.py --coverage-json coverage.json <touched Python files>
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/stream_assembler_structural_prefix_probe.py
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -80,6 +80,41 @@
     ]
   },
   {
+    "id": "stream-assembler-structural-prefix-cache",
+    "name": "Stream assembler structural prefix cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/stream_assembler.py",
+      "services/mlx-worker-python/tests/test_stream_assembler.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/stream_assembler_structural_prefix_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_structural_tag_prefixes_are_cached_per_parser_mode services/mlx-worker-python/tests/test_stream_assembler.py::test_partial_structural_tag_suffix_checks_all_prefixes_in_one_endswith_call services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_structural_tag_prefixes_are_cached_per_parser_mode services/mlx-worker-python/tests/test_stream_assembler.py::test_partial_structural_tag_suffix_checks_all_prefixes_in_one_endswith_call services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_structural_prefix_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/stream_assembler_structural_prefix_probe.py ]; then python scripts/stream_assembler_structural_prefix_probe.py; else python - <<\"PY\"\nimport json, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.runtime.stream_assembler import RequestStreamAssembler\nassembler = RequestStreamAssembler(request_id=\"probe-structural-prefixes\", reasoning_enabled=True, structured_output_mode=\"\", tool_parser_mode=\"qwen\")\nassembler._buffer = \"chunk-ending-with-partial-<tool\"\nexpected_prefixes = assembler._structural_tag_prefixes\niterations = 250000\nsample_count = 7\nelapsed_samples = []\npeak_samples = []\nheld_suffix_hits = prefix_identity_hits = 0\nfor _ in range(sample_count):\n    tracemalloc.start()\n    started = time.perf_counter()\n    for _index in range(iterations):\n        if assembler._has_partial_structural_tag_suffix():\n            held_suffix_hits += 1\n        if assembler._structural_tag_prefixes is expected_prefixes:\n            prefix_identity_hits += 1\n    elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n    _, peak = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    peak_samples.append(float(peak))\nexpected_hits = iterations * sample_count\nif held_suffix_hits != expected_hits:\n    raise RuntimeError(f\"unexpected partial suffix hits: {held_suffix_hits} != {expected_hits}\")\nif prefix_identity_hits != expected_hits:\n    raise RuntimeError(f\"prefix tuple was not stable: {prefix_identity_hits} != {expected_hits}\")\nprint(json.dumps({\"elapsed_ms_mean\": round(statistics.fmean(elapsed_samples), 6), \"elapsed_ms_min\": round(min(elapsed_samples), 6), \"peak_bytes_mean\": round(statistics.fmean(peak_samples), 3), \"iteration_count\": float(iterations), \"sample_count\": float(sample_count), \"held_suffix_hits\": float(held_suffix_hits), \"prefix_identity_hits\": float(prefix_identity_hits)}, sort_keys=True))\nPY\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      },
+      {
+        "key": "prefix_identity_hits",
+        "unit": "count",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "benchmark-evaluation-report-running-aggregates",
     "name": "Benchmark evaluation report running aggregates",
     "runner": "ubuntu-latest",

--- a/scripts/stream_assembler_structural_prefix_probe.py
+++ b/scripts/stream_assembler_structural_prefix_probe.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime.stream_assembler import RequestStreamAssembler  # noqa: E402
+
+
+def _build_assembler() -> RequestStreamAssembler:
+    assembler = RequestStreamAssembler(
+        request_id="probe-structural-prefixes",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+    assembler._buffer = "chunk-ending-with-partial-<tool"
+    return assembler
+
+
+def main() -> None:
+    iterations = int(os.environ.get("MELIX_STREAM_PREFIX_PROBE_ITERATIONS", "250000"))
+    sample_count = int(os.environ.get("MELIX_STREAM_PREFIX_PROBE_SAMPLES", "7"))
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    held_suffix_hits = 0
+    prefix_identity_hits = 0
+
+    assembler = _build_assembler()
+    expected_prefixes = assembler._structural_tag_prefixes
+
+    for _ in range(sample_count):
+        tracemalloc.start()
+        started = time.perf_counter()
+        for _index in range(iterations):
+            if assembler._has_partial_structural_tag_suffix():
+                held_suffix_hits += 1
+            if assembler._structural_tag_prefixes is expected_prefixes:
+                prefix_identity_hits += 1
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_samples.append(float(peak))
+
+    expected_hits = iterations * sample_count
+    if held_suffix_hits != expected_hits:
+        raise RuntimeError(
+            f"unexpected partial suffix hits: {held_suffix_hits} != {expected_hits}"
+        )
+    if prefix_identity_hits != expected_hits:
+        raise RuntimeError(
+            f"prefix tuple was not stable: {prefix_identity_hits} != {expected_hits}"
+        )
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+                "elapsed_ms_min": round(min(elapsed_samples), 6),
+                "peak_bytes_mean": round(statistics.fmean(peak_samples), 3),
+                "iteration_count": float(iterations),
+                "sample_count": float(sample_count),
+                "held_suffix_hits": float(held_suffix_hits),
+                "prefix_identity_hits": float(prefix_identity_hits),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -85,8 +85,12 @@ def test_scope_report_selects_stream_assembler_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/runtime/stream_assembler.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "stream-assembler-parser-mode-cache"
+    probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert scope["selected_count"] == 2
+    assert probe_ids == {
+        "stream-assembler-parser-mode-cache",
+        "stream-assembler-structural-prefix-cache",
+    }
 
 
 def test_scope_report_selects_only_matching_probe() -> None:
@@ -712,6 +716,26 @@ def test_deterministic_embedding_duplicate_probe_script_emits_metrics(
     assert metrics["checksum"] > 0
 
 
+def test_stream_assembler_structural_prefix_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_STREAM_PREFIX_PROBE_ITERATIONS", "3")
+    monkeypatch.setenv("MELIX_STREAM_PREFIX_PROBE_SAMPLES", "1")
+
+    runpy.run_path(
+        str(REPO_ROOT / "scripts/stream_assembler_structural_prefix_probe.py"),
+        run_name="__main__",
+    )
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["iteration_count"] == 3.0
+    assert metrics["held_suffix_hits"] == 3.0
+    assert metrics["prefix_identity_hits"] == 3.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
         "benchmark-evaluation-report-running-aggregates",
@@ -751,6 +775,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "phase8-metrics-closure-audit-reuse",
         "pr-scoped-performance-registry-cache",
         "real-model-support-hf-cache-latest-snapshot",
+        "stream-assembler-structural-prefix-cache",
         "swift-cli-json-envelope-encoding",
         "upload-receipt-published-files-scandir",
         "download-pipeline-directory-size-single-stat",

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -29,9 +29,11 @@ def test_structural_tag_prefixes_are_cached_per_parser_mode() -> None:
     )
 
     assert tool_enabled._structural_tag_prefixes == think_prefixes + tool_prefixes
+    assert tool_enabled._structural_tag_prefixes is tool_enabled._structural_tag_prefixes
     assert tool_disabled._structural_tag_prefixes == think_prefixes
     assert tool_enabled._structural_tag_prefixes is tool_enabled._structural_tag_prefixes
     assert tool_disabled._structural_tag_prefixes is tool_disabled._structural_tag_prefixes
+    assert tool_disabled._structural_tag_prefixes is RequestStreamAssembler._THINK_PREFIXES
 
 
 def test_parser_mode_flags_are_computed_once_at_initialization() -> None:


### PR DESCRIPTION
## Summary
- Cache the active `RequestStreamAssembler` structural tag prefix tuple once per request instead of rebuilding `THINK + TOOL` prefixes on each hot-path access.
- Add a focused regression assertion for stable prefix tuple identity and keep existing suffix parsing behavior covered.
- Register a dedicated `stream-assembler-structural-prefix-cache` PR-scoped performance probe with a base-compatible fallback command.

## Plan or Spec
- Plan: `docs/plans/2026-05-05-stream-assembler-structural-prefix-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_structural_tag_prefixes_are_cached_per_parser_mode services/mlx-worker-python/tests/test_stream_assembler.py::test_partial_structural_tag_suffix_checks_all_prefixes_in_one_endswith_call services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_script_emits_metrics
# 5 passed in 0.26s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage erase && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_structural_tag_prefixes_are_cached_per_parser_mode services/mlx-worker-python/tests/test_stream_assembler.py::test_partial_structural_tag_suffix_checks_all_prefixes_in_one_endswith_call services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_structural_prefix_probe.py
# 5 passed in 0.15s; TOTAL 19 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/stream_assembler_structural_prefix_probe.py
# {"elapsed_ms_mean": 550.597775, "elapsed_ms_min": 520.268674, "held_suffix_hits": 1750000.0, "iteration_count": 250000.0, "peak_bytes_mean": 168.0, "prefix_identity_hits": 1750000.0, "sample_count": 7.0}

uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id stream-assembler-structural-prefix-cache --base-repo /tmp/melix-base-stream-prefix-20260505072500 --head-repo "$PWD" --output /tmp/stream-prefix-perf-2.json
# head verification ok; base elapsed_ms_mean=622.909571, head elapsed_ms_mean=542.877678
# held_suffix_hits unchanged at 1,750,000; prefix_identity_hits 0 -> 1,750,000

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py
# 23 passed in 0.05s

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 19 0 100%`.
- Registered scoped CI probe: `stream-assembler-structural-prefix-cache`.
- Local base-vs-head scoped probe:
  - `elapsed_ms_mean`: `622.909571` -> `542.877678` (~12.85% lower)
  - `held_suffix_hits`: unchanged at `1,750,000`
  - `prefix_identity_hits`: `0` -> `1,750,000`
  - `peak_bytes_mean`: `136.0` -> `168.0` bytes, informational only; the absolute delta is tiny and elapsed time is the gated metric.

## Known Gaps
- Linux/Python-only verification was run. Swift/macOS checks were not run locally on this Linux host.
- Full repository `make py-test`, `make swift-test`, and integration checks were not run locally; this PR relies on focused local Python verification plus hosted CI.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
