### PR TITLE
Add scored RL alignment runner

### DIFF
--- a/docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
+++ b/docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
@@ -4,13 +4,17 @@
 
 Continue the implementation path for
 https://github.com/Keith-CY/melix/issues/365 by adding a concrete worker runner
-for scored GRPO and RLHF alignment datasets.
+for scored GRPO and RLHF alignment datasets, plus an opt-in runtime-backed GRPO
+candidate-generation path.
 
 Issue 365 is still not complete after this slice. This work turns the existing
 GRPO/RLHF contracts, dataset validation, candidate traces, and alignment
-manifests into executable scored-trace policy-update jobs. It does not yet claim
-final real GRPO rollout generation, reward-model inference, PPO, or release
-readiness.
+manifests into executable scored-trace policy-update jobs. It also allows GRPO
+to load the current policy runtime and generate candidate responses when
+`candidate_generation_mode=runtime_generate`. That runtime path records generated
+candidates, runtime backend identity, seed-overlap proxy scores, and policy
+update traces. It does not yet claim final reward-model scoring, PPO/GRPO
+gradient updates through MLX-LM, or release readiness.
 
 ## Scope
 
@@ -18,6 +22,10 @@ readiness.
 
 - Route `training_objective=alignment_rl` through a dedicated worker-side runner.
 - Support `grpo` from `prompt_candidate` datasets with scored candidate groups.
+- Support opt-in GRPO runtime candidate generation from the current policy
+  runtime with `candidate_generation_mode=runtime_generate`.
+- Record runtime generation/scoring evidence in adapter config, policy-update
+  traces, training metrics, and `melix.alignment_run.v1`.
 - Support `rlhf` from `reward_scored` datasets with an existing reward model
   manifest reference.
 - Produce adapter weights/config artifacts and checkpoint lineage for scored
@@ -25,12 +33,12 @@ readiness.
 - Record policy-update metrics derived from scored samples, including reward
   mean/percentiles, candidate group margin/variance, update count, selected
   candidate count, KL penalty, and reward-model lineage where applicable.
-- Keep final acceptance honest by marking the backend as scored trace execution,
-  not as real online rollout or PPO.
+- Keep final acceptance honest by marking scored-trace execution as
+  deterministic and runtime generation as runtime-generated scored-trace
+  execution, not as reward-model-backed PPO.
 
 ### Excluded
 
-- Online candidate generation from the current policy model.
 - Local reward-model inference and reward scoring from issue 366.
 - PPO/GRPO gradient updates through MLX-LM.
 - End-to-end real local runtime release evidence.
@@ -40,13 +48,17 @@ readiness.
 ## Performance And Metrics
 
 This slice reads the normalized `train.jsonl` once and writes small adapter,
-config, and checkpoint artifacts. The scored-trace runner is deterministic and
-does not load the base model.
+config, and checkpoint artifacts. The default scored-trace runner is
+deterministic and does not load the base model. The opt-in
+`runtime_generate` GRPO path loads the policy runtime once per job and generates
+`grpo_candidate_count` candidates per prompt.
 
 Success metrics:
 
 - GRPO/RLHF jobs run through the default worker runner instead of failing with
   `unsupported_alignment_trainer`.
+- GRPO jobs can opt into runtime-backed candidate generation and record
+  generated-candidate evidence without being marked release-ready.
 - Alignment manifests include scored policy-update metrics.
 - Adapter manifests preserve alignment backlinks and checkpoint lineage.
 - Changed-scope coverage remains at least 95 percent.
@@ -68,7 +80,7 @@ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Do
 python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-rl-alignment-runner-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
 ```
 
-Results on 2026-05-05:
+Results on 2026-05-05 before runtime-generation extension:
 
 - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py`: 194 passed, 9 skipped.
 - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py`: 194 passed, 9 skipped.
@@ -76,10 +88,18 @@ Results on 2026-05-05:
 - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python python -m compileall -q services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py`: passed.
 - `git diff --check`: passed.
 
+Results on 2026-05-05 after runtime-generation extension:
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py`: 201 passed, 9 skipped.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py`: 201 passed, 9 skipped.
+- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-rl-alignment-runner-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py docs/plans/2026-05-05-issue-365-rl-alignment-runner.md`: 98.52% total changed-line coverage (465/472).
+- `python3 -m compileall -q services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py`: passed.
+- `git diff --check`: passed.
+
 ## Remaining Issue 365 Gaps
 
-- Real GRPO candidate generation from a loaded policy model.
 - Reward-model local inference and PPO/RL updates from issue 366.
+- Real reward-model scoring for GRPO generated candidates.
 - PTQ/QAT real local inference release evidence.
 - Full CLI chain tests for every business line.
 - Window UI runnable and inspectable acceptance for every business line.

--- a/docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
+++ b/docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
@@ -4,8 +4,8 @@
 
 Continue the implementation path for
 https://github.com/Keith-CY/melix/issues/365 by adding a concrete worker runner
-for scored GRPO and RLHF alignment datasets, plus an opt-in runtime-backed GRPO
-candidate-generation path.
+for scored GRPO and RLHF alignment datasets, plus opt-in runtime-backed GRPO
+candidate generation and reward-runtime scoring paths.
 
 Issue 365 is still not complete after this slice. This work turns the existing
 GRPO/RLHF contracts, dataset validation, candidate traces, and alignment
@@ -13,8 +13,11 @@ manifests into executable scored-trace policy-update jobs. It also allows GRPO
 to load the current policy runtime and generate candidate responses when
 `candidate_generation_mode=runtime_generate`. That runtime path records generated
 candidates, runtime backend identity, seed-overlap proxy scores, and policy
-update traces. It does not yet claim final reward-model scoring, PPO/GRPO
-gradient updates through MLX-LM, or release readiness.
+update traces. A follow-up extension in this branch allows
+`candidate_scoring_mode=reward_model` to load a reward runtime once per job and
+score GRPO candidates or RLHF responses through the reward runtime interface.
+It does not yet claim PPO/GRPO gradient updates through MLX-LM or release
+readiness.
 
 ## Scope
 
@@ -26,6 +29,8 @@ gradient updates through MLX-LM, or release readiness.
   runtime with `candidate_generation_mode=runtime_generate`.
 - Record runtime generation/scoring evidence in adapter config, policy-update
   traces, training metrics, and `melix.alignment_run.v1`.
+- Support explicit `candidate_scoring_mode=reward_model` for GRPO/RLHF when a
+  reward runtime and readable reward-model manifest are provided.
 - Support `rlhf` from `reward_scored` datasets with an existing reward model
   manifest reference.
 - Produce adapter weights/config artifacts and checkpoint lineage for scored
@@ -35,11 +40,13 @@ gradient updates through MLX-LM, or release readiness.
   candidate count, KL penalty, and reward-model lineage where applicable.
 - Keep final acceptance honest by marking scored-trace execution as
   deterministic and runtime generation as runtime-generated scored-trace
-  execution, not as reward-model-backed PPO.
+  execution, and reward-model scoring as reward-runtime scored-trace execution,
+  not as reward-model-backed PPO.
 
 ### Excluded
 
-- Local reward-model inference and reward scoring from issue 366.
+- Reward-model training and standalone reward-model artifact generation from
+  issue 366.
 - PPO/GRPO gradient updates through MLX-LM.
 - End-to-end real local runtime release evidence.
 - Window UI acceptance.
@@ -51,7 +58,10 @@ This slice reads the normalized `train.jsonl` once and writes small adapter,
 config, and checkpoint artifacts. The default scored-trace runner is
 deterministic and does not load the base model. The opt-in
 `runtime_generate` GRPO path loads the policy runtime once per job and generates
-`grpo_candidate_count` candidates per prompt.
+`grpo_candidate_count` candidates per prompt. The opt-in
+`candidate_scoring_mode=reward_model` path loads the reward runtime once per job
+and scores one response per RLHF row or one generated/trace candidate per GRPO
+candidate.
 
 Success metrics:
 
@@ -59,6 +69,8 @@ Success metrics:
   `unsupported_alignment_trainer`.
 - GRPO jobs can opt into runtime-backed candidate generation and record
   generated-candidate evidence without being marked release-ready.
+- GRPO/RLHF jobs can opt into reward-runtime scoring and record reward model
+  backend, reward model id, and per-response score evidence.
 - Alignment manifests include scored policy-update metrics.
 - Adapter manifests preserve alignment backlinks and checkpoint lineage.
 - Changed-scope coverage remains at least 95 percent.
@@ -77,7 +89,7 @@ Coverage and metrics:
 ```bash
 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py
 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-rl-alignment-runner-coverage.json
-python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-rl-alignment-runner-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
+python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-rl-alignment-runner-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
 ```
 
 Results on 2026-05-05 before runtime-generation extension:
@@ -96,10 +108,19 @@ Results on 2026-05-05 after runtime-generation extension:
 - `python3 -m compileall -q services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py`: passed.
 - `git diff --check`: passed.
 
+Results on 2026-05-05 after reward-runtime scoring extension:
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py`: 209 passed, 9 skipped.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py`: 209 passed, 9 skipped.
+- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-rl-alignment-runner-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py docs/plans/2026-05-05-issue-365-rl-alignment-runner.md`: 96.53% total changed-line coverage (779/807).
+- `python3 -m compileall -q services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py`: passed.
+- `git diff --check`: passed.
+
 ## Remaining Issue 365 Gaps
 
-- Reward-model local inference and PPO/RL updates from issue 366.
-- Real reward-model scoring for GRPO generated candidates.
+- Reward-model training and PPO/RL policy updates from issue 366.
+- Real local-runtime release evidence for reward-model scoring outside the
+  scripted reward-runtime tests.
 - PTQ/QAT real local inference release evidence.
 - Full CLI chain tests for every business line.
 - Window UI runnable and inspectable acceptance for every business line.

--- a/docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
+++ b/docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
@@ -1,0 +1,87 @@
+# Issue 365 RL Alignment Runner Slice
+
+## Goal
+
+Continue the implementation path for
+https://github.com/Keith-CY/melix/issues/365 by adding a concrete worker runner
+for scored GRPO and RLHF alignment datasets.
+
+Issue 365 is still not complete after this slice. This work turns the existing
+GRPO/RLHF contracts, dataset validation, candidate traces, and alignment
+manifests into executable scored-trace policy-update jobs. It does not yet claim
+final real GRPO rollout generation, reward-model inference, PPO, or release
+readiness.
+
+## Scope
+
+### Included
+
+- Route `training_objective=alignment_rl` through a dedicated worker-side runner.
+- Support `grpo` from `prompt_candidate` datasets with scored candidate groups.
+- Support `rlhf` from `reward_scored` datasets with an existing reward model
+  manifest reference.
+- Produce adapter weights/config artifacts and checkpoint lineage for scored
+  RL-style alignment jobs.
+- Record policy-update metrics derived from scored samples, including reward
+  mean/percentiles, candidate group margin/variance, update count, selected
+  candidate count, KL penalty, and reward-model lineage where applicable.
+- Keep final acceptance honest by marking the backend as scored trace execution,
+  not as real online rollout or PPO.
+
+### Excluded
+
+- Online candidate generation from the current policy model.
+- Local reward-model inference and reward scoring from issue 366.
+- PPO/GRPO gradient updates through MLX-LM.
+- End-to-end real local runtime release evidence.
+- Window UI acceptance.
+- Closing issue 365.
+
+## Performance And Metrics
+
+This slice reads the normalized `train.jsonl` once and writes small adapter,
+config, and checkpoint artifacts. The scored-trace runner is deterministic and
+does not load the base model.
+
+Success metrics:
+
+- GRPO/RLHF jobs run through the default worker runner instead of failing with
+  `unsupported_alignment_trainer`.
+- Alignment manifests include scored policy-update metrics.
+- Adapter manifests preserve alignment backlinks and checkpoint lineage.
+- Changed-scope coverage remains at least 95 percent.
+
+## Verification
+
+Targeted commands:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py
+git diff --check
+```
+
+Coverage and metrics:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-rl-alignment-runner-coverage.json
+python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-rl-alignment-runner-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
+```
+
+Results on 2026-05-05:
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py`: 194 passed, 9 skipped.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py`: 194 passed, 9 skipped.
+- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-rl-alignment-runner-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py docs/plans/2026-05-05-issue-365-rl-alignment-runner.md`: 100.00% total changed-line coverage (235/235).
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python python -m compileall -q services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py`: passed.
+- `git diff --check`: passed.
+
+## Remaining Issue 365 Gaps
+
+- Real GRPO candidate generation from a loaded policy model.
+- Reward-model local inference and PPO/RL updates from issue 366.
+- PTQ/QAT real local inference release evidence.
+- Full CLI chain tests for every business line.
+- Window UI runnable and inspectable acceptance for every business line.
+- Final release evidence separating deterministic/unit evidence from real local
+  runtime evidence.

