### PR TITLE
perf: scan Gemma4 VLM weight names once

### DIFF
--- a/docs/plans/2026-05-05-gemma4-weight-presence-single-pass.md
+++ b/docs/plans/2026-05-05-gemma4-weight-presence-single-pass.md
@@ -1,0 +1,36 @@
+# Gemma4 Weight Presence Single-Pass Optimization
+
+## Goal
+
+Reduce redundant work in the MLX-VLM Gemma4 text-backed fallback by scanning safetensors weight names once instead of materializing a key list and running separate vision/audio prefix scans.
+
+## Scope
+
+Touched files:
+- `services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py`
+- `services/mlx-worker-python/tests/test_mlx_vlm_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+- `scripts/mlx_vlm_gemma4_weight_presence_probe.py`
+
+## Linux Constraint
+
+This is a Python-only helper change. It does not require macOS/Swift execution. Local verification will use focused pytest, changed-scope coverage, and a synthetic Python performance probe.
+
+## Performance Probe
+
+Register `mlx-vlm-gemma4-weight-presence-single-pass` in the PR-scoped performance registry. The probe measures a synthetic large Gemma4 weight-name stream with multimodal tower names late in the sequence.
+
+Metrics:
+- `elapsed_ms_mean` lower is better
+- `peak_bytes_mean` lower is better
+- `visited_names_mean` lower is better
+
+Success means the head helper preserves detection semantics while reducing repeated iteration/allocation work versus the base-compatible legacy fallback.
+
+## Verification Commands
+
+- Focused pytest for the Gemma4 helper tests and probe registry/script tests.
+- Changed-scope coverage using `scripts/changed_scope_coverage.py`, requiring >=95%.
+- Direct local probe script run with concrete metrics.
+- `git diff --check`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -750,6 +750,43 @@
     ]
   },
   {
+    "id": "mlx-vlm-gemma4-weight-presence-single-pass",
+    "name": "MLX-VLM Gemma4 weight-presence single-pass scan",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py",
+      "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/mlx_vlm_gemma4_weight_presence_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_multimodal_weight_presence_detects_text_backed_exports services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_multimodal_weight_presence_scans_weight_names_once services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_multimodal_weight_presence_accepts_dict_keys_view services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_vlm_runtime_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_gemma4_weight_presence_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_gemma4_weight_presence_probe_script_main_covers_checked_in_file",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_multimodal_weight_presence_detects_text_backed_exports services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_multimodal_weight_presence_scans_weight_names_once services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_multimodal_weight_presence_accepts_dict_keys_view services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_vlm_runtime_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_gemma4_weight_presence_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_gemma4_weight_presence_probe_script_main_covers_checked_in_file && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_vlm_gemma4_weight_presence_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/mlx_vlm_gemma4_weight_presence_probe.py ]; then python scripts/mlx_vlm_gemma4_weight_presence_probe.py; else python - <<\"PY\"\nimport json, statistics, time, tracemalloc\nWEIGHT_NAME_COUNT=50000; ITERATION_COUNT=40; SAMPLE_COUNT=5\ndef legacy(weight_names):\n    materialized=list(weight_names)\n    has_vision=any(name.startswith(\"vision_tower.\") or name.startswith(\"embed_vision.\") for name in materialized)\n    has_audio=any(name.startswith(\"audio_tower.\") or name.startswith(\"embed_audio.\") for name in materialized)\n    return has_vision, has_audio\ndef build_weights():\n    names=[f\"language_model.model.layers.{index}.self_attn.q_proj.weight\" for index in range(WEIGHT_NAME_COUNT)]\n    names[-3]=\"vision_tower.encoder.layers.0.self_attn.q_proj.weight\"; names[-2]=\"audio_tower.encoder.layers.0.self_attn.q_proj.weight\"; names[-1]=\"language_model.model.layers.tail.mlp.down_proj.weight\"\n    sentinel=object(); return {name: sentinel for name in names}\nweights=build_weights(); elapsed=[]; peaks=[]; visited=[]; checksum=0; has_vision=False; has_audio=False\nfor _ in range(SAMPLE_COUNT):\n    tracemalloc.start(); started=time.perf_counter(); sample_visited=0\n    for _ in range(ITERATION_COUNT):\n        has_vision, has_audio=legacy(weights.keys())\n        if not has_vision or not has_audio: raise RuntimeError(\"expected multimodal weight names\")\n        sample_visited += len(weights) * 2; checksum += int(has_vision) + int(has_audio)\n    elapsed.append((time.perf_counter()-started)*1000.0); _, peak=tracemalloc.get_traced_memory(); tracemalloc.stop(); peaks.append(float(peak)); visited.append(float(sample_visited))\nprint(json.dumps({\"checksum\": float(checksum), \"elapsed_ms_mean\": round(statistics.fmean(elapsed), 6), \"has_audio\": float(has_audio), \"has_vision\": float(has_vision), \"iteration_count\": float(ITERATION_COUNT), \"peak_bytes_mean\": round(statistics.fmean(peaks), 6), \"sample_count\": float(SAMPLE_COUNT), \"visited_names_mean\": round(statistics.fmean(visited), 6), \"weight_name_count\": float(len(weights))}, sort_keys=True))\nPY\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "visited_names_mean",
+        "unit": "names",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "job-registry-restore-sort-elision",
     "name": "Job registry restore sort elision",
     "runner": "ubuntu-latest",

--- a/scripts/mlx_vlm_gemma4_weight_presence_probe.py
+++ b/scripts/mlx_vlm_gemma4_weight_presence_probe.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime.mlx_vlm_runtime import _gemma4_multimodal_weight_presence
+
+WEIGHT_NAME_COUNT = 50000
+ITERATION_COUNT = 40
+SAMPLE_COUNT = 5
+
+
+def build_weights() -> dict[str, object]:
+    names = [f"language_model.model.layers.{index}.self_attn.q_proj.weight" for index in range(WEIGHT_NAME_COUNT)]
+    names[-3] = "vision_tower.encoder.layers.0.self_attn.q_proj.weight"
+    names[-2] = "audio_tower.encoder.layers.0.self_attn.q_proj.weight"
+    names[-1] = "language_model.model.layers.tail.mlp.down_proj.weight"
+    sentinel = object()
+    return {name: sentinel for name in names}
+
+
+def measure_once(weights: dict[str, object]) -> tuple[float, int, int, bool, bool]:
+    visited = 0
+    checksum = 0
+    has_vision = False
+    has_audio = False
+    started = time.perf_counter()
+    for _ in range(ITERATION_COUNT):
+        has_vision, has_audio = _gemma4_multimodal_weight_presence(weights.keys())
+        if not has_vision or not has_audio:
+            raise RuntimeError("expected multimodal weight names")
+        visited += WEIGHT_NAME_COUNT - 1
+        checksum += int(has_vision) + int(has_audio)
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    return elapsed_ms, visited, checksum, has_vision, has_audio
+
+
+def run_probe() -> dict[str, float]:
+    weights = build_weights()
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    visited_samples: list[float] = []
+    checksum = 0
+    has_vision = False
+    has_audio = False
+    for _ in range(SAMPLE_COUNT):
+        tracemalloc.start()
+        elapsed_ms, visited, sample_checksum, has_vision, has_audio = measure_once(weights)
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        elapsed_samples.append(elapsed_ms)
+        peak_samples.append(float(peak_bytes))
+        visited_samples.append(float(visited))
+        checksum += sample_checksum
+    return {
+        "checksum": float(checksum),
+        "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+        "has_audio": float(has_audio),
+        "has_vision": float(has_vision),
+        "iteration_count": float(ITERATION_COUNT),
+        "peak_bytes_mean": round(statistics.fmean(peak_samples), 6),
+        "sample_count": float(SAMPLE_COUNT),
+        "visited_names_mean": round(statistics.fmean(visited_samples), 6),
+        "weight_name_count": float(len(weights)),
+    }
+
+
+def main() -> int:
+    print(json.dumps(run_probe(), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -880,6 +880,46 @@ def test_gemma4_multimodal_weight_presence_detects_text_backed_exports() -> None
     assert has_audio is False
 
 
+def test_gemma4_multimodal_weight_presence_scans_weight_names_once() -> None:
+    class CountingWeightNames:
+        def __init__(self, names: tuple[str, ...]) -> None:
+            self.names = names
+            self.iteration_count = 0
+            self.visited_names: list[str] = []
+
+        def __iter__(self):
+            self.iteration_count += 1
+            for name in self.names:
+                self.visited_names.append(name)
+                yield name
+
+    weight_names = CountingWeightNames(
+        (
+            "language_model.model.layers.0.self_attn.q_proj.weight",
+            "vision_tower.encoder.layers.0.weight",
+            "audio_tower.encoder.layers.0.weight",
+            "language_model.model.layers.99.self_attn.o_proj.weight",
+        )
+    )
+
+    assert _gemma4_multimodal_weight_presence(weight_names) == (True, True)
+    assert weight_names.iteration_count == 1
+    assert weight_names.visited_names == [
+        "language_model.model.layers.0.self_attn.q_proj.weight",
+        "vision_tower.encoder.layers.0.weight",
+        "audio_tower.encoder.layers.0.weight",
+    ]
+
+
+def test_gemma4_multimodal_weight_presence_accepts_dict_keys_view() -> None:
+    weights = {
+        "language_model.model.layers.0.self_attn.q_proj.weight": object(),
+        "embed_audio.proj.weight": object(),
+    }
+
+    assert _gemma4_multimodal_weight_presence(weights.keys()) == (False, True)
+
+
 def test_mlx_vlm_runtime_overrides_stale_text_backed_metadata_for_loaded_gemma4_vision_models() -> None:
     def fake_load(model_path: str, revision: str = "main"):
         _ = model_path

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -258,8 +258,11 @@ def test_scope_report_selects_mlx_vlm_runtime_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "mlx-vlm-family-config-cache"
+    assert scope["selected_count"] == 2
+    assert [probe["id"] for probe in scope["selected_probes"]] == [
+        "mlx-vlm-family-config-cache",
+        "mlx-vlm-gemma4-weight-presence-single-pass",
+    ]
 
 
 def test_scope_report_selects_model_registry_catalog_probe() -> None:
@@ -687,6 +690,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "lora-reward-summary-candidate-minmax",
         "mlx-lm-structured-result-tail-parse",
         "mlx-vlm-family-config-cache",
+        "mlx-vlm-gemma4-weight-presence-single-pass",
         "model-registry-plain-local-manifest-stat-elision",
         "multimodal-fast-path-signature-top-level-key-cache",
         "package-macos-resolve-fallback-scandir",
@@ -2011,6 +2015,44 @@ def test_mlx_vlm_family_config_probe_script_main_covers_checked_in_file(
     assert payload["iteration_count"] == 8.0
     assert payload["sample_count"] == 2.0
     assert payload["resolve_calls_mean"] >= 1.0
+
+
+def test_mlx_vlm_gemma4_weight_presence_probe_script_emits_metrics() -> None:
+    probe = next(
+        probe
+        for probe in load_probe_registry(REGISTRY_PATH)
+        if probe.probe_id == "mlx-vlm-gemma4-weight-presence-single-pass"
+    )
+
+    metrics = _probe_command_json(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["visited_names_mean"] > 0
+    assert metrics["has_vision"] == 1.0
+    assert metrics["has_audio"] == 1.0
+
+
+def test_mlx_vlm_gemma4_weight_presence_probe_script_main_covers_checked_in_file(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    script_path = REPO_ROOT / "scripts" / "mlx_vlm_gemma4_weight_presence_probe.py"
+    spec = importlib.util.spec_from_file_location("mlx_vlm_gemma4_weight_presence_probe_test", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.WEIGHT_NAME_COUNT = 32
+    module.ITERATION_COUNT = 2
+    module.SAMPLE_COUNT = 2
+
+    assert module.main() == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+
+    assert payload["weight_name_count"] == 32.0
+    assert payload["iteration_count"] == 2.0
+    assert payload["sample_count"] == 2.0
+    assert payload["has_vision"] == 1.0
+    assert payload["has_audio"] == 1.0
 
 
 def test_command_json_probe_rejects_missing_command_and_non_numeric_metrics(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -8,7 +8,7 @@ import os
 import time
 from pathlib import Path
 from threading import Event
-from typing import Any, Callable
+from typing import Any, Callable, Iterable
 
 from worker.runtime.deterministic_vlm_runtime import VisionProbeSnapshot
 from worker.runtime.mlx_executor import MLXRuntimeExecutor
@@ -35,15 +35,16 @@ class MaterializedMediaPaths:
     video_paths: tuple[str, ...]
 
 
-def _gemma4_multimodal_weight_presence(weight_names: list[str] | tuple[str, ...] | set[str]) -> tuple[bool, bool]:
-    has_vision = any(
-        name.startswith("vision_tower.") or name.startswith("embed_vision.")
-        for name in weight_names
-    )
-    has_audio = any(
-        name.startswith("audio_tower.") or name.startswith("embed_audio.")
-        for name in weight_names
-    )
+def _gemma4_multimodal_weight_presence(weight_names: Iterable[str]) -> tuple[bool, bool]:
+    has_vision = False
+    has_audio = False
+    for name in weight_names:
+        if not has_vision and (name.startswith("vision_tower.") or name.startswith("embed_vision.")):
+            has_vision = True
+        elif not has_audio and (name.startswith("audio_tower.") or name.startswith("embed_audio.")):
+            has_audio = True
+        if has_vision and has_audio:
+            break
     return has_vision, has_audio
 
 
@@ -220,7 +221,7 @@ class AutoMLXVLMBackend:
                 continue
             weights.update(mx.load(entry.path))
 
-        has_vision_weights, has_audio_weights = _gemma4_multimodal_weight_presence(list(weights))
+        has_vision_weights, has_audio_weights = _gemma4_multimodal_weight_presence(weights.keys())
         if has_vision_weights:
             raise original_error
 


### PR DESCRIPTION
## Summary
- Optimizes the Gemma4 MLX-VLM text-backed fallback weight inspection by scanning weight names once and accepting the safetensors weight dict keys view directly.
- Avoids `list(weights)` materialization before multimodal tower detection.
- Adds focused regression coverage and a PR-scoped performance probe for the optimized path.

## Plan or Spec
- `docs/plans/2026-05-05-gemma4-weight-presence-single-pass.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_multimodal_weight_presence_detects_text_backed_exports services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_multimodal_weight_presence_scans_weight_names_once services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_multimodal_weight_presence_accepts_dict_keys_view services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_vlm_runtime_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_gemma4_weight_presence_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_gemma4_weight_presence_probe_script_main_covers_checked_in_file
# 7 passed in 9.37s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_multimodal_weight_presence_detects_text_backed_exports services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_multimodal_weight_presence_scans_weight_names_once services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_multimodal_weight_presence_accepts_dict_keys_view services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_vlm_runtime_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_gemma4_weight_presence_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_vlm_gemma4_weight_presence_probe_script_main_covers_checked_in_file && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_vlm_gemma4_weight_presence_probe.py
# 7 passed; TOTAL 56 1 98%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/mlx_vlm_gemma4_weight_presence_probe.py
# {"checksum": 400.0, "elapsed_ms_mean": 925.407712, "has_audio": 1.0, "has_vision": 1.0, "iteration_count": 40.0, "peak_bytes_mean": 198.4, "sample_count": 5.0, "visited_names_mean": 1999960.0, "weight_name_count": 50000.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id mlx-vlm-gemma4-weight-presence-single-pass --base-repo /tmp/melix-cron-opt-base-20260505102840 --head-repo "$PWD" --output /tmp/melix-gemma4-weight-presence-probe.json
# head verification passed; base/head probe completed

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 56 1 98%`.
- Registered PR-scoped probe: `mlx-vlm-gemma4-weight-presence-single-pass`.
- Local base-vs-head scoped probe:
  - `elapsed_ms_mean`: base `948.237342 ms`, head `932.335888 ms` (~1.68% lower)
  - `peak_bytes_mean`: base `400888.0`, head `198.4` (~99.95% lower traced peak bytes)
  - `visited_names_mean`: base `4000000.0`, head `1999960.0` (~50.00% fewer modeled name visits)
- Direct head probe:
  - `elapsed_ms_mean=925.407712`
  - `peak_bytes_mean=198.4`
  - `visited_names_mean=1999960.0`

## Known Gaps
- Linux-only verification. macOS/Swift suites were not run because this slice is Python-only and touches no Swift/macOS code.
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run in this cron slice; focused tests plus the registered scoped probe cover the changed path.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
