### PR TITLE
perf: cache changed-scope diff additions

### DIFF
--- a/docs/plans/2026-05-05-changed-scope-diff-current-set.md
+++ b/docs/plans/2026-05-05-changed-scope-diff-current-set.md
@@ -1,0 +1,33 @@
+# Changed-scope diff current-set cache optimization
+
+## Goal
+
+Reduce per-addition overhead in `scripts/changed_scope_coverage.py` while parsing large unified diffs. The hot parser currently looks up `changed_by_path[current_path]` for every added line even though a hunk belongs to a single active file.
+
+## Scope
+
+- `scripts/changed_scope_coverage.py`
+- Existing registered probe coverage in `infra/perf/pr_scoped_probes.json`
+- Existing focused tests for `tests/test_changed_scope_coverage.py` and PR-scoped probe selection
+
+## Registered probe
+
+The affected path is covered by the registered `changed-scope-coverage-diff-parser` PR-scoped probe. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and measures:
+
+- `elapsed_ms_mean` (lower is better)
+- `changed_line_count` (informational)
+- `line_count` (informational)
+
+This slice also keeps the registered command compatible with the repository's `python3` invocation policy for the touched probe.
+
+## Optimization hypothesis
+
+Cache the active file's changed-line set when parsing a `diff --git` header, then append additions directly to that set inside the hunk loop. This should preserve behavior while avoiding repeated dictionary lookups in the parser's inner loop.
+
+## Validation plan
+
+1. Run the focused registered tests.
+2. Run changed-scope coverage through the registered coverage command.
+3. Run the registered probe locally on Linux before and after the change, with at least three samples each.
+4. Require the local probe direction to improve before opening the PR.
+5. Require PR-scoped performance CI to select and complete `changed-scope-coverage-diff-parser` before merge.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -21,14 +21,16 @@ def _is_diff_file_marker(line: str) -> bool:
 def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     changed_by_path: dict[str, set[int]] = {}
     current_path: str | None = None
+    current_changed_lines: set[int] | None = None
     new_line: int | None = None
     for line in diff_text.splitlines():
         first_char = line[:1]
         if first_char == "d" and line.startswith("diff --git "):
             match = _DIFF_HEADER_RE.match(line)
             current_path = None if match is None else match.group(2)
-            if current_path is not None:
-                changed_by_path.setdefault(current_path, set())
+            current_changed_lines = (
+                None if current_path is None else changed_by_path.setdefault(current_path, set())
+            )
             new_line = None
             continue
         if first_char == "@" and line.startswith("@@"):
@@ -37,14 +39,14 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
                 continue
             new_line = int(match.group(1))
             continue
-        if current_path is None or new_line is None:
+        if current_changed_lines is None or new_line is None:
             continue
         if first_char == "\\" and line.startswith("\\ "):
             continue
         if first_char in {"+", "-"} and _is_diff_file_marker(line):
             continue
         if first_char == "+":
-            changed_by_path[current_path].add(new_line)
+            current_changed_lines.add(new_line)
             new_line += 1
         elif first_char == "-":
             continue


### PR DESCRIPTION
## Summary
- Cache the active changed-line set while parsing `git diff` output in `scripts/changed_scope_coverage.py`.
- Avoid repeated `changed_by_path[current_path]` lookups for every added line in the hot parser loop.
- Keep the existing registered `changed-scope-coverage-diff-parser` probe unchanged; this PR now only touches the parser and its plan doc.

## Plan or Spec
- `docs/plans/2026-05-05-changed-scope-diff-current-set.md`

## Commands Run
```text
# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
20 passed in 0.38s

# Changed-scope coverage command, using python3 for the final local invocation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py; code=$?; rm -f coverage.json; exit $code
20 passed in 0.50s
TOTAL 0 0 100%

# Baseline probe on origin/main, four local python3 runs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage_parse_probe.py
elapsed_ms_mean samples: 5.2969432338917, 5.09226658323314, 5.141591507708654, 5.3085229931942495

# Head probe on this branch, four local python3 runs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage_parse_probe.py
elapsed_ms_mean samples: 5.215920333284885, 4.997142260738959, 5.028035418945365, 5.1758766688484075

git diff --check --cached
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 0 0 100%` for the changed-scope report over the touched coverage/probe files.
- Registered probe: `changed-scope-coverage-diff-parser` is already registered with focused `test_command`, `coverage_command`, and `probe_command` entries.
- Local Linux probe comparison: `old_mean=5.209831 ms`, `new_mean=5.104244 ms`, `delta=-0.105587 ms`, `speedup=1.020686x` (`2.03%` lower mean elapsed time).
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local Linux probe validates the Python diff-parser path only; PR-scoped performance CI must confirm the registered probe report for this PR.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
