### PR TITLE
Add dataset management and selection

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -755,6 +755,42 @@ public struct ModelHubDownloadOptions: Equatable, Sendable {
     }
 }
 
+public struct DatasetListOptions: Equatable, Sendable {
+    public let json: Bool
+
+    public init(json: Bool = false) {
+        self.json = json
+    }
+}
+
+public struct DatasetHubDownloadOptions: Equatable, Sendable {
+    public let repoID: String
+    public let revision: String
+    public let hfToken: String
+    public let json: Bool
+
+    public init(repoID: String, revision: String = "main", hfToken: String = "", json: Bool = false) {
+        self.repoID = repoID
+        self.revision = revision.isEmpty ? "main" : revision
+        self.hfToken = hfToken
+        self.json = json
+    }
+}
+
+public struct DatasetRemoveOptions: Equatable, Sendable {
+    public let repoID: String
+    public let revision: String
+    public let snapshotID: String
+    public let json: Bool
+
+    public init(repoID: String, revision: String = "main", snapshotID: String = "", json: Bool = false) {
+        self.repoID = repoID
+        self.revision = revision.isEmpty ? "main" : revision
+        self.snapshotID = snapshotID
+        self.json = json
+    }
+}
+
 public struct ModelDownloadOptions: Equatable, Sendable {
     public let modelID: String
     public let outputDir: String
@@ -914,6 +950,40 @@ public struct ManagedModelReceipt: Codable, Equatable, Sendable {
         self.sourceKind = sourceKind
         self.sourceLocator = sourceLocator
         self.warnings = warnings
+    }
+}
+
+public struct ManagedDatasetReceipt: Codable, Equatable, Sendable {
+    public let datasetID: String
+    public let repoID: String
+    public let revision: String
+    public let snapshotID: String
+    public let managedDatasetPath: String
+    public let sourceKind: String
+
+    enum CodingKeys: String, CodingKey {
+        case datasetID = "dataset_id"
+        case repoID = "repo_id"
+        case revision
+        case snapshotID = "snapshot_id"
+        case managedDatasetPath = "managed_dataset_path"
+        case sourceKind = "source_kind"
+    }
+
+    public init(
+        datasetID: String,
+        repoID: String,
+        revision: String,
+        snapshotID: String,
+        managedDatasetPath: String,
+        sourceKind: String
+    ) {
+        self.datasetID = datasetID
+        self.repoID = repoID
+        self.revision = revision
+        self.snapshotID = snapshotID
+        self.managedDatasetPath = managedDatasetPath
+        self.sourceKind = sourceKind
     }
 }
 
@@ -1238,6 +1308,9 @@ public enum MelixCLICommand: Equatable, Sendable {
     case modelHubSearch(ModelHubSearchOptions)
     case modelHubShow(ModelHubShowOptions)
     case modelHubDownload(ModelHubDownloadOptions)
+    case datasetList(DatasetListOptions)
+    case datasetHubDownload(DatasetHubDownloadOptions)
+    case datasetRemove(DatasetRemoveOptions)
     case modelRootsList(ModelRootsListOptions)
     case modelRootsAdd(ModelRootsMutateOptions)
     case modelRootsRemove(ModelRootsMutateOptions)
@@ -1365,6 +1438,8 @@ public enum MelixCLIParser {
             return try parseUpload(tail)
         case "model":
             return try parseModel(tail)
+        case "dataset":
+            return try parseDataset(tail)
         case "server":
             return try parseServer(tail)
         case "remote-server":
@@ -1401,6 +1476,9 @@ public enum MelixCLIParser {
       melix model hub search --query QUERY [--page-size N] [--cursor TOKEN] [--mlx-only (true|false)] [--json]
       melix model hub show --repo-id HF_REPO [--json]
       melix model hub download --repo-id HF_REPO [--revision REV] [--hf-token TOKEN] [--json]
+      melix dataset list [--json]
+      melix dataset hub download --repo-id HF_DATASET [--revision REV] [--hf-token TOKEN] [--json]
+      melix dataset remove --repo-id HF_DATASET [--revision REV | --snapshot-id SHA] [--json]
       melix model roots list [--json]
       melix model roots add --path PATH [--json]
       melix model roots remove --path PATH [--json]
@@ -1437,21 +1515,21 @@ public enum MelixCLIParser {
       melix lora resume --group-id GROUP_ID [--model-id MODEL_ID] [--preset PRESET] [--adapter-name NAME] [--dataset-uri URI] [--json]
       melix lora publishes list [--model-id MODEL_ID] [--json]
       melix lora publishes show --job-id JOB_ID [--model-id MODEL_ID] [--json]
-      melix bench run (--model-id MODEL_ID | --repo-id HF_REPO) [--suite SUITE ...] [--context-length N ...] [--generation-length N] [--batch-size N ...] [--repeats N] [--cache-profile MODE] [--reasoning-mode MODE] [--structured-output-mode MODE] [--sample-size N] [--batch-factor N] [--json]
+      melix bench run (--model-id MODEL_ID | --repo-id HF_REPO) [--suite SUITE ...] [--dataset-ref HF_DATASET[@REV]] [--hf-dataset-name NAME] [--hf-dataset-split SPLIT] [--prompt-feature NAME] [--text-feature NAME] [--image-feature NAME] [--source-image-feature NAME] [--mask-feature NAME] [--context-length N ...] [--generation-length N] [--batch-size N ...] [--repeats N] [--cache-profile MODE] [--reasoning-mode MODE] [--structured-output-mode MODE] [--sample-size N] [--batch-factor N] [--json]
       melix bench list [--json]
       melix bench export-csv --job-id JOB_ID --output PATH [--json]
       melix bench matrix run (--model-id MODEL_ID | --repo-id HF_REPO) --suite SUITE ... --context-length N ... --generation-length N ... --batch-size N ... --cache-profile MODE ... --reasoning-mode MODE ... --structured-output-mode MODE ... --concurrency N ... [--repeats N] (--requests N | --duration-seconds N) [--allow-large-matrix] [--json]
       melix bench matrix list [--json]
       melix bench matrix export-summary-csv --job-id JOB_ID --output PATH [--json]
       melix bench matrix export-requests-csv --job-id JOB_ID --output PATH [--json]
-      melix eval run (--model-id MODEL_ID | --repo-id HF_REPO | --remote-server-id ID [--remote-model MODEL] ...) [--semantic-judge-remote-server-id ID] [--semantic-judge-model MODEL] [--remote-parallelism N] [--suite SUITE ...] [--dataset-id DATASET_ID] [--dataset-root PATH] [--source-csv PATH | --source-jsonl PATH | --hf-dataset-path REPO] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-dataset-split SPLIT] [--field-system-path PATH] [--field-input-text-path PATH] [--field-target-path PATH] [--field-sample-id-path PATH] [--profile-type TYPE] [--result-kind KIND] [--extraction-mode MODE] [--scoring-mode MODE] [--threshold N] [--output-schema-json JSON] [--ignored-path PATH ...] [--sample-size N] [--batch-factor N] [--seed N] [--few-shot N] [--code-exec-policy MODE] [--remote-extra-body-json JSON] [--eval-prompt-id ID] [--eval-prompt-revision REV] [--json]
+      melix eval run (--model-id MODEL_ID | --repo-id HF_REPO | --remote-server-id ID [--remote-model MODEL] ...) [--semantic-judge-remote-server-id ID] [--semantic-judge-model MODEL] [--remote-parallelism N] [--suite SUITE ...] [--dataset-id DATASET_ID] [--dataset-root PATH] [--source-csv PATH | --source-jsonl PATH | --hf-dataset-path REPO | --dataset-ref HF_DATASET[@REV]] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-dataset-split SPLIT] [--field-system-path PATH] [--field-input-text-path PATH] [--field-target-path PATH] [--field-sample-id-path PATH] [--profile-type TYPE] [--result-kind KIND] [--extraction-mode MODE] [--scoring-mode MODE] [--threshold N] [--output-schema-json JSON] [--ignored-path PATH ...] [--sample-size N] [--batch-factor N] [--seed N] [--few-shot N] [--code-exec-policy MODE] [--remote-extra-body-json JSON] [--eval-prompt-id ID] [--eval-prompt-revision REV] [--json]
       melix eval prompt list [--json]
       melix eval prompt show --prompt-id ID [--revision-id REV] [--json]
       melix eval prompt create --prompt-id ID --title TITLE --system-prompt-file PATH [--json]
       melix eval prompt update --prompt-id ID --system-prompt-file PATH [--json]
       melix eval prompt freeze --prompt-id ID [--revision-id REV] [--json]
       melix eval prompt archive --prompt-id ID [--json]
-      melix eval compare (--model-id MODEL_ID | --repo-id HF_REPO) (--target-model-id MODEL_ID | --target-adapter ADAPTER_MANIFEST_PATH)... [--suite SUITE ...] [--dataset-id DATASET_ID] [--dataset-root PATH] [--source-csv PATH | --source-jsonl PATH | --hf-dataset-path REPO] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-dataset-split SPLIT] [--field-system-path PATH] [--field-input-text-path PATH] [--field-target-path PATH] [--field-sample-id-path PATH] [--profile-type TYPE] [--result-kind KIND] [--extraction-mode MODE] [--scoring-mode MODE] [--threshold N] [--output-schema-json JSON] [--ignored-path PATH ...] [--sample-size N] [--batch-factor N] [--seed N] [--few-shot N] [--code-exec-policy MODE] [--json]
+      melix eval compare (--model-id MODEL_ID | --repo-id HF_REPO) (--target-model-id MODEL_ID | --target-adapter ADAPTER_MANIFEST_PATH)... [--suite SUITE ...] [--dataset-id DATASET_ID] [--dataset-root PATH] [--source-csv PATH | --source-jsonl PATH | --hf-dataset-path REPO | --dataset-ref HF_DATASET[@REV]] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-dataset-split SPLIT] [--field-system-path PATH] [--field-input-text-path PATH] [--field-target-path PATH] [--field-sample-id-path PATH] [--profile-type TYPE] [--result-kind KIND] [--extraction-mode MODE] [--scoring-mode MODE] [--threshold N] [--output-schema-json JSON] [--ignored-path PATH ...] [--sample-size N] [--batch-factor N] [--seed N] [--few-shot N] [--code-exec-policy MODE] [--json]
       melix eval compare export-summary-csv --job-id JOB_ID --output PATH [--json]
       melix eval compare export-samples-csv --job-id JOB_ID --output PATH [--json]
       melix eval compare export-samples-jsonl --job-id JOB_ID --output PATH [--json]
