### PR TITLE
perf: bound rerank top-k selection work

### DIFF
--- a/docs/plans/2026-05-05-rerank-top-k-heap-selection.md
+++ b/docs/plans/2026-05-05-rerank-top-k-heap-selection.md
@@ -1,0 +1,37 @@
+# Rerank Top-K Selection Optimization
+
+## Goal
+
+Reduce redundant ranking work in the Python rerank API response path when callers request a small `top_k` subset of a much larger document set.
+
+## Linux-only constraint
+
+This slice is Python-only and can be verified on Linux with focused pytest, changed-scope coverage, and a local PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/engine/rerank_core.py`
+- `services/mlx-worker-python/tests/test_rerank_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+- `scripts/rerank_top_k_probe.py`
+
+## Performance probe
+
+Register `rerank-core-top-k-heap-selection` in the PR-scoped performance registry.
+
+The probe builds a deterministic synthetic score vector for a large rerank result set and compares the production top-k selector path through `RerankCore._rank_scores(...)` on `origin/main` and the PR branch. It records:
+
+- `elapsed_ms_mean` (lower is better)
+- `peak_bytes_mean` (lower is better)
+- `document_count`
+- `top_k`
+- `result_count`
+- `checksum`
+
+## Success metrics
+
+- Preserve descending score ordering and original-index tie breaking.
+- Preserve full-sort behavior when `top_k` is omitted, zero, or greater than the result size.
+- Improve `elapsed_ms_mean` for `top_k << document_count` against `origin/main`.
+- Maintain at least 95% changed-scope coverage for touched executable Python files.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -819,6 +819,38 @@
     ]
   },
   {
+    "id": "rerank-core-top-k-heap-selection",
+    "name": "Rerank core bounded top-k selection",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/engine/rerank_core.py",
+      "services/mlx-worker-python/tests/test_rerank_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json",
+      "scripts/changed_scope_coverage.py",
+      "scripts/rerank_top_k_probe.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_preserves_sort_contract_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_uses_heap_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_keeps_full_sort_when_unbounded services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_returns_sorted_scores_and_honors_top_k services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_rerank_core_top_k_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_preserves_sort_contract_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_uses_heap_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_keeps_full_sort_when_unbounded services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_returns_sorted_scores_and_honors_top_k services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_rerank_core_top_k_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/rerank_core.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "if [ -f scripts/rerank_top_k_probe.py ]; then PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python scripts/rerank_top_k_probe.py; else python3 - <<'PY'\nimport gc, json, time, tracemalloc\ndef legacy(scores, top_k):\n    ranked = sorted(enumerate(scores), key=lambda item: (-item[1], item[0]))\n    return ranked[:top_k] if top_k < len(ranked) else ranked\ndocument_count=50000; top_k=10; iteration_count=12; sample_count=7\nscores=[(((i*7919)%104729)/104729.0)+(0.000001*(i%17)) for i in range(document_count)]\nexpected=legacy(scores, top_k); elapsed=[]; peaks=[]; checksum=0.0\nfor _ in range(sample_count):\n    gc.collect(); tracemalloc.start(); started=time.perf_counter()\n    for _ in range(iteration_count):\n        result=legacy(scores, top_k)\n        if result != expected: raise RuntimeError('rank mismatch')\n        checksum += sum((index + 1) * score for index, score in result)\n    elapsed.append((time.perf_counter()-started)*1000.0); _, peak=tracemalloc.get_traced_memory(); tracemalloc.stop(); peaks.append(float(peak))\nprint(json.dumps({'checksum': round(checksum, 6), 'document_count': float(document_count), 'elapsed_ms_mean': round(sum(elapsed)/len(elapsed), 6), 'iteration_count': float(iteration_count), 'peak_bytes_mean': round(sum(peaks)/len(peaks), 6), 'result_count': float(len(expected)), 'sample_count': float(sample_count), 'top_k': float(top_k)}, sort_keys=True))\nPY\nfi",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 10.0
+      }
+    ]
+  },
+  {
     "id": "pr-scoped-performance-registry-cache",
     "name": "PR-scoped performance registry cache",
     "runner": "ubuntu-latest",

--- a/scripts/rerank_top_k_probe.py
+++ b/scripts/rerank_top_k_probe.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import gc
+import json
+from pathlib import Path
+import sys
+import time
+import tracemalloc
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.engine.rerank_core import RerankCore  # noqa: E402
+
+
+def _legacy_rank_scores(scores: list[float], *, top_k: int | None) -> list[tuple[int, float]]:
+    ranked = sorted(enumerate(scores), key=lambda item: (-item[1], item[0]))
+    limit = top_k if top_k else len(ranked)
+    if limit < len(ranked):
+        ranked = ranked[:limit]
+    return ranked
+
+
+def _rank_scores(scores: list[float], *, top_k: int | None) -> list[tuple[int, float]]:
+    ranker = getattr(RerankCore, "_rank_scores", None)
+    if ranker is None:
+        return _legacy_rank_scores(scores, top_k=top_k)
+    return ranker(scores, top_k=top_k)
+
+
+def _build_scores(document_count: int) -> list[float]:
+    return [
+        (((index * 7919) % 104729) / 104729.0) + (0.000001 * (index % 17))
+        for index in range(document_count)
+    ]
+
+
+def main() -> int:
+    document_count = 50000
+    top_k = 10
+    iteration_count = 12
+    sample_count = 7
+    scores = _build_scores(document_count)
+
+    expected = _legacy_rank_scores(scores, top_k=top_k)
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    checksum = 0.0
+    result_count = 0
+
+    for _ in range(sample_count):
+        gc.collect()
+        tracemalloc.start()
+        started = time.perf_counter()
+        for _ in range(iteration_count):
+            result = _rank_scores(scores, top_k=top_k)
+            if result != expected:
+                raise RuntimeError("top-k ranker changed ordering or tie-break semantics")
+            result_count = len(result)
+            checksum += sum((index + 1) * score for index, score in result)
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_samples.append(float(peak))
+
+    metrics = {
+        "checksum": round(checksum, 6),
+        "document_count": float(document_count),
+        "elapsed_ms_mean": round(sum(elapsed_samples) / len(elapsed_samples), 6),
+        "iteration_count": float(iteration_count),
+        "peak_bytes_mean": round(sum(peak_samples) / len(peak_samples), 6),
+        "result_count": float(result_count),
+        "sample_count": float(sample_count),
+        "top_k": float(top_k),
+    }
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -270,6 +270,16 @@ def test_scope_report_selects_deterministic_rerank_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "deterministic-rerank-query-context-reuse"
 
 
+def test_scope_report_selects_rerank_core_top_k_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/engine/rerank_core.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "rerank-core-top-k-heap-selection"
+
+
 def test_scope_report_selects_deterministic_embedding_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -652,6 +662,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "closure-audit-probe-source-short-circuit",
         "deterministic-embedding-duplicate-input-cache",
         "deterministic-rerank-query-context-reuse",
+        "rerank-core-top-k-heap-selection",
         "dev-up-mlx-metal-dist-info-scandir",
         "evaluation-job-id-high-water-mark",
         "evaluation-final-result-materialization-streaming",

--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -5,6 +5,7 @@ import pytest
 
 from packages.protocol.python.worker.v1 import common_pb2, inference_pb2, runtime_pb2
 
+from worker.engine.rerank_core import RerankCore
 from worker.grpc_server import WorkerInferenceService, WorkerRuntimeService
 from worker.model_registry.catalog import WorkerModelCatalog
 from worker.registry import WorkerRegistry
@@ -48,6 +49,37 @@ def load_model(runtime_service: WorkerRuntimeService, model: common_pb2.ModelSpe
     )
     assert response.ok is True
     return response.model_handle
+
+
+def test_rerank_rank_scores_preserves_sort_contract_for_bounded_top_k() -> None:
+    scores = [0.4, 0.9, 0.9, -0.2, 0.7, 0.9]
+
+    ranked = RerankCore._rank_scores(scores, top_k=3)
+
+    assert ranked == [(1, 0.9), (2, 0.9), (5, 0.9)]
+
+
+def test_rerank_rank_scores_uses_heap_for_bounded_top_k(monkeypatch) -> None:
+    nsmallest = Mock(return_value=[(2, 0.8), (4, 0.7)])
+    monkeypatch.setattr("worker.engine.rerank_core.heapq.nsmallest", nsmallest)
+
+    ranked = RerankCore._rank_scores([0.1, 0.2, 0.8, 0.3, 0.7], top_k=2)
+
+    assert ranked == [(2, 0.8), (4, 0.7)]
+    nsmallest.assert_called_once()
+    assert nsmallest.call_args.args[0] == 2
+
+
+def test_rerank_rank_scores_keeps_full_sort_when_unbounded(monkeypatch) -> None:
+    nsmallest = Mock()
+    monkeypatch.setattr("worker.engine.rerank_core.heapq.nsmallest", nsmallest)
+
+    ranked = RerankCore._rank_scores([0.2, 0.5, 0.5], top_k=None)
+    oversized = RerankCore._rank_scores([0.2, 0.5, 0.5], top_k=5)
+
+    assert ranked == [(1, 0.5), (2, 0.5), (0, 0.2)]
+    assert oversized == ranked
+    nsmallest.assert_not_called()
 
 
 def test_rerank_returns_sorted_scores_and_honors_top_k() -> None:

--- a/services/mlx-worker-python/worker/engine/rerank_core.py
+++ b/services/mlx-worker-python/worker/engine/rerank_core.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import heapq
+
 from packages.protocol.python.worker.v1 import common_pb2, inference_pb2
 
 from worker.registry import WorkerRegistry
@@ -35,17 +37,24 @@ class RerankCore:
                 error=common_pb2.ErrorStatus(code="runtime_error", message=str(exc))
             )
 
