### PR TITLE
perf: reuse LoRA reward candidate minmax

### DIFF
--- a/docs/plans/2026-05-05-lora-reward-summary-minmax.md
+++ b/docs/plans/2026-05-05-lora-reward-summary-minmax.md
@@ -1,0 +1,30 @@
+# LoRA reward summary candidate min/max optimization
+
+## Goal
+
+Reduce redundant work in the LoRA alignment reward summary path by avoiding a per-candidate-group sort when the code only needs the group minimum and maximum reward score.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py`
+- `services/mlx-worker-python/tests/test_lora_model_ops.py`
+- `scripts/lora_reward_summary_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Linux-only constraint
+
+This slice is Python-only and can be verified locally on Linux with focused pytest, changed-scope coverage, and an explicit synthetic performance probe.
+
+## Performance probe
+
+Register `lora-reward-summary-candidate-minmax` in the PR-scoped performance registry. The probe builds synthetic reward-scored LoRA alignment samples with many candidates per prompt, runs `_reward_summary(...)`, and reports:
+
+- `elapsed_ms_mean` — lower is better.
+- `sorted_calls_mean` — lower is better; expected to drop from one sort per candidate group plus summary sorts to only the summary sorts.
+
+## Success metrics
+
+- Focused LoRA reward summary tests pass.
+- Changed executable line coverage is at least 95%.
+- Local probe shows fewer sort calls and improved or non-regressive elapsed time versus `origin/main`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1223,5 +1223,36 @@
         "direction": "informational"
       }
     ]
+  },
+  {
+    "id": "lora-reward-summary-candidate-minmax",
+    "name": "LoRA reward summary candidate min/max reuse",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py",
+      "services/mlx-worker-python/tests/test_lora_model_ops.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/lora_reward_summary_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_reward_summary_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/lora_reward_summary_probe.py ]; then python scripts/lora_reward_summary_probe.py; else python - <<\"PY\"\nimport json\nimport statistics\nimport sys\nimport time\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.model_ops import lora_training_pipeline as lora_training_pipeline_module\nsample_count = 5000\ncandidate_count = 32\niteration_count = 8\nsamples = []\nfor sample_index in range(sample_count):\n    base = (sample_index % 17) / 17.0\n    candidates = [{\"score\": ((sample_index * 31 + candidate_index * 7) % 101) / 100.0 - base} for candidate_index in range(candidate_count)]\n    samples.append({\"reward_score\": base, \"candidates\": candidates})\noriginal_sorted = sorted\nelapsed_ms = []\nsorted_calls = []\nchecksum = 0.0\ndef counting_sorted(values):\n    sorted_calls[-1] += 1\n    return original_sorted(values)\nprevious_sorted = getattr(lora_training_pipeline_module, \"sorted\", None)\nhad_module_sorted = hasattr(lora_training_pipeline_module, \"sorted\")\nsetattr(lora_training_pipeline_module, \"sorted\", counting_sorted)\ntry:\n    for _ in range(iteration_count):\n        sorted_calls.append(0)\n        start = time.perf_counter()\n        summary = lora_training_pipeline_module._reward_summary(samples)\n        elapsed_ms.append((time.perf_counter() - start) * 1000.0)\n        checksum += float(summary[\"candidate_group_reward_margin_mean\"])\nfinally:\n    if had_module_sorted:\n        setattr(lora_training_pipeline_module, \"sorted\", previous_sorted)\n    else:\n        delattr(lora_training_pipeline_module, \"sorted\")\nprint(json.dumps({\"elapsed_ms_mean\": statistics.mean(elapsed_ms), \"sorted_calls_mean\": statistics.mean(sorted_calls), \"sample_count\": float(sample_count), \"candidate_count\": float(candidate_count), \"checksum\": checksum}, sort_keys=True))\nPY\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 10.0
+      },
+      {
+        "key": "sorted_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
   }
 ]