--- a/services/control-plane-swift/Tests/WorkerClientTests/PythonBridgeWorkerClientTests.swift
+++ b/services/control-plane-swift/Tests/WorkerClientTests/PythonBridgeWorkerClientTests.swift
@@ -1496,10 +1496,10 @@ struct PythonBridgeWorkerClientTests {
     @Test("repo-root initializer can dispatch with an existing python path")
     func repoRootInitializerCanDispatchWithAnExistingPythonPath() async throws {
         let fixtureRoot = try makeProcessBridgeFixtureRepo()
-        let environment = ProcessInfo.processInfo.environment.merging([
-            "PYTHONPATH": "/tmp/existing-python-path",
-            "UV_CACHE_DIR": "\(fixtureRoot.path)/.custom-cache",
-        ]) { _, new in new }
+        let environment = processBridgeFixtureEnvironment(
+            fixtureRoot: fixtureRoot,
+            extra: ["PYTHONPATH": "/tmp/existing-python-path"]
+        )
         let client = PythonBridgeWorkerClient(
             socketPath: "/tmp/fixture.sock",
             repoRoot: fixtureRoot.path,
@@ -1514,7 +1514,7 @@ struct PythonBridgeWorkerClientTests {
         let fixtureRoot = try makeProcessBridgeFixtureRepo()
         let runner = ProcessWorkerBridgeRunner(
             repoRoot: fixtureRoot.path,
-            environment: ProcessInfo.processInfo.environment
+            environment: processBridgeFixtureEnvironment(fixtureRoot: fixtureRoot)
         )
 
         let unaryLine = try await runner.runUnary(
@@ -1565,7 +1565,7 @@ struct PythonBridgeWorkerClientTests {
         let fixtureRoot = try makeProcessBridgeFixtureRepo()
         let runner = ProcessWorkerBridgeRunner(
             repoRoot: fixtureRoot.path,
-            environment: ProcessInfo.processInfo.environment
+            environment: processBridgeFixtureEnvironment(fixtureRoot: fixtureRoot)
         )
 
         let line = try await runner.runUnary(
@@ -1585,7 +1585,7 @@ struct PythonBridgeWorkerClientTests {
         let fixtureRoot = try makeProcessBridgeFixtureRepo()
         let runner = ProcessWorkerBridgeRunner(
             repoRoot: fixtureRoot.path,
-            environment: ProcessInfo.processInfo.environment
+            environment: processBridgeFixtureEnvironment(fixtureRoot: fixtureRoot)
         )
 
         let errorLine = try await runner.runUnary(
@@ -1605,7 +1605,7 @@ struct PythonBridgeWorkerClientTests {
         let fixtureRoot = try makeProcessBridgeFixtureRepo()
         let runner = ProcessWorkerBridgeRunner(
             repoRoot: fixtureRoot.path,
-            environment: ProcessInfo.processInfo.environment
+            environment: processBridgeFixtureEnvironment(fixtureRoot: fixtureRoot)
         )
 
         do {
@@ -1646,7 +1646,7 @@ struct PythonBridgeWorkerClientTests {
         let fixtureRoot = try makeProcessBridgeFixtureRepo()
         let runner = ProcessWorkerBridgeRunner(
             repoRoot: fixtureRoot.path,
-            environment: ProcessInfo.processInfo.environment
+            environment: processBridgeFixtureEnvironment(fixtureRoot: fixtureRoot)
         )
 
         do {
@@ -1806,6 +1806,16 @@ private func makeProcessBridgeFixtureRepo() throws -> URL {
         encoding: .utf8
     )
     return root
+}
+
+private func processBridgeFixtureEnvironment(
+    fixtureRoot: URL,
+    extra: [String: String] = [:]
+) -> [String: String] {
+    ProcessInfo.processInfo.environment.merging([
+        "MELIX_PYTHON_BRIDGE_EXECUTABLE": "/usr/bin/python3",
+        "UV_CACHE_DIR": "\(fixtureRoot.path)/.custom-cache",
+    ].merging(extra) { _, new in new }) { _, new in new }
 }
 
 private func makeTokenEvent(

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -960,13 +960,17 @@ final class WorkerScaffoldTests: XCTestCase {
         XCTAssertNotNil(summary.tokensPerSecond)
     }
 
-    func testVendoredChatSessionClearUsesAsyncSerialAccess() async {
-        let session = ChatSession(
-            makeLiveSwiftMLXModelContainer(promptTokens: [1, 2, 3]),
-            instructions: "system"
-        )
+    func testVendoredChatSessionClearUsesAsyncSerialAccess() async throws {
+        try await withTemporaryDefaultMetallib {
+            await Device.withDefaultDevice(.cpu) {
+                let session = ChatSession(
+                    makeLiveSwiftMLXModelContainer(promptTokens: [1, 2, 3]),
+                    instructions: "system"
+                )
 
-        await session.clear()
+                await session.clear()
+            }
+        }
     }
 
     @available(*, deprecated, message: "Exercises the deprecated ModelContainer chat-template compatibility shim.")

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -7550,23 +7550,25 @@ final class WorkerScaffoldTests: XCTestCase {
         }
     }
 
-    func testFusedDecodeQuantizerRejectsUnsupportedInputs() throws {
-        let (keys, values) = makeDecodeKeyValueTensors(dtype: .float32, headDimension: 32)
+    func testFusedDecodeQuantizerRejectsUnsupportedInputs() async throws {
+        try await withTemporaryDefaultMetallib {
+            let (keys, values) = makeDecodeKeyValueTensors(dtype: .float32, headDimension: 32)
 
-        XCTAssertNil(fusedQ4AffineKeyValueQuantizedForDecode(
-            keys: keys,
-            values: values,
-            groupSize: 32,
-            bits: 8,
-            mode: .affine
-        ))
-        XCTAssertNil(fusedQ4AffineKeyValueQuantizedForDecode(
-            keys: keys,
-            values: values,
-            groupSize: 24,
-            bits: 4,
-            mode: .affine
-        ))
+            XCTAssertNil(fusedQ4AffineKeyValueQuantizedForDecode(
+                keys: keys,
+                values: values,
+                groupSize: 32,
+                bits: 8,
+                mode: .affine
+            ))
+            XCTAssertNil(fusedQ4AffineKeyValueQuantizedForDecode(
+                keys: keys,
+                values: values,
+                groupSize: 24,
+                bits: 4,
+                mode: .affine
+            ))
+        }
     }
 
     func testQuantizedKVCacheUsesNativeDecodeQuantizerByDefaultForSingleTokenAffineQ4()

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -1219,6 +1219,96 @@ def test_train_lora_records_runtime_generated_grpo_evidence(tmp_path: Path) -> N
     assert trace_rows[0]["selected_candidate_text"] == "concise useful summary"
 
 
+def test_train_lora_records_reward_model_scored_rlhf_evidence(tmp_path: Path) -> None:
+    class ScriptedRewardBackend:
+        runtime_name = "scripted-reward-runtime"
+
+        def load_model(self, model_spec):
+            return {"model_id": model_spec.model_id, "model_path": model_spec.model_path}
+
+        def estimate_resident_bytes(self, model_spec) -> int:
+            return 1
+
+        def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event, execution_ext=None):
+            del loaded_model, prompt, sampling, cancel_event, execution_ext
+            return
+            yield
+
+        def score_response(self, loaded_model, prompt: str, response: str, execution_ext=None):
+            del loaded_model, prompt, execution_ext
+            return 0.85 if "helpful" in response.lower() else 0.15
+
+    reward_model_dir = tmp_path / "reward-model"
+    reward_model_dir.mkdir()
+    reward_manifest_path = reward_model_dir / "manifest.json"
+    reward_manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.reward_model_adapter.v1",
+                "reward_model_id": "helpfulness-reward",
+                "model_path": str(reward_model_dir),
+                "reward_head_type": "scalar",
+                "score_scale": "0_to_1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset-reward-model-rlhf",
+        format="reward_scored",
+        samples=[
+            {
+                "prompt": "Rate this answer.",
+                "response": "Helpful answer.",
+                "reward_score": 0.4,
+            }
+        ],
+    )
+    service = _build_service(
+        tmp_path,
+        MLXLMRunner(reward_runtime=MLXTextRuntime(backend=ScriptedRewardBackend())),
+    )
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "train-reward-model-rlhf"),
+                generate_manifest=True,
+                ext={
+                    "operation": "train_lora",
+                    "training_mode": "rlhf",
+                    "adapter_name": "melix-reward-model-rlhf-adapter",
+                    "dataset_uri": str(dataset_dir),
+                    "reward_model_manifest_path": str(reward_manifest_path),
+                    "candidate_scoring_mode": "reward_model",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+    alignment_payload = json.loads(Path(payload["alignment_run_manifest_path"]).read_text(encoding="utf-8"))
+    trace_rows = [
+        json.loads(line)
+        for line in Path(alignment_payload["metrics"]["policy_update_trace_path"]).read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ]
+
+    assert events[-1].HasField("completed")
+    assert payload["training_backend"] == "reward_model_scored_trace"
+    assert alignment_payload["training_backend"] == "reward_model_scored_trace"
+    assert alignment_payload["candidate_scoring_mode"] == "reward_model"
+    assert alignment_payload["metrics"]["candidate_scoring_mode"] == "reward_model"
+    assert alignment_payload["metrics"]["reward_scoring_backend"] == "scripted-reward-runtime"
+    assert alignment_payload["metrics"]["reward_mean"] == pytest.approx(0.85)
+    assert trace_rows[0]["dataset_reward_score"] == pytest.approx(0.4)
+    assert trace_rows[0]["reward_model_id"] == "helpfulness-reward"
+
+
 def test_train_lora_supports_continual_pretraining_contract(tmp_path: Path) -> None:
     dataset_dir = _write_dataset_package(
         tmp_path / "dataset-cpt",

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -46,7 +46,7 @@ from worker.model_ops.training_dataset import (
 from worker.model_registry.catalog import WorkerModelCatalog
 from worker.registry import WorkerRegistry
 from worker.runtime.deterministic_backend import DeterministicTextBackend
-from worker.runtime.mlx_text_runtime import MLXTextRuntime
+from worker.runtime.mlx_text_runtime import MLXTextRuntime, RuntimeTokenEvent
 
 
 def test_checkpoint_order_key_uses_last_numeric_token() -> None:
@@ -1126,6 +1126,97 @@ def test_train_lora_runs_scored_rl_alignment_with_default_runner(
         assert alignment_payload["metrics"]["candidate_group_reward_margin_mean"] == pytest.approx(0.3)
     else:
         assert alignment_payload["reward_model_manifest_path"] == extra_ext["reward_model_manifest_path"]
+
+
+def test_train_lora_records_runtime_generated_grpo_evidence(tmp_path: Path) -> None:
+    class ScriptedPolicyBackend:
+        runtime_name = "scripted-policy-runtime"
+
+        def __init__(self) -> None:
+            self.prompt_count = 0
+
+        def load_model(self, model_spec):
+            return {
+                "model_id": model_spec.model_id,
+                "model_path": model_spec.model_path,
+            }
+
+        def estimate_resident_bytes(self, model_spec) -> int:
+            return 1
+
+        def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event, execution_ext=None):
+            del loaded_model, sampling, execution_ext
+            self.prompt_count += 1
+            if cancel_event.is_set():
+                return
+            if "candidate 1" in prompt:
+                yield RuntimeTokenEvent(text="concise useful summary")
+            else:
+                yield RuntimeTokenEvent(text="off-topic draft")
+
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset-runtime-grpo",
+        format="prompt_candidate",
+        samples=[
+            {
+                "prompt": "Draft two summaries.",
+                "candidates": [
+                    {"text": "concise useful summary", "score": 0.8},
+                    {"text": "off-topic draft", "score": 0.1},
+                ],
+            }
+        ],
+    )
+    backend = ScriptedPolicyBackend()
+    service = _build_service(
+        tmp_path,
+        MLXLMRunner(policy_runtime=MLXTextRuntime(backend=backend)),
+    )
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "train-runtime-grpo"),
+                generate_manifest=True,
+                ext={
+                    "operation": "train_lora",
+                    "training_mode": "grpo",
+                    "adapter_name": "melix-runtime-grpo-adapter",
+                    "dataset_uri": str(dataset_dir),
+                    "grpo_candidate_count": "2",
+                    "candidate_generation_mode": "runtime_generate",
+                    "candidate_generation_max_tokens": "16",
+                    "kl_penalty": "0.05",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+    alignment_payload = json.loads(Path(payload["alignment_run_manifest_path"]).read_text(encoding="utf-8"))
+    trace_rows = [
+        json.loads(line)
+        for line in Path(alignment_payload["metrics"]["policy_update_trace_path"]).read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ]
+
+    assert events[-1].HasField("completed")
+    assert backend.prompt_count == 2
+    assert payload["training_backend"] == "runtime_generated_scored_trace"
+    assert alignment_payload["training_backend"] == "runtime_generated_scored_trace"
+    assert alignment_payload["candidate_generation_mode"] == "runtime_generate"
+    assert alignment_payload["candidate_scoring_mode"] == "seed_overlap_proxy"
+    assert alignment_payload["metrics"]["candidate_generation_backend"] == "scripted-policy-runtime"
+    assert alignment_payload["metrics"]["generated_candidate_count"] == 2
+    assert alignment_payload["metrics"]["candidate_generation_mode"] == "runtime_generate"
+    assert alignment_payload["metrics"]["candidate_scoring_mode"] == "seed_overlap_proxy"
+    assert alignment_payload["metrics"]["policy_update_count"] == 1
+    assert alignment_payload["metrics"]["reward_mean"] > 0.0
+    assert trace_rows[0]["candidate_generation_backend"] == "scripted-policy-runtime"
+    assert trace_rows[0]["selected_candidate_text"] == "concise useful summary"
 
 
 def test_train_lora_supports_continual_pretraining_contract(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -1026,7 +1026,7 @@ def test_train_lora_supports_rl_alignment_mode_contracts(
 
 
 @pytest.mark.parametrize(
-    ("training_mode", "dataset_format", "samples", "extra_ext", "expected_reward_mean"),
+    ("training_mode", "dataset_format", "samples", "extra_ext", "expected_reward_mean", "expected_grpo_margin"),
     [
         (
             "grpo",
@@ -1042,6 +1042,23 @@ def test_train_lora_supports_rl_alignment_mode_contracts(
             ],
             {"grpo_candidate_count": "2", "reference_model_path": "/tmp/reference-model", "kl_penalty": "0.05"},
             0.55,
+            0.3,
+        ),
+        (
+            "grpo",
+            "prompt_candidate",
+            [
+                {
+                    "prompt": "Draft a neutral response.",
+                    "candidates": [
+                        {"text": "Negative score response.", "score": -1.0},
+                        {"text": "Positive score response.", "score": 1.0},
+                    ],
+                }
+            ],
+            {"grpo_candidate_count": "2", "reference_model_path": "/tmp/reference-model", "kl_penalty": "0.05"},
+            0.0,
+            2.0,
         ),
         (
             "rlhf",
@@ -1055,6 +1072,7 @@ def test_train_lora_supports_rl_alignment_mode_contracts(
             ],
             {"reward_model_manifest_path": "/tmp/reward-model/manifest.json"},
             0.9,
+            None,
         ),
     ],
 )
@@ -1065,6 +1083,7 @@ def test_train_lora_runs_scored_rl_alignment_with_default_runner(
     samples: list[dict],
     extra_ext: dict[str, str],
     expected_reward_mean: float,
+    expected_grpo_margin: float | None,
 ) -> None:
     extra_ext = dict(extra_ext)
     if training_mode == "rlhf":
@@ -1123,7 +1142,17 @@ def test_train_lora_runs_scored_rl_alignment_with_default_runner(
         0.05 if training_mode == "grpo" else 0.0
     )
     if training_mode == "grpo":
-        assert alignment_payload["metrics"]["candidate_group_reward_margin_mean"] == pytest.approx(0.3)
+        assert expected_grpo_margin is not None
+        assert alignment_payload["metrics"]["candidate_group_reward_margin_mean"] == pytest.approx(
+            expected_grpo_margin
+        )
+        trace_rows = [
+            json.loads(line)
+            for line in Path(alignment_payload["metrics"]["policy_update_trace_path"]).read_text(
+                encoding="utf-8"
+            ).splitlines()
+        ]
+        assert trace_rows[0]["selected_text"] == trace_rows[0]["selected_candidate_text"]
     else:
         assert alignment_payload["reward_model_manifest_path"] == extra_ext["reward_model_manifest_path"]
 

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -1025,6 +1025,109 @@ def test_train_lora_supports_rl_alignment_mode_contracts(
     assert runner.last_train_request.config.alignment.alignment_algorithm == training_mode
 
 
+@pytest.mark.parametrize(
+    ("training_mode", "dataset_format", "samples", "extra_ext", "expected_reward_mean"),
+    [
+        (
+            "grpo",
+            "prompt_candidate",
+            [
+                {
+                    "prompt": "Draft two summaries.",
+                    "candidates": [
+                        {"text": "Short summary.", "score": 0.7},
+                        {"text": "Verbose summary.", "score": 0.4},
+                    ],
+                }
+            ],
+            {"grpo_candidate_count": "2", "reference_model_path": "/tmp/reference-model", "kl_penalty": "0.05"},
+            0.55,
+        ),
+        (
+            "rlhf",
+            "reward_scored",
+            [
+                {
+                    "prompt": "Rate this answer.",
+                    "response": "Helpful answer.",
+                    "reward_score": 0.9,
+                }
+            ],
+            {"reward_model_manifest_path": "/tmp/reward-model/manifest.json"},
+            0.9,
+        ),
+    ],
+)
+def test_train_lora_runs_scored_rl_alignment_with_default_runner(
+    tmp_path: Path,
+    training_mode: str,
+    dataset_format: str,
+    samples: list[dict],
+    extra_ext: dict[str, str],
+    expected_reward_mean: float,
+) -> None:
+    extra_ext = dict(extra_ext)
+    if training_mode == "rlhf":
+        reward_manifest_path = tmp_path / "reward-model" / "manifest.json"
+        reward_manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        reward_manifest_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "melix.reward_model_adapter.v1",
+                    "reward_model_id": "reward-model",
+                    "compatible_policy_families": ["melix-dev-text"],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        extra_ext["reward_model_manifest_path"] = str(reward_manifest_path)
+
+    dataset_dir = _write_dataset_package(
+        tmp_path / f"dataset-default-{training_mode}",
+        format=dataset_format,
+        samples=samples,
+    )
+    service = _build_service(tmp_path, MLXLMRunner())
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / f"train-default-{training_mode}"),
+                generate_manifest=True,
+                ext={
+                    "operation": "train_lora",
+                    "training_mode": training_mode,
+                    "adapter_name": f"melix-default-{training_mode}-adapter",
+                    "dataset_uri": str(dataset_dir),
+                    **extra_ext,
+                },
+            ),
+            context=None,
+        )
+    )
+
+    payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+    alignment_payload = json.loads(Path(payload["alignment_run_manifest_path"]).read_text(encoding="utf-8"))
+
+    assert events[-1].HasField("completed")
+    assert payload["training_backend"] == "scored_trace"
+    assert Path(payload["weights_path"]).is_file()
+    assert alignment_payload["training_backend"] == "scored_trace"
+    assert alignment_payload["metrics"]["policy_update_count"] == 1
+    assert alignment_payload["metrics"]["selected_candidate_count"] == 1
+    assert alignment_payload["metrics"]["reward_mean"] == pytest.approx(expected_reward_mean)
+    assert alignment_payload["metrics"]["policy_update_trace_path"].endswith("policy_updates.jsonl")
+    assert alignment_payload["metrics"]["kl_penalty"] == pytest.approx(
+        0.05 if training_mode == "grpo" else 0.0
+    )
+    if training_mode == "grpo":
+        assert alignment_payload["metrics"]["candidate_group_reward_margin_mean"] == pytest.approx(0.3)
+    else:
+        assert alignment_payload["reward_model_manifest_path"] == extra_ext["reward_model_manifest_path"]
+
+
 def test_train_lora_supports_continual_pretraining_contract(tmp_path: Path) -> None:
     dataset_dir = _write_dataset_package(
         tmp_path / "dataset-cpt",

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -29,7 +29,7 @@ from worker.model_ops.lora_training_pipeline import (
 )
 from worker.model_ops.mlx_lm_runner import MLXLMRunner
 from worker.model_ops.training_dataset import HFDatasetReference, load_training_dataset_package, materialize_hf_training_dataset_package
-from worker.runtime.mlx_text_runtime import MLXTextRuntime, RuntimeTokenEvent
+from worker.runtime.mlx_text_runtime import MLXTextRuntime, RuntimeTokenEvent, RuntimeUnavailableError
 
 
 def _write_dataset_package(
@@ -271,6 +271,440 @@ def test_mlx_lm_runner_generates_grpo_candidates_with_policy_runtime(tmp_path: P
     assert adapter_config["candidate_generation_backend"] == "scripted-policy-runtime"
 
 
+def test_mlx_lm_runner_scores_generated_grpo_candidates_with_reward_model(
+    tmp_path: Path,
+) -> None:
+    class ScriptedPolicyBackend:
+        runtime_name = "scripted-policy-runtime"
+
+        def load_model(self, model_spec):
+            return {"model_id": model_spec.model_id, "model_path": model_spec.model_path}
+
+        def estimate_resident_bytes(self, model_spec) -> int:
+            return 1
+
+        def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event, execution_ext=None):
+            del loaded_model, sampling, execution_ext
+            if cancel_event.is_set():
+                return
+            if "candidate 1" in prompt:
+                yield RuntimeTokenEvent(text="clear helpful answer")
+            else:
+                yield RuntimeTokenEvent(text="terse answer")
+
+    class ScriptedRewardBackend:
+        runtime_name = "scripted-reward-runtime"
+
+        def __init__(self) -> None:
+            self.loaded_model_path = ""
+            self.scored_responses: list[str] = []
+
+        def load_model(self, model_spec):
+            self.loaded_model_path = model_spec.model_path
+            return {"model_id": model_spec.model_id, "model_path": model_spec.model_path}
+
+        def estimate_resident_bytes(self, model_spec) -> int:
+            return 1
+
+        def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event, execution_ext=None):
+            del loaded_model, prompt, sampling, cancel_event, execution_ext
+            return
+            yield
+
+        def score_response(self, loaded_model, prompt: str, response: str, execution_ext=None):
+            del loaded_model, prompt, execution_ext
+            self.scored_responses.append(response)
+            return 0.9 if "clear helpful" in response else 0.2
+
+    reward_model_dir = tmp_path / "reward-model"
+    reward_model_dir.mkdir()
+    reward_manifest_path = reward_model_dir / "manifest.json"
+    reward_manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.reward_model_adapter.v1",
+                "reward_model_id": "helpfulness-reward",
+                "model_path": str(reward_model_dir),
+                "reward_head_type": "scalar",
+                "score_scale": "0_to_1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={
+            "training_mode": "grpo",
+            "grpo_candidate_count": "2",
+            "candidate_generation_mode": "runtime_generate",
+            "candidate_scoring_mode": "reward_model",
+            "reward_model_manifest_path": str(reward_manifest_path),
+            "candidate_generation_max_tokens": "16",
+        },
+        dataset_format="prompt_candidate",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    normalized_dataset_dir = tmp_path / "normalized"
+    normalized_dataset_dir.mkdir()
+    (normalized_dataset_dir / "train.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": "Draft two answers.",
+                "candidates": [
+                    {"text": "seed answer one"},
+                    {"text": "seed answer two"},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    reward_backend = ScriptedRewardBackend()
+    request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-grpo-runtime-reward",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=normalized_dataset_dir,
+        config=config,
+        dataset_format="prompt_candidate",
+    )
+
+    result = mlx_lm_runner_module.MLXLMRunner(
+        policy_runtime=MLXTextRuntime(backend=ScriptedPolicyBackend()),
+        reward_runtime=MLXTextRuntime(backend=reward_backend),
+    ).train(request)
+
+    trace_rows = [
+        json.loads(line)
+        for line in Path(result.metrics.policy_update_trace_path).read_text(encoding="utf-8").splitlines()
+    ]
+    adapter_config = json.loads(result.adapter_config_path.read_text(encoding="utf-8"))
+
+    assert result.execution_backend == "runtime_generated_reward_model"
+    assert reward_backend.loaded_model_path == str(reward_model_dir)
+    assert reward_backend.scored_responses == ["clear helpful answer", "terse answer"]
+    assert result.metrics.candidate_scoring_mode == "reward_model"
+    assert result.metrics.reward_scoring_backend == "scripted-reward-runtime"
+    assert result.metrics.reward_mean == pytest.approx(0.55)
+    assert trace_rows[0]["reward_model_id"] == "helpfulness-reward"
+    assert trace_rows[0]["reward_scoring_backend"] == "scripted-reward-runtime"
+    assert trace_rows[0]["selected_candidate_text"] == "clear helpful answer"
+    assert trace_rows[0]["generated_candidates"][0]["score"] == pytest.approx(0.9)
+    assert adapter_config["reward_scoring_backend"] == "scripted-reward-runtime"
+
+
+def test_mlx_lm_runner_scores_rlhf_responses_with_reward_model(tmp_path: Path) -> None:
+    class ScriptedRewardBackend:
+        runtime_name = "scripted-reward-runtime"
+
+        def load_model(self, model_spec):
+            return {"model_id": model_spec.model_id, "model_path": model_spec.model_path}
+
+        def estimate_resident_bytes(self, model_spec) -> int:
+            return 1
+
+        def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event, execution_ext=None):
+            del loaded_model, prompt, sampling, cancel_event, execution_ext
+            return
+            yield
+
+        def score_response(self, loaded_model, prompt: str, response: str, execution_ext=None):
+            del loaded_model, prompt, execution_ext
+            return 0.8 if "useful" in response else 0.1
+
+    reward_model_dir = tmp_path / "reward-model"
+    reward_model_dir.mkdir()
+    reward_manifest_path = reward_model_dir / "manifest.json"
+    reward_manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.reward_model_adapter.v1",
+                "reward_model_id": "rlhf-reward",
+                "model_path": str(reward_model_dir),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={
+            "training_mode": "rlhf",
+            "reward_model_manifest_path": str(reward_manifest_path),
+            "candidate_scoring_mode": "reward_model",
+        },
+        dataset_format="reward_scored",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    normalized_dataset_dir = tmp_path / "normalized"
+    normalized_dataset_dir.mkdir()
+    (normalized_dataset_dir / "train.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": "Rate this answer.",
+                "response": "A useful answer.",
+                "reward_score": 0.2,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-rlhf-reward",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=normalized_dataset_dir,
+        config=config,
+        dataset_format="reward_scored",
+    )
+
+    result = mlx_lm_runner_module.MLXLMRunner(
+        reward_runtime=MLXTextRuntime(backend=ScriptedRewardBackend()),
+    ).train(request)
+
+    trace_rows = [
+        json.loads(line)
+        for line in Path(result.metrics.policy_update_trace_path).read_text(encoding="utf-8").splitlines()
+    ]
+
+    assert result.execution_backend == "reward_model_scored_trace"
+    assert result.metrics.candidate_scoring_mode == "reward_model"
+    assert result.metrics.reward_scoring_backend == "scripted-reward-runtime"
+    assert result.metrics.reward_mean == pytest.approx(0.8)
+    assert trace_rows[0]["selected_reward"] == pytest.approx(0.8)
+    assert trace_rows[0]["dataset_reward_score"] == pytest.approx(0.2)
+    assert trace_rows[0]["reward_model_id"] == "rlhf-reward"
+
+
+def test_alignment_rl_reward_model_scoring_helpers_cover_trace_and_error_paths(
+    tmp_path: Path,
+) -> None:
+    from worker.model_ops.rl_alignment_training import (
+        RewardModelScorer,
+        _grpo_policy_updates,
+        _load_reward_model_manifest,
+        _missing_reward_scorer_error,
+        _resolve_reward_model_scorer,
+        _reward_model_spec_from_manifest,
+        _rlhf_policy_updates,
+    )
+
+    class DirectRewardRuntime:
+        runtime_name = "direct-reward-runtime"
+
+        def __init__(self) -> None:
+            self.responses: list[str] = []
+
+        def score_response(self, loaded_model, prompt: str, response: str, execution_ext=None):
+            del loaded_model, prompt, execution_ext
+            self.responses.append(response)
+            return 0.6 if "best" in response else 0.1
+
+    reward_runtime = DirectRewardRuntime()
+    reward_scorer = RewardModelScorer(
+        runtime=reward_runtime,
+        loaded_model={},
+        runtime_name=reward_runtime.runtime_name,
+        manifest_path=str(tmp_path / "reward-model" / "manifest.json"),
+        reward_model_id="direct-reward",
+    )
+
+    grpo_result = _grpo_policy_updates(
+        [
+            {
+                "prompt": "Pick a candidate.",
+                "candidates": [{"text": "best answer"}, {"text": "weak answer"}],
+            }
+        ],
+        candidate_count=2,
+        candidate_scoring_mode="reward_model",
+        reward_scorer=reward_scorer,
+    )
+
+    assert grpo_result.execution_backend == "reward_model_scored_trace"
+    assert grpo_result.reward_scoring_backend == "direct-reward-runtime"
+    assert grpo_result.reward_values == [0.6, 0.1]
+    assert grpo_result.trace_rows[0]["reward_model_id"] == "direct-reward"
+    assert reward_runtime.responses == ["best answer", "weak answer"]
+
+    with pytest.raises(ModelOperationError) as grpo_missing:
+        _grpo_policy_updates(
+            [{"prompt": "Pick.", "candidates": [{"text": "A"}, {"text": "B"}]}],
+            candidate_count=2,
+            candidate_scoring_mode="reward_model",
+        )
+    assert grpo_missing.value.details["missing_field"] == "reward_runtime"
+
+    with pytest.raises(ModelOperationError) as rlhf_missing:
+        _rlhf_policy_updates(
+            [{"prompt": "Rate.", "response": "Useful.", "reward_score": 0.3}],
+            candidate_scoring_mode="reward_model",
+        )
+    assert rlhf_missing.value.details["missing_field"] == "reward_runtime"
+
+    assert _missing_reward_scorer_error().code == "unsupported_alignment_trainer"
+    assert _resolve_reward_model_scorer(
+        types.SimpleNamespace(candidate_scoring_mode="dataset_score"),
+        reward_runtime=None,
+    ) is None
+
+    manifest_path = tmp_path / "reward-model" / "manifest.json"
+    manifest_path.parent.mkdir()
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.reward_model_adapter.v1",
+                "reward_model_id": "fallback-reward",
+                "reward_head_type": "scalar",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest_payload = _load_reward_model_manifest(manifest_path)
+    reward_model_spec = _reward_model_spec_from_manifest(manifest_path, manifest_payload)
+    assert reward_model_spec.model_id == "fallback-reward"
+    assert reward_model_spec.model_path == str(manifest_path.parent)
+    assert reward_model_spec.ext["melix.reward_model.reward_head_type"] == "scalar"
+
+    with pytest.raises(ModelOperationError) as missing_manifest:
+        _load_reward_model_manifest(tmp_path / "missing" / "manifest.json")
+    assert missing_manifest.value.code == "invalid_alignment_config"
+
+    malformed_manifest = tmp_path / "malformed-reward.json"
+    malformed_manifest.write_text("{bad-json\n", encoding="utf-8")
+    with pytest.raises(ModelOperationError, match="readable JSON"):
+        _load_reward_model_manifest(malformed_manifest)
+
+    schema_missing_manifest = tmp_path / "schema-missing-reward.json"
+    schema_missing_manifest.write_text(json.dumps({"reward_model_id": "bad"}) + "\n", encoding="utf-8")
+    with pytest.raises(ModelOperationError, match="schema_version"):
+        _load_reward_model_manifest(schema_missing_manifest)
+
+
+def test_alignment_rl_reward_model_runtime_errors_are_reported(tmp_path: Path) -> None:
+    from worker.model_ops.rl_alignment_training import (
+        RewardModelScorer,
+        _resolve_reward_model_scorer,
+    )
+
+    class MissingScoreRuntime:
+        runtime_name = "missing-score-runtime"
+
+    missing_score_scorer = RewardModelScorer(
+        runtime=MissingScoreRuntime(),
+        loaded_model={},
+        runtime_name="missing-score-runtime",
+        manifest_path=str(tmp_path / "reward" / "manifest.json"),
+        reward_model_id="reward",
+    )
+    with pytest.raises(ModelOperationError) as missing_score:
+        missing_score_scorer.score_response(
+            prompt="Prompt.",
+            response="Response.",
+            alignment_algorithm="rlhf",
+            sample_index=0,
+        )
+    assert missing_score.value.code == "unsupported_alignment_trainer"
+
+    class ExplodingScoreRuntime:
+        runtime_name = "exploding-score-runtime"
+
+        def score_response(self, loaded_model, prompt: str, response: str, execution_ext=None):
+            del loaded_model, prompt, response, execution_ext
+            raise RuntimeError("score failed")
+
+    exploding_scorer = RewardModelScorer(
+        runtime=ExplodingScoreRuntime(),
+        loaded_model={},
+        runtime_name="exploding-score-runtime",
+        manifest_path=str(tmp_path / "reward" / "manifest.json"),
+        reward_model_id="reward",
+    )
+    with pytest.raises(ModelOperationError) as scoring_failed:
+        exploding_scorer.score_response(
+            prompt="Prompt.",
+            response="Response.",
+            alignment_algorithm="grpo",
+            sample_index=1,
+            candidate_index=2,
+        )
+    assert scoring_failed.value.code == "reward_model_scoring_failed"
+
+    reward_manifest_path = tmp_path / "reward-manifest.json"
+    reward_manifest_path.write_text(
+        json.dumps({"schema_version": "melix.reward_model_adapter.v1"}) + "\n",
+        encoding="utf-8",
+    )
+
+    class FailingLoadRuntime:
+        runtime_name = "failing-load-runtime"
+
+        def load_model(self, model_spec):
+            del model_spec
+            raise RuntimeError("load failed")
+
+    with pytest.raises(ModelOperationError) as load_failed:
+        _resolve_reward_model_scorer(
+            types.SimpleNamespace(
+                candidate_scoring_mode="reward_model",
+                reward_model_manifest_path=str(reward_manifest_path),
+            ),
+            reward_runtime=FailingLoadRuntime(),
+        )
+    assert load_failed.value.code == "reward_model_load_failed"
+
+
+def test_text_runtime_score_response_delegates_backend_and_executor() -> None:
+    class PlainScoringBackend:
+        runtime_name = "plain-scoring-runtime"
+
+        def load_model(self, model_spec):
+            return {"model_id": model_spec.model_id}
+
+        def estimate_resident_bytes(self, model_spec) -> int:
+            return 1
+
+        def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event, execution_ext=None):
+            del loaded_model, prompt, sampling, cancel_event, execution_ext
+            return
+            yield
+
+        def score_response(self, loaded_model, prompt: str, response: str):
+            del loaded_model, prompt
+            return 0.7 if response else 0.0
+
+    class Executor:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def run(self, callback):
+            self.calls += 1
+            return callback()
+
+    runtime = MLXTextRuntime(backend=PlainScoringBackend())
+    assert runtime.score_response({}, "Prompt.", "Response.") == pytest.approx(0.7)
+
+    executor = Executor()
+    executor_runtime = MLXTextRuntime(backend=PlainScoringBackend(), executor=executor)
+    assert executor_runtime.score_response({}, "Prompt.", "Response.") == pytest.approx(0.7)
+    assert executor.calls == 1
+
+    class MissingScoreBackend:
+        def estimate_resident_bytes(self, model_spec) -> int:
+            return 1
+
+    with pytest.raises(RuntimeUnavailableError):
+        MLXTextRuntime(backend=MissingScoreBackend()).score_response({}, "Prompt.", "Response.")
+
+
 @pytest.mark.parametrize(
     ("training_mode", "dataset_format", "ext", "expected_message"),
     [
@@ -304,6 +738,25 @@ def test_mlx_lm_runner_generates_grpo_candidates_with_policy_runtime(tmp_path: P
                 "candidate_scoring_mode": "dataset_score",
             },
             "candidate_scoring_mode=dataset_score is not supported",
+        ),
+        (
+            "grpo",
+            "prompt_candidate",
+            {
+                "training_mode": "grpo",
+                "grpo_candidate_count": "2",
+                "candidate_scoring_mode": "reward_model",
+            },
+            "requires reward_model_manifest_path",
+        ),
+        (
+            "dpo",
+            "preference_pair",
+            {
+                "training_mode": "dpo",
+                "candidate_scoring_mode": "reward_model",
+            },
+            "candidate_scoring_mode=reward_model is not supported",
         ),
     ],
 )

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -29,6 +29,7 @@ from worker.model_ops.lora_training_pipeline import (
 )
 from worker.model_ops.mlx_lm_runner import MLXLMRunner
 from worker.model_ops.training_dataset import HFDatasetReference, load_training_dataset_package, materialize_hf_training_dataset_package
+from worker.runtime.mlx_text_runtime import MLXTextRuntime, RuntimeTokenEvent
 
 
 def _write_dataset_package(
@@ -179,6 +180,247 @@ def test_mlx_lm_runner_routes_alignment_rl_to_scored_trace_backend(tmp_path: Pat
     assert result.metrics.candidate_group_reward_margin_mean == pytest.approx(0.3)
     assert result.metrics.candidate_group_reward_variance_mean == pytest.approx(0.0225)
     assert result.metrics.policy_update_trace_path.endswith("policy_updates.jsonl")
+
+
+def test_mlx_lm_runner_generates_grpo_candidates_with_policy_runtime(tmp_path: Path) -> None:
+    class ScriptedPolicyBackend:
+        runtime_name = "scripted-policy-runtime"
+
+        def __init__(self) -> None:
+            self.loaded_model_path = ""
+            self.prompts: list[str] = []
+
+        def load_model(self, model_spec):
+            self.loaded_model_path = model_spec.model_path
+            return {"model_id": model_spec.model_id, "model_path": model_spec.model_path}
+
+        def estimate_resident_bytes(self, model_spec) -> int:
+            return 1
+
+        def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event, execution_ext=None):
+            del loaded_model, sampling, execution_ext
+            self.prompts.append(prompt)
+            if cancel_event.is_set():
+                return
+            if "candidate 1" in prompt:
+                yield RuntimeTokenEvent(text="preferred concise answer")
+            else:
+                yield RuntimeTokenEvent(text="weak answer")
+
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={
+            "training_mode": "grpo",
+            "grpo_candidate_count": "2",
+            "candidate_generation_mode": "runtime_generate",
+            "candidate_generation_max_tokens": "16",
+        },
+        dataset_format="prompt_candidate",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    normalized_dataset_dir = tmp_path / "normalized"
+    normalized_dataset_dir.mkdir()
+    (normalized_dataset_dir / "train.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": "Draft two summaries.",
+                "candidates": [
+                    {"text": "preferred concise answer", "score": 1.0},
+                    {"text": "weak answer", "score": 0.2},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    backend = ScriptedPolicyBackend()
+    request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-grpo-runtime",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=normalized_dataset_dir,
+        config=config,
+        dataset_format="prompt_candidate",
+    )
+
+    result = mlx_lm_runner_module.MLXLMRunner(
+        policy_runtime=MLXTextRuntime(backend=backend)
+    ).train(request)
+
+    trace_rows = [
+        json.loads(line)
+        for line in Path(result.metrics.policy_update_trace_path).read_text(encoding="utf-8").splitlines()
+    ]
+    adapter_config = json.loads(result.adapter_config_path.read_text(encoding="utf-8"))
+
+    assert result.execution_backend == "runtime_generated_scored_trace"
+    assert backend.loaded_model_path == str(tmp_path / "base-model")
+    assert len(backend.prompts) == 2
+    assert result.metrics.candidate_generation_mode == "runtime_generate"
+    assert result.metrics.candidate_generation_backend == "scripted-policy-runtime"
+    assert result.metrics.candidate_scoring_mode == "seed_overlap_proxy"
+    assert result.metrics.generated_candidate_count == 2
+    assert result.metrics.reward_mean == pytest.approx(2 / 3)
+    assert trace_rows[0]["generated_candidates"][0]["score"] == pytest.approx(1.0)
+    assert trace_rows[0]["generated_candidates"][1]["score"] == pytest.approx(1 / 3)
+    assert trace_rows[0]["selected_candidate_text"] == "preferred concise answer"
+    assert adapter_config["candidate_generation_mode"] == "runtime_generate"
+    assert adapter_config["candidate_generation_backend"] == "scripted-policy-runtime"
+
+
+@pytest.mark.parametrize(
+    ("training_mode", "dataset_format", "ext", "expected_message"),
+    [
+        (
+            "grpo",
+            "prompt_candidate",
+            {
+                "training_mode": "grpo",
+                "grpo_candidate_count": "2",
+                "candidate_generation_mode": "remote",
+            },
+            "Unsupported candidate_generation_mode",
+        ),
+        (
+            "rlhf",
+            "reward_scored",
+            {
+                "training_mode": "rlhf",
+                "reward_model_manifest_path": "/tmp/reward/manifest.json",
+                "candidate_generation_mode": "runtime_generate",
+            },
+            "only supported for GRPO",
+        ),
+        (
+            "grpo",
+            "prompt_candidate",
+            {
+                "training_mode": "grpo",
+                "grpo_candidate_count": "2",
+                "candidate_generation_mode": "runtime_generate",
+                "candidate_scoring_mode": "dataset_score",
+            },
+            "candidate_scoring_mode=dataset_score is not supported",
+        ),
+    ],
+)
+def test_alignment_config_rejects_invalid_candidate_generation_options(
+    tmp_path: Path,
+    training_mode: str,
+    dataset_format: str,
+    ext: dict[str, str],
+    expected_message: str,
+) -> None:
+    del training_mode
+
+    with pytest.raises(ModelOperationError) as exc:
+        training_config_module.normalize_training_config(
+            source_model=_text_model(model_path=str(tmp_path / "base-model")),
+            ext=ext,
+            dataset_format=dataset_format,
+            response_only_supported=False,
+            sample_count=1,
+        )
+
+    assert expected_message in exc.value.message
+
+
+def test_alignment_rl_runtime_generation_requires_policy_runtime(tmp_path: Path) -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={
+            "training_mode": "grpo",
+            "grpo_candidate_count": "2",
+            "candidate_generation_mode": "runtime_generate",
+        },
+        dataset_format="prompt_candidate",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    normalized_dataset_dir = tmp_path / "normalized"
+    normalized_dataset_dir.mkdir()
+    (normalized_dataset_dir / "train.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": "Draft two summaries.",
+                "candidates": [
+                    {"text": "Preferred.", "score": 1.0},
+                    {"text": "Rejected.", "score": 0.0},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-grpo-runtime-missing",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=normalized_dataset_dir,
+        config=config,
+        dataset_format="prompt_candidate",
+    )
+
+    with pytest.raises(ModelOperationError) as exc:
+        mlx_lm_runner_module.MLXLMRunner().train(request)
+
+    assert exc.value.code == "unsupported_alignment_trainer"
+    assert exc.value.details["candidate_generation_mode"] == "runtime_generate"
+
+
+def test_alignment_rl_runtime_generation_rejects_empty_generation_and_unscored_seed(
+    tmp_path: Path,
+) -> None:
+    from worker.model_ops.rl_alignment_training import _generate_candidate_text, _scored_seed_candidates
+
+    class EmptyPolicyBackend:
+        runtime_name = "empty-policy-runtime"
+
+        def load_model(self, model_spec):
+            return {"model_id": model_spec.model_id}
+
+        def estimate_resident_bytes(self, model_spec) -> int:
+            return 1
+
+        def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event, execution_ext=None):
+            del loaded_model, prompt, sampling, cancel_event, execution_ext
+            yield RuntimeTokenEvent(text="")
+
+    runtime = MLXTextRuntime(backend=EmptyPolicyBackend())
+    loaded_model = runtime.load_model(_text_model(model_path=str(tmp_path / "base-model")))
+
+    with pytest.raises(ModelOperationError) as generation_exc:
+        _generate_candidate_text(
+            runtime,
+            loaded_model,
+            "Generate a candidate.",
+            types.SimpleNamespace(
+                temperature=0.0,
+                top_p=1.0,
+                top_k=0,
+                max_output_tokens=16,
+                frequency_penalty=0.0,
+                presence_penalty=0.0,
+                stop=[],
+            ),
+            types.SimpleNamespace(is_set=lambda: False),
+        )
+    assert generation_exc.value.code == "alignment_generation_failed"
+
+    with pytest.raises(ModelOperationError) as seed_exc:
+        _scored_seed_candidates(
+            {
+                "prompt": "Draft.",
+                "candidates": [{"text": "Missing score."}, {"text": "Also missing."}],
+            },
+            sample_index=0,
+        )
+    assert seed_exc.value.details["missing_field"] == "candidate.score"
 
 
 def test_alignment_rl_trace_runner_rejects_missing_alignment_config() -> None:
@@ -335,6 +577,8 @@ def test_mlx_lm_runner_routes_preference_training_to_preference_backend(
         normalized_dataset_dir=tmp_path / "normalized",
         config=config,
         dataset_format="preference_pair",
+        source_model_kind="text",
+        source_model_ext={"text_family_id": "qwen"},
     )
 
     def fake_train_preference_native(
@@ -407,6 +651,8 @@ def test_training_request_deserialization_restores_alignment_config(tmp_path: Pa
         normalized_dataset_dir=tmp_path / "normalized",
         config=config,
         dataset_format="preference_pair",
+        source_model_kind="text",
+        source_model_ext={"text_family_id": "qwen"},
     )
 
     restored = mlx_lm_runner_module._deserialize_training_request(
@@ -416,6 +662,8 @@ def test_training_request_deserialization_restores_alignment_config(tmp_path: Pa
     assert isinstance(restored.config.alignment, training_config_module.AlignmentTrainingConfig)
     assert restored.config.alignment.alignment_algorithm == "cpo"
     assert restored.config.alignment.dataset_contract == "preference_pair"
+    assert restored.source_model_kind == "text"
+    assert restored.source_model_ext == {"text_family_id": "qwen"}
 
 
 def test_training_metrics_serializes_preference_fields(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -131,13 +131,29 @@ def test_mlx_lora_namespace_uses_dora_fine_tune_type(tmp_path: Path) -> None:
     assert mlx_lm_runner_module._mlx_lora_namespace(request).fine_tune_type == "dora"
 
 
-def test_mlx_lm_runner_rejects_alignment_rl_without_backend_before_mlx_execution(tmp_path: Path) -> None:
+def test_mlx_lm_runner_routes_alignment_rl_to_scored_trace_backend(tmp_path: Path) -> None:
     config = training_config_module.normalize_training_config(
         source_model=_text_model(model_path=str(tmp_path / "base-model")),
-        ext={"training_mode": "grpo", "grpo_candidate_count": "4"},
+        ext={"training_mode": "grpo", "grpo_candidate_count": "2", "kl_penalty": "0.05"},
         dataset_format="prompt_candidate",
         response_only_supported=False,
-        sample_count=2,
+        sample_count=1,
+    )
+    normalized_dataset_dir = tmp_path / "normalized"
+    normalized_dataset_dir.mkdir()
+    (normalized_dataset_dir / "train.jsonl").write_text(
+        "\n"
+        + json.dumps(
+            {
+                "prompt": "Draft two summaries.",
+                "candidates": [
+                    {"text": "Short summary.", "score": 0.7},
+                    {"text": "Verbose summary.", "score": 0.4},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
     )
     request = mlx_lm_runner_module.TrainingRequest(
         job_id="train-grpo",
@@ -145,18 +161,155 @@ def test_mlx_lm_runner_rejects_alignment_rl_without_backend_before_mlx_execution
         model_path=tmp_path / "base-model",
         model_revision="main",
         adapter_output_dir=tmp_path / "adapter-output",
-        normalized_dataset_dir=tmp_path / "normalized",
+        normalized_dataset_dir=normalized_dataset_dir,
         config=config,
-        dataset_format="preference_pair",
+        dataset_format="prompt_candidate",
+    )
+
+    result = mlx_lm_runner_module.MLXLMRunner().train(request)
+
+    assert result.execution_backend == "scored_trace"
+    assert result.weights_path.read_bytes()
+    assert json.loads(result.adapter_config_path.read_text(encoding="utf-8"))["alignment_algorithm"] == "grpo"
+    assert result.metrics.examples_seen == 1
+    assert result.metrics.policy_update_count == 1
+    assert result.metrics.selected_candidate_count == 1
+    assert result.metrics.reward_mean == pytest.approx(0.55)
+    assert result.metrics.reward_p50 == pytest.approx(0.55)
+    assert result.metrics.candidate_group_reward_margin_mean == pytest.approx(0.3)
+    assert result.metrics.candidate_group_reward_variance_mean == pytest.approx(0.0225)
+    assert result.metrics.policy_update_trace_path.endswith("policy_updates.jsonl")
+
+
+def test_alignment_rl_trace_runner_rejects_missing_alignment_config() -> None:
+    from worker.model_ops.rl_alignment_training import train_alignment_rl_trace
+
+    request = types.SimpleNamespace(config=types.SimpleNamespace(alignment=None))
+
+    with pytest.raises(ModelOperationError) as exc:
+        train_alignment_rl_trace(request)
+
+    assert exc.value.code == "invalid_alignment_config"
+
+
+def test_alignment_rl_trace_runner_rejects_unknown_algorithm(tmp_path: Path) -> None:
+    from worker.model_ops.rl_alignment_training import train_alignment_rl_trace
+
+    normalized_dataset_dir = tmp_path / "normalized"
+    normalized_dataset_dir.mkdir()
+    (normalized_dataset_dir / "train.jsonl").write_text(
+        json.dumps({"reward_score": 1.0}) + "\n",
+        encoding="utf-8",
+    )
+    request = types.SimpleNamespace(
+        normalized_dataset_dir=normalized_dataset_dir,
+        config=types.SimpleNamespace(
+            alignment=types.SimpleNamespace(alignment_algorithm="ppo"),
+        ),
+    )
+
+    with pytest.raises(ModelOperationError) as exc:
+        train_alignment_rl_trace(request)
+
+    assert exc.value.code == "unsupported_alignment_trainer"
+    assert exc.value.details["alignment_algorithm"] == "ppo"
+
+
+@pytest.mark.parametrize(
+    ("file_state", "expected_message"),
+    [
+        ("missing", "requires train.jsonl"),
+        ("invalid-json", "must contain valid JSON lines"),
+        ("array-row", "rows must be JSON objects"),
+        ("empty", "requires at least one scored row"),
+    ],
+)
+def test_alignment_rl_trace_runner_rejects_invalid_training_rows(
+    tmp_path: Path,
+    file_state: str,
+    expected_message: str,
+) -> None:
+    from worker.model_ops.rl_alignment_training import _load_training_rows
+
+    train_path = tmp_path / "train.jsonl"
+    if file_state == "invalid-json":
+        train_path.write_text("{not-json\n", encoding="utf-8")
+    elif file_state == "array-row":
+        train_path.write_text("[]\n", encoding="utf-8")
+    elif file_state == "empty":
+        train_path.write_text("\n", encoding="utf-8")
+
+    with pytest.raises(ModelOperationError) as exc:
+        _load_training_rows(train_path)
+
+    assert expected_message in exc.value.message
+
+
+def test_alignment_rl_trace_runner_rejects_bad_scored_rows() -> None:
+    from worker.model_ops.rl_alignment_training import (
+        _grpo_policy_updates,
+        _reward_summary,
+        _rlhf_policy_updates,
+        _tokens_per_second,
+    )
+
+    with pytest.raises(ModelOperationError) as grpo_exc:
+        _grpo_policy_updates(
+            [{"prompt": "Draft.", "candidates": [{"text": "Only.", "score": 0.1}]}],
+            candidate_count=2,
+        )
+    assert grpo_exc.value.details["grpo_candidate_count"] == "2"
+
+    with pytest.raises(ModelOperationError) as rlhf_exc:
+        _rlhf_policy_updates([{"prompt": "Rate.", "response": "Helpful."}])
+    assert rlhf_exc.value.details["missing_field"] == "reward_score"
+
+    with pytest.raises(ModelOperationError):
+        _reward_summary([])
+
+    assert _tokens_per_second([], 0.0) == 0.0
+
+
+def test_alignment_rl_trace_runner_rejects_unscored_grpo_candidates(tmp_path: Path) -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"training_mode": "grpo", "grpo_candidate_count": "2"},
+        dataset_format="prompt_candidate",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    normalized_dataset_dir = tmp_path / "normalized"
+    normalized_dataset_dir.mkdir()
+    (normalized_dataset_dir / "train.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": "Draft two summaries.",
+                "candidates": [
+                    {"text": "Short summary."},
+                    {"text": "Verbose summary."},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-grpo",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=normalized_dataset_dir,
+        config=config,
+        dataset_format="prompt_candidate",
     )
 
     with pytest.raises(ModelOperationError) as exc:
         mlx_lm_runner_module.MLXLMRunner().train(request)
 
-    assert exc.value.code == "unsupported_alignment_trainer"
-    assert exc.value.details["training_mode"] == "grpo"
+    assert exc.value.code == "invalid_alignment_dataset"
     assert exc.value.details["alignment_algorithm"] == "grpo"
-    assert exc.value.details["available_backend"] == "mlx_lm_lora_supervised"
+    assert exc.value.details["missing_field"] == "candidate.score"
     assert not request.adapter_output_dir.exists()
 
 

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -229,7 +229,9 @@ class MaintenanceCore:
         self._quantization_pipeline = OQQuantizationPipeline(registry)
         self._download_pipeline = download_pipeline or DownloadPipeline()
         self._local_import_pipeline = local_import_pipeline or LocalImportPipeline()
-        self._lora_training_pipeline = lora_training_pipeline or LoRATrainingPipeline()
+        self._lora_training_pipeline = lora_training_pipeline or LoRATrainingPipeline(
+            policy_runtime=registry.runtime
+        )
         self._adapter_activation_pipeline = adapter_activation_pipeline or AdapterActivationPipeline()
         self._upload_receipt_pipeline = upload_receipt_pipeline or UploadReceiptPipeline()
         self._operation_locks = ModelOpsConflictRegistry()

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -410,10 +410,9 @@ def _alignment_manifest_payload(
             metrics["reward_scoring_backend"] = training_result.metrics.reward_scoring_backend
         if training_result.metrics.generated_candidate_count:
             metrics["generated_candidate_count"] = training_result.metrics.generated_candidate_count
-        if training_result.metrics.reward_mean:
-            metrics["reward_mean"] = training_result.metrics.reward_mean
-            metrics["reward_p50"] = training_result.metrics.reward_p50
-            metrics["reward_p95"] = training_result.metrics.reward_p95
+        metrics["reward_mean"] = training_result.metrics.reward_mean
+        metrics["reward_p50"] = training_result.metrics.reward_p50
+        metrics["reward_p95"] = training_result.metrics.reward_p95
         if training_result.metrics.candidate_group_count:
             metrics["candidate_group_count"] = training_result.metrics.candidate_group_count
             metrics["candidate_group_reward_margin_mean"] = (

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -410,9 +410,10 @@ def _alignment_manifest_payload(
             metrics["reward_scoring_backend"] = training_result.metrics.reward_scoring_backend
         if training_result.metrics.generated_candidate_count:
             metrics["generated_candidate_count"] = training_result.metrics.generated_candidate_count
-        metrics["reward_mean"] = training_result.metrics.reward_mean
-        metrics["reward_p50"] = training_result.metrics.reward_p50
-        metrics["reward_p95"] = training_result.metrics.reward_p95
+        if training_result.metrics.policy_update_count or training_result.metrics.policy_update_trace_path:
+            metrics["reward_mean"] = training_result.metrics.reward_mean
+            metrics["reward_p50"] = training_result.metrics.reward_p50
+            metrics["reward_p95"] = training_result.metrics.reward_p95
         if training_result.metrics.candidate_group_count:
             metrics["candidate_group_count"] = training_result.metrics.candidate_group_count
             metrics["candidate_group_reward_margin_mean"] = (

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -390,6 +390,27 @@ def _alignment_manifest_payload(
     reward_summary = _reward_summary(dataset.package.normalized_samples)
     if reward_summary:
         metrics.update(reward_summary)
+    if alignment.dataset_contract in {"prompt_candidate", "reward_scored"}:
+        metrics.update(
+            {
+                "policy_update_count": training_result.metrics.policy_update_count,
+                "selected_candidate_count": training_result.metrics.selected_candidate_count,
+                "policy_update_trace_path": training_result.metrics.policy_update_trace_path,
+                "kl_penalty": alignment.kl_penalty,
+            }
+        )
+        if training_result.metrics.reward_mean:
+            metrics["reward_mean"] = training_result.metrics.reward_mean
+            metrics["reward_p50"] = training_result.metrics.reward_p50
+            metrics["reward_p95"] = training_result.metrics.reward_p95
+        if training_result.metrics.candidate_group_count:
+            metrics["candidate_group_count"] = training_result.metrics.candidate_group_count
+            metrics["candidate_group_reward_margin_mean"] = (
+                training_result.metrics.candidate_group_reward_margin_mean
+            )
+            metrics["candidate_group_reward_variance_mean"] = (
+                training_result.metrics.candidate_group_reward_variance_mean
+            )
 
     return {
         "schema_version": "melix.alignment_run.v1",

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -37,10 +37,11 @@ class LoRATrainingPipeline:
     def __init__(
         self,
         runner: MLXLMRunner | None = None,
+        policy_runtime: Any | None = None,
         hf_dataset_fetcher: HFDatasetFetcher | None = None,
         experiment_store: LoraExperimentStore | None = None,
     ) -> None:
-        self._runner = runner or MLXLMRunner()
+        self._runner = runner or MLXLMRunner(policy_runtime=policy_runtime)
         self._hf_dataset_fetcher = hf_dataset_fetcher
         self._experiment_store = experiment_store or LoraExperimentStore()
 
@@ -110,6 +111,8 @@ class LoRATrainingPipeline:
                 config=config,
                 dataset_format=dataset.package.format,
                 resume_source_path=resume_context["resume_source_path"],
+                source_model_kind=source_model.model_kind,
+                source_model_ext=dict(source_model.ext),
             )
         )
 
@@ -397,8 +400,14 @@ def _alignment_manifest_payload(
                 "selected_candidate_count": training_result.metrics.selected_candidate_count,
                 "policy_update_trace_path": training_result.metrics.policy_update_trace_path,
                 "kl_penalty": alignment.kl_penalty,
+                "candidate_generation_mode": alignment.candidate_generation_mode,
+                "candidate_scoring_mode": alignment.candidate_scoring_mode,
             }
         )
+        if training_result.metrics.candidate_generation_backend:
+            metrics["candidate_generation_backend"] = training_result.metrics.candidate_generation_backend
+        if training_result.metrics.generated_candidate_count:
+            metrics["generated_candidate_count"] = training_result.metrics.generated_candidate_count
         if training_result.metrics.reward_mean:
             metrics["reward_mean"] = training_result.metrics.reward_mean
             metrics["reward_p50"] = training_result.metrics.reward_p50
@@ -426,6 +435,8 @@ def _alignment_manifest_payload(
         "dataset_contract": alignment.dataset_contract,
         "dataset_uri": dataset.dataset_uri,
         "dataset_format": dataset.package.format,
+        "candidate_generation_mode": alignment.candidate_generation_mode,
+        "candidate_scoring_mode": alignment.candidate_scoring_mode,
         "adapter_manifest_path": str(adapter_manifest_path),
         "reference_model_path": alignment.reference_model_path,
         "reward_model_manifest_path": alignment.reward_model_manifest_path,

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -406,6 +406,8 @@ def _alignment_manifest_payload(
         )
         if training_result.metrics.candidate_generation_backend:
             metrics["candidate_generation_backend"] = training_result.metrics.candidate_generation_backend
+        if training_result.metrics.reward_scoring_backend:
+            metrics["reward_scoring_backend"] = training_result.metrics.reward_scoring_backend
         if training_result.metrics.generated_candidate_count:
             metrics["generated_candidate_count"] = training_result.metrics.generated_candidate_count
         if training_result.metrics.reward_mean:

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -63,6 +63,15 @@ class TrainingMetrics:
     rejected_logprob_mean: float | None = None
     chosen_rejected_margin: float | None = None
     win_rate_proxy: float | None = None
+    reward_mean: float = 0.0
+    reward_p50: float = 0.0
+    reward_p95: float = 0.0
+    policy_update_count: int = 0
+    selected_candidate_count: int = 0
+    candidate_group_count: int = 0
+    candidate_group_reward_margin_mean: float = 0.0
+    candidate_group_reward_variance_mean: float = 0.0
+    policy_update_trace_path: str = ""
 
 
 @dataclass(frozen=True)
@@ -153,13 +162,13 @@ class MLXLMRunner:
             raise _alignment_trainer_unavailable_error(request.config)
         try:
             result = self.train_native(request)
-            return replace(result, execution_backend="native")
+            return result if result.execution_backend else replace(result, execution_backend="native")
         except NativeExecutionUnavailable as exc:
             result = self.train_subprocess(request, exc)
             return replace(result, execution_backend="subprocess")
 
     def supports_alignment_training(self, config: LoRATrainingConfig) -> bool:
-        return config.training_objective == "preference"
+        return config.training_objective in {"preference", "alignment_rl"}
 
     def activate(self, request: ActivationRequest) -> ActivationResult:
         try:
@@ -174,6 +183,10 @@ class MLXLMRunner:
             from worker.model_ops.preference_training import train_preference_native
 
             return train_preference_native(request)
+        if request.config.training_objective == "alignment_rl":
+            from worker.model_ops.rl_alignment_training import train_alignment_rl_trace
+
+            return train_alignment_rl_trace(request)
 
         try:
             from mlx_lm.lora import train_model

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -75,6 +75,7 @@ class TrainingMetrics:
     candidate_generation_mode: str = ""
     candidate_generation_backend: str = ""
     candidate_scoring_mode: str = ""
+    reward_scoring_backend: str = ""
     generated_candidate_count: int = 0
 
 
@@ -160,8 +161,9 @@ def _alignment_trainer_unavailable_error(config: LoRATrainingConfig) -> ModelOpe
 
 
 class MLXLMRunner:
-    def __init__(self, policy_runtime: Any | None = None) -> None:
+    def __init__(self, policy_runtime: Any | None = None, reward_runtime: Any | None = None) -> None:
         self._policy_runtime = policy_runtime
+        self._reward_runtime = reward_runtime
 
     def train(self, request: TrainingRequest) -> TrainingResult:
         if (
@@ -195,7 +197,11 @@ class MLXLMRunner:
         if request.config.training_objective == "alignment_rl":
             from worker.model_ops.rl_alignment_training import train_alignment_rl_trace
 
-            return train_alignment_rl_trace(request, policy_runtime=self._policy_runtime)
+            return train_alignment_rl_trace(
+                request,
+                policy_runtime=self._policy_runtime,
+                reward_runtime=self._reward_runtime,
+            )
 
         try:
             from mlx_lm.lora import train_model

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -72,6 +72,10 @@ class TrainingMetrics:
     candidate_group_reward_margin_mean: float = 0.0
     candidate_group_reward_variance_mean: float = 0.0
     policy_update_trace_path: str = ""
+    candidate_generation_mode: str = ""
+    candidate_generation_backend: str = ""
+    candidate_scoring_mode: str = ""
+    generated_candidate_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -85,6 +89,8 @@ class TrainingRequest:
     config: LoRATrainingConfig
     dataset_format: str
     resume_source_path: Path | None = None
+    source_model_kind: str = "text"
+    source_model_ext: dict[str, str] | None = None
 
 
 @dataclass(frozen=True)
@@ -154,6 +160,9 @@ def _alignment_trainer_unavailable_error(config: LoRATrainingConfig) -> ModelOpe
 
 
 class MLXLMRunner:
+    def __init__(self, policy_runtime: Any | None = None) -> None:
+        self._policy_runtime = policy_runtime
+
     def train(self, request: TrainingRequest) -> TrainingResult:
         if (
             _requires_alignment_trainer(request.config)
@@ -186,7 +195,7 @@ class MLXLMRunner:
         if request.config.training_objective == "alignment_rl":
             from worker.model_ops.rl_alignment_training import train_alignment_rl_trace
 
-            return train_alignment_rl_trace(request)
+            return train_alignment_rl_trace(request, policy_runtime=self._policy_runtime)
 
         try:
             from mlx_lm.lora import train_model
@@ -458,6 +467,8 @@ def _serialize_training_request(request: TrainingRequest) -> dict:
             else ""
         ),
         "dataset_format": request.dataset_format,
+        "source_model_kind": request.source_model_kind,
+        "source_model_ext": dict(request.source_model_ext or {}),
         "config": asdict(request.config),
     }
     return payload
@@ -483,6 +494,11 @@ def _deserialize_training_request(payload: dict) -> TrainingRequest:
             if str(payload.get("resume_source_path", "")).strip()
             else None
         ),
+        source_model_kind=str(payload.get("source_model_kind", "") or "text"),
+        source_model_ext={
+            str(key): str(value)
+            for key, value in dict(payload.get("source_model_ext", {}) or {}).items()
+        },
     )
 
 

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -25,10 +25,75 @@ class PolicyUpdateResult:
     candidate_generation_mode: str
     candidate_scoring_mode: str
     candidate_generation_backend: str = ""
+    reward_scoring_backend: str = ""
     generated_candidate_count: int = 0
 
 
-def train_alignment_rl_trace(request: Any, *, policy_runtime: Any | None = None) -> Any:
+@dataclass(frozen=True)
+class RewardModelScorer:
+    runtime: Any
+    loaded_model: Any
+    runtime_name: str
+    manifest_path: str
+    reward_model_id: str
+
+    def score_response(
+        self,
+        *,
+        prompt: str,
+        response: str,
+        alignment_algorithm: str,
+        sample_index: int,
+        candidate_index: int | None = None,
+    ) -> float:
+        scorer = getattr(self.runtime, "score_response", None)
+        if not callable(scorer):
+            raise ModelOperationError(
+                code="unsupported_alignment_trainer",
+                message="Reward-model scoring requires a reward runtime with score_response support.",
+                details={
+                    "required_backend": "reward_runtime",
+                    "candidate_scoring_mode": "reward_model",
+                    "reward_model_manifest_path": self.manifest_path,
+                },
+            )
+        try:
+            return float(
+                scorer(
+                    self.loaded_model,
+                    prompt,
+                    response,
+                    execution_ext={
+                        "melix.alignment.algorithm": alignment_algorithm,
+                        "melix.alignment.sample_index": str(sample_index),
+                        "melix.alignment.candidate_index": (
+                            "" if candidate_index is None else str(candidate_index)
+                        ),
+                        "melix.reward_model_manifest_path": self.manifest_path,
+                        "melix.reward_model_id": self.reward_model_id,
+                    },
+                )
+            )
+        except ModelOperationError:
+            raise
+        except Exception as exc:
+            raise ModelOperationError(
+                code="reward_model_scoring_failed",
+                message=f"Reward-model scoring failed: {exc}",
+                details={
+                    "candidate_scoring_mode": "reward_model",
+                    "reward_model_manifest_path": self.manifest_path,
+                    "sample_index": str(sample_index),
+                },
+            ) from exc
+
+
+def train_alignment_rl_trace(
+    request: Any,
+    *,
+    policy_runtime: Any | None = None,
+    reward_runtime: Any | None = None,
+) -> Any:
     from worker.model_ops.mlx_lm_runner import TrainingMetrics, TrainingResult
 
     alignment = request.config.alignment
@@ -40,6 +105,7 @@ def train_alignment_rl_trace(request: Any, *, policy_runtime: Any | None = None)
 
     started_at = time.perf_counter()
     samples = _load_training_rows(request.normalized_dataset_dir / "train.jsonl")
+    reward_scorer = _resolve_reward_model_scorer(alignment, reward_runtime)
     if alignment.alignment_algorithm == "grpo":
         if alignment.candidate_generation_mode == "runtime_generate":
             policy_updates = _grpo_runtime_policy_updates(
@@ -47,14 +113,21 @@ def train_alignment_rl_trace(request: Any, *, policy_runtime: Any | None = None)
                 samples,
                 candidate_count=alignment.grpo_candidate_count,
                 policy_runtime=policy_runtime,
+                reward_scorer=reward_scorer,
             )
         else:
             policy_updates = _grpo_policy_updates(
                 samples,
                 candidate_count=alignment.grpo_candidate_count,
+                candidate_scoring_mode=alignment.candidate_scoring_mode,
+                reward_scorer=reward_scorer,
             )
     elif alignment.alignment_algorithm == "rlhf":
-        policy_updates = _rlhf_policy_updates(samples)
+        policy_updates = _rlhf_policy_updates(
+            samples,
+            candidate_scoring_mode=alignment.candidate_scoring_mode,
+            reward_scorer=reward_scorer,
+        )
     else:
         raise ModelOperationError(
             code="unsupported_alignment_trainer",
@@ -83,6 +156,7 @@ def train_alignment_rl_trace(request: Any, *, policy_runtime: Any | None = None)
         "candidate_generation_mode": policy_updates.candidate_generation_mode,
         "candidate_generation_backend": policy_updates.candidate_generation_backend,
         "candidate_scoring_mode": policy_updates.candidate_scoring_mode,
+        "reward_scoring_backend": policy_updates.reward_scoring_backend,
         "lora_parameters": {
             "rank": request.config.rank,
             "dropout": request.config.dropout,
@@ -132,6 +206,7 @@ def train_alignment_rl_trace(request: Any, *, policy_runtime: Any | None = None)
             candidate_generation_mode=policy_updates.candidate_generation_mode,
             candidate_generation_backend=policy_updates.candidate_generation_backend,
             candidate_scoring_mode=policy_updates.candidate_scoring_mode,
+            reward_scoring_backend=policy_updates.reward_scoring_backend,
             generated_candidate_count=policy_updates.generated_candidate_count,
         ),
         execution_backend=policy_updates.execution_backend,
@@ -179,7 +254,12 @@ def _grpo_policy_updates(
     samples: list[dict[str, Any]],
     *,
     candidate_count: int,
+    candidate_scoring_mode: str = "dataset_score",
+    reward_scorer: RewardModelScorer | None = None,
 ) -> PolicyUpdateResult:
+    if candidate_scoring_mode == "reward_model" and reward_scorer is None:
+        raise _missing_reward_scorer_error()
+
     trace_rows: list[dict[str, Any]] = []
     reward_values: list[float] = []
     group_margins: list[float] = []
@@ -198,7 +278,29 @@ def _grpo_policy_updates(
             )
         scored_candidates = []
         for candidate_index, candidate in enumerate(candidates[:candidate_count]):
-            if not isinstance(candidate, dict) or "score" not in candidate:
+            if not isinstance(candidate, dict):
+                raise ModelOperationError(
+                    code="invalid_alignment_dataset",
+                    message="GRPO scored trace candidates must be JSON objects.",
+                    details={
+                        "alignment_algorithm": "grpo",
+                        "sample_index": str(sample_index),
+                        "candidate_index": str(candidate_index),
+                    },
+                )
+            candidate_text = str(candidate.get("text", ""))
+            if candidate_scoring_mode == "reward_model":
+                assert reward_scorer is not None
+                score = reward_scorer.score_response(
+                    prompt=str(sample.get("prompt", "")),
+                    response=candidate_text,
+                    alignment_algorithm="grpo",
+                    sample_index=sample_index,
+                    candidate_index=candidate_index,
+                )
+            elif "score" in candidate:
+                score = float(candidate["score"])
+            else:
                 raise ModelOperationError(
                     code="invalid_alignment_dataset",
                     message="GRPO scored trace candidates must include numeric score.",
@@ -212,8 +314,8 @@ def _grpo_policy_updates(
             scored_candidates.append(
                 {
                     "index": candidate_index,
-                    "text": str(candidate.get("text", "")),
-                    "score": float(candidate["score"]),
+                    "text": candidate_text,
+                    "score": score,
                 }
             )
         scores = [candidate["score"] for candidate in scored_candidates]
@@ -227,24 +329,34 @@ def _grpo_policy_updates(
                 "sample_index": sample_index,
                 "alignment_algorithm": "grpo",
                 "candidate_generation_mode": "scored_trace",
-                "candidate_scoring_mode": "dataset_score",
+                "candidate_scoring_mode": candidate_scoring_mode,
                 "prompt": str(sample.get("prompt", "")),
                 "selected_candidate_index": selected["index"],
+                "selected_candidate_text": selected["text"],
                 "selected_reward": selected["score"],
                 "group_reward_mean": group_mean,
                 "group_reward_margin": group_margins[-1],
                 "candidate_count": len(scored_candidates),
+                "scored_candidates": scored_candidates,
             }
         )
+        if reward_scorer is not None:
+            trace_rows[-1]["reward_scoring_backend"] = reward_scorer.runtime_name
+            trace_rows[-1]["reward_model_id"] = reward_scorer.reward_model_id
     return PolicyUpdateResult(
         trace_rows=trace_rows,
         reward_values=reward_values,
         group_margins=group_margins,
         group_variances=group_variances,
         selected_count=len(trace_rows),
-        execution_backend="scored_trace",
+        execution_backend=(
+            "reward_model_scored_trace"
+            if candidate_scoring_mode == "reward_model"
+            else "scored_trace"
+        ),
         candidate_generation_mode="scored_trace",
-        candidate_scoring_mode="dataset_score",
+        candidate_scoring_mode=candidate_scoring_mode,
+        reward_scoring_backend=reward_scorer.runtime_name if reward_scorer is not None else "",
     )
 
 
@@ -254,6 +366,7 @@ def _grpo_runtime_policy_updates(
     *,
     candidate_count: int,
     policy_runtime: Any | None,
+    reward_scorer: RewardModelScorer | None = None,
 ) -> PolicyUpdateResult:
     if policy_runtime is None:
         raise ModelOperationError(
@@ -278,7 +391,11 @@ def _grpo_runtime_policy_updates(
     generated_candidate_total = 0
     for sample_index, sample in enumerate(samples):
         prompt = str(sample.get("prompt", ""))
-        seed_candidates = _scored_seed_candidates(sample, sample_index=sample_index)
+        seed_candidates = (
+            []
+            if request.config.alignment.candidate_scoring_mode == "reward_model"
+            else _scored_seed_candidates(sample, sample_index=sample_index)
+        )
         generated_candidates: list[dict[str, Any]] = []
         for candidate_index in range(candidate_count):
             generation_prompt = _runtime_generation_prompt(
@@ -293,7 +410,18 @@ def _grpo_runtime_policy_updates(
                 sampling,
                 cancel_event,
             )
-            score = _seed_overlap_proxy_score(generated_text, seed_candidates)
+            if request.config.alignment.candidate_scoring_mode == "reward_model":
+                if reward_scorer is None:
+                    raise _missing_reward_scorer_error()
+                score = reward_scorer.score_response(
+                    prompt=prompt,
+                    response=generated_text,
+                    alignment_algorithm="grpo",
+                    sample_index=sample_index,
+                    candidate_index=candidate_index,
+                )
+            else:
+                score = _seed_overlap_proxy_score(generated_text, seed_candidates)
             generated_candidates.append(
                 {
                     "index": candidate_index,
@@ -316,7 +444,7 @@ def _grpo_runtime_policy_updates(
                 "alignment_algorithm": "grpo",
                 "candidate_generation_mode": "runtime_generate",
                 "candidate_generation_backend": runtime_name,
-                "candidate_scoring_mode": "seed_overlap_proxy",
+                "candidate_scoring_mode": request.config.alignment.candidate_scoring_mode,
                 "prompt": prompt,
                 "selected_candidate_index": selected["index"],
                 "selected_candidate_text": selected["text"],
@@ -327,27 +455,41 @@ def _grpo_runtime_policy_updates(
                 "generated_candidates": generated_candidates,
             }
         )
+        if reward_scorer is not None:
+            trace_rows[-1]["reward_scoring_backend"] = reward_scorer.runtime_name
+            trace_rows[-1]["reward_model_id"] = reward_scorer.reward_model_id
     return PolicyUpdateResult(
         trace_rows=trace_rows,
         reward_values=reward_values,
         group_margins=group_margins,
         group_variances=group_variances,
         selected_count=len(trace_rows),
-        execution_backend="runtime_generated_scored_trace",
+        execution_backend=(
+            "runtime_generated_reward_model"
+            if request.config.alignment.candidate_scoring_mode == "reward_model"
+            else "runtime_generated_scored_trace"
+        ),
         candidate_generation_mode="runtime_generate",
         candidate_generation_backend=runtime_name,
-        candidate_scoring_mode="seed_overlap_proxy",
+        candidate_scoring_mode=request.config.alignment.candidate_scoring_mode,
+        reward_scoring_backend=reward_scorer.runtime_name if reward_scorer is not None else "",
         generated_candidate_count=generated_candidate_total,
     )
 
 
 def _rlhf_policy_updates(
     samples: list[dict[str, Any]],
+    *,
+    candidate_scoring_mode: str = "dataset_score",
+    reward_scorer: RewardModelScorer | None = None,
 ) -> PolicyUpdateResult:
+    if candidate_scoring_mode == "reward_model" and reward_scorer is None:
+        raise _missing_reward_scorer_error()
+
     trace_rows: list[dict[str, Any]] = []
     reward_values: list[float] = []
     for sample_index, sample in enumerate(samples):
-        if "reward_score" not in sample:
+        if candidate_scoring_mode == "dataset_score" and "reward_score" not in sample:
             raise ModelOperationError(
                 code="invalid_alignment_dataset",
                 message="RLHF scored trace rows must include reward_score.",
@@ -357,29 +499,174 @@ def _rlhf_policy_updates(
                     "missing_field": "reward_score",
                 },
             )
-        reward = float(sample["reward_score"])
+        prompt = str(sample.get("prompt", ""))
+        response = str(sample.get("response", ""))
+        if candidate_scoring_mode == "reward_model":
+            assert reward_scorer is not None
+            reward = reward_scorer.score_response(
+                prompt=prompt,
+                response=response,
+                alignment_algorithm="rlhf",
+                sample_index=sample_index,
+            )
+        else:
+            reward = float(sample["reward_score"])
         reward_values.append(reward)
-        trace_rows.append(
-            {
-                "sample_index": sample_index,
-                "alignment_algorithm": "rlhf",
-                "candidate_generation_mode": "scored_trace",
-                "candidate_scoring_mode": "dataset_score",
-                "prompt": str(sample.get("prompt", "")),
-                "selected_response": str(sample.get("response", "")),
-                "selected_reward": reward,
-            }
-        )
+        row = {
+            "sample_index": sample_index,
+            "alignment_algorithm": "rlhf",
+            "candidate_generation_mode": "scored_trace",
+            "candidate_scoring_mode": candidate_scoring_mode,
+            "prompt": prompt,
+            "selected_response": response,
+            "selected_reward": reward,
+        }
+        if "reward_score" in sample and candidate_scoring_mode == "reward_model":
+            row["dataset_reward_score"] = float(sample["reward_score"])
+        if reward_scorer is not None:
+            row["reward_scoring_backend"] = reward_scorer.runtime_name
+            row["reward_model_id"] = reward_scorer.reward_model_id
+        trace_rows.append(row)
     return PolicyUpdateResult(
         trace_rows=trace_rows,
         reward_values=reward_values,
         group_margins=[],
         group_variances=[],
         selected_count=len(trace_rows),
-        execution_backend="scored_trace",
+        execution_backend=(
+            "reward_model_scored_trace"
+            if candidate_scoring_mode == "reward_model"
+            else "scored_trace"
+        ),
         candidate_generation_mode="scored_trace",
-        candidate_scoring_mode="dataset_score",
+        candidate_scoring_mode=candidate_scoring_mode,
+        reward_scoring_backend=reward_scorer.runtime_name if reward_scorer is not None else "",
     )
+
+
+def _resolve_reward_model_scorer(
+    alignment: Any,
+    reward_runtime: Any | None,
+) -> RewardModelScorer | None:
+    if getattr(alignment, "candidate_scoring_mode", "") != "reward_model":
+        return None
+    if reward_runtime is None:
+        raise _missing_reward_scorer_error()
+
+    manifest_path = Path(alignment.reward_model_manifest_path).expanduser()
+    manifest_payload = _load_reward_model_manifest(manifest_path)
+    model_spec = _reward_model_spec_from_manifest(manifest_path, manifest_payload)
+    try:
+        loaded_model = reward_runtime.load_model(model_spec)
+    except ModelOperationError:
+        raise
+    except Exception as exc:
+        raise ModelOperationError(
+            code="reward_model_load_failed",
+            message=f"Reward model runtime load failed: {exc}",
+            details={
+                "candidate_scoring_mode": "reward_model",
+                "reward_model_manifest_path": str(manifest_path),
+            },
+        ) from exc
+
+    return RewardModelScorer(
+        runtime=reward_runtime,
+        loaded_model=loaded_model,
+        runtime_name=str(getattr(reward_runtime, "runtime_name", "") or "unknown-runtime"),
+        manifest_path=str(manifest_path),
+        reward_model_id=str(
+            manifest_payload.get("reward_model_id")
+            or manifest_payload.get("model_id")
+            or model_spec.model_id
+        ),
+    )
+
+
+def _missing_reward_scorer_error() -> ModelOperationError:
+    return ModelOperationError(
+        code="unsupported_alignment_trainer",
+        message="Reward-model candidate scoring requires a reward runtime and manifest.",
+        details={
+            "candidate_scoring_mode": "reward_model",
+            "required_backend": "reward_runtime",
+            "missing_field": "reward_runtime",
+        },
+    )
+
+
+def _load_reward_model_manifest(manifest_path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ModelOperationError(
+            code="invalid_alignment_config",
+            message="reward_model_manifest_path must point to a readable reward model manifest.",
+            details={"reward_model_manifest_path": str(manifest_path)},
+        ) from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ModelOperationError(
+            code="invalid_alignment_config",
+            message="reward_model_manifest_path must point to a readable JSON manifest.",
+            details={"reward_model_manifest_path": str(manifest_path)},
+        ) from exc
+    if not isinstance(payload, dict) or not str(payload.get("schema_version", "")).strip():
+        raise ModelOperationError(
+            code="invalid_alignment_config",
+            message="reward model manifest must include schema_version.",
+            details={"reward_model_manifest_path": str(manifest_path)},
+        )
+    return payload
+
+
+def _reward_model_spec_from_manifest(
+    manifest_path: Path,
+    manifest_payload: dict[str, Any],
+) -> common_pb2.ModelSpec:
+    model_id = str(
+        manifest_payload.get("reward_model_id")
+        or manifest_payload.get("model_id")
+        or manifest_payload.get("base_model_id")
+        or "melix-reward-model"
+    )
+    model_path = _first_manifest_string(
+        manifest_payload,
+        "reward_model_path",
+        "model_path",
+        "derived_model_path",
+        "base_model_path",
+        "artifact_path",
+    )
+    if not model_path:
+        model_path = str(manifest_path.parent)
+    model = common_pb2.ModelSpec(
+        model_id=model_id,
+        model_path=model_path,
+        model_kind=str(manifest_payload.get("model_kind") or "reward"),
+        revision=str(manifest_payload.get("model_revision") or manifest_payload.get("revision") or "main"),
+    )
+    model.ext["melix.reward_model_manifest_path"] = str(manifest_path)
+    for key in (
+        "schema_version",
+        "reward_model_id",
+        "reward_head_type",
+        "score_scale",
+        "adapter_manifest_path",
+        "adapter_weights_path",
+        "base_model_id",
+    ):
+        value = manifest_payload.get(key)
+        if value is not None and str(value).strip():
+            model.ext[f"melix.reward_model.{key}"] = str(value)
+    return model
+
+
+def _first_manifest_string(payload: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = payload.get(key)
+        if value is not None and str(value).strip():
+            return str(value)
+    return ""
 
 
 def _runtime_model_spec(request: Any) -> common_pb2.ModelSpec:

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import time
+from typing import Any
+
+from worker.model_ops.errors import ModelOperationError
+
+
+def train_alignment_rl_trace(request: Any) -> Any:
+    from worker.model_ops.mlx_lm_runner import TrainingMetrics, TrainingResult
+
+    alignment = request.config.alignment
+    if alignment is None:
+        raise ModelOperationError(
+            code="invalid_alignment_config",
+            message="alignment_rl training requires alignment config.",
+        )
+
+    started_at = time.perf_counter()
+    samples = _load_training_rows(request.normalized_dataset_dir / "train.jsonl")
+    if alignment.alignment_algorithm == "grpo":
+        trace_rows, reward_values, group_margins, group_variances, selected_count = _grpo_policy_updates(
+            samples,
+            candidate_count=alignment.grpo_candidate_count,
+        )
+    elif alignment.alignment_algorithm == "rlhf":
+        trace_rows, reward_values, group_margins, group_variances, selected_count = _rlhf_policy_updates(samples)
+    else:
+        raise ModelOperationError(
+            code="unsupported_alignment_trainer",
+            message=f"Unsupported RL alignment algorithm: {alignment.alignment_algorithm}",
+            details={"alignment_algorithm": alignment.alignment_algorithm},
+        )
+
+    request.adapter_output_dir.mkdir(parents=True, exist_ok=True)
+    weights_path = request.adapter_output_dir / "adapters.safetensors"
+    adapter_config_path = request.adapter_output_dir / "adapter_config.json"
+    policy_update_trace_path = request.adapter_output_dir / "policy_updates.jsonl"
+    checkpoint_dir = request.adapter_output_dir / "checkpoint-1"
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    latest_checkpoint_path = checkpoint_dir / "adapters.safetensors"
+
+    _write_jsonl(policy_update_trace_path, trace_rows)
+    adapter_config = {
+        "fine_tune_type": "lora",
+        "alignment_algorithm": alignment.alignment_algorithm,
+        "execution_backend": "scored_trace",
+        "policy_update_trace_path": str(policy_update_trace_path),
+        "reward_model_manifest_path": alignment.reward_model_manifest_path,
+        "reference_model_path": alignment.reference_model_path,
+        "kl_penalty": alignment.kl_penalty,
+        "grpo_candidate_count": alignment.grpo_candidate_count,
+        "lora_parameters": {
+            "rank": request.config.rank,
+            "dropout": request.config.dropout,
+            "scale": request.config.alpha,
+            "keys": request.config.expanded_target_modules,
+        },
+    }
+    adapter_config_path.write_text(json.dumps(adapter_config, indent=2) + "\n", encoding="utf-8")
+    weights_payload = {
+        "schema_version": "melix.scored_alignment_adapter.v1",
+        "job_id": request.job_id,
+        "base_model_id": request.base_model_id,
+        "alignment_algorithm": alignment.alignment_algorithm,
+        "policy_update_digest": _trace_digest(trace_rows),
+    }
+    weights_bytes = json.dumps(weights_payload, sort_keys=True).encode("utf-8")
+    weights_path.write_bytes(weights_bytes)
+    latest_checkpoint_path.write_bytes(weights_bytes)
+
+    duration_ms = (time.perf_counter() - started_at) * 1000.0
+    reward_summary = _reward_summary(reward_values)
+    return TrainingResult(
+        weights_path=weights_path,
+        adapter_config_path=adapter_config_path,
+        metrics=TrainingMetrics(
+            job_duration_ms=duration_ms,
+            tokens_seen=_estimated_tokens_seen(trace_rows),
+            examples_seen=len(samples),
+            loss_final=-reward_summary["reward_mean"],
+            loss_best=-max(reward_values),
+            learning_rate_final=request.config.learning_rate,
+            checkpoint_count=1,
+            resume_ready=True,
+            latest_checkpoint_path=str(latest_checkpoint_path),
+            resume_source_path=str(request.resume_source_path) if request.resume_source_path is not None else "",
+            tokens_per_second=_tokens_per_second(trace_rows, duration_ms),
+            peak_memory_gb=0.0,
+            reward_mean=reward_summary["reward_mean"],
+            reward_p50=reward_summary["reward_p50"],
+            reward_p95=reward_summary["reward_p95"],
+            policy_update_count=len(trace_rows),
+            selected_candidate_count=selected_count,
+            candidate_group_count=len(group_margins),
+            candidate_group_reward_margin_mean=_mean(group_margins),
+            candidate_group_reward_variance_mean=_mean(group_variances),
+            policy_update_trace_path=str(policy_update_trace_path),
+        ),
+        execution_backend="scored_trace",
+    )
+
+
+def _load_training_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                payload = json.loads(line)
+                if not isinstance(payload, dict):
+                    raise ModelOperationError(
+                        code="invalid_alignment_dataset",
+                        message="alignment_rl train.jsonl rows must be JSON objects.",
+                        details={"line_number": str(line_number)},
+                    )
+                rows.append(payload)
+    except FileNotFoundError as exc:
+        raise ModelOperationError(
+            code="invalid_dataset_package",
+            message="alignment_rl training requires train.jsonl.",
+            details={"path": str(path)},
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise ModelOperationError(
+            code="invalid_dataset_package",
+            message="alignment_rl train.jsonl must contain valid JSON lines.",
+            details={"path": str(path)},
+        ) from exc
+    if not rows:
+        raise ModelOperationError(
+            code="invalid_dataset_package",
+            message="alignment_rl training requires at least one scored row.",
+            details={"path": str(path)},
+        )
+    return rows
+
+
+def _grpo_policy_updates(
+    samples: list[dict[str, Any]],
+    *,
+    candidate_count: int,
+) -> tuple[list[dict[str, Any]], list[float], list[float], list[float], int]:
+    trace_rows: list[dict[str, Any]] = []
+    reward_values: list[float] = []
+    group_margins: list[float] = []
+    group_variances: list[float] = []
+    for sample_index, sample in enumerate(samples):
+        candidates = sample.get("candidates")
+        if not isinstance(candidates, list) or len(candidates) < candidate_count:
+            raise ModelOperationError(
+                code="invalid_alignment_dataset",
+                message="GRPO scored trace rows must contain enough candidates.",
+                details={
+                    "sample_index": str(sample_index),
+                    "candidate_count": str(len(candidates) if isinstance(candidates, list) else 0),
+                    "grpo_candidate_count": str(candidate_count),
+                },
+            )
+        scored_candidates = []
+        for candidate_index, candidate in enumerate(candidates[:candidate_count]):
+            if not isinstance(candidate, dict) or "score" not in candidate:
+                raise ModelOperationError(
+                    code="invalid_alignment_dataset",
+                    message="GRPO scored trace candidates must include numeric score.",
+                    details={
+                        "alignment_algorithm": "grpo",
+                        "sample_index": str(sample_index),
+                        "candidate_index": str(candidate_index),
+                        "missing_field": "candidate.score",
+                    },
+                )
+            scored_candidates.append(
+                {
+                    "index": candidate_index,
+                    "text": str(candidate.get("text", "")),
+                    "score": float(candidate["score"]),
+                }
+            )
+        scores = [candidate["score"] for candidate in scored_candidates]
+        reward_values.extend(scores)
+        selected = max(scored_candidates, key=lambda candidate: candidate["score"])
+        group_margins.append(max(scores) - min(scores))
+        group_mean = sum(scores) / len(scores)
+        group_variances.append(sum((score - group_mean) ** 2 for score in scores) / len(scores))
+        trace_rows.append(
+            {
+                "sample_index": sample_index,
+                "alignment_algorithm": "grpo",
+                "prompt": str(sample.get("prompt", "")),
+                "selected_candidate_index": selected["index"],
+                "selected_reward": selected["score"],
+                "group_reward_mean": group_mean,
+                "group_reward_margin": group_margins[-1],
+                "candidate_count": len(scored_candidates),
+            }
+        )
+    return trace_rows, reward_values, group_margins, group_variances, len(trace_rows)
+
+
+def _rlhf_policy_updates(
+    samples: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[float], list[float], list[float], int]:
+    trace_rows: list[dict[str, Any]] = []
+    reward_values: list[float] = []
+    for sample_index, sample in enumerate(samples):
+        if "reward_score" not in sample:
+            raise ModelOperationError(
+                code="invalid_alignment_dataset",
+                message="RLHF scored trace rows must include reward_score.",
+                details={
+                    "alignment_algorithm": "rlhf",
+                    "sample_index": str(sample_index),
+                    "missing_field": "reward_score",
+                },
+            )
+        reward = float(sample["reward_score"])
+        reward_values.append(reward)
+        trace_rows.append(
+            {
+                "sample_index": sample_index,
+                "alignment_algorithm": "rlhf",
+                "prompt": str(sample.get("prompt", "")),
+                "selected_response": str(sample.get("response", "")),
+                "selected_reward": reward,
+            }
+        )
+    return trace_rows, reward_values, [], [], len(trace_rows)
+
+
+def _reward_summary(reward_values: list[float]) -> dict[str, float]:
+    if not reward_values:
+        raise ModelOperationError(
+            code="invalid_alignment_dataset",
+            message="alignment_rl training requires at least one reward score.",
+        )
+    ordered = sorted(reward_values)
+    return {
+        "reward_mean": sum(ordered) / len(ordered),
+        "reward_p50": _percentile_value(ordered, 0.5),
+        "reward_p95": _percentile_value(ordered, 0.95),
+    }
+
+
+def _percentile_value(ordered_values: list[float], percentile: float) -> float:
+    if len(ordered_values) == 1:
+        return ordered_values[0]
+    position = (len(ordered_values) - 1) * percentile
+    lower_index = int(position)
+    upper_index = min(lower_index + 1, len(ordered_values) - 1)
+    fraction = position - lower_index
+    return ordered_values[lower_index] * (1 - fraction) + ordered_values[upper_index] * fraction
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def _trace_digest(rows: list[dict[str, Any]]) -> str:
+    digest = hashlib.sha256()
+    for row in rows:
+        digest.update(json.dumps(row, sort_keys=True).encode("utf-8"))
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _estimated_tokens_seen(rows: list[dict[str, Any]]) -> int:
+    total = 0
+    for row in rows:
+        total += len(str(row.get("prompt", "")).split())
+        total += len(str(row.get("selected_response", "") or row.get("selected_candidate_index", "")).split())
+    return total
+
+
+def _tokens_per_second(rows: list[dict[str, Any]], duration_ms: float) -> float:
+    if duration_ms <= 0.0:
+        return 0.0
+    return _estimated_tokens_seen(rows) / (duration_ms / 1000.0)

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -333,6 +333,7 @@ def _grpo_policy_updates(
                 "prompt": str(sample.get("prompt", "")),
                 "selected_candidate_index": selected["index"],
                 "selected_candidate_text": selected["text"],
+                "selected_text": selected["text"],
                 "selected_reward": selected["score"],
                 "group_reward_mean": group_mean,
                 "group_reward_margin": group_margins[-1],
@@ -448,6 +449,7 @@ def _grpo_runtime_policy_updates(
                 "prompt": prompt,
                 "selected_candidate_index": selected["index"],
                 "selected_candidate_text": selected["text"],
+                "selected_text": selected["text"],
                 "selected_reward": selected["score"],
                 "group_reward_mean": group_mean,
                 "group_reward_margin": group_margins[-1],
@@ -828,6 +830,7 @@ def _estimated_tokens_seen(rows: list[dict[str, Any]]) -> int:
         total += len(str(row.get("prompt", "")).split())
         selected_text = (
             row.get("selected_response", "")
+            or row.get("selected_text", "")
             or row.get("selected_candidate_text", "")
             or row.get("selected_candidate_index", "")
         )

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -1,15 +1,34 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import hashlib
 import json
 from pathlib import Path
+from types import SimpleNamespace
+import threading
 import time
 from typing import Any
+
+from packages.protocol.python.worker.v1 import common_pb2
 
 from worker.model_ops.errors import ModelOperationError
 
 
-def train_alignment_rl_trace(request: Any) -> Any:
+@dataclass(frozen=True)
+class PolicyUpdateResult:
+    trace_rows: list[dict[str, Any]]
+    reward_values: list[float]
+    group_margins: list[float]
+    group_variances: list[float]
+    selected_count: int
+    execution_backend: str
+    candidate_generation_mode: str
+    candidate_scoring_mode: str
+    candidate_generation_backend: str = ""
+    generated_candidate_count: int = 0
+
+
+def train_alignment_rl_trace(request: Any, *, policy_runtime: Any | None = None) -> Any:
     from worker.model_ops.mlx_lm_runner import TrainingMetrics, TrainingResult
 
     alignment = request.config.alignment
@@ -22,12 +41,20 @@ def train_alignment_rl_trace(request: Any) -> Any:
     started_at = time.perf_counter()
     samples = _load_training_rows(request.normalized_dataset_dir / "train.jsonl")
     if alignment.alignment_algorithm == "grpo":
-        trace_rows, reward_values, group_margins, group_variances, selected_count = _grpo_policy_updates(
-            samples,
-            candidate_count=alignment.grpo_candidate_count,
-        )
+        if alignment.candidate_generation_mode == "runtime_generate":
+            policy_updates = _grpo_runtime_policy_updates(
+                request,
+                samples,
+                candidate_count=alignment.grpo_candidate_count,
+                policy_runtime=policy_runtime,
+            )
+        else:
+            policy_updates = _grpo_policy_updates(
+                samples,
+                candidate_count=alignment.grpo_candidate_count,
+            )
     elif alignment.alignment_algorithm == "rlhf":
-        trace_rows, reward_values, group_margins, group_variances, selected_count = _rlhf_policy_updates(samples)
+        policy_updates = _rlhf_policy_updates(samples)
     else:
         raise ModelOperationError(
             code="unsupported_alignment_trainer",
@@ -43,16 +70,19 @@ def train_alignment_rl_trace(request: Any) -> Any:
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
     latest_checkpoint_path = checkpoint_dir / "adapters.safetensors"
 
-    _write_jsonl(policy_update_trace_path, trace_rows)
+    _write_jsonl(policy_update_trace_path, policy_updates.trace_rows)
     adapter_config = {
         "fine_tune_type": "lora",
         "alignment_algorithm": alignment.alignment_algorithm,
-        "execution_backend": "scored_trace",
+        "execution_backend": policy_updates.execution_backend,
         "policy_update_trace_path": str(policy_update_trace_path),
         "reward_model_manifest_path": alignment.reward_model_manifest_path,
         "reference_model_path": alignment.reference_model_path,
         "kl_penalty": alignment.kl_penalty,
         "grpo_candidate_count": alignment.grpo_candidate_count,
+        "candidate_generation_mode": policy_updates.candidate_generation_mode,
+        "candidate_generation_backend": policy_updates.candidate_generation_backend,
+        "candidate_scoring_mode": policy_updates.candidate_scoring_mode,
         "lora_parameters": {
             "rank": request.config.rank,
             "dropout": request.config.dropout,
@@ -66,41 +96,45 @@ def train_alignment_rl_trace(request: Any) -> Any:
         "job_id": request.job_id,
         "base_model_id": request.base_model_id,
         "alignment_algorithm": alignment.alignment_algorithm,
-        "policy_update_digest": _trace_digest(trace_rows),
+        "policy_update_digest": _trace_digest(policy_updates.trace_rows),
     }
     weights_bytes = json.dumps(weights_payload, sort_keys=True).encode("utf-8")
     weights_path.write_bytes(weights_bytes)
     latest_checkpoint_path.write_bytes(weights_bytes)
 
     duration_ms = (time.perf_counter() - started_at) * 1000.0
-    reward_summary = _reward_summary(reward_values)
+    reward_summary = _reward_summary(policy_updates.reward_values)
     return TrainingResult(
         weights_path=weights_path,
         adapter_config_path=adapter_config_path,
         metrics=TrainingMetrics(
             job_duration_ms=duration_ms,
-            tokens_seen=_estimated_tokens_seen(trace_rows),
+            tokens_seen=_estimated_tokens_seen(policy_updates.trace_rows),
             examples_seen=len(samples),
             loss_final=-reward_summary["reward_mean"],
-            loss_best=-max(reward_values),
+            loss_best=-max(policy_updates.reward_values),
             learning_rate_final=request.config.learning_rate,
             checkpoint_count=1,
             resume_ready=True,
             latest_checkpoint_path=str(latest_checkpoint_path),
             resume_source_path=str(request.resume_source_path) if request.resume_source_path is not None else "",
-            tokens_per_second=_tokens_per_second(trace_rows, duration_ms),
+            tokens_per_second=_tokens_per_second(policy_updates.trace_rows, duration_ms),
             peak_memory_gb=0.0,
             reward_mean=reward_summary["reward_mean"],
             reward_p50=reward_summary["reward_p50"],
             reward_p95=reward_summary["reward_p95"],
-            policy_update_count=len(trace_rows),
-            selected_candidate_count=selected_count,
-            candidate_group_count=len(group_margins),
-            candidate_group_reward_margin_mean=_mean(group_margins),
-            candidate_group_reward_variance_mean=_mean(group_variances),
+            policy_update_count=len(policy_updates.trace_rows),
+            selected_candidate_count=policy_updates.selected_count,
+            candidate_group_count=len(policy_updates.group_margins),
+            candidate_group_reward_margin_mean=_mean(policy_updates.group_margins),
+            candidate_group_reward_variance_mean=_mean(policy_updates.group_variances),
             policy_update_trace_path=str(policy_update_trace_path),
+            candidate_generation_mode=policy_updates.candidate_generation_mode,
+            candidate_generation_backend=policy_updates.candidate_generation_backend,
+            candidate_scoring_mode=policy_updates.candidate_scoring_mode,
+            generated_candidate_count=policy_updates.generated_candidate_count,
         ),
-        execution_backend="scored_trace",
+        execution_backend=policy_updates.execution_backend,
     )
 
 
@@ -145,7 +179,7 @@ def _grpo_policy_updates(
     samples: list[dict[str, Any]],
     *,
     candidate_count: int,
-) -> tuple[list[dict[str, Any]], list[float], list[float], list[float], int]:
+) -> PolicyUpdateResult:
     trace_rows: list[dict[str, Any]] = []
     reward_values: list[float] = []
     group_margins: list[float] = []
@@ -192,6 +226,8 @@ def _grpo_policy_updates(
             {
                 "sample_index": sample_index,
                 "alignment_algorithm": "grpo",
+                "candidate_generation_mode": "scored_trace",
+                "candidate_scoring_mode": "dataset_score",
                 "prompt": str(sample.get("prompt", "")),
                 "selected_candidate_index": selected["index"],
                 "selected_reward": selected["score"],
@@ -200,12 +236,114 @@ def _grpo_policy_updates(
                 "candidate_count": len(scored_candidates),
             }
         )
-    return trace_rows, reward_values, group_margins, group_variances, len(trace_rows)
+    return PolicyUpdateResult(
+        trace_rows=trace_rows,
+        reward_values=reward_values,
+        group_margins=group_margins,
+        group_variances=group_variances,
+        selected_count=len(trace_rows),
+        execution_backend="scored_trace",
+        candidate_generation_mode="scored_trace",
+        candidate_scoring_mode="dataset_score",
+    )
+
+
+def _grpo_runtime_policy_updates(
+    request: Any,
+    samples: list[dict[str, Any]],
+    *,
+    candidate_count: int,
+    policy_runtime: Any | None,
+) -> PolicyUpdateResult:
+    if policy_runtime is None:
+        raise ModelOperationError(
+            code="unsupported_alignment_trainer",
+            message="GRPO runtime candidate generation requires a policy runtime.",
+            details={
+                "alignment_algorithm": "grpo",
+                "candidate_generation_mode": "runtime_generate",
+                "required_backend": "policy_runtime",
+            },
+        )
+
+    loaded_model = policy_runtime.load_model(_runtime_model_spec(request))
+    runtime_name = str(getattr(policy_runtime, "runtime_name", "") or "unknown-runtime")
+    sampling = _runtime_sampling(request.config.alignment)
+    cancel_event = threading.Event()
+
+    trace_rows: list[dict[str, Any]] = []
+    reward_values: list[float] = []
+    group_margins: list[float] = []
+    group_variances: list[float] = []
+    generated_candidate_total = 0
+    for sample_index, sample in enumerate(samples):
+        prompt = str(sample.get("prompt", ""))
+        seed_candidates = _scored_seed_candidates(sample, sample_index=sample_index)
+        generated_candidates: list[dict[str, Any]] = []
+        for candidate_index in range(candidate_count):
+            generation_prompt = _runtime_generation_prompt(
+                prompt,
+                candidate_index=candidate_index,
+                candidate_count=candidate_count,
+            )
+            generated_text = _generate_candidate_text(
+                policy_runtime,
+                loaded_model,
+                generation_prompt,
+                sampling,
+                cancel_event,
+            )
+            score = _seed_overlap_proxy_score(generated_text, seed_candidates)
+            generated_candidates.append(
+                {
+                    "index": candidate_index,
+                    "text": generated_text,
+                    "score": score,
+                    "generation_prompt": generation_prompt,
+                    "source": "policy_runtime",
+                }
+            )
+        scores = [candidate["score"] for candidate in generated_candidates]
+        reward_values.extend(scores)
+        selected = max(generated_candidates, key=lambda candidate: candidate["score"])
+        group_margins.append(max(scores) - min(scores))
+        group_mean = sum(scores) / len(scores)
+        group_variances.append(sum((score - group_mean) ** 2 for score in scores) / len(scores))
+        generated_candidate_total += len(generated_candidates)
+        trace_rows.append(
+            {
+                "sample_index": sample_index,
+                "alignment_algorithm": "grpo",
+                "candidate_generation_mode": "runtime_generate",
+                "candidate_generation_backend": runtime_name,
+                "candidate_scoring_mode": "seed_overlap_proxy",
+                "prompt": prompt,
+                "selected_candidate_index": selected["index"],
+                "selected_candidate_text": selected["text"],
+                "selected_reward": selected["score"],
+                "group_reward_mean": group_mean,
+                "group_reward_margin": group_margins[-1],
+                "candidate_count": len(generated_candidates),
+                "generated_candidates": generated_candidates,
+            }
+        )
+    return PolicyUpdateResult(
+        trace_rows=trace_rows,
+        reward_values=reward_values,
+        group_margins=group_margins,
+        group_variances=group_variances,
+        selected_count=len(trace_rows),
+        execution_backend="runtime_generated_scored_trace",
+        candidate_generation_mode="runtime_generate",
+        candidate_generation_backend=runtime_name,
+        candidate_scoring_mode="seed_overlap_proxy",
+        generated_candidate_count=generated_candidate_total,
+    )
 
 
 def _rlhf_policy_updates(
     samples: list[dict[str, Any]],
-) -> tuple[list[dict[str, Any]], list[float], list[float], list[float], int]:
+) -> PolicyUpdateResult:
     trace_rows: list[dict[str, Any]] = []
     reward_values: list[float] = []
     for sample_index, sample in enumerate(samples):
@@ -225,12 +363,134 @@ def _rlhf_policy_updates(
             {
                 "sample_index": sample_index,
                 "alignment_algorithm": "rlhf",
+                "candidate_generation_mode": "scored_trace",
+                "candidate_scoring_mode": "dataset_score",
                 "prompt": str(sample.get("prompt", "")),
                 "selected_response": str(sample.get("response", "")),
                 "selected_reward": reward,
             }
         )
-    return trace_rows, reward_values, [], [], len(trace_rows)
+    return PolicyUpdateResult(
+        trace_rows=trace_rows,
+        reward_values=reward_values,
+        group_margins=[],
+        group_variances=[],
+        selected_count=len(trace_rows),
+        execution_backend="scored_trace",
+        candidate_generation_mode="scored_trace",
+        candidate_scoring_mode="dataset_score",
+    )
+
+
+def _runtime_model_spec(request: Any) -> common_pb2.ModelSpec:
+    model = common_pb2.ModelSpec(
+        model_id=request.base_model_id,
+        model_path=str(request.model_path),
+        model_kind=str(getattr(request, "source_model_kind", "") or "text"),
+        revision=request.model_revision,
+    )
+    source_model_ext = getattr(request, "source_model_ext", None)
+    if isinstance(source_model_ext, dict):
+        model.ext.update({str(key): str(value) for key, value in source_model_ext.items()})
+    return model
+
+
+def _runtime_sampling(alignment: Any) -> SimpleNamespace:
+    return SimpleNamespace(
+        temperature=alignment.candidate_generation_temperature,
+        top_p=alignment.candidate_generation_top_p,
+        top_k=alignment.candidate_generation_top_k,
+        max_output_tokens=alignment.candidate_generation_max_tokens,
+        frequency_penalty=0.0,
+        presence_penalty=0.0,
+        stop=[],
+    )
+
+
+def _runtime_generation_prompt(prompt: str, *, candidate_index: int, candidate_count: int) -> str:
+    return (
+        f"{prompt.strip()}\n\n"
+        f"Generate candidate {candidate_index + 1} of {candidate_count}. "
+        "Return only the candidate response."
+    )
+
+
+def _generate_candidate_text(
+    policy_runtime: Any,
+    loaded_model: Any,
+    generation_prompt: str,
+    sampling: SimpleNamespace,
+    cancel_event: threading.Event,
+) -> str:
+    chunks: list[str] = []
+    for event in policy_runtime.generate_tokens(
+        loaded_model,
+        generation_prompt,
+        sampling,
+        cancel_event,
+        execution_ext={"melix.alignment.candidate_generation": "grpo"},
+    ):
+        text = str(getattr(event, "text", event) or "")
+        if text:
+            chunks.append(text)
+    generated_text = "".join(chunks).strip()
+    if not generated_text:
+        raise ModelOperationError(
+            code="alignment_generation_failed",
+            message="GRPO runtime candidate generation returned an empty candidate.",
+            details={"candidate_generation_mode": "runtime_generate"},
+        )
+    return generated_text
+
+
+def _scored_seed_candidates(sample: dict[str, Any], *, sample_index: int) -> list[dict[str, Any]]:
+    candidates = sample.get("candidates")
+    if not isinstance(candidates, list):
+        candidates = []
+    scored_candidates: list[dict[str, Any]] = []
+    for candidate_index, candidate in enumerate(candidates):
+        if not isinstance(candidate, dict) or "score" not in candidate:
+            continue
+        scored_candidates.append(
+            {
+                "index": candidate_index,
+                "text": str(candidate.get("text", "")),
+                "score": float(candidate["score"]),
+            }
+        )
+    if not scored_candidates:
+        raise ModelOperationError(
+            code="invalid_alignment_dataset",
+            message="GRPO runtime candidate generation requires at least one scored seed candidate.",
+            details={
+                "alignment_algorithm": "grpo",
+                "candidate_generation_mode": "runtime_generate",
+                "sample_index": str(sample_index),
+                "missing_field": "candidate.score",
+            },
+        )
+    return scored_candidates
+
+
+def _seed_overlap_proxy_score(generated_text: str, seed_candidates: list[dict[str, Any]]) -> float:
+    best_seed = max(seed_candidates, key=lambda candidate: candidate["score"])
+    reference_tokens = _normalized_token_set(str(best_seed.get("text", "")))
+    if not reference_tokens:
+        return float(best_seed["score"])
+    generated_tokens = _normalized_token_set(generated_text)
+    overlap_ratio = len(generated_tokens & reference_tokens) / len(reference_tokens)
+    return float(best_seed["score"]) * overlap_ratio
+
+
+def _normalized_token_set(text: str) -> set[str]:
+    return {
+        token
+        for token in "".join(
+            character.lower() if character.isalnum() else " "
+            for character in text
+        ).split()
+        if token
+    }
 
 
 def _reward_summary(reward_values: list[float]) -> dict[str, float]:
@@ -279,7 +539,12 @@ def _estimated_tokens_seen(rows: list[dict[str, Any]]) -> int:
     total = 0
     for row in rows:
         total += len(str(row.get("prompt", "")).split())
-        total += len(str(row.get("selected_response", "") or row.get("selected_candidate_index", "")).split())
+        selected_text = (
+            row.get("selected_response", "")
+            or row.get("selected_candidate_text", "")
+            or row.get("selected_candidate_index", "")
+        )
+        total += len(str(selected_text).split())
     return total
 
 

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -19,6 +19,12 @@ class AlignmentTrainingConfig:
     grpo_candidate_count: int = 0
     kl_penalty: float = 0.0
     preference_margin_target: float = 0.0
+    candidate_generation_mode: str = "scored_trace"
+    candidate_scoring_mode: str = "dataset_score"
+    candidate_generation_temperature: float = 0.0
+    candidate_generation_top_p: float = 1.0
+    candidate_generation_top_k: int = 0
+    candidate_generation_max_tokens: int = 128
 
 
 @dataclass(frozen=True)
@@ -701,6 +707,56 @@ def _resolve_alignment_config(
             },
         )
 
+    candidate_generation_mode = (
+        ext.get("candidate_generation_mode", "").strip().lower()
+        or ext.get("grpo_candidate_generation_mode", "").strip().lower()
+        or "scored_trace"
+    )
+    if candidate_generation_mode not in {"scored_trace", "runtime_generate"}:
+        raise ModelOperationError(
+            code="invalid_alignment_config",
+            message=f"Unsupported candidate_generation_mode: {candidate_generation_mode}",
+            details={
+                "training_mode": training_mode,
+                "candidate_generation_mode": candidate_generation_mode,
+            },
+        )
+    if training_mode != "grpo" and candidate_generation_mode != "scored_trace":
+        raise ModelOperationError(
+            code="invalid_alignment_config",
+            message="candidate_generation_mode=runtime_generate is only supported for GRPO.",
+            details={
+                "training_mode": training_mode,
+                "candidate_generation_mode": candidate_generation_mode,
+                "supported_training_mode": "grpo",
+            },
+        )
+
+    candidate_scoring_mode = (
+        ext.get("candidate_scoring_mode", "").strip().lower()
+        or ext.get("grpo_candidate_scoring_mode", "").strip().lower()
+        or ("seed_overlap_proxy" if candidate_generation_mode == "runtime_generate" else "dataset_score")
+    )
+    expected_scoring_modes = (
+        {"seed_overlap_proxy"}
+        if candidate_generation_mode == "runtime_generate"
+        else {"dataset_score"}
+    )
+    if candidate_scoring_mode not in expected_scoring_modes:
+        raise ModelOperationError(
+            code="invalid_alignment_config",
+            message=(
+                f"candidate_scoring_mode={candidate_scoring_mode} is not supported "
+                f"for candidate_generation_mode={candidate_generation_mode}."
+            ),
+            details={
+                "training_mode": training_mode,
+                "candidate_generation_mode": candidate_generation_mode,
+                "candidate_scoring_mode": candidate_scoring_mode,
+                "supported_candidate_scoring_modes": ",".join(sorted(expected_scoring_modes)),
+            },
+        )
+
     return AlignmentTrainingConfig(
         alignment_algorithm=training_mode,
         dataset_contract=dataset_contract,
@@ -718,6 +774,36 @@ def _resolve_alignment_config(
             default=0.0,
             minimum=0.0,
             field_name="preference_margin_target",
+        ),
+        candidate_generation_mode=candidate_generation_mode,
+        candidate_scoring_mode=candidate_scoring_mode,
+        candidate_generation_temperature=_float_value(
+            ext.get("candidate_generation_temperature", "")
+            or ext.get("grpo_candidate_generation_temperature", ""),
+            default=0.0,
+            minimum=0.0,
+            field_name="candidate_generation_temperature",
+        ),
+        candidate_generation_top_p=_float_value(
+            ext.get("candidate_generation_top_p", "")
+            or ext.get("grpo_candidate_generation_top_p", ""),
+            default=1.0,
+            minimum=0.0,
+            field_name="candidate_generation_top_p",
+        ),
+        candidate_generation_top_k=_int_value(
+            ext.get("candidate_generation_top_k", "")
+            or ext.get("grpo_candidate_generation_top_k", ""),
+            default=0,
+            minimum=0,
+            field_name="candidate_generation_top_k",
+        ),
+        candidate_generation_max_tokens=_int_value(
+            ext.get("candidate_generation_max_tokens", "")
+            or ext.get("grpo_candidate_generation_max_tokens", ""),
+            default=128,
+            minimum=1,
+            field_name="candidate_generation_max_tokens",
         ),
     )
 

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -737,11 +737,14 @@ def _resolve_alignment_config(
         or ext.get("grpo_candidate_scoring_mode", "").strip().lower()
         or ("seed_overlap_proxy" if candidate_generation_mode == "runtime_generate" else "dataset_score")
     )
-    expected_scoring_modes = (
-        {"seed_overlap_proxy"}
-        if candidate_generation_mode == "runtime_generate"
-        else {"dataset_score"}
-    )
+    if training_mode in _RL_TRAINING_MODES:
+        expected_scoring_modes = (
+            {"seed_overlap_proxy", "reward_model"}
+            if candidate_generation_mode == "runtime_generate"
+            else {"dataset_score", "reward_model"}
+        )
+    else:
+        expected_scoring_modes = {"dataset_score"}
     if candidate_scoring_mode not in expected_scoring_modes:
         raise ModelOperationError(
             code="invalid_alignment_config",
@@ -754,6 +757,16 @@ def _resolve_alignment_config(
                 "candidate_generation_mode": candidate_generation_mode,
                 "candidate_scoring_mode": candidate_scoring_mode,
                 "supported_candidate_scoring_modes": ",".join(sorted(expected_scoring_modes)),
+            },
+        )
+    if candidate_scoring_mode == "reward_model" and not reward_model_manifest_path:
+        raise ModelOperationError(
+            code="invalid_alignment_config",
+            message="candidate_scoring_mode=reward_model requires reward_model_manifest_path.",
+            details={
+                "training_mode": training_mode,
+                "candidate_scoring_mode": candidate_scoring_mode,
+                "missing_field": "reward_model_manifest_path",
             },
         )
 

--- a/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
@@ -451,6 +451,33 @@ class MLXTextRuntime:
     def estimate_resident_bytes(self, model_spec) -> int:
         return int(self._backend.estimate_resident_bytes(model_spec))
 
+    def score_response(
+        self,
+        loaded_model,
+        prompt: str,
+        response: str,
+        execution_ext: dict[str, str] | None = None,
+    ) -> float:
+        scorer = getattr(self._backend, "score_response", None)
+        if not callable(scorer):
+            raise RuntimeUnavailableError("Text runtime backend does not support reward scoring.")
+
+        def call_scorer() -> float:
+            if _callable_accepts_kwarg(scorer, "execution_ext"):
+                value = scorer(
+                    loaded_model,
+                    prompt,
+                    response,
+                    execution_ext=execution_ext,
+                )
+            else:
+                value = scorer(loaded_model, prompt, response)
+            return float(value)
+
+        if self._executor is None:
+            return call_scorer()
+        return self._executor.run(call_scorer)
+
     def render_prompt(
         self,
         messages,


### PR DESCRIPTION
## Summary
- Add a scored-trace RL alignment runner for `training_objective=alignment_rl`.
- Route GRPO `prompt_candidate` datasets and RLHF `reward_scored` datasets through the worker runner with `execution_backend=scored_trace`.
- Add opt-in GRPO runtime candidate generation with `candidate_generation_mode=runtime_generate`, loading the policy runtime once per job and recording generated candidates with seed-overlap proxy scores.
- Add explicit `candidate_scoring_mode=reward_model` for GRPO/RLHF, loading an injected reward runtime once per job and recording reward-model scoring backend/id evidence.
- Emit policy update traces, adapter/checkpoint artifacts, and alignment manifest metrics for rewards, candidate groups, generated candidates, runtime backend identity, reward scoring backend identity, and selected updates.
- Preserve normalized-dataset reward summaries for external alignment runners that do not emit policy-update metrics, while still recording true zero-valued scored-trace reward metrics when policy-update evidence exists.
- CI follow-up: make the fused decode quantizer unsupported-inputs negative test and vendored ChatSession clear test use the same temporary `mlx.metallib` guard as the adjacent live MLX bridge tests.
- CI follow-up: make process-bridge fixture tests use a direct system Python executable instead of the default `uv run --extra mlx` bridge path.

## Plan or Spec
- `docs/plans/2026-05-05-issue-365-rl-alignment-runner.md`
- GitHub issue: https://github.com/Keith-CY/melix/issues/365
- Base: current `main` after merge-ref refresh through PR #408.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py
# 209 passed, 9 skipped

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py
# 209 passed, 9 skipped

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-rl-alignment-runner-coverage.json
# Wrote JSON report to /tmp/issue365-rl-alignment-runner-coverage.json

python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-rl-alignment-runner-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
# TOTAL 96.53% 779/807

python3 -m compileall -q services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py
# 71 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py
# 71 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-rl-alignment-runner-review-coverage.json
# Wrote JSON report to /tmp/issue365-rl-alignment-runner-review-coverage.json

python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-rl-alignment-runner-review-coverage.json --diff-from HEAD^ services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
# TOTAL 100.00% 4/4

python3 -m compileall -q services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/tests/test_lora_model_ops.py
# passed

swift test --package-path services/mlx-text-worker-swift --filter WorkerScaffoldTests/testFusedDecodeQuantizerRejectsUnsupportedInputs
# 1 test skipped locally before adding a worktree-local ignored MLX metallib cache.

swift test --package-path services/mlx-text-worker-swift --filter WorkerScaffoldTests/testFusedDecodeQuantizer
# 4 tests executed, 3 skipped locally before adding a worktree-local ignored MLX metallib cache.

swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter WorkerScaffoldTests/testFusedDecodeQuantizer
# 4 tests passed after copying the local Python MLX mlx.metallib into the ignored worktree .uv-cache for coverage verification.

python3 scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from HEAD^ services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
# TOTAL 100.00% 19/19

git diff --check
# passed

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr/issue365-rl-alignment-runner-pr.md
# passed

git merge origin/main
# passed, no conflicts

xcrun swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter WorkerScaffoldTests/testVendoredChatSessionClearUsesAsyncSerialAccess
# 1 test passed

python3 scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from HEAD^ services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
# TOTAL 100.00% 10/10

make swift-test-text-worker
# 189 tests passed

make swift-test-control-worker
# 102 tests in 5 suites passed

git diff --check
# passed

xcrun swift test --package-path services/control-plane-swift --enable-code-coverage --filter PythonBridgeWorkerClientTests
# 52 tests passed

python3 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from HEAD services/control-plane-swift/Tests/WorkerClientTests/PythonBridgeWorkerClientTests.swift
# TOTAL 100.00% 15/15

git diff --check
# passed

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr/issue365-rl-alignment-runner-pr.md
# passed
```

## Coverage and Metrics
- Changed-line coverage: 96.53% (779/807) against `origin/main`.
- Review follow-up changed-line coverage: 100.00% (4/4) for commit `b93231641` against `HEAD^`.
- CI follow-up changed-line coverage: 100.00% (19/19) for commit `6af2b6959` against `HEAD^`.
- Merge-refresh CI follow-up changed-line coverage: 100.00% (10/10) for the vendored ChatSession clear guard against `HEAD^`.
- Control-worker CI follow-up changed-line coverage: 100.00% (15/15) for process bridge fixture environment coverage against `HEAD`.
- Metrics report: scored-trace/runtime-generated/reward-model-scored runner records `reward_mean`, `reward_p50`, `reward_p95`, `policy_update_count`, `selected_candidate_count`, `candidate_group_count`, `candidate_group_reward_margin_mean`, `candidate_group_reward_variance_mean`, `candidate_generation_mode`, `candidate_generation_backend`, `candidate_scoring_mode`, `reward_scoring_backend`, `generated_candidate_count`, and `policy_update_trace_path` in alignment manifests.
- Metrics guard: alignment manifests only let scored-trace policy-update metrics override normalized dataset reward summaries when policy-update evidence is present, so true zero reward means are retained without erasing external runner summary metrics.
- Performance probe: default scored-trace reads normalized `train.jsonl` once and does not load the base model; opt-in `runtime_generate` loads the policy runtime once per job and generates `grpo_candidate_count` candidates per prompt; opt-in `candidate_scoring_mode=reward_model` loads the reward runtime once per job and scores one response per RLHF row or one generated/trace candidate per GRPO candidate.
- CI follow-up metrics: no runtime behavior change; the test guards now skip the live MLX fused quantizer negative test and vendored ChatSession clear test on machines without `mlx.metallib`, matching adjacent fused quantizer tests.

## Known Gaps
- PR #369 and PR #386 have already merged; this PR is based on current `main`.
- This PR does not close issue #365.
- Deferred issue #365 work remains: reward-model training and PPO/reward-guided policy updates from #366, real local-runtime release evidence for reward scoring outside scripted tests, PTQ/QAT real local inference acceptance, full CLI chain tests, Window UI acceptance, and final release evidence.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
