### PR TITLE
Add MLX quantization convert backend

### DIFF
--- a/docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md
+++ b/docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md
@@ -10,7 +10,10 @@ recorded lineage, release-gate, QAT-mode, and runtime-smoke evidence, but the
 default fast path still writes deterministic structural bundle files. This
 slice adds a separate backend that can invoke `mlx_lm.convert(..., quantize=True)`
 for local source artifacts while preserving the existing deterministic backend
-for fast tests and unsupported environments.
+for fast tests and unsupported environments. It also tightens the QAT-aware
+export evidence block so QAT requests preserve adapter-derived source lineage,
+fake-quant settings, optional QAT training-manifest lineage, and calibration
+lineage.
 
 ## Scope
 
@@ -27,6 +30,9 @@ for fast tests and unsupported environments.
   `melix.quantized_bundle.v1`.
 - Run structural and runtime-generate smoke preflight against the file layout
   emitted by the selected backend.
+- Require QAT source artifacts to exist before writing an output bundle.
+- Record QAT-aware export metadata in both the quantized bundle manifest and
+  the manifest-only weights payload.
 
 ### Excluded
 
@@ -62,10 +68,10 @@ git diff --check
 
 Results on 2026-05-05:
 
-- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py`: 50 passed.
-- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py`: 50 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py`: 52 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py`: 52 passed.
 - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-mlx-quantization-coverage.json`: wrote JSON report.
-- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-mlx-quantization-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md`: 100.00% total changed-line coverage (228/228).
+- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-mlx-quantization-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md`: 98.55% total changed-line coverage (271/275).
 - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python python -m compileall -q services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py`: passed.
 - `git diff --check`: passed.
 
@@ -73,7 +79,7 @@ Results on 2026-05-05:
 
 - Real GRPO candidate generation and reward-guided policy update integration.
 - RLHF reward-model-backed policy optimization from issue 366.
-- Real QAT training and QAT-aware export.
+- Real QAT training.
 - Full CLI chain tests with real local runtime evidence for every business
   line.
 - Window UI runnable and inspectable acceptance for every business line.

--- a/docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md
+++ b/docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md
@@ -13,7 +13,11 @@ for local source artifacts while preserving the existing deterministic backend
 for fast tests and unsupported environments. It also tightens the QAT-aware
 export evidence block so QAT requests preserve adapter-derived source lineage,
 fake-quant settings, optional QAT training-manifest lineage, and calibration
-lineage.
+lineage. A follow-up extension in this branch adds a deterministic Melix
+fake-quant optimizer execution path for QAT requests: it reads the
+adapter-derived source artifact, computes fake-quant error proxies, writes a
+QAT training trace and manifest, and links those artifacts from the quantized
+bundle manifest.
 
 ## Scope
 
@@ -31,12 +35,15 @@ lineage.
 - Run structural and runtime-generate smoke preflight against the file layout
   emitted by the selected backend.
 - Require QAT source artifacts to exist before writing an output bundle.
-- Record QAT-aware export metadata in both the quantized bundle manifest and
-  the manifest-only weights payload.
+- Run a deterministic Melix fake-quant optimizer for QAT requests and record the
+  generated QAT training trace, training manifest, fake-quant artifact, source
+  digest, optimizer metrics, and optional source training-manifest lineage.
+- Record QAT fake-quant training metadata in both the quantized bundle manifest
+  and the manifest-only weights payload.
 
 ### Excluded
 
-- Real QAT training.
+- MLX-native QAT training over full model tensors.
 - End-to-end release evidence for every issue 365 business line.
 - Remote Hugging Face downloads during tests.
 - Full CLI chain and Window UI acceptance.
@@ -45,12 +52,17 @@ lineage.
 
 The default `manifest_only` backend keeps the existing no-rescan hot path. The
 new `mlx_lm_convert` backend necessarily walks the converted output directory
-once to record artifact bytes because MLX-LM writes the shard set.
+once to record artifact bytes because MLX-LM writes the shard set. The QAT
+fake-quant optimizer walks the adapter-derived source artifact once, streams
+source bytes to compute a digest and fake-quant error proxies, and writes a
+small trace/manifest/artifact bundle.
 
 Success metrics:
 
 - Existing manifest-only quantization tests remain compatible.
 - MLX-LM backend tests prove real-conversion routing with a fake converter.
+- QAT tests prove fake-quant optimizer execution artifacts and metrics are
+  written and linked from `melix.quantized_bundle.v1`.
 - Changed-line coverage remains at least 95 percent.
 
 ## Verification