-        ranked = sorted(
-            enumerate(scores),
-            key=lambda item: (-item[1], item[0]),
-        )
-        limit = int(request.top_k) if request.top_k else len(ranked)
-        if limit < len(ranked):
-            ranked = ranked[:limit]
+        ranked = self._rank_scores(scores, top_k=int(request.top_k) if request.top_k else None)
 
         return inference_pb2.RerankResponse(
             items=[
                 inference_pb2.RerankItem(index=index, score=score)
                 for index, score in ranked
             ]
+        )
+
+    @staticmethod
+    def _rank_scores(scores: list[float], *, top_k: int | None) -> list[tuple[int, float]]:
+        if top_k is not None and top_k < len(scores):
+            return heapq.nsmallest(
+                top_k,
+                enumerate(scores),
+                key=lambda item: (-item[1], item[0]),
+            )
+        return sorted(
+            enumerate(scores),
+            key=lambda item: (-item[1], item[0]),
         )


### PR DESCRIPTION
## Summary
- Replaces the rerank response path's unconditional full score sort with a bounded `heapq.nsmallest(...)` selection when `top_k` is smaller than the score list.
- Preserves descending score order and original-index tie breaking for ties.
- Registers `rerank-core-top-k-heap-selection` so PR-scoped performance CI compares the bounded selector against `origin/main`.

