### PR TITLE
perf: cache derived model target payloads

### DIFF
--- a/docs/plans/2026-05-05-job-registry-target-payload-cache.md
+++ b/docs/plans/2026-05-05-job-registry-target-payload-cache.md
@@ -1,0 +1,30 @@
+# Job Registry Target Payload Cache Slice
+
+## Goal
+
+Reduce repeated derived-model target payload construction overhead in `ModelOpsJobRegistry.resolve_derived_model_target` after the active derived-model lookup has already been resolved.
+
+## Scope
+
+- Affected path: `services/mlx-worker-python/worker/model_ops/job_registry.py`.
+- Behavior remains unchanged: callers still receive a fresh mutable payload dict on every lookup.
+- Registered PR-scoped probe: `job-registry-derived-model-single-pass` in `infra/perf/pr_scoped_probes.json`.
+- Probe support path: `scripts/job_registry_derived_model_probe.py`.
+
+## Implementation
+
+The derived-model lookup cache already stores the matching active row and the resolved activation manifest path. This slice extends the same lookup entry with a cached target payload so repeated `derived_model_id` or manifest-path lookups avoid rebuilding the same string-normalized response fields and runtime-mode value. The public method returns a shallow copy of the cached payload to preserve caller mutation isolation.
+
+## Validation Plan
+
+Run the registered probe's focused local Linux commands:
+
+1. Focused tests from `job-registry-derived-model-single-pass`.
+2. Changed-scope coverage from `job-registry-derived-model-single-pass`.
+3. Registered probe command from `job-registry-derived-model-single-pass`.
+
+## Success Criteria
+
+- Focused tests pass.
+- Changed-scope coverage remains at or above 95%.
+- Registered probe shows a lower or stable `resolve_target_elapsed_ms_mean` for repeated derived-model target resolution, without regressing restore metrics beyond the probe warning threshold.

--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -506,6 +506,49 @@ def test_resolve_derived_model_target_model_id_uses_cached_resolved_path(
     assert second_target["activation_manifest_path"] == manifest_path
 
 
+def test_resolve_derived_model_target_caches_payload_without_sharing_return_dict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = ModelOpsJobRegistry()
+    job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")
+    manifest_path = "/runtime/activate/melix-dev-active/manifest.json"
+    registry.attach_manifest(
+        job.job_id,
+        json.dumps(
+            {
+                "derived_model_id": "melix-dev-active",
+                "derived_model_path": "/runtime/activate/melix-dev-active",
+                "activation_mode": "fused_derived_model",
+            }
+        ),
+    )
+    registry.complete(job.job_id, manifest_path)
+
+    build_calls = 0
+    original_payload_builder = ModelOpsJobRegistry._derived_model_target_payload
+
+    def counted_payload_builder(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        nonlocal build_calls
+        build_calls += 1
+        return original_payload_builder(*args, **kwargs)
+
+    monkeypatch.setattr(
+        ModelOpsJobRegistry,
+        "_derived_model_target_payload",
+        staticmethod(counted_payload_builder),
+    )
+
+    first_target = registry.resolve_derived_model_target(derived_model_id="melix-dev-active")
+    assert first_target is not None
+    first_target["derived_model_id"] = "mutated-by-caller"
+
+    second_target = registry.resolve_derived_model_target(derived_model_id="melix-dev-active")
+
+    assert second_target is not None
+    assert second_target["derived_model_id"] == "melix-dev-active"
+    assert build_calls == 1
+
+
 def test_resolve_derived_model_target_id_lookup_negative_paths() -> None:
     registry = ModelOpsJobRegistry()
     job = registry.start("activate_adapter", "melix-dev-text", "/runtime/activate")

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -51,6 +51,7 @@ class _ActiveDerivedModelLookup:
     manifest: dict[str, Any]
     activation_manifest_path: str
     resolved_activation_manifest_path: str | None = None
+    target_payload: dict[str, Any] | None = None
 
 
 class ModelOpsJobRegistry:
@@ -396,6 +397,24 @@ class ModelOpsJobRegistry:
         }
 
     @classmethod
+    def _cached_derived_model_target_payload(
+        cls,
+        lookup: _ActiveDerivedModelLookup,
+        *,
+        resolved_activation_manifest_path: str,
+    ) -> dict[str, Any]:
+        target_payload = lookup.target_payload
+        if target_payload is None:
+            target_payload = cls._derived_model_target_payload(
+                lookup.job,
+                lookup.manifest,
+                lookup.activation_manifest_path,
+                resolved_activation_manifest_path=resolved_activation_manifest_path,
+            )
+            lookup.target_payload = target_payload
+        return dict(target_payload)
+
+    @classmethod
     def _job_manifest(cls, job: ModelOpsJob) -> dict[str, Any]:
         if job.operation == "registry_snapshot":
             return {}
@@ -485,20 +504,16 @@ class ModelOpsJobRegistry:
                 lookup.resolved_activation_manifest_path = resolved_activation_manifest_path
             if normalized_manifest_path and resolved_activation_manifest_path != normalized_manifest_path:
                 return None
-            return self._derived_model_target_payload(
-                lookup.job,
-                lookup.manifest,
-                lookup.activation_manifest_path,
+            return self._cached_derived_model_target_payload(
+                lookup,
                 resolved_activation_manifest_path=resolved_activation_manifest_path,
             )
 
         lookup = self._cached_active_derived_model_by_manifest_path().get(normalized_manifest_path)
         if lookup is None:
             return None
-        return self._derived_model_target_payload(
-            lookup.job,
-            lookup.manifest,
-            lookup.activation_manifest_path,
+        return self._cached_derived_model_target_payload(
+            lookup,
             resolved_activation_manifest_path=normalized_manifest_path,
         )
 


### PR DESCRIPTION
## Summary
- Cache the derived-model target payload on each active derived-model lookup entry after the first resolution.
- Preserve caller mutation isolation by returning a shallow copy of the cached payload for every lookup.
- Add a focused regression test for payload-cache reuse and return-dict isolation.

## Plan or Spec
- `docs/plans/2026-05-05-job-registry-target-payload-cache.md`
- Registered PR-scoped probe: `job-registry-derived-model-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main d8f8ff2 (3 local Linux probe runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
resolve_target_elapsed_ms_mean: 0.002852, 0.002727, 0.002605

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
24 passed in 0.68s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py
24 passed in 0.76s
TOTAL 29 0 100%

# Probe after change (3 local Linux runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
resolve_target_elapsed_ms_mean: 0.001703, 0.001794, 0.002105

# Whitespace
rm -f coverage.json
git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 29 0 100%`.
- Registered local probe metric: `resolve_target_elapsed_ms_mean` old_mean=`0.002728 ms`, new_mean=`0.001867 ms`, delta=`-0.000861 ms`, speedup=`1.461x`, improvement=`31.55%`.
- The full registered PR-scoped performance workflow remains the CI merge gate.

## Known Gaps
- Local verification is Linux/Python only. No Swift runtime behavior is touched.
- CI is required for the registered PR-scoped probe report before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
