### PR TITLE
perf: lazily read startup worker logs

### DIFF
--- a/docs/plans/2026-05-05-startup-signals-lazy-worker-log-probe.md
+++ b/docs/plans/2026-05-05-startup-signals-lazy-worker-log-probe.md
@@ -1,0 +1,27 @@
+# Startup Signals Lazy Worker Log Probe Plan
+
+## Goal
+
+Reduce redundant startup-failure log work in `classify_startup_failure(...)` by avoiding worker log reads when the control-plane signal already proves a host-port conflict or control-plane crash.
+
+## Linux-only constraint
+
+This slice is Python-only and can be verified on Linux with focused pytest, changed-scope coverage, and a synthetic performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/productization/startup_signals.py`
+- `services/mlx-worker-python/tests/test_startup_signals.py`
+- `scripts/startup_signals_log_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Performance probe definition
+
+Register `startup-signals-lazy-worker-log-excerpts` in PR-scoped performance CI. The probe runs `scripts/startup_signals_log_probe.py`, which builds synthetic control-plane and worker log files, repeatedly classifies three startup failure cases, and reports elapsed time plus log-read counts.
+
+## Success metrics
+
+- Host-port conflict and control-plane crash cases should read only the control-plane log (`*_log_reads_mean=1.0`) instead of also reading worker logs.
+- Worker-crash classification must still inspect worker logs and preserve classification behavior.
+- Changed-scope automated coverage must be at least 95%.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1506,5 +1506,61 @@
         "warn_pct": 5.0
       }
     ]
+  },
+  {
+    "id": "startup-signals-lazy-worker-log-excerpts",
+    "name": "Startup signals lazy worker log excerpts",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/startup_signals.py",
+      "services/mlx-worker-python/tests/test_startup_signals.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/startup_signals_log_probe.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "metrics": [
+      {
+        "key": "conflict_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 15.0
+      },
+      {
+        "key": "conflict_log_reads_mean",
+        "unit": "reads",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "control_crash_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 15.0
+      },
+      {
+        "key": "control_crash_log_reads_mean",
+        "unit": "reads",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "worker_crash_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 15.0
+      },
+      {
+        "key": "worker_crash_log_reads_mean",
+        "unit": "reads",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/startup_signals_log_probe.py ]; then python scripts/startup_signals_log_probe.py; else python - <<\"PY_FALLBACK\"\nimport json\nimport statistics\nimport sys\nimport tempfile\nimport time\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nimport worker.productization.startup_signals as startup_signals\ndef write_logs(root):\n    cp = root / \"control-plane.stderr.log\"\n    worker = root / \"python-worker.stderr.log\"\n    noise = \"boot line with enough content to make reads realistic\\n\" * 2500\n    cp.write_text(noise + \"fatal error: control plane crashed\\n\", encoding=\"utf-8\")\n    worker.write_text(noise + \"Traceback: worker bootstrap failed\\n\", encoding=\"utf-8\")\n    return {\"http_port\": 11434, \"ready_probe_url\": \"http://127.0.0.1:11434/v1/models\", \"control_plane_stderr_path\": str(cp), \"python_worker_stderr_path\": str(worker)}\ndef measure(manifest, error_text, expected, iterations):\n    original = startup_signals._read_last_nonempty_line\n    reads = 0\n    def tracked(path, *, chunk_size=8192):\n        nonlocal reads\n        reads += 1\n        return original(path, chunk_size=chunk_size)\n    startup_signals._read_last_nonempty_line = tracked\n    try:\n        started = time.perf_counter()\n        for _ in range(iterations):\n            report = startup_signals.classify_startup_failure(manifest, error_text=error_text)\n            if report.classification != expected:\n                raise AssertionError((expected, report.classification))\n        elapsed = (time.perf_counter() - started) * 1000.0\n    finally:\n        startup_signals._read_last_nonempty_line = original\n    return elapsed, float(reads)\niterations = 400\nsamples = 5\nconflict_elapsed=[]; conflict_reads=[]; control_elapsed=[]; control_reads=[]; worker_elapsed=[]; worker_reads=[]\nwith tempfile.TemporaryDirectory() as d:\n    manifest = write_logs(Path(d))\n    for _ in range(samples):\n        elapsed, reads = measure(manifest, \"bind() failed: Address already in use\", \"host_port_conflict\", iterations)\n        conflict_elapsed.append(elapsed); conflict_reads.append(reads / iterations)\n        elapsed, reads = measure(manifest, \"handshake failed\", \"control_plane_crash\", iterations)\n        control_elapsed.append(elapsed); control_reads.append(reads / iterations)\n        worker_manifest = dict(manifest); worker_manifest.pop(\"control_plane_stderr_path\")\n        elapsed, reads = measure(worker_manifest, \"handshake failed\", \"worker_crash\", iterations)\n        worker_elapsed.append(elapsed); worker_reads.append(reads / iterations)\nprint(json.dumps({\"conflict_elapsed_ms_mean\": round(statistics.fmean(conflict_elapsed), 6), \"conflict_log_reads_mean\": round(statistics.fmean(conflict_reads), 6), \"control_crash_elapsed_ms_mean\": round(statistics.fmean(control_elapsed), 6), \"control_crash_log_reads_mean\": round(statistics.fmean(control_reads), 6), \"iterations\": float(iterations), \"sample_count\": float(samples), \"worker_crash_elapsed_ms_mean\": round(statistics.fmean(worker_elapsed), 6), \"worker_crash_log_reads_mean\": round(statistics.fmean(worker_reads), 6)}, sort_keys=True))\nPY_FALLBACK\nfi' ",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "notes": "Compares startup failure classification log-read work for control-plane-resolved failures versus worker-crash fallback."
   }
 ]

