### PR TITLE
perf: multiply deterministic embedding projection repeats

### DIFF
--- a/docs/plans/2026-05-05-deterministic-embedding-project-digest-repeat-multiply.md
+++ b/docs/plans/2026-05-05-deterministic-embedding-project-digest-repeat-multiply.md
@@ -1,0 +1,39 @@
+# Deterministic Embedding Projection Repeat Multiply
+
+## Goal
+
+Reduce Python-level list growth overhead in deterministic embedding digest projection without changing the deterministic vector values or normalization contract.
+
+## Linux-only constraint
+
+This is a Python worker-runtime slice. It is locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/embedding_backends.py`
+- `services/mlx-worker-python/tests/test_embedding_runtime.py`
+- `scripts/deterministic_embedding_project_digest_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Optimization hypothesis
+
+`DeterministicEmbeddingBackend._project_digest()` computes the normalized digest base vector once and then appends it into the output vector with a Python loop that calls `list.extend()` once per digest repeat. Large embedding dimensions such as 4096 produce hundreds of Python-level list-growth operations for every projected vector.
+
+Use CPython's list multiplication for full digest repeats and one remainder append so the repeated-vector expansion runs in optimized list machinery while preserving exact output ordering and rounded values.
+
+## Registered performance probe
+
+The affected path is covered by `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+Metrics:
+
+- `elapsed_ms_mean` — lower is better
+- `peak_bytes_mean` — lower is better
+- `dimensions`, `vector_count`, and checksum provide behavior context
+
+## Verification commands
+
+- Focused pytest for embedding runtime and PR-scoped probe selection/smoke tests
+- Changed-scope coverage for touched Python/tests with at least 95% automated coverage
+- Local registered probe run before and after the implementation
+- `git diff --check`

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -57,9 +57,7 @@ class DeterministicEmbeddingBackend:
         if l2_norm == 0.0:
             return [0.0] * dimensions
         normalized_base = [round(value / l2_norm, 6) for value in base_values]
-        result: list[float] = []
-        for _ in range(full_repeats):
-            result.extend(normalized_base)
+        result = normalized_base * full_repeats
         result.extend(normalized_base[:remainder])
         return result
 


### PR DESCRIPTION
## Summary
- Replace the Python-level repeat/extend loop in deterministic embedding digest projection with list multiplication plus the existing remainder append.
- Preserve exact deterministic projection values while reducing repeated vector expansion overhead for large dimensions.

## Plan or Spec
- `docs/plans/2026-05-05-deterministic-embedding-project-digest-repeat-multiply.md`
- Registered probe: `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json` already covers the affected path with focused test, coverage, and probe commands.

## Commands Run
```text
# Baseline probe on origin/main worktree (3 local invocations)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
run1: elapsed_ms_mean=152.177217, peak_bytes_mean=74163.666667
run2: elapsed_ms_mean=153.552687, peak_bytes_mean=74163.666667
run3: elapsed_ms_mean=149.835821, peak_bytes_mean=74163.666667

# Candidate probe after implementation (3 local invocations)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
run1: elapsed_ms_mean=25.122007, peak_bytes_mean=66955.666667
run2: elapsed_ms_mean=30.840906, peak_bytes_mean=66955.666667
run3: elapsed_ms_mean=24.789297, peak_bytes_mean=66955.666667

# Registered focused test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
17 passed in 12.20s

# Registered changed-scope coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
17 passed in 37.64s; TOTAL 1 0 100%

# Registered PR-scoped performance runner
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-project-digest-allocation --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output .runtime/pr-scoped-performance/deterministic-embedding-project-digest-allocation.json
head verification ok; base probe ok; head probe ok

# Whitespace check
git diff --check
pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%` for `services/mlx-worker-python/worker/runtime/embedding_backends.py` and related focused probe/test paths.
- Registered probe comparison from `scripts/pr_scoped_performance_run.py`:
  - `elapsed_ms_mean`: base `157.641928` ms → head `24.379236` ms (`-133.262692` ms, `84.535%` lower, `6.466x` speedup)
  - `peak_bytes_mean`: base `74163.666667` bytes → head `66955.666667` bytes (`-7208` bytes, `9.719%` lower)
  - `checksum`: unchanged at `0.348915`

## Known Gaps
- Full repository `make` gates were not run locally; this PR uses the focused registered Python probe/test/coverage path for this small performance slice.
- GitHub Actions PR-scoped performance validation is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