@@ -1704,6 +1782,57 @@ public enum MelixCLIParser {
             return .modelRootsMove(.init(path: path, index: index, json: values.flags.contains("--json")))
         case "rescan":
             return .modelRootsRescan(.init(json: values.flags.contains("--json")))
+        default:
+            throw MelixCLIError.usage(usageText)
+        }
+    }
+
+    private static func parseDataset(_ arguments: [String]) throws -> MelixCLICommand {
+        guard let action = arguments.first else {
+            throw MelixCLIError.usage(usageText)
+        }
+        switch action {
+        case "list":
+            let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse()
+            return .datasetList(.init(json: values.flags.contains("--json")))
+        case "hub":
+            return try parseDatasetHub(Array(arguments.dropFirst()))
+        case "remove":
+            let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse()
+            guard let repoID = values.single["--repo-id"], !repoID.isEmpty else {
+                throw MelixCLIError.missingRequired("--repo-id is required for melix dataset remove.")
+            }
+            return .datasetRemove(
+                .init(
+                    repoID: repoID,
+                    revision: values.single["--revision"] ?? "main",
+                    snapshotID: values.single["--snapshot-id"] ?? "",
+                    json: values.flags.contains("--json")
+                )
+            )
+        default:
+            throw MelixCLIError.usage(usageText)
+        }
+    }
+
+    private static func parseDatasetHub(_ arguments: [String]) throws -> MelixCLICommand {
+        guard let action = arguments.first else {
+            throw MelixCLIError.usage(usageText)
+        }
+        let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse()
+        switch action {
+        case "download":
+            guard let repoID = values.single["--repo-id"], !repoID.isEmpty else {
+                throw MelixCLIError.missingRequired("--repo-id is required for melix dataset hub download.")
+            }
+            return .datasetHubDownload(
+                .init(
+                    repoID: repoID,
+                    revision: values.single["--revision"] ?? "main",
+                    hfToken: values.single["--hf-token"] ?? "",
+                    json: values.flags.contains("--json")
+                )
+            )
         default:
             throw MelixCLIError.usage(usageText)
         }
@@ -2560,6 +2689,25 @@ public enum MelixCLIParser {
             if let batchFactor = values.single["--batch-factor"] {
                 parameters["batch_factor"] = batchFactor
             }
+            if let datasetRef = values.single["--dataset-ref"], datasetRef.isEmpty == false {
+                let parsedRef = parseDatasetReference(datasetRef)
+                parameters["dataset_ref"] = datasetRef
+                parameters["hf_dataset_path"] = parsedRef.repoID
+                parameters["hf_dataset_revision"] = parsedRef.revision
+            }
+            for option in [
+                "--hf-dataset-name",
+                "--hf-dataset-split",
+                "--prompt-feature",
+                "--text-feature",
+                "--image-feature",
+                "--source-image-feature",
+                "--mask-feature",
+            ] {
+                if let value = values.single[option], value.isEmpty == false {
+                    parameters[normalizedParameterKey(option)] = value
+                }
+            }
             return .benchRun(
                 BenchRunOptions(
                     modelID: modelID,
@@ -3031,6 +3179,12 @@ public enum MelixCLIParser {
         if let remoteExtraBodyJSON = values.single["--remote-extra-body-json"] {
             parameters["remote_provider_extra_body_json"] = remoteExtraBodyJSON
         }
+        if let datasetRef = values.single["--dataset-ref"], datasetRef.isEmpty == false {
+            let parsedRef = parseDatasetReference(datasetRef)
+            parameters["dataset_ref"] = datasetRef
+            parameters["hf_dataset_path"] = parsedRef.repoID
+            parameters["hf_dataset_revision"] = parsedRef.revision
+        }
         return parameters
     }
 
@@ -3045,12 +3199,14 @@ public enum MelixCLIParser {
         let localCSVPath = values.single["--source-csv"] ?? ""
         let localJSONLPath = values.single["--source-jsonl"] ?? ""
         let hfDatasetPath = values.single["--hf-dataset-path"] ?? ""
-        let customSourceCount = [localCSVPath, localJSONLPath, hfDatasetPath].filter { $0.isEmpty == false }.count
+        let datasetRef = values.single["--dataset-ref"] ?? ""
+        let customSourceCount = [localCSVPath, localJSONLPath, hfDatasetPath, datasetRef].filter { $0.isEmpty == false }.count
         guard customSourceCount <= 1 else {
             throw MelixCLIError.usage(
-                "At most one of --source-csv, --source-jsonl, or --hf-dataset-path may be provided for \(command)."
+                "At most one of --source-csv, --source-jsonl, --hf-dataset-path, or --dataset-ref may be provided for \(command)."
             )
         }
+        let parsedDatasetRef = datasetRef.isEmpty ? nil : parseDatasetReference(datasetRef)
 
         let fieldMapping = ControlPlaneEvaluationRequest.FieldMapping(
             systemPath: values.single["--field-system-path"] ?? "",
@@ -3080,6 +3236,13 @@ public enum MelixCLIParser {
                 datasetRevision: values.single["--hf-dataset-revision"] ?? "main",
                 split: values.single["--hf-dataset-split"] ?? "train"
             )
+        } else if let parsedDatasetRef {
+            source = .huggingFaceDataset(
+                datasetPath: parsedDatasetRef.repoID,
+                datasetName: values.single["--hf-dataset-name"] ?? "",
+                datasetRevision: values.single["--hf-dataset-revision"] ?? parsedDatasetRef.revision,
+                split: values.single["--hf-dataset-split"] ?? "train"
+            )
         } else {
             source = .builtinPackage
         }
@@ -3106,6 +3269,17 @@ public enum MelixCLIParser {
         option
             .replacingOccurrences(of: "--", with: "")
             .replacingOccurrences(of: "-", with: "_")
+    }
+
+    private static func parseDatasetReference(_ datasetRef: String) -> (repoID: String, revision: String) {
+        let trimmed = datasetRef.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let separator = trimmed.lastIndex(of: "@") else {
+            return (trimmed, "main")
+        }
+        let repoID = String(trimmed[..<separator]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let revision = String(trimmed[trimmed.index(after: separator)...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (repoID, revision.isEmpty ? "main" : revision)
     }
 
     private static func parseUInt32Value(
@@ -3471,6 +3645,68 @@ public actor MelixCLIRunner {
         )
     }
 
+    public func datasetRegistrySnapshot() async throws -> Melix_Controlplane_V1_ModelOperationResult {
+        try await performModelOperation(
+            modelID: "melix-datasets",
+            operation: "dataset_snapshot",
+            outputDir: "",
+            ext: [:]
+        )
+    }
+
+    public func downloadHubDataset(
+        repoID: String,
+        revision: String = "main",
+        hfToken: String = ""
+    ) async throws -> Melix_Controlplane_V1_ModelOperationResult {
+        let tokenStore = HuggingFaceTokenStore(melixHome: MelixHome(environment: environment))
+        let providedToken = hfToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        let effectiveToken: String
+        if providedToken.isEmpty == false {
+            _ = try tokenStore.saveToken(providedToken)
+            effectiveToken = providedToken
+        } else {
+            effectiveToken = (try tokenStore.loadToken()?.token ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        var ext: [String: String] = [
+            "melix.source_kind": "hf_dataset",
+            "melix.source_locator": repoID,
+            "melix.hf_dataset_repo_id": repoID,
+            "melix.hf_revision": revision.isEmpty ? "main" : revision,
+            "melix.managed_import": "true",
+        ]
+        if effectiveToken.isEmpty == false {
+            ext["melix.hf_token"] = effectiveToken
+        }
+        return try await performModelOperation(
+            modelID: repoID,
+            operation: "dataset_download",
+            outputDir: "",
+            ext: ext
+        )
+    }
+
+    public func removeDataset(
+        repoID: String,
+        revision: String = "main",
+        snapshotID: String = ""
+    ) async throws -> Melix_Controlplane_V1_ModelOperationResult {
+        var ext: [String: String] = [
+            "melix.hf_dataset_repo_id": repoID,
+            "melix.hf_revision": revision.isEmpty ? "main" : revision,
+        ]
+        if snapshotID.isEmpty == false {
+            ext["melix.hf_snapshot_id"] = snapshotID
+        }
+        return try await performModelOperation(
+            modelID: repoID,
+            operation: "dataset_remove",
+            outputDir: "",
+            ext: ext
+        )
+    }
+
     public func downloadModel(
         modelID: String,
         outputDir: String = ""
@@ -3783,6 +4019,28 @@ public actor MelixCLIRunner {
             let result = try await downloadHubModel(repoID: options.repoID, revision: options.revision, hfToken: options.hfToken)
             let receipt = try makeManagedModelReceipt(from: result)
             return options.json ? try prettyJSON(receipt) : receipt.managedModelPath + "\n"
+        case .datasetList(let options):
+            let result = try await datasetRegistrySnapshot()
+            if options.json {
+                return try prettyJSON(
+                    try filterManifestKeys(
+                        fromManifestJson: result.manifestJson,
+                        defaults: datasetRegistrySnapshotDefaults()
+                    )
+                )
+            }
+            return renderDatasetRegistrySnapshot(result.manifestJson)
+        case .datasetHubDownload(let options):
+            let result = try await downloadHubDataset(repoID: options.repoID, revision: options.revision, hfToken: options.hfToken)
+            let receipt = try makeManagedDatasetReceipt(from: result)
+            return options.json ? try prettyJSON(receipt) : receipt.managedDatasetPath + "\n"
+        case .datasetRemove(let options):
+            let result = try await removeDataset(
+                repoID: options.repoID,
+                revision: options.revision,
+                snapshotID: options.snapshotID
+            )
+            return options.json ? result.manifestJson : result.outputPath + "\n"
         case .modelRootsList(let options):
             let state = try loadOperatorState()
             if options.json {
@@ -4632,6 +4890,20 @@ public actor MelixCLIRunner {
             var arguments = ["lora", "remove-derived", "--model-id", modelID]
             appendOption("--derived-model-id", value: ext["derived_model_id"], into: &arguments)
             appendOption("--manifest-path", value: ext["manifest_path"], into: &arguments)
+            arguments.append("--json")
+            return arguments
+        case "dataset_snapshot":
+            return ["dataset", "list", "--json"]
+        case "dataset_download":
+            var arguments = ["dataset", "hub", "download", "--repo-id", modelID]
+            appendOption("--revision", value: ext["melix.hf_revision"], into: &arguments)
+            appendOption("--hf-token", value: ext["melix.hf_token"], into: &arguments)
+            arguments.append("--json")
+            return arguments
+        case "dataset_remove":
+            var arguments = ["dataset", "remove", "--repo-id", modelID]
+            appendOption("--revision", value: ext["melix.hf_revision"], into: &arguments)
+            appendOption("--snapshot-id", value: ext["melix.hf_snapshot_id"], into: &arguments)
             arguments.append("--json")
             return arguments
         case "registry_snapshot":
@@ -5802,6 +6074,41 @@ public actor MelixCLIRunner {
         ]
     }
 
+    private func datasetRegistrySnapshotDefaults() -> [String: Any] {
+        [
+            "dataset_registry": [
+                "schema_version": "melix.dataset_registry_snapshot.v1",
+                "roots": [] as [Any],
+                "datasets": [] as [Any],
+            ] as [String: Any],
+            "warnings": [] as [Any],
+        ]
+    }
+
+    private func renderDatasetRegistrySnapshot(_ manifestJSON: String) -> String {
+        guard
+            let data = manifestJSON.data(using: .utf8),
+            let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let registry = payload["dataset_registry"] as? [String: Any]
+        else {
+            return manifestJSON
+        }
+        let datasets = registry["datasets"] as? [[String: Any]] ?? []
+        if datasets.isEmpty {
+            return "No managed datasets found.\n"
+        }
+        let lines = datasets.map { dataset in
+            let repoID = (dataset["repo_id"] as? String) ?? ""
+            let revision = (dataset["revision"] as? String) ?? ""
+            let snapshotID = (dataset["snapshot_id"] as? String) ?? ""
+            let totalBytes = formatBinaryBytes(UInt64((dataset["total_bytes"] as? Int) ?? 0))
+            let path = (dataset["snapshot_path"] as? String) ?? ""
+            return "\(repoID)\t\(revision)\t\(snapshotID)\t\(totalBytes)\t\(path)"
+        }
+        return (["repo_id\trevision\tsnapshot_id\ttotal_bytes\tsnapshot_path"] + lines)
+            .joined(separator: "\n") + "\n"
+    }
+
     private func renderRegistrySnapshot(_ manifestJSON: String) -> String {
         guard
             let data = manifestJSON.data(using: .utf8),
@@ -6482,6 +6789,44 @@ public actor MelixCLIRunner {
             sourceKind: sourceKind,
             sourceLocator: sourceLocator,
             warnings: warnings
+        )
+    }
+
+    private func makeManagedDatasetReceipt(
+        from result: Melix_Controlplane_V1_ModelOperationResult
+    ) throws -> ManagedDatasetReceipt {
+        guard let data = result.manifestJson.data(using: .utf8) else {
+            throw MelixCLIError.runtime("Managed dataset operations must return a JSON manifest.")
+        }
+        let payloadObject: Any
+        do {
+            payloadObject = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw MelixCLIError.runtime("Managed dataset operations must return a JSON manifest.")
+        }
+        guard let payload = payloadObject as? [String: Any] else {
+            throw MelixCLIError.runtime("Managed dataset operations must return a JSON manifest.")
+        }
+        let datasetID = (payload["dataset_id"] as? String) ?? ""
+        let repoID = (payload["repo_id"] as? String) ?? ""
+        let revision = (payload["revision"] as? String) ?? ""
+        let snapshotID = (payload["snapshot_id"] as? String) ?? ""
+        let managedDatasetPath = (payload["snapshot_path"] as? String)
+            ?? (payload["output_path"] as? String)
+            ?? result.outputPath
+        let sourceKind = (payload["source_kind"] as? String) ?? "hf_cache_snapshot"
+
+        guard repoID.isEmpty == false, managedDatasetPath.isEmpty == false else {
+            throw MelixCLIError.runtime("Managed dataset manifest did not include a repo identifier and snapshot path.")
+        }
+
+        return ManagedDatasetReceipt(
+            datasetID: datasetID.isEmpty ? "\(repoID)@\(revision.isEmpty ? "main" : revision)" : datasetID,
+            repoID: repoID,
+            revision: revision.isEmpty ? "main" : revision,
+            snapshotID: snapshotID,
+            managedDatasetPath: managedDatasetPath,
+            sourceKind: sourceKind
         )
     }
 

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1538,6 +1538,10 @@ public enum MelixCLIParser {
       melix eval export-samples-csv --job-id JOB_ID --output PATH [--json]
       melix eval export-samples-jsonl --job-id JOB_ID --output PATH [--json]
       melix pipeline run --file PIPELINE.json [--inputs INPUTS.json] [--receipt-dir PATH] [--trace-id ID] [--resume] [--from-step STEP_ID] [--dry-run] [--format json-v1]
+
+    Notes:
+      --hf-token passed to model or dataset hub download is saved for later Hugging Face operations.
+      For eval run/compare, --hf-dataset-revision overrides a revision embedded in --dataset-ref.
     """
 
     private static func extractOutputFormat(
@@ -2690,7 +2694,7 @@ public enum MelixCLIParser {
                 parameters["batch_factor"] = batchFactor
             }
             if let datasetRef = values.single["--dataset-ref"], datasetRef.isEmpty == false {
-                let parsedRef = parseDatasetReference(datasetRef)
+                let parsedRef = try parseDatasetReference(datasetRef)
                 parameters["dataset_ref"] = datasetRef
                 parameters["hf_dataset_path"] = parsedRef.repoID
                 parameters["hf_dataset_revision"] = parsedRef.revision
@@ -2926,7 +2930,7 @@ public enum MelixCLIParser {
                     source: sourceConfiguration.source,
                     fieldMapping: sourceConfiguration.fieldMapping,
                     profile: sourceConfiguration.profile,
-                    parameters: parseEvalParameters(values),
+                    parameters: try parseEvalParameters(values),
                     evalPromptID: values.single["--eval-prompt-id"] ?? "",
                     evalPromptRevisionID: values.single["--eval-prompt-revision"] ?? "",
                     semanticJudgeRemoteServerID: semanticJudgeRemoteServerID,
@@ -3137,7 +3141,7 @@ public enum MelixCLIParser {
                 source: sourceConfiguration.source,
                 fieldMapping: sourceConfiguration.fieldMapping,
                 profile: sourceConfiguration.profile,
-                parameters: parseEvalParameters(values),
+                parameters: try parseEvalParameters(values),
                 json: values.flags.contains("--json")
             )
         )
@@ -3156,7 +3160,7 @@ public enum MelixCLIParser {
         return EvalExportOptions(jobID: jobID, outputPath: outputPath, json: values.flags.contains("--json"))
     }
 
-    private static func parseEvalParameters(_ values: ParsedArguments) -> [String: String] {
+    private static func parseEvalParameters(_ values: ParsedArguments) throws -> [String: String] {
         var parameters: [String: String] = [:]
         if let batchFactor = values.single["--batch-factor"] {
             parameters["batch_factor"] = batchFactor
@@ -3180,10 +3184,10 @@ public enum MelixCLIParser {
             parameters["remote_provider_extra_body_json"] = remoteExtraBodyJSON
         }
         if let datasetRef = values.single["--dataset-ref"], datasetRef.isEmpty == false {
-            let parsedRef = parseDatasetReference(datasetRef)
+            let parsedRef = try parseDatasetReference(datasetRef)
             parameters["dataset_ref"] = datasetRef
             parameters["hf_dataset_path"] = parsedRef.repoID
-            parameters["hf_dataset_revision"] = parsedRef.revision
+            parameters["hf_dataset_revision"] = values.single["--hf-dataset-revision"] ?? parsedRef.revision
         }
         return parameters
     }
@@ -3206,7 +3210,12 @@ public enum MelixCLIParser {
                 "At most one of --source-csv, --source-jsonl, --hf-dataset-path, or --dataset-ref may be provided for \(command)."
             )
         }
-        let parsedDatasetRef = datasetRef.isEmpty ? nil : parseDatasetReference(datasetRef)
+        let parsedDatasetRef: (repoID: String, revision: String)?
+        if datasetRef.isEmpty {
+            parsedDatasetRef = nil
+        } else {
+            parsedDatasetRef = try parseDatasetReference(datasetRef)
+        }
 
         let fieldMapping = ControlPlaneEvaluationRequest.FieldMapping(
             systemPath: values.single["--field-system-path"] ?? "",
@@ -3271,14 +3280,20 @@ public enum MelixCLIParser {
             .replacingOccurrences(of: "-", with: "_")
     }
 
-    private static func parseDatasetReference(_ datasetRef: String) -> (repoID: String, revision: String) {
+    private static func parseDatasetReference(_ datasetRef: String) throws -> (repoID: String, revision: String) {
         let trimmed = datasetRef.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let separator = trimmed.lastIndex(of: "@") else {
+            guard trimmed.isEmpty == false else {
+                throw MelixCLIError.usage("Invalid --dataset-ref: expected format is repo/name[@revision].")
+            }
             return (trimmed, "main")
         }
         let repoID = String(trimmed[..<separator]).trimmingCharacters(in: .whitespacesAndNewlines)
         let revision = String(trimmed[trimmed.index(after: separator)...])
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard repoID.isEmpty == false, repoID.contains("@") == false else {
+            throw MelixCLIError.usage("Invalid --dataset-ref: '\(repoID)' is not a valid repo id; expected format is repo/name[@revision].")
+        }
         return (repoID, revision.isEmpty ? "main" : revision)
     }
 
@@ -4029,7 +4044,7 @@ public actor MelixCLIRunner {
                     )
                 )
             }
-            return renderDatasetRegistrySnapshot(result.manifestJson)
+            return try renderDatasetRegistrySnapshot(result.manifestJson)
         case .datasetHubDownload(let options):
             let result = try await downloadHubDataset(repoID: options.repoID, revision: options.revision, hfToken: options.hfToken)
             let receipt = try makeManagedDatasetReceipt(from: result)
@@ -4040,7 +4055,7 @@ public actor MelixCLIRunner {
                 revision: options.revision,
                 snapshotID: options.snapshotID
             )
-            return options.json ? result.manifestJson : result.outputPath + "\n"
+            return options.json ? result.manifestJson : renderDatasetRemoveResult(result)
         case .modelRootsList(let options):
             let state = try loadOperatorState()
             if options.json {
@@ -5096,6 +5111,9 @@ public actor MelixCLIRunner {
         result.stage = stringValue("stage", from: payload)
         result.pct = Float(doubleValue("pct", from: payload))
         result.outputPath = stringValue("output_path", from: payload)
+        if result.outputPath.isEmpty, result.operation == "dataset_download" {
+            result.outputPath = stringValue("snapshot_path", from: payload)
+        }
         return result
     }
 
@@ -6085,13 +6103,13 @@ public actor MelixCLIRunner {
         ]
     }
 
-    private func renderDatasetRegistrySnapshot(_ manifestJSON: String) -> String {
+    private func renderDatasetRegistrySnapshot(_ manifestJSON: String) throws -> String {
         guard
             let data = manifestJSON.data(using: .utf8),
             let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
             let registry = payload["dataset_registry"] as? [String: Any]
         else {
-            return manifestJSON
+            throw MelixCLIError.runtime("dataset_snapshot response did not include a dataset_registry JSON object.")
         }
         let datasets = registry["datasets"] as? [[String: Any]] ?? []
         if datasets.isEmpty {
@@ -6101,12 +6119,44 @@ public actor MelixCLIRunner {
             let repoID = (dataset["repo_id"] as? String) ?? ""
             let revision = (dataset["revision"] as? String) ?? ""
             let snapshotID = (dataset["snapshot_id"] as? String) ?? ""
-            let totalBytes = formatBinaryBytes(UInt64((dataset["total_bytes"] as? Int) ?? 0))
+            let totalBytes = formatBinaryBytes((dataset["total_bytes"] as? NSNumber)?.uint64Value ?? 0)
             let path = (dataset["snapshot_path"] as? String) ?? ""
             return "\(repoID)\t\(revision)\t\(snapshotID)\t\(totalBytes)\t\(path)"
         }
         return (["repo_id\trevision\tsnapshot_id\ttotal_bytes\tsnapshot_path"] + lines)
             .joined(separator: "\n") + "\n"
+    }
+
+    private func renderDatasetRemoveResult(_ result: Melix_Controlplane_V1_ModelOperationResult) -> String {
+        let outputPath = result.outputPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if outputPath.isEmpty == false {
+            return outputPath + "\n"
+        }
+        guard
+            let data = result.manifestJson.data(using: .utf8),
+            let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return "Dataset removal completed.\n"
+        }
+
+        let repoID = (payload["repo_id"] as? String) ?? ""
+        let revision = (payload["revision"] as? String) ?? ""
+        let snapshotID = (payload["snapshot_id"] as? String)
+            ?? (payload["removed_snapshot_id"] as? String)
+            ?? ""
+        let removedPath = (payload["removed_snapshot_path"] as? String) ?? ""
+        let datasetLabel = [
+            repoID,
+            revision.isEmpty ? "" : "@\(revision)",
+            snapshotID.isEmpty ? "" : " (\(snapshotID))",
+        ].joined()
+        let headline = datasetLabel.isEmpty
+            ? "Removed dataset snapshot."
+            : "Removed dataset snapshot \(datasetLabel)."
+        if removedPath.isEmpty {
+            return headline + "\n"
+        }
+        return headline + "\nRemoved path: \(removedPath)\n"
     }
 
     private func renderRegistrySnapshot(_ manifestJSON: String) -> String {
@@ -6811,6 +6861,8 @@ public actor MelixCLIRunner {
         let repoID = (payload["repo_id"] as? String) ?? ""
         let revision = (payload["revision"] as? String) ?? ""
         let snapshotID = (payload["snapshot_id"] as? String) ?? ""
+        // snapshot_path is the canonical worker field; output_path and the
+        // stream output path cover older or newer worker versions during skew.
         let managedDatasetPath = (payload["snapshot_path"] as? String)
             ?? (payload["output_path"] as? String)
             ?? result.outputPath

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -30,6 +30,12 @@ public enum MelixCLICommandCodec {
             return "model.hub.show"
         case .modelHubDownload:
             return "model.hub.download"
+        case .datasetList:
+            return "dataset.list"
+        case .datasetHubDownload:
+            return "dataset.hub.download"
+        case .datasetRemove:
+            return "dataset.remove"
         case .modelRootsList:
             return "model.roots.list"
         case .modelRootsAdd:
@@ -210,6 +216,21 @@ public enum MelixCLICommandCodec {
             appendOption("--repo-id", value: options.repoID, into: &arguments)
             appendOption("--revision", value: options.revision, into: &arguments)
             appendOption("--hf-token", value: options.hfToken, into: &arguments)
+            json = options.json
+        case .datasetList(let options):
+            arguments = ["dataset", "list"]
+            json = options.json
+        case .datasetHubDownload(let options):
+            arguments = ["dataset", "hub", "download"]
+            appendOption("--repo-id", value: options.repoID, into: &arguments)
+            appendOption("--revision", value: options.revision, into: &arguments)
+            appendOption("--hf-token", value: options.hfToken, into: &arguments)
+            json = options.json
+        case .datasetRemove(let options):
+            arguments = ["dataset", "remove"]
+            appendOption("--repo-id", value: options.repoID, into: &arguments)
+            appendOption("--revision", value: options.revision, into: &arguments)
+            appendOption("--snapshot-id", value: options.snapshotID, into: &arguments)
             json = options.json
         case .modelRootsRescan(let options):
             arguments = ["model", "roots", "rescan"]
@@ -402,6 +423,14 @@ public enum MelixCLICommandCodec {
             appendOption("--structured-output-mode", value: options.structuredOutputMode, into: &arguments)
             appendOption("--sample-size", value: options.parameters["sample_size"], into: &arguments)
             appendOption("--batch-factor", value: options.parameters["batch_factor"], into: &arguments)
+            appendOption("--dataset-ref", value: options.parameters["dataset_ref"], into: &arguments)
+            appendOption("--hf-dataset-name", value: options.parameters["hf_dataset_name"], into: &arguments)
+            appendOption("--hf-dataset-split", value: options.parameters["hf_dataset_split"], into: &arguments)
+            appendOption("--prompt-feature", value: options.parameters["prompt_feature"], into: &arguments)
+            appendOption("--text-feature", value: options.parameters["text_feature"], into: &arguments)
+            appendOption("--image-feature", value: options.parameters["image_feature"], into: &arguments)
+            appendOption("--source-image-feature", value: options.parameters["source_image_feature"], into: &arguments)
+            appendOption("--mask-feature", value: options.parameters["mask_feature"], into: &arguments)
             json = options.json
         case .benchMatrixRun(let options):
             arguments = ["bench", "matrix", "run"]

--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -77,6 +77,26 @@ When `hf_repo_id` is used:
 - the imported target must appear in persisted run metadata as `source_repo`
 - the control plane remains the orchestration truth for target resolution
 
+## Shared Dataset Selection
+
+Both product lines may run against an operator-selected managed dataset using a
+dataset reference in the form `repo_id[@revision]`.
+
+When a managed dataset reference is provided:
+
+- `repo_id` is the Hugging Face dataset repository id
+- `revision` defaults to `main`
+- the worker should prefer a local Hugging Face cache snapshot under
+  `~/.cache/huggingface/hub/datasets--*`
+- if no local snapshot is available, the evaluation and benchmark materializers
+  may fall back to the Hugging Face Dataset Viewer API
+- persisted run parameters must include `dataset_ref`, `hf_dataset_path`, and
+  `hf_dataset_revision`
+
+Dataset references select the dataset source only. Existing field mapping,
+split, config, sample-size, and suite semantics still determine how rows become
+benchmark prompts or evaluation samples.
+
 ## Task Kinds
 
 Melix benchmark and evaluation targets use the following task-aligned values:

--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -85,7 +85,11 @@ dataset reference in the form `repo_id[@revision]`.
 When a managed dataset reference is provided:
 
 - `repo_id` is the Hugging Face dataset repository id
+- `repo_id` must not contain `@`; malformed references are rejected before
+  reaching worker-side Hugging Face calls
 - `revision` defaults to `main`
+- for evaluation commands that also pass `--hf-dataset-revision`, the explicit
+  revision option takes precedence over the revision embedded in `dataset_ref`
 - the worker should prefer a local Hugging Face cache snapshot under
   `~/.cache/huggingface/hub/datasets--*`
 - if no local snapshot is available, the evaluation and benchmark materializers

--- a/docs/plans/2026-05-05-dataset-management-and-selection.md
+++ b/docs/plans/2026-05-05-dataset-management-and-selection.md
@@ -1,0 +1,118 @@
+# Dataset Management And Selection
+
+## Context
+
+Melix model management already treats the default Hugging Face hub cache as an
+implicit local root. Operators can download a model through `melix model hub
+download`, rescan the registry, and then use the cached snapshot as a managed
+local artifact. Datasets need the same local-first treatment so benchmark,
+evaluation, and training workflows can reuse datasets that were downloaded with
+Melix or with the Hugging Face CLI.
+
+## Goals
+
+- Discover Hugging Face dataset snapshots under the default hub cache
+  (`~/.cache/huggingface/hub/datasets--*`) without requiring a separate import.
+- Add CLI dataset management commands for listing, downloading, and removing
+  managed dataset snapshots.
+- Download datasets through the same model-operation job channel used by model
+  hub downloads, while passing `repo_type="dataset"` to Hugging Face Hub.
+- Remove only snapshot working trees from the HF cache. Blob and lock cleanup is
+  intentionally out of scope because those files may be shared by other
+  revisions.
+- Let `bench run` and `eval run` accept an explicit managed dataset reference.
+- Make evaluation HF dataset materialization prefer a local cached snapshot
+  before falling back to the Hugging Face Dataset Viewer API.
+
+## Non-Goals
+
+- No new protobuf RPCs in this slice. Dataset management reuses
+  `ConvertModelRequest.ext.operation`, matching the current model operations
+  path and avoiding generated artifact churn.
+- No dataset root CRUD in the first slice. The implicit HF cache root is the
+  required local-first source of truth; extra roots can follow after the data
+  model settles.
+- No blob reference counting or cache vacuuming.
+- No broad desktop UI redesign. The CLI and worker semantics are the stable
+  backend contract for a later UI surface.
+
+## Design
+
+### Dataset Snapshot Catalog
+
+The worker owns a small dataset catalog that scans the default HF hub cache for
+directories named `datasets--*`. Each repo directory is interpreted as:
+
+- `datasets--org--repo` -> `org/repo`
+- `datasets--repo` -> `repo`
+
+For each `snapshots/<sha>` directory the catalog records:
+
+- `dataset_id`: `repo_id@revision`
+- `repo_id`
+- `revision`, resolved from `refs/*` when present, otherwise the snapshot hash
+- `snapshot_id`
+- `snapshot_path`
+- `source_kind`: `hf_cache_snapshot`
+- file inventory for JSONL, JSON, CSV, Parquet, Arrow, and README files
+- total snapshot bytes
+- inferred split names from dataset file names
+- a restore command using `melix dataset hub download`
+
+### Operations
+
+Dataset operations use the existing `ConvertModel` stream:
+
+- `dataset_snapshot`: emits a manifest containing `dataset_registry.datasets`
+- `dataset_download`: calls `snapshot_download(..., repo_type="dataset")`,
+  then emits a completed manifest for the cached snapshot
+- `dataset_remove`: resolves a repo plus revision or snapshot id and removes
+  only `snapshots/<sha>`
+
+HF tokens use the same CLI token store as model hub downloads. Worker manifests
+must not echo tokens.
+
+### Selection
+
+`melix eval run --dataset-ref REPO[@REV]` is equivalent to passing
+`--hf-dataset-path REPO --hf-dataset-revision REV`, with the additional intent
+that the worker should prefer a locally cached snapshot. `--hf-dataset-name`,
+`--hf-dataset-split`, and the existing field mapping options keep their current
+meaning.
+
+`melix bench run --dataset-ref REPO[@REV]` overrides the suite dataset source.
+The existing suite prompt/image feature defaults remain in force unless the
+operator passes explicit dataset feature options. The selected dataset reference
+is persisted in benchmark parameters and suite metadata.
+
+### Local Materialization
+
+When a requested HF dataset snapshot is present locally, materialization reads
+rows directly from supported snapshot files:
+
+- `.jsonl`
+- `.json`
+- `.csv`
+- `.parquet` when `pyarrow` is available
+
+If no local snapshot can satisfy the request, the existing Dataset Viewer API
+fallback remains in place.
+
+## Verification Plan
+
+- Python unit tests for synthetic HF dataset cache scanning, row loading,
+  download manifest behavior, safe snapshot removal, and local evaluation
+  materialization.
+- Swift parser and runner tests for new `dataset` commands, `--dataset-ref`
+  parsing, token redaction/reuse, and benchmark/evaluation parameter plumbing.
+- Targeted commands:
+  - `uv run pytest services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_benchmark_suites.py`
+  - `swift test --filter MelixCLIParserTests`
+  - `swift test --filter MelixCLIRunnerTests`
+
+## Metrics Report
+
+Changed-scope coverage is measurable for the Python and Swift test scopes above.
+The success criterion before handoff is targeted test pass plus an explicit
+coverage or N/A note if the local coverage tooling does not support the touched
+mixed Python/Swift slice in one command.

--- a/docs/plans/2026-05-05-dataset-management-and-selection.md
+++ b/docs/plans/2026-05-05-dataset-management-and-selection.md
@@ -38,6 +38,22 @@ Melix or with the Hugging Face CLI.
 
 ## Design
 
+### Review Follow-Up Decisions
+
+The PR review follow-up keeps the dataset reference grammar shared across Swift
+and Python implementations: `repo_id[@revision]`, with `revision` defaulting to
+`main` and embedded `@` characters rejected in the `repo_id` portion. When an
+evaluation command passes both `--dataset-ref REPO@REV` and
+`--hf-dataset-revision OTHER`, the explicit revision option remains the
+precedence rule for backward compatibility and must be documented in the CLI
+contract.
+
+Local cached snapshots are an optimization, not an availability boundary. If a
+requested local snapshot is present but cannot satisfy the requested split, the
+benchmark materializer falls through to the Hugging Face Dataset Viewer API just
+as the evaluation materializer does. Reader implementations must apply sample
+limits before converting Arrow or Parquet tables to Python dictionaries.
+
 ### Dataset Snapshot Catalog
 
 The worker owns a small dataset catalog that scans the default HF hub cache for
@@ -106,13 +122,30 @@ fallback remains in place.
 - Swift parser and runner tests for new `dataset` commands, `--dataset-ref`
   parsing, token redaction/reuse, and benchmark/evaluation parameter plumbing.
 - Targeted commands:
-  - `uv run pytest services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_benchmark_suites.py`
+  - `PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_benchmark_suites.py services/mlx-worker-python/tests/test_maintenance_service.py -q`
   - `swift test --filter MelixCLIParserTests`
   - `swift test --filter MelixCLIRunnerTests`
+  - `swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'`
 
 ## Metrics Report
 
-Changed-scope coverage is measurable for the Python and Swift test scopes above.
-The success criterion before handoff is targeted test pass plus an explicit
-coverage or N/A note if the local coverage tooling does not support the touched
-mixed Python/Swift slice in one command.
+Review follow-up metrics from the focused handoff:
+
+- Python targeted tests: 207 passed.
+- Swift parser tests: 69 passed.
+- Swift runner tests: 158 passed.
+- Swift parser plus runner coverage tests: 227 passed.
+- Python production changed-line coverage:
+  `TOTAL 100.00% 31/31` across `dataset_registry/catalog.py`,
+  `engine/maintenance_core.py`, `productization/benchmark_suites.py`, and
+  `productization/evaluation_final_result.py`.
+- Python production plus touched-test changed-line coverage:
+  `TOTAL 99.29% 139/140`.
+- Swift changed-line coverage for `Sources/MelixCLICore/MelixCLI.swift`,
+  `tests/MelixCLITests/MelixCLIParserTests.swift`, and
+  `tests/MelixCLITests/MelixCLIRunnerTests.swift`: `98.45%` (`254/258`).
+- Focused Python statement report for touched production files:
+  `catalog.py` 97%, `maintenance_core.py` 94%, `benchmark_suites.py` 98%,
+  `evaluation_final_result.py` 75%, total 92%. The lower statement totals are
+  from existing broad modules; changed-line coverage above is the commit gate
+  for the review follow-up.

--- a/services/mlx-worker-python/tests/test_benchmark_suites.py
+++ b/services/mlx-worker-python/tests/test_benchmark_suites.py
@@ -111,6 +111,7 @@ def test_benchmark_suite_catalog_materializes_curated_hf_suite_and_reuses_cache(
     assert len(first.prompt_batches) == 2
     assert first.prompt_batches[0] == "Say hi.\n\nSay bye."
     assert first.metadata()["dataset_uri"].startswith("hf://HuggingFaceH4/ultrachat_200k")
+    assert first.metadata()["source_kind"] == "hf_dataset"
 
 
 def test_load_materialized_rows_streams_without_read_text(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -558,6 +559,10 @@ def test_parse_positive_int_returns_default_for_non_numeric_and_empty_input() ->
     assert benchmark_suites._parse_positive_int("  ", 4) == 4
 
 
+def test_benchmark_dataset_ref_parser_supports_explicit_revision() -> None:
+    assert benchmark_suites._parse_dataset_ref("org/bench@feature-branch") == ("org/bench", "feature-branch")
+
+
 def test_benchmark_suite_catalog_raises_for_unknown_task_kind(tmp_path: Path) -> None:
     catalog = BenchmarkSuiteCatalog(hf_dataset_fetcher=FakeBenchmarkSuiteFetcher())
 
@@ -571,3 +576,48 @@ def test_benchmark_suite_catalog_raises_for_unknown_task_kind(tmp_path: Path) ->
 
     assert error.value.code == "invalid_benchmark_suite"
     assert error.value.details == {"suite_id": "smoke", "task_kind": "audio-to-text"}
+
+
+def test_benchmark_suite_dataset_ref_prefers_local_cache_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    cache_repo = home / ".cache" / "huggingface" / "hub" / "datasets--org--bench"
+    snapshot = cache_repo / "snapshots" / "abc123"
+    data_dir = snapshot / "data"
+    data_dir.mkdir(parents=True)
+    (cache_repo / "refs").mkdir()
+    (cache_repo / "refs" / "main").write_text("abc123", encoding="utf-8")
+    (data_dir / "train-00000-of-00001.jsonl").write_text(
+        '{"instruction":"Use the local cache."}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+
+    def fail_fetcher(endpoint: str, params: dict[str, str]) -> dict[str, object]:
+        raise AssertionError(f"unexpected remote fetch {endpoint} {params}")
+
+    catalog = BenchmarkSuiteCatalog(hf_dataset_fetcher=fail_fetcher)
+    suite = catalog.resolve_suite(
+        "latency",
+        jobs_root=tmp_path / "jobs",
+        parameters={
+            "dataset_ref": "org/bench",
+            "prompt_feature": "instruction",
+            "sample_size": "1",
+        },
+        task_kind="text-generation",
+    )
+    manifest = json.loads((suite.materialized_package_path / "manifest.json").read_text(encoding="utf-8"))
+
+    assert suite.dataset_path == "org/bench"
+    assert suite.dataset_revision == "main"
+    assert suite.prompt_batches == ("Use the local cache.",)
+    assert suite.cache_hit is False
+    assert suite.metadata()["source_kind"] == "hf_cache_snapshot"
+    assert suite.metadata()["hf_snapshot_id"] == "abc123"
+    assert suite.metadata()["hf_snapshot_path"] == str(snapshot.resolve())
+    assert manifest["source_kind"] == "hf_cache_snapshot"
+    assert manifest["hf_snapshot_id"] == "abc123"
+    assert manifest["hf_snapshot_path"] == str(snapshot.resolve())

--- a/services/mlx-worker-python/tests/test_benchmark_suites.py
+++ b/services/mlx-worker-python/tests/test_benchmark_suites.py
@@ -561,6 +561,9 @@ def test_parse_positive_int_returns_default_for_non_numeric_and_empty_input() ->
 
 def test_benchmark_dataset_ref_parser_supports_explicit_revision() -> None:
     assert benchmark_suites._parse_dataset_ref("org/bench@feature-branch") == ("org/bench", "feature-branch")
+    with pytest.raises(ModelOperationError) as error:
+        benchmark_suites._parse_dataset_ref("org@bench@main")
+    assert error.value.code == "invalid_argument"
 
 
 def test_benchmark_suite_catalog_raises_for_unknown_task_kind(tmp_path: Path) -> None:
@@ -621,3 +624,58 @@ def test_benchmark_suite_dataset_ref_prefers_local_cache_snapshot(
     assert manifest["source_kind"] == "hf_cache_snapshot"
     assert manifest["hf_snapshot_id"] == "abc123"
     assert manifest["hf_snapshot_path"] == str(snapshot.resolve())
+
+
+def test_benchmark_suite_dataset_ref_falls_back_when_local_split_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    cache_repo = home / ".cache" / "huggingface" / "hub" / "datasets--org--bench"
+    snapshot = cache_repo / "snapshots" / "abc123"
+    data_dir = snapshot / "data"
+    data_dir.mkdir(parents=True)
+    (cache_repo / "refs").mkdir()
+    (cache_repo / "refs" / "main").write_text("abc123", encoding="utf-8")
+    (data_dir / "test-00000-of-00001.jsonl").write_text(
+        '{"instruction":"Wrong split."}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    def fetcher(endpoint: str, params: dict[str, str]) -> dict[str, object]:
+        calls.append((endpoint, dict(params)))
+        assert endpoint == "rows"
+        return {"rows": [{"row": {"instruction": "Use the remote fallback."}}]}
+
+    catalog = BenchmarkSuiteCatalog(hf_dataset_fetcher=fetcher)
+    suite = catalog.resolve_suite(
+        "latency",
+        jobs_root=tmp_path / "jobs",
+        parameters={
+            "dataset_ref": "org/bench",
+            "prompt_feature": "instruction",
+            "sample_size": "1",
+        },
+        task_kind="text-generation",
+    )
+    manifest = json.loads((suite.materialized_package_path / "manifest.json").read_text(encoding="utf-8"))
+
+    assert calls == [
+        (
+            "rows",
+            {
+                "dataset": "org/bench",
+                "config": "default",
+                "split": "train",
+                "offset": "0",
+                "length": "8",
+            },
+        )
+    ]
+    assert suite.prompt_batches == ("Use the remote fallback.",)
+    assert suite.metadata()["source_kind"] == "hf_dataset"
+    assert "hf_snapshot_id" not in suite.metadata()
+    assert manifest["source_kind"] == "hf_dataset"
+    assert "hf_snapshot_id" not in manifest

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+import worker.dataset_registry.catalog as catalog
+from worker.model_ops.errors import ModelOperationError
+from worker.dataset_registry.catalog import (
+    DatasetCatalog,
+    read_hf_dataset_snapshot_rows,
+)
+
+
+def _write_hf_dataset_snapshot(
+    home: Path,
+    *,
+    repo_dir_name: str = "datasets--org--repo",
+    snapshot_id: str = "abc123",
+    revision: str = "main",
+    rows: list[dict[str, object]] | None = None,
+) -> Path:
+    cache_repo_dir = home / ".cache" / "huggingface" / "hub" / repo_dir_name
+    snapshot_dir = cache_repo_dir / "snapshots" / snapshot_id
+    snapshot_dir.mkdir(parents=True)
+    (cache_repo_dir / "refs").mkdir()
+    (cache_repo_dir / "refs" / revision).write_text(snapshot_id, encoding="utf-8")
+    data_dir = snapshot_dir / "data"
+    data_dir.mkdir()
+    with (data_dir / "train-00000-of-00001.jsonl").open("w", encoding="utf-8") as handle:
+        for row in rows or [{"prompt": "hello", "answer": "world"}]:
+            handle.write(json.dumps(row))
+            handle.write("\n")
+    (snapshot_dir / "README.md").write_text("# Dataset\n", encoding="utf-8")
+    return snapshot_dir
+
+
+def test_dataset_catalog_discovers_default_huggingface_cache_snapshot(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    snapshot_dir = _write_hf_dataset_snapshot(home)
+
+    payload = DatasetCatalog(environment={"HOME": str(home)}).registry_snapshot_payload()
+
+    datasets = payload["datasets"]
+    assert len(datasets) == 1
+    dataset = datasets[0]
+    assert dataset["dataset_id"] == "org/repo@main"
+    assert dataset["repo_id"] == "org/repo"
+    assert dataset["revision"] == "main"
+    assert dataset["snapshot_id"] == "abc123"
+    assert dataset["snapshot_path"] == str(snapshot_dir.resolve())
+    assert dataset["source_kind"] == "hf_cache_snapshot"
+    assert dataset["splits"] == ["train"]
+    assert dataset["configs"] == ["default"]
+    assert dataset["total_bytes"] > 0
+    assert dataset["restore_command"] == "melix dataset hub download --repo-id org/repo --revision main"
+
+
+def test_dataset_catalog_reports_unavailable_roots_and_filters_snapshots(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    _write_hf_dataset_snapshot(home)
+    cache_root = home / ".cache" / "huggingface" / "hub"
+    missing_root = tmp_path / "missing-root"
+
+    payload = DatasetCatalog(environment={"HOME": str(home)}).registry_snapshot_payload(
+        repo_id="org/repo",
+        revision="missing",
+        roots=[missing_root, cache_root],
+    )
+
+    assert payload["datasets"] == []
+    assert payload["roots"][0]["accessible"] is False
+    assert payload["roots"][0]["error_code"] == "not_found"
+    assert payload["roots"][1]["accessible"] is True
+    assert payload["roots"][1]["discovered_dataset_ids"] == []
+
+    repo_filtered = DatasetCatalog(environment={"HOME": str(home)}).registry_snapshot_payload(
+        repo_id="other/repo",
+        roots=[cache_root],
+    )
+    assert repo_filtered["datasets"] == []
+
+
+def test_dataset_catalog_reports_scan_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    root = tmp_path / "hub"
+    root.mkdir()
+
+    def fail_scan(_root: Path):
+        raise OSError("boom")
+
+    monkeypatch.setattr(DatasetCatalog, "_scan_root", staticmethod(fail_scan))
+
+    payload = DatasetCatalog(environment={"HOME": str(tmp_path)}).registry_snapshot_payload(roots=[root])
+
+    assert payload["roots"][0]["accessible"] is False
+    assert payload["roots"][0]["error_code"] == "scan_failed"
+    assert payload["roots"][0]["error_message"] == "boom"
+
+
+def test_dataset_catalog_resolves_by_revision_snapshot_id_and_missing_roots(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    snapshot_dir = _write_hf_dataset_snapshot(home)
+    cache_root = home / ".cache" / "huggingface" / "hub"
+    catalog_instance = DatasetCatalog(environment={"HOME": str(home)})
+
+    assert catalog_instance.resolve_snapshot(repo_id="") is None
+    assert catalog_instance.resolve_snapshot(repo_id="org/repo", roots=[tmp_path / "missing"]) is None
+    by_revision = catalog_instance.resolve_snapshot(repo_id="org/repo", revision="main")
+    by_snapshot = catalog_instance.resolve_snapshot(repo_id="org/repo", snapshot_id="abc123")
+    wrong_snapshot = catalog_instance.resolve_snapshot(repo_id="org/repo", snapshot_id="missing")
+
+    assert by_revision is not None
+    assert by_revision.snapshot_path == snapshot_dir.resolve()
+    assert by_snapshot is not None
+    assert by_snapshot.snapshot_id == "abc123"
+    assert wrong_snapshot is None
+    assert catalog_instance.snapshot_for_path(tmp_path / "outside") is None
+    assert catalog_instance.snapshot_for_path(cache_root / "not-a-snapshot") is None
+    invalid_repo_snapshot = cache_root / "datasets--" / "snapshots" / "abc123"
+    invalid_repo_snapshot.mkdir(parents=True)
+    assert catalog_instance.snapshot_for_path(invalid_repo_snapshot) is None
+
+
+def test_dataset_catalog_reads_rows_from_selected_split(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    snapshot_dir = _write_hf_dataset_snapshot(
+        home,
+        rows=[
+            {"prompt": "first", "answer": "a"},
+            {"prompt": "second", "answer": "b"},
+        ],
+    )
+    (snapshot_dir / "data" / "test.jsonl").write_text('{"prompt":"test","answer":"c"}\n', encoding="utf-8")
+
+    rows = read_hf_dataset_snapshot_rows(snapshot_dir, split="test")
+
+    assert rows == [{"prompt": "test", "answer": "c"}]
+
+
+def test_dataset_catalog_row_reader_respects_limit(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    snapshot_dir = _write_hf_dataset_snapshot(
+        home,
+        rows=[
+            {"prompt": "first", "answer": "a"},
+            {"prompt": "second", "answer": "b"},
+        ],
+    )
+
+    rows = read_hf_dataset_snapshot_rows(snapshot_dir, split="train", limit=1)
+
+    assert rows == [{"prompt": "first", "answer": "a"}]
+
+
+def test_dataset_catalog_reads_json_and_csv_snapshots(tmp_path: Path) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    data_dir = snapshot_dir / "custom"
+    data_dir.mkdir(parents=True)
+    (data_dir / "validation.json").write_text(
+        json.dumps({"rows": [{"prompt": "json-row"}]}),
+        encoding="utf-8",
+    )
+    (data_dir / "train.csv").write_text("prompt,answer\ncsv-row,ok\n", encoding="utf-8")
+
+    assert read_hf_dataset_snapshot_rows(snapshot_dir, split="validation") == [{"prompt": "json-row"}]
+    assert read_hf_dataset_snapshot_rows(snapshot_dir, split="train") == [{"prompt": "csv-row", "answer": "ok"}]
+    assert read_hf_dataset_snapshot_rows(snapshot_dir, split="missing", limit=1) == [{"prompt": "csv-row", "answer": "ok"}]
+
+
+def test_dataset_catalog_reads_parquet_and_arrow_with_fake_pyarrow(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    parquet_path = tmp_path / "train.parquet"
+    arrow_path = tmp_path / "train.arrow"
+    parquet_path.write_bytes(b"parquet")
+    arrow_path.write_bytes(b"arrow")
+
+    pyarrow_module = types.ModuleType("pyarrow")
+    pyarrow_module.__path__ = []
+    parquet_module = types.ModuleType("pyarrow.parquet")
+    parquet_module.read_table = lambda _path: types.SimpleNamespace(to_pylist=lambda: [{"prompt": "parquet"}, "ignored"])
+
+    class FakeArrowReader:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def read_all(self):
+            return types.SimpleNamespace(to_pylist=lambda: [{"prompt": "arrow"}, "ignored"])
+
+    ipc_module = types.ModuleType("pyarrow.ipc")
+    ipc_module.open_file = lambda _path: FakeArrowReader()
+
+    monkeypatch.setitem(sys.modules, "pyarrow", pyarrow_module)
+    monkeypatch.setitem(sys.modules, "pyarrow.parquet", parquet_module)
+    monkeypatch.setitem(sys.modules, "pyarrow.ipc", ipc_module)
+
+    assert catalog._read_rows_from_file(parquet_path) == [{"prompt": "parquet"}]
+    assert catalog._read_rows_from_file(arrow_path) == [{"prompt": "arrow"}]
+
+
+def test_dataset_catalog_surfaces_missing_pyarrow(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    parquet_path = tmp_path / "train.parquet"
+    arrow_path = tmp_path / "train.arrow"
+    parquet_path.write_bytes(b"parquet")
+    arrow_path.write_bytes(b"arrow")
+    original_import = __import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {"pyarrow.parquet", "pyarrow.ipc"}:
+            raise ImportError(name)
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    with pytest.raises(ModelOperationError) as parquet_error:
+        catalog._read_rows_from_file(parquet_path)
+    assert parquet_error.value.code == "unavailable"
+
+    with pytest.raises(ModelOperationError) as arrow_error:
+        catalog._read_rows_from_file(arrow_path)
+    assert arrow_error.value.code == "unavailable"
+
+
+def test_dataset_catalog_json_payload_helpers_cover_supported_shapes() -> None:
+    assert catalog._rows_from_json_payload([{"a": 1}, ["ignored"]]) == [{"a": 1}]
+    assert catalog._rows_from_json_payload({"data": [{"a": 2}]}) == [{"a": 2}]
+    assert catalog._rows_from_json_payload({"items": [{"a": 3}]}) == [{"a": 3}]
+    assert catalog._rows_from_json_payload({"single": "row"}) == [{"single": "row"}]
+    assert catalog._rows_from_json_payload("ignored") == []
+
+
+def test_dataset_catalog_downloads_dataset_repo_type_without_leaking_token(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    snapshot_dir = _write_hf_dataset_snapshot(home, repo_dir_name="datasets--org--downloaded")
+    captured_kwargs: dict[str, object] = {}
+
+    def fake_snapshot_download(**kwargs):
+        captured_kwargs.update(kwargs)
+        return str(snapshot_dir)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        types.SimpleNamespace(snapshot_download=fake_snapshot_download),
+    )
+
+    result = DatasetCatalog(environment={"HOME": str(home)}).download_hf_dataset(
+        repo_id="org/downloaded",
+        revision="main",
+        hf_token="hf_secret",
+        job_id="job-1",
+        output_dir=tmp_path / "job",
+    )
+
+    assert captured_kwargs["repo_type"] == "dataset"
+    assert captured_kwargs["repo_id"] == "org/downloaded"
+    assert captured_kwargs["token"] == "hf_secret"
+    assert result.snapshot.repo_id == "org/downloaded"
+    assert "hf_secret" not in json.dumps(result.manifest)
+    assert result.manifest["snapshot_path"] == str(snapshot_dir.resolve())
+
+
+def test_dataset_catalog_download_validates_repo_and_hub_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ModelOperationError) as invalid_error:
+        DatasetCatalog().download_hf_dataset(repo_id="")
+    assert invalid_error.value.code == "invalid_argument"
+
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+    with pytest.raises(ModelOperationError) as import_error:
+        DatasetCatalog().download_hf_dataset(repo_id="org/repo")
+    assert import_error.value.code == "unavailable"
+    monkeypatch.delitem(sys.modules, "huggingface_hub", raising=False)
+
+    class AuthFailure(Exception):
+        def __init__(self) -> None:
+            super().__init__("private")
+            self.response = types.SimpleNamespace(status_code=401)
+
+    class HubFailure(Exception):
+        pass
+
+    HubFailure.__module__ = "huggingface_hub.errors"
+
+    def auth_download(**_kwargs):
+        raise AuthFailure()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        types.SimpleNamespace(snapshot_download=auth_download),
+    )
+    with pytest.raises(ModelOperationError) as auth_error:
+        DatasetCatalog().download_hf_dataset(repo_id="org/private")
+    assert auth_error.value.code == "hf_auth_failed"
+
+    def hub_download(**_kwargs):
+        raise HubFailure("offline")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        types.SimpleNamespace(snapshot_download=hub_download),
+    )
+    with pytest.raises(ModelOperationError) as hub_error:
+        DatasetCatalog().download_hf_dataset(repo_id="org/repo")
+    assert hub_error.value.code == "unavailable"
+
+    fallback_snapshot = tmp_path / "manual" / "snapshots" / "def456"
+    fallback_snapshot.mkdir(parents=True)
+    (fallback_snapshot / "train.jsonl").write_text('{"prompt":"fallback"}\n', encoding="utf-8")
+
+    def fallback_download(**_kwargs):
+        return str(fallback_snapshot)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        types.SimpleNamespace(snapshot_download=fallback_download),
+    )
+    result = DatasetCatalog(environment={"HOME": str(tmp_path / "home")}).download_hf_dataset(
+        repo_id="org/fallback",
+        revision="rev",
+    )
+    assert result.snapshot.repo_id == "org/fallback"
+    assert result.snapshot.snapshot_path == fallback_snapshot.resolve()
+
+    def unexpected_download(**_kwargs):
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        types.SimpleNamespace(snapshot_download=unexpected_download),
+    )
+    with pytest.raises(RuntimeError):
+        DatasetCatalog().download_hf_dataset(repo_id="org/repo")
+
+
+def test_dataset_catalog_remove_deletes_only_selected_snapshot(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    snapshot_dir = _write_hf_dataset_snapshot(home)
+
+    result = DatasetCatalog(environment={"HOME": str(home)}).remove_hf_dataset_snapshot(
+        repo_id="org/repo",
+        revision="main",
+        job_id="job-remove",
+        output_dir=tmp_path / "job",
+    )
+
+    assert result.removed_snapshot.snapshot_id == "abc123"
+    assert result.manifest["removed_snapshot_path"] == str(snapshot_dir.resolve())
+    assert not snapshot_dir.exists()
+    assert snapshot_dir.parents[1].exists()
+
+
+def test_dataset_catalog_remove_validates_target(tmp_path: Path) -> None:
+    with pytest.raises(ModelOperationError) as invalid_error:
+        DatasetCatalog().remove_hf_dataset_snapshot(repo_id="")
+    assert invalid_error.value.code == "invalid_argument"
+
+    with pytest.raises(ModelOperationError) as missing_error:
+        DatasetCatalog(environment={"HOME": str(tmp_path)}).remove_hf_dataset_snapshot(
+            repo_id="org/missing",
+            revision="main",
+            snapshot_id="missing",
+        )
+    assert missing_error.value.code == "not_found"
+    assert missing_error.value.details == {
+        "repo_id": "org/missing",
+        "revision": "main",
+        "snapshot_id": "missing",
+    }
+
+
+def test_dataset_catalog_private_helpers_cover_cache_edge_cases(tmp_path: Path) -> None:
+    assert catalog.default_huggingface_cache_root(environment={}).name == "hub"
+    assert catalog._hf_dataset_repo_id(tmp_path / "models--org--repo") is None
+    assert catalog._hf_dataset_repo_id(tmp_path / "datasets--") is None
+    assert catalog._hf_dataset_repo_id(tmp_path / "datasets--repo") == "repo"
+    assert catalog._hf_dataset_repo_id(tmp_path / "datasets--org--repo") == "org/repo"
+    assert catalog._hf_dataset_repo_id(tmp_path / "datasets----repo") is None
+    assert catalog._hf_dataset_repo_id(tmp_path / "datasets--org--") is None
+
+    cache_repo = tmp_path / "datasets--org--repo"
+    assert catalog._hf_cache_revision_map(cache_repo, snapshot_ids=set()) == {}
+    assert catalog._hf_cache_revision(cache_repo, "abc123") == "abc123"
+
+    refs_dir = cache_repo / "refs" / "pull"
+    refs_dir.mkdir(parents=True)
+    (refs_dir / "1").write_text("abc123", encoding="utf-8")
+    assert catalog._hf_cache_revision_map(cache_repo, snapshot_ids={"abc123"}) == {"abc123": "pull/1"}
+    assert list(catalog._iter_relative_file_paths_sorted(cache_repo / "refs")) == [
+        (refs_dir / "1", "pull/1")
+    ]
+
+    (cache_repo / "refs" / "blank").write_text("", encoding="utf-8")
+    (cache_repo / "refs" / "other").write_text("other", encoding="utf-8")
+    assert catalog._hf_cache_revision_map(cache_repo, snapshot_ids={"missing"}) == {}
+
+    original_read_text = Path.read_text
+
+    def guarded_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        if self.name == "broken":
+            raise OSError("broken")
+        return original_read_text(self, *args, **kwargs)
+
+    (cache_repo / "refs" / "broken").write_text("abc123", encoding="utf-8")
+    with pytest.MonkeyPatch.context() as local_monkeypatch:
+        local_monkeypatch.setattr(Path, "read_text", guarded_read_text)
+        assert catalog._hf_cache_revision_map(cache_repo, snapshot_ids={"abc123"}) == {"abc123": "pull/1"}
+
+    with pytest.MonkeyPatch.context() as local_monkeypatch:
+        local_monkeypatch.setattr(
+            catalog,
+            "_iter_relative_file_paths_sorted",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("scan")),
+        )
+        assert catalog._hf_cache_revision_map(cache_repo) == {}
+
+    assert catalog._limit_rows([{"a": 1}], None) == [{"a": 1}]
+    assert catalog.public_ext({"melix.hf_token": "secret", "safe": "value"}) == {"safe": "value"}
+    assert catalog.repo_id_shell_arg("org/repo") == "org/repo"
+    assert catalog.repo_id_shell_arg("org/repo with space") == '"org/repo with space"'
+
+
+def test_dataset_catalog_filesystem_error_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_dir.mkdir()
+    data_file = snapshot_dir / "train.jsonl"
+    data_file.write_text('{"prompt":"ok"}\n', encoding="utf-8")
+    original_stat = Path.stat
+
+    def guarded_stat(self: Path, *args: object, **kwargs: object):
+        if self == data_file:
+            raise OSError("stat failed")
+        return original_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", guarded_stat)
+    assert list(catalog._dataset_files(snapshot_dir)) == []
+
+    def raising_scandir(_path):
+        raise OSError("scan failed")
+
+    monkeypatch.setattr(catalog.os, "scandir", raising_scandir)
+    assert list(catalog._iter_supported_dataset_files(snapshot_dir)) == []
+    assert catalog._sorted_child_directories(snapshot_dir) == ()

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -167,7 +167,8 @@ def test_dataset_catalog_reads_json_and_csv_snapshots(tmp_path: Path) -> None:
 
     assert read_hf_dataset_snapshot_rows(snapshot_dir, split="validation") == [{"prompt": "json-row"}]
     assert read_hf_dataset_snapshot_rows(snapshot_dir, split="train") == [{"prompt": "csv-row", "answer": "ok"}]
-    assert read_hf_dataset_snapshot_rows(snapshot_dir, split="missing", limit=1) == [{"prompt": "csv-row", "answer": "ok"}]
+    assert read_hf_dataset_snapshot_rows(snapshot_dir, split="missing", limit=1) == []
+    assert read_hf_dataset_snapshot_rows(snapshot_dir, limit=1) == [{"prompt": "csv-row", "answer": "ok"}]
 
 
 def test_dataset_catalog_reads_parquet_and_arrow_with_fake_pyarrow(
@@ -178,11 +179,24 @@ def test_dataset_catalog_reads_parquet_and_arrow_with_fake_pyarrow(
     arrow_path = tmp_path / "train.arrow"
     parquet_path.write_bytes(b"parquet")
     arrow_path.write_bytes(b"arrow")
+    sliced_offsets: list[tuple[int, int | None]] = []
+
+    class FakeArrowTable:
+        def __init__(self, rows: list[object]) -> None:
+            self._rows = rows
+
+        def slice(self, offset: int, length: int | None = None) -> "FakeArrowTable":
+            sliced_offsets.append((offset, length))
+            end = None if length is None else offset + length
+            return FakeArrowTable(self._rows[offset:end])
+
+        def to_pylist(self) -> list[object]:
+            return list(self._rows)
 
     pyarrow_module = types.ModuleType("pyarrow")
     pyarrow_module.__path__ = []
     parquet_module = types.ModuleType("pyarrow.parquet")
-    parquet_module.read_table = lambda _path: types.SimpleNamespace(to_pylist=lambda: [{"prompt": "parquet"}, "ignored"])
+    parquet_module.read_table = lambda _path: FakeArrowTable([{"prompt": "parquet"}, {"prompt": "extra"}, "ignored"])
 
     class FakeArrowReader:
         def __enter__(self):
@@ -192,7 +206,7 @@ def test_dataset_catalog_reads_parquet_and_arrow_with_fake_pyarrow(
             return False
 
         def read_all(self):
-            return types.SimpleNamespace(to_pylist=lambda: [{"prompt": "arrow"}, "ignored"])
+            return FakeArrowTable([{"prompt": "arrow"}, {"prompt": "extra"}, "ignored"])
 
     ipc_module = types.ModuleType("pyarrow.ipc")
     ipc_module.open_file = lambda _path: FakeArrowReader()
@@ -201,8 +215,9 @@ def test_dataset_catalog_reads_parquet_and_arrow_with_fake_pyarrow(
     monkeypatch.setitem(sys.modules, "pyarrow.parquet", parquet_module)
     monkeypatch.setitem(sys.modules, "pyarrow.ipc", ipc_module)
 
-    assert catalog._read_rows_from_file(parquet_path) == [{"prompt": "parquet"}]
-    assert catalog._read_rows_from_file(arrow_path) == [{"prompt": "arrow"}]
+    assert catalog._read_rows_from_file(parquet_path, limit=1) == [{"prompt": "parquet"}]
+    assert catalog._read_rows_from_file(arrow_path, limit=1) == [{"prompt": "arrow"}]
+    assert sliced_offsets == [(0, 1), (0, 1)]
 
 
 def test_dataset_catalog_surfaces_missing_pyarrow(

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -673,3 +673,65 @@ def test_materialize_hf_evaluation_dataset_invalidates_cache_when_rows_change(
     assert second.package_path != first.package_path
     assert sample["input"]["text"] == "Capital of Italy?"
     assert sample["target"] == "Rome"
+
+
+def test_hf_evaluation_materialization_prefers_local_cache_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    cache_repo = home / ".cache" / "huggingface" / "hub" / "datasets--org--cached"
+    snapshot = cache_repo / "snapshots" / "abc123"
+    data_dir = snapshot / "data"
+    data_dir.mkdir(parents=True)
+    (cache_repo / "refs").mkdir()
+    (cache_repo / "refs" / "main").write_text("abc123", encoding="utf-8")
+    (data_dir / "train-00000-of-00001.jsonl").write_text(
+        json.dumps(
+            {
+                "question": "Capital of France?",
+                "gold": "Paris",
+                "id": "sample-1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+
+    def fail_fetcher(endpoint: str, params: dict[str, str]) -> dict[str, object]:
+        raise AssertionError(f"unexpected remote fetch {endpoint} {params}")
+
+    materialized = materialize_hf_evaluation_dataset(
+        source=HFEvaluationDatasetSource(
+            dataset_path="org/cached",
+            dataset_revision="main",
+            split="train",
+        ),
+        profile=EvaluationProfileDefinition(
+            profile_type="final_result",
+            result_kind="text",
+            extraction_mode="heuristic_final",
+            scoring_mode="normalized_exact_match",
+            threshold=1.0,
+        ),
+        field_mapping=EvaluationFieldMapping(
+            input_text_path="question",
+            target_path="gold",
+            sample_id_path="id",
+        ),
+        dataset_id="cached.dev.v1",
+        suite_id="cached",
+        cache_root=tmp_path / "cache",
+        fetch_json=fail_fetcher,
+    )
+
+    manifest = json.loads((materialized.package_path / "manifest.json").read_text(encoding="utf-8"))
+    sample = json.loads((materialized.package_path / "samples.jsonl").read_text(encoding="utf-8").strip())
+
+    assert manifest["source_kind"] == "hf_cache_snapshot"
+    assert manifest["hf_snapshot_id"] == "abc123"
+    assert manifest["hf_snapshot_path"] == str(snapshot.resolve())
+    assert sample["id"] == "sample-1"
+    assert sample["input"]["text"] == "Capital of France?"
+    assert sample["target"] == "Paris"

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -735,3 +735,56 @@ def test_hf_evaluation_materialization_prefers_local_cache_snapshot(
     assert sample["id"] == "sample-1"
     assert sample["input"]["text"] == "Capital of France?"
     assert sample["target"] == "Paris"
+
+
+def test_hf_evaluation_materialization_surfaces_local_snapshot_read_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    cache_repo = home / ".cache" / "huggingface" / "hub" / "datasets--org--cached"
+    snapshot = cache_repo / "snapshots" / "abc123"
+    data_dir = snapshot / "data"
+    data_dir.mkdir(parents=True)
+    (cache_repo / "refs").mkdir()
+    (cache_repo / "refs" / "main").write_text("abc123", encoding="utf-8")
+    (data_dir / "train-00000-of-00001.parquet").write_bytes(b"broken-parquet")
+    monkeypatch.setenv("HOME", str(home))
+
+    def fail_reader(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+        raise ModelOperationError(
+            code="unavailable",
+            message="pyarrow is required to read local parquet dataset snapshots.",
+        )
+
+    def fail_fetcher(endpoint: str, params: dict[str, str]) -> dict[str, object]:
+        raise AssertionError(f"unexpected remote fetch after local read failure {endpoint} {params}")
+
+    monkeypatch.setattr(evaluation_final_result_module, "read_hf_dataset_snapshot_rows", fail_reader)
+
+    with pytest.raises(ModelOperationError) as error:
+        materialize_hf_evaluation_dataset(
+            source=HFEvaluationDatasetSource(
+                dataset_path="org/cached",
+                dataset_revision="main",
+                split="train",
+            ),
+            profile=EvaluationProfileDefinition(
+                profile_type="final_result",
+                result_kind="text",
+                extraction_mode="heuristic_final",
+                scoring_mode="normalized_exact_match",
+                threshold=1.0,
+            ),
+            field_mapping=EvaluationFieldMapping(
+                input_text_path="question",
+                target_path="gold",
+                sample_id_path="id",
+            ),
+            dataset_id="cached.dev.v1",
+            suite_id="cached",
+            cache_root=tmp_path / "cache",
+            fetch_json=fail_fetcher,
+        )
+
+    assert error.value.code == "unavailable"

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -407,6 +407,106 @@ class FailingHubCatalog:
         raise self.card_error or AssertionError("card_error must be configured")
 
 
+class FakeDatasetCatalog:
+    def __init__(self, *, failure: ModelOperationError | None = None) -> None:
+        self.failure = failure
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def _raise_if_configured(self) -> None:
+        if self.failure is not None:
+            raise self.failure
+
+    def registry_snapshot_payload(self, *, repo_id: str = "", revision: str = "") -> dict[str, object]:
+        self._raise_if_configured()
+        self.calls.append(("registry_snapshot_payload", {"repo_id": repo_id, "revision": revision}))
+        return {
+            "schema_version": "melix.dataset_registry_snapshot.v1",
+            "roots": [],
+            "datasets": [
+                {
+                    "dataset_id": f"{repo_id or 'org/repo'}@{revision or 'main'}",
+                    "repo_id": repo_id or "org/repo",
+                    "revision": revision or "main",
+                    "snapshot_id": "abc123",
+                    "snapshot_path": "/tmp/hf-cache/datasets--org--repo/snapshots/abc123",
+                    "total_bytes": 123,
+                }
+            ],
+        }
+
+    def download_hf_dataset(
+        self,
+        *,
+        repo_id: str,
+        revision: str = "main",
+        hf_token: str = "",
+        job_id: str = "",
+        output_dir: Path | None = None,
+    ) -> SimpleNamespace:
+        self._raise_if_configured()
+        self.calls.append(
+            (
+                "download_hf_dataset",
+                {
+                    "repo_id": repo_id,
+                    "revision": revision,
+                    "hf_token": hf_token,
+                    "job_id": job_id,
+                    "output_dir": output_dir,
+                },
+            )
+        )
+        snapshot_path = Path(output_dir or "/tmp") / "snapshots" / "abc123"
+        snapshot = SimpleNamespace(snapshot_path=snapshot_path)
+        return SimpleNamespace(
+            snapshot=snapshot,
+            manifest={
+                "schema_version": "melix.dataset_operation.v1",
+                "operation": "dataset_download",
+                "repo_id": repo_id,
+                "revision": revision,
+                "snapshot_id": "abc123",
+                "snapshot_path": str(snapshot_path),
+                "job_id": job_id,
+            },
+        )
+
+    def remove_hf_dataset_snapshot(
+        self,
+        *,
+        repo_id: str,
+        revision: str = "",
+        snapshot_id: str = "",
+        job_id: str = "",
+        output_dir: Path | None = None,
+    ) -> SimpleNamespace:
+        self._raise_if_configured()
+        self.calls.append(
+            (
+                "remove_hf_dataset_snapshot",
+                {
+                    "repo_id": repo_id,
+                    "revision": revision,
+                    "snapshot_id": snapshot_id,
+                    "job_id": job_id,
+                    "output_dir": output_dir,
+                },
+            )
+        )
+        return SimpleNamespace(
+            removed_snapshot=SimpleNamespace(snapshot_id=snapshot_id),
+            manifest={
+                "schema_version": "melix.dataset_operation.v1",
+                "operation": "dataset_remove",
+                "repo_id": repo_id,
+                "revision": revision or "main",
+                "snapshot_id": snapshot_id,
+                "removed_snapshot_id": snapshot_id,
+                "job_id": job_id,
+            },
+        )
+
+
 def _write_training_dataset_package(tmp_path: Path, *, dataset_id: str = "melix-dev") -> Path:
     dataset_dir = tmp_path / "dataset"
     dataset_dir.mkdir(parents=True, exist_ok=True)
@@ -545,6 +645,7 @@ def build_service(
     registry: WorkerRegistry | None = None,
     benchmark_fetcher: FakeBenchmarkHFDatasetFetcher | None = None,
     publish_backend: FakePublishBackend | None = None,
+    dataset_catalog: FakeDatasetCatalog | None = None,
 ) -> WorkerMaintenanceService:
     registry = registry or WorkerRegistry(
         runtime=MLXTextRuntime(backend=DeterministicTextBackend()),
@@ -567,6 +668,7 @@ def build_service(
         benchmark_suite_catalog=BenchmarkSuiteCatalog(
             hf_dataset_fetcher=benchmark_fetcher or FakeBenchmarkHFDatasetFetcher()
         ),
+        dataset_catalog=dataset_catalog,
     )
     service._fake_publish_backend = publish_backend
     return service
@@ -776,6 +878,112 @@ def test_convert_model_supports_download_and_upload_jobs(tmp_path: Path) -> None
     assert upload_payload["upload_backend"] == "huggingface_hub"
     assert upload_payload["published_url"] == "https://huggingface.co/melix/upload-target"
     assert upload_manifest.artifact.artifact_kind == "upload_receipt"
+
+
+def test_convert_model_dispatches_dataset_operations_through_injected_catalog(tmp_path: Path) -> None:
+    dataset_catalog = FakeDatasetCatalog()
+    service = build_service(tmp_path, dataset_catalog=dataset_catalog)
+
+    snapshot_events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-datasets",
+                output_dir=str(tmp_path / "dataset-snapshot"),
+                generate_manifest=True,
+                ext={
+                    "operation": "dataset_snapshot",
+                    "melix.hf_dataset_repo_id": "org/repo",
+                    "melix.hf_revision": "main",
+                },
+            ),
+            context=None,
+        )
+    )
+    download_events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="org/repo",
+                output_dir=str(tmp_path / "dataset-download"),
+                generate_manifest=True,
+                ext={
+                    "operation": "dataset_download",
+                    "melix.hf_dataset_repo_id": "org/repo",
+                    "melix.hf_revision": "feature",
+                    "melix.hf_token": "hf_secret",
+                },
+            ),
+            context=None,
+        )
+    )
+    remove_events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="org/repo",
+                output_dir=str(tmp_path / "dataset-remove"),
+                generate_manifest=True,
+                ext={
+                    "operation": "dataset_remove",
+                    "melix.hf_dataset_repo_id": "org/repo",
+                    "melix.hf_revision": "feature",
+                    "melix.hf_snapshot_id": "abc123",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    snapshot_payload = json.loads(
+        next(event.manifest for event in snapshot_events if event.HasField("manifest")).manifest_json
+    )
+    download_payload = json.loads(
+        next(event.manifest for event in download_events if event.HasField("manifest")).manifest_json
+    )
+    remove_payload = json.loads(
+        next(event.manifest for event in remove_events if event.HasField("manifest")).manifest_json
+    )
+
+    assert snapshot_events[0].HasField("started")
+    assert snapshot_events[-1].HasField("completed")
+    assert snapshot_payload["dataset_registry"]["datasets"][0]["repo_id"] == "org/repo"
+    assert download_events[-1].completed.output_path.endswith("snapshots/abc123")
+    assert download_payload["operation"] == "dataset_download"
+    assert remove_events[-1].completed.output_path.endswith("dataset_remove.json")
+    assert remove_payload["operation"] == "dataset_remove"
+    assert [name for name, _payload in dataset_catalog.calls] == [
+        "registry_snapshot_payload",
+        "download_hf_dataset",
+        "remove_hf_dataset_snapshot",
+    ]
+    assert dataset_catalog.calls[1][1]["hf_token"] == "hf_secret"
+
+
+def test_convert_model_dataset_operation_surfaces_catalog_errors(tmp_path: Path) -> None:
+    dataset_catalog = FakeDatasetCatalog(
+        failure=ModelOperationError(
+            code="not_found",
+            message="No matching managed dataset snapshot was found.",
+        )
+    )
+    service = build_service(tmp_path, dataset_catalog=dataset_catalog)
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="org/missing",
+                ext={
+                    "operation": "dataset_remove",
+                    "melix.hf_dataset_repo_id": "org/missing",
+                    "melix.hf_snapshot_id": "missing",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[0].HasField("started")
+    assert events[-1].HasField("failed")
+    assert events[-1].failed.error.code == "not_found"
+    assert events[-1].failed.error.message == "No matching managed dataset snapshot was found."
 
 
 def test_upload_job_writes_receipt_once_after_in_memory_byte_convergence(

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -452,6 +452,7 @@ def _selected_dataset_files(snapshot_path: Path, *, split: str) -> tuple[Path, .
         ]
         if split_matches:
             return tuple(split_matches)
+        return ()
     return tuple(data_files)
 
 
@@ -489,7 +490,10 @@ def _read_rows_from_file(path: Path, *, limit: int | None = None) -> list[dict[s
                 code="unavailable",
                 message="pyarrow is required to read local parquet dataset snapshots.",
             ) from exc
-        return _limit_rows([row for row in pq.read_table(path).to_pylist() if isinstance(row, dict)], limit)
+        table = pq.read_table(path)
+        if limit is not None:
+            table = table.slice(0, limit)
+        return [row for row in table.to_pylist() if isinstance(row, dict)]
     if suffix == ".arrow":
         try:
             import pyarrow.ipc as ipc
@@ -499,7 +503,10 @@ def _read_rows_from_file(path: Path, *, limit: int | None = None) -> list[dict[s
                 message="pyarrow is required to read local Arrow dataset snapshots.",
             ) from exc
         with ipc.open_file(path) as reader:
-            return _limit_rows([row for row in reader.read_all().to_pylist() if isinstance(row, dict)], limit)
+            table = reader.read_all()
+            if limit is not None:
+                table = table.slice(0, limit)
+            return [row for row in table.to_pylist() if isinstance(row, dict)]
     return []
 
 
@@ -597,19 +604,19 @@ def _dataset_files(snapshot_dir: Path) -> Iterator[DatasetFile]:
 def _iter_supported_dataset_files(snapshot_dir: Path) -> Iterator[Path]:
     try:
         with os.scandir(os.fspath(snapshot_dir)) as entries:
-            child_names = sorted(entry.name for entry in entries)
+            child_entries = sorted(entries, key=lambda entry: entry.name)
     except OSError:
         return
-    for child_name in child_names:
-        child_path = snapshot_dir / child_name
+    for entry in child_entries:
         try:
-            if child_path.is_dir():
-                yield from _iter_supported_dataset_files(child_path)
+            if entry.is_dir():
+                yield from _iter_supported_dataset_files(Path(entry.path))
                 continue
-            if not child_path.is_file():
+            if not entry.is_file():
                 continue
         except OSError:
             continue
+        child_path = Path(entry.path)
         if _dataset_file_format(child_path):
             yield child_path
 

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -1,0 +1,787 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import time
+from typing import Any, Iterable, Iterator, Mapping
+
+from worker.model_ops.errors import ModelOperationError
+
+_HF_TOKEN_KEYS = {
+    "melix.hf_token",
+    "hf_token",
+    "HUGGINGFACE_HUB_TOKEN",
+    "HF_TOKEN",
+}
+_SUPPORTED_DATASET_SUFFIXES = {
+    ".jsonl": "jsonl",
+    ".json": "json",
+    ".csv": "csv",
+    ".parquet": "parquet",
+    ".arrow": "arrow",
+}
+_README_NAMES = {"README.md", "README.txt", "dataset_infos.json"}
+_SPLIT_ALIASES = {
+    "train": "train",
+    "training": "train",
+    "validation": "validation",
+    "valid": "validation",
+    "val": "validation",
+    "dev": "validation",
+    "test": "test",
+}
+
+
+@dataclass(frozen=True)
+class DatasetFile:
+    relative_path: str
+    size_bytes: int
+    file_format: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "relative_path": self.relative_path,
+            "size_bytes": self.size_bytes,
+            "file_format": self.file_format,
+        }
+
+
+@dataclass(frozen=True)
+class DatasetSnapshot:
+    dataset_id: str
+    repo_id: str
+    revision: str
+    snapshot_id: str
+    snapshot_path: Path
+    cache_repo_path: Path
+    source_kind: str
+    files: tuple[DatasetFile, ...]
+    total_bytes: int
+    splits: tuple[str, ...]
+    configs: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "dataset_id": self.dataset_id,
+            "repo_id": self.repo_id,
+            "revision": self.revision,
+            "snapshot_id": self.snapshot_id,
+            "snapshot_path": str(self.snapshot_path),
+            "cache_repo_path": str(self.cache_repo_path),
+            "source_kind": self.source_kind,
+            "files": [file.to_dict() for file in self.files],
+            "total_bytes": self.total_bytes,
+            "splits": list(self.splits),
+            "configs": list(self.configs),
+            "restore_command": (
+                f"melix dataset hub download --repo-id {repo_id_shell_arg(self.repo_id)} "
+                f"--revision {repo_id_shell_arg(self.revision)}"
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class DatasetRegistryRoot:
+    root_id: str
+    root_path: str
+    root_order: int
+    accessible: bool
+    error_code: str = ""
+    error_message: str = ""
+    discovered_dataset_ids: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "root_id": self.root_id,
+            "root_path": self.root_path,
+            "root_order": self.root_order,
+            "accessible": self.accessible,
+            "error_code": self.error_code,
+            "error_message": self.error_message,
+            "discovered_dataset_ids": list(self.discovered_dataset_ids),
+        }
+
+
+@dataclass(frozen=True)
+class DatasetDownloadResult:
+    snapshot: DatasetSnapshot
+    manifest: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class DatasetRemoveResult:
+    removed_snapshot: DatasetSnapshot
+    manifest: dict[str, Any]
+
+
+class DatasetCatalog:
+    def __init__(self, environment: Mapping[str, str] | None = None) -> None:
+        self._environment = dict(environment or os.environ)
+
+    def registry_snapshot_payload(
+        self,
+        *,
+        repo_id: str = "",
+        revision: str = "",
+        roots: Iterable[Path | str] | None = None,
+    ) -> dict[str, Any]:
+        root_records: list[DatasetRegistryRoot] = []
+        datasets: list[DatasetSnapshot] = []
+        normalized_repo_id = _normalized(repo_id)
+        normalized_revision = _normalized(revision)
+
+        for index, root in enumerate(self._resolved_roots(roots), start=1):
+            root_path = Path(root).expanduser().resolve()
+            root_id = _root_id(root_path)
+            if not root_path.is_dir():
+                root_records.append(
+                    DatasetRegistryRoot(
+                        root_id=root_id,
+                        root_path=str(root_path),
+                        root_order=index,
+                        accessible=False,
+                        error_code="not_found",
+                        error_message="Dataset registry root does not exist.",
+                    )
+                )
+                continue
+
+            discovered_for_root: list[str] = []
+            try:
+                root_snapshots = tuple(self._scan_root(root_path))
+            except OSError as exc:
+                root_records.append(
+                    DatasetRegistryRoot(
+                        root_id=root_id,
+                        root_path=str(root_path),
+                        root_order=index,
+                        accessible=False,
+                        error_code="scan_failed",
+                        error_message=str(exc),
+                    )
+                )
+                continue
+
+            for snapshot in root_snapshots:
+                if normalized_repo_id and snapshot.repo_id != normalized_repo_id:
+                    continue
+                if normalized_revision and snapshot.revision != normalized_revision and snapshot.snapshot_id != normalized_revision:
+                    continue
+                datasets.append(snapshot)
+                discovered_for_root.append(snapshot.dataset_id)
+
+            root_records.append(
+                DatasetRegistryRoot(
+                    root_id=root_id,
+                    root_path=str(root_path),
+                    root_order=index,
+                    accessible=True,
+                    discovered_dataset_ids=tuple(sorted(discovered_for_root)),
+                )
+            )
+
+        return {
+            "schema_version": "melix.dataset_registry_snapshot.v1",
+            "scanned_at_unix_ms": int(time.time() * 1000),
+            "roots": [root.to_dict() for root in root_records],
+            "datasets": [snapshot.to_dict() for snapshot in sorted(datasets, key=lambda item: item.dataset_id)],
+        }
+
+    def resolve_snapshot(
+        self,
+        *,
+        repo_id: str,
+        revision: str = "",
+        snapshot_id: str = "",
+        roots: Iterable[Path | str] | None = None,
+    ) -> DatasetSnapshot | None:
+        normalized_repo_id = _normalized(repo_id)
+        normalized_revision = _normalized(revision) or "main"
+        normalized_snapshot_id = _normalized(snapshot_id)
+        if not normalized_repo_id:
+            return None
+        for root in self._resolved_roots(roots):
+            root_path = Path(root).expanduser().resolve()
+            if not root_path.is_dir():
+                continue
+            for snapshot in self._scan_root(root_path):
+                if snapshot.repo_id != normalized_repo_id:
+                    continue
+                if normalized_snapshot_id:
+                    if snapshot.snapshot_id == normalized_snapshot_id:
+                        return snapshot
+                    continue
+                if snapshot.revision == normalized_revision or snapshot.snapshot_id == normalized_revision:
+                    return snapshot
+        return None
+
+    def snapshot_for_path(self, snapshot_path: Path) -> DatasetSnapshot | None:
+        resolved_snapshot_path = Path(snapshot_path).expanduser().resolve()
+        for root in self._resolved_roots(None):
+            root_path = Path(root).expanduser().resolve()
+            try:
+                relative_parts = resolved_snapshot_path.relative_to(root_path).parts
+            except ValueError:
+                continue
+            if len(relative_parts) < 3 or relative_parts[1] != "snapshots":
+                continue
+            repo_id = _hf_dataset_repo_id(root_path / relative_parts[0])
+            if repo_id is None:
+                continue
+            cache_repo_dir = root_path / relative_parts[0]
+            revision = _hf_cache_revision(cache_repo_dir, relative_parts[2])
+            return _build_dataset_snapshot(
+                cache_repo_dir=cache_repo_dir,
+                repo_id=repo_id,
+                snapshot_dir=resolved_snapshot_path,
+                revision=revision,
+            )
+        return None
+
+    def download_hf_dataset(
+        self,
+        *,
+        repo_id: str,
+        revision: str = "main",
+        hf_token: str = "",
+        job_id: str = "",
+        output_dir: Path | None = None,
+    ) -> DatasetDownloadResult:
+        normalized_repo_id = _normalized(repo_id)
+        if not normalized_repo_id:
+            raise ModelOperationError(
+                code="invalid_argument",
+                message="dataset download requires a Hugging Face repo id.",
+            )
+        normalized_revision = _normalized(revision) or "main"
+        try:
+            from huggingface_hub import snapshot_download
+        except ImportError as exc:
+            raise ModelOperationError(
+                code="unavailable",
+                message="huggingface_hub is required for dataset downloads.",
+            ) from exc
+
+        kwargs: dict[str, object] = {
+            "repo_id": normalized_repo_id,
+            "repo_type": "dataset",
+            "revision": normalized_revision,
+            "cache_dir": os.fspath(default_huggingface_cache_root(self._environment)),
+        }
+        token = _normalized(hf_token)
+        if token:
+            kwargs["token"] = token
+
+        try:
+            downloaded = snapshot_download(**kwargs)
+        except Exception as exc:
+            if _is_huggingface_auth_failure(exc):
+                raise ModelOperationError(
+                    code="hf_auth_failed",
+                    message="Hugging Face authentication failed. Check your token and try again.",
+                ) from exc
+            if _is_huggingface_hub_failure(exc):
+                raise ModelOperationError(
+                    code="unavailable",
+                    message=f"dataset download failed for {normalized_repo_id}: {exc}",
+                ) from exc
+            raise
+
+        snapshot = self.snapshot_for_path(Path(downloaded))
+        if snapshot is None:
+            snapshot_path = Path(downloaded).resolve()
+            cache_repo_dir = snapshot_path.parents[1] if len(snapshot_path.parents) >= 2 else snapshot_path.parent
+            snapshot = _build_dataset_snapshot(
+                cache_repo_dir=cache_repo_dir,
+                repo_id=normalized_repo_id,
+                snapshot_dir=snapshot_path,
+                revision=normalized_revision,
+            )
+        manifest = _dataset_operation_manifest(
+            operation="dataset_download",
+            job_id=job_id,
+            output_dir=output_dir,
+            dataset=snapshot,
+            status="completed",
+            extra={
+                "downloaded_bytes": snapshot.total_bytes,
+                "total_bytes": snapshot.total_bytes,
+                "ext": {
+                    "melix.source_kind": "hf_dataset",
+                    "melix.hf_dataset_repo_id": normalized_repo_id,
+                    "melix.hf_revision": normalized_revision,
+                    "melix.dataset_path": str(snapshot.snapshot_path),
+                },
+            },
+        )
+        return DatasetDownloadResult(snapshot=snapshot, manifest=manifest)
+
+    def remove_hf_dataset_snapshot(
+        self,
+        *,
+        repo_id: str,
+        revision: str = "",
+        snapshot_id: str = "",
+        job_id: str = "",
+        output_dir: Path | None = None,
+    ) -> DatasetRemoveResult:
+        normalized_repo_id = _normalized(repo_id)
+        if not normalized_repo_id:
+            raise ModelOperationError(
+                code="invalid_argument",
+                message="dataset remove requires --repo-id.",
+            )
+        snapshot = self.resolve_snapshot(
+            repo_id=normalized_repo_id,
+            revision=_normalized(revision) or "main",
+            snapshot_id=snapshot_id,
+        )
+        if snapshot is None:
+            raise ModelOperationError(
+                code="not_found",
+                message="No matching managed dataset snapshot was found.",
+                details={
+                    "repo_id": normalized_repo_id,
+                    "revision": _normalized(revision) or "main",
+                    "snapshot_id": _normalized(snapshot_id),
+                },
+            )
+
+        shutil.rmtree(snapshot.snapshot_path)
+        manifest = _dataset_operation_manifest(
+            operation="dataset_remove",
+            job_id=job_id,
+            output_dir=output_dir,
+            dataset=snapshot,
+            status="completed",
+            extra={
+                "removed_snapshot_path": str(snapshot.snapshot_path),
+                "removed_snapshot_id": snapshot.snapshot_id,
+            },
+        )
+        return DatasetRemoveResult(removed_snapshot=snapshot, manifest=manifest)
+
+    def _resolved_roots(self, roots: Iterable[Path | str] | None) -> tuple[Path, ...]:
+        if roots is not None:
+            raw_roots = [Path(root) for root in roots]
+        else:
+            raw_roots = [default_huggingface_cache_root(self._environment)]
+        resolved: list[Path] = []
+        seen: set[str] = set()
+        for root in raw_roots:
+            canonical = str(Path(root).expanduser().resolve())
+            if canonical in seen:
+                continue
+            seen.add(canonical)
+            resolved.append(Path(canonical))
+        return tuple(resolved)
+
+    @staticmethod
+    def _scan_root(root: Path) -> Iterator[DatasetSnapshot]:
+        for cache_repo_dir in _sorted_child_directories(root, name_prefix="datasets--"):
+            repo_id = _hf_dataset_repo_id(cache_repo_dir)
+            if repo_id is None:
+                continue
+            snapshots_dir = cache_repo_dir / "snapshots"
+            if not snapshots_dir.is_dir():
+                continue
+            snapshot_dirs = _sorted_child_directories(snapshots_dir)
+            revision_map = _hf_cache_revision_map(
+                cache_repo_dir,
+                snapshot_ids={snapshot_dir.name for snapshot_dir in snapshot_dirs},
+            )
+            for snapshot_dir in snapshot_dirs:
+                revision = _hf_cache_revision(cache_repo_dir, snapshot_dir.name, revision_map=revision_map)
+                yield _build_dataset_snapshot(
+                    cache_repo_dir=cache_repo_dir,
+                    repo_id=repo_id,
+                    snapshot_dir=snapshot_dir.resolve(),
+                    revision=revision,
+                )
+
+
+def default_huggingface_cache_root(environment: Mapping[str, str] | None = None) -> Path:
+    env = environment or os.environ
+    home = _normalized(env.get("HOME"))
+    root = (Path(home).expanduser() if home else Path.home()) / ".cache" / "huggingface" / "hub"
+    return root.resolve()
+
+
+def resolve_cached_hf_dataset_snapshot(
+    *,
+    repo_id: str,
+    revision: str = "main",
+    environment: Mapping[str, str] | None = None,
+) -> DatasetSnapshot | None:
+    return DatasetCatalog(environment=environment).resolve_snapshot(repo_id=repo_id, revision=revision or "main")
+
+
+def read_hf_dataset_snapshot_rows(
+    snapshot_path: Path,
+    *,
+    split: str = "",
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    files = _selected_dataset_files(Path(snapshot_path).expanduser().resolve(), split=split)
+    rows: list[dict[str, Any]] = []
+    for path in files:
+        remaining = None if limit is None else max(limit - len(rows), 0)
+        if remaining == 0:
+            return rows
+        rows.extend(_read_rows_from_file(path, limit=remaining))
+    return rows
+
+
+def _selected_dataset_files(snapshot_path: Path, *, split: str) -> tuple[Path, ...]:
+    data_files = [
+        path
+        for path in _iter_supported_dataset_files(snapshot_path)
+        if path.name not in _README_NAMES
+    ]
+    normalized_split = _normalized(split)
+    if normalized_split:
+        split_matches = [
+            path
+            for path in data_files
+            if _path_matches_split(path.relative_to(snapshot_path), normalized_split)
+        ]
+        if split_matches:
+            return tuple(split_matches)
+    return tuple(data_files)
+
+
+def _read_rows_from_file(path: Path, *, limit: int | None = None) -> list[dict[str, Any]]:
+    suffix = path.suffix.lower()
+    if suffix == ".jsonl":
+        rows: list[dict[str, Any]] = []
+        with path.open("r", encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                payload = json.loads(line)
+                if isinstance(payload, dict):
+                    rows.append(payload)
+                    if limit is not None and len(rows) >= limit:
+                        break
+        return rows
+    if suffix == ".json":
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return _limit_rows(_rows_from_json_payload(payload), limit)
+    if suffix == ".csv":
+        rows: list[dict[str, Any]] = []
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            for row in csv.DictReader(handle):
+                rows.append(dict(row))
+                if limit is not None and len(rows) >= limit:
+                    break
+        return rows
+    if suffix == ".parquet":
+        try:
+            import pyarrow.parquet as pq
+        except ImportError as exc:
+            raise ModelOperationError(
+                code="unavailable",
+                message="pyarrow is required to read local parquet dataset snapshots.",
+            ) from exc
+        return _limit_rows([row for row in pq.read_table(path).to_pylist() if isinstance(row, dict)], limit)
+    if suffix == ".arrow":
+        try:
+            import pyarrow.ipc as ipc
+        except ImportError as exc:
+            raise ModelOperationError(
+                code="unavailable",
+                message="pyarrow is required to read local Arrow dataset snapshots.",
+            ) from exc
+        with ipc.open_file(path) as reader:
+            return _limit_rows([row for row in reader.read_all().to_pylist() if isinstance(row, dict)], limit)
+    return []
+
+
+def _limit_rows(rows: list[dict[str, Any]], limit: int | None) -> list[dict[str, Any]]:
+    if limit is None:
+        return rows
+    return rows[:limit]
+
+
+def _rows_from_json_payload(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, dict)]
+    if isinstance(payload, dict):
+        rows = payload.get("rows")
+        if isinstance(rows, list):
+            return [row for row in rows if isinstance(row, dict)]
+        data = payload.get("data")
+        if isinstance(data, list):
+            return [row for row in data if isinstance(row, dict)]
+        for value in payload.values():
+            if isinstance(value, list) and all(isinstance(row, dict) for row in value):
+                return list(value)
+        return [payload]
+    return []
+
+
+def _dataset_operation_manifest(
+    *,
+    operation: str,
+    job_id: str,
+    output_dir: Path | None,
+    dataset: DatasetSnapshot,
+    status: str,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": "melix.dataset_operation.v1",
+        "operation": operation,
+        "job_id": job_id,
+        "status": status,
+        "dataset_id": dataset.dataset_id,
+        "repo_id": dataset.repo_id,
+        "revision": dataset.revision,
+        "snapshot_id": dataset.snapshot_id,
+        "snapshot_path": str(dataset.snapshot_path),
+        "source_kind": dataset.source_kind,
+        "output_dir": str(output_dir) if output_dir is not None else "",
+        "dataset": dataset.to_dict(),
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def _build_dataset_snapshot(
+    *,
+    cache_repo_dir: Path,
+    repo_id: str,
+    snapshot_dir: Path,
+    revision: str,
+) -> DatasetSnapshot:
+    files = tuple(_dataset_files(snapshot_dir))
+    total_bytes = sum(file.size_bytes for file in files)
+    splits = tuple(sorted(set(_inferred_split(file.relative_path) for file in files) - {""}))
+    configs = tuple(sorted(set(_inferred_config(file.relative_path) for file in files) - {""}))
+    revision_label = revision or snapshot_dir.name
+    return DatasetSnapshot(
+        dataset_id=f"{repo_id}@{revision_label}",
+        repo_id=repo_id,
+        revision=revision_label,
+        snapshot_id=snapshot_dir.name,
+        snapshot_path=snapshot_dir,
+        cache_repo_path=cache_repo_dir.resolve(),
+        source_kind="hf_cache_snapshot",
+        files=files,
+        total_bytes=total_bytes,
+        splits=splits,
+        configs=configs,
+    )
+
+
+def _dataset_files(snapshot_dir: Path) -> Iterator[DatasetFile]:
+    for path in _iter_supported_dataset_files(snapshot_dir):
+        try:
+            stat_result = path.stat()
+        except OSError:
+            continue
+        yield DatasetFile(
+            relative_path=os.fspath(path.relative_to(snapshot_dir)),
+            size_bytes=stat_result.st_size,
+            file_format=_dataset_file_format(path),
+        )
+
+
+def _iter_supported_dataset_files(snapshot_dir: Path) -> Iterator[Path]:
+    try:
+        with os.scandir(os.fspath(snapshot_dir)) as entries:
+            child_names = sorted(entry.name for entry in entries)
+    except OSError:
+        return
+    for child_name in child_names:
+        child_path = snapshot_dir / child_name
+        try:
+            if child_path.is_dir():
+                yield from _iter_supported_dataset_files(child_path)
+                continue
+            if not child_path.is_file():
+                continue
+        except OSError:
+            continue
+        if _dataset_file_format(child_path):
+            yield child_path
+
+
+def _dataset_file_format(path: Path) -> str:
+    if path.name in _README_NAMES:
+        return "metadata"
+    return _SUPPORTED_DATASET_SUFFIXES.get(path.suffix.lower(), "")
+
+
+def _inferred_split(relative_path: str) -> str:
+    path = Path(relative_path)
+    candidates = [path.stem]
+    candidates.extend(part for part in path.parts[:-1] if part not in {"data", "default"})
+    for candidate in candidates:
+        prefix = candidate.split("-", 1)[0].split("_", 1)[0].lower()
+        if prefix in _SPLIT_ALIASES:
+            return _SPLIT_ALIASES[prefix]
+    return ""
+
+
+def _inferred_config(relative_path: str) -> str:
+    parts = Path(relative_path).parts
+    if len(parts) < 2:
+        return "default"
+    first = parts[0]
+    if first in {"data", "train", "test", "validation", "valid", "dev"}:
+        return "default"
+    return first
+
+
+def _path_matches_split(relative_path: Path, split: str) -> bool:
+    normalized_split = split.lower()
+    for part in relative_path.parts:
+        lowered = part.lower()
+        stem = Path(part).stem.lower()
+        if (
+            lowered == normalized_split
+            or lowered.startswith(f"{normalized_split}-")
+            or lowered.startswith(f"{normalized_split}_")
+            or stem == normalized_split
+            or stem.startswith(f"{normalized_split}-")
+            or stem.startswith(f"{normalized_split}_")
+        ):
+            return True
+    return False
+
+
+def _hf_dataset_repo_id(cache_repo_dir: Path) -> str | None:
+    name = cache_repo_dir.name
+    if not name.startswith("datasets--"):
+        return None
+    payload = name.removeprefix("datasets--")
+    if not payload:
+        return None
+    parts = payload.split("--", maxsplit=1)
+    if len(parts) == 1:
+        return parts[0] or None
+    if not parts[0] or not parts[1]:
+        return None
+    return f"{parts[0]}/{parts[1]}"
+
+
+def _hf_cache_revision_map(
+    cache_repo_dir: Path,
+    *,
+    snapshot_ids: set[str] | None = None,
+) -> dict[str, str]:
+    refs_dir = cache_repo_dir / "refs"
+    revisions: dict[str, str] = {}
+    remaining_snapshot_ids = set(snapshot_ids) if snapshot_ids is not None else None
+    if remaining_snapshot_ids is not None and not remaining_snapshot_ids:
+        return revisions
+    if not refs_dir.is_dir():
+        return revisions
+
+    try:
+        for ref_path, relative_name in _iter_relative_file_paths_sorted(refs_dir):
+            try:
+                snapshot_id = ref_path.read_text(encoding="utf-8").strip()
+            except OSError:
+                continue
+            if not snapshot_id:
+                continue
+            if remaining_snapshot_ids is not None and snapshot_id not in remaining_snapshot_ids:
+                continue
+            revisions.setdefault(snapshot_id, relative_name)
+            if remaining_snapshot_ids is not None:
+                remaining_snapshot_ids.discard(snapshot_id)
+                if not remaining_snapshot_ids:
+                    return revisions
+    except OSError:
+        return revisions
+    return revisions
+
+
+def _hf_cache_revision(
+    cache_repo_dir: Path,
+    snapshot_id: str,
+    *,
+    revision_map: Mapping[str, str] | None = None,
+) -> str:
+    revisions = revision_map if revision_map is not None else _hf_cache_revision_map(cache_repo_dir)
+    return revisions.get(snapshot_id, snapshot_id)
+
+
+def _iter_relative_file_paths_sorted(root: Path, *, prefix: str = "") -> Iterable[tuple[Path, str]]:
+    try:
+        with os.scandir(os.fspath(root)) as entries:
+            child_entries = sorted(entries, key=lambda entry: entry.name)
+    except OSError as exc:
+        raise OSError(str(exc)) from exc
+    for entry in child_entries:
+        try:
+            if entry.is_dir():
+                child_prefix = f"{prefix}{entry.name}/"
+                yield from _iter_relative_file_paths_sorted(root / entry.name, prefix=child_prefix)
+                continue
+            if entry.is_file():
+                yield root / entry.name, f"{prefix}{entry.name}"
+        except OSError as exc:
+            raise OSError(str(exc)) from exc
+
+
+def _sorted_child_directories(root: Path, *, name_prefix: str | None = None) -> tuple[Path, ...]:
+    child_names: list[str] = []
+    try:
+        with os.scandir(os.fspath(root)) as entries:
+            for entry in entries:
+                if name_prefix is not None and not entry.name.startswith(name_prefix):
+                    continue
+                try:
+                    if entry.is_dir():
+                        child_names.append(entry.name)
+                except OSError:
+                    continue
+    except OSError:
+        return ()
+    return tuple(root / name for name in sorted(child_names))
+
+
+def _root_id(root: Path) -> str:
+    digest = hashlib.sha1(os.fspath(root).encode("utf-8")).hexdigest()[:12]
+    return f"dataset-root-{digest}"
+
+
+def _normalized(value: str | None) -> str:
+    return (value or "").strip()
+
+
+def _is_huggingface_hub_failure(exc: Exception) -> bool:
+    module = type(exc).__module__
+    return module.startswith("huggingface_hub") or module.startswith("requests")
+
+
+def _is_huggingface_auth_failure(exc: Exception) -> bool:
+    status_code = getattr(getattr(exc, "response", None), "status_code", None)
+    if status_code in {401, 403}:
+        return True
+    message = str(exc).lower()
+    return "401" in message or "403" in message or "unauthorized" in message or "forbidden" in message
+
+
+def public_ext(ext: Mapping[str, str] | Any) -> dict[str, str]:
+    return {
+        str(key): str(value)
+        for key, value in dict(ext).items()
+        if str(key) not in _HF_TOKEN_KEYS and "token" not in str(key).lower()
+    }
+
+
+def repo_id_shell_arg(value: str) -> str:
+    if value.replace("/", "").replace("-", "").replace("_", "").replace(".", "").isalnum():
+        return value
+    return json.dumps(value)

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -14,6 +14,7 @@ from typing import Any, Iterator, NoReturn
 
 from packages.protocol.python.worker.v1 import common_pb2, inference_pb2, maintenance_pb2
 
+from worker.dataset_registry.catalog import DatasetCatalog
 from worker.model_ops.adapter_activation_pipeline import AdapterActivationPipeline
 from worker.model_ops.conversion_pipeline import ModelConversionPipeline
 from worker.model_ops.download_pipeline import DownloadPipeline
@@ -236,6 +237,7 @@ class MaintenanceCore:
         self._benchmark_store = None
         self._benchmark_queue_store = BenchmarkQueueStore()
         self._benchmark_suite_catalog = benchmark_suite_catalog or BenchmarkSuiteCatalog()
+        self._dataset_catalog = DatasetCatalog()
         self._restore_derived_models_into_catalog()
 
     @staticmethod
@@ -349,6 +351,9 @@ class MaintenanceCore:
             "activate_adapter",
             "remove_derived_model",
             "registry_snapshot",
+            "dataset_snapshot",
+            "dataset_download",
+            "dataset_remove",
         }:
             yield maintenance_pb2.ConvertModelEvent(
                 failed=maintenance_pb2.ConvertFailed(
@@ -392,6 +397,49 @@ class MaintenanceCore:
             yield maintenance_pb2.ConvertModelEvent(
                 started=maintenance_pb2.ConvertStarted(job_id=job.job_id)
             )
+
+            if operation in {"dataset_snapshot", "dataset_download", "dataset_remove"}:
+                try:
+                    result = self._run_dataset_operation(
+                        operation=operation,
+                        job_id=job.job_id,
+                        request=request,
+                        output_dir=output_dir,
+                    )
+                except ModelOperationError as exc:
+                    self._job_registry.fail(job.job_id, exc.code, exc.message)
+                    yield maintenance_pb2.ConvertModelEvent(
+                        failed=maintenance_pb2.ConvertFailed(
+                            error=common_pb2.ErrorStatus(
+                                code=exc.code,
+                                message=exc.message,
+                                retriable=exc.retriable,
+                                details=exc.details,
+                            )
+                        )
+                    )
+                    return
+
+                for stage, pct in result["progress_events"]:
+                    self._job_registry.progress(job.job_id, stage, pct)
+                    yield maintenance_pb2.ConvertModelEvent(
+                        progress=maintenance_pb2.ConvertProgress(stage=stage, pct=pct)
+                    )
+                manifest_payload = result["manifest"]
+                manifest_json = json.dumps(manifest_payload, sort_keys=True)
+                artifact_path = output_dir / f"{operation}.json"
+                artifact_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
+                self._job_registry.attach_manifest(job.job_id, manifest_json)
+                if request.generate_manifest:
+                    yield maintenance_pb2.ConvertModelEvent(
+                        manifest=maintenance_pb2.ConvertManifest(manifest_json=manifest_json)
+                    )
+                completed_output_path = str(result.get("output_path") or artifact_path)
+                self._job_registry.complete(job.job_id, completed_output_path)
+                yield maintenance_pb2.ConvertModelEvent(
+                    completed=maintenance_pb2.ConvertCompleted(output_path=completed_output_path)
+                )
+                return
 
             if operation == "quantize":
                 stage_sequence = [
@@ -1722,6 +1770,9 @@ class MaintenanceCore:
             "activate_adapter": "activate_adapter.derived_model.json",
             "remove_derived_model": "remove_derived_model.lifecycle.json",
             "registry_snapshot": "registry_snapshot.json",
+            "dataset_snapshot": "dataset_snapshot.json",
+            "dataset_download": "dataset_download.json",
+            "dataset_remove": "dataset_remove.json",
         }[operation]
         return output_dir / filename
 
@@ -1766,7 +1817,83 @@ class MaintenanceCore:
                 or request.source_model
                 or operation
             )
+        if operation in {"dataset_download", "dataset_remove", "dataset_snapshot"}:
+            return (
+                request.ext.get("melix.hf_dataset_repo_id", "")
+                or request.ext.get("repo_id", "")
+                or request.source_model
+                or operation
+            )
         return request.source_model or operation
+
+    def _run_dataset_operation(
+        self,
+        *,
+        operation: str,
+        job_id: str,
+        request: maintenance_pb2.ConvertModelRequest,
+        output_dir: Path,
+    ) -> dict[str, Any]:
+        ext = dict(request.ext)
+        progress_events: list[tuple[str, float]] = [("prepare", 0.1)]
+        if operation == "dataset_snapshot":
+            repo_id = ext.get("melix.hf_dataset_repo_id", "").strip() or ext.get("repo_id", "").strip()
+            revision = ext.get("melix.hf_revision", "").strip() or ext.get("revision", "").strip()
+            manifest = {
+                "schema_version": "melix.dataset_operation.v1",
+                "operation": operation,
+                "job_id": job_id,
+                "source_model": request.source_model,
+                "output_dir": str(output_dir),
+                "dataset_registry": self._dataset_catalog.registry_snapshot_payload(
+                    repo_id=repo_id,
+                    revision=revision,
+                ),
+            }
+            progress_events.append(("scan", 1.0))
+            return {
+                "manifest": manifest,
+                "progress_events": progress_events,
+                "output_path": output_dir / "dataset_snapshot.json",
+            }
+
+        if operation == "dataset_download":
+            repo_id = ext.get("melix.hf_dataset_repo_id", "").strip() or request.source_model.strip()
+            revision = ext.get("melix.hf_revision", "").strip() or "main"
+            result = self._dataset_catalog.download_hf_dataset(
+                repo_id=repo_id,
+                revision=revision,
+                hf_token=ext.get("melix.hf_token", "").strip() or ext.get("hf_token", "").strip(),
+                job_id=job_id,
+                output_dir=output_dir,
+            )
+            progress_events.append(("materialize", 1.0))
+            return {
+                "manifest": result.manifest,
+                "progress_events": progress_events,
+                "output_path": result.snapshot.snapshot_path,
+            }
+
+        if operation == "dataset_remove":
+            repo_id = ext.get("melix.hf_dataset_repo_id", "").strip() or ext.get("repo_id", "").strip() or request.source_model.strip()
+            result = self._dataset_catalog.remove_hf_dataset_snapshot(
+                repo_id=repo_id,
+                revision=ext.get("melix.hf_revision", "").strip() or ext.get("revision", "").strip(),
+                snapshot_id=ext.get("melix.hf_snapshot_id", "").strip() or ext.get("snapshot_id", "").strip(),
+                job_id=job_id,
+                output_dir=output_dir,
+            )
+            progress_events.append(("remove_snapshot", 1.0))
+            return {
+                "manifest": result.manifest,
+                "progress_events": progress_events,
+                "output_path": output_dir / "dataset_remove.json",
+            }
+
+        raise ModelOperationError(
+            code="invalid_argument",
+            message=f"Unsupported dataset operation: {operation}",
+        )
 
     def _run_specialized_model_operation(
         self,

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -221,6 +221,7 @@ class MaintenanceCore:
         adapter_activation_pipeline: AdapterActivationPipeline | None = None,
         upload_receipt_pipeline: UploadReceiptPipeline | None = None,
         benchmark_suite_catalog: BenchmarkSuiteCatalog | None = None,
+        dataset_catalog: DatasetCatalog | None = None,
     ) -> None:
         self._registry = registry
         self._jobs_root = Path(jobs_root)
@@ -237,7 +238,7 @@ class MaintenanceCore:
         self._benchmark_store = None
         self._benchmark_queue_store = BenchmarkQueueStore()
         self._benchmark_suite_catalog = benchmark_suite_catalog or BenchmarkSuiteCatalog()
-        self._dataset_catalog = DatasetCatalog()
+        self._dataset_catalog = dataset_catalog or DatasetCatalog()
         self._restore_derived_models_into_catalog()
 
     @staticmethod

--- a/services/mlx-worker-python/worker/productization/benchmark_suites.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_suites.py
@@ -9,6 +9,10 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+from worker.dataset_registry.catalog import (
+    read_hf_dataset_snapshot_rows,
+    resolve_cached_hf_dataset_snapshot,
+)
 from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.training_dataset import HFDatasetFetcher
 
@@ -55,17 +59,21 @@ class ResolvedBenchmarkSuite:
     materialized_package_path: Path
     cache_key: str
     cache_hit: bool
+    source_kind: str
     sample_size: int
     batch_factor: int
     prompt_batches: tuple[str, ...]
     cases: tuple[BenchmarkCase, ...]
+    hf_snapshot_id: str = ""
+    hf_snapshot_path: str = ""
+    hf_cache_repo_path: str = ""
 
     def metadata(self) -> dict[str, object]:
-        return {
+        metadata: dict[str, object] = {
             "suite_id": self.suite_id,
             "task_kind": self.task_kind,
             "title": self.title,
-            "source_kind": "hf_dataset",
+            "source_kind": self.source_kind,
             "dataset_uri": self.dataset_uri,
             "dataset_path": self.dataset_path,
             "dataset_name": self.dataset_name,
@@ -77,6 +85,11 @@ class ResolvedBenchmarkSuite:
             "sample_size": self.sample_size,
             "batch_factor": self.batch_factor,
         }
+        if self.hf_snapshot_id:
+            metadata["hf_snapshot_id"] = self.hf_snapshot_id
+            metadata["hf_snapshot_path"] = self.hf_snapshot_path
+            metadata["hf_cache_repo_path"] = self.hf_cache_repo_path
+        return metadata
 
 
 class BenchmarkSuiteCatalog:
@@ -93,7 +106,7 @@ class BenchmarkSuiteCatalog:
         }
         self._hf_dataset_fetcher = hf_dataset_fetcher or _fetch_hf_dataset_server_json
         self._resolved_suite_cache: dict[
-            tuple[str, str, Path, int, int],
+            tuple[str, str, Path, int, int, str],
             ResolvedBenchmarkSuite,
         ] = {}
 
@@ -115,10 +128,18 @@ class BenchmarkSuiteCatalog:
                 message=f"Unknown benchmark suite: {suite_id}",
                 details={"suite_id": suite_id, "task_kind": task_kind},
             )
+        definition = _definition_with_dataset_override(definition, parameters)
 
         sample_size = _parse_positive_int(parameters.get("sample_size", ""), definition.default_sample_size)
         batch_factor = _parse_positive_int(parameters.get("batch_factor", ""), definition.default_batch_factor)
-        cache_key = (definition.task_kind, definition.suite_id, jobs_root, sample_size, batch_factor)
+        cache_key = (
+            definition.task_kind,
+            definition.suite_id,
+            jobs_root,
+            sample_size,
+            batch_factor,
+            _benchmark_suite_cache_key(definition),
+        )
         cached_suite = self._resolved_suite_cache.get(cache_key)
         if cached_suite is not None:
             return cached_suite
@@ -155,6 +176,10 @@ class BenchmarkSuiteCatalog:
             materialized_package_path=materialized["package_path"],
             cache_key=materialized["cache_key"],
             cache_hit=materialized["cache_hit"],
+            source_kind=materialized["source_kind"],
+            hf_snapshot_id=materialized.get("hf_snapshot_id", ""),
+            hf_snapshot_path=materialized.get("hf_snapshot_path", ""),
+            hf_cache_repo_path=materialized.get("hf_cache_repo_path", ""),
             sample_size=sample_size,
             batch_factor=batch_factor,
             prompt_batches=tuple(case.prompt for case in cases),
@@ -357,26 +382,44 @@ def _materialize_benchmark_suite(
             "package_path": package_path,
             "cache_key": cache_key,
             "cache_hit": True,
+            "source_kind": str(manifest.get("source_kind", "hf_dataset")),
+            "hf_snapshot_id": str(manifest.get("hf_snapshot_id", "")),
+            "hf_snapshot_path": str(manifest.get("hf_snapshot_path", "")),
+            "hf_cache_repo_path": str(manifest.get("hf_cache_repo_path", "")),
             "dataset_name": str(manifest.get("dataset_name", definition.dataset_name or "default")),
             "rows": _load_materialized_rows(rows_path, limit=sample_hint),
         }
 
-    dataset_name = definition.dataset_name or _resolve_dataset_name(definition, fetch_json)
-    row_payload = fetch_json(
-        "rows",
-        {
-            "dataset": definition.dataset_path,
-            "config": dataset_name,
-            "split": definition.dataset_split,
-            "offset": "0",
-            "length": str(max(1, sample_hint)),
-        },
+    source_kind = "hf_dataset"
+    snapshot = resolve_cached_hf_dataset_snapshot(
+        repo_id=definition.dataset_path,
+        revision=definition.dataset_revision or "main",
     )
-    rows = [
-        entry["row"]
-        for entry in row_payload.get("rows", [])
-        if isinstance(entry, dict) and isinstance(entry.get("row"), dict)
-    ]
+    if snapshot is not None:
+        dataset_name = definition.dataset_name or (snapshot.configs[0] if snapshot.configs else "default")
+        rows = read_hf_dataset_snapshot_rows(
+            snapshot.snapshot_path,
+            split=definition.dataset_split,
+            limit=sample_hint,
+        )
+        source_kind = "hf_cache_snapshot"
+    else:
+        dataset_name = definition.dataset_name or _resolve_dataset_name(definition, fetch_json)
+        row_payload = fetch_json(
+            "rows",
+            {
+                "dataset": definition.dataset_path,
+                "config": dataset_name,
+                "split": definition.dataset_split,
+                "offset": "0",
+                "length": str(max(1, sample_hint)),
+            },
+        )
+        rows = [
+            entry["row"]
+            for entry in row_payload.get("rows", [])
+            if isinstance(entry, dict) and isinstance(entry.get("row"), dict)
+        ]
     if not rows:
         raise ModelOperationError(
             code="hf_dataset_fetch_failed",
@@ -387,6 +430,7 @@ def _materialize_benchmark_suite(
     package_path.mkdir(parents=True, exist_ok=True)
     manifest = {
         "schema_version": "melix.benchmark_suite_materialization.v1",
+        "source_kind": source_kind,
         "task_kind": definition.task_kind,
         "suite_id": definition.suite_id,
         "dataset_path": definition.dataset_path,
@@ -400,15 +444,65 @@ def _materialize_benchmark_suite(
         "mask_feature": definition.mask_feature,
         "default_prompt": definition.default_prompt,
     }
+    if snapshot is not None:
+        manifest.update(
+            {
+                "hf_snapshot_id": snapshot.snapshot_id,
+                "hf_snapshot_path": str(snapshot.snapshot_path),
+                "hf_cache_repo_path": str(snapshot.cache_repo_path),
+            }
+        )
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
     _write_jsonl_rows(rows_path, rows)
     return {
         "package_path": package_path,
         "cache_key": cache_key,
         "cache_hit": False,
+        "source_kind": source_kind,
+        "hf_snapshot_id": snapshot.snapshot_id if snapshot is not None else "",
+        "hf_snapshot_path": str(snapshot.snapshot_path) if snapshot is not None else "",
+        "hf_cache_repo_path": str(snapshot.cache_repo_path) if snapshot is not None else "",
         "dataset_name": dataset_name,
         "rows": rows,
     }
+
+
+def _definition_with_dataset_override(
+    definition: BenchmarkSuiteDefinition,
+    parameters: dict[str, str],
+) -> BenchmarkSuiteDefinition:
+    dataset_ref = parameters.get("dataset_ref", "").strip()
+    dataset_path = parameters.get("hf_dataset_path", "").strip()
+    dataset_revision = parameters.get("hf_dataset_revision", "").strip()
+    if dataset_ref:
+        ref_path, ref_revision = _parse_dataset_ref(dataset_ref)
+        dataset_path = dataset_path or ref_path
+        dataset_revision = dataset_revision or ref_revision
+
+    if not dataset_path:
+        return definition
+
+    return replace(
+        definition,
+        dataset_path=dataset_path,
+        dataset_name=parameters.get("hf_dataset_name", "").strip() or definition.dataset_name,
+        dataset_revision=dataset_revision or definition.dataset_revision or "main",
+        dataset_split=parameters.get("hf_dataset_split", "").strip()
+        or parameters.get("dataset_split", "").strip()
+        or definition.dataset_split,
+        prompt_feature=parameters.get("prompt_feature", "").strip() or definition.prompt_feature,
+        text_feature=parameters.get("text_feature", "").strip() or definition.text_feature,
+        image_feature=parameters.get("image_feature", "").strip() or definition.image_feature,
+        source_image_feature=parameters.get("source_image_feature", "").strip() or definition.source_image_feature,
+        mask_feature=parameters.get("mask_feature", "").strip() or definition.mask_feature,
+    )
+
+
+def _parse_dataset_ref(dataset_ref: str) -> tuple[str, str]:
+    if "@" not in dataset_ref:
+        return dataset_ref, "main"
+    repo_id, revision = dataset_ref.rsplit("@", 1)
+    return repo_id.strip(), revision.strip() or "main"
 
 
 def _suite_cases(

--- a/services/mlx-worker-python/worker/productization/benchmark_suites.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_suites.py
@@ -391,6 +391,7 @@ def _materialize_benchmark_suite(
         }
 
     source_kind = "hf_dataset"
+    local_snapshot = None
     snapshot = resolve_cached_hf_dataset_snapshot(
         repo_id=definition.dataset_path,
         revision=definition.dataset_revision or "main",
@@ -402,8 +403,10 @@ def _materialize_benchmark_suite(
             split=definition.dataset_split,
             limit=sample_hint,
         )
-        source_kind = "hf_cache_snapshot"
-    else:
+        if rows:
+            source_kind = "hf_cache_snapshot"
+            local_snapshot = snapshot
+    if local_snapshot is None:
         dataset_name = definition.dataset_name or _resolve_dataset_name(definition, fetch_json)
         row_payload = fetch_json(
             "rows",
@@ -444,12 +447,12 @@ def _materialize_benchmark_suite(
         "mask_feature": definition.mask_feature,
         "default_prompt": definition.default_prompt,
     }
-    if snapshot is not None:
+    if local_snapshot is not None:
         manifest.update(
             {
-                "hf_snapshot_id": snapshot.snapshot_id,
-                "hf_snapshot_path": str(snapshot.snapshot_path),
-                "hf_cache_repo_path": str(snapshot.cache_repo_path),
+                "hf_snapshot_id": local_snapshot.snapshot_id,
+                "hf_snapshot_path": str(local_snapshot.snapshot_path),
+                "hf_cache_repo_path": str(local_snapshot.cache_repo_path),
             }
         )
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
@@ -459,9 +462,9 @@ def _materialize_benchmark_suite(
         "cache_key": cache_key,
         "cache_hit": False,
         "source_kind": source_kind,
-        "hf_snapshot_id": snapshot.snapshot_id if snapshot is not None else "",
-        "hf_snapshot_path": str(snapshot.snapshot_path) if snapshot is not None else "",
-        "hf_cache_repo_path": str(snapshot.cache_repo_path) if snapshot is not None else "",
+        "hf_snapshot_id": local_snapshot.snapshot_id if local_snapshot is not None else "",
+        "hf_snapshot_path": str(local_snapshot.snapshot_path) if local_snapshot is not None else "",
+        "hf_cache_repo_path": str(local_snapshot.cache_repo_path) if local_snapshot is not None else "",
         "dataset_name": dataset_name,
         "rows": rows,
     }
@@ -499,10 +502,21 @@ def _definition_with_dataset_override(
 
 
 def _parse_dataset_ref(dataset_ref: str) -> tuple[str, str]:
-    if "@" not in dataset_ref:
-        return dataset_ref, "main"
-    repo_id, revision = dataset_ref.rsplit("@", 1)
-    return repo_id.strip(), revision.strip() or "main"
+    # Keep this grammar in sync with MelixCLIParser.parseDatasetReference.
+    trimmed = dataset_ref.strip()
+    if "@" not in trimmed:
+        repo_id, revision = trimmed, "main"
+    else:
+        repo_id, revision = trimmed.rsplit("@", 1)
+        repo_id = repo_id.strip()
+        revision = revision.strip() or "main"
+    if not repo_id or "@" in repo_id:
+        raise ModelOperationError(
+            code="invalid_argument",
+            message="Invalid dataset_ref. Expected format: repo/name[@revision].",
+            details={"dataset_ref": dataset_ref},
+        )
+    return repo_id, revision
 
 
 def _suite_cases(

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -15,6 +15,10 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+from worker.dataset_registry.catalog import (
+    read_hf_dataset_snapshot_rows,
+    resolve_cached_hf_dataset_snapshot,
+)
 from worker.model_ops.errors import ModelOperationError
 
 _DEFAULT_IGNORED_PATHS = {
@@ -165,6 +169,38 @@ def materialize_hf_evaluation_dataset(
     cache_root: Path,
     fetch_json: HFEvaluationDatasetFetcher | None = None,
 ) -> MaterializedEvaluationDataset:
+    local_snapshot = resolve_cached_hf_dataset_snapshot(
+        repo_id=source.dataset_path,
+        revision=source.dataset_revision or "main",
+    )
+    if local_snapshot is not None:
+        rows = read_hf_dataset_snapshot_rows(
+            local_snapshot.snapshot_path,
+            split=source.split or "train",
+        )
+        if rows:
+            resolved_name = source.dataset_name or (local_snapshot.configs[0] if local_snapshot.configs else "default")
+            source_slug = _hf_source_slug(source.dataset_path)
+            resolved_source = HFEvaluationDatasetSource(
+                dataset_path=source.dataset_path,
+                dataset_name=resolved_name,
+                dataset_revision=source.dataset_revision or local_snapshot.revision,
+                split=source.split or "train",
+            )
+            return _materialize_evaluation_rows(
+                rows=rows,
+                profile=profile,
+                field_mapping=field_mapping,
+                dataset_id=dataset_id or f"{source_slug}.dev.v1",
+                suite_id=suite_id or source_slug,
+                cache_root=cache_root,
+                source_metadata=_hf_cache_source_metadata(
+                    source=resolved_source,
+                    snapshot=local_snapshot,
+                    rows=rows,
+                ),
+            )
+
     fetcher = fetch_json or _fetch_hf_dataset_server_json
     resolved_name = source.dataset_name or _resolve_hf_dataset_name(source, fetcher)
     rows = _fetch_hf_dataset_rows(
@@ -371,6 +407,24 @@ def _hf_source_metadata(*, source: HFEvaluationDatasetSource, rows: list[dict[st
         ),
         "hf_rows_sha256": hashlib.sha256(rows_payload.encode("utf-8")).hexdigest(),
     }
+
+
+def _hf_cache_source_metadata(
+    *,
+    source: HFEvaluationDatasetSource,
+    snapshot: Any,
+    rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    metadata = _hf_source_metadata(source=source, rows=rows)
+    metadata.update(
+        {
+            "source_kind": "hf_cache_snapshot",
+            "hf_snapshot_id": snapshot.snapshot_id,
+            "hf_snapshot_path": str(snapshot.snapshot_path),
+            "hf_cache_repo_path": str(snapshot.cache_repo_path),
+        }
+    )
+    return metadata
 
 
 def _sha256_for_path(path: Path, *, chunk_size: int = 1024 * 1024) -> str:

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -16,6 +16,7 @@ from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 from worker.dataset_registry.catalog import (
+    DatasetSnapshot,
     read_hf_dataset_snapshot_rows,
     resolve_cached_hf_dataset_snapshot,
 )
@@ -412,7 +413,7 @@ def _hf_source_metadata(*, source: HFEvaluationDatasetSource, rows: list[dict[st
 def _hf_cache_source_metadata(
     *,
     source: HFEvaluationDatasetSource,
-    snapshot: Any,
+    snapshot: DatasetSnapshot,
     rows: list[dict[str, Any]],
 ) -> dict[str, Any]:
     metadata = _hf_source_metadata(source=source, rows=rows)

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -577,6 +577,9 @@ struct MelixCLIParserTests {
             (.modelHubSearch(.init(query: "qwen", pageSize: 5, cursor: "next", mlxOnly: false, json: true)), "model.hub.search"),
             (.modelHubShow(.init(repoID: "mlx/qwen", json: true)), "model.hub.show"),
             (.modelHubDownload(.init(repoID: "mlx/qwen", revision: "main", json: true)), "model.hub.download"),
+            (.datasetList(.init(json: true)), "dataset.list"),
+            (.datasetHubDownload(.init(repoID: "org/dataset", revision: "main", json: true)), "dataset.hub.download"),
+            (.datasetRemove(.init(repoID: "org/dataset", revision: "main", snapshotID: "abc123", json: true)), "dataset.remove"),
             (.modelRootsList(.init(json: true)), "model.roots.list"),
             (.modelRootsAdd(.init(path: "/models", json: true)), "model.roots.add"),
             (.modelRootsRemove(.init(path: "/models", json: true)), "model.roots.remove"),
@@ -651,6 +654,9 @@ struct MelixCLIParserTests {
             .upload(.init(modelID: "model", outputDir: "/tmp/out", targetRepo: "melix/model", artifactPath: "/tmp/model", artifactKind: "bundle", artifactManifestPath: "/tmp/model/manifest.json", json: true)),
             .modelImport(.init(path: "/tmp/model", modelID: "model", modelKind: "text", revision: "main", json: true)),
             .modelHubDownload(.init(repoID: "mlx/qwen", revision: "main", json: true)),
+            .datasetList(.init(json: true)),
+            .datasetHubDownload(.init(repoID: "org/dataset", revision: "main", json: true)),
+            .datasetRemove(.init(repoID: "org/dataset", revision: "main", snapshotID: "abc123", json: true)),
             .modelRootsList(.init(json: true)),
             .modelRootsAdd(.init(path: "/models", json: true)),
             .modelRootsRemove(.init(path: "/models", json: true)),
@@ -819,6 +825,54 @@ struct MelixCLIParserTests {
         #expect(addOptions.path == "/tmp/models-a")
         #expect(moveOptions.path == "/tmp/models-a")
         #expect(moveOptions.index == 1)
+    }
+
+    @Test("parses dataset list download and remove commands")
+    func parsesDatasetListDownloadAndRemoveCommands() throws {
+        let listCommand = try MelixCLIParser.parse([
+            "dataset",
+            "list",
+            "--json",
+        ])
+        let downloadCommand = try MelixCLIParser.parse([
+            "dataset",
+            "hub",
+            "download",
+            "--repo-id", "Jax-dan/HundredCV-Chat",
+            "--revision", "main",
+            "--hf-token", "hf_secret_token",
+            "--json",
+        ])
+        let removeCommand = try MelixCLIParser.parse([
+            "dataset",
+            "remove",
+            "--repo-id", "Jax-dan/HundredCV-Chat",
+            "--snapshot-id", "abc123",
+            "--json",
+        ])
+
+        guard case .datasetList(let listOptions) = listCommand else {
+            Issue.record("Expected datasetList command")
+            return
+        }
+        guard case .datasetHubDownload(let downloadOptions) = downloadCommand else {
+            Issue.record("Expected datasetHubDownload command")
+            return
+        }
+        guard case .datasetRemove(let removeOptions) = removeCommand else {
+            Issue.record("Expected datasetRemove command")
+            return
+        }
+
+        #expect(listOptions.json)
+        #expect(downloadOptions.repoID == "Jax-dan/HundredCV-Chat")
+        #expect(downloadOptions.revision == "main")
+        #expect(downloadOptions.hfToken == "hf_secret_token")
+        #expect(downloadOptions.json)
+        #expect(removeOptions.repoID == "Jax-dan/HundredCV-Chat")
+        #expect(removeOptions.revision == "main")
+        #expect(removeOptions.snapshotID == "abc123")
+        #expect(removeOptions.json)
     }
 
     @Test("parses model import command and rejects missing import path")
@@ -1664,6 +1718,32 @@ struct MelixCLIParserTests {
         #expect(options.json)
     }
 
+    @Test("parses bench run with managed dataset reference")
+    func parsesBenchRunWithManagedDatasetReference() throws {
+        let command = try MelixCLIParser.parse([
+            "bench",
+            "run",
+            "--model-id", "melix-dev-text",
+            "--suite", "latency",
+            "--dataset-ref", "Jax-dan/HundredCV-Chat@main",
+            "--hf-dataset-name", "default",
+            "--hf-dataset-split", "train",
+            "--prompt-feature", "messages",
+        ])
+
+        guard case .benchRun(let options) = command else {
+            Issue.record("Expected benchRun command")
+            return
+        }
+
+        #expect(options.parameters["dataset_ref"] == "Jax-dan/HundredCV-Chat@main")
+        #expect(options.parameters["hf_dataset_path"] == "Jax-dan/HundredCV-Chat")
+        #expect(options.parameters["hf_dataset_revision"] == "main")
+        #expect(options.parameters["hf_dataset_name"] == "default")
+        #expect(options.parameters["hf_dataset_split"] == "train")
+        #expect(options.parameters["prompt_feature"] == "messages")
+    }
+
     @Test("parses bench list and export-csv commands")
     func parsesBenchListAndExportCSVCommands() throws {
         let listCommand = try MelixCLIParser.parse([
@@ -2060,6 +2140,35 @@ struct MelixCLIParserTests {
         #expect(options.profile.ignoredPaths == ["metadata.trace_id"])
     }
 
+    @Test("parses eval run with managed dataset reference")
+    func parsesEvalRunWithManagedDatasetReference() throws {
+        let command = try MelixCLIParser.parse([
+            "eval",
+            "run",
+            "--model-id", "melix-dev-text",
+            "--suite", "dolly",
+            "--dataset-ref", "IRUCAAI/extract_group_chat_dataset_with_summary@main",
+            "--hf-dataset-split", "train",
+            "--field-input-text-path", "dialogue",
+            "--field-target-path", "summary",
+        ])
+
+        guard case .evalRun(let options) = command else {
+            Issue.record("Expected evalRun command")
+            return
+        }
+
+        #expect(options.source.kind == .huggingFaceDataset)
+        #expect(options.source.datasetPath == "IRUCAAI/extract_group_chat_dataset_with_summary")
+        #expect(options.source.datasetRevision == "main")
+        #expect(options.source.split == "train")
+        #expect(options.parameters["dataset_ref"] == "IRUCAAI/extract_group_chat_dataset_with_summary@main")
+        #expect(options.parameters["hf_dataset_path"] == "IRUCAAI/extract_group_chat_dataset_with_summary")
+        #expect(options.parameters["hf_dataset_revision"] == "main")
+        #expect(options.fieldMapping.inputTextPath == "dialogue")
+        #expect(options.fieldMapping.targetPath == "summary")
+    }
+
     @Test("parses eval compare with target model ids and comparison controls")
     func parsesEvalCompareCommand() throws {
         let command = try MelixCLIParser.parse([
@@ -2156,6 +2265,38 @@ struct MelixCLIParserTests {
 
         #expect(options.targetModelIDs == ["melix-dev-text-lora-registered"])
         #expect(options.targetAdapterManifestPaths == ["/tmp/melix-adapters/fresh.adapter.json"])
+    }
+
+    @Test("parses eval compare with managed dataset reference")
+    func parsesEvalCompareWithManagedDatasetReference() throws {
+        let command = try MelixCLIParser.parse([
+            "eval",
+            "compare",
+            "--model-id", "melix-dev-text",
+            "--target-model-id", "melix-dev-text-lora",
+            "--suite", "dolly",
+            "--dataset-ref", "IRUCAAI/extract_group_chat_dataset_with_summary@main",
+            "--hf-dataset-split", "train",
+            "--field-input-text-path", "dialogue",
+            "--field-target-path", "summary",
+            "--json",
+        ])
+
+        guard case .evalCompare(let options) = command else {
+            Issue.record("Expected evalCompare command")
+            return
+        }
+
+        #expect(options.suites == ["dolly"])
+        #expect(options.source.kind == .huggingFaceDataset)
+        #expect(options.source.datasetPath == "IRUCAAI/extract_group_chat_dataset_with_summary")
+        #expect(options.source.datasetRevision == "main")
+        #expect(options.source.split == "train")
+        #expect(options.fieldMapping.inputTextPath == "dialogue")
+        #expect(options.fieldMapping.targetPath == "summary")
+        #expect(options.parameters["dataset_ref"] == "IRUCAAI/extract_group_chat_dataset_with_summary@main")
+        #expect(options.parameters["hf_dataset_path"] == "IRUCAAI/extract_group_chat_dataset_with_summary")
+        #expect(options.parameters["hf_dataset_revision"] == "main")
     }
 
     @Test("eval compare rejects invocations missing both target types")

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -9,6 +9,8 @@ struct MelixCLIParserTests {
     @Test("documents eval dataset root in usage text")
     func documentsEvalDatasetRootInUsageText() {
         #expect(MelixCLIParser.usageText.contains("[--dataset-root PATH]"))
+        #expect(MelixCLIParser.usageText.contains("--hf-token passed to model or dataset hub download is saved"))
+        #expect(MelixCLIParser.usageText.contains("--hf-dataset-revision overrides a revision embedded in --dataset-ref"))
     }
 
     @Test("documents and parses remote server direct target commands")
@@ -1742,6 +1744,37 @@ struct MelixCLIParserTests {
         #expect(options.parameters["hf_dataset_name"] == "default")
         #expect(options.parameters["hf_dataset_split"] == "train")
         #expect(options.parameters["prompt_feature"] == "messages")
+
+        let defaultRevisionCommand = try MelixCLIParser.parse([
+            "bench",
+            "run",
+            "--model-id", "melix-dev-text",
+            "--suite", "latency",
+            "--dataset-ref", "Jax-dan/HundredCV-Chat",
+        ])
+        #expect(defaultRevisionCommand == .benchRun(.init(
+            modelID: "melix-dev-text",
+            suites: ["latency"],
+            parameters: [
+                "dataset_ref": "Jax-dan/HundredCV-Chat",
+                "hf_dataset_path": "Jax-dan/HundredCV-Chat",
+                "hf_dataset_revision": "main",
+            ]
+        )))
+    }
+
+    @Test("rejects malformed managed dataset references")
+    func rejectsMalformedManagedDatasetReferences() throws {
+        try assertError(
+            for: [
+                "bench",
+                "run",
+                "--model-id", "melix-dev-text",
+                "--suite", "latency",
+                "--dataset-ref", "org@repo@main",
+            ],
+            equals: .usage("Invalid --dataset-ref: 'org@repo' is not a valid repo id; expected format is repo/name[@revision].")
+        )
     }
 
     @Test("parses bench list and export-csv commands")
@@ -2167,6 +2200,30 @@ struct MelixCLIParserTests {
         #expect(options.parameters["hf_dataset_revision"] == "main")
         #expect(options.fieldMapping.inputTextPath == "dialogue")
         #expect(options.fieldMapping.targetPath == "summary")
+    }
+
+    @Test("eval dataset revision option overrides managed dataset reference revision")
+    func evalDatasetRevisionOptionOverridesManagedDatasetReferenceRevision() throws {
+        let command = try MelixCLIParser.parse([
+            "eval",
+            "run",
+            "--model-id", "melix-dev-text",
+            "--suite", "dolly",
+            "--dataset-ref", "IRUCAAI/extract_group_chat_dataset_with_summary@pinned",
+            "--hf-dataset-revision", "main",
+            "--field-input-text-path", "dialogue",
+            "--field-target-path", "summary",
+        ])
+
+        guard case .evalRun(let options) = command else {
+            Issue.record("Expected evalRun command")
+            return
+        }
+
+        #expect(options.source.datasetPath == "IRUCAAI/extract_group_chat_dataset_with_summary")
+        #expect(options.source.datasetRevision == "main")
+        #expect(options.parameters["dataset_ref"] == "IRUCAAI/extract_group_chat_dataset_with_summary@pinned")
+        #expect(options.parameters["hf_dataset_revision"] == "main")
     }
 
     @Test("parses eval compare with target model ids and comparison controls")
@@ -2740,6 +2797,18 @@ struct MelixCLIParserTests {
 
     @Test("surfaces malformed option errors")
     func surfacesMalformedOptionErrors() throws {
+        try assertError(for: ["dataset"], equals: .usage(MelixCLIParser.usageText))
+        try assertError(for: ["dataset", "unknown"], equals: .usage(MelixCLIParser.usageText))
+        try assertError(for: ["dataset", "hub"], equals: .usage(MelixCLIParser.usageText))
+        try assertError(for: ["dataset", "hub", "unknown"], equals: .usage(MelixCLIParser.usageText))
+        try assertError(
+            for: ["dataset", "hub", "download"],
+            equals: .missingRequired("--repo-id is required for melix dataset hub download.")
+        )
+        try assertError(
+            for: ["dataset", "remove"],
+            equals: .missingRequired("--repo-id is required for melix dataset remove.")
+        )
         try assertError(for: ["server"], equals: .usage(MelixCLIParser.usageText))
         try assertError(for: ["server", "hibernate"], equals: .usage(MelixCLIParser.usageText))
         try assertError(
@@ -2761,6 +2830,16 @@ struct MelixCLIParserTests {
         try assertError(for: ["bench", "run", "oops"], equals: .usage(MelixCLIParser.usageText))
         try assertError(for: ["bench", "run", "--model-id"], equals: .missingValue("--model-id"))
         try assertError(for: ["eval", "run", "--repo-id"], equals: .missingValue("--repo-id"))
+        try assertError(
+            for: [
+                "eval",
+                "run",
+                "--model-id", "melix-dev-text",
+                "--source-csv", "/tmp/eval.csv",
+                "--dataset-ref", "org/dataset",
+            ],
+            equals: .usage("At most one of --source-csv, --source-jsonl, --hf-dataset-path, or --dataset-ref may be provided for melix eval run.")
+        )
         try assertError(for: ["lora", "list", "--model-id"], equals: .missingValue("--model-id"))
         try assertError(for: ["lora", "activate", "--model-id", "melix-dev-text", "oops"], equals: .usage(MelixCLIParser.usageText))
         #expect(MelixCLIError.usage("usage").errorDescription == "usage")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -1988,7 +1988,7 @@ struct MelixCLIRunnerTests {
                     "revision": "main",
                     "snapshot_id": "abc123",
                     "snapshot_path": "/tmp/hf-cache/datasets--Jax-dan--HundredCV-Chat/snapshots/abc123",
-                    "total_bytes": 2048
+                    "total_bytes": 9007199254740993
                   }
                 ],
                 "roots": []
@@ -2003,6 +2003,38 @@ struct MelixCLIRunnerTests {
         #expect(call.operation == "dataset_snapshot")
         #expect(output.contains("repo_id\trevision\tsnapshot_id\ttotal_bytes\tsnapshot_path"))
         #expect(output.contains("Jax-dan/HundredCV-Chat\tmain\tabc123"))
+        #expect(output.contains("\t8192.00 TB\t"))
+
+        let jsonOutput = try await MelixCLIRunner(client: client).run(.datasetList(.init(json: true)))
+        let jsonPayload = try #require(parseJSONObject(jsonOutput))
+        let registry = try #require(jsonPayload["dataset_registry"] as? [String: Any])
+        let datasets = try #require(registry["datasets"] as? [[String: Any]])
+        #expect(datasets.first?["repo_id"] as? String == "Jax-dan/HundredCV-Chat")
+    }
+
+    @Test("dataset list renders empty managed dataset state")
+    func datasetListRendersEmptyManagedDatasetState() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(makeModelOperationResult(
+            manifestJSON: #"{"operation":"dataset_snapshot","dataset_registry":{"datasets":[],"roots":[]}}"#
+        ))
+
+        let output = try await MelixCLIRunner(client: client).run(.datasetList(.init(json: false)))
+
+        #expect(output == "No managed datasets found.\n")
+    }
+
+    @Test("dataset list surfaces malformed registry responses")
+    func datasetListSurfacesMalformedRegistryResponses() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(makeModelOperationResult(manifestJSON: #"{"datasets":[]}"#))
+
+        do {
+            _ = try await MelixCLIRunner(client: client).run(.datasetList(.init(json: false)))
+            Issue.record("Expected dataset list to throw for missing dataset_registry")
+        } catch let error as MelixCLIError {
+            #expect(error == .runtime("dataset_snapshot response did not include a dataset_registry JSON object."))
+        }
     }
 
     @Test("dataset hub download forwards dataset repo operation and redacts token from output")
@@ -2026,10 +2058,11 @@ struct MelixCLIRunnerTests {
             """#
         ))
 
-        let output = try await MelixCLIRunner(
+        let runner = MelixCLIRunner(
             client: client,
             environment: ["MELIX_HOME": temporaryRoot.path]
-        ).run(
+        )
+        let output = try await runner.run(
             .datasetHubDownload(.init(repoID: "Jax-dan/HundredCV-Chat", revision: "main", hfToken: "hf_secret_token", json: true))
         )
         let call = try #require(await client.lastModelOperationCall)
@@ -2044,6 +2077,12 @@ struct MelixCLIRunnerTests {
         #expect(payload["repo_id"] as? String == "Jax-dan/HundredCV-Chat")
         #expect(payload["managed_dataset_path"] as? String == "/tmp/hf-cache/datasets--Jax-dan--HundredCV-Chat/snapshots/abc123")
         #expect(output.contains("hf_secret_token") == false)
+
+        _ = try await runner.run(
+            .datasetHubDownload(.init(repoID: "Jax-dan/HundredCV-Chat", revision: "main", json: true))
+        )
+        let reusedTokenCall = try #require(await client.lastModelOperationCall)
+        #expect(reusedTokenCall.ext["melix.hf_token"] == "hf_secret_token")
     }
 
     @Test("dataset remove forwards safe snapshot selector")
@@ -2065,6 +2104,45 @@ struct MelixCLIRunnerTests {
         #expect(call.ext["melix.hf_dataset_repo_id"] == "Jax-dan/HundredCV-Chat")
         #expect(call.ext["melix.hf_revision"] == "main")
         #expect(call.ext["melix.hf_snapshot_id"] == "abc123")
+    }
+
+    @Test("dataset remove renders manifest summary when worker output path is empty")
+    func datasetRemoveRendersManifestSummaryWhenWorkerOutputPathIsEmpty() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(makeModelOperationResult(
+            outputPath: "",
+            manifestJSON: #"""
+            {
+              "operation": "dataset_remove",
+              "repo_id": "Jax-dan/HundredCV-Chat",
+              "revision": "main",
+              "removed_snapshot_id": "abc123",
+              "removed_snapshot_path": "/tmp/hf-cache/datasets--Jax-dan--HundredCV-Chat/snapshots/abc123"
+            }
+            """#
+        ))
+
+        let output = try await MelixCLIRunner(client: client).run(
+            .datasetRemove(.init(repoID: "Jax-dan/HundredCV-Chat", revision: "main", snapshotID: "abc123", json: false))
+        )
+
+        #expect(output.contains("Removed dataset snapshot Jax-dan/HundredCV-Chat@main (abc123)."))
+        #expect(output.contains("Removed path: /tmp/hf-cache/datasets--Jax-dan--HundredCV-Chat/snapshots/abc123"))
+
+        await client.setModelOperationResult(makeModelOperationResult(
+            outputPath: "",
+            manifestJSON: #"{"operation":"dataset_remove","repo_id":"Jax-dan/HundredCV-Chat","revision":"main","snapshot_id":"abc123"}"#
+        ))
+        let summaryWithoutPath = try await MelixCLIRunner(client: client).run(
+            .datasetRemove(.init(repoID: "Jax-dan/HundredCV-Chat", revision: "main", snapshotID: "abc123", json: false))
+        )
+        #expect(summaryWithoutPath == "Removed dataset snapshot Jax-dan/HundredCV-Chat@main (abc123).\n")
+
+        await client.setModelOperationResult(makeModelOperationResult(outputPath: "", manifestJSON: "not-json"))
+        let genericSummary = try await MelixCLIRunner(client: client).run(
+            .datasetRemove(.init(repoID: "Jax-dan/HundredCV-Chat", revision: "main", snapshotID: "abc123", json: false))
+        )
+        #expect(genericSummary == "Dataset removal completed.\n")
     }
 
     @Test("model import forwards a local import operation and renders a managed model receipt")
@@ -4592,6 +4670,56 @@ struct MelixCLIRunnerTests {
         #expect(commands[1].contains("--activation-mode"))
         #expect(commands[1].contains("adapter_backed_runtime"))
         #expect(commands[2] == ["lora", "list", "--model-id", "mlx-community/Qwen3.5-0.8B-OptiQ-4bit", "--json"])
+    }
+
+    @Test("subprocess-backed dataset operations build public melix arguments")
+    func subprocessBackedDatasetOperationsBuildPublicCLIArguments() async throws {
+        let client = StubControlPlaneXPCClient()
+        let executor = RecordingCLICommandExecutor(
+            responses: [
+                #"{"operation":"dataset_snapshot","dataset_registry":{"datasets":[],"roots":[]}}"#,
+                #"{"operation":"dataset_download","repo_id":"org/dataset","revision":"main","snapshot_path":"/tmp/hf-cache/datasets--org--dataset/snapshots/abc123"}"#,
+                #"{"operation":"dataset_remove","repo_id":"org/dataset","revision":"main","snapshot_id":"abc123","removed_snapshot_path":"/tmp/hf-cache/datasets--org--dataset/snapshots/abc123"}"#,
+            ]
+        )
+        let runner = MelixCLIRunner(
+            client: client,
+            commandExecutor: executor.run
+        )
+
+        let snapshotResult = try await runner.performModelOperation(
+            modelID: "melix-datasets",
+            operation: "dataset_snapshot",
+            outputDir: "",
+            ext: [:]
+        )
+        let downloadResult = try await runner.performModelOperation(
+            modelID: "org/dataset",
+            operation: "dataset_download",
+            outputDir: "",
+            ext: [
+                "melix.hf_revision": "main",
+                "melix.hf_token": "hf_secret",
+            ]
+        )
+        let removeResult = try await runner.performModelOperation(
+            modelID: "org/dataset",
+            operation: "dataset_remove",
+            outputDir: "",
+            ext: [
+                "melix.hf_revision": "main",
+                "melix.hf_snapshot_id": "abc123",
+            ]
+        )
+        let commands = await executor.commands
+
+        #expect(await client.lastModelOperationCall == nil)
+        #expect(parseJSONObject(snapshotResult.manifestJson)?["operation"] as? String == "dataset_snapshot")
+        #expect(downloadResult.outputPath == "/tmp/hf-cache/datasets--org--dataset/snapshots/abc123")
+        #expect(parseJSONObject(removeResult.manifestJson)?["operation"] as? String == "dataset_remove")
+        #expect(commands[0] == ["dataset", "list", "--json"])
+        #expect(commands[1] == ["dataset", "hub", "download", "--repo-id", "org/dataset", "--revision", "main", "--hf-token", "hf_secret", "--json"])
+        #expect(commands[2] == ["dataset", "remove", "--repo-id", "org/dataset", "--revision", "main", "--snapshot-id", "abc123", "--json"])
     }
 
     @Test("subprocess-backed legacy alignment training mode uses alignment train")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -1974,6 +1974,99 @@ struct MelixCLIRunnerTests {
         #expect(secondCall.ext["melix.hf_token"] == "hf_secret_token")
     }
 
+    @Test("dataset list renders managed Hugging Face cache snapshots")
+    func datasetListRendersManagedHuggingFaceCacheSnapshots() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(makeModelOperationResult(
+            manifestJSON: #"""
+            {
+              "operation": "dataset_snapshot",
+              "dataset_registry": {
+                "datasets": [
+                  {
+                    "repo_id": "Jax-dan/HundredCV-Chat",
+                    "revision": "main",
+                    "snapshot_id": "abc123",
+                    "snapshot_path": "/tmp/hf-cache/datasets--Jax-dan--HundredCV-Chat/snapshots/abc123",
+                    "total_bytes": 2048
+                  }
+                ],
+                "roots": []
+              }
+            }
+            """#
+        ))
+
+        let output = try await MelixCLIRunner(client: client).run(.datasetList(.init(json: false)))
+        let call = try #require(await client.lastModelOperationCall)
+
+        #expect(call.operation == "dataset_snapshot")
+        #expect(output.contains("repo_id\trevision\tsnapshot_id\ttotal_bytes\tsnapshot_path"))
+        #expect(output.contains("Jax-dan/HundredCV-Chat\tmain\tabc123"))
+    }
+
+    @Test("dataset hub download forwards dataset repo operation and redacts token from output")
+    func datasetHubDownloadForwardsDatasetRepoOperationAndRedactsTokenFromOutput() async throws {
+        let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-cli-hf-dataset-token-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(makeModelOperationResult(
+            outputPath: "/tmp/hf-cache/datasets--Jax-dan--HundredCV-Chat/snapshots/abc123",
+            manifestJSON: #"""
+            {
+              "dataset_id": "Jax-dan/HundredCV-Chat@main",
+              "repo_id": "Jax-dan/HundredCV-Chat",
+              "revision": "main",
+              "snapshot_id": "abc123",
+              "snapshot_path": "/tmp/hf-cache/datasets--Jax-dan--HundredCV-Chat/snapshots/abc123",
+              "source_kind": "hf_cache_snapshot"
+            }
+            """#
+        ))
+
+        let output = try await MelixCLIRunner(
+            client: client,
+            environment: ["MELIX_HOME": temporaryRoot.path]
+        ).run(
+            .datasetHubDownload(.init(repoID: "Jax-dan/HundredCV-Chat", revision: "main", hfToken: "hf_secret_token", json: true))
+        )
+        let call = try #require(await client.lastModelOperationCall)
+        let payload = try #require(parseJSONObject(output))
+
+        #expect(call.modelID == "Jax-dan/HundredCV-Chat")
+        #expect(call.operation == "dataset_download")
+        #expect(call.ext["melix.source_kind"] == "hf_dataset")
+        #expect(call.ext["melix.hf_dataset_repo_id"] == "Jax-dan/HundredCV-Chat")
+        #expect(call.ext["melix.hf_revision"] == "main")
+        #expect(call.ext["melix.hf_token"] == "hf_secret_token")
+        #expect(payload["repo_id"] as? String == "Jax-dan/HundredCV-Chat")
+        #expect(payload["managed_dataset_path"] as? String == "/tmp/hf-cache/datasets--Jax-dan--HundredCV-Chat/snapshots/abc123")
+        #expect(output.contains("hf_secret_token") == false)
+    }
+
+    @Test("dataset remove forwards safe snapshot selector")
+    func datasetRemoveForwardsSafeSnapshotSelector() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(makeModelOperationResult(
+            outputPath: "/tmp/melix/model-ops/dataset_remove.json",
+            manifestJSON: #"{"operation":"dataset_remove","repo_id":"Jax-dan/HundredCV-Chat","snapshot_id":"abc123"}"#
+        ))
+
+        let output = try await MelixCLIRunner(client: client).run(
+            .datasetRemove(.init(repoID: "Jax-dan/HundredCV-Chat", revision: "main", snapshotID: "abc123", json: false))
+        )
+        let call = try #require(await client.lastModelOperationCall)
+
+        #expect(output == "/tmp/melix/model-ops/dataset_remove.json\n")
+        #expect(call.operation == "dataset_remove")
+        #expect(call.modelID == "Jax-dan/HundredCV-Chat")
+        #expect(call.ext["melix.hf_dataset_repo_id"] == "Jax-dan/HundredCV-Chat")
+        #expect(call.ext["melix.hf_revision"] == "main")
+        #expect(call.ext["melix.hf_snapshot_id"] == "abc123")
+    }
+
     @Test("model import forwards a local import operation and renders a managed model receipt")
     func modelImportForwardsALocalImportOperationAndRendersAManagedModelReceipt() async throws {
         let client = StubControlPlaneXPCClient()
@@ -5124,6 +5217,41 @@ struct MelixCLIRunnerTests {
         #expect(metrics["bench.smoke.ttft_ms"] == 24.45)
     }
 
+    @Test("bench run forwards managed dataset reference parameters")
+    func benchRunForwardsManagedDatasetReferenceParameters() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setBenchResult(
+            .init(
+                reportPath: "/tmp/melix/bench/job-dataset/report.md",
+                reportMarkdown: "# Melix Bench\n",
+                metrics: [:]
+            )
+        )
+
+        _ = try await MelixCLIRunner(client: client).run(
+            .benchRun(
+                .init(
+                    modelID: "melix-dev-text",
+                    suites: ["latency"],
+                    parameters: [
+                        "dataset_ref": "Jax-dan/HundredCV-Chat@main",
+                        "hf_dataset_path": "Jax-dan/HundredCV-Chat",
+                        "hf_dataset_revision": "main",
+                        "hf_dataset_split": "train",
+                        "prompt_feature": "messages",
+                    ]
+                )
+            )
+        )
+        let benchRequest = try #require(await client.lastBenchRequest)
+
+        #expect(benchRequest.parameters["dataset_ref"] == "Jax-dan/HundredCV-Chat@main")
+        #expect(benchRequest.parameters["hf_dataset_path"] == "Jax-dan/HundredCV-Chat")
+        #expect(benchRequest.parameters["hf_dataset_revision"] == "main")
+        #expect(benchRequest.parameters["hf_dataset_split"] == "train")
+        #expect(benchRequest.parameters["prompt_feature"] == "messages")
+    }
+
     @Test("bench run forwards canonical normalized request values")
     func benchRunForwardsCanonicalNormalizedRequestValues() async throws {
         let client = StubControlPlaneXPCClient()
@@ -5839,6 +5967,48 @@ struct MelixCLIRunnerTests {
         #expect(request.profile.ignoredPaths == ["metadata.trace_id"])
     }
 
+    @Test("eval run forwards managed dataset reference parameters")
+    func evalRunForwardsManagedDatasetReferenceParameters() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setEvaluationResults([
+            makeEvaluationRunResult(
+                jobID: "eval-managed-dataset",
+                suiteID: "dolly",
+                datasetID: "managed.dev.v1",
+                metricName: "eval.dolly.exact_match",
+                metricValue: 0.5
+            ),
+        ])
+
+        _ = try await MelixCLIRunner(client: client).run(
+            .evalRun(
+                .init(
+                    modelID: "melix-dev-text",
+                    suites: ["dolly"],
+                    source: .huggingFaceDataset(
+                        datasetPath: "IRUCAAI/extract_group_chat_dataset_with_summary",
+                        datasetRevision: "main",
+                        split: "train"
+                    ),
+                    fieldMapping: .init(inputTextPath: "dialogue", targetPath: "summary"),
+                    parameters: [
+                        "dataset_ref": "IRUCAAI/extract_group_chat_dataset_with_summary@main",
+                        "hf_dataset_path": "IRUCAAI/extract_group_chat_dataset_with_summary",
+                        "hf_dataset_revision": "main",
+                    ]
+                )
+            )
+        )
+        let request = try #require((await client.evaluationRequests).first)
+
+        #expect(request.source.kind == .huggingFaceDataset)
+        #expect(request.source.datasetPath == "IRUCAAI/extract_group_chat_dataset_with_summary")
+        #expect(request.source.datasetRevision == "main")
+        #expect(request.parameters["dataset_ref"] == "IRUCAAI/extract_group_chat_dataset_with_summary@main")
+        #expect(request.parameters["hf_dataset_path"] == "IRUCAAI/extract_group_chat_dataset_with_summary")
+        #expect(request.parameters["hf_dataset_revision"] == "main")
+    }
+
     @Test("eval compare preloads base and target models and forwards comparison parameters")
     func evalComparePreloadsBaseAndTargetsAndReturnsJSON() async throws {
         let client = StubControlPlaneXPCClient()
@@ -5951,6 +6121,53 @@ struct MelixCLIRunnerTests {
         #expect(request.profile.scoringMode == "normalized_exact_match")
         #expect(request.profile.threshold == 0.8)
         #expect(request.profile.ignoredPaths == ["metadata.trace_id"])
+    }
+
+    @Test("eval compare forwards managed dataset reference parameters")
+    func evalCompareForwardsManagedDatasetReferenceParameters() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setEvaluationResults([
+            makeEvaluationRunResult(
+                jobID: "eval-compare-managed-dataset",
+                suiteID: "dolly",
+                datasetID: "managed.dev.v1",
+                metricName: "eval.compare.win_rate",
+                metricValue: 0.5
+            ),
+        ])
+
+        _ = try await MelixCLIRunner(client: client).run(
+            .evalCompare(
+                .init(
+                    modelID: "melix-dev-text",
+                    targetModelIDs: ["melix-dev-text-lora"],
+                    suites: ["dolly"],
+                    source: .huggingFaceDataset(
+                        datasetPath: "IRUCAAI/extract_group_chat_dataset_with_summary",
+                        datasetRevision: "main",
+                        split: "train"
+                    ),
+                    fieldMapping: .init(inputTextPath: "dialogue", targetPath: "summary"),
+                    parameters: [
+                        "dataset_ref": "IRUCAAI/extract_group_chat_dataset_with_summary@main",
+                        "hf_dataset_path": "IRUCAAI/extract_group_chat_dataset_with_summary",
+                        "hf_dataset_revision": "main",
+                    ],
+                    json: true
+                )
+            )
+        )
+        let request = try #require((await client.evaluationRequests).first)
+
+        #expect(await client.loadedModelIDs == ["melix-dev-text", "melix-dev-text-lora"])
+        #expect(request.parameters["compare_mode"] == "base_vs_targets")
+        #expect(request.parameters["compare_target_model_ids"] == "melix-dev-text-lora")
+        #expect(request.source.kind == .huggingFaceDataset)
+        #expect(request.source.datasetPath == "IRUCAAI/extract_group_chat_dataset_with_summary")
+        #expect(request.source.datasetRevision == "main")
+        #expect(request.parameters["dataset_ref"] == "IRUCAAI/extract_group_chat_dataset_with_summary@main")
+        #expect(request.parameters["hf_dataset_path"] == "IRUCAAI/extract_group_chat_dataset_with_summary")
+        #expect(request.parameters["hf_dataset_revision"] == "main")
     }
 
     @Test("eval compare rejects requests without target models before dispatch")


### PR DESCRIPTION
## Summary
- Add local-first Hugging Face dataset management for Melix and address PR review feedback.
- Harden dataset reference parsing, docs, and CLI usage around `repo_id[@revision]` and revision precedence.
- Improve local dataset materialization and registry rendering: memory-safe Arrow/Parquet limits, remote fallback for missing local splits, explicit malformed registry errors, and dataset remove/download receipt fallbacks.
- Add MaintenanceCore dataset operation injection and focused tests for dispatch, manifests, progress, and error behavior.

## Plan or Spec
- `docs/plans/2026-05-05-dataset-management-and-selection.md`
- `docs/benchmark-evaluation-contract.md`

## Commands Run
```text
PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_benchmark_suites.py services/mlx-worker-python/tests/test_maintenance_service.py -q
Result: 207 passed in 6.50s

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_benchmark_suites.py services/mlx-worker-python/tests/test_maintenance_service.py -q
Result: 207 passed in 7.66s

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python coverage json -o coverage.json
Result: wrote JSON report to coverage.json

python3 scripts/python_changed_line_coverage.py --coverage-json coverage.json --diff-from HEAD^ services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/worker/productization/benchmark_suites.py services/mlx-worker-python/worker/productization/evaluation_final_result.py
Result: TOTAL 100.00% 31/31

python3 scripts/python_changed_line_coverage.py --coverage-json coverage.json --diff-from HEAD^ services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/worker/productization/benchmark_suites.py services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_benchmark_suites.py services/mlx-worker-python/tests/test_evaluation_final_result.py
Result: TOTAL 99.29% 139/140

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python coverage report --include='services/mlx-worker-python/worker/dataset_registry/catalog.py,services/mlx-worker-python/worker/engine/maintenance_core.py,services/mlx-worker-python/worker/productization/benchmark_suites.py,services/mlx-worker-python/worker/productization/evaluation_final_result.py'
Result: catalog.py 97%, maintenance_core.py 94%, benchmark_suites.py 98%, evaluation_final_result.py 75%, total 92%

swift test --filter MelixCLIParserTests
Result: 69 tests passed

swift test --filter MelixCLIRunnerTests
Result: 158 tests passed

swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
Result: 227 tests passed

python3 scripts/swift_changed_line_coverage.py --diff-from HEAD^ --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata Sources/MelixCLICore/MelixCLI.swift tests/MelixCLITests/MelixCLIParserTests.swift tests/MelixCLITests/MelixCLIRunnerTests.swift
Result: TOTAL 98.45% 254/258

git diff --check HEAD^
Result: passed

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-bodies/pr-393.md
Result: PR evidence looks valid.
```

## Coverage and Metrics
- Python production changed-line coverage for touched worker paths: `100.00%` (`31/31`).
- Python production plus touched-test changed-line coverage: `99.29%` (`139/140`).
- Swift CLI changed-line coverage for touched parser/runner scope: `98.45%` (`254/258`).
- Focused Python statement coverage for touched production files: `catalog.py` 97%, `maintenance_core.py` 94%, `benchmark_suites.py` 98%, `evaluation_final_result.py` 75%, total 92%. The lower statement totals are from broad pre-existing modules; changed-line coverage above is the commit gate for this review follow-up.

## Known Gaps
- No dataset root CRUD in this slice; only the default Hugging Face cache root is managed.
- Dataset removal deletes only selected snapshot working trees, not shared blobs or locks.
- No desktop UI surface in this PR.
- Full repository gates `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run in this focused review-follow-up pass.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or no protocol changes were made.
- [x] Dependency changes include updated lockfiles, or no dependency changes were made.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