--- a/scripts/startup_signals_log_probe.py
+++ b/scripts/startup_signals_log_probe.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import statistics
+import sys
+import tempfile
+import time
+from typing import Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+import worker.productization.startup_signals as startup_signals  # noqa: E402
+
+
+def _write_logs(root: Path) -> dict[str, str]:
+    control_plane_stderr = root / "control-plane.stderr.log"
+    worker_stderr = root / "python-worker.stderr.log"
+    noise = "boot line with enough content to make reads realistic\n" * 2500
+    control_plane_stderr.write_text(noise + "fatal error: control plane crashed\n", encoding="utf-8")
+    worker_stderr.write_text(noise + "Traceback: worker bootstrap failed\n", encoding="utf-8")
+    return {
+        "http_port": 11434,
+        "ready_probe_url": "http://127.0.0.1:11434/v1/models",
+        "control_plane_stderr_path": str(control_plane_stderr),
+        "python_worker_stderr_path": str(worker_stderr),
+    }
+
+
+def _measure_case(
+    manifest: dict[str, str | int],
+    *,
+    error_text: str,
+    expected_classification: str,
+    iterations: int,
+) -> tuple[float, float]:
+    original_reader: Callable[..., str] = startup_signals._read_last_nonempty_line
+    read_count = 0
+
+    def tracked_reader(path: Path, *, chunk_size: int = 8192) -> str:
+        nonlocal read_count
+        read_count += 1
+        return original_reader(path, chunk_size=chunk_size)
+
+    startup_signals._read_last_nonempty_line = tracked_reader
+    try:
+        started = time.perf_counter()
+        for _ in range(iterations):
+            report = startup_signals.classify_startup_failure(manifest, error_text=error_text)
+            if report.classification != expected_classification:
+                raise AssertionError(
+                    f"expected {expected_classification}, got {report.classification}"
+                )
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+    finally:
+        startup_signals._read_last_nonempty_line = original_reader
+    return elapsed_ms, float(read_count)
+
+
+def main() -> int:
+    iterations = 400
+    samples = 5
+    conflict_elapsed: list[float] = []
+    conflict_reads: list[float] = []
+    control_elapsed: list[float] = []
+    control_reads: list[float] = []
+    worker_elapsed: list[float] = []
+    worker_reads: list[float] = []
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        manifest = _write_logs(Path(tmp_dir))
+        for _ in range(samples):
+            elapsed, reads = _measure_case(
+                manifest,
+                error_text="bind() failed: Address already in use",
+                expected_classification="host_port_conflict",
+                iterations=iterations,
+            )
+            conflict_elapsed.append(elapsed)
+            conflict_reads.append(reads / iterations)
+
+            elapsed, reads = _measure_case(
+                manifest,
+                error_text="handshake failed",
+                expected_classification="control_plane_crash",
+                iterations=iterations,
+            )
+            control_elapsed.append(elapsed)
+            control_reads.append(reads / iterations)
+
+            worker_manifest = dict(manifest)
+            worker_manifest.pop("control_plane_stderr_path")
+            elapsed, reads = _measure_case(
+                worker_manifest,
+                error_text="handshake failed",
+                expected_classification="worker_crash",
+                iterations=iterations,
+            )
+            worker_elapsed.append(elapsed)
+            worker_reads.append(reads / iterations)
+
+    print(
+        json.dumps(
+            {
+                "conflict_elapsed_ms_mean": round(statistics.fmean(conflict_elapsed), 6),
+                "conflict_log_reads_mean": round(statistics.fmean(conflict_reads), 6),
+                "control_crash_elapsed_ms_mean": round(statistics.fmean(control_elapsed), 6),
+                "control_crash_log_reads_mean": round(statistics.fmean(control_reads), 6),
+                "iterations": float(iterations),
+                "sample_count": float(samples),
+                "worker_crash_elapsed_ms_mean": round(statistics.fmean(worker_elapsed), 6),
+                "worker_crash_log_reads_mean": round(statistics.fmean(worker_reads), 6),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -125,6 +125,16 @@ def test_scope_report_selects_training_dataset_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "training-dataset-token-percentiles-single-sort"
 
 
+def test_scope_report_selects_startup_signals_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/startup_signals.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "startup-signals-lazy-worker-log-excerpts"
+
+
 def test_scope_report_selects_real_model_support_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -817,6 +827,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "real-model-support-hf-cache-latest-snapshot",
         "stream-assembler-structural-prefix-cache",
         "swift-cli-json-envelope-encoding",
+        "startup-signals-lazy-worker-log-excerpts",
         "upload-receipt-published-files-scandir",
         "download-pipeline-directory-size-single-stat",
         "worker-registry-resident-bytes-accumulator",
@@ -1495,6 +1506,21 @@ def test_worker_registry_probe_script_emits_metrics(capsys: pytest.CaptureFixtur
     assert payload["request_stats_elapsed_ms_mean"] > 0
     assert payload["resident_bytes_mean"] > 0
     assert payload["sample_count"] == 3.0
+
+
+def test_startup_signals_probe_script_emits_metrics(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(REPO_ROOT / "scripts/startup_signals_log_probe.py"), run_name="__main__")
+
+    assert excinfo.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["conflict_elapsed_ms_mean"] > 0
+    assert payload["conflict_log_reads_mean"] == 1.0
+    assert payload["control_crash_elapsed_ms_mean"] > 0
+    assert payload["control_crash_log_reads_mean"] == 1.0
+    assert payload["worker_crash_elapsed_ms_mean"] > 0
+    assert payload["worker_crash_log_reads_mean"] == 1.0
+    assert payload["sample_count"] == 5.0
 
 
 def test_job_registry_probe_script_emits_metrics(capsys: pytest.CaptureFixture[str]) -> None:

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -4,6 +4,9 @@ import json
 import socket
 from pathlib import Path
 
+import pytest
+
+import worker.productization.startup_signals as startup_signals_module
 from worker.productization.startup_signals import (
     _read_last_nonempty_line,
     check_for_updates,
@@ -171,6 +174,70 @@ def test_classify_startup_failure_reports_worker_crash(tmp_path: Path) -> None:
     assert report.classification == "worker_crash"
     assert "worker" in report.summary.lower()
     assert "Traceback" in report.log_excerpt
+
+
+def test_classify_startup_failure_skips_worker_logs_for_host_port_conflict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    control_plane_stderr = tmp_path / "control-plane.stderr.log"
+    worker_stderr = tmp_path / "python-worker.stderr.log"
+    control_plane_stderr.write_text("bind() failed: Address already in use\n", encoding="utf-8")
+    worker_stderr.write_text("Traceback: worker should not be inspected\n", encoding="utf-8")
+    read_paths: list[str] = []
+
+    def tracked_read(path: Path, *, chunk_size: int = 8192) -> str:
+        read_paths.append(path.name)
+        if path == worker_stderr:
+            raise AssertionError("worker log should not be read for host port conflicts")
+        return _read_last_nonempty_line(path, chunk_size=chunk_size)
+
+    monkeypatch.setattr(startup_signals_module, "_read_last_nonempty_line", tracked_read)
+
+    report = classify_startup_failure(
+        {
+            "http_port": 11434,
+            "ready_probe_url": "http://127.0.0.1:11434/v1/models",
+            "control_plane_stderr_path": str(control_plane_stderr),
+            "python_worker_stderr_path": str(worker_stderr),
+        },
+        error_text="handshake failed",
+    )
+
+    assert report.classification == "host_port_conflict"
+    assert read_paths == ["control-plane.stderr.log"]
+
+
+def test_classify_startup_failure_skips_worker_logs_for_control_plane_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    control_plane_stderr = tmp_path / "control-plane.stderr.log"
+    worker_stderr = tmp_path / "python-worker.stderr.log"
+    control_plane_stderr.write_text("fatal error: crashed\n", encoding="utf-8")
+    worker_stderr.write_text("Traceback: worker should not be inspected\n", encoding="utf-8")
+    read_paths: list[str] = []
+
+    def tracked_read(path: Path, *, chunk_size: int = 8192) -> str:
+        read_paths.append(path.name)
+        if path == worker_stderr:
+            raise AssertionError("worker log should not be read for control-plane crashes")
+        return _read_last_nonempty_line(path, chunk_size=chunk_size)
+
+    monkeypatch.setattr(startup_signals_module, "_read_last_nonempty_line", tracked_read)
+
+    report = classify_startup_failure(
+        {
+            "http_port": 11434,
+            "ready_probe_url": "http://127.0.0.1:11434/v1/models",
+            "control_plane_stderr_path": str(control_plane_stderr),
+            "python_worker_stderr_path": str(worker_stderr),
+        },
+        error_text="handshake failed",
+    )
+
+    assert report.classification == "control_plane_crash"
+    assert read_paths == ["control-plane.stderr.log"]
 
 
 def test_classify_startup_failure_reports_control_plane_crash(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -162,14 +162,7 @@ def classify_startup_failure(
         manifest.get("control_plane_stderr_path"),
         manifest.get("control_plane_stdout_path"),
     )
-    worker_excerpt = _log_excerpt(
-        manifest.get("python_worker_stderr_path"),
-        manifest.get("swift_text_worker_stderr_path"),
-        manifest.get("python_worker_stdout_path"),
-        manifest.get("swift_text_worker_stdout_path"),
-    )
     combined_control_plane = f"{error_text}\n{control_plane_excerpt}".lower()
-    combined_worker = worker_excerpt.lower()
 
     if any(pattern in combined_control_plane for pattern in PORT_CONFLICT_PATTERNS):
         primary_log_path = str(manifest.get("control_plane_stderr_path", ""))
@@ -186,18 +179,30 @@ def classify_startup_failure(
         detail = f"Melix never reached {ready_probe_url}. Inspect the control-plane logs for the crash cause."
         excerpt = control_plane_excerpt
         classification = "control_plane_crash"
-    elif worker_excerpt and any(pattern in combined_worker for pattern in CRASH_PATTERNS):
-        primary_log_path = str(manifest.get("python_worker_stderr_path") or manifest.get("swift_text_worker_stderr_path") or "")
-        summary = "A worker crashed before Melix became ready."
-        detail = "Inspect the worker logs and restart Melix after fixing the failing runtime."
-        excerpt = worker_excerpt
-        classification = "worker_crash"
     else:
-        primary_log_path = str(manifest.get("control_plane_stderr_path", ""))
-        summary = f"Melix startup timed out before {ready_probe_url} became ready."
-        detail = "Inspect the startup logs and ready probe path to determine whether the services hung or never launched."
-        excerpt = control_plane_excerpt or worker_excerpt or error_text
-        classification = "startup_hang"
+        worker_excerpt_value = _log_excerpt(
+            manifest.get("python_worker_stderr_path"),
+            manifest.get("swift_text_worker_stderr_path"),
+            manifest.get("python_worker_stdout_path"),
+            manifest.get("swift_text_worker_stdout_path"),
+        )
+        combined_worker = worker_excerpt_value.lower()
+        if worker_excerpt_value and any(pattern in combined_worker for pattern in CRASH_PATTERNS):
+            primary_log_path = str(
+                manifest.get("python_worker_stderr_path")
+                or manifest.get("swift_text_worker_stderr_path")
+                or ""
+            )
+            summary = "A worker crashed before Melix became ready."
+            detail = "Inspect the worker logs and restart Melix after fixing the failing runtime."
+            excerpt = worker_excerpt_value
+            classification = "worker_crash"
+        else:
+            primary_log_path = str(manifest.get("control_plane_stderr_path", ""))
+            summary = f"Melix startup timed out before {ready_probe_url} became ready."
+            detail = "Inspect the startup logs and ready probe path to determine whether the services hung or never launched."
+            excerpt = control_plane_excerpt or worker_excerpt_value or error_text
+            classification = "startup_hang"
 
     return StartupFailureReport(
         classification=classification,


### PR DESCRIPTION
## Summary
- Lazily read worker startup logs only after control-plane evidence fails to classify the startup failure.
- Adds focused regression coverage proving host-port conflict and control-plane crash paths do not inspect worker logs.
- Registers the `startup-signals-lazy-worker-log-excerpts` PR-scoped performance probe with a base-compatible fallback command.

## Plan or Spec
- Plan: `docs/plans/2026-05-05-startup-signals-lazy-worker-log-probe.md`

## Commands Run
```text
python -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.json.check
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# 22 passed in 0.28s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py
# 22 passed; TOTAL 66 2 97%

python scripts/startup_signals_log_probe.py
# {"conflict_elapsed_ms_mean": 10.571443, "conflict_log_reads_mean": 1.0, "control_crash_elapsed_ms_mean": 9.799363, "control_crash_log_reads_mean": 1.0, "iterations": 400.0, "sample_count": 5.0, "worker_crash_elapsed_ms_mean": 9.977572, "worker_crash_log_reads_mean": 1.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id startup-signals-lazy-worker-log-excerpts --base-repo /tmp/melix-startup-signals-base --head-repo "$PWD" --output /tmp/startup-signals-probe-result.json
# head verification passed; changed-scope coverage 97%; base/head probe succeeded

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 66 2 97%`.
- Registered scoped probe: `startup-signals-lazy-worker-log-excerpts`.
- Local base-vs-head scoped probe (`origin/main` at `f1faa3e` vs head `28f2225`):
  - `conflict_log_reads_mean`: `2.0` → `1.0` (50% fewer reads)
  - `control_crash_log_reads_mean`: `2.0` → `1.0` (50% fewer reads)
  - `worker_crash_log_reads_mean`: `1.0` → `1.0` (unchanged fallback behavior)
  - `conflict_elapsed_ms_mean`: `25.438364` → `13.356623`
  - `control_crash_elapsed_ms_mean`: `25.668789` → `12.921778`
  - `worker_crash_elapsed_ms_mean`: `14.3102` → `13.340685`

## Known Gaps
- Linux-only verification; macOS/Swift checks were not run locally because this slice is Python-only and the host is Linux.
- Hosted `pr-scoped-performance` remains the merge gate after PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