--- a/scripts/lora_reward_summary_probe.py
+++ b/scripts/lora_reward_summary_probe.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
+
+from worker.model_ops import lora_training_pipeline as lora_training_pipeline_module
+
+
+def _build_samples(sample_count: int, candidate_count: int) -> list[dict[str, object]]:
+    samples: list[dict[str, object]] = []
+    for sample_index in range(sample_count):
+        base = (sample_index % 17) / 17.0
+        candidates = [
+            {"score": ((sample_index * 31 + candidate_index * 7) % 101) / 100.0 - base}
+            for candidate_index in range(candidate_count)
+        ]
+        samples.append(
+            {
+                "reward_score": base,
+                "candidates": candidates,
+            }
+        )
+    return samples
+
+
+def main() -> int:
+    sample_count = 5000
+    candidate_count = 32
+    iteration_count = 8
+    samples = _build_samples(sample_count, candidate_count)
+    original_sorted = sorted
+    elapsed_ms: list[float] = []
+    sorted_calls: list[int] = []
+    checksum = 0.0
+
+    def counting_sorted(values):  # type: ignore[no-untyped-def]
+        sorted_calls[-1] += 1
+        return original_sorted(values)
+
+    previous_sorted = getattr(lora_training_pipeline_module, "sorted", None)
+    had_module_sorted = hasattr(lora_training_pipeline_module, "sorted")
+    setattr(lora_training_pipeline_module, "sorted", counting_sorted)
+    try:
+        for _ in range(iteration_count):
+            sorted_calls.append(0)
+            start = time.perf_counter()
+            summary = lora_training_pipeline_module._reward_summary(samples)
+            elapsed_ms.append((time.perf_counter() - start) * 1000.0)
+            checksum += float(summary["candidate_group_reward_margin_mean"])
+    finally:
+        if had_module_sorted:
+            setattr(lora_training_pipeline_module, "sorted", previous_sorted)
+        else:
+            delattr(lora_training_pipeline_module, "sorted")
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.mean(elapsed_ms),
+                "sorted_calls_mean": statistics.mean(sorted_calls),
+                "sample_count": float(sample_count),
+                "candidate_count": float(candidate_count),
+                "checksum": checksum,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -71,6 +71,50 @@ def test_alignment_percentile_uses_interpolation_and_upper_bound() -> None:
     ) == pytest.approx(0.7)
 
 
