### PR TITLE
[codex] Optimize PR CI gates

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -41,6 +41,26 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
 
+      - name: Restore Python dependency cache
+        uses: actions/cache@v4
+        with:
+          path: .uv-cache
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock', 'pyproject.toml', 'services/mlx-worker-python/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Restore Swift protocol cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .swift-home/protocol
+            .build/ModuleCache.noindex/protocol
+            packages/protocol/swift/.build
+          key: ${{ runner.os }}-swift-protocol-${{ hashFiles('packages/protocol/swift/Package.swift', 'packages/protocol/swift/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-protocol-
+            ${{ runner.os }}-swift-
+
       - name: Bootstrap
         run: bash scripts/ci_progress.sh "Bootstrap" make bootstrap
 
@@ -48,23 +68,76 @@ jobs:
         run: bash scripts/ci_progress.sh "Protocol drift check" make proto-check
 
   swift-tests:
+    name: swift-tests (${{ matrix.shard }})
     runs-on: macos-15
-    timeout-minutes: 90
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: protocol
+            target: swift-test-protocol
+          - shard: text-worker
+            target: swift-test-text-worker
+          - shard: control-core
+            target: swift-test-control-core
+          - shard: request-coordinator-a
+            target: swift-test-control-request-coordinator-a
+          - shard: request-coordinator-b
+            target: swift-test-control-request-coordinator-b
+          - shard: request-coordinator-c
+            target: swift-test-control-request-coordinator-c
+          - shard: request-coordinator-d
+            target: swift-test-control-request-coordinator-d
+          - shard: request-coordinator-e
+            target: swift-test-control-request-coordinator-e
+          - shard: control-openai
+            target: swift-test-control-openai
+          - shard: control-rest
+            target: swift-test-control-rest
+          - shard: control-worker
+            target: swift-test-control-worker
+          - shard: menubar
+            target: swift-test-menubar
 
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v6
+      - name: Restore Swift dependency cache
+        uses: actions/cache@v4
         with:
-          python-version: "3.12"
-
-      - uses: astral-sh/setup-uv@v7
-
-      - name: Bootstrap
-        run: bash scripts/ci_progress.sh "Bootstrap" make bootstrap
+          path: |
+            .swift-home
+            .build/ModuleCache.noindex
+            .build
+            packages/protocol/swift/.build
+            services/control-plane-swift/.build
+            services/mlx-text-worker-swift/.build
+            apps/macos-menubar/.build
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-swift-${{ matrix.target }}-${{ hashFiles('Package.swift', 'Package.resolved', 'packages/protocol/swift/Package.swift', 'packages/protocol/swift/Package.resolved', 'services/control-plane-swift/Package.swift', 'services/control-plane-swift/Package.resolved', 'services/mlx-text-worker-swift/Package.swift', 'services/mlx-text-worker-swift/Package.resolved', 'apps/macos-menubar/Package.swift', 'apps/macos-menubar/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-${{ matrix.target }}-
+            ${{ runner.os }}-swift-
 
       - name: Swift tests
-        run: bash scripts/ci_progress.sh "Swift tests" make swift-test
+        run: |
+          bash scripts/ci_progress.sh "Swift tests: ${{ matrix.shard }}" make ${{ matrix.target }}
+
+  swift-tests-report:
+    if: always()
+    needs:
+      - swift-tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Swift test shards
+        run: |
+          if [ "${{ needs.swift-tests.result }}" != "success" ]; then
+            echo "Swift test shards completed with result: ${{ needs.swift-tests.result }}"
+            exit 1
+          fi
+          echo "Swift test shards completed successfully."
 
   python-tests:
     runs-on: macos-15
@@ -78,6 +151,14 @@ jobs:
           python-version: "3.12"
 
       - uses: astral-sh/setup-uv@v7
+
+      - name: Restore Python dependency cache
+        uses: actions/cache@v4
+        with:
+          path: .uv-cache
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock', 'pyproject.toml', 'services/mlx-worker-python/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
 
       - name: Bootstrap
         run: bash scripts/ci_progress.sh "Bootstrap" make bootstrap
@@ -130,6 +211,31 @@ jobs:
           python-version: "3.12"
 
       - uses: astral-sh/setup-uv@v7
+
+      - name: Restore Python dependency cache
+        uses: actions/cache@v4
+        with:
+          path: .uv-cache
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock', 'pyproject.toml', 'services/mlx-worker-python/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Restore Swift integration cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .swift-home/mlx-text-worker-swift
+            .swift-home/control-plane-swift
+            .build/ModuleCache.noindex/mlx-text-worker-swift
+            .build/ModuleCache.noindex/control-plane-swift
+            services/control-plane-swift/.build
+            services/mlx-text-worker-swift/.build
+            packages/protocol/swift/.build
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-swift-integration-${{ hashFiles('Package.swift', 'Package.resolved', 'packages/protocol/swift/Package.swift', 'packages/protocol/swift/Package.resolved', 'services/control-plane-swift/Package.swift', 'services/control-plane-swift/Package.resolved', 'services/mlx-text-worker-swift/Package.swift', 'services/mlx-text-worker-swift/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-integration-
+            ${{ runner.os }}-swift-
 
       - name: Bootstrap
         run: bash scripts/ci_progress.sh "Bootstrap" make bootstrap

--- a/.github/workflows/package-self-contained-app.yml
+++ b/.github/workflows/package-self-contained-app.yml
@@ -3,6 +3,12 @@ name: package-self-contained-app
 on:
   workflow_dispatch:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
     paths:
       - ".github/workflows/package-self-contained-app.yml"
       - "apps/macos-menubar/**"
@@ -36,6 +42,7 @@ concurrency:
 
 jobs:
   package-app:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'package-app')
     runs-on: macos-15
     outputs:
       artifact_name: ${{ steps.compute-build-metadata.outputs.artifact_name }}
@@ -48,6 +55,32 @@ jobs:
           python-version: "3.13"
 
       - uses: astral-sh/setup-uv@v7
+
+      - name: Restore Python dependency cache
+        uses: actions/cache@v4
+        with:
+          path: .uv-cache
+          key: ${{ runner.os }}-uv-package-${{ hashFiles('uv.lock', 'pyproject.toml', 'services/mlx-worker-python/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-package-
+            ${{ runner.os }}-uv-
+
+      - name: Restore Swift build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .swift-home
+            .build/ModuleCache.noindex
+            .build
+            packages/protocol/swift/.build
+            services/control-plane-swift/.build
+            services/mlx-text-worker-swift/.build
+            apps/macos-menubar/.build
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-swift-package-${{ hashFiles('Package.swift', 'Package.resolved', 'packages/protocol/swift/Package.swift', 'packages/protocol/swift/Package.resolved', 'services/control-plane-swift/Package.swift', 'services/control-plane-swift/Package.resolved', 'services/mlx-text-worker-swift/Package.swift', 'services/mlx-text-worker-swift/Package.resolved', 'apps/macos-menubar/Package.swift', 'apps/macos-menubar/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-package-
+            ${{ runner.os }}-swift-
 
       - name: Bootstrap Python worker environment
         run: bash scripts/ci_progress.sh "Package app bootstrap" make bootstrap

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,21 @@ CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_E := \
 CONTROL_PLANE_TEST_FILTER_OPENAI := OpenAIHandlerTests
 CONTROL_PLANE_TEST_FILTER_HTTP_REST := RichOutputSanitizerTests|PersistentAuthSessionStoreTests|ProtocolCompatibilityMatrixTests|ConnectionLifecyclePolicyTests|SSEStreamWriterTests
 
-.PHONY: bootstrap proto proto-check swift-build-integration-prereqs swift-test py-test integration-test package-smoke swift-coverage py-coverage coverage phase1-metrics phase2-metrics phase5-metrics phase6-metrics phase7-metrics phase8-acceptance phase8-real-e2e phase8-install-smoke phase8-release-gate phase8-metrics phase17-metrics
+SWIFT_TEST_SHARD_TARGETS := \
+	swift-test-protocol \
+	swift-test-text-worker \
+	swift-test-control-core \
+	swift-test-control-request-coordinator-a \
+	swift-test-control-request-coordinator-b \
+	swift-test-control-request-coordinator-c \
+	swift-test-control-request-coordinator-d \
+	swift-test-control-request-coordinator-e \
+	swift-test-control-openai \
+	swift-test-control-rest \
+	swift-test-control-worker \
+	swift-test-menubar
+
+.PHONY: bootstrap proto proto-check swift-build-integration-prereqs swift-test $(SWIFT_TEST_SHARD_TARGETS) py-test integration-test package-smoke swift-coverage py-coverage coverage phase1-metrics phase2-metrics phase5-metrics phase6-metrics phase7-metrics phase8-acceptance phase8-real-e2e phase8-install-smoke phase8-release-gate phase8-metrics phase17-metrics
 
 PHASE1_METRICS_ARGS ?=
 PHASE2_METRICS_ARGS ?=
@@ -104,17 +118,78 @@ swift-build-integration-prereqs:
 
 swift-test:
 	/bin/zsh -lc 'set -e; \
-	mkdir -p "$(PROTOCOL_SWIFT_HOME)" "$(TEXT_WORKER_SWIFT_HOME)" "$(CONTROL_PLANE_SWIFT_HOME)" "$(MENUBAR_SWIFT_HOME)"; \
-	mkdir -p "$(PROTOCOL_MODULE_CACHE_PATH)" "$(TEXT_WORKER_MODULE_CACHE_PATH)" "$(CONTROL_PLANE_MODULE_CACHE_PATH)" "$(MENUBAR_MODULE_CACHE_PATH)"; \
-	bash scripts/ci_progress.sh "swift-test stage: protocol package" env HOME="$(PROTOCOL_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(PROTOCOL_MODULE_CACHE_PATH)" xcrun swift test --package-path packages/protocol/swift; \
-	bash scripts/ci_progress.sh "swift-test stage: text worker package" env HOME="$(TEXT_WORKER_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(TEXT_WORKER_MODULE_CACHE_PATH)" xcrun swift test --package-path services/mlx-text-worker-swift; \
-	bash scripts/ci_progress.sh "swift-test stage: control-plane core groups" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_CONTROL)"; \
-	for specifier in $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_A) $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_B) $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_C) $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_D) $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_E); do \
+	for target in $(SWIFT_TEST_SHARD_TARGETS); do \
+		$(MAKE) "$$target"; \
+	done'
+
+swift-test-protocol:
+	/bin/zsh -lc 'set -e; \
+	mkdir -p "$(PROTOCOL_SWIFT_HOME)" "$(PROTOCOL_MODULE_CACHE_PATH)"; \
+	bash scripts/ci_progress.sh "swift-test stage: protocol package" env HOME="$(PROTOCOL_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(PROTOCOL_MODULE_CACHE_PATH)" xcrun swift test --package-path packages/protocol/swift'
+
+swift-test-text-worker:
+	/bin/zsh -lc 'set -e; \
+	mkdir -p "$(TEXT_WORKER_SWIFT_HOME)" "$(TEXT_WORKER_MODULE_CACHE_PATH)"; \
+	bash scripts/ci_progress.sh "swift-test stage: text worker package" env HOME="$(TEXT_WORKER_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(TEXT_WORKER_MODULE_CACHE_PATH)" xcrun swift test --package-path services/mlx-text-worker-swift'
+
+swift-test-control-core:
+	/bin/zsh -lc 'set -e; \
+	mkdir -p "$(CONTROL_PLANE_SWIFT_HOME)" "$(CONTROL_PLANE_MODULE_CACHE_PATH)"; \
+	bash scripts/ci_progress.sh "swift-test stage: control-plane core groups" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_CONTROL)"'
+
+swift-test-control-request-coordinator-a:
+	/bin/zsh -lc 'set -e; \
+	mkdir -p "$(CONTROL_PLANE_SWIFT_HOME)" "$(CONTROL_PLANE_MODULE_CACHE_PATH)"; \
+	for specifier in $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_A); do \
 		bash scripts/ci_progress.sh "swift-test stage: control-plane request coordinator $$specifier" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$$specifier"; \
-	done; \
-	bash scripts/ci_progress.sh "swift-test stage: control-plane OpenAI handler" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_OPENAI)"; \
-	bash scripts/ci_progress.sh "swift-test stage: control-plane REST compatibility" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_HTTP_REST)"; \
-	bash scripts/ci_progress.sh "swift-test stage: control-plane worker clients" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_WORKER)"; \
+	done'
+
+swift-test-control-request-coordinator-b:
+	/bin/zsh -lc 'set -e; \
+	mkdir -p "$(CONTROL_PLANE_SWIFT_HOME)" "$(CONTROL_PLANE_MODULE_CACHE_PATH)"; \
+	for specifier in $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_B); do \
+		bash scripts/ci_progress.sh "swift-test stage: control-plane request coordinator $$specifier" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$$specifier"; \
+	done'
+
+swift-test-control-request-coordinator-c:
+	/bin/zsh -lc 'set -e; \
+	mkdir -p "$(CONTROL_PLANE_SWIFT_HOME)" "$(CONTROL_PLANE_MODULE_CACHE_PATH)"; \
+	for specifier in $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_C); do \
+		bash scripts/ci_progress.sh "swift-test stage: control-plane request coordinator $$specifier" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$$specifier"; \
+	done'
+
+swift-test-control-request-coordinator-d:
+	/bin/zsh -lc 'set -e; \
+	mkdir -p "$(CONTROL_PLANE_SWIFT_HOME)" "$(CONTROL_PLANE_MODULE_CACHE_PATH)"; \
+	for specifier in $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_D); do \
+		bash scripts/ci_progress.sh "swift-test stage: control-plane request coordinator $$specifier" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$$specifier"; \
+	done'
+
+swift-test-control-request-coordinator-e:
+	/bin/zsh -lc 'set -e; \
+	mkdir -p "$(CONTROL_PLANE_SWIFT_HOME)" "$(CONTROL_PLANE_MODULE_CACHE_PATH)"; \
+	for specifier in $(CONTROL_PLANE_REQUEST_COORDINATOR_SPECIFIERS_E); do \
+		bash scripts/ci_progress.sh "swift-test stage: control-plane request coordinator $$specifier" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$$specifier"; \
+	done'
+
+swift-test-control-openai:
+	/bin/zsh -lc 'set -e; \
+	mkdir -p "$(CONTROL_PLANE_SWIFT_HOME)" "$(CONTROL_PLANE_MODULE_CACHE_PATH)"; \
+	bash scripts/ci_progress.sh "swift-test stage: control-plane OpenAI handler" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_OPENAI)"'
+
+swift-test-control-rest:
+	/bin/zsh -lc 'set -e; \
+	mkdir -p "$(CONTROL_PLANE_SWIFT_HOME)" "$(CONTROL_PLANE_MODULE_CACHE_PATH)"; \
+	bash scripts/ci_progress.sh "swift-test stage: control-plane REST compatibility" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_HTTP_REST)"'
+
+swift-test-control-worker:
+	/bin/zsh -lc 'set -e; \
+	mkdir -p "$(CONTROL_PLANE_SWIFT_HOME)" "$(CONTROL_PLANE_MODULE_CACHE_PATH)"; \
+	bash scripts/ci_progress.sh "swift-test stage: control-plane worker clients" env HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --no-parallel --package-path services/control-plane-swift --filter "$(CONTROL_PLANE_TEST_FILTER_WORKER)"'
+
+swift-test-menubar:
+	/bin/zsh -lc 'set -e; \
+	mkdir -p "$(MENUBAR_SWIFT_HOME)" "$(MENUBAR_MODULE_CACHE_PATH)"; \
 	bash scripts/ci_progress.sh "swift-test stage: macOS menubar package" env HOME="$(MENUBAR_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(MENUBAR_MODULE_CACHE_PATH)" xcrun swift test --package-path apps/macos-menubar'
 
 py-test:

--- a/docs/plans/2026-05-05-ci-fast-pr-gates.md
+++ b/docs/plans/2026-05-05-ci-fast-pr-gates.md
@@ -1,0 +1,60 @@
+# CI Fast PR Gates Plan
+
+## Goal
+
+Reduce pull request feedback latency and macOS runner contention so multiple Melix
+PRs can iterate concurrently without weakening the full pre-merge safety net.
+
+## Current Bottleneck
+
+The pull request gate runs broad macOS jobs on every push. The Swift test job is
+the heaviest default gate because it runs all Swift packages and many
+`RequestCoordinatorTests` cases serially inside one long macOS job. The packaged
+app workflow also starts a full macOS packaging build for broad runtime path
+changes, even when the PR only needs fast validation.
+
+## Touched Files
+
+- `.github/workflows/ci-pr.yml`
+- `.github/workflows/package-self-contained-app.yml`
+- `Makefile`
+
+## Optimization Slice
+
+- Split `make swift-test` into stable shard targets while preserving the
+  existing aggregate `make swift-test` command for local and release workflows.
+- Run PR Swift shards as a macOS matrix with a stable `swift-tests-report`
+  aggregation job for branch protection.
+- Remove Python environment bootstrap from the Swift-only PR job path.
+- Restore dependency caches for Python, SwiftPM, package build directories, and
+  the repository-local module cache in CI jobs that reuse those artifacts.
+- Keep full integration tests on PRs when affected and always on merge queue
+  events.
+- Make the self-contained app package job opt-in on pull requests through a
+  `package-app` label, while preserving manual, main, develop, and tag builds.
+
+## Success Metrics
+
+- PR Swift feedback can fan out across shards instead of waiting on one
+  long-running serial job.
+- Default PR pushes no longer start a full packaged app build unless the operator
+  labels the PR with `package-app`.
+- The required branch-protection surface can depend on stable aggregate checks:
+  `swift-tests-report`, `python-tests`, `proto-drift`, `integration-tests` when
+  selected, `pr-evidence`, and fast lint/scope checks.
+- Full safety remains available through merge queue and release gates.
+
+## Verification Commands
+
+- `make swift-test-protocol`
+- `make swift-test-control-request-coordinator-a`
+- `actionlint .github/workflows/ci-pr.yml .github/workflows/package-self-contained-app.yml`
+- `git diff --check`
+
+## Metrics Report
+
+The changed scope is CI configuration and command orchestration. Runtime coverage
+is not applicable because no executable product code changes. Metrics are the
+CI measurement points introduced by the workflow split: per-shard Swift job
+duration, `swift-tests-report` completion time, and package workflow skipped vs.
+executed counts on pull requests.


### PR DESCRIPTION
## Summary
- Split the PR Swift test gate into parallel matrix shards with a stable `swift-tests-report` aggregate check.
- Add dependency caches for Swift and Python CI paths, and make full app packaging opt-in on PRs through the `package-app` label.
- Preserve the existing `make swift-test` aggregate command for local and full-gate workflows.

## Plan or Spec
- `docs/plans/2026-05-05-ci-fast-pr-gates.md`

## Commands Run
```text
make -n swift-test
# PASS: expanded all Swift shard targets in the preserved aggregate order.

ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "#{path}: ok" }' .github/workflows/ci-pr.yml .github/workflows/package-self-contained-app.yml
# PASS: both workflow files parsed as YAML.

/private/tmp/actionlint .github/workflows/ci-pr.yml .github/workflows/package-self-contained-app.yml
# PASS: workflow syntax and GitHub expression lint passed.

make swift-test-protocol
# PASS: protocol Swift shard passed, 1 XCTest test and 0 Swift Testing tests, elapsed 53s.

make swift-test-control-request-coordinator-a
# PASS: RequestCoordinator shard A passed, including the previously flaky disconnect grace expiry case.

git diff --check
# PASS: no whitespace errors.
```

## Coverage and Metrics
- Coverage: N/A. This change only touches CI workflow orchestration, Makefile command wiring, and a plan document; no product runtime code changed.
- Metrics: CI measurement points are per-shard Swift job duration, `swift-tests-report` completion time, and pull request package workflow skipped vs. executed counts after the `package-app` label gate.

## Known Gaps
- None. Branch protection may need to require the new stable `swift-tests-report` aggregate check instead of the old single `swift-tests` job name after this PR merges.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