## Plan or Spec
- Plan: `docs/plans/2026-05-05-rerank-top-k-heap-selection.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_preserves_sort_contract_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_uses_heap_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_keeps_full_sort_when_unbounded services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_rerank_core_top_k_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 5 passed in 0.96s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_preserves_sort_contract_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_uses_heap_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_keeps_full_sort_when_unbounded services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_returns_sorted_scores_and_honors_top_k services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_rerank_core_top_k_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/rerank_core.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 6 passed in 0.54s; TOTAL 31 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/rerank_top_k_probe.py
# {"checksum": 20018010.630116, "document_count": 50000.0, "elapsed_ms_mean": 1228.306958, "iteration_count": 12.0, "peak_bytes_mean": 4250.857143, "result_count": 10.0, "sample_count": 7.0, "top_k": 10.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id rerank-core-top-k-heap-selection --base-repo /tmp/melix-base-rerank-topk-postrebase-20260505-074957 --head-repo /tmp/melix-cron-opt-20260505-074026 --output /tmp/rerank-topk-probe-result-postrebase.json
# passed: base elapsed_ms_mean=2085.935882 / peak_bytes_mean=9438444.0; head elapsed_ms_mean=1240.105516 / peak_bytes_mean=4250.857143

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes_formatted.json
# passed

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage before commit: `TOTAL 31 0 100%`.
  - `services/mlx-worker-python/worker/engine/rerank_core.py`: 7/7 changed executable lines covered, 100%.
  - `services/mlx-worker-python/tests/test_rerank_runtime.py`: 20/20 changed executable lines covered, 100%.
  - `services/mlx-worker-python/tests/test_pr_scoped_performance.py`: 4/4 changed executable lines covered, 100%.
- Registered scoped probe: `rerank-core-top-k-heap-selection`.
- Local base-vs-head probe on 50,000 scores with `top_k=10`, 12 iterations x 7 samples:
  - `elapsed_ms_mean`: base `2085.935882` ms -> head `1240.105516` ms (~40.55% lower).
  - `peak_bytes_mean`: base `9438444.0` bytes -> head `4250.857143` bytes (~99.95% lower traced peak allocation).
  - `checksum`: unchanged at `20018010.630116`.

## Known Gaps
- Linux-only local verification; full macOS/Swift gates were not run locally.
- Touching `infra/perf/pr_scoped_probes.json` should trigger the hosted PR-scoped performance matrix; hosted CI remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