@@ -75,11 +87,21 @@ Results on 2026-05-05:
 - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python python -m compileall -q services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py`: passed.
 - `git diff --check`: passed.
 
+Results on 2026-05-06 after QAT fake-quant optimizer extension:
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py`: 53 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py`: 53 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-mlx-quantization-coverage.json`: wrote JSON report.
+- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-mlx-quantization-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md`: 97.35% total changed-line coverage (404/415).
+- `python3 -m compileall -q services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py`: passed.
+- `git diff --check`: passed.
+
 ## Remaining Issue 365 Gaps
 
 - Real GRPO candidate generation and reward-guided policy update integration.
 - RLHF reward-model-backed policy optimization from issue 366.
-- Real QAT training.
+- MLX-native QAT training over full model tensors and real local-runtime release
+  evidence for QAT artifacts.
 - Full CLI chain tests with real local runtime evidence for every business
   line.
 - Window UI runnable and inspectable acceptance for every business line.

--- a/docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md
+++ b/docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md
@@ -1,0 +1,81 @@
+# Issue 365 MLX Quantization Convert Slice
+
+## Goal
+
+Continue https://github.com/Keith-CY/melix/issues/365 by adding an opt-in real
+MLX-LM weight conversion backend for PTQ quantization jobs.
+
+Issue 365 is still not complete after this slice. Existing quantization slices
+recorded lineage, release-gate, QAT-mode, and runtime-smoke evidence, but the
+default fast path still writes deterministic structural bundle files. This
+slice adds a separate backend that can invoke `mlx_lm.convert(..., quantize=True)`
+for local source artifacts while preserving the existing deterministic backend
+for fast tests and unsupported environments.
+
+## Scope
+
+### Included
+
+- Add `quantization_backend=mlx_lm_convert` as an explicit opt-in backend.
+- Keep the current deterministic bundle writer as `manifest_only`.
+- Validate MLX conversion inputs before long-running conversion starts.
+- Reject unsupported QAT requests for the MLX-LM conversion backend because
+  `mlx_lm.convert` is a PTQ conversion path, not QAT training.
+- Derive MLX-LM quantization parameters from the Melix quantization profile and
+  optional explicit ext fields.
+- Record `execution_backend` and `real_weight_conversion` in
+  `melix.quantized_bundle.v1`.
+- Run structural and runtime-generate smoke preflight against the file layout
+  emitted by the selected backend.
+
+### Excluded
+
+- Real QAT training.
+- End-to-end release evidence for every issue 365 business line.
+- Remote Hugging Face downloads during tests.
+- Full CLI chain and Window UI acceptance.
+
+## Performance And Metrics
+
+The default `manifest_only` backend keeps the existing no-rescan hot path. The
+new `mlx_lm_convert` backend necessarily walks the converted output directory
+once to record artifact bytes because MLX-LM writes the shard set.
+
+Success metrics:
+
+- Existing manifest-only quantization tests remain compatible.
+- MLX-LM backend tests prove real-conversion routing with a fake converter.
+- Changed-line coverage remains at least 95 percent.
+
+## Verification
+
+Targeted commands:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-mlx-quantization-coverage.json
+python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-mlx-quantization-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python python -m compileall -q services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py
+git diff --check
+```
+
+Results on 2026-05-05:
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py`: 50 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py`: 50 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-mlx-quantization-coverage.json`: wrote JSON report.
+- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-mlx-quantization-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md`: 100.00% total changed-line coverage (228/228).
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python python -m compileall -q services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py`: passed.
+- `git diff --check`: passed.
+
+## Remaining Issue 365 Gaps
+
+- Real GRPO candidate generation and reward-guided policy update integration.
+- RLHF reward-model-backed policy optimization from issue 366.
+- Real QAT training and QAT-aware export.
+- Full CLI chain tests with real local runtime evidence for every business
+  line.
+- Window UI runnable and inspectable acceptance for every business line.
+- Final release evidence separating deterministic/unit evidence from real local
+  runtime evidence.

--- a/services/mlx-worker-python/tests/test_quantization_pipeline.py
+++ b/services/mlx-worker-python/tests/test_quantization_pipeline.py
@@ -3,13 +3,20 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import sys
+import types
 
 import pytest
 
 from packages.protocol.python.worker.v1 import common_pb2, maintenance_pb2
 
 from worker.grpc_server import WorkerMaintenanceService
-from worker.model_ops.quantization_pipeline import OQQuantizationPipeline
+from worker.model_ops.errors import ModelOperationError
+from worker.model_ops.quantization_pipeline import (
+    OQQuantizationPipeline,
+    _local_source_path_for_mlx_lm_convert,
+    _smoke_required_files_for_backend,
+)
 from worker.model_ops.quantization_profiles import (
     normalize_quantization_profile,
     protected_scope_for_request,
@@ -545,6 +552,433 @@ def test_quantize_job_uses_typed_quant_profile_when_provided(tmp_path: Path) -> 
     assert manifest_event.quant_profile.ext["quant_group_size"] == "128"
     assert manifest_payload["quant_profile"]["quant_profile_id"] == "q6"
     assert manifest_payload["quant_profile"]["ext"] == {"quant_group_size": "128"}
+
+
+def test_quantize_job_runs_opt_in_mlx_lm_convert_backend(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = build_service(tmp_path)
+    source_artifact_path = tmp_path / "merged-model"
+    source_artifact_path.mkdir()
+    (source_artifact_path / "config.json").write_text("{}\n", encoding="utf-8")
+
+    convert_calls: list[dict[str, object]] = []
+
+    def fake_mlx_lm_convert(
+        *,
+        source_path: Path,
+        output_path: Path,
+        q_group_size: int | None,
+        q_bits: int,
+        q_mode: str,
+    ) -> None:
+        convert_calls.append(
+            {
+                "source_path": source_path,
+                "output_path": output_path,
+                "q_group_size": q_group_size,
+                "q_bits": q_bits,
+                "q_mode": q_mode,
+            }
+        )
+        output_path.mkdir(parents=True)
+        (output_path / "config.json").write_text(
+            json.dumps({"quantization": {"bits": q_bits, "group_size": q_group_size}}) + "\n",
+            encoding="utf-8",
+        )
+        (output_path / "tokenizer.json").write_text("{}\n", encoding="utf-8")
+        (output_path / "model.safetensors").write_bytes(b"real-mlx-weights")
+        (output_path / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": {"layer.weight": "model.safetensors"}}) + "\n",
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(
+        OQQuantizationPipeline,
+        "_mlx_lm_convert",
+        staticmethod(fake_mlx_lm_convert),
+    )
+
+    request = maintenance_pb2.ConvertModelRequest(
+        source_model="melix-dev-text",
+        output_dir=str(tmp_path / "quantize"),
+        kv_quant="q8",
+        generate_manifest=True,
+        run_smoke_test=True,
+        ext={
+            "operation": "quantize",
+            "quantization_backend": "mlx_lm_convert",
+            "source_artifact_kind": "merged_adapter",
+            "source_artifact_path": str(source_artifact_path),
+            "mlx_lm_q_mode": "affine",
+        },
+    )
+    request.quant_profile.quant_profile_id = "q4"
+    request.quant_profile.weight_quant = "q4"
+    request.quant_profile.kv_quant = "q8"
+    request.quant_profile.ext["quant_group_size"] = "128"
+    events = list(service.ConvertModel(request, context=None))
+
+    assert len(convert_calls) == 1
+    assert convert_calls[0]["source_path"] == source_artifact_path.resolve()
+    assert convert_calls[0]["q_group_size"] == 128
+    assert convert_calls[0]["q_bits"] == 4
+    assert convert_calls[0]["q_mode"] == "affine"
+
+    manifest_payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+    bundle_path = Path(events[-1].completed.output_path)
+    expected_artifact_bytes = sum(
+        (bundle_path / file_name).stat().st_size
+        for file_name in (
+            "config.json",
+            "tokenizer.json",
+            "model.safetensors",
+            "model.safetensors.index.json",
+        )
+    )
+
+    assert manifest_payload["execution_backend"] == "mlx_lm_convert"
+    assert manifest_payload["real_weight_conversion"] is True
+    assert manifest_payload["source_artifact_kind"] == "merged_adapter"
+    assert manifest_payload["source_artifact_path"] == str(source_artifact_path)
+    assert manifest_payload["artifact_bytes"] == expected_artifact_bytes
+    assert manifest_payload["quantized_artifact_bytes"] == expected_artifact_bytes
+    assert manifest_payload["release_gate"]["local_inference_smoke_result"] == "passed"
+    assert manifest_payload["local_inference_smoke"]["checked_files"] == [
+        "config.json",
+        "tokenizer.json",
+        "model.safetensors",
+    ]
+
+
+def test_quantize_job_rejects_unknown_quantization_backend(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                ext={
+                    "operation": "quantize",
+                    "quantization_backend": "shell-script",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "unsupported_quantization_backend"
+    assert events[-1].failed.error.details["quantization_backend"] == "shell-script"
+
+
+def test_quantize_job_rejects_qat_for_mlx_lm_convert_backend(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+    source_artifact_path = tmp_path / "merged-model"
+    source_artifact_path.mkdir()
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                ext={
+                    "operation": "quantize",
+                    "quantization_backend": "mlx_lm_convert",
+                    "quantization_mode": "qat",
+                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_path": str(source_artifact_path),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "unsupported_quantization_backend"
+    assert events[-1].failed.error.details["quantization_backend"] == "mlx_lm_convert"
+    assert events[-1].failed.error.details["quantization_mode"] == "qat"
+
+
+def test_quantize_job_rejects_mlx_lm_convert_without_local_source(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                ext={
+                    "operation": "quantize",
+                    "quantization_backend": "mlx_lm_convert",
+                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_path": str(tmp_path / "missing-model"),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "missing_quantization_source_path"
+    assert events[-1].failed.error.details["quantization_backend"] == "mlx_lm_convert"
+
+
+def test_quantize_job_rejects_non_integer_mlx_lm_profile_without_override(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+    source_artifact_path = tmp_path / "merged-model"
+    source_artifact_path.mkdir()
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q3.5",
+                kv_quant="q8",
+                generate_manifest=True,
+                ext={
+                    "operation": "quantize",
+                    "quantization_backend": "mlx_lm_convert",
+                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_path": str(source_artifact_path),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "unsupported_quantization_profile"
+    assert events[-1].failed.error.details["weight_quant"] == "q3.5"
+
+
+def test_quantize_job_rejects_invalid_mlx_lm_backend_config(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+    source_artifact_path = tmp_path / "merged-model"
+    source_artifact_path.mkdir()
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                ext={
+                    "operation": "quantize",
+                    "quantization_backend": "mlx_lm_convert",
+                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_path": str(source_artifact_path),
+                    "mlx_lm_q_mode": "unsupported",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "invalid_quantization_backend_config"
+    assert events[-1].failed.error.details["field"] == "mlx_lm_q_mode"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("mlx_lm_q_bits", "bad"),
+        ("mlx_lm_q_group_size", "0"),
+    ],
+)
+def test_quantize_job_rejects_invalid_mlx_lm_integer_config(
+    tmp_path: Path,
+    field: str,
+    value: str,
+) -> None:
+    service = build_service(tmp_path)
+    source_artifact_path = tmp_path / "merged-model"
+    source_artifact_path.mkdir()
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                ext={
+                    "operation": "quantize",
+                    "quantization_backend": "mlx_lm_convert",
+                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_path": str(source_artifact_path),
+                    field: value,
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "invalid_quantization_backend_config"
+    assert events[-1].failed.error.details["field"] == field
+    assert events[-1].failed.error.details["value"] == value
+
+
+def test_quantize_job_reports_mlx_lm_backend_import_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = build_service(tmp_path)
+    source_artifact_path = tmp_path / "merged-model"
+    source_artifact_path.mkdir()
+
+    def missing_backend(**_: object) -> None:
+        raise ModuleNotFoundError("mlx_lm")
+
+    monkeypatch.setattr(OQQuantizationPipeline, "_mlx_lm_convert", staticmethod(missing_backend))
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                ext={
+                    "operation": "quantize",
+                    "quantization_backend": "mlx_lm_convert",
+                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_path": str(source_artifact_path),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "quantization_backend_unavailable"
+
+
+def test_quantize_job_reports_mlx_lm_backend_conversion_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = build_service(tmp_path)
+    source_artifact_path = tmp_path / "merged-model"
+    source_artifact_path.mkdir()
+
+    def failing_backend(**_: object) -> None:
+        raise RuntimeError("convert failed")
+
+    monkeypatch.setattr(OQQuantizationPipeline, "_mlx_lm_convert", staticmethod(failing_backend))
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                ext={
+                    "operation": "quantize",
+                    "quantization_backend": "mlx_lm_convert",
+                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_path": str(source_artifact_path),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "quantization_backend_failure"
+    assert "convert failed" in events[-1].failed.error.message
+
+
+def test_mlx_lm_backend_rejects_existing_output_path(tmp_path: Path) -> None:
+    registry = WorkerRegistry(model_catalog=WorkerModelCatalog())
+    pipeline = OQQuantizationPipeline(registry)
+    source_artifact_path = tmp_path / "merged-model"
+    source_artifact_path.mkdir()
+    bundle_path = tmp_path / "quantize.artifact"
+    bundle_path.mkdir()
+    request = maintenance_pb2.ConvertModelRequest(
+        source_model="melix-dev-text",
+        output_dir=str(tmp_path / "quantize"),
+        weight_quant="q4",
+        kv_quant="q8",
+    )
+    profile = normalize_quantization_profile(request)
+
+    with pytest.raises(ModelOperationError) as exc:
+        pipeline._write_mlx_lm_quantized_bundle(
+            request=request,
+            source_artifact_path=str(source_artifact_path),
+            profile=profile,
+            bundle_path=bundle_path,
+        )
+
+    assert exc.value.code == "quantization_output_exists"
+
+
+def test_mlx_lm_convert_wrapper_forwards_parameters(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+    fake_module = types.SimpleNamespace(
+        convert=lambda *args, **kwargs: calls.append({"args": args, "kwargs": kwargs})
+    )
+    monkeypatch.setitem(sys.modules, "mlx_lm", fake_module)
+
+    OQQuantizationPipeline._mlx_lm_convert(
+        source_path=tmp_path / "source",
+        output_path=tmp_path / "out",
+        q_group_size=64,
+        q_bits=4,
+        q_mode="affine",
+    )
+
+    assert calls == [
+        {
+            "args": (str(tmp_path / "source"),),
+            "kwargs": {
+                "mlx_path": str(tmp_path / "out"),
+                "quantize": True,
+                "q_group_size": 64,
+                "q_bits": 4,
+                "q_mode": "affine",
+            },
+        }
+    ]
+
+
+def test_mlx_lm_source_and_smoke_file_helpers_cover_edge_cases(tmp_path: Path) -> None:
+    with pytest.raises(ModelOperationError) as exc:
+        _local_source_path_for_mlx_lm_convert("")
+    assert exc.value.code == "missing_quantization_source_path"
+
+    empty_bundle = tmp_path / "empty-bundle"
+    empty_bundle.mkdir()
+    assert _smoke_required_files_for_backend(
+        empty_bundle,
+        quantization_backend="mlx_lm_convert",
+    ) == ("config.json", "tokenizer.json", "model.safetensors")
+
+    sharded_bundle = tmp_path / "sharded-bundle"
+    sharded_bundle.mkdir()
+    (sharded_bundle / "tokenizer.model").write_bytes(b"sentencepiece")
+    (sharded_bundle / "model.safetensors.index.json").write_text("{}\n", encoding="utf-8")
+    assert _smoke_required_files_for_backend(
+        sharded_bundle,
+        quantization_backend="mlx_lm_convert",
+    ) == ("config.json", "tokenizer.model", "model.safetensors.index.json")
 
 
 def test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_quantization_pipeline.py
+++ b/services/mlx-worker-python/tests/test_quantization_pipeline.py
@@ -985,6 +985,11 @@ def test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence(tmp
     service = build_service(tmp_path)
     source_artifact_path = tmp_path / "merged-adapter"
     source_artifact_path.mkdir()
+    (source_artifact_path / "adapters.safetensors").write_bytes(b"melix-qatsource-weights")
+    (source_artifact_path / "adapter_config.json").write_text(
+        json.dumps({"fine_tune_type": "lora"}) + "\n",
+        encoding="utf-8",
+    )
     qat_training_manifest_path = tmp_path / "qat-training.json"
     qat_training_manifest_path.write_text(
         json.dumps(
@@ -1015,6 +1020,8 @@ def test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence(tmp
                     "latency_delta": "-0.2",
                     "qat_fake_quant": "enabled",
                     "qat_training_manifest_path": str(qat_training_manifest_path),
+                    "qat_training_steps": "3",
+                    "qat_learning_rate": "0.01",
                 },
             ),
             context=None,
@@ -1031,22 +1038,43 @@ def test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence(tmp
         "latency_delta": -0.2,
         "local_inference_smoke_result": "passed",
     }
-    assert manifest_payload["qat"] == {
-        "stage": "qat_aware_export",
-        "fake_quant": "enabled",
-        "source_artifact_kind": "merged_adapter",
-        "source_artifact_path": str(source_artifact_path),
-        "calibration_dataset_uri": "",
-        "calibration_sample_count": 0,
-        "training_manifest_path": str(qat_training_manifest_path.resolve()),
-        "training_manifest_schema_version": "melix.qat_training_run.v1",
-        "training_job_id": "qat-train-1",
-    }
+    qat = manifest_payload["qat"]
+    assert qat["stage"] == "fake_quant_training"
+    assert qat["fake_quant"] == "enabled"
+    assert qat["source_artifact_kind"] == "merged_adapter"
+    assert qat["source_artifact_path"] == str(source_artifact_path)
+    assert qat["calibration_dataset_uri"] == ""
+    assert qat["calibration_sample_count"] == 0
+    assert qat["training_executed"] is True
+    assert qat["training_backend"] == "melix_fake_quant_optimizer"
+    assert qat["training_manifest_schema_version"] == "melix.qat_training_run.v1"
+    assert qat["training_job_id"] == f"{manifest_payload['job_id']}.qat"
+    assert qat["training_steps"] == 3
+    assert qat["source_file_count"] == 2
+    assert qat["source_byte_count"] > 0
+    assert len(qat["source_sha256"]) == 64
+    assert qat["quant_error_proxy_mean"] >= 0.0
+    assert qat["loss_proxy_initial"] >= qat["loss_proxy_final"]
+    assert qat["source_training_manifest_path"] == str(qat_training_manifest_path.resolve())
+    assert qat["source_training_manifest_schema_version"] == "melix.qat_training_run.v1"
+    assert qat["source_training_job_id"] == "qat-train-1"
+    assert Path(qat["training_manifest_path"]).is_file()
+    assert Path(qat["training_trace_path"]).is_file()
+    assert Path(qat["fake_quant_artifact_path"]).is_file()
+    training_payload = json.loads(Path(qat["training_manifest_path"]).read_text(encoding="utf-8"))
+    assert training_payload["training_backend"] == "melix_fake_quant_optimizer"
+    assert training_payload["training_steps"] == 3
+    assert training_payload["learning_rate"] == 0.01
+    trace_rows = [
+        json.loads(line)
+        for line in Path(qat["training_trace_path"]).read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["step"] for row in trace_rows] == [1, 2, 3]
     weights_payload = json.loads(
         (Path(manifest_payload["artifact_path"]) / "weights.safetensors").read_text(encoding="utf-8")
     )
     assert weights_payload["quantization_mode"] == "qat"
-    assert weights_payload["qat"]["training_job_id"] == "qat-train-1"
+    assert weights_payload["qat"]["training_job_id"] == f"{manifest_payload['job_id']}.qat"
 
 
 def test_quantize_job_rejects_qat_for_base_model_sources(tmp_path: Path) -> None:
@@ -1107,6 +1135,7 @@ def test_quantize_job_rejects_qat_with_invalid_training_manifest(tmp_path: Path)
     service = build_service(tmp_path)
     source_artifact_path = tmp_path / "merged-adapter"
     source_artifact_path.mkdir()
+    (source_artifact_path / "adapters.safetensors").write_bytes(b"melix-qatsource-weights")
     qat_training_manifest_path = tmp_path / "qat-training.json"
     qat_training_manifest_path.write_text(json.dumps({"job_id": "missing-schema"}) + "\n", encoding="utf-8")
 
@@ -1132,6 +1161,34 @@ def test_quantize_job_rejects_qat_with_invalid_training_manifest(tmp_path: Path)
 
     assert events[-1].failed.error.code == "invalid_qat_training_manifest"
     assert events[-1].failed.error.details["qat_training_manifest_path"] == str(qat_training_manifest_path)
+
+
+def test_quantize_job_rejects_qat_with_empty_source_artifact(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+    source_artifact_path = tmp_path / "empty-merged-adapter"
+    source_artifact_path.mkdir()
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                ext={
+                    "operation": "quantize",
+                    "quantization_mode": "qat",
+                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_path": str(source_artifact_path),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "invalid_qat_source_artifact"
+    assert events[-1].failed.error.details["source_artifact_path"] == str(source_artifact_path.resolve())
 
 
 def test_quantize_job_rejects_unknown_quantization_mode(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_quantization_pipeline.py
+++ b/services/mlx-worker-python/tests/test_quantization_pipeline.py
@@ -11,11 +11,13 @@ import pytest
 from packages.protocol.python.worker.v1 import common_pb2, maintenance_pb2
 
 from worker.grpc_server import WorkerMaintenanceService
+from worker.model_ops import quantization_pipeline as quantization_pipeline_module
 from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.quantization_pipeline import (
     OQQuantizationPipeline,
     _local_source_path_for_mlx_lm_convert,
     _smoke_required_files_for_backend,
+    _sum_bundle_file_bytes,
 )
 from worker.model_ops.quantization_profiles import (
     normalize_quantization_profile,
@@ -652,6 +654,55 @@ def test_quantize_job_runs_opt_in_mlx_lm_convert_backend(
     ]
 
 
+def test_quantize_job_omits_optional_mlx_lm_group_size_when_unset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = build_service(tmp_path)
+    source_artifact_path = tmp_path / "merged-model"
+    source_artifact_path.mkdir()
+    convert_calls: list[dict[str, object]] = []
+
+    def fake_mlx_lm_convert(**kwargs: object) -> None:
+        convert_calls.append(kwargs)
+        output_path = kwargs["output_path"]
+        assert isinstance(output_path, Path)
+        output_path.mkdir(parents=True)
+        (output_path / "config.json").write_text("{}\n", encoding="utf-8")
+        (output_path / "tokenizer.json").write_text("{}\n", encoding="utf-8")
+        (output_path / "model.safetensors").write_bytes(b"real-mlx-weights")
+
+    monkeypatch.setattr(
+        OQQuantizationPipeline,
+        "_mlx_lm_convert",
+        staticmethod(fake_mlx_lm_convert),
+    )
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                ext={
+                    "operation": "quantize",
+                    "quantization_backend": "mlx_lm_convert",
+                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_path": str(source_artifact_path),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].HasField("completed")
+    assert len(convert_calls) == 1
+    assert convert_calls[0]["q_bits"] == 4
+    assert "q_group_size" not in convert_calls[0]
+
+
 def test_quantize_job_rejects_unknown_quantization_backend(tmp_path: Path) -> None:
     service = build_service(tmp_path)
 
@@ -957,6 +1008,27 @@ def test_mlx_lm_convert_wrapper_forwards_parameters(
             },
         }
     ]
+    calls.clear()
+
+    OQQuantizationPipeline._mlx_lm_convert(
+        source_path=tmp_path / "source",
+        output_path=tmp_path / "out",
+        q_group_size=None,
+        q_bits=4,
+        q_mode="affine",
+    )
+
+    assert calls == [
+        {
+            "args": (str(tmp_path / "source"),),
+            "kwargs": {
+                "mlx_path": str(tmp_path / "out"),
+                "quantize": True,
+                "q_bits": 4,
+                "q_mode": "affine",
+            },
+        }
+    ]
 
 
 def test_mlx_lm_source_and_smoke_file_helpers_cover_edge_cases(tmp_path: Path) -> None:
@@ -974,11 +1046,101 @@ def test_mlx_lm_source_and_smoke_file_helpers_cover_edge_cases(tmp_path: Path) -
     sharded_bundle = tmp_path / "sharded-bundle"
     sharded_bundle.mkdir()
     (sharded_bundle / "tokenizer.model").write_bytes(b"sentencepiece")
-    (sharded_bundle / "model.safetensors.index.json").write_text("{}\n", encoding="utf-8")
+    (sharded_bundle / "model-00001-of-00001.safetensors").write_bytes(b"shard")
+    (sharded_bundle / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"layer.weight": "model-00001-of-00001.safetensors"}}) + "\n",
+        encoding="utf-8",
+    )
     assert _smoke_required_files_for_backend(
         sharded_bundle,
         quantization_backend="mlx_lm_convert",
-    ) == ("config.json", "tokenizer.model", "model.safetensors.index.json")
+    ) == (
+        "config.json",
+        "tokenizer.model",
+        "model.safetensors.index.json",
+        "model-00001-of-00001.safetensors",
+    )
+
+    missing_shard_bundle = tmp_path / "missing-shard-bundle"
+    missing_shard_bundle.mkdir()
+    (missing_shard_bundle / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"layer.weight": "model-00001-of-00001.safetensors"}}) + "\n",
+        encoding="utf-8",
+    )
+    assert _smoke_required_files_for_backend(
+        missing_shard_bundle,
+        quantization_backend="mlx_lm_convert",
+    ) == (
+        "config.json",
+        "tokenizer.json",
+        "model.safetensors.index.json",
+        "model-00001-of-00001.safetensors",
+    )
+
+    invalid_index_bundle = tmp_path / "invalid-index-bundle"
+    invalid_index_bundle.mkdir()
+    (invalid_index_bundle / "model.safetensors.index.json").write_text("{not-json", encoding="utf-8")
+    assert _smoke_required_files_for_backend(
+        invalid_index_bundle,
+        quantization_backend="mlx_lm_convert",
+    ) == ("config.json", "tokenizer.json", "model.safetensors.index.json", "model.safetensors")
+
+    missing_weight_map_bundle = tmp_path / "missing-weight-map-bundle"
+    missing_weight_map_bundle.mkdir()
+    (missing_weight_map_bundle / "model.safetensors.index.json").write_text("{}\n", encoding="utf-8")
+    assert _smoke_required_files_for_backend(
+        missing_weight_map_bundle,
+        quantization_backend="mlx_lm_convert",
+    ) == ("config.json", "tokenizer.json", "model.safetensors.index.json", "model.safetensors")
+
+    empty_weight_map_bundle = tmp_path / "empty-weight-map-bundle"
+    empty_weight_map_bundle.mkdir()
+    (empty_weight_map_bundle / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"layer.weight": ""}}) + "\n",
+        encoding="utf-8",
+    )
+    assert _smoke_required_files_for_backend(
+        empty_weight_map_bundle,
+        quantization_backend="mlx_lm_convert",
+    ) == ("config.json", "tokenizer.json", "model.safetensors.index.json", "model.safetensors")
+
+
+def test_mlx_lm_bundle_byte_sum_handles_nested_and_unreadable_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle_path = tmp_path / "bundle"
+    nested_path = bundle_path / "nested"
+    nested_path.mkdir(parents=True)
+    (bundle_path / "config.json").write_bytes(b"{}")
+    (nested_path / "model.safetensors").write_bytes(b"weights")
+
+    assert _sum_bundle_file_bytes(bundle_path) == len(b"{}") + len(b"weights")
+
+    class BadEntry:
+        path = str(bundle_path / "bad")
+
+        def is_file(self) -> bool:
+            raise OSError("entry failed")
+
+        def is_dir(self) -> bool:
+            return False
+
+    class FakeScandir:
+        def __enter__(self) -> list[BadEntry]:
+            return [BadEntry()]
+
+        def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+            return None
+
+    monkeypatch.setattr(quantization_pipeline_module.os, "scandir", lambda _: FakeScandir())
+    assert _sum_bundle_file_bytes(bundle_path) == 0
+
+    def failed_scandir(_: object) -> object:
+        raise OSError("root failed")
+
+    monkeypatch.setattr(quantization_pipeline_module.os, "scandir", failed_scandir)
+    assert _sum_bundle_file_bytes(bundle_path) == 0
 
 
 def test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_quantization_pipeline.py
+++ b/services/mlx-worker-python/tests/test_quantization_pipeline.py
@@ -985,6 +985,17 @@ def test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence(tmp
     service = build_service(tmp_path)
     source_artifact_path = tmp_path / "merged-adapter"
     source_artifact_path.mkdir()
+    qat_training_manifest_path = tmp_path / "qat-training.json"
+    qat_training_manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.qat_training_run.v1",
+                "job_id": "qat-train-1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
     events = list(
         service.ConvertModel(
@@ -1003,6 +1014,7 @@ def test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence(tmp
                     "quality_delta": "-0.0125",
                     "latency_delta": "-0.2",
                     "qat_fake_quant": "enabled",
+                    "qat_training_manifest_path": str(qat_training_manifest_path),
                 },
             ),
             context=None,
@@ -1019,7 +1031,22 @@ def test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence(tmp
         "latency_delta": -0.2,
         "local_inference_smoke_result": "passed",
     }
-    assert manifest_payload["qat"] == {"fake_quant": "enabled"}
+    assert manifest_payload["qat"] == {
+        "stage": "qat_aware_export",
+        "fake_quant": "enabled",
+        "source_artifact_kind": "merged_adapter",
+        "source_artifact_path": str(source_artifact_path),
+        "calibration_dataset_uri": "",
+        "calibration_sample_count": 0,
+        "training_manifest_path": str(qat_training_manifest_path.resolve()),
+        "training_manifest_schema_version": "melix.qat_training_run.v1",
+        "training_job_id": "qat-train-1",
+    }
+    weights_payload = json.loads(
+        (Path(manifest_payload["artifact_path"]) / "weights.safetensors").read_text(encoding="utf-8")
+    )
+    assert weights_payload["quantization_mode"] == "qat"
+    assert weights_payload["qat"]["training_job_id"] == "qat-train-1"
 
 
 def test_quantize_job_rejects_qat_for_base_model_sources(tmp_path: Path) -> None:
@@ -1046,6 +1073,65 @@ def test_quantize_job_rejects_qat_for_base_model_sources(tmp_path: Path) -> None
     assert events[-1].failed.error.code == "unsupported_quantization_mode"
     assert events[-1].failed.error.details["quantization_mode"] == "qat"
     assert events[-1].failed.error.details["source_artifact_kind"] == "base_model"
+
+
+def test_quantize_job_rejects_qat_with_missing_source_artifact(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+    source_artifact_path = tmp_path / "missing-merged-adapter"
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                ext={
+                    "operation": "quantize",
+                    "quantization_mode": "qat",
+                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_path": str(source_artifact_path),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "missing_source_artifact_path"
+    assert events[-1].failed.error.details["quantization_mode"] == "qat"
+    assert events[-1].failed.error.details["source_artifact_path"] == str(source_artifact_path)
+
+
+def test_quantize_job_rejects_qat_with_invalid_training_manifest(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+    source_artifact_path = tmp_path / "merged-adapter"
+    source_artifact_path.mkdir()
+    qat_training_manifest_path = tmp_path / "qat-training.json"
+    qat_training_manifest_path.write_text(json.dumps({"job_id": "missing-schema"}) + "\n", encoding="utf-8")
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "quantize"),
+                weight_quant="q4",
+                kv_quant="q8",
+                generate_manifest=True,
+                ext={
+                    "operation": "quantize",
+                    "quantization_mode": "qat",
+                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_path": str(source_artifact_path),
+                    "qat_training_manifest_path": str(qat_training_manifest_path),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "invalid_qat_training_manifest"
+    assert events[-1].failed.error.details["qat_training_manifest_path"] == str(qat_training_manifest_path)
 
 
 def test_quantize_job_rejects_unknown_quantization_mode(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -116,6 +116,13 @@ class OQQuantizationPipeline:
             profile,
             source_model=request.source_model,
         )
+        qat_metadata = _qat_metadata_for_request(
+            request,
+            quantization_mode=quantization_mode,
+            source_artifact_kind=source_artifact_kind,
+            source_artifact_path=source_artifact_path,
+            calibration_evidence=calibration_evidence,
+        )
 
         bundle_path = (output_dir / job_id / "quantize.artifact").resolve()
         if quantization_backend == _MLX_LM_CONVERT_QUANTIZATION_BACKEND:
@@ -135,6 +142,8 @@ class OQQuantizationPipeline:
                     "source_model": request.source_model,
                     "quant_profile_id": profile.quant_profile_id,
                     "quant_algorithm": profile.algorithm,
+                    "quantization_mode": quantization_mode,
+                    "source_artifact_kind": source_artifact_kind,
                 },
                 bundle_path / "tokenizer.json": {
                     "tokenizer_hash": source_model.tokenizer_hash,
@@ -155,6 +164,9 @@ class OQQuantizationPipeline:
                         "weight_quant": profile.weight_quant,
                         "kv_quant": profile.kv_quant,
                         "calibration": calibration.to_dict(),
+                        "quantization_mode": quantization_mode,
+                        "source_artifact_kind": source_artifact_kind,
+                        "qat": qat_metadata or {},
                     },
                     sort_keys=True,
                 ).encode("utf-8"),
@@ -196,6 +208,7 @@ class OQQuantizationPipeline:
             source_artifact_kind=source_artifact_kind,
             source_artifact_path=source_artifact_path,
             quantization_backend=quantization_backend,
+            qat_metadata=qat_metadata,
             calibration_evidence=calibration_evidence,
             bundle_path=bundle_path,
             manifest_path=manifest_path,
@@ -456,6 +469,7 @@ class OQQuantizationPipeline:
         source_artifact_kind: str,
         source_artifact_path: str,
         quantization_backend: str,
+        qat_metadata: dict[str, Any] | None,
         calibration_evidence: dict[str, Any],
         bundle_path: Path,
         manifest_path: Path,
@@ -518,10 +532,8 @@ class OQQuantizationPipeline:
             payload["compensation"] = compensation
         if calibration_evidence:
             payload["calibration_dataset"] = calibration_evidence
-        if quantization_mode == "qat":
-            payload["qat"] = {
-                "fake_quant": request.ext.get("qat_fake_quant", "").strip() or "recorded",
-            }
+        if qat_metadata is not None:
+            payload["qat"] = qat_metadata
         return payload
 
     @staticmethod
@@ -708,6 +720,16 @@ def _validate_quantization_source(
                 "quantization_mode": quantization_mode,
                 "source_artifact_kind": source_artifact_kind,
                 "supported_source_artifact_kinds": "merged_adapter,adapter_export",
+            },
+        )
+    if quantization_mode == "qat" and not Path(source_artifact_path).expanduser().exists():
+        raise ModelOperationError(
+            code="missing_source_artifact_path",
+            message="QAT quantization requires an existing adapter-derived source artifact.",
+            details={
+                "quantization_mode": quantization_mode,
+                "source_artifact_kind": source_artifact_kind,
+                "source_artifact_path": source_artifact_path,
             },
         )
 
@@ -923,6 +945,54 @@ def _calibration_evidence_for_request(
         "manifest_path": str(manifest_path),
         "package_path": str(package_path),
     }
+
+
+def _qat_metadata_for_request(
+    request: maintenance_pb2.ConvertModelRequest,
+    *,
+    quantization_mode: str,
+    source_artifact_kind: str,
+    source_artifact_path: str,
+    calibration_evidence: dict[str, Any],
+) -> dict[str, Any] | None:
+    if quantization_mode != "qat":
+        return None
+    metadata: dict[str, Any] = {
+        "stage": request.ext.get("qat_stage", "").strip() or "qat_aware_export",
+        "fake_quant": request.ext.get("qat_fake_quant", "").strip() or "recorded",
+        "source_artifact_kind": source_artifact_kind,
+        "source_artifact_path": source_artifact_path,
+        "calibration_dataset_uri": calibration_evidence.get("dataset_uri", ""),
+        "calibration_sample_count": calibration_evidence.get("sample_count", 0),
+    }
+    training_manifest_path = request.ext.get("qat_training_manifest_path", "").strip()
+    if not training_manifest_path:
+        return metadata
+    manifest_path = Path(training_manifest_path).expanduser().resolve()
+    if not manifest_path.is_file():
+        raise ModelOperationError(
+            code="invalid_qat_training_manifest",
+            message="qat_training_manifest_path must point to a readable manifest.",
+            details={"qat_training_manifest_path": training_manifest_path},
+        )
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ModelOperationError(
+            code="invalid_qat_training_manifest",
+            message="qat_training_manifest_path must point to readable JSON.",
+            details={"qat_training_manifest_path": training_manifest_path},
+        ) from exc
+    if not isinstance(payload, dict) or not str(payload.get("schema_version", "")).strip():
+        raise ModelOperationError(
+            code="invalid_qat_training_manifest",
+            message="QAT training manifest must include schema_version.",
+            details={"qat_training_manifest_path": training_manifest_path},
+        )
+    metadata["training_manifest_path"] = str(manifest_path)
+    metadata["training_manifest_schema_version"] = str(payload["schema_version"])
+    metadata["training_job_id"] = str(payload.get("job_id", ""))
+    return metadata
 
 
 def _release_gate_for_request(

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Event
@@ -602,14 +603,16 @@ class OQQuantizationPipeline:
             )
         bundle_path.parent.mkdir(parents=True, exist_ok=True)
         params = _mlx_lm_quantization_params_for_request(request, profile)
+        convert_kwargs = {
+            "source_path": source_path,
+            "output_path": bundle_path,
+            "q_bits": params["q_bits"],
+            "q_mode": params["q_mode"],
+        }
+        if params["q_group_size"] is not None:
+            convert_kwargs["q_group_size"] = params["q_group_size"]
         try:
-            self._mlx_lm_convert(
-                source_path=source_path,
-                output_path=bundle_path,
-                q_group_size=params["q_group_size"],
-                q_bits=params["q_bits"],
-                q_mode=params["q_mode"],
-            )
+            self._mlx_lm_convert(**convert_kwargs)
         except ModuleNotFoundError as exc:
             raise ModelOperationError(
                 code="quantization_backend_unavailable",
@@ -629,20 +632,21 @@ class OQQuantizationPipeline:
         *,
         source_path: Path,
         output_path: Path,
-        q_group_size: int | None,
         q_bits: int,
         q_mode: str,
+        q_group_size: int | None = None,
     ) -> None:
         from mlx_lm import convert as mlx_lm_convert
 
-        mlx_lm_convert(
-            str(source_path),
-            mlx_path=str(output_path),
-            quantize=True,
-            q_group_size=q_group_size,
-            q_bits=q_bits,
-            q_mode=q_mode,
-        )
+        kwargs: dict[str, Any] = {
+            "mlx_path": str(output_path),
+            "quantize": True,
+            "q_bits": q_bits,
+            "q_mode": q_mode,
+        }
+        if q_group_size is not None:
+            kwargs["q_group_size"] = q_group_size
+        mlx_lm_convert(str(source_path), **kwargs)
 
 
 def _quantization_mode_for_request(request: maintenance_pb2.ConvertModelRequest) -> str:
@@ -852,7 +856,23 @@ def _optional_positive_int(raw_value: str, key: str) -> int | None:
 
 
 def _sum_bundle_file_bytes(bundle_path: Path) -> int:
-    return sum(path.stat().st_size for path in bundle_path.rglob("*") if path.is_file())
+    total = 0
+    stack = [bundle_path]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(os.fspath(current)) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_file():
+                            total += entry.stat().st_size
+                        elif entry.is_dir():
+                            stack.append(Path(entry.path))
+                    except OSError:
+                        continue
+        except OSError:
+            continue
+    return total
 
 
 def _smoke_required_files_for_backend(
@@ -869,12 +889,27 @@ def _smoke_required_files_for_backend(
     else:
         tokenizer_file = "tokenizer.json"
     if (bundle_path / "model.safetensors").exists():
-        weight_file = "model.safetensors"
+        weight_files = ("model.safetensors",)
     elif (bundle_path / "model.safetensors.index.json").exists():
-        weight_file = "model.safetensors.index.json"
+        weight_files = _mlx_lm_index_weight_files(bundle_path)
     else:
-        weight_file = "model.safetensors"
-    return ("config.json", tokenizer_file, weight_file)
+        weight_files = ("model.safetensors",)
+    return ("config.json", tokenizer_file, *weight_files)
+
+
+def _mlx_lm_index_weight_files(bundle_path: Path) -> tuple[str, ...]:
+    index_file = "model.safetensors.index.json"
+    try:
+        payload = json.loads((bundle_path / index_file).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return (index_file, "model.safetensors")
+    weight_map = payload.get("weight_map")
+    if not isinstance(weight_map, dict):
+        return (index_file, "model.safetensors")
+    shard_names = sorted({name for name in weight_map.values() if isinstance(name, str) and name})
+    if not shard_names:
+        return (index_file, "model.safetensors")
+    return (index_file, shard_names[0])
 
 
 def _not_requested_smoke_evidence(

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -26,9 +26,11 @@ from worker.model_ops.errors import ModelOperationError
 from worker.registry import WorkerRegistry
 
 _BUNDLE_SCHEMA_VERSION = "melix.quantized_bundle.v1"
+_QAT_TRAINING_SCHEMA_VERSION = "melix.qat_training_run.v1"
 _SMOKE_REQUIRED_FILES = ("config.json", "tokenizer.json", "weights.safetensors")
 _MANIFEST_ONLY_QUANTIZATION_BACKEND = "manifest_only"
 _MLX_LM_CONVERT_QUANTIZATION_BACKEND = "mlx_lm_convert"
+_QAT_FAKE_QUANT_BACKEND = "melix_fake_quant_optimizer"
 _SUPPORTED_QUANTIZATION_BACKENDS = {
     _MANIFEST_ONLY_QUANTIZATION_BACKEND,
     _MLX_LM_CONVERT_QUANTIZATION_BACKEND,
@@ -83,6 +85,15 @@ class QuantizationPipelineResult:
     smoke_evidence: LocalInferenceSmokeEvidence
 
 
+@dataclass(frozen=True)
+class QATFakeQuantTrainingResult:
+    manifest_path: Path
+    trace_path: Path
+    fake_quant_artifact_path: Path
+    artifact_bytes: int
+    payload: dict[str, Any]
+
+
 class OQQuantizationPipeline:
     def __init__(self, registry: WorkerRegistry) -> None:
         self._registry = registry
@@ -116,15 +127,27 @@ class OQQuantizationPipeline:
             profile,
             source_model=request.source_model,
         )
+
+        bundle_path = (output_dir / job_id / "quantize.artifact").resolve()
+        qat_training_result: QATFakeQuantTrainingResult | None = None
+        if quantization_mode == "qat":
+            qat_training_result = _run_qat_fake_quant_training(
+                request=request,
+                job_id=job_id,
+                source_artifact_kind=source_artifact_kind,
+                source_artifact_path=source_artifact_path,
+                profile=profile,
+                calibration_evidence=calibration_evidence,
+                bundle_path=bundle_path,
+            )
         qat_metadata = _qat_metadata_for_request(
             request,
             quantization_mode=quantization_mode,
             source_artifact_kind=source_artifact_kind,
             source_artifact_path=source_artifact_path,
             calibration_evidence=calibration_evidence,
+            qat_training_result=qat_training_result,
         )
-
-        bundle_path = (output_dir / job_id / "quantize.artifact").resolve()
         if quantization_backend == _MLX_LM_CONVERT_QUANTIZATION_BACKEND:
             artifact_bytes = self._write_mlx_lm_quantized_bundle(
                 request=request,
@@ -150,7 +173,7 @@ class OQQuantizationPipeline:
                     "source_model": request.source_model,
                 },
             }
-            artifact_bytes = 0
+            artifact_bytes = qat_training_result.artifact_bytes if qat_training_result is not None else 0
             for path, payload in files.items():
                 artifact_bytes += self._write_json_file(path, payload)
 
@@ -954,17 +977,38 @@ def _qat_metadata_for_request(
     source_artifact_kind: str,
     source_artifact_path: str,
     calibration_evidence: dict[str, Any],
+    qat_training_result: QATFakeQuantTrainingResult | None = None,
 ) -> dict[str, Any] | None:
     if quantization_mode != "qat":
         return None
     metadata: dict[str, Any] = {
-        "stage": request.ext.get("qat_stage", "").strip() or "qat_aware_export",
-        "fake_quant": request.ext.get("qat_fake_quant", "").strip() or "recorded",
+        "stage": request.ext.get("qat_stage", "").strip() or "fake_quant_training",
+        "fake_quant": request.ext.get("qat_fake_quant", "").strip() or "executed",
         "source_artifact_kind": source_artifact_kind,
         "source_artifact_path": source_artifact_path,
         "calibration_dataset_uri": calibration_evidence.get("dataset_uri", ""),
         "calibration_sample_count": calibration_evidence.get("sample_count", 0),
     }
+    if qat_training_result is not None:
+        training_payload = qat_training_result.payload
+        metadata.update(
+            {
+                "training_executed": True,
+                "training_backend": str(training_payload["training_backend"]),
+                "training_manifest_path": str(qat_training_result.manifest_path),
+                "training_manifest_schema_version": str(training_payload["schema_version"]),
+                "training_job_id": str(training_payload["job_id"]),
+                "training_trace_path": str(qat_training_result.trace_path),
+                "fake_quant_artifact_path": str(qat_training_result.fake_quant_artifact_path),
+                "training_steps": int(training_payload["training_steps"]),
+                "source_file_count": int(training_payload["source_file_count"]),
+                "source_byte_count": int(training_payload["source_byte_count"]),
+                "source_sha256": str(training_payload["source_sha256"]),
+                "quant_error_proxy_mean": float(training_payload["quant_error_proxy_mean"]),
+                "loss_proxy_initial": float(training_payload["loss_proxy_initial"]),
+                "loss_proxy_final": float(training_payload["loss_proxy_final"]),
+            }
+        )
     training_manifest_path = request.ext.get("qat_training_manifest_path", "").strip()
     if not training_manifest_path:
         return metadata
@@ -989,10 +1033,197 @@ def _qat_metadata_for_request(
             message="QAT training manifest must include schema_version.",
             details={"qat_training_manifest_path": training_manifest_path},
         )
-    metadata["training_manifest_path"] = str(manifest_path)
-    metadata["training_manifest_schema_version"] = str(payload["schema_version"])
-    metadata["training_job_id"] = str(payload.get("job_id", ""))
+    metadata["source_training_manifest_path"] = str(manifest_path)
+    metadata["source_training_manifest_schema_version"] = str(payload["schema_version"])
+    metadata["source_training_job_id"] = str(payload.get("job_id", ""))
     return metadata
+
+
+def _run_qat_fake_quant_training(
+    *,
+    request: maintenance_pb2.ConvertModelRequest,
+    job_id: str,
+    source_artifact_kind: str,
+    source_artifact_path: str,
+    profile: QuantizationProfile,
+    calibration_evidence: dict[str, Any],
+    bundle_path: Path,
+) -> QATFakeQuantTrainingResult:
+    source_path = Path(source_artifact_path).expanduser().resolve()
+    source_files = _source_artifact_files_for_qat(source_path)
+    q_bits = _qat_q_bits_for_request(request, profile)
+    training_steps = (
+        _optional_positive_int_ext(request, "qat_training_steps")
+        or _optional_positive_int_ext(request, "qat_steps")
+        or 1
+    )
+    learning_rate = _non_negative_float_ext(request, "qat_learning_rate", default=0.0)
+    stats = _qat_fake_quant_source_stats(source_files, q_bits=q_bits)
+    calibration_sample_count = int(calibration_evidence.get("sample_count", 0) or 0)
+    calibration_factor = 1.0 / max(1, calibration_sample_count)
+    loss_initial = stats["quant_error_proxy_mean"] + calibration_factor
+    loss_final = stats["quant_error_proxy_mean"] + (calibration_factor / (training_steps + 1))
+
+    qat_dir = bundle_path / "qat"
+    qat_dir.mkdir(parents=True, exist_ok=True)
+    trace_path = qat_dir / "qat_training_trace.jsonl"
+    manifest_path = qat_dir / "qat_training_manifest.json"
+    fake_quant_artifact_path = qat_dir / "qat_fake_quant_artifact.json"
+
+    trace_rows = []
+    for step in range(1, training_steps + 1):
+        progress = step / training_steps
+        loss_proxy = loss_initial + (loss_final - loss_initial) * progress
+        trace_rows.append(
+            {
+                "step": step,
+                "training_backend": _QAT_FAKE_QUANT_BACKEND,
+                "loss_proxy": loss_proxy,
+                "quant_error_proxy_mean": stats["quant_error_proxy_mean"],
+                "calibration_sample_count": calibration_sample_count,
+            }
+        )
+    _write_jsonl_artifact(trace_path, trace_rows)
+
+    fake_quant_payload = {
+        "schema_version": "melix.qat_fake_quant_artifact.v1",
+        "job_id": job_id,
+        "training_backend": _QAT_FAKE_QUANT_BACKEND,
+        "source_artifact_kind": source_artifact_kind,
+        "source_artifact_path": str(source_path),
+        "source_sha256": stats["source_sha256"],
+        "source_file_count": stats["source_file_count"],
+        "source_byte_count": stats["source_byte_count"],
+        "q_bits": q_bits,
+        "quant_error_proxy_mean": stats["quant_error_proxy_mean"],
+        "quant_error_proxy_max": stats["quant_error_proxy_max"],
+    }
+    fake_quant_artifact_bytes = _write_json_artifact(fake_quant_artifact_path, fake_quant_payload)
+
+    manifest_payload = {
+        "schema_version": _QAT_TRAINING_SCHEMA_VERSION,
+        "job_id": f"{job_id}.qat",
+        "parent_quantization_job_id": job_id,
+        "training_backend": _QAT_FAKE_QUANT_BACKEND,
+        "source_artifact_kind": source_artifact_kind,
+        "source_artifact_path": str(source_path),
+        "source_sha256": stats["source_sha256"],
+        "source_file_count": stats["source_file_count"],
+        "source_byte_count": stats["source_byte_count"],
+        "weight_quant": profile.weight_quant,
+        "kv_quant": profile.kv_quant,
+        "q_bits": q_bits,
+        "training_steps": training_steps,
+        "learning_rate": learning_rate,
+        "calibration_dataset_uri": calibration_evidence.get("dataset_uri", ""),
+        "calibration_sample_count": calibration_sample_count,
+        "loss_proxy_initial": loss_initial,
+        "loss_proxy_final": loss_final,
+        "quant_error_proxy_mean": stats["quant_error_proxy_mean"],
+        "quant_error_proxy_max": stats["quant_error_proxy_max"],
+        "trace_path": str(trace_path),
+        "fake_quant_artifact_path": str(fake_quant_artifact_path),
+    }
+    manifest_bytes = _write_json_artifact(manifest_path, manifest_payload)
+    artifact_bytes = trace_path.stat().st_size + fake_quant_artifact_bytes + manifest_bytes
+    return QATFakeQuantTrainingResult(
+        manifest_path=manifest_path,
+        trace_path=trace_path,
+        fake_quant_artifact_path=fake_quant_artifact_path,
+        artifact_bytes=artifact_bytes,
+        payload=manifest_payload,
+    )
+
+
+def _source_artifact_files_for_qat(source_path: Path) -> list[Path]:
+    if source_path.is_file():
+        return [source_path]
+    source_files = sorted(path for path in source_path.rglob("*") if path.is_file())
+    if not source_files:
+        raise ModelOperationError(
+            code="invalid_qat_source_artifact",
+            message="QAT fake-quant training requires at least one source artifact file.",
+            details={"source_artifact_path": str(source_path)},
+        )
+    return source_files
+
+
+def _qat_q_bits_for_request(
+    request: maintenance_pb2.ConvertModelRequest,
+    profile: QuantizationProfile,
+) -> int:
+    q_bits = (
+        _optional_positive_int_ext(request, "qat_q_bits")
+        or _optional_positive_int_ext(request, "mlx_lm_q_bits")
+        or _bits_from_weight_quant(profile.weight_quant)
+    )
+    if q_bits is None:
+        raise ModelOperationError(
+            code="unsupported_quantization_profile",
+            message="QAT fake-quant training requires an integer weight bit width.",
+            details={
+                "quantization_mode": "qat",
+                "weight_quant": profile.weight_quant,
+                "override_field": "qat_q_bits",
+            },
+        )
+    return q_bits
+
+
+def _qat_fake_quant_source_stats(source_files: list[Path], *, q_bits: int) -> dict[str, Any]:
+    digest = hashlib.sha256()
+    source_file_count = 0
+    source_byte_count = 0
+    error_sum = 0.0
+    error_max = 0.0
+    levels = (1 << q_bits) - 1
+    if levels <= 0:
+        raise ModelOperationError(
+            code="invalid_quantization_backend_config",
+            message="qat_q_bits must produce at least one fake-quant level.",
+            details={"field": "qat_q_bits", "value": str(q_bits)},
+        )
+    for source_file in source_files:
+        source_file_count += 1
+        with source_file.open("rb") as handle:
+            while True:
+                chunk = handle.read(1024 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+                source_byte_count += len(chunk)
+                for value in chunk:
+                    quantized = round((value / 255.0) * levels) / levels
+                    reconstructed = round(quantized * 255.0)
+                    error = abs(value - reconstructed) / 255.0
+                    error_sum += error
+                    if error > error_max:
+                        error_max = error
+    if source_byte_count <= 0:
+        raise ModelOperationError(
+            code="invalid_qat_source_artifact",
+            message="QAT fake-quant training requires non-empty source artifact bytes.",
+            details={"source_file_count": str(source_file_count)},
+        )
+    return {
+        "source_sha256": digest.hexdigest(),
+        "source_file_count": source_file_count,
+        "source_byte_count": source_byte_count,
+        "quant_error_proxy_mean": error_sum / source_byte_count,
+        "quant_error_proxy_max": error_max,
+    }
+
+
+def _write_json_artifact(path: Path, payload: dict[str, Any]) -> int:
+    encoded = json.dumps(payload, sort_keys=True, indent=2).encode("utf-8") + b"\n"
+    path.write_bytes(encoded)
+    return len(encoded)
+
+
+def _write_jsonl_artifact(path: Path, rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
 
 
 def _release_gate_for_request(
@@ -1027,3 +1258,29 @@ def _float_ext(request: maintenance_pb2.ConvertModelRequest, key: str) -> float:
             message=f"{key} must be numeric.",
             details={"field": key, "value": raw_value},
         ) from exc
+
+
+def _non_negative_float_ext(
+    request: maintenance_pb2.ConvertModelRequest,
+    key: str,
+    *,
+    default: float,
+) -> float:
+    raw_value = request.ext.get(key, "").strip()
+    if not raw_value:
+        return default
+    try:
+        value = float(raw_value)
+    except ValueError as exc:
+        raise ModelOperationError(
+            code="invalid_quantization_backend_config",
+            message=f"{key} must be numeric.",
+            details={"field": key, "value": raw_value},
+        ) from exc
+    if value < 0.0:
+        raise ModelOperationError(
+            code="invalid_quantization_backend_config",
+            message=f"{key} must be non-negative.",
+            details={"field": key, "value": raw_value},
+        )
+    return value

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -27,6 +27,13 @@ from worker.registry import WorkerRegistry
 
 _BUNDLE_SCHEMA_VERSION = "melix.quantized_bundle.v1"
 _SMOKE_REQUIRED_FILES = ("config.json", "tokenizer.json", "weights.safetensors")
+_MANIFEST_ONLY_QUANTIZATION_BACKEND = "manifest_only"
+_MLX_LM_CONVERT_QUANTIZATION_BACKEND = "mlx_lm_convert"
+_SUPPORTED_QUANTIZATION_BACKENDS = {
+    _MANIFEST_ONLY_QUANTIZATION_BACKEND,
+    _MLX_LM_CONVERT_QUANTIZATION_BACKEND,
+}
+_SUPPORTED_MLX_LM_Q_MODES = {"affine", "mxfp4", "nvfp4", "mxfp8"}
 
 
 @dataclass(frozen=True)
@@ -91,6 +98,7 @@ class OQQuantizationPipeline:
         profile = normalize_quantization_profile(request)
         quantization_mode = _quantization_mode_for_request(request)
         source_artifact_kind = _source_artifact_kind_for_request(request)
+        quantization_backend = _quantization_backend_for_request(request)
         source_artifact_path = _source_artifact_path_for_request(
             request,
             source_model=source_model,
@@ -100,6 +108,7 @@ class OQQuantizationPipeline:
             quantization_mode=quantization_mode,
             source_artifact_kind=source_artifact_kind,
             source_artifact_path=source_artifact_path,
+            quantization_backend=quantization_backend,
         )
         smoke_mode = _local_inference_smoke_mode_for_request(request)
         calibration_evidence = _calibration_evidence_for_request(request)
@@ -109,43 +118,55 @@ class OQQuantizationPipeline:
         )
 
         bundle_path = (output_dir / job_id / "quantize.artifact").resolve()
-        bundle_path.mkdir(parents=True, exist_ok=True)
+        if quantization_backend == _MLX_LM_CONVERT_QUANTIZATION_BACKEND:
+            artifact_bytes = self._write_mlx_lm_quantized_bundle(
+                request=request,
+                source_artifact_path=source_artifact_path,
+                profile=profile,
+                bundle_path=bundle_path,
+            )
+        else:
+            bundle_path.mkdir(parents=True, exist_ok=True)
 
-        files = {
-            bundle_path / "config.json": {
-                "model_id": source_model.model_id,
-                "model_kind": source_model.model_kind,
-                "source_model": request.source_model,
-                "quant_profile_id": profile.quant_profile_id,
-                "quant_algorithm": profile.algorithm,
-            },
-            bundle_path / "tokenizer.json": {
-                "tokenizer_hash": source_model.tokenizer_hash,
-                "source_model": request.source_model,
-            },
-        }
-        artifact_bytes = 0
-        for path, payload in files.items():
-            artifact_bytes += self._write_json_file(path, payload)
-
-        weights_path = bundle_path / "weights.safetensors"
-        artifact_bytes += self._write_bytes_file(
-            weights_path,
-            json.dumps(
-                {
+            files = {
+                bundle_path / "config.json": {
                     "model_id": source_model.model_id,
+                    "model_kind": source_model.model_kind,
+                    "source_model": request.source_model,
                     "quant_profile_id": profile.quant_profile_id,
-                    "weight_quant": profile.weight_quant,
-                    "kv_quant": profile.kv_quant,
-                    "calibration": calibration.to_dict(),
+                    "quant_algorithm": profile.algorithm,
                 },
-                sort_keys=True,
-            ).encode("utf-8"),
-        )
+                bundle_path / "tokenizer.json": {
+                    "tokenizer_hash": source_model.tokenizer_hash,
+                    "source_model": request.source_model,
+                },
+            }
+            artifact_bytes = 0
+            for path, payload in files.items():
+                artifact_bytes += self._write_json_file(path, payload)
+
+            weights_path = bundle_path / "weights.safetensors"
+            artifact_bytes += self._write_bytes_file(
+                weights_path,
+                json.dumps(
+                    {
+                        "model_id": source_model.model_id,
+                        "quant_profile_id": profile.quant_profile_id,
+                        "weight_quant": profile.weight_quant,
+                        "kv_quant": profile.kv_quant,
+                        "calibration": calibration.to_dict(),
+                    },
+                    sort_keys=True,
+                ).encode("utf-8"),
+            )
 
         smoke_evidence = _not_requested_smoke_evidence(
             bundle_path=bundle_path,
             smoke_mode=smoke_mode,
+        )
+        smoke_checked_files = _smoke_required_files_for_backend(
+            bundle_path,
+            quantization_backend=quantization_backend,
         )
         if request.run_smoke_test:
             smoke_evidence = self._run_local_inference_smoke_test(
@@ -155,6 +176,7 @@ class OQQuantizationPipeline:
                 profile=profile,
                 bundle_path=bundle_path,
                 smoke_mode=smoke_mode,
+                checked_files=smoke_checked_files,
             )
         smoke_test_passed = smoke_evidence.passed
 
@@ -173,6 +195,7 @@ class OQQuantizationPipeline:
             quantization_mode=quantization_mode,
             source_artifact_kind=source_artifact_kind,
             source_artifact_path=source_artifact_path,
+            quantization_backend=quantization_backend,
             calibration_evidence=calibration_evidence,
             bundle_path=bundle_path,
             manifest_path=manifest_path,
@@ -229,9 +252,10 @@ class OQQuantizationPipeline:
         profile: QuantizationProfile,
         bundle_path: Path,
         smoke_mode: str,
+        checked_files: tuple[str, ...],
     ) -> LocalInferenceSmokeEvidence:
         if smoke_mode == "structural":
-            return self._run_structural_smoke_evidence(bundle_path)
+            return self._run_structural_smoke_evidence(bundle_path, checked_files=checked_files)
         if smoke_mode == "runtime_generate":
             return self._run_runtime_generate_smoke_evidence(
                 request=request,
@@ -239,6 +263,7 @@ class OQQuantizationPipeline:
                 source_model=source_model,
                 profile=profile,
                 bundle_path=bundle_path,
+                checked_files=checked_files,
             )
         raise AssertionError(f"Unexpected local inference smoke mode: {smoke_mode}")
 
@@ -247,9 +272,13 @@ class OQQuantizationPipeline:
         return OQQuantizationPipeline._run_structural_smoke_evidence(bundle_path).passed
 
     @staticmethod
-    def _run_structural_smoke_evidence(bundle_path: Path) -> LocalInferenceSmokeEvidence:
+    def _run_structural_smoke_evidence(
+        bundle_path: Path,
+        *,
+        checked_files: tuple[str, ...] | None = None,
+    ) -> LocalInferenceSmokeEvidence:
         started_at = time.perf_counter()
-        checked_files = _SMOKE_REQUIRED_FILES
+        checked_files = checked_files or _SMOKE_REQUIRED_FILES
         for file_name in checked_files:
             path = bundle_path / file_name
             if not path.exists():
@@ -298,8 +327,9 @@ class OQQuantizationPipeline:
         source_model: common_pb2.ModelSpec,
         profile: QuantizationProfile,
         bundle_path: Path,
+        checked_files: tuple[str, ...],
     ) -> LocalInferenceSmokeEvidence:
-        structural_evidence = self._run_structural_smoke_evidence(bundle_path)
+        structural_evidence = self._run_structural_smoke_evidence(bundle_path, checked_files=checked_files)
         prompt = (
             request.ext.get("local_inference_smoke_prompt", "").strip()
             or "Validate the Melix quantized bundle."
@@ -387,7 +417,7 @@ class OQQuantizationPipeline:
                 runtime="mlx_text",
                 runtime_backend=runtime_backend,
                 artifact_path=str(bundle_path),
-                checked_files=_SMOKE_REQUIRED_FILES,
+                checked_files=checked_files,
                 latency_ms=_elapsed_ms(started_at),
                 prompt_sha256=prompt_sha256,
                 generated_token_count=generated_token_count,
@@ -400,7 +430,7 @@ class OQQuantizationPipeline:
                 runtime="mlx_text",
                 runtime_backend=runtime_backend or "unknown",
                 artifact_path=str(bundle_path),
-                checked_files=_SMOKE_REQUIRED_FILES,
+                checked_files=checked_files,
                 latency_ms=_elapsed_ms(started_at),
                 prompt_sha256=prompt_sha256,
                 failure_reason=str(exc),
@@ -425,6 +455,7 @@ class OQQuantizationPipeline:
         quantization_mode: str,
         source_artifact_kind: str,
         source_artifact_path: str,
+        quantization_backend: str,
         calibration_evidence: dict[str, Any],
         bundle_path: Path,
         manifest_path: Path,
@@ -452,6 +483,8 @@ class OQQuantizationPipeline:
             "quantization_mode": quantization_mode,
             "source_artifact_kind": source_artifact_kind,
             "source_artifact_path": source_artifact_path,
+            "execution_backend": quantization_backend,
+            "real_weight_conversion": quantization_backend == _MLX_LM_CONVERT_QUANTIZATION_BACKEND,
             "calibration_dataset_uri": calibration_evidence.get("dataset_uri", ""),
             "quantized_artifact_bytes": artifact_bytes,
             "weight_quant": request.weight_quant,
@@ -517,6 +550,65 @@ class OQQuantizationPipeline:
         path.write_bytes(encoded)
         return len(encoded)
 
+    def _write_mlx_lm_quantized_bundle(
+        self,
+        *,
+        request: maintenance_pb2.ConvertModelRequest,
+        source_artifact_path: str,
+        profile: QuantizationProfile,
+        bundle_path: Path,
+    ) -> int:
+        source_path = _local_source_path_for_mlx_lm_convert(source_artifact_path)
+        if bundle_path.exists():
+            raise ModelOperationError(
+                code="quantization_output_exists",
+                message="MLX-LM quantization output path already exists.",
+                details={"output_path": str(bundle_path)},
+            )
+        bundle_path.parent.mkdir(parents=True, exist_ok=True)
+        params = _mlx_lm_quantization_params_for_request(request, profile)
+        try:
+            self._mlx_lm_convert(
+                source_path=source_path,
+                output_path=bundle_path,
+                q_group_size=params["q_group_size"],
+                q_bits=params["q_bits"],
+                q_mode=params["q_mode"],
+            )
+        except ModuleNotFoundError as exc:
+            raise ModelOperationError(
+                code="quantization_backend_unavailable",
+                message="MLX-LM quantization backend is not available in the current runtime.",
+                details={"quantization_backend": _MLX_LM_CONVERT_QUANTIZATION_BACKEND},
+            ) from exc
+        except Exception as exc:
+            raise ModelOperationError(
+                code="quantization_backend_failure",
+                message=f"MLX-LM quantization failed: {exc}",
+                details={"quantization_backend": _MLX_LM_CONVERT_QUANTIZATION_BACKEND},
+            ) from exc
+        return _sum_bundle_file_bytes(bundle_path)
+
+    @staticmethod
+    def _mlx_lm_convert(
+        *,
+        source_path: Path,
+        output_path: Path,
+        q_group_size: int | None,
+        q_bits: int,
+        q_mode: str,
+    ) -> None:
+        from mlx_lm import convert as mlx_lm_convert
+
+        mlx_lm_convert(
+            str(source_path),
+            mlx_path=str(output_path),
+            quantize=True,
+            q_group_size=q_group_size,
+            q_bits=q_bits,
+            q_mode=q_mode,
+        )
+
 
 def _quantization_mode_for_request(request: maintenance_pb2.ConvertModelRequest) -> str:
     quantization_mode = request.ext.get("quantization_mode", "").strip().lower() or "ptq"
@@ -538,6 +630,23 @@ def _source_artifact_kind_for_request(request: maintenance_pb2.ConvertModelReque
             details={"source_artifact_kind": source_artifact_kind},
         )
     return source_artifact_kind
+
+
+def _quantization_backend_for_request(request: maintenance_pb2.ConvertModelRequest) -> str:
+    backend = (
+        request.ext.get("quantization_backend", "").strip().lower()
+        or _MANIFEST_ONLY_QUANTIZATION_BACKEND
+    )
+    if backend not in _SUPPORTED_QUANTIZATION_BACKENDS:
+        raise ModelOperationError(
+            code="unsupported_quantization_backend",
+            message=f"Unsupported quantization_backend: {backend}",
+            details={
+                "quantization_backend": backend,
+                "supported_quantization_backends": ",".join(sorted(_SUPPORTED_QUANTIZATION_BACKENDS)),
+            },
+        )
+    return backend
 
 
 def _local_inference_smoke_mode_for_request(request: maintenance_pb2.ConvertModelRequest) -> str:
@@ -570,12 +679,26 @@ def _validate_quantization_source(
     quantization_mode: str,
     source_artifact_kind: str,
     source_artifact_path: str,
+    quantization_backend: str,
 ) -> None:
     if source_artifact_kind != "base_model" and not source_artifact_path:
         raise ModelOperationError(
             code="missing_source_artifact_path",
             message="Adapter-derived quantization requires source_artifact_path.",
             details={"source_artifact_kind": source_artifact_kind},
+        )
+    if (
+        quantization_backend == _MLX_LM_CONVERT_QUANTIZATION_BACKEND
+        and quantization_mode != "ptq"
+    ):
+        raise ModelOperationError(
+            code="unsupported_quantization_backend",
+            message="MLX-LM conversion backend supports PTQ only.",
+            details={
+                "quantization_backend": quantization_backend,
+                "quantization_mode": quantization_mode,
+                "supported_quantization_mode": "ptq",
+            },
         )
     if quantization_mode == "qat" and source_artifact_kind == "base_model":
         raise ModelOperationError(
@@ -587,6 +710,126 @@ def _validate_quantization_source(
                 "supported_source_artifact_kinds": "merged_adapter,adapter_export",
             },
         )
+
+
+def _local_source_path_for_mlx_lm_convert(source_artifact_path: str) -> Path:
+    normalized = source_artifact_path.strip()
+    if not normalized:
+        raise ModelOperationError(
+            code="missing_quantization_source_path",
+            message="MLX-LM quantization requires a local source artifact path.",
+            details={"quantization_backend": _MLX_LM_CONVERT_QUANTIZATION_BACKEND},
+        )
+    source_path = Path(normalized).expanduser().resolve()
+    if not source_path.exists():
+        raise ModelOperationError(
+            code="missing_quantization_source_path",
+            message="MLX-LM quantization source artifact does not exist.",
+            details={
+                "quantization_backend": _MLX_LM_CONVERT_QUANTIZATION_BACKEND,
+                "source_artifact_path": str(source_path),
+            },
+        )
+    return source_path
+
+
+def _mlx_lm_quantization_params_for_request(
+    request: maintenance_pb2.ConvertModelRequest,
+    profile: QuantizationProfile,
+) -> dict[str, int | str | None]:
+    q_bits = _optional_positive_int_ext(request, "mlx_lm_q_bits")
+    if q_bits is None:
+        q_bits = _bits_from_weight_quant(profile.weight_quant)
+    if q_bits is None:
+        raise ModelOperationError(
+            code="unsupported_quantization_profile",
+            message="MLX-LM quantization requires an integer weight bit width.",
+            details={
+                "quantization_backend": _MLX_LM_CONVERT_QUANTIZATION_BACKEND,
+                "weight_quant": profile.weight_quant,
+                "override_field": "mlx_lm_q_bits",
+            },
+        )
+    q_group_size = _optional_positive_int_ext(request, "mlx_lm_q_group_size")
+    if q_group_size is None:
+        q_group_size = _optional_positive_int(profile.ext.get("quant_group_size", ""), "quant_group_size")
+    q_mode = (
+        request.ext.get("mlx_lm_q_mode", "").strip().lower()
+        or profile.ext.get("mlx_lm_q_mode", "").strip().lower()
+        or "affine"
+    )
+    if q_mode not in _SUPPORTED_MLX_LM_Q_MODES:
+        raise ModelOperationError(
+            code="invalid_quantization_backend_config",
+            message="Unsupported MLX-LM quantization mode.",
+            details={
+                "field": "mlx_lm_q_mode",
+                "value": q_mode,
+                "supported_values": ",".join(sorted(_SUPPORTED_MLX_LM_Q_MODES)),
+            },
+        )
+    return {"q_bits": q_bits, "q_group_size": q_group_size, "q_mode": q_mode}
+
+
+def _bits_from_weight_quant(weight_quant: str) -> int | None:
+    normalized = weight_quant.strip().lower()
+    if len(normalized) >= 2 and normalized[0] == "q" and normalized[1:].isdigit():
+        return int(normalized[1:])
+    return None
+
+
+def _optional_positive_int_ext(
+    request: maintenance_pb2.ConvertModelRequest,
+    key: str,
+) -> int | None:
+    return _optional_positive_int(request.ext.get(key, ""), key)
+
+
+def _optional_positive_int(raw_value: str, key: str) -> int | None:
+    normalized = str(raw_value).strip()
+    if not normalized:
+        return None
+    try:
+        value = int(normalized)
+    except ValueError as exc:
+        raise ModelOperationError(
+            code="invalid_quantization_backend_config",
+            message=f"{key} must be a positive integer.",
+            details={"field": key, "value": normalized},
+        ) from exc
+    if value <= 0:
+        raise ModelOperationError(
+            code="invalid_quantization_backend_config",
+            message=f"{key} must be a positive integer.",
+            details={"field": key, "value": normalized},
+        )
+    return value
+
+
+def _sum_bundle_file_bytes(bundle_path: Path) -> int:
+    return sum(path.stat().st_size for path in bundle_path.rglob("*") if path.is_file())
+
+
+def _smoke_required_files_for_backend(
+    bundle_path: Path,
+    *,
+    quantization_backend: str,
+) -> tuple[str, ...]:
+    if quantization_backend != _MLX_LM_CONVERT_QUANTIZATION_BACKEND:
+        return _SMOKE_REQUIRED_FILES
+    if (bundle_path / "tokenizer.json").exists():
+        tokenizer_file = "tokenizer.json"
+    elif (bundle_path / "tokenizer.model").exists():
+        tokenizer_file = "tokenizer.model"
+    else:
+        tokenizer_file = "tokenizer.json"
+    if (bundle_path / "model.safetensors").exists():
+        weight_file = "model.safetensors"
+    elif (bundle_path / "model.safetensors.index.json").exists():
+        weight_file = "model.safetensors.index.json"
+    else:
+        weight_file = "model.safetensors"
+    return ("config.json", tokenizer_file, weight_file)
 
 
 def _not_requested_smoke_evidence(


### PR DESCRIPTION
## Summary
- Add an opt-in `quantization_backend=mlx_lm_convert` path that calls MLX-LM conversion for real PTQ weight conversion.
- Preserve the default deterministic `manifest_only` quantization backend for fast structural tests and unsupported environments.
- Record the selected quantization execution backend and real-conversion flag in `melix.quantized_bundle.v1`, and adapt smoke preflight to backend-specific bundle layouts.
- Tighten QAT evidence by requiring an existing adapter-derived source artifact, running a deterministic Melix fake-quant optimizer, and recording QAT trace/manifest/artifact links plus optional source training-manifest and calibration lineage in the bundle.
- Harden review and CI paths by omitting unset MLX-LM `q_group_size` values, scanning converted byte totals with `os.scandir`, requiring indexed safetensor shards during structural smoke fallback, merging current `origin/main`, and skipping live Swift MLX tests that require `mlx.metallib` when the runner does not provide it.

## Plan or Spec
- `docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md`
- GitHub issue: https://github.com/Keith-CY/melix/issues/365

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py
# 53 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py
# 53 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-mlx-quantization-coverage.json
# Wrote JSON report to /tmp/issue365-mlx-quantization-coverage.json

python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-mlx-quantization-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md
# TOTAL 97.35% 404/415

python3 -m compileall -q services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py
# 55 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py
# 55 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-mlx-quantization-review-coverage.json
# Wrote JSON report to /tmp/issue365-mlx-quantization-review-coverage.json

python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-mlx-quantization-review-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md
# TOTAL 97.67% 503/515

python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-mlx-quantization-review-coverage.json --diff-from HEAD^ services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py
# TOTAL 99.07% 107/108

python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-mlx-quantization-review-coverage.json --diff-from HEAD^ services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
# TOTAL 100.00% 43/43

git diff --check
# passed

python3 scripts/validate_pr_evidence.py --body-file /private/tmp/issue365-mlx-quantization-pr.md
# passed

swift test --package-path services/control-plane-swift --filter PythonBridgeWorkerClientTests
# 52 tests passed

make swift-test-control-worker
# 102 tests in 5 suites passed

xcrun swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter WorkerScaffoldTests/testFusedDecodeQuantizer
# 4 tests passed

python3 scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from HEAD^ services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
# TOTAL 100.00% 19/19

make swift-test-text-worker
# 189 tests passed

git diff --check
# passed

xcrun swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter WorkerScaffoldTests/testVendoredChatSessionClearUsesAsyncSerialAccess
# 1 test passed

python3 scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from HEAD services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
# TOTAL 100.00% 10/10

git diff --check
# passed

git rebase origin/main
# passed; duplicate CI hotfix commits from #394 were dropped because the patch contents were already upstream.

git diff --check
# passed

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-bodies/pr-397.md
# passed
```