+def test_reward_summary_reuses_candidate_group_minmax(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sorted_calls: list[int] = []
+    original_sorted = sorted
+
+    def counting_sorted(values: list[float]) -> list[float]:
+        sorted_calls.append(len(values))
+        return original_sorted(values)
+
+    monkeypatch.setattr(
+        lora_training_pipeline_module,
+        "sorted",
+        counting_sorted,
+        raising=False,
+    )
+
+    samples = [
+        {
+            "reward_score": 0.05,
+            "candidates": [
+                {"score": 0.4},
+                {"score": 0.1},
+                {"score": 0.9},
+            ],
+        },
+        {
+            "reward_score": 0.2,
+            "candidates": [
+                {"score": 1.1},
+                {"score": -0.2},
+                {"score": 0.3},
+            ],
+        },
+    ]
+
+    summary = lora_training_pipeline_module._reward_summary(samples)
+
+    assert summary["candidate_group_count"] == 2
+    assert summary["candidate_group_reward_margin_mean"] == pytest.approx(1.05)
+    assert summary["candidate_group_reward_margin_p50"] == pytest.approx(1.05)
+    assert sorted_calls == [8, 2]
+
+
 def test_latest_checkpoint_from_directory_prefers_last_numeric_token(tmp_path: Path) -> None:
     older = (
         tmp_path / "model-ops-999" / "adapter" / "checkpoint-2" / "adapters.safetensors"

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -185,6 +185,18 @@ def test_scope_report_selects_worker_registry_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "worker-registry-resident-bytes-accumulator"
 
 
+def test_scope_report_selects_lora_reward_summary_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=[
+            "services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py"
+        ],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "lora-reward-summary-candidate-minmax"
+
+
 def test_scope_report_selects_pr_scoped_scope_script_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -661,6 +673,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "evaluation-store-samples-csv-streaming",
         "job-registry-derived-model-single-pass",
         "job-registry-restore-sort-elision",
+        "lora-reward-summary-candidate-minmax",
         "mlx-lm-structured-result-tail-parse",
         "mlx-vlm-family-config-cache",
         "model-registry-plain-local-manifest-stat-elision",
@@ -1900,6 +1913,39 @@ def test_mlx_lm_result_tail_probe_script_emits_metrics() -> None:
     assert metrics["payload_value"] == 42.0
     assert metrics["line_count"] == 50002.0
     assert metrics["sample_count"] == 5.0
+
+
+def test_lora_reward_summary_probe_script_emits_metrics() -> None:
+    probe = next(
+        probe
+        for probe in load_probe_registry(REGISTRY_PATH)
+        if probe.probe_id == "lora-reward-summary-candidate-minmax"
+    )
+
+    metrics = _probe_command_json(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["sorted_calls_mean"] == 2.0
+    assert metrics["sample_count"] == 5000.0
+    assert metrics["candidate_count"] == 32.0
+    assert metrics["checksum"] > 0
+
+
+def test_lora_reward_summary_probe_script_main_covers_checked_in_file(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    script_path = REPO_ROOT / "scripts" / "lora_reward_summary_probe.py"
+    spec = importlib.util.spec_from_file_location("lora_reward_summary_probe_test", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module.main() == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+
+    assert payload["sorted_calls_mean"] == 2.0
+    assert payload["sample_count"] == 5000.0
+    assert payload["candidate_count"] == 32.0
 
 
 def test_mlx_vlm_family_config_probe_script_emits_metrics() -> None:

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -429,17 +429,25 @@ def _reward_summary(samples: list[dict[str, Any]]) -> dict[str, float | int]:
             scores.append(float(sample["reward_score"]))
         candidates = sample.get("candidates")
         candidate_scores: list[float] = []
+        candidate_score_min: float | None = None
+        candidate_score_max: float | None = None
         if isinstance(candidates, list):
             for candidate in candidates:
                 if isinstance(candidate, dict) and "score" in candidate:
-                    candidate_scores.append(float(candidate["score"]))
+                    candidate_score = float(candidate["score"])
+                    candidate_scores.append(candidate_score)
+                    if candidate_score_min is None or candidate_score < candidate_score_min:
+                        candidate_score_min = candidate_score
+                    if candidate_score_max is None or candidate_score > candidate_score_max:
+                        candidate_score_max = candidate_score
         if candidate_scores:
             scores.extend(candidate_scores)
         if len(candidate_scores) >= 2:
-            ordered_candidate_scores = sorted(candidate_scores)
+            assert candidate_score_min is not None
+            assert candidate_score_max is not None
             group_mean = sum(candidate_scores) / len(candidate_scores)
             candidate_group_margins.append(
-                ordered_candidate_scores[-1] - ordered_candidate_scores[0]
+                candidate_score_max - candidate_score_min
             )
             candidate_group_variances.append(
                 sum((score - group_mean) ** 2 for score in candidate_scores)


### PR DESCRIPTION
## Summary
- Replaced the per-candidate-group `sorted(candidate_scores)` call in LoRA reward summaries with single-pass candidate min/max tracking.
- Added a regression test that proves candidate groups no longer perform their own sort while preserving reward margin metrics.
- Registered the `lora-reward-summary-candidate-minmax` PR-scoped performance probe with a base-compatible fallback command.

## Plan or Spec
- `docs/plans/2026-05-05-lora-reward-summary-minmax.md`

## Commands Run
```text
# Focused pytest
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file
# 8 passed in 2.61s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_reward_summary_probe.py
# 8 passed in 4.00s
# TOTAL 92 2 98%

# Head-only local probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/lora_reward_summary_probe.py
# {"candidate_count": 32.0, "checksum": 7.809919999999999, "elapsed_ms_mean": 69.38166962208925, "sample_count": 5000.0, "sorted_calls_mean": 2}

# Local PR-scoped base-vs-head probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id lora-reward-summary-candidate-minmax --base-repo /tmp/melix-base-lora-20260505081824b --head-repo "$PWD" --output /tmp/lora-pr-scoped-compare.json
# head verification passed; base and head probes completed successfully

# Diff hygiene
git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 92 2 98%`.
- Registered scoped probe: `lora-reward-summary-candidate-minmax`.
- Local base-vs-head probe:
  - `elapsed_ms_mean`: base `66.26594874978764` ms → head `64.61365137511166` ms (~2.49% lower).
  - `sorted_calls_mean`: base `5002.0` → head `2.0`.
  - `sample_count`: `5000.0`; `candidate_count`: `32.0`; checksum unchanged at `7.809919999999999`.

## Known Gaps
- Linux-only Python verification was run locally. Full repository `make swift-test` / macOS checks were not run on this Linux host.
- Hosted `pr-scoped-performance` and broader required PR checks must still validate the branch before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