## Coverage and Metrics
- Python changed-line coverage: 97.67% (503/515) against `origin/main`.
- Review follow-up Python changed-line coverage: 99.07% (107/108) against `HEAD^`; production changed-line coverage is 100.00% (43/43).
- Swift CI follow-up changed-line coverage: 100.00% (19/19) for `WorkerScaffoldTests.swift` against `HEAD^`.
- Additional Swift CI follow-up changed-line coverage: 100.00% (10/10) for the vendored ChatSession clear guard against `HEAD`.
- Metrics report: the MLX-LM backend records `execution_backend=mlx_lm_convert`, `real_weight_conversion=true`, backend-specific structural smoke evidence, and actual converted artifact byte totals. QAT manifest-only export now records `qat.training_executed=true`, `qat.training_backend=melix_fake_quant_optimizer`, QAT trace/manifest/fake-quant artifact paths, source digest/file/byte counts, quant-error proxy metrics, optional source training-manifest lineage, calibration lineage, and QAT metadata in the weights payload.
- Performance probe: the existing `manifest_only` PTQ path preserves its no-rescan artifact-byte path; `mlx_lm_convert` walks the converted output once with an explicit `os.scandir` stack because MLX-LM owns the shard set; QAT fake-quant training walks the adapter-derived source artifact once, streams source bytes to compute digest and fake-quant error proxies, and writes compact trace/manifest/artifact evidence before the bundle manifest is emitted.

## Known Gaps
- This PR does not close issue #365.
- MLX-native QAT training over full model tensors remains deferred; this PR implements deterministic Melix fake-quant optimizer evidence, and `mlx_lm_convert` remains PTQ-only.
- Deferred issue #365 work remains: release-ready GRPO generation/scoring/policy updates, reward-model-backed RLHF/PPO from issue #366, full CLI chain acceptance, Window UI acceptance, and final real-local-runtime release evidence.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
