### PR TITLE
Add CLI pipeline chain routing slice

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -870,6 +870,8 @@ public struct QuantizeOptions: Equatable, Sendable {
     public let calibrationDatasetURI: String
     public let qualityDelta: String
     public let latencyDelta: String
+    public let localInferenceSmokeMode: String
+    public let localInferenceSmokePrompt: String
     public let json: Bool
 
     public init(
@@ -884,6 +886,8 @@ public struct QuantizeOptions: Equatable, Sendable {
         calibrationDatasetURI: String = "",
         qualityDelta: String = "",
         latencyDelta: String = "",
+        localInferenceSmokeMode: String = "",
+        localInferenceSmokePrompt: String = "",
         json: Bool = false
     ) {
         self.modelID = modelID
@@ -897,6 +901,8 @@ public struct QuantizeOptions: Equatable, Sendable {
         self.calibrationDatasetURI = calibrationDatasetURI
         self.qualityDelta = qualityDelta
         self.latencyDelta = latencyDelta
+        self.localInferenceSmokeMode = localInferenceSmokeMode
+        self.localInferenceSmokePrompt = localInferenceSmokePrompt
         self.json = json
     }
 }
@@ -1477,7 +1483,7 @@ public enum MelixCLIParser {
     Usage:
       melix doctor [--json]
       melix convert --model-id MODEL_ID [--output-dir PATH] [--target-format FORMAT] [--json]
-      melix quantize --model-id MODEL_ID [--output-dir PATH] [--quant-profile-id ID] [--weight-quant MODE] [--kv-quant MODE] [--quantization-mode (ptq|qat)] [--source-artifact-kind (base_model|merged_adapter|adapter_export)] [--source-artifact-path PATH] [--calibration-dataset-uri PATH] [--quality-delta N] [--latency-delta N] [--json]
+      melix quantize --model-id MODEL_ID [--output-dir PATH] [--quant-profile-id ID] [--weight-quant MODE] [--kv-quant MODE] [--quantization-mode (ptq|qat)] [--source-artifact-kind (base_model|merged_adapter|adapter_export)] [--source-artifact-path PATH] [--calibration-dataset-uri PATH] [--quality-delta N] [--latency-delta N] [--local-inference-smoke-mode (structural|runtime_generate)] [--local-inference-smoke-prompt TEXT] [--json]
       melix upload --model-id MODEL_ID --target-repo REPO [--output-dir PATH] [--artifact-path PATH] [--artifact-kind KIND] [--artifact-manifest-path PATH] [--publish-backend BACKEND] [--local-publish-root PATH] [--json]
       melix model list [--json]
       melix model inspect --model-id MODEL_ID [--json]
@@ -1623,6 +1629,10 @@ public enum MelixCLIParser {
         if !sourceArtifactKind.isEmpty, ["base_model", "merged_adapter", "adapter_export"].contains(sourceArtifactKind) == false {
             throw MelixCLIError.usage("Invalid value for --source-artifact-kind. Expected one of: base_model, merged_adapter, adapter_export.")
         }
+        let localInferenceSmokeMode = values.single["--local-inference-smoke-mode"] ?? ""
+        if !localInferenceSmokeMode.isEmpty, ["structural", "runtime_generate"].contains(localInferenceSmokeMode) == false {
+            throw MelixCLIError.usage("Invalid value for --local-inference-smoke-mode. Expected one of: structural, runtime_generate.")
+        }
         return .quantize(
             .init(
                 modelID: modelID,
@@ -1636,6 +1646,8 @@ public enum MelixCLIParser {
                 calibrationDatasetURI: values.single["--calibration-dataset-uri"] ?? "",
                 qualityDelta: values.single["--quality-delta"] ?? "",
                 latencyDelta: values.single["--latency-delta"] ?? "",
+                localInferenceSmokeMode: localInferenceSmokeMode,
+                localInferenceSmokePrompt: values.single["--local-inference-smoke-prompt"] ?? "",
                 json: values.flags.contains("--json")
             )
         )
@@ -3951,6 +3963,12 @@ public actor MelixCLIRunner {
             if !options.latencyDelta.isEmpty {
                 ext["latency_delta"] = options.latencyDelta
             }
+            if !options.localInferenceSmokeMode.isEmpty {
+                ext["local_inference_smoke_mode"] = options.localInferenceSmokeMode
+            }
+            if !options.localInferenceSmokePrompt.isEmpty {
+                ext["local_inference_smoke_prompt"] = options.localInferenceSmokePrompt
+            }
             let result = try await performModelOperation(
                 modelID: options.modelID,
                 operation: "quantize",
@@ -4987,6 +5005,8 @@ public actor MelixCLIRunner {
             appendOption("--calibration-dataset-uri", value: ext["calibration_dataset_uri"], into: &arguments)
             appendOption("--quality-delta", value: ext["quality_delta"], into: &arguments)
             appendOption("--latency-delta", value: ext["latency_delta"], into: &arguments)
+            appendOption("--local-inference-smoke-mode", value: ext["local_inference_smoke_mode"], into: &arguments)
+            appendOption("--local-inference-smoke-prompt", value: ext["local_inference_smoke_prompt"], into: &arguments)
             arguments.append("--json")
             return arguments
         case "upload":

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -179,6 +179,8 @@ public struct LoraPublishOptions: Equatable, Sendable {
     public let exportKind: LoraPublishExportKind?
     public let artifactPath: String
     public let artifactManifestPath: String
+    public let publishBackend: String
+    public let localPublishRoot: String
     public let json: Bool
 
     public init(
@@ -187,6 +189,8 @@ public struct LoraPublishOptions: Equatable, Sendable {
         exportKind: LoraPublishExportKind?,
         artifactPath: String,
         artifactManifestPath: String = "",
+        publishBackend: String = "",
+        localPublishRoot: String = "",
         json: Bool = false
     ) {
         self.modelID = modelID
@@ -194,6 +198,8 @@ public struct LoraPublishOptions: Equatable, Sendable {
         self.exportKind = exportKind
         self.artifactPath = artifactPath
         self.artifactManifestPath = artifactManifestPath
+        self.publishBackend = publishBackend
+        self.localPublishRoot = localPublishRoot
         self.json = json
     }
 }
@@ -902,6 +908,8 @@ public struct UploadOptions: Equatable, Sendable {
     public let artifactPath: String
     public let artifactKind: String
     public let artifactManifestPath: String
+    public let publishBackend: String
+    public let localPublishRoot: String
     public let json: Bool
 
     public init(
@@ -911,6 +919,8 @@ public struct UploadOptions: Equatable, Sendable {
         artifactPath: String = "",
         artifactKind: String = "",
         artifactManifestPath: String = "",
+        publishBackend: String = "",
+        localPublishRoot: String = "",
         json: Bool = false
     ) {
         self.modelID = modelID
@@ -919,6 +929,8 @@ public struct UploadOptions: Equatable, Sendable {
         self.artifactPath = artifactPath
         self.artifactKind = artifactKind
         self.artifactManifestPath = artifactManifestPath
+        self.publishBackend = publishBackend
+        self.localPublishRoot = localPublishRoot
         self.json = json
     }
 }
@@ -1466,7 +1478,7 @@ public enum MelixCLIParser {
       melix doctor [--json]
       melix convert --model-id MODEL_ID [--output-dir PATH] [--target-format FORMAT] [--json]
       melix quantize --model-id MODEL_ID [--output-dir PATH] [--quant-profile-id ID] [--weight-quant MODE] [--kv-quant MODE] [--quantization-mode (ptq|qat)] [--source-artifact-kind (base_model|merged_adapter|adapter_export)] [--source-artifact-path PATH] [--calibration-dataset-uri PATH] [--quality-delta N] [--latency-delta N] [--json]
-      melix upload --model-id MODEL_ID --target-repo REPO [--output-dir PATH] [--artifact-path PATH] [--artifact-kind KIND] [--artifact-manifest-path PATH] [--json]
+      melix upload --model-id MODEL_ID --target-repo REPO [--output-dir PATH] [--artifact-path PATH] [--artifact-kind KIND] [--artifact-manifest-path PATH] [--publish-backend BACKEND] [--local-publish-root PATH] [--json]
       melix model list [--json]
       melix model inspect --model-id MODEL_ID [--json]
       melix model load --model-id MODEL_ID [--memory-budget-bytes N] [--json]
@@ -1509,7 +1521,7 @@ public enum MelixCLIParser {
       melix lora dataset build --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) [--output-dir PATH] [--template TEMPLATE] [--dataset-id ID] [--validation-ratio N] [--sample-limit N] [--preview-count N] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-train-split SPLIT] [--hf-valid-split SPLIT] [--text-feature NAME] [--prompt-feature NAME] [--completion-feature NAME] [--chat-feature NAME] [--json]
       melix lora activate --model-id MODEL_ID --adapter-path PATH [--activation-mode (fused_derived_model|adapter_backed_runtime)] [--alias NAME] [--json]
       melix lora remove-derived --model-id MODEL_ID (--derived-model-id ID | --manifest-path PATH) [--json]
-      melix lora publish --model-id MODEL_ID --target-repo REPO (--adapter-path PATH | --merged-model-path PATH | --manifest-path PATH) [--export-kind (adapter|merged)] [--json]
+      melix lora publish --model-id MODEL_ID --target-repo REPO (--adapter-path PATH | --merged-model-path PATH | --manifest-path PATH) [--export-kind (adapter|merged)] [--publish-backend BACKEND] [--local-publish-root PATH] [--json]
       melix lora experiments list [--model-id MODEL_ID] [--json]
       melix lora experiments show --group-id GROUP_ID [--model-id MODEL_ID] [--json]
       melix lora resume --group-id GROUP_ID [--model-id MODEL_ID] [--preset PRESET] [--adapter-name NAME] [--dataset-uri URI] [--json]
@@ -1645,6 +1657,8 @@ public enum MelixCLIParser {
                 artifactPath: values.single["--artifact-path"] ?? "",
                 artifactKind: values.single["--artifact-kind"] ?? "",
                 artifactManifestPath: values.single["--artifact-manifest-path"] ?? "",
+                publishBackend: values.single["--publish-backend"] ?? "",
+                localPublishRoot: values.single["--local-publish-root"] ?? "",
                 json: values.flags.contains("--json")
             )
         )
@@ -2503,6 +2517,8 @@ public enum MelixCLIParser {
                     exportKind: exportKind,
                     artifactPath: artifactPath,
                     artifactManifestPath: artifactManifestPath,
+                    publishBackend: values.single["--publish-backend"] ?? "",
+                    localPublishRoot: values.single["--local-publish-root"] ?? "",
                     json: values.flags.contains("--json")
                 )
             )
@@ -3956,6 +3972,12 @@ public actor MelixCLIRunner {
             if !options.artifactManifestPath.isEmpty {
                 ext["artifact_manifest_path"] = options.artifactManifestPath
             }
+            if !options.publishBackend.isEmpty {
+                ext["publish_backend"] = options.publishBackend
+            }
+            if !options.localPublishRoot.isEmpty {
+                ext["local_publish_root"] = options.localPublishRoot
+            }
             let result = try await performModelOperation(
                 modelID: options.modelID,
                 operation: "upload",
@@ -4535,6 +4557,12 @@ public actor MelixCLIRunner {
             if !options.artifactManifestPath.isEmpty {
                 ext["artifact_manifest_path"] = options.artifactManifestPath
             }
+            if !options.publishBackend.isEmpty {
+                ext["publish_backend"] = options.publishBackend
+            }
+            if !options.localPublishRoot.isEmpty {
+                ext["local_publish_root"] = options.localPublishRoot
+            }
             let result = try await performModelOperation(
                 modelID: options.modelID,
                 operation: "upload",
@@ -4978,6 +5006,8 @@ public actor MelixCLIRunner {
                         appendOption("--merged-model-path", value: artifactPath, into: &arguments)
                     }
                 }
+                appendOption("--publish-backend", value: ext["publish_backend"], into: &arguments)
+                appendOption("--local-publish-root", value: ext["local_publish_root"], into: &arguments)
                 arguments.append("--json")
                 return arguments
             }
@@ -4989,6 +5019,8 @@ public actor MelixCLIRunner {
             appendOption("--artifact-path", value: ext["artifact_path"], into: &arguments)
             appendOption("--artifact-kind", value: ext["artifact_kind"], into: &arguments)
             appendOption("--artifact-manifest-path", value: ext["artifact_manifest_path"], into: &arguments)
+            appendOption("--publish-backend", value: ext["publish_backend"], into: &arguments)
+            appendOption("--local-publish-root", value: ext["local_publish_root"], into: &arguments)
             arguments.append("--json")
             return arguments
         default:

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -194,6 +194,8 @@ public enum MelixCLICommandCodec {
             appendOption("--calibration-dataset-uri", value: options.calibrationDatasetURI, into: &arguments)
             appendOption("--quality-delta", value: options.qualityDelta, into: &arguments)
             appendOption("--latency-delta", value: options.latencyDelta, into: &arguments)
+            appendOption("--local-inference-smoke-mode", value: options.localInferenceSmokeMode, into: &arguments)
+            appendOption("--local-inference-smoke-prompt", value: options.localInferenceSmokePrompt, into: &arguments)
             json = options.json
         case .upload(let options):
             arguments = ["upload"]

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -203,6 +203,8 @@ public enum MelixCLICommandCodec {
             appendOption("--artifact-path", value: options.artifactPath, into: &arguments)
             appendOption("--artifact-kind", value: options.artifactKind, into: &arguments)
             appendOption("--artifact-manifest-path", value: options.artifactManifestPath, into: &arguments)
+            appendOption("--publish-backend", value: options.publishBackend, into: &arguments)
+            appendOption("--local-publish-root", value: options.localPublishRoot, into: &arguments)
             json = options.json
         case .modelImport(let options):
             arguments = ["model", "import"]
@@ -409,6 +411,8 @@ public enum MelixCLICommandCodec {
                 // runner; emit only `--manifest-path` and the runner infers.
                 appendOption("--manifest-path", value: options.artifactManifestPath, into: &arguments)
             }
+            appendOption("--publish-backend", value: options.publishBackend, into: &arguments)
+            appendOption("--local-publish-root", value: options.localPublishRoot, into: &arguments)
             json = options.json
         case .benchRun(let options):
             arguments = ["bench", "run"]

--- a/Sources/MelixCLICore/MelixPipelineRunner.swift
+++ b/Sources/MelixCLICore/MelixPipelineRunner.swift
@@ -852,6 +852,41 @@ private enum MelixPipelineCommandBuilder {
     static func command(named name: String, args: [String: Any]) throws -> MelixCLICommand {
         try validateSupportedCommand(named: name)
         switch name {
+        case "convert":
+            return .convert(
+                ConvertOptions(
+                    modelID: try requiredString("model_id", args),
+                    outputDir: string("output_dir", args) ?? "",
+                    targetFormat: string("target_format", args) ?? "melix_model_bundle"
+                )
+            )
+        case "quantize":
+            return .quantize(
+                QuantizeOptions(
+                    modelID: try requiredString("model_id", args),
+                    outputDir: string("output_dir", args) ?? "",
+                    quantProfileID: string("quant_profile_id", args) ?? "",
+                    weightQuant: string("weight_quant", args) ?? "",
+                    kvQuant: string("kv_quant", args) ?? "",
+                    quantizationMode: try quantizationMode(args),
+                    sourceArtifactKind: try sourceArtifactKind(args),
+                    sourceArtifactPath: string("source_artifact_path", args) ?? "",
+                    calibrationDatasetURI: string("calibration_dataset_uri", args) ?? "",
+                    qualityDelta: string("quality_delta", args) ?? "",
+                    latencyDelta: string("latency_delta", args) ?? ""
+                )
+            )
+        case "upload":
+            return .upload(
+                UploadOptions(
+                    modelID: try requiredString("model_id", args),
+                    outputDir: string("output_dir", args) ?? "",
+                    targetRepo: try requiredString("target_repo", args),
+                    artifactPath: string("artifact_path", args) ?? "",
+                    artifactKind: string("artifact_kind", args) ?? "",
+                    artifactManifestPath: string("artifact_manifest_path", args) ?? ""
+                )
+            )
         case "model.import":
             return .modelImport(
                 ModelImportOptions(
@@ -926,6 +961,27 @@ private enum MelixPipelineCommandBuilder {
                     ])
                 )
             )
+        case "alignment.train":
+            return .alignmentTrain(
+                AlignmentTrainOptions(
+                    modelID: try requiredString("model_id", args),
+                    datasetSourceKind: datasetSourceKind(args),
+                    datasetURI: try datasetURI(args),
+                    adapterName: try requiredString("adapter_name", args),
+                    targetRepo: string("target_repo", args) ?? "",
+                    algorithm: try alignmentAlgorithm(args),
+                    parameters: parameters(args, excluding: [
+                        "model_id",
+                        "dataset_uri",
+                        "hf_dataset_path",
+                        "adapter_name",
+                        "target_repo",
+                        "algorithm",
+                        "alignment_algorithm",
+                        "training_mode",
+                    ])
+                )
+            )
         case "lora.activate":
             return .loraActivate(
                 LoraActivateOptions(
@@ -935,6 +991,8 @@ private enum MelixPipelineCommandBuilder {
                     activationMode: string("activation_mode", args) ?? ""
                 )
             )
+        case "lora.publish":
+            return try .loraPublish(loraPublishOptions(args))
         case "bench.run":
             return .benchRun(
                 BenchRunOptions(
@@ -1040,6 +1098,9 @@ private enum MelixPipelineCommandBuilder {
     }
 
     private static let supportedCommandNames: Set<String> = [
+        "convert",
+        "quantize",
+        "upload",
         "model.import",
         "model.hub.download",
         "model.roots.rescan",
@@ -1048,7 +1109,9 @@ private enum MelixPipelineCommandBuilder {
         "server.start",
         "chat.run",
         "lora.train",
+        "alignment.train",
         "lora.activate",
+        "lora.publish",
         "bench.run",
         "bench.matrix.run",
         "bench.export-csv",
@@ -1059,6 +1122,114 @@ private enum MelixPipelineCommandBuilder {
         "eval.export-samples-csv",
         "eval.export-samples-jsonl",
     ]
+
+    private static func alignmentAlgorithm(_ args: [String: Any]) throws -> String {
+        let algorithm = (string("algorithm", args) ?? string("alignment_algorithm", args) ?? string("training_mode", args) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard algorithm.isEmpty == false else {
+            throw MelixCLIError.missingRequired("Pipeline command argument algorithm is required.")
+        }
+        guard ["dpo", "orpo", "cpo", "grpo", "rlhf"].contains(algorithm) else {
+            throw MelixCLIError.usage("Pipeline command argument algorithm must be one of: dpo, orpo, cpo, grpo, rlhf.")
+        }
+        return algorithm
+    }
+
+    private static func quantizationMode(_ args: [String: Any]) throws -> String {
+        let mode = string("quantization_mode", args) ?? ""
+        guard mode.isEmpty || ["ptq", "qat"].contains(mode) else {
+            throw MelixCLIError.usage("Pipeline command argument quantization_mode must be one of: ptq, qat.")
+        }
+        return mode
+    }
+
+    private static func sourceArtifactKind(_ args: [String: Any]) throws -> String {
+        let kind = string("source_artifact_kind", args) ?? ""
+        guard kind.isEmpty || ["base_model", "merged_adapter", "adapter_export"].contains(kind) else {
+            throw MelixCLIError.usage("Pipeline command argument source_artifact_kind must be one of: base_model, merged_adapter, adapter_export.")
+        }
+        return kind
+    }
+
+    private static func loraPublishOptions(_ args: [String: Any]) throws -> LoraPublishOptions {
+        let modelID = try requiredString("model_id", args)
+        let targetRepo = try requiredString("target_repo", args)
+        let exportKind = try loraPublishExportKind(args)
+        let adapterPath = string("adapter_path", args) ?? ""
+        let mergedModelPath = string("merged_model_path", args) ?? ""
+        let manifestPath = string("manifest_path", args) ?? ""
+        let artifactPath = string("artifact_path", args) ?? ""
+        let selectedCount = [adapterPath, mergedModelPath, manifestPath, artifactPath]
+            .filter { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false }
+            .count
+        guard selectedCount == 1 else {
+            throw MelixCLIError.missingRequired(
+                "Exactly one of adapter_path, merged_model_path, manifest_path, or artifact_path is required for pipeline command lora.publish."
+            )
+        }
+
+        if adapterPath.isEmpty == false {
+            if exportKind == .mergedExport {
+                throw MelixCLIError.usage("Pipeline command argument export_kind merged is incompatible with adapter_path.")
+            }
+            return LoraPublishOptions(
+                modelID: modelID,
+                targetRepo: targetRepo,
+                exportKind: .adapterExport,
+                artifactPath: adapterPath,
+                artifactManifestPath: adapterPath
+            )
+        }
+        if mergedModelPath.isEmpty == false {
+            if exportKind == .adapterExport {
+                throw MelixCLIError.usage("Pipeline command argument export_kind adapter is incompatible with merged_model_path.")
+            }
+            return LoraPublishOptions(
+                modelID: modelID,
+                targetRepo: targetRepo,
+                exportKind: .mergedExport,
+                artifactPath: mergedModelPath
+            )
+        }
+        if manifestPath.isEmpty == false {
+            return LoraPublishOptions(
+                modelID: modelID,
+                targetRepo: targetRepo,
+                exportKind: exportKind,
+                artifactPath: manifestPath,
+                artifactManifestPath: manifestPath
+            )
+        }
+        guard let exportKind else {
+            throw MelixCLIError.missingRequired(
+                "Pipeline command argument export_kind is required when lora.publish uses artifact_path."
+            )
+        }
+        return LoraPublishOptions(
+            modelID: modelID,
+            targetRepo: targetRepo,
+            exportKind: exportKind,
+            artifactPath: artifactPath,
+            artifactManifestPath: string("artifact_manifest_path", args) ?? artifactPath
+        )
+    }
+
+    private static func loraPublishExportKind(_ args: [String: Any]) throws -> LoraPublishExportKind? {
+        guard let rawKind = string("export_kind", args),
+              rawKind.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        else {
+            return nil
+        }
+        switch rawKind {
+        case "adapter", "adapter_export":
+            return .adapterExport
+        case "merged", "merged_export":
+            return .mergedExport
+        default:
+            throw MelixCLIError.usage("Pipeline command argument export_kind must be one of: adapter, merged.")
+        }
+    }
 
     private static func requiredString(_ key: String, _ args: [String: Any]) throws -> String {
         guard let value = string(key, args), value.isEmpty == false else {

--- a/Sources/MelixCLICore/MelixPipelineRunner.swift
+++ b/Sources/MelixCLICore/MelixPipelineRunner.swift
@@ -893,7 +893,9 @@ private enum MelixPipelineCommandBuilder {
                     sourceArtifactPath: string("source_artifact_path", args) ?? "",
                     calibrationDatasetURI: string("calibration_dataset_uri", args) ?? "",
                     qualityDelta: string("quality_delta", args) ?? "",
-                    latencyDelta: string("latency_delta", args) ?? ""
+                    latencyDelta: string("latency_delta", args) ?? "",
+                    localInferenceSmokeMode: try localInferenceSmokeMode(args),
+                    localInferenceSmokePrompt: string("local_inference_smoke_prompt", args) ?? ""
                 )
             )
         case "upload":
@@ -1177,6 +1179,16 @@ private enum MelixPipelineCommandBuilder {
             throw MelixCLIError.usage("Pipeline command argument source_artifact_kind must be one of: base_model, merged_adapter, adapter_export.")
         }
         return kind
+    }
+
+    private static func localInferenceSmokeMode(_ args: [String: Any]) throws -> String {
+        let mode = (string("local_inference_smoke_mode", args) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard mode.isEmpty || ["structural", "runtime_generate"].contains(mode) else {
+            throw MelixCLIError.usage("Pipeline command argument local_inference_smoke_mode must be one of: structural, runtime_generate.")
+        }
+        return mode
     }
 
     private static func loraPublishOptions(_ args: [String: Any]) throws -> LoraPublishOptions {

--- a/Sources/MelixCLICore/MelixPipelineRunner.swift
+++ b/Sources/MelixCLICore/MelixPipelineRunner.swift
@@ -974,6 +974,7 @@ private enum MelixPipelineCommandBuilder {
                         "model_id",
                         "dataset_uri",
                         "hf_dataset_path",
+                        "dataset_source_kind",
                         "adapter_name",
                         "target_repo",
                         "algorithm",
@@ -1137,7 +1138,9 @@ private enum MelixPipelineCommandBuilder {
     }
 
     private static func quantizationMode(_ args: [String: Any]) throws -> String {
-        let mode = string("quantization_mode", args) ?? ""
+        let mode = (string("quantization_mode", args) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
         guard mode.isEmpty || ["ptq", "qat"].contains(mode) else {
             throw MelixCLIError.usage("Pipeline command argument quantization_mode must be one of: ptq, qat.")
         }
@@ -1145,7 +1148,9 @@ private enum MelixPipelineCommandBuilder {
     }
 
     private static func sourceArtifactKind(_ args: [String: Any]) throws -> String {
-        let kind = string("source_artifact_kind", args) ?? ""
+        let kind = (string("source_artifact_kind", args) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
         guard kind.isEmpty || ["base_model", "merged_adapter", "adapter_export"].contains(kind) else {
             throw MelixCLIError.usage("Pipeline command argument source_artifact_kind must be one of: base_model, merged_adapter, adapter_export.")
         }
@@ -1156,12 +1161,12 @@ private enum MelixPipelineCommandBuilder {
         let modelID = try requiredString("model_id", args)
         let targetRepo = try requiredString("target_repo", args)
         let exportKind = try loraPublishExportKind(args)
-        let adapterPath = string("adapter_path", args) ?? ""
-        let mergedModelPath = string("merged_model_path", args) ?? ""
-        let manifestPath = string("manifest_path", args) ?? ""
-        let artifactPath = string("artifact_path", args) ?? ""
+        let adapterPath = (string("adapter_path", args) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let mergedModelPath = (string("merged_model_path", args) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let manifestPath = (string("manifest_path", args) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let artifactPath = (string("artifact_path", args) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let selectedCount = [adapterPath, mergedModelPath, manifestPath, artifactPath]
-            .filter { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false }
+            .filter { $0.isEmpty == false }
             .count
         guard selectedCount == 1 else {
             throw MelixCLIError.missingRequired(
@@ -1211,14 +1216,16 @@ private enum MelixPipelineCommandBuilder {
             targetRepo: targetRepo,
             exportKind: exportKind,
             artifactPath: artifactPath,
-            artifactManifestPath: string("artifact_manifest_path", args) ?? artifactPath
+            artifactManifestPath: (string("artifact_manifest_path", args) ?? artifactPath)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
         )
     }
 
     private static func loraPublishExportKind(_ args: [String: Any]) throws -> LoraPublishExportKind? {
-        guard let rawKind = string("export_kind", args),
-              rawKind.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-        else {
+        let rawKind = (string("export_kind", args) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard rawKind.isEmpty == false else {
             return nil
         }
         switch rawKind {

--- a/Sources/MelixCLICore/MelixPipelineRunner.swift
+++ b/Sources/MelixCLICore/MelixPipelineRunner.swift
@@ -145,7 +145,7 @@ extension MelixCLIRunner {
                             expectedMetadata: metadata,
                             allowedStatuses: options.dryRun ? ["planned", "skipped", "succeeded"] : ["succeeded", "skipped"]
                         )
-                        context.setStepEnvelope(receipt, for: step.id)
+                        context.setStepEnvelope(normalizedResultEnvelope(receipt), for: step.id)
                         stepSummaries.append(
                             stepSummary(
                                 step,
@@ -171,7 +171,7 @@ extension MelixCLIRunner {
                         expectedMetadata: metadata,
                         allowedStatuses: ["succeeded"]
                     )
-                    context.setStepEnvelope(receipt, for: step.id)
+                    context.setStepEnvelope(normalizedResultEnvelope(receipt), for: step.id)
                     resumeSkippedCount += 1
                     metrics["melix.pipeline.resume_skipped_count"] = Double(resumeSkippedCount)
                     stepSummaries.append(
@@ -231,9 +231,9 @@ extension MelixCLIRunner {
                     guard let parsedEnvelope = MelixPipelineJSON.object(from: output) else {
                         throw MelixCLIError.runtime("Step \(step.id) did not return a JSON envelope.")
                     }
-                    context.setStepEnvelope(parsedEnvelope, for: step.id)
-                    try MelixPipelineChecks.validate(step.checks, envelope: parsedEnvelope, context: context)
-                    envelope = parsedEnvelope
+                    envelope = normalizedResultEnvelope(parsedEnvelope)
+                    context.setStepEnvelope(envelope, for: step.id)
+                    try MelixPipelineChecks.validate(step.checks, envelope: envelope, context: context)
                 }
                 envelope = attachStepMetadata(metadata, to: envelope)
 
@@ -494,6 +494,26 @@ extension MelixCLIRunner {
             return
         }
         paths.append(path)
+    }
+
+    private func normalizedResultEnvelope(_ envelope: [String: Any]) -> [String: Any] {
+        guard var result = envelope["result"] as? [String: Any],
+              (result["output_path"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false
+        else {
+            return envelope
+        }
+        for alias in ["artifact_path", "bundle_path", "managed_model_path", "report_path"] {
+            guard let outputPath = result[alias] as? String,
+                  outputPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            else {
+                continue
+            }
+            result["output_path"] = outputPath
+            var normalized = envelope
+            normalized["result"] = result
+            return normalized
+        }
+        return envelope
     }
 
     private func runSummary(
@@ -884,7 +904,9 @@ private enum MelixPipelineCommandBuilder {
                     targetRepo: try requiredString("target_repo", args),
                     artifactPath: string("artifact_path", args) ?? "",
                     artifactKind: string("artifact_kind", args) ?? "",
-                    artifactManifestPath: string("artifact_manifest_path", args) ?? ""
+                    artifactManifestPath: string("artifact_manifest_path", args) ?? "",
+                    publishBackend: string("publish_backend", args) ?? "",
+                    localPublishRoot: string("local_publish_root", args) ?? ""
                 )
             )
         case "model.import":
@@ -1183,7 +1205,9 @@ private enum MelixPipelineCommandBuilder {
                 targetRepo: targetRepo,
                 exportKind: .adapterExport,
                 artifactPath: adapterPath,
-                artifactManifestPath: adapterPath
+                artifactManifestPath: adapterPath,
+                publishBackend: string("publish_backend", args) ?? "",
+                localPublishRoot: string("local_publish_root", args) ?? ""
             )
         }
         if mergedModelPath.isEmpty == false {
@@ -1194,7 +1218,9 @@ private enum MelixPipelineCommandBuilder {
                 modelID: modelID,
                 targetRepo: targetRepo,
                 exportKind: .mergedExport,
-                artifactPath: mergedModelPath
+                artifactPath: mergedModelPath,
+                publishBackend: string("publish_backend", args) ?? "",
+                localPublishRoot: string("local_publish_root", args) ?? ""
             )
         }
         if manifestPath.isEmpty == false {
@@ -1203,7 +1229,9 @@ private enum MelixPipelineCommandBuilder {
                 targetRepo: targetRepo,
                 exportKind: exportKind,
                 artifactPath: manifestPath,
-                artifactManifestPath: manifestPath
+                artifactManifestPath: manifestPath,
+                publishBackend: string("publish_backend", args) ?? "",
+                localPublishRoot: string("local_publish_root", args) ?? ""
             )
         }
         guard let exportKind else {
@@ -1217,7 +1245,9 @@ private enum MelixPipelineCommandBuilder {
             exportKind: exportKind,
             artifactPath: artifactPath,
             artifactManifestPath: (string("artifact_manifest_path", args) ?? artifactPath)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            publishBackend: string("publish_backend", args) ?? "",
+            localPublishRoot: string("local_publish_root", args) ?? ""
         )
     }
 

--- a/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
+++ b/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
@@ -37,10 +37,17 @@ local runtime acceptance requirements.
 - Add an Issue 365 CLI acceptance bundle harness that writes a machine-readable
   matrix for every required CLI chain and separates planning, deterministic
   dry-run, and real-local-runtime evidence.
+- Add real-local-runtime preflight evidence to the acceptance bundle so `real`
+  mode records missing CLI, dataset, calibration, and reward-model prerequisites
+  as machine-readable blockers before launching long-running pipeline cases.
+- Add `--case-id` selection for the acceptance bundle so operators can run a
+  real local runtime subset without requiring unused business-line inputs.
 
 ### Excluded
 
-- Real local runtime acceptance for every business line.
+- Real local runtime acceptance for every business line. This slice can preflight
+  and run real-mode cases, but it does not provide the required local model,
+  dataset, reward-model, or runtime evidence bundle for all cases.
 - GRPO candidate generation from a live policy runtime.
 - RLHF reward-model integration from issue 366.
 - QAT trainer/export implementation.
@@ -49,9 +56,10 @@ local runtime acceptance requirements.
 
 ## Performance And Metrics
 
-This slice changes command construction and dry-run planning only. It should not
-add model execution, background polling, or file-system scans beyond the
-existing pipeline receipt writes.
+This slice changes command construction, acceptance planning, and real-mode
+preflight only. It should not add model execution in plan/dry-run mode,
+background polling, or broad file-system scans beyond checking the explicit CLI
+and input paths that the operator passes to the acceptance bundle.
 
 Success metrics:
 
@@ -62,6 +70,12 @@ Success metrics:
 - Existing pipeline resume, check, and reference behavior remains unchanged.
 - The Issue 365 acceptance bundle must mark plan-only and dry-run evidence as
   not release-ready even when every planned pipeline case is covered.
+- The Issue 365 acceptance bundle must mark real-mode cases as `blocked` when
+  required local prerequisites are missing, and must record the blocker codes in
+  the bundle rather than invoking long-running pipelines that cannot succeed.
+- Real-mode subset runs must only preflight the selected case inputs, so a LoRA
+  subset can run without requiring unused RLHF reward-model or quantization
+  calibration artifacts.
 - Changed-line coverage for the touched Swift/doc scope is at least 95 percent.
 
 ## Verification
@@ -100,6 +114,27 @@ python3 scripts/python_changed_line_coverage.py \
 Expected changed-line coverage target: at least 95 percent for the changed
 Swift scope. Documentation-only lines are reported as N/A when the coverage
 tool does not map them to executable statements.
+
+Results on 2026-05-06 after adding real-mode preflight and case selection:
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q tests/integration/test_issue365_acceptance_bundle.py`:
+  13 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_issue365_acceptance_bundle.py`:
+  13 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-cli-acceptance-bundle-coverage.json`:
+  wrote JSON coverage.
+- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-cli-acceptance-bundle-coverage.json --diff-from origin/main scripts/issue365_acceptance_bundle.py tests/integration/test_issue365_acceptance_bundle.py docs/plans/2026-05-05-issue-365-cli-chain-routing.md`:
+  97.30 percent total changed-line coverage, 469/482 executable lines.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python python -m compileall -q scripts/issue365_acceptance_bundle.py tests/integration/test_issue365_acceptance_bundle.py`:
+  passed.
+- `python3 scripts/issue365_acceptance_bundle.py --execution-mode plan --output-dir .runtime/issue365/acceptance-smoke --timestamp 2026-05-06T010000Z --json`:
+  wrote a plan bundle with 10 planned cases, 0 blocked cases, and
+  `release_ready=false`.
+- `python3 scripts/issue365_acceptance_bundle.py --execution-mode dry-run --melix-cli .build/arm64-apple-macosx/debug/melix --output-dir .runtime/issue365/acceptance-dry-run --timestamp 2026-05-06T010000Z`:
+  wrote a dry-run bundle with 10 succeeded cases, 0 failed cases, 0 blocked
+  cases, and `release_ready=false`.
+- `swift test --filter 'MelixCLIRunnerTests|MelixCLIParserTests'`:
+  212 tests passed in 3 suites.
 
 Results on 2026-05-05 after adding the acceptance bundle harness:
 

--- a/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
+++ b/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
@@ -113,6 +113,9 @@ Results on 2026-05-05 after adding the acceptance bundle harness:
   99.37 percent total changed-line coverage, 316/318 executable lines.
 - `python3 scripts/issue365_acceptance_bundle.py --execution-mode plan --output-dir .runtime/issue365/acceptance-smoke --timestamp 2026-05-05T000000Z --json`:
   wrote a plan bundle with 10 planned cases and `release_ready=false`.
+- `python3 scripts/issue365_acceptance_bundle.py --execution-mode dry-run --melix-cli .build/arm64-apple-macosx/debug/melix --output-dir .runtime/issue365/acceptance-dry-run --timestamp 2026-05-05T000000Z --json`:
+  passed with 10 succeeded dry-run cases, 0 failures, and
+  `release_ready=false`.
 - `swift test --filter 'MelixCLIRunnerTests|MelixCLIParserTests'`:
   212 tests passed in 3 suites. Existing `try await store.save` warnings
   remain.

--- a/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
+++ b/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
@@ -58,6 +58,14 @@ local runtime acceptance requirements.
   single-process DPO, ORPO, and CPO real-runtime runs do not fail when the
   upstream trainer passes `mx.distributed.init()` into the custom preference
   batch iterator.
+- Add public `melix quantize` and pipeline routing for
+  `--local-inference-smoke-mode` and `--local-inference-smoke-prompt` so PTQ
+  and QAT acceptance can request the quantization pipeline's own typed
+  `runtime_generate` local inference evidence.
+- Route PTQ/QAT acceptance through the quantized bundle manifest's
+  `local_inference_smoke` and `release_gate.local_inference_smoke_result`
+  checks instead of treating `quantized_model_bundle` directories as generic
+  `chat.run` targets.
 
 ### Excluded
 
@@ -97,6 +105,9 @@ Success metrics:
 - Real local LoRA, QLoRA, DoRA, DPO, ORPO, and CPO subset evidence proves the
   fixed chain can complete: training, local publish receipt, direct adapter
   activation, chat smoke, and eval smoke.
+- Quantized PTQ/QAT real-mode subsets must not be marked successful unless the
+  quantize step reports `local_runtime_generate` smoke evidence with
+  `status=passed` and `release_gate.local_inference_smoke_result=passed`.
 
 ## Verification
 
@@ -226,6 +237,47 @@ running the remaining supervised/preference real-mode subsets:
 - `MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-dpo" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-swift.sock" bash scripts/dev_down.sh`:
   stopped the named real local preference runtime stack.
 
+Results on 2026-05-06 after routing quantize runtime smoke through public CLI
+and pipeline options:
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q tests/integration/test_issue365_acceptance_bundle.py`:
+  13 passed.
+- `swift test --filter 'MelixCLIParserTests|MelixCLIRunnerTests'`:
+  213 tests passed in 3 suites.
+- `swift test --enable-code-coverage --filter 'MelixCLIRunnerTests|MelixCLIParserTests'`:
+  213 tests passed in 3 suites and wrote Swift coverage data.
+- `python3 scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/MelixPackageTests.xctest/Contents/MacOS/MelixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main Sources/MelixCLICore/MelixCLI.swift Sources/MelixCLICore/MelixCLICommandCodec.swift Sources/MelixCLICore/MelixPipelineRunner.swift tests/MelixCLITests/MelixCLIParserTests.swift tests/MelixCLITests/MelixCLIRunnerTests.swift docs/plans/2026-05-05-issue-365-cli-chain-routing.md`:
+  99.48 percent total changed-line coverage, 962/967 executable lines.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_issue365_acceptance_bundle.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py`:
+  273 passed with 2 warnings from MLX SWIG types.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-cli-chain-routing-python-coverage.json`:
+  wrote JSON coverage.
+- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-cli-chain-routing-python-coverage.json --diff-from origin/main scripts/issue365_acceptance_bundle.py services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/worker/model_ops/preference_training.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py tests/integration/test_issue365_acceptance_bundle.py docs/plans/2026-05-05-issue-365-cli-chain-routing.md`:
+  97.80 percent total changed-line coverage, 621/635 executable lines.
+- `python3 scripts/issue365_acceptance_bundle.py --execution-mode plan --output-dir .runtime/issue365/acceptance-plan-runtime-smoke --timestamp 2026-05-06T170000Z --json`:
+  wrote a plan bundle with 10 planned cases and `release_ready=false`.
+- `python3 scripts/issue365_acceptance_bundle.py --execution-mode dry-run --melix-cli .build/arm64-apple-macosx/debug/melix --output-dir .runtime/issue365/acceptance-dry-run-runtime-smoke --timestamp 2026-05-06T170500Z --json`:
+  wrote a dry-run bundle with 10 succeeded cases, 0 failed cases, 0 blocked
+  cases, and `release_ready=false`.
+- `MELIX_SERVICE_INSTANCE_NAME=issue365-real-ptq-runtime-smoke MELIX_HTTP_PORT=12472 MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-ptq-runtime-smoke" MELIX_HOME="$PWD/.runtime/home-issue365-real-ptq-runtime-smoke" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-ptq-runtime-smoke-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-ptq-runtime-smoke-swift.sock" bash scripts/dev_up.sh --prefer-built`:
+  started a named real local runtime stack for the PTQ runtime smoke probe.
+- `MELIX_HOME="$PWD/.runtime/home-issue365-real-ptq-runtime-smoke" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-ptq-runtime-smoke-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-ptq-runtime-smoke-swift.sock" MELIX_HTTP_PORT=12472 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id lora_preference_ptq_quantized_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --preference-dataset-uri "$PWD/.runtime/issue365/input-datasets/preference_pair" --calibration-dataset-uri "$PWD/.runtime/issue365/input-datasets/calibration" --output-dir .runtime/issue365/real-ptq-runtime-smoke-probe --timestamp 2026-05-06T171500Z --json`:
+  failed as expected because the quantize step's `runtime_generate` local
+  inference smoke did not pass; the selected case has `status=failed` and
+  `release_ready=false`.
+- `.runtime/issue365/real-ptq-runtime-smoke-probe/artifacts/ptq/model-ops-0015/quantize.artifact/manifest.json`:
+  recorded `local_inference_smoke.evidence_kind=local_runtime_generate`,
+  `local_inference_smoke.smoke_mode=runtime_generate`,
+  `local_inference_smoke.status=failed`,
+  `release_gate.local_inference_smoke_result=failed`, and failure reason
+  `No safetensors found in .../quantize.artifact`.
+- `MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-ptq-runtime-smoke" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-ptq-runtime-smoke-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-ptq-runtime-smoke-swift.sock" bash scripts/dev_down.sh`:
+  stopped the named PTQ runtime smoke stack.
+- `find .runtime -type f \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.webp' \) -print`:
+  passed with no generated screenshot artifacts found.
+- `git diff --check`:
+  passed.
+
 Results on 2026-05-05 after adding the acceptance bundle harness:
 
 - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q tests/integration/test_issue365_acceptance_bundle.py`:
@@ -261,6 +313,10 @@ Results on 2026-05-05 after adding the acceptance bundle harness:
   real local runtime evidence: `lora_grpo_export_inference`,
   `lora_rlhf_export_inference`, `lora_preference_ptq_quantized_inference`, and
   `qat_quantized_inference`.
+- The latest `lora_preference_ptq_quantized_inference` real probe is
+  intentionally counted as failed evidence, not completion evidence, because
+  the quantize step recorded failed `runtime_generate` smoke and
+  `release_gate.local_inference_smoke_result=failed`.
 - Window UI runnable/inspectable acceptance for every listed business line.
 - Final release evidence that separates deterministic/unit/scored-trace results
   from real local runtime results.

--- a/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
+++ b/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
@@ -1,0 +1,100 @@
+# Issue 365 CLI Chain Routing Slice
+
+## Goal
+
+Continue the implementation path for
+https://github.com/Keith-CY/melix/issues/365 by making `melix pipeline run`
+able to describe the post-training CLI chain in one machine-readable workflow:
+adapter training, alignment training, export/publish, quantization, activation,
+local chat smoke, and evaluation/benchmark evidence.
+
+Issue 365 is still not complete after this slice. This work adds pipeline
+routing and fast dry-run chain coverage; it does not replace the remaining real
+local runtime acceptance requirements.
+
+## Scope
+
+### Included
+
+- Add `alignment.train` support to the pipeline command builder so DPO, ORPO,
+  CPO, GRPO, and RLHF alignment runs are addressable outside `lora.train`.
+- Add post-training model operation routing for `lora.publish`, `quantize`,
+  `convert`, and `upload` pipeline steps.
+- Preserve existing pipeline behavior for `lora.train`, `lora.activate`,
+  `chat.run`, bench, and eval steps.
+- Add dry-run coverage proving a post-training chain can be planned with
+  step-to-step artifact references across:
+  - `lora.train`
+  - `alignment.train`
+  - `lora.publish`
+  - `quantize`
+  - `lora.activate`
+  - `chat.run`
+  - eval or bench evidence steps
+- Keep screenshot cleanup scoped to temporary generated screenshot artifacts
+  only. Tracked app branding images, evaluation fixtures, docs, and source
+  files are not cleanup targets.
+
+### Excluded
+
+- Real local runtime acceptance for every business line.
+- GRPO candidate generation from a live policy runtime.
+- RLHF reward-model integration from issue 366.
+- QAT trainer/export implementation.
+- Native Window UI acceptance.
+- Closing issue 365.
+
+## Performance And Metrics
+
+This slice changes command construction and dry-run planning only. It should not
+add model execution, background polling, or file-system scans beyond the
+existing pipeline receipt writes.
+
+Success metrics:
+
+- Pipeline command construction keeps using typed Swift options rather than
+  shell string concatenation.
+- Pipeline dry-run receipts include stable command IDs for the new post-training
+  steps.
+- Existing pipeline resume, check, and reference behavior remains unchanged.
+- Changed-line coverage for the touched Swift/doc scope is at least 95 percent.
+
+## Verification
+
+Targeted commands:
+
+```bash
+swift test --filter MelixCLIRunnerTests
+swift test --filter MelixCLIParserTests
+git diff --check
+```
+
+Coverage and metrics:
+
+```bash
+swift test --enable-code-coverage --filter 'MelixCLIRunnerTests|MelixCLIParserTests'
+python3 scripts/swift_changed_line_coverage.py \
+  --binary .build/arm64-apple-macosx/debug/MelixPackageTests.xctest/Contents/MacOS/MelixPackageTests \
+  --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata \
+  --diff-from origin/main \
+  Sources/MelixCLICore/MelixPipelineRunner.swift \
+  tests/MelixCLITests/MelixCLIRunnerTests.swift \
+  tests/MelixCLITests/MelixCLIParserTests.swift \
+  docs/plans/2026-05-05-issue-365-cli-chain-routing.md
+```
+
+Expected changed-line coverage target: at least 95 percent for the changed
+Swift scope. Documentation-only lines are reported as N/A when the coverage
+tool does not map them to executable statements.
+
+## Remaining Issue 365 Gaps
+
+- Real GRPO policy-runtime candidate generation, scoring, and policy updates.
+- RLHF reward-model inference and PPO/reward-guided update integration from
+  issue 366.
+- QAT training and QAT-aware quantized export.
+- Full CLI chain tests backed by real local runtime evidence for every listed
+  business line.
+- Window UI runnable/inspectable acceptance for every listed business line.
+- Final release evidence that separates deterministic/unit/scored-trace results
+  from real local runtime results.

--- a/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
+++ b/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
@@ -42,6 +42,18 @@ local runtime acceptance requirements.
   as machine-readable blockers before launching long-running pipeline cases.
 - Add `--case-id` selection for the acceptance bundle so operators can run a
   real local runtime subset without requiring unused business-line inputs.
+- Add a local-filesystem publish backend for real local acceptance runs so
+  `lora.publish` can produce publish receipts without requiring networked
+  Hugging Face credentials.
+- Preserve real-runtime adapter activation by activating the trained or aligned
+  adapter manifest directly, while still publishing a receipt as evidence.
+- Normalize successful pipeline result envelopes so downstream steps can refer
+  to `result.output_path` even when a command reports an artifact-specific path
+  such as `artifact_path`, `bundle_path`, `managed_model_path`, or `report_path`.
+- Fix MLX text runtime stop handling so stop sequences are only forwarded to
+  `mlx_lm.utils.stream_generate` when the callable declares the specific stop
+  keyword. This avoids passing unsupported `stop` kwargs through a variadic
+  wrapper to installed `mlx-lm` versions whose generation step rejects them.
 
 ### Excluded
 
@@ -77,6 +89,10 @@ Success metrics:
   subset can run without requiring unused RLHF reward-model or quantization
   calibration artifacts.
 - Changed-line coverage for the touched Swift/doc scope is at least 95 percent.
+- Changed-line coverage for the touched Python scope is at least 95 percent.
+- Real local LoRA subset evidence proves the fixed chain can complete:
+  training, local publish receipt, direct adapter activation, chat smoke, and
+  eval smoke.
 
 ## Verification
 
@@ -136,6 +152,35 @@ Results on 2026-05-06 after adding real-mode preflight and case selection:
 - `swift test --filter 'MelixCLIRunnerTests|MelixCLIParserTests'`:
   212 tests passed in 3 suites.
 
+Results on 2026-05-06 after adding local publish, pipeline output-path
+normalization, direct adapter activation, and the MLX stop-kwarg fix:
+
+- `swift test --filter 'MelixCLIRunnerTests|MelixCLIParserTests'`:
+  213 tests passed in 3 suites.
+- `swift test --enable-code-coverage --filter 'MelixCLIRunnerTests|MelixCLIParserTests'`:
+  213 tests passed in 3 suites and wrote Swift coverage data.
+- `python3 scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/MelixPackageTests.xctest/Contents/MacOS/MelixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main Sources/MelixCLICore/MelixCLI.swift Sources/MelixCLICore/MelixCLICommandCodec.swift Sources/MelixCLICore/MelixPipelineRunner.swift tests/MelixCLITests/MelixCLIParserTests.swift tests/MelixCLITests/MelixCLIRunnerTests.swift docs/plans/2026-05-05-issue-365-cli-chain-routing.md`:
+  99.44 percent total changed-line coverage, 880/885 executable lines.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q tests/integration/test_issue365_acceptance_bundle.py`:
+  13 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_issue365_acceptance_bundle.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_mlx_backend.py`:
+  196 passed.
+- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-cli-chain-routing-python-coverage.json --diff-from origin/main scripts/issue365_acceptance_bundle.py services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_mlx_backend.py tests/integration/test_issue365_acceptance_bundle.py docs/plans/2026-05-05-issue-365-cli-chain-routing.md`:
+  97.65 percent total changed-line coverage, 582/596 executable lines.
+- `MELIX_SERVICE_INSTANCE_NAME=issue365-real MELIX_HTTP_PORT=12465 MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real" MELIX_HOME="$PWD/.runtime/home-issue365-real" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-swift.sock" bash scripts/dev_up.sh --prefer-built`:
+  started a named real local runtime stack.
+- `MELIX_HOME="$PWD/.runtime/home-issue365-real" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-swift.sock" MELIX_HTTP_PORT=12465 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id lora_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --output-dir .runtime/issue365/real-lora-final-probe --timestamp 2026-05-06T133000Z --json`:
+  selected real case passed with `release_ready=true`; evidence bundle written
+  to `.runtime/issue365/real-lora-final-probe/bundle.json`.
+- The selected real local chain proved:
+  `lora.train -> lora.publish(local_filesystem) -> lora.activate -> chat.run -> eval.run`.
+- `MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-swift.sock" bash scripts/dev_down.sh`:
+  stopped the named real local runtime stack.
+- `python3 scripts/issue365_acceptance_bundle.py --execution-mode dry-run --melix-cli .build/arm64-apple-macosx/debug/melix --output-dir .runtime/issue365/acceptance-dry-run-final --timestamp 2026-05-06T140000Z --json`:
+  wrote a dry-run bundle with 10 succeeded cases, 0 failed cases, 0 blocked
+  cases, and `release_ready=false`.
+- `git diff --check`: passed.
+
 Results on 2026-05-05 after adding the acceptance bundle harness:
 
 - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q tests/integration/test_issue365_acceptance_bundle.py`:
@@ -164,6 +209,14 @@ Results on 2026-05-05 after adding the acceptance bundle harness:
 - QAT training and QAT-aware quantized export.
 - Full CLI chain tests backed by real local runtime evidence for every listed
   business line.
+- Real local runtime evidence for `lora_export_inference` now exists, but the
+  remaining nine CLI chains still require real local runtime evidence:
+  `qlora_export_inference`, `dora_export_inference`,
+  `lora_dpo_export_inference`, `lora_orpo_export_inference`,
+  `lora_cpo_export_inference`, `lora_grpo_export_inference`,
+  `lora_rlhf_export_inference`,
+  `lora_preference_ptq_quantized_inference`, and
+  `qat_quantized_inference`.
 - Window UI runnable/inspectable acceptance for every listed business line.
 - Final release evidence that separates deterministic/unit/scored-trace results
   from real local runtime results.

--- a/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
+++ b/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
@@ -54,6 +54,10 @@ local runtime acceptance requirements.
   `mlx_lm.utils.stream_generate` when the callable declares the specific stop
   keyword. This avoids passing unsupported `stop` kwargs through a variadic
   wrapper to installed `mlx-lm` versions whose generation step rejects them.
+- Add preference batch sharding support for MLX-LM trainer comm groups so
+  single-process DPO, ORPO, and CPO real-runtime runs do not fail when the
+  upstream trainer passes `mx.distributed.init()` into the custom preference
+  batch iterator.
 
 ### Excluded
 
@@ -90,10 +94,9 @@ Success metrics:
   calibration artifacts.
 - Changed-line coverage for the touched Swift/doc scope is at least 95 percent.
 - Changed-line coverage for the touched Python scope is at least 95 percent.
-- Real local LoRA and QLoRA subset evidence proves the fixed chain can
-  complete:
-  training, local publish receipt, direct adapter activation, chat smoke, and
-  eval smoke.
+- Real local LoRA, QLoRA, DoRA, DPO, ORPO, and CPO subset evidence proves the
+  fixed chain can complete: training, local publish receipt, direct adapter
+  activation, chat smoke, and eval smoke.
 
 ## Verification
 
@@ -191,6 +194,38 @@ normalization, direct adapter activation, and the MLX stop-kwarg fix:
   stopped the named real local QLoRA runtime stack.
 - `git diff --check`: passed.
 
+Results on 2026-05-06 after adding preference batch comm-group sharding and
+running the remaining supervised/preference real-mode subsets:
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q tests/integration/test_issue365_acceptance_bundle.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py`:
+  273 passed with 2 warnings from MLX SWIG types.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_issue365_acceptance_bundle.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py`:
+  273 passed with 2 warnings from MLX SWIG types.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-cli-chain-routing-python-coverage.json`:
+  wrote JSON coverage.
+- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-cli-chain-routing-python-coverage.json --diff-from origin/main scripts/issue365_acceptance_bundle.py services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/worker/model_ops/preference_training.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py tests/integration/test_issue365_acceptance_bundle.py docs/plans/2026-05-05-issue-365-cli-chain-routing.md`:
+  97.74 percent total changed-line coverage, 605/619 executable lines.
+- `MELIX_SERVICE_INSTANCE_NAME=issue365-real-dora MELIX_HTTP_PORT=12467 MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-dora" MELIX_HOME="$PWD/.runtime/home-issue365-real-dora" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dora-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dora-swift.sock" bash scripts/dev_up.sh --prefer-built`:
+  started a named real local runtime stack for the DoRA subset.
+- `MELIX_HOME="$PWD/.runtime/home-issue365-real-dora" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dora-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dora-swift.sock" MELIX_HTTP_PORT=12467 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id dora_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --output-dir .runtime/issue365/real-dora-probe --timestamp 2026-05-06T150000Z --json`:
+  selected real DoRA case passed with `release_ready=true`; evidence bundle
+  written to `.runtime/issue365/real-dora-probe/bundle.json`.
+- `MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-dora" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dora-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dora-swift.sock" bash scripts/dev_down.sh`:
+  stopped the named real local DoRA runtime stack.
+- `MELIX_SERVICE_INSTANCE_NAME=issue365-real-dpo MELIX_HTTP_PORT=12469 MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-dpo" MELIX_HOME="$PWD/.runtime/home-issue365-real-dpo" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-swift.sock" bash scripts/dev_up.sh --prefer-built`:
+  started a named real local runtime stack for preference alignment subsets.
+- `MELIX_HOME="$PWD/.runtime/home-issue365-real-dpo" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-swift.sock" MELIX_HTTP_PORT=12469 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id lora_dpo_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --preference-dataset-uri "$PWD/.runtime/issue365/input-datasets/preference_pair" --output-dir .runtime/issue365/real-dpo-probe-pass2 --timestamp 2026-05-06T153500Z --json`:
+  selected real DPO case passed with `release_ready=true`; evidence bundle
+  written to `.runtime/issue365/real-dpo-probe-pass2/bundle.json`.
+- `MELIX_HOME="$PWD/.runtime/home-issue365-real-dpo" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-swift.sock" MELIX_HTTP_PORT=12469 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id lora_orpo_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --preference-dataset-uri "$PWD/.runtime/issue365/input-datasets/preference_pair" --output-dir .runtime/issue365/real-orpo-probe --timestamp 2026-05-06T154500Z --json`:
+  selected real ORPO case passed with `release_ready=true`; evidence bundle
+  written to `.runtime/issue365/real-orpo-probe/bundle.json`.
+- `MELIX_HOME="$PWD/.runtime/home-issue365-real-dpo" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-swift.sock" MELIX_HTTP_PORT=12469 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id lora_cpo_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --preference-dataset-uri "$PWD/.runtime/issue365/input-datasets/preference_pair" --output-dir .runtime/issue365/real-cpo-probe --timestamp 2026-05-06T155500Z --json`:
+  selected real CPO case passed with `release_ready=true`; evidence bundle
+  written to `.runtime/issue365/real-cpo-probe/bundle.json`.
+- `MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-dpo" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-swift.sock" bash scripts/dev_down.sh`:
+  stopped the named real local preference runtime stack.
+
 Results on 2026-05-05 after adding the acceptance bundle harness:
 
 - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q tests/integration/test_issue365_acceptance_bundle.py`:
@@ -219,13 +254,12 @@ Results on 2026-05-05 after adding the acceptance bundle harness:
 - QAT training and QAT-aware quantized export.
 - Full CLI chain tests backed by real local runtime evidence for every listed
   business line.
-- Real local runtime evidence for `lora_export_inference` and
-  `qlora_export_inference` now exists, but the remaining eight CLI chains still
-  require real local runtime evidence:
-  `dora_export_inference`, `lora_dpo_export_inference`,
-  `lora_orpo_export_inference`, `lora_cpo_export_inference`,
-  `lora_grpo_export_inference`, `lora_rlhf_export_inference`,
-  `lora_preference_ptq_quantized_inference`, and
+- Real local runtime evidence now exists for `lora_export_inference`,
+  `qlora_export_inference`, `dora_export_inference`,
+  `lora_dpo_export_inference`, `lora_orpo_export_inference`, and
+  `lora_cpo_export_inference`, but the remaining four CLI chains still require
+  real local runtime evidence: `lora_grpo_export_inference`,
+  `lora_rlhf_export_inference`, `lora_preference_ptq_quantized_inference`, and
   `qat_quantized_inference`.
 - Window UI runnable/inspectable acceptance for every listed business line.
 - Final release evidence that separates deterministic/unit/scored-trace results

--- a/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
+++ b/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
@@ -34,6 +34,9 @@ local runtime acceptance requirements.
 - Keep screenshot cleanup scoped to temporary generated screenshot artifacts
   only. Tracked app branding images, evaluation fixtures, docs, and source
   files are not cleanup targets.
+- Add an Issue 365 CLI acceptance bundle harness that writes a machine-readable
+  matrix for every required CLI chain and separates planning, deterministic
+  dry-run, and real-local-runtime evidence.
 
 ### Excluded
 
@@ -57,6 +60,8 @@ Success metrics:
 - Pipeline dry-run receipts include stable command IDs for the new post-training
   steps.
 - Existing pipeline resume, check, and reference behavior remains unchanged.
+- The Issue 365 acceptance bundle must mark plan-only and dry-run evidence as
+  not release-ready even when every planned pipeline case is covered.
 - Changed-line coverage for the touched Swift/doc scope is at least 95 percent.
 
 ## Verification
@@ -66,6 +71,7 @@ Targeted commands:
 ```bash
 swift test --filter MelixCLIRunnerTests
 swift test --filter MelixCLIParserTests
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q tests/integration/test_issue365_acceptance_bundle.py
 git diff --check
 ```
 
@@ -81,11 +87,36 @@ python3 scripts/swift_changed_line_coverage.py \
   tests/MelixCLITests/MelixCLIRunnerTests.swift \
   tests/MelixCLITests/MelixCLIParserTests.swift \
   docs/plans/2026-05-05-issue-365-cli-chain-routing.md
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_issue365_acceptance_bundle.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-cli-acceptance-bundle-coverage.json
+python3 scripts/python_changed_line_coverage.py \
+  --coverage-json /tmp/issue365-cli-acceptance-bundle-coverage.json \
+  --diff-from origin/main \
+  scripts/issue365_acceptance_bundle.py \
+  tests/integration/test_issue365_acceptance_bundle.py \
+  docs/plans/2026-05-05-issue-365-cli-chain-routing.md
 ```
 
 Expected changed-line coverage target: at least 95 percent for the changed
 Swift scope. Documentation-only lines are reported as N/A when the coverage
 tool does not map them to executable statements.
+
+Results on 2026-05-05 after adding the acceptance bundle harness:
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q tests/integration/test_issue365_acceptance_bundle.py`:
+  9 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_issue365_acceptance_bundle.py`:
+  9 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-cli-acceptance-bundle-coverage.json`:
+  wrote JSON coverage.
+- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-cli-acceptance-bundle-coverage.json --diff-from origin/main scripts/issue365_acceptance_bundle.py tests/integration/test_issue365_acceptance_bundle.py docs/plans/2026-05-05-issue-365-cli-chain-routing.md`:
+  99.37 percent total changed-line coverage, 316/318 executable lines.
+- `python3 scripts/issue365_acceptance_bundle.py --execution-mode plan --output-dir .runtime/issue365/acceptance-smoke --timestamp 2026-05-05T000000Z --json`:
+  wrote a plan bundle with 10 planned cases and `release_ready=false`.
+- `swift test --filter 'MelixCLIRunnerTests|MelixCLIParserTests'`:
+  212 tests passed in 3 suites. Existing `try await store.save` warnings
+  remain.
+- `git diff --check`: passed.
 
 ## Remaining Issue 365 Gaps
 

--- a/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
+++ b/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
@@ -90,7 +90,8 @@ Success metrics:
   calibration artifacts.
 - Changed-line coverage for the touched Swift/doc scope is at least 95 percent.
 - Changed-line coverage for the touched Python scope is at least 95 percent.
-- Real local LoRA subset evidence proves the fixed chain can complete:
+- Real local LoRA and QLoRA subset evidence proves the fixed chain can
+  complete:
   training, local publish receipt, direct adapter activation, chat smoke, and
   eval smoke.
 
@@ -179,6 +180,15 @@ normalization, direct adapter activation, and the MLX stop-kwarg fix:
 - `python3 scripts/issue365_acceptance_bundle.py --execution-mode dry-run --melix-cli .build/arm64-apple-macosx/debug/melix --output-dir .runtime/issue365/acceptance-dry-run-final --timestamp 2026-05-06T140000Z --json`:
   wrote a dry-run bundle with 10 succeeded cases, 0 failed cases, 0 blocked
   cases, and `release_ready=false`.
+- `MELIX_SERVICE_INSTANCE_NAME=issue365-real-qlora MELIX_HTTP_PORT=12466 MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-qlora" MELIX_HOME="$PWD/.runtime/home-issue365-real-qlora" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-qlora-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-qlora-swift.sock" bash scripts/dev_up.sh --prefer-built`:
+  started a named real local runtime stack for the QLoRA subset.
+- `MELIX_HOME="$PWD/.runtime/home-issue365-real-qlora" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-qlora-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-qlora-swift.sock" MELIX_HTTP_PORT=12466 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id qlora_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --output-dir .runtime/issue365/real-qlora-probe --timestamp 2026-05-06T143000Z --json`:
+  selected real QLoRA case passed with `release_ready=true`; evidence bundle
+  written to `.runtime/issue365/real-qlora-probe/bundle.json`.
+- The selected real local QLoRA chain proved:
+  `lora.train -> lora.publish(local_filesystem) -> lora.activate -> chat.run -> eval.run`.
+- `MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-qlora" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-qlora-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-qlora-swift.sock" bash scripts/dev_down.sh`:
+  stopped the named real local QLoRA runtime stack.
 - `git diff --check`: passed.
 
 Results on 2026-05-05 after adding the acceptance bundle harness:
@@ -209,12 +219,12 @@ Results on 2026-05-05 after adding the acceptance bundle harness:
 - QAT training and QAT-aware quantized export.
 - Full CLI chain tests backed by real local runtime evidence for every listed
   business line.
-- Real local runtime evidence for `lora_export_inference` now exists, but the
-  remaining nine CLI chains still require real local runtime evidence:
-  `qlora_export_inference`, `dora_export_inference`,
-  `lora_dpo_export_inference`, `lora_orpo_export_inference`,
-  `lora_cpo_export_inference`, `lora_grpo_export_inference`,
-  `lora_rlhf_export_inference`,
+- Real local runtime evidence for `lora_export_inference` and
+  `qlora_export_inference` now exists, but the remaining eight CLI chains still
+  require real local runtime evidence:
+  `dora_export_inference`, `lora_dpo_export_inference`,
+  `lora_orpo_export_inference`, `lora_cpo_export_inference`,
+  `lora_grpo_export_inference`, `lora_rlhf_export_inference`,
   `lora_preference_ptq_quantized_inference`, and
   `qat_quantized_inference`.
 - Window UI runnable/inspectable acceptance for every listed business line.

--- a/scripts/issue365_acceptance_bundle.py
+++ b/scripts/issue365_acceptance_bundle.py
@@ -243,6 +243,8 @@ def _supervised_case(training_mode: str) -> Issue365PipelineCase:
                     "model_id": "${inputs.model_id}",
                     "target_repo": f"melix/issue365-{training_mode}-adapter",
                     "adapter_path": f"${{steps.{train_step}.result.output_path}}",
+                    "publish_backend": "local_filesystem",
+                    "local_publish_root": "${inputs.local_publish_root}",
                 },
             },
             {
@@ -250,13 +252,13 @@ def _supervised_case(training_mode: str) -> Issue365PipelineCase:
                 "command": "lora.activate",
                 "args": {
                     "model_id": "${inputs.model_id}",
-                    "adapter_path": f"${{steps.{publish_step}.result.output_path}}",
+                    "adapter_path": f"${{steps.{train_step}.result.output_path}}",
                     "derived_model_alias": derived_alias,
                     "activation_mode": "adapter_backed_runtime",
                 },
             },
-            _chat_step(f"{training_mode}_chat", derived_alias),
-            _eval_step(f"{training_mode}_eval", derived_alias),
+            _chat_step(f"{training_mode}_chat", f"${{steps.{activate_step}.result.derived_model_id}}"),
+            _eval_step(f"{training_mode}_eval", f"${{steps.{activate_step}.result.derived_model_id}}"),
         ),
     )
 
@@ -323,6 +325,8 @@ def _alignment_case(
                     "model_id": "${inputs.model_id}",
                     "target_repo": f"melix/issue365-{algorithm}-aligned",
                     "adapter_path": f"${{steps.{align_step}.result.output_path}}",
+                    "publish_backend": "local_filesystem",
+                    "local_publish_root": "${inputs.local_publish_root}",
                 },
             },
             {
@@ -330,13 +334,13 @@ def _alignment_case(
                 "command": "lora.activate",
                 "args": {
                     "model_id": "${inputs.model_id}",
-                    "adapter_path": f"${{steps.{publish_step}.result.output_path}}",
+                    "adapter_path": f"${{steps.{align_step}.result.output_path}}",
                     "derived_model_alias": derived_alias,
                     "activation_mode": "adapter_backed_runtime",
                 },
             },
-            _chat_step(f"{algorithm}_chat", derived_alias),
-            _eval_step(f"{algorithm}_eval", derived_alias),
+            _chat_step(f"{algorithm}_chat", f"${{steps.{activate_step}.result.derived_model_id}}"),
+            _eval_step(f"{algorithm}_eval", f"${{steps.{activate_step}.result.derived_model_id}}"),
         ),
     )
 
@@ -394,6 +398,8 @@ def _ptq_case() -> Issue365PipelineCase:
                     "target_repo": "melix/issue365-ptq-merged",
                     "manifest_path": f"${{steps.{align_step}.result.output_path}}",
                     "export_kind": "merged",
+                    "publish_backend": "local_filesystem",
+                    "local_publish_root": "${inputs.local_publish_root}",
                 },
             },
             {
@@ -458,6 +464,8 @@ def _qat_case() -> Issue365PipelineCase:
                     "target_repo": "melix/issue365-qat-merged",
                     "manifest_path": f"${{steps.{train_step}.result.output_path}}",
                     "export_kind": "merged",
+                    "publish_backend": "local_filesystem",
+                    "local_publish_root": "${inputs.local_publish_root}",
                 },
             },
             {
@@ -503,7 +511,7 @@ def _eval_step(step_id: str, model_id: str) -> dict[str, Any]:
         "args": {
             "model_id": model_id,
             "suites": ["mmlu"],
-            "dataset_id": "issue365.smoke.v1",
+            "dataset_id": "mmlu.dev.v1",
             "sample_size": 1,
             "scoring_mode": "multiple_choice_accuracy",
         },
@@ -530,6 +538,7 @@ def _default_inputs(config: Issue365AcceptanceConfig, *, output_dir: Path) -> di
         "calibration_dataset_uri": config.calibration_dataset_uri,
         "reward_model_manifest_path": config.reward_model_manifest_path,
         "acceptance_output_dir": str(output_dir / "artifacts"),
+        "local_publish_root": str(output_dir / "artifacts" / "local-publish"),
         "server_session_id": "issue365-acceptance",
     }
 

--- a/scripts/issue365_acceptance_bundle.py
+++ b/scripts/issue365_acceptance_bundle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -31,6 +32,7 @@ class Issue365AcceptanceConfig:
     calibration_dataset_uri: str = "/tmp/melix-issue365/datasets/calibration"
     reward_model_manifest_path: str = "/tmp/melix-issue365/reward-model/manifest.json"
     melix_cli: str = "melix"
+    case_ids: tuple[str, ...] = ()
     timestamp: str = ""
     json_output: bool = False
 
@@ -42,6 +44,7 @@ class Issue365PipelineCase:
     business_line: str
     steps: tuple[dict[str, Any], ...]
     acceptance_requirements: tuple[str, ...]
+    required_inputs: tuple[str, ...] = ()
 
 
 class JSONCommandExecutor(Protocol):
@@ -93,12 +96,19 @@ def build_acceptance_bundle(
     receipt_root.mkdir(parents=True, exist_ok=True)
 
     inputs = _default_inputs(config, output_dir=output_dir)
+    cases = _selected_pipeline_cases(config.case_ids)
+    real_runtime_preflight = _real_runtime_preflight(config, cases) if config.execution_mode == "real" else {
+        "status": "not_run",
+        "ready": False,
+        "reason": "Real local runtime preflight only runs in execution_mode=real.",
+        "cases": {},
+    }
     case_results: list[dict[str, Any]] = []
     runner = executor
     if config.execution_mode != "plan" and runner is None:
         runner = SubprocessJSONExecutor(repo_root=config.repo_root)
 
-    for case in issue365_pipeline_cases():
+    for case in cases:
         pipeline_path = pipeline_dir / f"{case.case_id}.pipeline.json"
         pipeline = {
             "schema_version": PIPELINE_SCHEMA_VERSION,
@@ -117,7 +127,11 @@ def build_acceptance_bundle(
         summary: dict[str, Any] | None = None
         status = "planned"
         error = ""
-        if config.execution_mode != "plan":
+        case_preflight = real_runtime_preflight.get("cases", {}).get(case.case_id)
+        if config.execution_mode == "real" and case_preflight is not None and not case_preflight["ready"]:
+            status = "blocked"
+            error = "Real local runtime preflight failed."
+        elif config.execution_mode != "plan":
             try:
                 assert runner is not None
                 summary = runner.run_json(command)
@@ -135,6 +149,7 @@ def build_acceptance_bundle(
                 status=status,
                 summary=summary,
                 error=error,
+                real_runtime_preflight=case_preflight,
             )
         )
 
@@ -149,8 +164,11 @@ def build_acceptance_bundle(
             "unit_and_plan_evidence_release_ready": False,
             "deterministic_dry_run_release_ready": False,
             "real_local_runtime_required": True,
+            "real_local_runtime_preflight_required": True,
         },
         "inputs": inputs,
+        "selected_case_ids": [case.case_id for case in cases],
+        "real_runtime_preflight": real_runtime_preflight,
         "summary": summary,
         "cases": case_results,
         "known_gaps": _known_gaps(case_results, execution_mode=config.execution_mode),
@@ -204,6 +222,7 @@ def _supervised_case(training_mode: str) -> Issue365PipelineCase:
             "evaluation evidence recorded",
             "real local runtime evidence captured",
         ),
+        required_inputs=("sft_dataset_uri",),
         steps=(
             {
                 "id": train_step,
@@ -278,6 +297,7 @@ def _alignment_case(
             "evaluation evidence recorded",
             "real local runtime evidence captured",
         ),
+        required_inputs=_alignment_required_inputs(algorithm),
         steps=(
             {
                 "id": train_step,
@@ -339,6 +359,7 @@ def _ptq_case() -> Issue365PipelineCase:
             "quality and latency evidence recorded",
             "real local runtime evidence captured",
         ),
+        required_inputs=("sft_dataset_uri", "preference_dataset_uri", "calibration_dataset_uri"),
         steps=(
             {
                 "id": train_step,
@@ -414,6 +435,7 @@ def _qat_case() -> Issue365PipelineCase:
             "quality and latency evidence recorded",
             "real local runtime evidence captured",
         ),
+        required_inputs=("sft_dataset_uri", "calibration_dataset_uri"),
         steps=(
             {
                 "id": train_step,
@@ -488,6 +510,16 @@ def _eval_step(step_id: str, model_id: str) -> dict[str, Any]:
     }
 
 
+def _alignment_required_inputs(algorithm: str) -> tuple[str, ...]:
+    if algorithm in {"dpo", "orpo", "cpo"}:
+        return ("sft_dataset_uri", "preference_dataset_uri")
+    if algorithm == "grpo":
+        return ("sft_dataset_uri", "prompt_candidate_dataset_uri")
+    if algorithm == "rlhf":
+        return ("sft_dataset_uri", "reward_scored_dataset_uri", "reward_model_manifest_path")
+    raise ValueError(f"Unsupported alignment algorithm: {algorithm}")
+
+
 def _default_inputs(config: Issue365AcceptanceConfig, *, output_dir: Path) -> dict[str, Any]:
     return {
         "model_id": config.model_id,
@@ -500,6 +532,180 @@ def _default_inputs(config: Issue365AcceptanceConfig, *, output_dir: Path) -> di
         "acceptance_output_dir": str(output_dir / "artifacts"),
         "server_session_id": "issue365-acceptance",
     }
+
+
+def _selected_pipeline_cases(case_ids: tuple[str, ...]) -> tuple[Issue365PipelineCase, ...]:
+    cases = issue365_pipeline_cases()
+    if not case_ids:
+        return cases
+    case_by_id = {case.case_id: case for case in cases}
+    unknown = sorted(set(case_ids) - set(case_by_id))
+    if unknown:
+        raise ValueError(f"Unknown Issue 365 case_id(s): {', '.join(unknown)}")
+    return tuple(case_by_id[case_id] for case_id in case_ids)
+
+
+def _real_runtime_preflight(
+    config: Issue365AcceptanceConfig,
+    cases: tuple[Issue365PipelineCase, ...],
+) -> dict[str, Any]:
+    common_checks = [
+        _repo_root_check(config.repo_root),
+        _cli_executable_check(config.melix_cli, repo_root=config.repo_root),
+    ]
+    input_checks = _input_preflight_checks(config)
+    case_results: dict[str, Any] = {}
+    for case in cases:
+        blockers: list[dict[str, Any]] = []
+        warnings: list[dict[str, Any]] = []
+        for check in common_checks:
+            if check["ready"]:
+                if check.get("warning"):
+                    warnings.append(check)
+            else:
+                blockers.append(check)
+        required_input_checks = []
+        for input_name in case.required_inputs:
+            input_check = input_checks[input_name]
+            required_input_checks.append(input_check)
+            if input_check["ready"]:
+                if input_check.get("warning"):
+                    warnings.append(input_check)
+            else:
+                blockers.append(input_check)
+        case_results[case.case_id] = {
+            "ready": not blockers,
+            "required_inputs": list(case.required_inputs),
+            "blockers": blockers,
+            "warnings": warnings,
+            "checks": {
+                "common": common_checks,
+                "inputs": required_input_checks,
+            },
+        }
+    ready = all(case["ready"] for case in case_results.values())
+    return {
+        "status": "ready" if ready else "blocked",
+        "ready": ready,
+        "checked_case_count": len(case_results),
+        "common_checks": common_checks,
+        "cases": case_results,
+    }
+
+
+def _repo_root_check(repo_root: Path) -> dict[str, Any]:
+    return _preflight_check(
+        code="repo_root_missing",
+        label="repo_root",
+        value=str(repo_root),
+        ready=repo_root.exists() and repo_root.is_dir(),
+        detail="Repository root must exist before real local runtime execution.",
+    )
+
+
+def _cli_executable_check(melix_cli: str, *, repo_root: Path) -> dict[str, Any]:
+    resolved = _resolve_cli_path(melix_cli, repo_root=repo_root)
+    ready = resolved is not None and resolved.exists() and os.access(resolved, os.X_OK)
+    return _preflight_check(
+        code="melix_cli_not_executable",
+        label="melix_cli",
+        value=melix_cli,
+        ready=ready,
+        detail="Real local runtime execution requires an executable melix CLI path.",
+        resolved_path=str(resolved) if resolved is not None else "",
+    )
+
+
+def _resolve_cli_path(melix_cli: str, *, repo_root: Path) -> Path | None:
+    if "/" in melix_cli:
+        path = Path(melix_cli).expanduser()
+        return path if path.is_absolute() else (repo_root / path).resolve()
+    resolved = shutil.which(melix_cli)
+    return Path(resolved) if resolved else None
+
+
+def _input_preflight_checks(config: Issue365AcceptanceConfig) -> dict[str, dict[str, Any]]:
+    values = {
+        "sft_dataset_uri": config.sft_dataset_uri,
+        "preference_dataset_uri": config.preference_dataset_uri,
+        "prompt_candidate_dataset_uri": config.prompt_candidate_dataset_uri,
+        "reward_scored_dataset_uri": config.reward_scored_dataset_uri,
+        "calibration_dataset_uri": config.calibration_dataset_uri,
+        "reward_model_manifest_path": config.reward_model_manifest_path,
+    }
+    return {
+        name: _input_uri_check(
+            name,
+            value,
+            require_file=name == "reward_model_manifest_path",
+            repo_root=config.repo_root,
+        )
+        for name, value in values.items()
+    }
+
+
+def _input_uri_check(name: str, value: str, *, require_file: bool, repo_root: Path) -> dict[str, Any]:
+    if not value.strip():
+        return _preflight_check(
+            code=f"empty_{name}",
+            label=name,
+            value=value,
+            ready=False,
+            detail="Real local runtime execution requires a non-empty input value before running the case.",
+        )
+    local_path = _local_uri_path(value, repo_root=repo_root)
+    if local_path is None:
+        return _preflight_check(
+            code="non_local_input_not_checked",
+            label=name,
+            value=value,
+            ready=True,
+            detail="Input is not a local path, so the acceptance bundle cannot preflight its contents.",
+            warning=True,
+        )
+    ready = local_path.exists() and (local_path.is_file() if require_file else True)
+    expected = "file" if require_file else "path"
+    return _preflight_check(
+        code=f"missing_{name}",
+        label=name,
+        value=value,
+        ready=ready,
+        detail=f"Real local runtime execution requires this {expected} before running the case.",
+        resolved_path=str(local_path),
+    )
+
+
+def _local_uri_path(value: str, *, repo_root: Path) -> Path | None:
+    if value.startswith("file://"):
+        return Path(value.removeprefix("file://")).expanduser()
+    if "://" in value:
+        return None
+    path = Path(value).expanduser()
+    return path if path.is_absolute() else (repo_root / path).resolve()
+
+
+def _preflight_check(
+    *,
+    code: str,
+    label: str,
+    value: str,
+    ready: bool,
+    detail: str,
+    resolved_path: str = "",
+    warning: bool = False,
+) -> dict[str, Any]:
+    payload = {
+        "code": code,
+        "label": label,
+        "value": value,
+        "ready": ready,
+        "detail": detail,
+    }
+    if resolved_path:
+        payload["resolved_path"] = resolved_path
+    if warning:
+        payload["warning"] = True
+    return payload
 
 
 def _pipeline_command(
@@ -536,6 +742,7 @@ def _case_result(
     status: str,
     summary: dict[str, Any] | None,
     error: str,
+    real_runtime_preflight: dict[str, Any] | None,
 ) -> dict[str, Any]:
     evidence_tier = {
         "plan": "planning_matrix",
@@ -558,6 +765,8 @@ def _case_result(
         "commands": [str(step["command"]) for step in case.steps],
         "missing_evidence": [] if release_ready else _missing_evidence(execution_mode, status),
     }
+    if real_runtime_preflight is not None:
+        result["real_runtime_preflight"] = real_runtime_preflight
     if summary is not None:
         result["pipeline_summary"] = summary
         if summary.get("summary_path"):
@@ -575,6 +784,8 @@ def _missing_evidence(execution_mode: str, status: str) -> list[str]:
         missing.append("pipeline_execution")
     if execution_mode == "dry-run":
         missing.append("non_dry_run_execution")
+    if status == "blocked":
+        missing.append("real_local_runtime_preflight")
     if status == "failed":
         missing.append("passing_pipeline_summary")
     return missing
@@ -585,6 +796,7 @@ def _bundle_summary(case_results: list[dict[str, Any]], *, execution_mode: str) 
     succeeded = sum(1 for case in case_results if case["status"] == "succeeded")
     planned = sum(1 for case in case_results if case["status"] == "planned")
     failed = sum(1 for case in case_results if case["status"] == "failed")
+    blocked = sum(1 for case in case_results if case["status"] == "blocked")
     release_ready_cases = sum(1 for case in case_results if case["release_ready"] is True)
     release_ready = execution_mode == "real" and release_ready_cases == total and total > 0
     return {
@@ -592,6 +804,7 @@ def _bundle_summary(case_results: list[dict[str, Any]], *, execution_mode: str) 
         "planned_count": planned,
         "succeeded_count": succeeded,
         "failed_count": failed,
+        "blocked_count": blocked,
         "release_ready_case_count": release_ready_cases,
         "release_ready": release_ready,
         "required_case_ids": [case["case_id"] for case in case_results],
@@ -645,6 +858,12 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument("--reward-scored-dataset-uri", default="/tmp/melix-issue365/datasets/reward_scored")
     parser.add_argument("--calibration-dataset-uri", default="/tmp/melix-issue365/datasets/calibration")
     parser.add_argument("--reward-model-manifest-path", default="/tmp/melix-issue365/reward-model/manifest.json")
+    parser.add_argument(
+        "--case-id",
+        action="append",
+        default=[],
+        help="Run only the selected Issue 365 acceptance case. May be repeated.",
+    )
     parser.add_argument("--timestamp", default="")
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
@@ -664,6 +883,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         calibration_dataset_uri=args.calibration_dataset_uri,
         reward_model_manifest_path=args.reward_model_manifest_path,
         melix_cli=args.melix_cli,
+        case_ids=tuple(args.case_id),
         timestamp=args.timestamp,
         json_output=args.json,
     )

--- a/scripts/issue365_acceptance_bundle.py
+++ b/scripts/issue365_acceptance_bundle.py
@@ -1,0 +1,681 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol, Sequence
+
+
+ISSUE_URL = "https://github.com/Keith-CY/melix/issues/365"
+BUNDLE_SCHEMA_VERSION = "melix.issue365.acceptance_bundle.v1"
+PIPELINE_SCHEMA_VERSION = "melix.pipeline.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class Issue365AcceptanceConfig:
+    repo_root: Path
+    output_dir: Path
+    execution_mode: str = "plan"
+    model_id: str = "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"
+    sft_dataset_uri: str = "/tmp/melix-issue365/datasets/sft"
+    preference_dataset_uri: str = "/tmp/melix-issue365/datasets/preference_pair"
+    prompt_candidate_dataset_uri: str = "/tmp/melix-issue365/datasets/prompt_candidate"
+    reward_scored_dataset_uri: str = "/tmp/melix-issue365/datasets/reward_scored"
+    calibration_dataset_uri: str = "/tmp/melix-issue365/datasets/calibration"
+    reward_model_manifest_path: str = "/tmp/melix-issue365/reward-model/manifest.json"
+    melix_cli: str = "melix"
+    timestamp: str = ""
+    json_output: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class Issue365PipelineCase:
+    case_id: str
+    requirement: str
+    business_line: str
+    steps: tuple[dict[str, Any], ...]
+    acceptance_requirements: tuple[str, ...]
+
+
+class JSONCommandExecutor(Protocol):
+    def run_json(self, command: Sequence[str]) -> dict[str, Any]:
+        ...
+
+
+class SubprocessJSONExecutor:
+    def __init__(self, *, repo_root: Path, environment: dict[str, str] | None = None) -> None:
+        self.repo_root = repo_root
+        self.environment = dict(os.environ if environment is None else environment)
+
+    def run_json(self, command: Sequence[str]) -> dict[str, Any]:
+        completed = subprocess.run(
+            list(command),
+            cwd=self.repo_root,
+            env=self.environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"{' '.join(command)} failed with exit code {completed.returncode}: "
+                f"{(completed.stderr or completed.stdout).strip()}"
+            )
+        try:
+            payload = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"{' '.join(command)} did not return JSON: {exc.msg}") from exc
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"{' '.join(command)} returned non-object JSON.")
+        return payload
+
+
+def build_acceptance_bundle(
+    config: Issue365AcceptanceConfig,
+    *,
+    executor: JSONCommandExecutor | None = None,
+) -> dict[str, Any]:
+    if config.execution_mode not in {"plan", "dry-run", "real"}:
+        raise ValueError("execution_mode must be plan, dry-run, or real")
+
+    timestamp = config.timestamp or _utc_timestamp()
+    output_dir = config.output_dir.resolve()
+    pipeline_dir = output_dir / "pipelines"
+    receipt_root = output_dir / "receipts"
+    pipeline_dir.mkdir(parents=True, exist_ok=True)
+    receipt_root.mkdir(parents=True, exist_ok=True)
+
+    inputs = _default_inputs(config, output_dir=output_dir)
+    case_results: list[dict[str, Any]] = []
+    runner = executor
+    if config.execution_mode != "plan" and runner is None:
+        runner = SubprocessJSONExecutor(repo_root=config.repo_root)
+
+    for case in issue365_pipeline_cases():
+        pipeline_path = pipeline_dir / f"{case.case_id}.pipeline.json"
+        pipeline = {
+            "schema_version": PIPELINE_SCHEMA_VERSION,
+            "name": f"issue365-{case.case_id}",
+            "inputs": inputs,
+            "steps": list(case.steps),
+        }
+        _write_json(pipeline_path, pipeline)
+
+        command = _pipeline_command(
+            config,
+            pipeline_path=pipeline_path,
+            receipt_dir=receipt_root / case.case_id,
+            trace_id=f"issue365-{case.case_id}-{timestamp}",
+        )
+        summary: dict[str, Any] | None = None
+        status = "planned"
+        error = ""
+        if config.execution_mode != "plan":
+            try:
+                assert runner is not None
+                summary = runner.run_json(command)
+                status = str(summary.get("status", "unknown"))
+            except Exception as exc:  # pragma: no cover - subprocess path is covered via fake executor.
+                status = "failed"
+                error = str(exc)
+
+        case_results.append(
+            _case_result(
+                case,
+                execution_mode=config.execution_mode,
+                pipeline_path=pipeline_path,
+                command=command,
+                status=status,
+                summary=summary,
+                error=error,
+            )
+        )
+
+    summary = _bundle_summary(case_results, execution_mode=config.execution_mode)
+    bundle = {
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "issue_url": ISSUE_URL,
+        "generated_at": timestamp,
+        "execution_mode": config.execution_mode,
+        "release_ready": summary["release_ready"],
+        "evidence_policy": {
+            "unit_and_plan_evidence_release_ready": False,
+            "deterministic_dry_run_release_ready": False,
+            "real_local_runtime_required": True,
+        },
+        "inputs": inputs,
+        "summary": summary,
+        "cases": case_results,
+        "known_gaps": _known_gaps(case_results, execution_mode=config.execution_mode),
+    }
+    bundle_path = output_dir / "bundle.json"
+    _write_json(bundle_path, bundle)
+    bundle["bundle_path"] = str(bundle_path)
+    _write_json(bundle_path, bundle)
+    return bundle
+
+
+def issue365_pipeline_cases() -> tuple[Issue365PipelineCase, ...]:
+    return (
+        _supervised_case("lora"),
+        _supervised_case("qlora"),
+        _supervised_case("dora"),
+        _alignment_case("dpo", "${inputs.preference_dataset_uri}"),
+        _alignment_case("orpo", "${inputs.preference_dataset_uri}"),
+        _alignment_case("cpo", "${inputs.preference_dataset_uri}"),
+        _alignment_case(
+            "grpo",
+            "${inputs.prompt_candidate_dataset_uri}",
+            extra_alignment_args={"grpo_candidate_count": 4},
+            requirement="BaseModel -> LoRA -> GRPO -> export -> local inference.",
+        ),
+        _alignment_case(
+            "rlhf",
+            "${inputs.reward_scored_dataset_uri}",
+            extra_alignment_args={"reward_model_manifest_path": "${inputs.reward_model_manifest_path}"},
+            requirement="BaseModel -> LoRA -> RLHF using a reward model from #366 -> export -> local inference.",
+        ),
+        _ptq_case(),
+        _qat_case(),
+    )
+
+
+def _supervised_case(training_mode: str) -> Issue365PipelineCase:
+    case_id = f"{training_mode}_export_inference"
+    train_step = f"{training_mode}_train"
+    publish_step = f"{training_mode}_publish"
+    activate_step = f"{training_mode}_activate"
+    derived_alias = f"issue365-{training_mode}-derived"
+    return Issue365PipelineCase(
+        case_id=case_id,
+        requirement=f"BaseModel -> {training_mode.upper()} -> export -> local inference.",
+        business_line="supervised_adapter_training",
+        acceptance_requirements=(
+            "adapter training completed",
+            "export or publish artifact exists",
+            "local inference smoke completed",
+            "evaluation evidence recorded",
+            "real local runtime evidence captured",
+        ),
+        steps=(
+            {
+                "id": train_step,
+                "command": "lora.train",
+                "args": {
+                    "model_id": "${inputs.model_id}",
+                    "dataset_uri": "${inputs.sft_dataset_uri}",
+                    "adapter_name": f"issue365-{training_mode}",
+                    "training_mode": training_mode,
+                    "preset_id": "debug_fast",
+                    "max_steps": 2,
+                },
+            },
+            {
+                "id": publish_step,
+                "command": "lora.publish",
+                "args": {
+                    "model_id": "${inputs.model_id}",
+                    "target_repo": f"melix/issue365-{training_mode}-adapter",
+                    "adapter_path": f"${{steps.{train_step}.result.output_path}}",
+                },
+            },
+            {
+                "id": activate_step,
+                "command": "lora.activate",
+                "args": {
+                    "model_id": "${inputs.model_id}",
+                    "adapter_path": f"${{steps.{publish_step}.result.output_path}}",
+                    "derived_model_alias": derived_alias,
+                    "activation_mode": "adapter_backed_runtime",
+                },
+            },
+            _chat_step(f"{training_mode}_chat", derived_alias),
+            _eval_step(f"{training_mode}_eval", derived_alias),
+        ),
+    )
+
+
+def _alignment_case(
+    algorithm: str,
+    dataset_uri: str,
+    *,
+    extra_alignment_args: dict[str, Any] | None = None,
+    requirement: str | None = None,
+) -> Issue365PipelineCase:
+    train_step = f"{algorithm}_base_lora"
+    align_step = f"{algorithm}_align"
+    publish_step = f"{algorithm}_publish"
+    activate_step = f"{algorithm}_activate"
+    derived_alias = f"issue365-{algorithm}-derived"
+    alignment_args: dict[str, Any] = {
+        "model_id": "${inputs.model_id}",
+        "dataset_uri": dataset_uri,
+        "adapter_name": f"issue365-{algorithm}",
+        "algorithm": algorithm,
+        "source_adapter_path": f"${{steps.{train_step}.result.output_path}}",
+        "preset_id": "debug_fast",
+        "max_steps": 2,
+    }
+    if extra_alignment_args:
+        alignment_args.update(extra_alignment_args)
+    return Issue365PipelineCase(
+        case_id=f"lora_{algorithm}_export_inference",
+        requirement=requirement or f"BaseModel -> LoRA -> {algorithm.upper()} -> export -> local inference.",
+        business_line="alignment_training",
+        acceptance_requirements=(
+            "base adapter training completed",
+            f"{algorithm} alignment run completed",
+            "alignment_run manifest exists",
+            "export or publish artifact exists",
+            "local inference smoke completed",
+            "evaluation evidence recorded",
+            "real local runtime evidence captured",
+        ),
+        steps=(
+            {
+                "id": train_step,
+                "command": "lora.train",
+                "args": {
+                    "model_id": "${inputs.model_id}",
+                    "dataset_uri": "${inputs.sft_dataset_uri}",
+                    "adapter_name": f"issue365-{algorithm}-base",
+                    "training_mode": "lora",
+                    "preset_id": "debug_fast",
+                    "max_steps": 2,
+                },
+            },
+            {
+                "id": align_step,
+                "command": "alignment.train",
+                "args": alignment_args,
+            },
+            {
+                "id": publish_step,
+                "command": "lora.publish",
+                "args": {
+                    "model_id": "${inputs.model_id}",
+                    "target_repo": f"melix/issue365-{algorithm}-aligned",
+                    "adapter_path": f"${{steps.{align_step}.result.output_path}}",
+                },
+            },
+            {
+                "id": activate_step,
+                "command": "lora.activate",
+                "args": {
+                    "model_id": "${inputs.model_id}",
+                    "adapter_path": f"${{steps.{publish_step}.result.output_path}}",
+                    "derived_model_alias": derived_alias,
+                    "activation_mode": "adapter_backed_runtime",
+                },
+            },
+            _chat_step(f"{algorithm}_chat", derived_alias),
+            _eval_step(f"{algorithm}_eval", derived_alias),
+        ),
+    )
+
+
+def _ptq_case() -> Issue365PipelineCase:
+    train_step = "ptq_base_lora"
+    align_step = "ptq_dpo_align"
+    publish_step = "ptq_publish_merged"
+    quantize_step = "ptq_quantize"
+    return Issue365PipelineCase(
+        case_id="lora_preference_ptq_quantized_inference",
+        requirement="BaseModel -> LoRA/preference result -> merge/export -> PTQ -> local inference.",
+        business_line="quantization_optimization",
+        acceptance_requirements=(
+            "base adapter training completed",
+            "preference alignment completed",
+            "merged or exported artifact exists",
+            "PTQ quantization completed",
+            "quantized local inference smoke completed",
+            "quality and latency evidence recorded",
+            "real local runtime evidence captured",
+        ),
+        steps=(
+            {
+                "id": train_step,
+                "command": "lora.train",
+                "args": {
+                    "model_id": "${inputs.model_id}",
+                    "dataset_uri": "${inputs.sft_dataset_uri}",
+                    "adapter_name": "issue365-ptq-base",
+                    "training_mode": "lora",
+                    "preset_id": "debug_fast",
+                    "max_steps": 2,
+                },
+            },
+            {
+                "id": align_step,
+                "command": "alignment.train",
+                "args": {
+                    "model_id": "${inputs.model_id}",
+                    "dataset_uri": "${inputs.preference_dataset_uri}",
+                    "adapter_name": "issue365-ptq-dpo",
+                    "algorithm": "dpo",
+                    "source_adapter_path": f"${{steps.{train_step}.result.output_path}}",
+                    "preset_id": "debug_fast",
+                    "max_steps": 2,
+                },
+            },
+            {
+                "id": publish_step,
+                "command": "lora.publish",
+                "args": {
+                    "model_id": "${inputs.model_id}",
+                    "target_repo": "melix/issue365-ptq-merged",
+                    "manifest_path": f"${{steps.{align_step}.result.output_path}}",
+                    "export_kind": "merged",
+                },
+            },
+            {
+                "id": quantize_step,
+                "command": "quantize",
+                "args": {
+                    "model_id": "${inputs.model_id}",
+                    "output_dir": "${inputs.acceptance_output_dir}/ptq",
+                    "quant_profile_id": "q4",
+                    "weight_quant": "q4",
+                    "kv_quant": "q8",
+                    "quantization_mode": "ptq",
+                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_path": f"${{steps.{publish_step}.result.output_path}}",
+                    "calibration_dataset_uri": "${inputs.calibration_dataset_uri}",
+                    "quality_delta": 0,
+                    "latency_delta": 0,
+                },
+            },
+            _chat_step("ptq_chat", f"${{steps.{quantize_step}.result.output_path}}"),
+            _eval_step("ptq_eval", f"${{steps.{quantize_step}.result.output_path}}"),
+        ),
+    )
+
+
+def _qat_case() -> Issue365PipelineCase:
+    train_step = "qat_train"
+    publish_step = "qat_publish_merged"
+    quantize_step = "qat_quantize"
+    return Issue365PipelineCase(
+        case_id="qat_quantized_inference",
+        requirement="BaseModel -> QAT/QAT-aware export -> quantized local inference.",
+        business_line="quantization_optimization",
+        acceptance_requirements=(
+            "QAT or QAT-aware training/export completed",
+            "fake-quant or quantization-aware settings recorded",
+            "QAT quantized export completed",
+            "quantized local inference smoke completed",
+            "quality and latency evidence recorded",
+            "real local runtime evidence captured",
+        ),
+        steps=(
+            {
+                "id": train_step,
+                "command": "lora.train",
+                "args": {
+                    "model_id": "${inputs.model_id}",
+                    "dataset_uri": "${inputs.sft_dataset_uri}",
+                    "adapter_name": "issue365-qat-aware",
+                    "training_mode": "qlora",
+                    "preset_id": "debug_fast",
+                    "max_steps": 2,
+                    "qat_fake_quant": "enabled",
+                },
+            },
+            {
+                "id": publish_step,
+                "command": "lora.publish",
+                "args": {
+                    "model_id": "${inputs.model_id}",
+                    "target_repo": "melix/issue365-qat-merged",
+                    "manifest_path": f"${{steps.{train_step}.result.output_path}}",
+                    "export_kind": "merged",
+                },
+            },
+            {
+                "id": quantize_step,
+                "command": "quantize",
+                "args": {
+                    "model_id": "${inputs.model_id}",
+                    "output_dir": "${inputs.acceptance_output_dir}/qat",
+                    "quant_profile_id": "q4",
+                    "weight_quant": "q4",
+                    "kv_quant": "q8",
+                    "quantization_mode": "qat",
+                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_path": f"${{steps.{publish_step}.result.output_path}}",
+                    "calibration_dataset_uri": "${inputs.calibration_dataset_uri}",
+                    "quality_delta": 0,
+                    "latency_delta": 0,
+                    "qat_fake_quant": "enabled",
+                },
+            },
+            _chat_step("qat_chat", f"${{steps.{quantize_step}.result.output_path}}"),
+            _eval_step("qat_eval", f"${{steps.{quantize_step}.result.output_path}}"),
+        ),
+    )
+
+
+def _chat_step(step_id: str, model_id: str) -> dict[str, Any]:
+    return {
+        "id": step_id,
+        "command": "chat.run",
+        "args": {
+            "model_id": model_id,
+            "message": "Reply with ISSUE365_OK",
+            "server_session_id": "${inputs.server_session_id}",
+        },
+    }
+
+
+def _eval_step(step_id: str, model_id: str) -> dict[str, Any]:
+    return {
+        "id": step_id,
+        "command": "eval.run",
+        "args": {
+            "model_id": model_id,
+            "suites": ["mmlu"],
+            "dataset_id": "issue365.smoke.v1",
+            "sample_size": 1,
+            "scoring_mode": "multiple_choice_accuracy",
+        },
+    }
+
+
+def _default_inputs(config: Issue365AcceptanceConfig, *, output_dir: Path) -> dict[str, Any]:
+    return {
+        "model_id": config.model_id,
+        "sft_dataset_uri": config.sft_dataset_uri,
+        "preference_dataset_uri": config.preference_dataset_uri,
+        "prompt_candidate_dataset_uri": config.prompt_candidate_dataset_uri,
+        "reward_scored_dataset_uri": config.reward_scored_dataset_uri,
+        "calibration_dataset_uri": config.calibration_dataset_uri,
+        "reward_model_manifest_path": config.reward_model_manifest_path,
+        "acceptance_output_dir": str(output_dir / "artifacts"),
+        "server_session_id": "issue365-acceptance",
+    }
+
+
+def _pipeline_command(
+    config: Issue365AcceptanceConfig,
+    *,
+    pipeline_path: Path,
+    receipt_dir: Path,
+    trace_id: str,
+) -> list[str]:
+    command = [
+        config.melix_cli,
+        "pipeline",
+        "run",
+        "--file",
+        str(pipeline_path),
+        "--receipt-dir",
+        str(receipt_dir),
+        "--trace-id",
+        trace_id,
+        "--format",
+        "json-v1",
+    ]
+    if config.execution_mode == "dry-run":
+        command.append("--dry-run")
+    return command
+
+
+def _case_result(
+    case: Issue365PipelineCase,
+    *,
+    execution_mode: str,
+    pipeline_path: Path,
+    command: Sequence[str],
+    status: str,
+    summary: dict[str, Any] | None,
+    error: str,
+) -> dict[str, Any]:
+    evidence_tier = {
+        "plan": "planning_matrix",
+        "dry-run": "deterministic_dry_run",
+        "real": "real_local_runtime",
+    }[execution_mode]
+    release_ready = execution_mode == "real" and status == "succeeded"
+    result = {
+        "case_id": case.case_id,
+        "requirement": case.requirement,
+        "business_line": case.business_line,
+        "status": status,
+        "evidence_tier": evidence_tier,
+        "release_ready": release_ready,
+        "real_local_runtime_required": True,
+        "pipeline_path": str(pipeline_path),
+        "command": list(command),
+        "acceptance_requirements": list(case.acceptance_requirements),
+        "step_ids": [str(step["id"]) for step in case.steps],
+        "commands": [str(step["command"]) for step in case.steps],
+        "missing_evidence": [] if release_ready else _missing_evidence(execution_mode, status),
+    }
+    if summary is not None:
+        result["pipeline_summary"] = summary
+        if summary.get("summary_path"):
+            result["summary_path"] = summary["summary_path"]
+    if error:
+        result["error"] = error
+    return result
+
+
+def _missing_evidence(execution_mode: str, status: str) -> list[str]:
+    missing = []
+    if status != "succeeded" or execution_mode != "real":
+        missing.append("real_local_runtime_pipeline_success")
+    if execution_mode == "plan":
+        missing.append("pipeline_execution")
+    if execution_mode == "dry-run":
+        missing.append("non_dry_run_execution")
+    if status == "failed":
+        missing.append("passing_pipeline_summary")
+    return missing
+
+
+def _bundle_summary(case_results: list[dict[str, Any]], *, execution_mode: str) -> dict[str, Any]:
+    total = len(case_results)
+    succeeded = sum(1 for case in case_results if case["status"] == "succeeded")
+    planned = sum(1 for case in case_results if case["status"] == "planned")
+    failed = sum(1 for case in case_results if case["status"] == "failed")
+    release_ready_cases = sum(1 for case in case_results if case["release_ready"] is True)
+    release_ready = execution_mode == "real" and release_ready_cases == total and total > 0
+    return {
+        "case_count": total,
+        "planned_count": planned,
+        "succeeded_count": succeeded,
+        "failed_count": failed,
+        "release_ready_case_count": release_ready_cases,
+        "release_ready": release_ready,
+        "required_case_ids": [case["case_id"] for case in case_results],
+    }
+
+
+def _known_gaps(case_results: list[dict[str, Any]], *, execution_mode: str) -> list[str]:
+    if execution_mode == "real" and all(case["release_ready"] is True for case in case_results):
+        return []
+    gaps = [
+        "Issue 365 is not release-ready until every case has real_local_runtime evidence.",
+        "Plan-only and deterministic dry-run evidence are regression coverage, not final acceptance.",
+    ]
+    missing = sorted(
+        {
+            item
+            for case in case_results
+            for item in case.get("missing_evidence", [])
+        }
+    )
+    gaps.extend(missing)
+    return gaps
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H%M%SZ")
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Write or run the Issue 365 CLI acceptance matrix bundle."
+    )
+    parser.add_argument(
+        "--execution-mode",
+        choices=("plan", "dry-run", "real"),
+        default="plan",
+        help="plan writes matrix files only; dry-run invokes melix pipeline run --dry-run; real invokes the pipelines.",
+    )
+    parser.add_argument("--output-dir", default=".runtime/issue365/acceptance")
+    parser.add_argument("--repo-root", default=str(Path(__file__).resolve().parents[1]))
+    parser.add_argument("--melix-cli", default="melix")
+    parser.add_argument("--model-id", default="mlx-community/Qwen3.5-0.8B-OptiQ-4bit")
+    parser.add_argument("--sft-dataset-uri", default="/tmp/melix-issue365/datasets/sft")
+    parser.add_argument("--preference-dataset-uri", default="/tmp/melix-issue365/datasets/preference_pair")
+    parser.add_argument("--prompt-candidate-dataset-uri", default="/tmp/melix-issue365/datasets/prompt_candidate")
+    parser.add_argument("--reward-scored-dataset-uri", default="/tmp/melix-issue365/datasets/reward_scored")
+    parser.add_argument("--calibration-dataset-uri", default="/tmp/melix-issue365/datasets/calibration")
+    parser.add_argument("--reward-model-manifest-path", default="/tmp/melix-issue365/reward-model/manifest.json")
+    parser.add_argument("--timestamp", default="")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    config = Issue365AcceptanceConfig(
+        repo_root=Path(args.repo_root),
+        output_dir=Path(args.output_dir),
+        execution_mode=args.execution_mode,
+        model_id=args.model_id,
+        sft_dataset_uri=args.sft_dataset_uri,
+        preference_dataset_uri=args.preference_dataset_uri,
+        prompt_candidate_dataset_uri=args.prompt_candidate_dataset_uri,
+        reward_scored_dataset_uri=args.reward_scored_dataset_uri,
+        calibration_dataset_uri=args.calibration_dataset_uri,
+        reward_model_manifest_path=args.reward_model_manifest_path,
+        melix_cli=args.melix_cli,
+        timestamp=args.timestamp,
+        json_output=args.json,
+    )
+    bundle = build_acceptance_bundle(config)
+    if args.json:
+        print(json.dumps(bundle, indent=2, sort_keys=True))
+    else:
+        print(bundle["bundle_path"])
+        print(f"release_ready={str(bundle['release_ready']).lower()}")
+        print(f"execution_mode={bundle['execution_mode']}")
+    return 0 if bundle["release_ready"] or args.execution_mode != "real" else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/issue365_acceptance_bundle.py
+++ b/scripts/issue365_acceptance_bundle.py
@@ -348,7 +348,7 @@ def _alignment_case(
 def _ptq_case() -> Issue365PipelineCase:
     train_step = "ptq_base_lora"
     align_step = "ptq_dpo_align"
-    publish_step = "ptq_publish_merged"
+    publish_step = "ptq_publish_export"
     quantize_step = "ptq_quantize"
     return Issue365PipelineCase(
         case_id="lora_preference_ptq_quantized_inference",
@@ -395,9 +395,9 @@ def _ptq_case() -> Issue365PipelineCase:
                 "command": "lora.publish",
                 "args": {
                     "model_id": "${inputs.model_id}",
-                    "target_repo": "melix/issue365-ptq-merged",
+                    "target_repo": "melix/issue365-ptq-export",
                     "manifest_path": f"${{steps.{align_step}.result.output_path}}",
-                    "export_kind": "merged",
+                    "export_kind": "adapter",
                     "publish_backend": "local_filesystem",
                     "local_publish_root": "${inputs.local_publish_root}",
                 },
@@ -412,22 +412,23 @@ def _ptq_case() -> Issue365PipelineCase:
                     "weight_quant": "q4",
                     "kv_quant": "q8",
                     "quantization_mode": "ptq",
-                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_kind": "adapter_export",
                     "source_artifact_path": f"${{steps.{publish_step}.result.output_path}}",
                     "calibration_dataset_uri": "${inputs.calibration_dataset_uri}",
                     "quality_delta": 0,
                     "latency_delta": 0,
+                    "local_inference_smoke_mode": "runtime_generate",
+                    "local_inference_smoke_prompt": "Reply with ISSUE365_OK",
                 },
+                "checks": _quantized_runtime_smoke_checks(),
             },
-            _chat_step("ptq_chat", f"${{steps.{quantize_step}.result.output_path}}"),
-            _eval_step("ptq_eval", f"${{steps.{quantize_step}.result.output_path}}"),
         ),
     )
 
 
 def _qat_case() -> Issue365PipelineCase:
     train_step = "qat_train"
-    publish_step = "qat_publish_merged"
+    publish_step = "qat_publish_export"
     quantize_step = "qat_quantize"
     return Issue365PipelineCase(
         case_id="qat_quantized_inference",
@@ -461,9 +462,9 @@ def _qat_case() -> Issue365PipelineCase:
                 "command": "lora.publish",
                 "args": {
                     "model_id": "${inputs.model_id}",
-                    "target_repo": "melix/issue365-qat-merged",
+                    "target_repo": "melix/issue365-qat-export",
                     "manifest_path": f"${{steps.{train_step}.result.output_path}}",
-                    "export_kind": "merged",
+                    "export_kind": "adapter",
                     "publish_backend": "local_filesystem",
                     "local_publish_root": "${inputs.local_publish_root}",
                 },
@@ -478,18 +479,37 @@ def _qat_case() -> Issue365PipelineCase:
                     "weight_quant": "q4",
                     "kv_quant": "q8",
                     "quantization_mode": "qat",
-                    "source_artifact_kind": "merged_adapter",
+                    "source_artifact_kind": "adapter_export",
                     "source_artifact_path": f"${{steps.{publish_step}.result.output_path}}",
                     "calibration_dataset_uri": "${inputs.calibration_dataset_uri}",
                     "quality_delta": 0,
                     "latency_delta": 0,
                     "qat_fake_quant": "enabled",
+                    "local_inference_smoke_mode": "runtime_generate",
+                    "local_inference_smoke_prompt": "Reply with ISSUE365_OK",
                 },
+                "checks": _quantized_runtime_smoke_checks(),
             },
-            _chat_step("qat_chat", f"${{steps.{quantize_step}.result.output_path}}"),
-            _eval_step("qat_eval", f"${{steps.{quantize_step}.result.output_path}}"),
         ),
     )
+
+
+def _quantized_runtime_smoke_checks() -> dict[str, Any]:
+    return {
+        "required_result_fields": [
+            "job_id",
+            "output_path",
+            "artifact_path",
+            "local_inference_smoke.status",
+            "release_gate.local_inference_smoke_result",
+        ],
+        "equals": {
+            "result.local_inference_smoke.status": "passed",
+            "result.local_inference_smoke.evidence_kind": "local_runtime_generate",
+            "result.local_inference_smoke.smoke_mode": "runtime_generate",
+            "result.release_gate.local_inference_smoke_result": "passed",
+        },
+    }
 
 
 def _chat_step(step_id: str, model_id: str) -> dict[str, Any]:

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -1546,7 +1546,7 @@ def test_preference_training_iterate_batches_rejects_too_small_dataset() -> None
         next(iterate_preference_batches(dataset, batch_size=2, max_seq_length=16))
 
 
-def test_preference_training_iterate_batches_rejects_distributed_sharding() -> None:
+def test_preference_training_iterate_batches_shards_comm_group_batches() -> None:
     pytest.importorskip("mlx.core")
     from worker.model_ops.preference_training import (
         PreferencePair,
@@ -1559,30 +1559,60 @@ def test_preference_training_iterate_batches_rejects_distributed_sharding() -> N
 
         def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
             del add_special_tokens
-            return {
-                "Prompt": [0],
-                "Good": [2],
-                "Bad": [3],
-            }[text]
+            suffix = int(text.rsplit("-", maxsplit=1)[-1])
+            return [suffix]
 
     class FakeCommGroup:
-        pass
+        def __init__(self, *, rank: int, size: int) -> None:
+            self._rank = rank
+            self._size = size
+
+        def rank(self) -> int:
+            return self._rank
+
+        def size(self) -> int:
+            return self._size
 
     dataset = PreferenceTokenDataset(
         [
-            PreferencePair(prompt="Prompt", chosen="Good", rejected="Bad"),
-            PreferencePair(prompt="Prompt", chosen="Good", rejected="Bad"),
+            PreferencePair(prompt="Prompt-0", chosen="Good-0", rejected="Bad-10"),
+            PreferencePair(prompt="Prompt-1", chosen="Good-1", rejected="Bad-11"),
+            PreferencePair(prompt="Prompt-2", chosen="Good-2", rejected="Bad-12"),
+            PreferencePair(prompt="Prompt-3", chosen="Good-3", rejected="Bad-13"),
         ],
         SimpleTokenizer(),
     )
 
-    with pytest.raises(NotImplementedError, match="Distributed preference batch sharding"):
+    rank_zero_batch = next(
+        iterate_preference_batches(
+            dataset,
+            batch_size=4,
+            max_seq_length=16,
+            seed=0,
+            comm_group=FakeCommGroup(rank=0, size=2),
+        )
+    )
+    rank_one_batch = next(
+        iterate_preference_batches(
+            dataset,
+            batch_size=4,
+            max_seq_length=16,
+            seed=0,
+            comm_group=FakeCommGroup(rank=1, size=2),
+        )
+    )
+
+    assert rank_zero_batch[1].tolist() == [[1, 3], [1, 3]]
+    assert rank_one_batch[1].tolist() == [[1, 3], [1, 3]]
+    assert rank_zero_batch[0][:, 1].tolist() == [0, 2]
+    assert rank_one_batch[0][:, 1].tolist() == [1, 3]
+    with pytest.raises(ValueError, match="divisible by the number of workers"):
         next(
             iterate_preference_batches(
                 dataset,
-                batch_size=2,
+                batch_size=4,
                 max_seq_length=16,
-                comm_group=FakeCommGroup(),
+                comm_group=FakeCommGroup(rank=0, size=3),
             )
         )
 

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -44,6 +44,7 @@ from worker.model_ops.mlx_lm_runner import (
 )
 from worker.model_ops.upload_receipt_pipeline import (
     HuggingFacePublishBackend,
+    LocalFilesystemPublishBackend,
     PublishResult,
     SourceArtifactDescriptor,
     UploadReceiptPipeline,
@@ -2700,6 +2701,83 @@ def test_upload_job_publishes_adapter_bundle_to_hugging_face(tmp_path: Path) -> 
     assert staged_manifest["weights_path"] == "adapter/adapters.safetensors"
     assert staged_manifest["adapter_config_path"] == "adapter/adapter_config.json"
     assert staged_manifest["published_repo"] == "melix/adapters/melix-dev-adapter"
+
+
+def test_upload_receipt_pipeline_local_filesystem_backend_writes_publish_bundle(tmp_path: Path) -> None:
+    adapter_dir = tmp_path / "adapter-source"
+    adapter_dir.mkdir()
+    weights_path = adapter_dir / "adapters.safetensors"
+    config_path = adapter_dir / "adapter_config.json"
+    manifest_path = adapter_dir / "train_lora.adapter.json"
+    weights_path.write_bytes(b"adapter")
+    config_path.write_text('{"fine_tune_type":"lora"}\n', encoding="utf-8")
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.lora_adapter_package.v1",
+                "artifact_kind": "adapter",
+                "adapter_name": "local-adapter",
+                "job_id": "train-1",
+                "source_model": "melix-dev-text",
+                "weights_path": str(weights_path),
+                "adapter_config_path": str(config_path),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = UploadReceiptPipeline().run(
+        maintenance_pb2.ConvertModelRequest(
+            source_model="melix-dev-text",
+            generate_manifest=True,
+            ext={
+                "operation": "upload",
+                "artifact_kind": "adapter_export",
+                "artifact_path": str(manifest_path),
+                "target_repo": "melix/adapters/local-adapter",
+                "publish_backend": "local_filesystem",
+                "local_publish_root": str(tmp_path / "local-publish"),
+            },
+        ),
+        job_id="upload-local-1",
+        output_dir=tmp_path / "upload-local",
+    )
+
+    publish_root = tmp_path / "local-publish" / "melix" / "adapters" / "local-adapter"
+    payload = result.manifest_payload
+    assert payload["status"] == "published"
+    assert payload["upload_backend"] == "local_filesystem"
+    assert payload["published_url"] == publish_root.as_uri()
+    assert payload["published_ref"] == str(publish_root)
+    assert payload["distribution_contract"] == "adapter_only"
+    assert (publish_root / "adapter" / "adapters.safetensors").is_file()
+    assert (publish_root / "adapter" / "adapter_config.json").is_file()
+    assert (publish_root / "train_lora.adapter.json").is_file()
+
+
+def test_local_filesystem_publish_backend_handles_file_source_and_backend_edges(tmp_path: Path) -> None:
+    source_path = tmp_path / "artifact.json"
+    source_path.write_text('{"ok":true}\n', encoding="utf-8")
+    target_file = tmp_path / "publish" / "artifact"
+    target_file.parent.mkdir()
+    target_file.write_text("stale", encoding="utf-8")
+
+    result = LocalFilesystemPublishBackend(root=tmp_path / "publish").publish(
+        source_path=source_path,
+        target_repo="/",
+        artifact_kind="model_export",
+    )
+
+    assert result.backend == "local_filesystem"
+    assert result.target_repo == "/"
+    assert result.published_files == ["artifact.json"]
+    assert (tmp_path / "publish" / "artifact" / "artifact.json").read_text(encoding="utf-8") == '{"ok":true}\n'
+    assert isinstance(UploadReceiptPipeline._resolve_publisher_from_ext({}), HuggingFacePublishBackend)
+    with pytest.raises(ModelOperationError, match="local_publish_root"):
+        UploadReceiptPipeline._resolve_publisher_from_ext({"publish_backend": "local_filesystem"})
+    with pytest.raises(ModelOperationError, match="publish_backend must be one of"):
+        UploadReceiptPipeline._resolve_publisher_from_ext({"publish_backend": "unknown"})
 
 
 def test_upload_job_publishes_fused_derived_model_as_merged_export(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_mlx_backend.py
+++ b/services/mlx-worker-python/tests/test_mlx_backend.py
@@ -315,6 +315,42 @@ def test_auto_backend_passes_resolved_stop_sequences_when_supported() -> None:
     assert [chunk.text for chunk in chunks] == ["done"]
 
 
+def test_auto_backend_does_not_pass_stop_to_variadic_stream_generate() -> None:
+    seen: dict[str, object] = {}
+
+    def fake_load(model_source: str, **kwargs):
+        _ = model_source, kwargs
+        return object(), FakeTokenizer()
+
+    def fake_stream_generate(*args, **kwargs):
+        seen["kwargs"] = dict(kwargs)
+        yield FakeGenerationResponse(text="done", prompt_tokens=1, generation_tokens=1, finish_reason="stop")
+
+    backend = AutoMLXBackend(
+        load_fn=fake_load,
+        stream_generate_fn=fake_stream_generate,
+        sampler_factory=lambda **kwargs: "sampler",
+    )
+    model_spec = WorkerModelCatalog.dev_text_model()
+    model_spec.ext["melix.stop_sequences"] = "</model>"
+    loaded_model = backend.load_model(model_spec)
+
+    chunks = list(
+        backend.generate_tokens(
+            loaded_model,
+            "prompt",
+            common_pb2.SamplingConfig(max_output_tokens=4, stop=["</request>"]),
+            Event(),
+        )
+    )
+
+    assert "stop" not in seen["kwargs"]
+    assert "stop_words" not in seen["kwargs"]
+    assert "stop_sequences" not in seen["kwargs"]
+    assert mlx_text_runtime_module._callable_declares_kwarg(42, "stop") is False
+    assert [chunk.text for chunk in chunks] == ["done"]
+
+
 def test_runtime_enforces_stop_sequences_across_backend_chunk_boundaries() -> None:
     class ChunkedStopBackend:
         runtime_name = "fake-stop-runtime"

--- a/services/mlx-worker-python/worker/model_ops/preference_training.py
+++ b/services/mlx-worker-python/worker/model_ops/preference_training.py
@@ -423,12 +423,16 @@ def iterate_preference_batches(
             f"but only has {len(dataset)}."
         )
     if comm_group is not None:
-        raise NotImplementedError(
-            "Distributed preference batch sharding is deferred until GRPO support lands."
-        )
+        offset = comm_group.rank()
+        step = comm_group.size()
+    else:
+        offset = 0
+        step = 1
+    if batch_size % step != 0:
+        raise ValueError("The batch size must be divisible by the number of workers.")
     idx = sorted(range(len(dataset)), key=dataset.itemlen)
     batch_idx = [
-        idx[i: i + batch_size]
+        idx[i + offset : i + offset + batch_size : step]
         for i in range(0, len(idx) - batch_size + 1, batch_size)
     ]
     if seed is not None:

--- a/services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py
@@ -128,6 +128,59 @@ class HuggingFacePublishBackend:
         )
 
 
+@dataclass(frozen=True)
+class LocalFilesystemPublishBackend:
+    root: Path
+
+    def publish(
+        self,
+        *,
+        source_path: Path,
+        target_repo: str,
+        artifact_kind: str,
+        token: str = "",
+        private: bool = False,
+        commit_message: str = "",
+        published_files: list[str] | None = None,
+    ) -> PublishResult:
+        del artifact_kind, token, private, commit_message
+        resolved_source_path = source_path.expanduser().resolve()
+        target_path = self.root.expanduser().resolve() / _local_target_repo_path(target_repo)
+        if target_path.exists() and not target_path.is_dir():
+            target_path.unlink()
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        if resolved_source_path.is_dir():
+            shutil.copytree(resolved_source_path, target_path, dirs_exist_ok=True)
+        else:
+            target_path.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(resolved_source_path, target_path / resolved_source_path.name)
+
+        if published_files is None:
+            if target_path.is_dir():
+                published_files = _collect_published_file_list(target_path)
+            else:
+                published_files = [target_path.name]
+
+        return PublishResult(
+            backend="local_filesystem",
+            target_repo=target_repo,
+            target_url=target_path.as_uri(),
+            remote_ref=str(target_path),
+            published_files=published_files,
+        )
+
+
+def _local_target_repo_path(target_repo: str) -> Path:
+    normalized_parts = [
+        part.strip().replace("\\", "_")
+        for part in target_repo.split("/")
+        if part.strip() not in {"", ".", ".."}
+    ]
+    if not normalized_parts:
+        normalized_parts = ["artifact"]
+    return Path(*normalized_parts)
+
+
 def _resolve_hf_cli_command() -> str:
     for candidate in ("hf", "huggingface-cli"):
         if shutil.which(candidate):
@@ -159,7 +212,7 @@ class UploadReceiptPipeline:
         return _collect_published_file_list(source_dir)
 
     def __init__(self, publisher: Any | None = None) -> None:
-        self._publisher = publisher or HuggingFacePublishBackend()
+        self._publisher = publisher
 
     def run(
         self,
@@ -197,7 +250,7 @@ class UploadReceiptPipeline:
         processor_config_files = UploadReceiptPipeline._collect_processor_config_files(
             prepared_source.published_files
         )
-        publish_result = self._publisher.publish(
+        publish_result = self._resolve_publisher(request.ext).publish(
             source_path=prepared_source.source_path,
             target_repo=target_repo,
             artifact_kind=export_artifact_kind,
@@ -350,6 +403,29 @@ class UploadReceiptPipeline:
                 ]
             ),
         )
+
+    @staticmethod
+    def _resolve_publisher_from_ext(ext: dict[str, str]) -> Any:
+        backend = ext.get("publish_backend", "").strip().lower()
+        if backend in {"", "huggingface", "huggingface_hub"}:
+            return HuggingFacePublishBackend()
+        if backend in {"local", "local_filesystem", "filesystem"}:
+            root = ext.get("local_publish_root", "").strip()
+            if not root:
+                raise ModelOperationError(
+                    code="invalid_argument",
+                    message="local_filesystem publish requires local_publish_root.",
+                )
+            return LocalFilesystemPublishBackend(root=Path(root))
+        raise ModelOperationError(
+            code="unsupported_publish_backend",
+            message="publish_backend must be one of: huggingface_hub, local_filesystem.",
+        )
+
+    def _resolve_publisher(self, ext: dict[str, str]) -> Any:
+        if self._publisher is not None:
+            return self._publisher
+        return self._resolve_publisher_from_ext(ext)
 
     @staticmethod
     def _resolve_export_artifact_kind(

--- a/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from dataclasses import replace
 import importlib.util
+import inspect
 import json
 from pathlib import Path
 from typing import Any
@@ -109,6 +110,20 @@ def _tokenizer_eos_token_ids(tokenizer: Any) -> tuple[str, ...]:
     if isinstance(eos_token_id, list | tuple | set):
         return tuple(str(item) for item in eos_token_id if str(item).strip())
     return (str(eos_token_id),) if str(eos_token_id).strip() else ()
+
+
+def _callable_declares_kwarg(callable_obj: Any, keyword: str) -> bool:
+    try:
+        signature = inspect.signature(callable_obj)
+    except (TypeError, ValueError):
+        return False
+    parameter = signature.parameters.get(keyword)
+    if parameter is None:
+        return False
+    return parameter.kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )
 
 
 def resolve_text_stop_contract(
@@ -387,7 +402,7 @@ class AutoMLXBackend:
         stream_kwargs: dict[str, Any] = {}
         if stop_contract.sequences:
             for kwarg_name in ("stop", "stop_words", "stop_sequences"):
-                if _callable_accepts_kwarg(self._stream_generate_fn, kwarg_name):
+                if _callable_declares_kwarg(self._stream_generate_fn, kwarg_name):
                     stream_kwargs[kwarg_name] = list(stop_contract.sequences)
                     break
 

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -363,6 +363,8 @@ struct MelixCLIParserTests {
             "--calibration-dataset-uri", "/tmp/melix-datasets/calibration",
             "--quality-delta", "-0.01",
             "--latency-delta", "-0.15",
+            "--local-inference-smoke-mode", "runtime_generate",
+            "--local-inference-smoke-prompt", "Reply with ISSUE365_OK",
             "--json",
         ])
         let uploadCommand = try MelixCLIParser.parse([
@@ -409,6 +411,8 @@ struct MelixCLIParserTests {
         #expect(quantizeOptions.calibrationDatasetURI == "/tmp/melix-datasets/calibration")
         #expect(quantizeOptions.qualityDelta == "-0.01")
         #expect(quantizeOptions.latencyDelta == "-0.15")
+        #expect(quantizeOptions.localInferenceSmokeMode == "runtime_generate")
+        #expect(quantizeOptions.localInferenceSmokePrompt == "Reply with ISSUE365_OK")
         #expect(quantizeOptions.json)
         #expect(uploadOptions.modelID == "melix-dev-text")
         #expect(uploadOptions.outputDir == "/tmp/melix-upload")
@@ -568,7 +572,7 @@ struct MelixCLIParserTests {
         let allCommands: [(MelixCLICommand, String)] = [
             (.doctor(.init()), "doctor"),
             (.convert(.init(modelID: "model", outputDir: "/tmp/out", targetFormat: "bundle", json: true)), "convert"),
-            (.quantize(.init(modelID: "model", outputDir: "/tmp/out", quantProfileID: "q4", weightQuant: "int4", kvQuant: "int8", quantizationMode: "ptq", sourceArtifactKind: "base_model", sourceArtifactPath: "/tmp/model", calibrationDatasetURI: "/tmp/calibration", qualityDelta: "-0.01", latencyDelta: "-0.2", json: true)), "quantize"),
+            (.quantize(.init(modelID: "model", outputDir: "/tmp/out", quantProfileID: "q4", weightQuant: "int4", kvQuant: "int8", quantizationMode: "ptq", sourceArtifactKind: "base_model", sourceArtifactPath: "/tmp/model", calibrationDatasetURI: "/tmp/calibration", qualityDelta: "-0.01", latencyDelta: "-0.2", localInferenceSmokeMode: "runtime_generate", localInferenceSmokePrompt: "smoke", json: true)), "quantize"),
             (.upload(.init(modelID: "model", outputDir: "/tmp/out", targetRepo: "melix/model", artifactPath: "/tmp/model", artifactKind: "bundle", artifactManifestPath: "/tmp/model/manifest.json", json: true)), "upload"),
             (.modelList(.init(json: true)), "model.list"),
             (.modelInspect(.init(modelID: "model", json: true)), "model.inspect"),
@@ -652,7 +656,7 @@ struct MelixCLIParserTests {
         let supportedCommands: [MelixCLICommand] = [
             .doctor(.init(json: true)),
             .convert(.init(modelID: "model", outputDir: "/tmp/out", targetFormat: "bundle", json: true)),
-            .quantize(.init(modelID: "model", outputDir: "/tmp/out", quantProfileID: "q4", weightQuant: "int4", kvQuant: "int8", quantizationMode: "ptq", sourceArtifactKind: "base_model", sourceArtifactPath: "/tmp/model", calibrationDatasetURI: "/tmp/calibration", qualityDelta: "-0.01", latencyDelta: "-0.2", json: true)),
+            .quantize(.init(modelID: "model", outputDir: "/tmp/out", quantProfileID: "q4", weightQuant: "int4", kvQuant: "int8", quantizationMode: "ptq", sourceArtifactKind: "base_model", sourceArtifactPath: "/tmp/model", calibrationDatasetURI: "/tmp/calibration", qualityDelta: "-0.01", latencyDelta: "-0.2", localInferenceSmokeMode: "runtime_generate", localInferenceSmokePrompt: "smoke", json: true)),
             .upload(.init(modelID: "model", outputDir: "/tmp/out", targetRepo: "melix/model", artifactPath: "/tmp/model", artifactKind: "bundle", artifactManifestPath: "/tmp/model/manifest.json", json: true)),
             .modelImport(.init(path: "/tmp/model", modelID: "model", modelKind: "text", revision: "main", json: true)),
             .modelHubDownload(.init(repoID: "mlx/qwen", revision: "main", json: true)),
@@ -2613,6 +2617,14 @@ struct MelixCLIParserTests {
                 "--source-artifact-kind", "checkpoint",
             ],
             equals: .usage("Invalid value for --source-artifact-kind. Expected one of: base_model, merged_adapter, adapter_export.")
+        )
+        try assertError(
+            for: [
+                "quantize",
+                "--model-id", "melix-dev-text",
+                "--local-inference-smoke-mode", "screenshot",
+            ],
+            equals: .usage("Invalid value for --local-inference-smoke-mode. Expected one of: structural, runtime_generate.")
         )
         try assertError(
             for: ["upload", "--model-id", "melix-dev-text"],

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -1549,6 +1549,8 @@ struct MelixCLIParserTests {
             "--target-repo", "melix/adapters/demo",
             "--manifest-path", "/tmp/demo/manifest.json",
             "--export-kind", "adapter",
+            "--publish-backend", "local_filesystem",
+            "--local-publish-root", "/tmp/melix-local-publish",
         ])
         guard case .loraPublish(let options) = command else {
             Issue.record("Expected loraPublish command")
@@ -1557,6 +1559,8 @@ struct MelixCLIParserTests {
         #expect(options.exportKind == .adapterExport)
         #expect(options.artifactPath == "/tmp/demo/manifest.json")
         #expect(options.artifactManifestPath == "/tmp/demo/manifest.json")
+        #expect(options.publishBackend == "local_filesystem")
+        #expect(options.localPublishRoot == "/tmp/melix-local-publish")
     }
 
     @Test("lora publish --manifest-path without --export-kind defers classification to the runner")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -1051,8 +1051,9 @@ struct MelixCLIRunnerTests {
               "args": {
                 "model_id": "${inputs.base_model_id}",
                 "dataset_uri": "/tmp/preference-pairs.jsonl",
+                "dataset_source_kind": "local_package",
                 "adapter_name": "issue365-dpo",
-                "algorithm": "dpo",
+                "algorithm": " DPO ",
                 "reference_model_path": "${steps.train_lora.result.output_path}",
                 "max_steps": 2
               },
@@ -1066,8 +1067,9 @@ struct MelixCLIRunnerTests {
               "args": {
                 "model_id": "${inputs.base_model_id}",
                 "target_repo": "melix/models/issue365-dpo-merged",
+                "adapter_path": "   ",
                 "manifest_path": "${steps.align_adapter.result.output_path}",
-                "export_kind": "merged"
+                "export_kind": " MERGED "
               },
               "checks": {
                 "required_result_fields": ["job_id", "output_path"]
@@ -1082,8 +1084,8 @@ struct MelixCLIRunnerTests {
                 "quant_profile_id": "q4",
                 "weight_quant": "q4",
                 "kv_quant": "q8",
-                "quantization_mode": "ptq",
-                "source_artifact_kind": "merged_adapter",
+                "quantization_mode": " PTQ ",
+                "source_artifact_kind": " MERGED_ADAPTER ",
                 "source_artifact_path": "${steps.publish_merged.result.output_path}",
                 "calibration_dataset_uri": "/tmp/calibration.jsonl",
                 "quality_delta": "-0.01",
@@ -1202,9 +1204,17 @@ struct MelixCLIRunnerTests {
         #expect(Array(operationCommands[1].prefix(2)) == ["alignment", "train"])
         #expect(operationCommands[1].contains("--reference-model-path"))
         #expect(operationCommands[1].contains("/tmp/melix/train_lora/issue365-sft.adapter.json"))
+        #expect(operationCommands[1].contains("--algorithm"))
+        #expect(operationCommands[1].contains("dpo"))
+        #expect(operationCommands[1].contains(where: { $0.contains("dataset_source_kind") }) == false)
         #expect(Array(operationCommands[2].prefix(2)) == ["lora", "publish"])
         #expect(operationCommands[2].contains("/tmp/melix/alignment/issue365-dpo.adapter.json"))
+        #expect(operationCommands[2].contains(where: { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) == false)
         #expect(operationCommands[3].starts(with: ["quantize", "--model-id", "melix-dev-text"]))
+        #expect(operationCommands[3].contains("--quantization-mode"))
+        #expect(operationCommands[3].contains("ptq"))
+        #expect(operationCommands[3].contains("--source-artifact-kind"))
+        #expect(operationCommands[3].contains("merged_adapter"))
         #expect(operationCommands[3].contains("--source-artifact-path"))
         #expect(operationCommands[3].contains("/tmp/melix/publish/issue365-dpo-merged"))
         #expect(Array(operationCommands[4].prefix(2)) == ["lora", "activate"])

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -442,7 +442,9 @@ struct MelixCLIRunnerTests {
                 "source_artifact_path": "/tmp/merged-model",
                 "calibration_dataset_uri": "/tmp/calibration.jsonl",
                 "quality_delta": "-0.01",
-                "latency_delta": "-0.15"
+                "latency_delta": "-0.15",
+                "local_inference_smoke_mode": "runtime_generate",
+                "local_inference_smoke_prompt": "Reply with ISSUE365_OK"
               }
             },
             {
@@ -653,6 +655,8 @@ struct MelixCLIRunnerTests {
         #expect(alignArguments.contains("grpo"))
         #expect(quantizeArguments.contains("--source-artifact-kind"))
         #expect(quantizeArguments.contains("merged_adapter"))
+        #expect(quantizeArguments.contains("--local-inference-smoke-mode"))
+        #expect(quantizeArguments.contains("runtime_generate"))
     }
 
     @Test("pipeline dry run redacts Hugging Face download token arguments")
@@ -1190,10 +1194,16 @@ struct MelixCLIRunnerTests {
                 "source_artifact_path": "${steps.publish_merged.result.output_path}",
                 "calibration_dataset_uri": "/tmp/calibration.jsonl",
                 "quality_delta": "-0.01",
-                "latency_delta": "-0.12"
+                "latency_delta": "-0.12",
+                "local_inference_smoke_mode": " runtime_generate ",
+                "local_inference_smoke_prompt": "Reply with ISSUE365_OK"
               },
               "checks": {
-                "required_result_fields": ["job_id", "output_path", "bundle_path"]
+                "required_result_fields": ["job_id", "output_path", "local_inference_smoke.status"],
+                "equals": {
+                  "result.local_inference_smoke.status": "passed",
+                  "result.local_inference_smoke.smoke_mode": "runtime_generate"
+                }
               }
             },
             {
@@ -1269,7 +1279,7 @@ struct MelixCLIRunnerTests {
                 #"{"operation":"train_alignment","job_id":"align-job-1","output_path":"/tmp/melix/alignment/issue365-dpo.adapter.json","alignment_run_manifest_path":"/tmp/melix/alignment/issue365-dpo.alignment_run.json"}"#,
                 #"{"operation":"upload","job_id":"publish-job-1","output_path":"/tmp/melix/publish/issue365-dpo-merged","artifact_manifest_path":"/tmp/melix/publish/issue365-dpo-merged/manifest.json"}"#,
                 #"{"operation":"registry_snapshot","adapters":[]}"#,
-                #"{"operation":"quantize","job_id":"quantize-job-1","output_path":"/tmp/melix/quantized/issue365-dpo-q4","bundle_path":"/tmp/melix/quantized/issue365-dpo-q4"}"#,
+                #"{"operation":"quantize","job_id":"quantize-job-1","output_path":"/tmp/melix/quantized/issue365-dpo-q4","bundle_path":"/tmp/melix/quantized/issue365-dpo-q4","local_inference_smoke":{"status":"passed","smoke_mode":"runtime_generate"}}"#,
                 #"{"operation":"registry_snapshot","adapters":[]}"#,
                 #"{"operation":"activate_adapter","job_id":"activate-job-1","output_path":"/tmp/melix/activate_adapter/issue365-dpo"}"#,
                 #"{"operation":"registry_snapshot","adapters":[]}"#,
@@ -1322,6 +1332,10 @@ struct MelixCLIRunnerTests {
         #expect(operationCommands[3].contains("merged_adapter"))
         #expect(operationCommands[3].contains("--source-artifact-path"))
         #expect(operationCommands[3].contains("/tmp/melix/publish/issue365-dpo-merged"))
+        #expect(operationCommands[3].contains("--local-inference-smoke-mode"))
+        #expect(operationCommands[3].contains("runtime_generate"))
+        #expect(operationCommands[3].contains("--local-inference-smoke-prompt"))
+        #expect(operationCommands[3].contains("Reply with ISSUE365_OK"))
         #expect(Array(operationCommands[4].prefix(2)) == ["lora", "activate"])
         #expect(quantizeArtifactPaths.contains("/tmp/melix/quantized/issue365-dpo-q4"))
     }
@@ -1961,6 +1975,27 @@ struct MelixCLIRunnerTests {
                 "Pipeline command argument source_artifact_kind must be one of: base_model, merged_adapter, adapter_export."
             ),
             (
+                "quantize-invalid-smoke-mode",
+                #"""
+                {
+                  "schema_version": "melix.pipeline.v1",
+                  "name": "quantize-invalid-smoke-mode",
+                  "inputs": {},
+                  "steps": [
+                    {
+                      "id": "quantize",
+                      "command": "quantize",
+                      "args": {
+                        "model_id": "melix-dev-text",
+                        "local_inference_smoke_mode": "screenshot"
+                      }
+                    }
+                  ]
+                }
+                """#,
+                "Pipeline command argument local_inference_smoke_mode must be one of: structural, runtime_generate."
+            ),
+            (
                 "publish-missing-artifact-selector",
                 #"""
                 {
@@ -2454,6 +2489,8 @@ struct MelixCLIRunnerTests {
                     calibrationDatasetURI: "/tmp/melix-datasets/calibration",
                     qualityDelta: "-0.01",
                     latencyDelta: "-0.15",
+                    localInferenceSmokeMode: "runtime_generate",
+                    localInferenceSmokePrompt: "Reply with ISSUE365_OK",
                     json: true
                 )
             )
@@ -2499,6 +2536,8 @@ struct MelixCLIRunnerTests {
         #expect(quantizeCall.ext["calibration_dataset_uri"] == "/tmp/melix-datasets/calibration")
         #expect(quantizeCall.ext["quality_delta"] == "-0.01")
         #expect(quantizeCall.ext["latency_delta"] == "-0.15")
+        #expect(quantizeCall.ext["local_inference_smoke_mode"] == "runtime_generate")
+        #expect(quantizeCall.ext["local_inference_smoke_prompt"] == "Reply with ISSUE365_OK")
         #expect(uploadPayload["job_id"] as? String == "upload-job-1")
         #expect(uploadCall.operation == "upload")
         #expect(uploadCall.outputDir == "/tmp/melix-upload")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -708,6 +708,105 @@ struct MelixCLIRunnerTests {
         #expect(String(data: try JSONSerialization.data(withJSONObject: receipt), encoding: .utf8)?.contains("hf_secret_token") == false)
     }
 
+    @Test("pipeline result output path falls back to artifact path")
+    func pipelineResultOutputPathFallsBackToArtifactPath() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let pipelineURL = root.appendingPathComponent("artifact-alias.pipeline.json")
+        let receiptURL = root.appendingPathComponent("receipts")
+        let adapterManifestPath = root.appendingPathComponent("train_lora.adapter.json").path
+        let activationManifestPath = root.appendingPathComponent("activate_adapter.json").path
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let pipelineJSON = #"""
+        {
+          "schema_version": "melix.pipeline.v1",
+          "name": "artifact-alias",
+          "inputs": {
+            "model_id": "melix-dev-text"
+          },
+          "steps": [
+            {
+              "id": "train_lora",
+              "command": "lora.train",
+              "args": {
+                "model_id": "${inputs.model_id}",
+                "dataset_uri": "/tmp/sft.jsonl",
+                "adapter_name": "artifact-alias",
+                "training_mode": "lora"
+              }
+            },
+            {
+              "id": "activate_lora",
+              "command": "lora.activate",
+              "args": {
+                "model_id": "${inputs.model_id}",
+                "adapter_path": "${steps.train_lora.result.output_path}",
+                "activation_mode": "adapter_backed_runtime",
+                "derived_model_alias": "artifact-alias-derived"
+              }
+            }
+          ]
+        }
+        """#
+        try Data(pipelineJSON.utf8).write(to: pipelineURL)
+
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(
+            makeModelOperationResult(
+                outputPath: "",
+                manifestJSON: #"""
+                {
+                  "operation": "train_lora",
+                  "job_id": "train-1",
+                  "artifact_path": "\#(adapterManifestPath)"
+                }
+                """#
+            ),
+            forOperation: "train_lora"
+        )
+        await client.setModelOperationResult(
+            makeModelOperationResult(
+                outputPath: activationManifestPath,
+                manifestJSON: #"""
+                {
+                  "operation": "activate_adapter",
+                  "job_id": "activate-1",
+                  "output_path": "\#(activationManifestPath)"
+                }
+                """#
+            ),
+            forOperation: "activate_adapter"
+        )
+
+        let output = try await MelixCLIRunner(
+            client: client,
+            environment: ["MELIX_HOME": root.path]
+        ).run(
+            .pipelineRun(
+                .init(
+                    filePath: pipelineURL.path,
+                    receiptDir: receiptURL.path,
+                    traceID: "trace-artifact-alias"
+                )
+            )
+        )
+        let summary = try #require(parseJSONObject(output))
+        let steps = try #require(summary["steps"] as? [[String: Any]])
+        let trainStep = try #require(steps.first { $0["id"] as? String == "train_lora" })
+        let trainReceiptPath = try #require(trainStep["receipt_path"] as? String)
+        let trainReceipt = try #require(try parseJSONFile(trainReceiptPath))
+        let trainResult = try #require(trainReceipt["result"] as? [String: Any])
+        let calls = await client.modelOperationCalls.filter { $0.ext["melix.registry_rescan"] != "true" }
+
+        #expect(summary["status"] as? String == "succeeded")
+        #expect(trainResult["artifact_path"] as? String == adapterManifestPath)
+        #expect(trainResult["output_path"] as? String == adapterManifestPath)
+        #expect(calls.count == 2)
+        #expect(calls[1].operation == "activate_adapter")
+        #expect(calls[1].ext["artifact_path"] == adapterManifestPath)
+    }
+
     @Test("successful fake phase 8 pipeline writes receipts summary and artifact paths")
     func successfulFakePhase8PipelineWritesReceiptsSummaryAndArtifactPaths() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
@@ -1069,7 +1168,9 @@ struct MelixCLIRunnerTests {
                 "target_repo": "melix/models/issue365-dpo-merged",
                 "adapter_path": "   ",
                 "manifest_path": "${steps.align_adapter.result.output_path}",
-                "export_kind": " MERGED "
+                "export_kind": " MERGED ",
+                "publish_backend": "local_filesystem",
+                "local_publish_root": "/tmp/melix/issue365-local-publish"
               },
               "checks": {
                 "required_result_fields": ["job_id", "output_path"]
@@ -1209,6 +1310,10 @@ struct MelixCLIRunnerTests {
         #expect(operationCommands[1].contains(where: { $0.contains("dataset_source_kind") }) == false)
         #expect(Array(operationCommands[2].prefix(2)) == ["lora", "publish"])
         #expect(operationCommands[2].contains("/tmp/melix/alignment/issue365-dpo.adapter.json"))
+        #expect(operationCommands[2].contains("--publish-backend"))
+        #expect(operationCommands[2].contains("local_filesystem"))
+        #expect(operationCommands[2].contains("--local-publish-root"))
+        #expect(operationCommands[2].contains("/tmp/melix/issue365-local-publish"))
         #expect(operationCommands[2].contains(where: { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) == false)
         #expect(operationCommands[3].starts(with: ["quantize", "--model-id", "melix-dev-text"]))
         #expect(operationCommands[3].contains("--quantization-mode"))

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -365,6 +365,99 @@ struct MelixCLIRunnerTests {
               }
             },
             {
+              "id": "align",
+              "command": "alignment.train",
+              "args": {
+                "model_id": "${inputs.model_id}",
+                "dataset_uri": "/tmp/preference-pairs.jsonl",
+                "adapter_name": "aligned-adapter",
+                "target_repo": "melix/aligned-adapter",
+                "algorithm": "grpo",
+                "grpo_candidate_count": 4,
+                "reference_model_path": "/tmp/reference-model",
+                "reward_model_manifest_path": "/tmp/reward-model.json",
+                "kl_penalty": "0.05",
+                "max_steps": 2
+              }
+            },
+            {
+              "id": "publish_adapter",
+              "command": "lora.publish",
+              "args": {
+                "model_id": "${inputs.model_id}",
+                "target_repo": "melix/adapters/demo",
+                "adapter_path": "/tmp/adapter.json"
+              }
+            },
+            {
+              "id": "publish_merged_path",
+              "command": "lora.publish",
+              "args": {
+                "model_id": "${inputs.model_id}",
+                "target_repo": "melix/models/demo-merged",
+                "merged_model_path": "/tmp/merged-model",
+                "export_kind": "merged"
+              }
+            },
+            {
+              "id": "publish_manifest",
+              "command": "lora.publish",
+              "args": {
+                "model_id": "${inputs.model_id}",
+                "target_repo": "melix/models/demo-manifest",
+                "manifest_path": "/tmp/merged-manifest.json"
+              }
+            },
+            {
+              "id": "publish_artifact",
+              "command": "lora.publish",
+              "args": {
+                "model_id": "${inputs.model_id}",
+                "target_repo": "melix/adapters/artifact",
+                "artifact_path": "/tmp/artifact-adapter.json",
+                "artifact_manifest_path": "/tmp/artifact-adapter.json",
+                "export_kind": "adapter"
+              }
+            },
+            {
+              "id": "convert",
+              "command": "convert",
+              "args": {
+                "model_id": "${inputs.model_id}",
+                "output_dir": "/tmp/converted",
+                "target_format": "melix_model_bundle"
+              }
+            },
+            {
+              "id": "quantize",
+              "command": "quantize",
+              "args": {
+                "model_id": "${inputs.model_id}",
+                "output_dir": "/tmp/quantized",
+                "quant_profile_id": "q4",
+                "weight_quant": "q4",
+                "kv_quant": "q8",
+                "quantization_mode": "ptq",
+                "source_artifact_kind": "merged_adapter",
+                "source_artifact_path": "/tmp/merged-model",
+                "calibration_dataset_uri": "/tmp/calibration.jsonl",
+                "quality_delta": "-0.01",
+                "latency_delta": "-0.15"
+              }
+            },
+            {
+              "id": "upload",
+              "command": "upload",
+              "args": {
+                "model_id": "${inputs.model_id}",
+                "output_dir": "/tmp/upload",
+                "target_repo": "melix/models/uploaded",
+                "artifact_path": "/tmp/quantized",
+                "artifact_kind": "quantized_model_bundle",
+                "artifact_manifest_path": "/tmp/quantized/manifest.json"
+              }
+            },
+            {
               "id": "activate",
               "command": "lora.activate",
               "args": {
@@ -537,14 +630,29 @@ struct MelixCLIRunnerTests {
         let trainReceipt = try #require(try parseJSONFile(trainReceiptPath))
         let trainResult = try #require(trainReceipt["result"] as? [String: Any])
         let trainArguments = try #require(trainResult["arguments"] as? [String])
+        let alignStep = try #require(steps.first { $0["id"] as? String == "align" })
+        let alignReceiptPath = try #require(alignStep["receipt_path"] as? String)
+        let alignReceipt = try #require(try parseJSONFile(alignReceiptPath))
+        let alignResult = try #require(alignReceipt["result"] as? [String: Any])
+        let alignArguments = try #require(alignResult["arguments"] as? [String])
+        let quantizeStep = try #require(steps.first { $0["id"] as? String == "quantize" })
+        let quantizeReceiptPath = try #require(quantizeStep["receipt_path"] as? String)
+        let quantizeReceipt = try #require(try parseJSONFile(quantizeReceiptPath))
+        let quantizeResult = try #require(quantizeReceipt["result"] as? [String: Any])
+        let quantizeArguments = try #require(quantizeResult["arguments"] as? [String])
 
         #expect(summary["receipt_dir"] as? String == expectedReceiptDir)
         #expect(summary["status"] as? String == "planned")
-        #expect(steps.count == 19)
+        #expect(steps.count == 27)
         #expect(steps.allSatisfy { $0["status"] as? String == "planned" })
         #expect(chatArguments.contains("override-model"))
         #expect(chatArguments.contains(#"number 7 flag true object {"suite":"smoke"}"#))
         #expect(trainArguments.contains("--response-only"))
+        #expect(Array(alignArguments.prefix(2)) == ["alignment", "train"])
+        #expect(alignArguments.contains("--algorithm"))
+        #expect(alignArguments.contains("grpo"))
+        #expect(quantizeArguments.contains("--source-artifact-kind"))
+        #expect(quantizeArguments.contains("merged_adapter"))
     }
 
     @Test("pipeline dry run redacts Hugging Face download token arguments")
@@ -903,6 +1011,204 @@ struct MelixCLIRunnerTests {
         #expect(FileManager.default.fileExists(atPath: artifactRoot.appendingPathComponent("matrix-summary.csv").path))
         #expect(FileManager.default.fileExists(atPath: artifactRoot.appendingPathComponent("eval-summary.csv").path))
         #expect(FileManager.default.fileExists(atPath: artifactRoot.appendingPathComponent("eval-samples.jsonl").path))
+    }
+
+    @Test("post training pipeline routes alignment publish quantize and local evidence steps")
+    func postTrainingPipelineRoutesAlignmentPublishQuantizeAndLocalEvidenceSteps() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let pipelineURL = root.appendingPathComponent("issue365-post-training.pipeline.json")
+        let receiptURL = root.appendingPathComponent("receipts")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let pipelineJSON = #"""
+        {
+          "schema_version": "melix.pipeline.v1",
+          "name": "issue365-post-training-chain",
+          "inputs": {
+            "base_model_id": "melix-dev-text",
+            "quantized_model_id": "melix-dev-text-aligned-q4",
+            "server_session_id": "server-session-issue365"
+          },
+          "steps": [
+            {
+              "id": "train_lora",
+              "command": "lora.train",
+              "args": {
+                "model_id": "${inputs.base_model_id}",
+                "dataset_uri": "/tmp/sft.jsonl",
+                "adapter_name": "issue365-sft",
+                "training_mode": "lora",
+                "max_steps": 2
+              },
+              "checks": {
+                "required_result_fields": ["job_id", "output_path"]
+              }
+            },
+            {
+              "id": "align_adapter",
+              "command": "alignment.train",
+              "args": {
+                "model_id": "${inputs.base_model_id}",
+                "dataset_uri": "/tmp/preference-pairs.jsonl",
+                "adapter_name": "issue365-dpo",
+                "algorithm": "dpo",
+                "reference_model_path": "${steps.train_lora.result.output_path}",
+                "max_steps": 2
+              },
+              "checks": {
+                "required_result_fields": ["job_id", "output_path", "alignment_run_manifest_path"]
+              }
+            },
+            {
+              "id": "publish_merged",
+              "command": "lora.publish",
+              "args": {
+                "model_id": "${inputs.base_model_id}",
+                "target_repo": "melix/models/issue365-dpo-merged",
+                "manifest_path": "${steps.align_adapter.result.output_path}",
+                "export_kind": "merged"
+              },
+              "checks": {
+                "required_result_fields": ["job_id", "output_path"]
+              }
+            },
+            {
+              "id": "quantize_merged",
+              "command": "quantize",
+              "args": {
+                "model_id": "${inputs.base_model_id}",
+                "output_dir": "/tmp/melix/quantized/issue365-dpo-q4",
+                "quant_profile_id": "q4",
+                "weight_quant": "q4",
+                "kv_quant": "q8",
+                "quantization_mode": "ptq",
+                "source_artifact_kind": "merged_adapter",
+                "source_artifact_path": "${steps.publish_merged.result.output_path}",
+                "calibration_dataset_uri": "/tmp/calibration.jsonl",
+                "quality_delta": "-0.01",
+                "latency_delta": "-0.12"
+              },
+              "checks": {
+                "required_result_fields": ["job_id", "output_path", "bundle_path"]
+              }
+            },
+            {
+              "id": "activate_adapter_runtime",
+              "command": "lora.activate",
+              "args": {
+                "model_id": "${inputs.base_model_id}",
+                "adapter_path": "${steps.align_adapter.result.output_path}",
+                "activation_mode": "adapter_backed_runtime",
+                "derived_model_alias": "${inputs.quantized_model_id}"
+              },
+              "checks": {
+                "required_result_fields": ["job_id", "output_path"]
+              }
+            },
+            {
+              "id": "local_chat_smoke",
+              "command": "chat.run",
+              "args": {
+                "model_id": "${inputs.quantized_model_id}",
+                "server_session_id": "${inputs.server_session_id}",
+                "message": "Reply with ISSUE365_OK only."
+              },
+              "checks": {
+                "required_result_fields": ["assistant_text", "request_id"]
+              }
+            },
+            {
+              "id": "eval_smoke",
+              "command": "eval.run",
+              "args": {
+                "model_id": "${inputs.quantized_model_id}",
+                "suites": ["smoke"],
+                "dataset_id": "issue365.smoke.v1",
+                "sample_size": 2
+              },
+              "checks": {
+                "required_result_fields": ["0.job.job_id"]
+              }
+            }
+          ]
+        }
+        """#
+        try Data(pipelineJSON.utf8).write(to: pipelineURL)
+
+        let client = StubControlPlaneXPCClient()
+        await client.setServerSnapshot(makeServerSnapshot(models: [
+            makeModelSummary(id: "melix-dev-text", kind: "text"),
+            makeModelSummary(id: "melix-dev-text-aligned-q4", kind: "text"),
+        ]))
+        await client.setChatExecution(
+            requestID: "chat-issue365",
+            modelID: "melix-dev-text-aligned-q4",
+            events: [
+                .tokenDelta("ISSUE365_OK"),
+                .completed(finishReason: "stop", assistantText: "", reasoningText: ""),
+            ]
+        )
+        await client.setEvaluationResults([
+            makeEvaluationRunResult(
+                jobID: "eval-issue365",
+                suiteID: "smoke",
+                datasetID: "issue365.smoke.v1",
+                metricName: "eval.smoke.accuracy",
+                metricValue: 1.0
+            ),
+        ])
+        let executor = RecordingCLICommandExecutor(
+            responses: [
+                #"{"operation":"registry_snapshot","adapters":[]}"#,
+                #"{"operation":"train_lora","job_id":"lora-job-1","output_path":"/tmp/melix/train_lora/issue365-sft.adapter.json"}"#,
+                #"{"operation":"registry_snapshot","adapters":[]}"#,
+                #"{"operation":"train_alignment","job_id":"align-job-1","output_path":"/tmp/melix/alignment/issue365-dpo.adapter.json","alignment_run_manifest_path":"/tmp/melix/alignment/issue365-dpo.alignment_run.json"}"#,
+                #"{"operation":"upload","job_id":"publish-job-1","output_path":"/tmp/melix/publish/issue365-dpo-merged","artifact_manifest_path":"/tmp/melix/publish/issue365-dpo-merged/manifest.json"}"#,
+                #"{"operation":"registry_snapshot","adapters":[]}"#,
+                #"{"operation":"quantize","job_id":"quantize-job-1","output_path":"/tmp/melix/quantized/issue365-dpo-q4","bundle_path":"/tmp/melix/quantized/issue365-dpo-q4"}"#,
+                #"{"operation":"registry_snapshot","adapters":[]}"#,
+                #"{"operation":"activate_adapter","job_id":"activate-job-1","output_path":"/tmp/melix/activate_adapter/issue365-dpo"}"#,
+                #"{"operation":"registry_snapshot","adapters":[]}"#,
+                #"{"operation":"registry_snapshot","adapters":[]}"#,
+            ]
+        )
+
+        let output = try await MelixCLIRunner(
+            client: client,
+            environment: ["MELIX_HOME": root.path],
+            commandExecutor: executor.run
+        ).run(
+            .pipelineRun(
+                .init(
+                    filePath: pipelineURL.path,
+                    receiptDir: receiptURL.path,
+                    traceID: "trace-issue365-post-training"
+                )
+            )
+        )
+        let summary = try #require(parseJSONObject(output))
+        let steps = try #require(summary["steps"] as? [[String: Any]])
+        let quantizeStep = try #require(steps.first { $0["id"] as? String == "quantize_merged" })
+        let quantizeArtifactPaths = try #require(quantizeStep["artifact_paths"] as? [String])
+        let commands = await executor.commands
+        let operationCommands = commands.filter { Array($0.prefix(2)) != ["lora", "list"] }
+
+        #expect(summary["status"] as? String == "succeeded")
+        #expect(steps.count == 7)
+        #expect(steps.allSatisfy { $0["status"] as? String == "succeeded" })
+        #expect(operationCommands.count == 5)
+        #expect(Array(operationCommands[0].prefix(2)) == ["lora", "train"])
+        #expect(Array(operationCommands[1].prefix(2)) == ["alignment", "train"])
+        #expect(operationCommands[1].contains("--reference-model-path"))
+        #expect(operationCommands[1].contains("/tmp/melix/train_lora/issue365-sft.adapter.json"))
+        #expect(Array(operationCommands[2].prefix(2)) == ["lora", "publish"])
+        #expect(operationCommands[2].contains("/tmp/melix/alignment/issue365-dpo.adapter.json"))
+        #expect(operationCommands[3].starts(with: ["quantize", "--model-id", "melix-dev-text"]))
+        #expect(operationCommands[3].contains("--source-artifact-path"))
+        #expect(operationCommands[3].contains("/tmp/melix/publish/issue365-dpo-merged"))
+        #expect(Array(operationCommands[4].prefix(2)) == ["lora", "activate"])
+        #expect(quantizeArtifactPaths.contains("/tmp/melix/quantized/issue365-dpo-q4"))
     }
 
     @Test("pipeline writes an error receipt and summary when a step fails")
@@ -1451,6 +1757,205 @@ struct MelixCLIRunnerTests {
                 }
                 """#,
                 "Pipeline command argument context_lengths must be an array of unsigned integers."
+            ),
+            (
+                "alignment-missing-algorithm",
+                #"""
+                {
+                  "schema_version": "melix.pipeline.v1",
+                  "name": "alignment-missing-algorithm",
+                  "inputs": {},
+                  "steps": [
+                    {
+                      "id": "align",
+                      "command": "alignment.train",
+                      "args": {
+                        "model_id": "melix-dev-text",
+                        "dataset_uri": "/tmp/preference-pairs.jsonl",
+                        "adapter_name": "aligned-adapter"
+                      }
+                    }
+                  ]
+                }
+                """#,
+                "Pipeline command argument algorithm is required."
+            ),
+            (
+                "alignment-invalid-algorithm",
+                #"""
+                {
+                  "schema_version": "melix.pipeline.v1",
+                  "name": "alignment-invalid-algorithm",
+                  "inputs": {},
+                  "steps": [
+                    {
+                      "id": "align",
+                      "command": "alignment.train",
+                      "args": {
+                        "model_id": "melix-dev-text",
+                        "dataset_uri": "/tmp/preference-pairs.jsonl",
+                        "adapter_name": "aligned-adapter",
+                        "algorithm": "ppo"
+                      }
+                    }
+                  ]
+                }
+                """#,
+                "Pipeline command argument algorithm must be one of: dpo, orpo, cpo, grpo, rlhf."
+            ),
+            (
+                "quantize-invalid-mode",
+                #"""
+                {
+                  "schema_version": "melix.pipeline.v1",
+                  "name": "quantize-invalid-mode",
+                  "inputs": {},
+                  "steps": [
+                    {
+                      "id": "quantize",
+                      "command": "quantize",
+                      "args": {
+                        "model_id": "melix-dev-text",
+                        "quantization_mode": "dynamic"
+                      }
+                    }
+                  ]
+                }
+                """#,
+                "Pipeline command argument quantization_mode must be one of: ptq, qat."
+            ),
+            (
+                "quantize-invalid-source-kind",
+                #"""
+                {
+                  "schema_version": "melix.pipeline.v1",
+                  "name": "quantize-invalid-source-kind",
+                  "inputs": {},
+                  "steps": [
+                    {
+                      "id": "quantize",
+                      "command": "quantize",
+                      "args": {
+                        "model_id": "melix-dev-text",
+                        "source_artifact_kind": "checkpoint"
+                      }
+                    }
+                  ]
+                }
+                """#,
+                "Pipeline command argument source_artifact_kind must be one of: base_model, merged_adapter, adapter_export."
+            ),
+            (
+                "publish-missing-artifact-selector",
+                #"""
+                {
+                  "schema_version": "melix.pipeline.v1",
+                  "name": "publish-missing-artifact-selector",
+                  "inputs": {},
+                  "steps": [
+                    {
+                      "id": "publish",
+                      "command": "lora.publish",
+                      "args": {
+                        "model_id": "melix-dev-text",
+                        "target_repo": "melix/adapters/demo"
+                      }
+                    }
+                  ]
+                }
+                """#,
+                "Exactly one of adapter_path, merged_model_path, manifest_path, or artifact_path is required for pipeline command lora.publish."
+            ),
+            (
+                "publish-adapter-kind-mismatch",
+                #"""
+                {
+                  "schema_version": "melix.pipeline.v1",
+                  "name": "publish-adapter-kind-mismatch",
+                  "inputs": {},
+                  "steps": [
+                    {
+                      "id": "publish",
+                      "command": "lora.publish",
+                      "args": {
+                        "model_id": "melix-dev-text",
+                        "target_repo": "melix/adapters/demo",
+                        "adapter_path": "/tmp/adapter.json",
+                        "export_kind": "merged"
+                      }
+                    }
+                  ]
+                }
+                """#,
+                "Pipeline command argument export_kind merged is incompatible with adapter_path."
+            ),
+            (
+                "publish-merged-kind-mismatch",
+                #"""
+                {
+                  "schema_version": "melix.pipeline.v1",
+                  "name": "publish-merged-kind-mismatch",
+                  "inputs": {},
+                  "steps": [
+                    {
+                      "id": "publish",
+                      "command": "lora.publish",
+                      "args": {
+                        "model_id": "melix-dev-text",
+                        "target_repo": "melix/models/demo",
+                        "merged_model_path": "/tmp/merged-model",
+                        "export_kind": "adapter"
+                      }
+                    }
+                  ]
+                }
+                """#,
+                "Pipeline command argument export_kind adapter is incompatible with merged_model_path."
+            ),
+            (
+                "publish-artifact-missing-export-kind",
+                #"""
+                {
+                  "schema_version": "melix.pipeline.v1",
+                  "name": "publish-artifact-missing-export-kind",
+                  "inputs": {},
+                  "steps": [
+                    {
+                      "id": "publish",
+                      "command": "lora.publish",
+                      "args": {
+                        "model_id": "melix-dev-text",
+                        "target_repo": "melix/adapters/demo",
+                        "artifact_path": "/tmp/artifact.json"
+                      }
+                    }
+                  ]
+                }
+                """#,
+                "Pipeline command argument export_kind is required when lora.publish uses artifact_path."
+            ),
+            (
+                "publish-invalid-export-kind",
+                #"""
+                {
+                  "schema_version": "melix.pipeline.v1",
+                  "name": "publish-invalid-export-kind",
+                  "inputs": {},
+                  "steps": [
+                    {
+                      "id": "publish",
+                      "command": "lora.publish",
+                      "args": {
+                        "model_id": "melix-dev-text",
+                        "target_repo": "melix/adapters/demo",
+                        "adapter_path": "/tmp/adapter.json",
+                        "export_kind": "full"
+                      }
+                    }
+                  ]
+                }
+                """#,
+                "Pipeline command argument export_kind must be one of: adapter, merged."
             ),
         ]
 

--- a/tests/integration/test_issue365_acceptance_bundle.py
+++ b/tests/integration/test_issue365_acceptance_bundle.py
@@ -120,6 +120,17 @@ def test_issue365_acceptance_bundle_plan_covers_required_cli_matrix(tmp_path: Pa
     all_steps = [step for pipeline in pipelines for step in pipeline["steps"]]
     commands = {step["command"] for step in all_steps}
     assert {"lora.train", "alignment.train", "lora.publish", "quantize", "chat.run", "eval.run"} <= commands
+    publish_steps = [step for step in all_steps if step["command"] == "lora.publish"]
+    assert publish_steps
+    assert all(step["args"]["publish_backend"] == "local_filesystem" for step in publish_steps)
+    assert all(step["args"]["local_publish_root"] == "${inputs.local_publish_root}" for step in publish_steps)
+
+    lora_pipeline = next(
+        pipeline for pipeline in pipelines if pipeline["name"] == "issue365-lora_export_inference"
+    )
+    lora_steps = {step["id"]: step for step in lora_pipeline["steps"]}
+    assert lora_steps["lora_activate"]["args"]["adapter_path"] == "${steps.lora_train.result.output_path}"
+    assert lora_steps["lora_chat"]["args"]["model_id"] == "${steps.lora_activate.result.derived_model_id}"
 
     lora_modes = {
         step["args"].get("training_mode")

--- a/tests/integration/test_issue365_acceptance_bundle.py
+++ b/tests/integration/test_issue365_acceptance_bundle.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from typing import Any, Sequence
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "issue365_acceptance_bundle.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("issue365_acceptance_bundle", MODULE_PATH)
+issue365_acceptance_bundle = importlib.util.module_from_spec(MODULE_SPEC)
+assert MODULE_SPEC.loader is not None
+sys.modules["issue365_acceptance_bundle"] = issue365_acceptance_bundle
+MODULE_SPEC.loader.exec_module(issue365_acceptance_bundle)
+
+
+class RecordingExecutor:
+    def __init__(self, statuses: Sequence[str]) -> None:
+        self.statuses = list(statuses)
+        self.commands: list[list[str]] = []
+
+    def run_json(self, command: Sequence[str]) -> dict[str, Any]:
+        self.commands.append(list(command))
+        status = self.statuses[min(len(self.commands) - 1, len(self.statuses) - 1)]
+        return {
+            "schema_version": "melix.pipeline.run.v1",
+            "status": status,
+            "summary_path": f"/tmp/issue365/{len(self.commands)}.json",
+        }
+
+
+class RaisingExecutor:
+    def run_json(self, command: Sequence[str]) -> dict[str, Any]:
+        raise RuntimeError(f"boom: {' '.join(command)}")
+
+
+def test_issue365_acceptance_bundle_plan_covers_required_cli_matrix(tmp_path: Path) -> None:
+    bundle = issue365_acceptance_bundle.build_acceptance_bundle(
+        issue365_acceptance_bundle.Issue365AcceptanceConfig(
+            repo_root=Path(__file__).resolve().parents[2],
+            output_dir=tmp_path,
+            execution_mode="plan",
+            timestamp="2026-05-05T000000Z",
+        )
+    )
+
+    assert bundle["schema_version"] == "melix.issue365.acceptance_bundle.v1"
+    assert bundle["issue_url"] == "https://github.com/Keith-CY/melix/issues/365"
+    assert bundle["execution_mode"] == "plan"
+    assert bundle["release_ready"] is False
+    assert bundle["summary"]["case_count"] == 10
+    assert bundle["summary"]["planned_count"] == 10
+
+    case_ids = {case["case_id"] for case in bundle["cases"]}
+    assert case_ids == {
+        "lora_export_inference",
+        "qlora_export_inference",
+        "dora_export_inference",
+        "lora_dpo_export_inference",
+        "lora_orpo_export_inference",
+        "lora_cpo_export_inference",
+        "lora_grpo_export_inference",
+        "lora_rlhf_export_inference",
+        "lora_preference_ptq_quantized_inference",
+        "qat_quantized_inference",
+    }
+
+    pipelines = [
+        json.loads(Path(case["pipeline_path"]).read_text(encoding="utf-8"))
+        for case in bundle["cases"]
+    ]
+    for pipeline in pipelines:
+        assert pipeline["schema_version"] == "melix.pipeline.v1"
+        assert pipeline["steps"]
+
+    all_steps = [step for pipeline in pipelines for step in pipeline["steps"]]
+    commands = {step["command"] for step in all_steps}
+    assert {"lora.train", "alignment.train", "lora.publish", "quantize", "chat.run", "eval.run"} <= commands
+
+    lora_modes = {
+        step["args"].get("training_mode")
+        for step in all_steps
+        if step["command"] == "lora.train" and "training_mode" in step["args"]
+    }
+    assert {"lora", "qlora", "dora"} <= lora_modes
+
+    alignment_algorithms = {
+        step["args"]["algorithm"]
+        for step in all_steps
+        if step["command"] == "alignment.train"
+    }
+    assert alignment_algorithms == {"dpo", "orpo", "cpo", "grpo", "rlhf"}
+
+    quantization_modes = {
+        step["args"]["quantization_mode"]
+        for step in all_steps
+        if step["command"] == "quantize"
+    }
+    assert quantization_modes == {"ptq", "qat"}
+    assert any("real_local_runtime" in gap for gap in bundle["known_gaps"])
+    assert all(case["evidence_tier"] == "planning_matrix" for case in bundle["cases"])
+    assert all(case["release_ready"] is False for case in bundle["cases"])
+
+
+def test_issue365_acceptance_bundle_dry_run_invokes_pipeline_runner_without_release_ready(
+    tmp_path: Path,
+) -> None:
+    executor = RecordingExecutor(statuses=["planned"])
+    bundle = issue365_acceptance_bundle.build_acceptance_bundle(
+        issue365_acceptance_bundle.Issue365AcceptanceConfig(
+            repo_root=Path(__file__).resolve().parents[2],
+            output_dir=tmp_path,
+            execution_mode="dry-run",
+            melix_cli="/tmp/melix",
+            timestamp="2026-05-05T000000Z",
+        ),
+        executor=executor,
+    )
+
+    assert len(executor.commands) == 10
+    assert all(command[:3] == ["/tmp/melix", "pipeline", "run"] for command in executor.commands)
+    assert all("--dry-run" in command for command in executor.commands)
+    assert bundle["release_ready"] is False
+    assert bundle["summary"]["planned_count"] == 10
+    assert all(case["evidence_tier"] == "deterministic_dry_run" for case in bundle["cases"])
+    assert all("non_dry_run_execution" in case["missing_evidence"] for case in bundle["cases"])
+
+
+def test_issue365_acceptance_bundle_real_success_is_release_ready_only_after_all_cases_pass(
+    tmp_path: Path,
+) -> None:
+    executor = RecordingExecutor(statuses=["succeeded"])
+    bundle = issue365_acceptance_bundle.build_acceptance_bundle(
+        issue365_acceptance_bundle.Issue365AcceptanceConfig(
+            repo_root=Path(__file__).resolve().parents[2],
+            output_dir=tmp_path,
+            execution_mode="real",
+            melix_cli="/tmp/melix",
+            timestamp="2026-05-05T000000Z",
+        ),
+        executor=executor,
+    )
+
+    assert len(executor.commands) == 10
+    assert all("--dry-run" not in command for command in executor.commands)
+    assert bundle["release_ready"] is True
+    assert bundle["known_gaps"] == []
+    assert bundle["summary"]["release_ready_case_count"] == 10
+    assert all(case["evidence_tier"] == "real_local_runtime" for case in bundle["cases"])
+    assert all(case["missing_evidence"] == [] for case in bundle["cases"])
+
+
+def test_issue365_acceptance_bundle_real_failure_keeps_bundle_not_release_ready(
+    tmp_path: Path,
+) -> None:
+    executor = RecordingExecutor(statuses=["succeeded", "failed"])
+    bundle = issue365_acceptance_bundle.build_acceptance_bundle(
+        issue365_acceptance_bundle.Issue365AcceptanceConfig(
+            repo_root=Path(__file__).resolve().parents[2],
+            output_dir=tmp_path,
+            execution_mode="real",
+            melix_cli="/tmp/melix",
+            timestamp="2026-05-05T000000Z",
+        ),
+        executor=executor,
+    )
+
+    assert bundle["release_ready"] is False
+    assert bundle["summary"]["failed_count"] == 9
+    assert bundle["summary"]["release_ready_case_count"] == 1
+    assert "passing_pipeline_summary" in bundle["known_gaps"]
+
+
+def test_issue365_acceptance_bundle_records_executor_errors(tmp_path: Path) -> None:
+    bundle = issue365_acceptance_bundle.build_acceptance_bundle(
+        issue365_acceptance_bundle.Issue365AcceptanceConfig(
+            repo_root=Path(__file__).resolve().parents[2],
+            output_dir=tmp_path,
+            execution_mode="dry-run",
+            melix_cli="/tmp/melix",
+            timestamp="2026-05-05T000000Z",
+        ),
+        executor=RaisingExecutor(),
+    )
+
+    assert bundle["release_ready"] is False
+    assert bundle["summary"]["failed_count"] == 10
+    assert all(case["status"] == "failed" for case in bundle["cases"])
+    assert all(case["error"].startswith("boom: /tmp/melix pipeline run") for case in bundle["cases"])
+
+
+def test_issue365_acceptance_bundle_uses_default_subprocess_executor_when_requested(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    created: list[Path] = []
+
+    class FakeSubprocessExecutor:
+        def __init__(self, *, repo_root: Path) -> None:
+            created.append(repo_root)
+
+        def run_json(self, command: Sequence[str]) -> dict[str, Any]:
+            return {
+                "schema_version": "melix.pipeline.run.v1",
+                "status": "planned",
+                "summary_path": "/tmp/issue365/default-executor.json",
+            }
+
+    monkeypatch.setattr(issue365_acceptance_bundle, "SubprocessJSONExecutor", FakeSubprocessExecutor)
+
+    bundle = issue365_acceptance_bundle.build_acceptance_bundle(
+        issue365_acceptance_bundle.Issue365AcceptanceConfig(
+            repo_root=Path("/tmp/repo"),
+            output_dir=tmp_path,
+            execution_mode="dry-run",
+            melix_cli="/tmp/melix",
+            timestamp="2026-05-05T000000Z",
+        )
+    )
+
+    assert created == [Path("/tmp/repo")]
+    assert bundle["summary"]["planned_count"] == 10
+
+
+def test_issue365_acceptance_bundle_rejects_invalid_execution_mode(tmp_path: Path) -> None:
+    try:
+        issue365_acceptance_bundle.build_acceptance_bundle(
+            issue365_acceptance_bundle.Issue365AcceptanceConfig(
+                repo_root=Path(__file__).resolve().parents[2],
+                output_dir=tmp_path,
+                execution_mode="screenshots",
+            )
+        )
+    except ValueError as exc:
+        assert "execution_mode" in str(exc)
+    else:
+        raise AssertionError("Expected invalid execution mode to raise")
+
+
+def test_subprocess_json_executor_covers_success_and_failure_edges(tmp_path: Path) -> None:
+    executor = issue365_acceptance_bundle.SubprocessJSONExecutor(repo_root=tmp_path, environment={})
+
+    payload = executor.run_json(
+        [
+            sys.executable,
+            "-c",
+            "import json; print(json.dumps({'status': 'succeeded'}))",
+        ]
+    )
+    assert payload == {"status": "succeeded"}
+
+    for command, expected in [
+        ([sys.executable, "-c", "import sys; print('bad', file=sys.stderr); sys.exit(3)"], "exit code 3"),
+        ([sys.executable, "-c", "print('not json')"], "did not return JSON"),
+        ([sys.executable, "-c", "import json; print(json.dumps([1, 2]))"], "non-object JSON"),
+    ]:
+        try:
+            executor.run_json(command)
+        except RuntimeError as exc:
+            assert expected in str(exc)
+        else:
+            raise AssertionError(f"Expected {command} to fail")
+
+
+def test_issue365_acceptance_bundle_main_writes_json_and_text_outputs(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    json_output_dir = tmp_path / "json"
+    result = issue365_acceptance_bundle.main(
+        [
+            "--execution-mode",
+            "plan",
+            "--output-dir",
+            str(json_output_dir),
+            "--timestamp",
+            "2026-05-05T000000Z",
+            "--json",
+        ]
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert result == 0
+    assert payload["bundle_path"] == str(json_output_dir.resolve() / "bundle.json")
+    assert payload["release_ready"] is False
+
+    text_output_dir = tmp_path / "text"
+    result = issue365_acceptance_bundle.main(
+        [
+            "--execution-mode",
+            "plan",
+            "--output-dir",
+            str(text_output_dir),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert result == 0
+    assert str(text_output_dir.resolve() / "bundle.json") in captured.out
+    assert "release_ready=false" in captured.out

--- a/tests/integration/test_issue365_acceptance_bundle.py
+++ b/tests/integration/test_issue365_acceptance_bundle.py
@@ -35,6 +35,47 @@ class RaisingExecutor:
         raise RuntimeError(f"boom: {' '.join(command)}")
 
 
+def _write_executable(path: Path) -> Path:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _real_config(
+    tmp_path: Path,
+    *,
+    case_ids: tuple[str, ...] = (),
+    execution_mode: str = "real",
+) -> issue365_acceptance_bundle.Issue365AcceptanceConfig:
+    prereqs = tmp_path / "real-prereqs"
+    datasets = prereqs / "datasets"
+    sft = datasets / "sft"
+    preference = datasets / "preference_pair"
+    prompt_candidate = datasets / "prompt_candidate"
+    reward_scored = datasets / "reward_scored"
+    calibration = datasets / "calibration"
+    for path in (sft, preference, prompt_candidate, reward_scored, calibration):
+        path.mkdir(parents=True, exist_ok=True)
+    reward_manifest = prereqs / "reward-model" / "manifest.json"
+    reward_manifest.parent.mkdir(parents=True, exist_ok=True)
+    reward_manifest.write_text('{"schema_version":"melix.reward_model.v1"}\n', encoding="utf-8")
+    melix_cli = _write_executable(prereqs / "melix")
+    return issue365_acceptance_bundle.Issue365AcceptanceConfig(
+        repo_root=Path(__file__).resolve().parents[2],
+        output_dir=tmp_path / "bundle",
+        execution_mode=execution_mode,
+        melix_cli=str(melix_cli),
+        sft_dataset_uri=str(sft),
+        preference_dataset_uri=str(preference),
+        prompt_candidate_dataset_uri=str(prompt_candidate),
+        reward_scored_dataset_uri=str(reward_scored),
+        calibration_dataset_uri=str(calibration),
+        reward_model_manifest_path=str(reward_manifest),
+        case_ids=case_ids,
+        timestamp="2026-05-05T000000Z",
+    )
+
+
 def test_issue365_acceptance_bundle_plan_covers_required_cli_matrix(tmp_path: Path) -> None:
     bundle = issue365_acceptance_bundle.build_acceptance_bundle(
         issue365_acceptance_bundle.Issue365AcceptanceConfig(
@@ -51,6 +92,8 @@ def test_issue365_acceptance_bundle_plan_covers_required_cli_matrix(tmp_path: Pa
     assert bundle["release_ready"] is False
     assert bundle["summary"]["case_count"] == 10
     assert bundle["summary"]["planned_count"] == 10
+    assert bundle["summary"]["blocked_count"] == 0
+    assert bundle["real_runtime_preflight"]["status"] == "not_run"
 
     case_ids = {case["case_id"] for case in bundle["cases"]}
     assert case_ids == {
@@ -132,13 +175,7 @@ def test_issue365_acceptance_bundle_real_success_is_release_ready_only_after_all
 ) -> None:
     executor = RecordingExecutor(statuses=["succeeded"])
     bundle = issue365_acceptance_bundle.build_acceptance_bundle(
-        issue365_acceptance_bundle.Issue365AcceptanceConfig(
-            repo_root=Path(__file__).resolve().parents[2],
-            output_dir=tmp_path,
-            execution_mode="real",
-            melix_cli="/tmp/melix",
-            timestamp="2026-05-05T000000Z",
-        ),
+        _real_config(tmp_path),
         executor=executor,
     )
 
@@ -147,8 +184,10 @@ def test_issue365_acceptance_bundle_real_success_is_release_ready_only_after_all
     assert bundle["release_ready"] is True
     assert bundle["known_gaps"] == []
     assert bundle["summary"]["release_ready_case_count"] == 10
+    assert bundle["real_runtime_preflight"]["status"] == "ready"
     assert all(case["evidence_tier"] == "real_local_runtime" for case in bundle["cases"])
     assert all(case["missing_evidence"] == [] for case in bundle["cases"])
+    assert all(case["real_runtime_preflight"]["ready"] is True for case in bundle["cases"])
 
 
 def test_issue365_acceptance_bundle_real_failure_keeps_bundle_not_release_ready(
@@ -156,13 +195,7 @@ def test_issue365_acceptance_bundle_real_failure_keeps_bundle_not_release_ready(
 ) -> None:
     executor = RecordingExecutor(statuses=["succeeded", "failed"])
     bundle = issue365_acceptance_bundle.build_acceptance_bundle(
-        issue365_acceptance_bundle.Issue365AcceptanceConfig(
-            repo_root=Path(__file__).resolve().parents[2],
-            output_dir=tmp_path,
-            execution_mode="real",
-            melix_cli="/tmp/melix",
-            timestamp="2026-05-05T000000Z",
-        ),
+        _real_config(tmp_path),
         executor=executor,
     )
 
@@ -170,6 +203,107 @@ def test_issue365_acceptance_bundle_real_failure_keeps_bundle_not_release_ready(
     assert bundle["summary"]["failed_count"] == 9
     assert bundle["summary"]["release_ready_case_count"] == 1
     assert "passing_pipeline_summary" in bundle["known_gaps"]
+
+
+def test_issue365_acceptance_bundle_real_preflight_blocks_missing_local_inputs(
+    tmp_path: Path,
+) -> None:
+    melix_cli = _write_executable(tmp_path / "melix")
+    executor = RecordingExecutor(statuses=["succeeded"])
+
+    bundle = issue365_acceptance_bundle.build_acceptance_bundle(
+        issue365_acceptance_bundle.Issue365AcceptanceConfig(
+            repo_root=Path(__file__).resolve().parents[2],
+            output_dir=tmp_path / "bundle",
+            execution_mode="real",
+            melix_cli=str(melix_cli),
+            sft_dataset_uri=str(tmp_path / "missing-sft"),
+            reward_scored_dataset_uri=str(tmp_path / "missing-reward-scored"),
+            reward_model_manifest_path=str(tmp_path / "missing-reward-model.json"),
+            case_ids=("lora_export_inference", "lora_rlhf_export_inference"),
+            timestamp="2026-05-05T000000Z",
+        ),
+        executor=executor,
+    )
+
+    assert executor.commands == []
+    assert bundle["release_ready"] is False
+    assert bundle["real_runtime_preflight"]["status"] == "blocked"
+    assert bundle["summary"]["case_count"] == 2
+    assert bundle["summary"]["blocked_count"] == 2
+    assert all(case["status"] == "blocked" for case in bundle["cases"])
+    assert all("real_local_runtime_preflight" in case["missing_evidence"] for case in bundle["cases"])
+    rlhf = next(case for case in bundle["cases"] if case["case_id"] == "lora_rlhf_export_inference")
+    blocker_codes = {blocker["code"] for blocker in rlhf["real_runtime_preflight"]["blockers"]}
+    assert {"missing_sft_dataset_uri", "missing_reward_scored_dataset_uri", "missing_reward_model_manifest_path"} <= blocker_codes
+
+
+def test_issue365_acceptance_bundle_real_case_filter_runs_only_selected_ready_case(
+    tmp_path: Path,
+) -> None:
+    prereqs = tmp_path / "minimal-real-prereqs"
+    sft = prereqs / "datasets" / "sft"
+    sft.mkdir(parents=True)
+    melix_cli = _write_executable(prereqs / "melix")
+    executor = RecordingExecutor(statuses=["succeeded"])
+
+    bundle = issue365_acceptance_bundle.build_acceptance_bundle(
+        issue365_acceptance_bundle.Issue365AcceptanceConfig(
+            repo_root=prereqs,
+            output_dir=tmp_path / "bundle",
+            execution_mode="real",
+            melix_cli=str(melix_cli),
+            sft_dataset_uri="datasets/sft",
+            preference_dataset_uri=str(tmp_path / "missing-preference"),
+            prompt_candidate_dataset_uri=str(tmp_path / "missing-prompt-candidate"),
+            reward_scored_dataset_uri=str(tmp_path / "missing-reward-scored"),
+            calibration_dataset_uri=str(tmp_path / "missing-calibration"),
+            reward_model_manifest_path=str(tmp_path / "missing-reward-model.json"),
+            case_ids=("lora_export_inference",),
+            timestamp="2026-05-05T000000Z",
+        ),
+        executor=executor,
+    )
+
+    assert len(executor.commands) == 1
+    assert bundle["release_ready"] is True
+    assert bundle["selected_case_ids"] == ["lora_export_inference"]
+    assert bundle["summary"]["case_count"] == 1
+    assert bundle["cases"][0]["real_runtime_preflight"]["required_inputs"] == ["sft_dataset_uri"]
+    input_check = bundle["cases"][0]["real_runtime_preflight"]["checks"]["inputs"][0]
+    assert input_check["resolved_path"] == str(sft)
+
+
+def test_issue365_acceptance_bundle_real_preflight_blocks_empty_required_inputs(
+    tmp_path: Path,
+) -> None:
+    prereqs = tmp_path / "empty-required-prereqs"
+    sft = prereqs / "datasets" / "sft"
+    reward_scored = prereqs / "datasets" / "reward_scored"
+    sft.mkdir(parents=True)
+    reward_scored.mkdir(parents=True)
+    melix_cli = _write_executable(prereqs / "melix")
+    executor = RecordingExecutor(statuses=["succeeded"])
+
+    bundle = issue365_acceptance_bundle.build_acceptance_bundle(
+        issue365_acceptance_bundle.Issue365AcceptanceConfig(
+            repo_root=Path(__file__).resolve().parents[2],
+            output_dir=tmp_path / "bundle",
+            execution_mode="real",
+            melix_cli=str(melix_cli),
+            sft_dataset_uri=str(sft),
+            reward_scored_dataset_uri=str(reward_scored),
+            reward_model_manifest_path="",
+            case_ids=("lora_rlhf_export_inference",),
+            timestamp="2026-05-05T000000Z",
+        ),
+        executor=executor,
+    )
+
+    assert executor.commands == []
+    assert bundle["summary"]["blocked_count"] == 1
+    blockers = bundle["cases"][0]["real_runtime_preflight"]["blockers"]
+    assert {blocker["code"] for blocker in blockers} == {"empty_reward_model_manifest_path"}
 
 
 def test_issue365_acceptance_bundle_records_executor_errors(tmp_path: Path) -> None:
@@ -238,6 +372,21 @@ def test_issue365_acceptance_bundle_rejects_invalid_execution_mode(tmp_path: Pat
         raise AssertionError("Expected invalid execution mode to raise")
 
 
+def test_issue365_acceptance_bundle_rejects_unknown_case_id(tmp_path: Path) -> None:
+    try:
+        issue365_acceptance_bundle.build_acceptance_bundle(
+            issue365_acceptance_bundle.Issue365AcceptanceConfig(
+                repo_root=Path(__file__).resolve().parents[2],
+                output_dir=tmp_path,
+                case_ids=("missing_case",),
+            )
+        )
+    except ValueError as exc:
+        assert "missing_case" in str(exc)
+    else:
+        raise AssertionError("Expected unknown case_id to raise")
+
+
 def test_subprocess_json_executor_covers_success_and_failure_edges(tmp_path: Path) -> None:
     executor = issue365_acceptance_bundle.SubprocessJSONExecutor(repo_root=tmp_path, environment={})
 
@@ -276,6 +425,8 @@ def test_issue365_acceptance_bundle_main_writes_json_and_text_outputs(
             str(json_output_dir),
             "--timestamp",
             "2026-05-05T000000Z",
+            "--case-id",
+            "lora_export_inference",
             "--json",
         ]
     )
@@ -284,6 +435,7 @@ def test_issue365_acceptance_bundle_main_writes_json_and_text_outputs(
     assert result == 0
     assert payload["bundle_path"] == str(json_output_dir.resolve() / "bundle.json")
     assert payload["release_ready"] is False
+    assert payload["selected_case_ids"] == ["lora_export_inference"]
 
     text_output_dir = tmp_path / "text"
     result = issue365_acceptance_bundle.main(

--- a/tests/integration/test_issue365_acceptance_bundle.py
+++ b/tests/integration/test_issue365_acceptance_bundle.py
@@ -152,6 +152,33 @@ def test_issue365_acceptance_bundle_plan_covers_required_cli_matrix(tmp_path: Pa
         if step["command"] == "quantize"
     }
     assert quantization_modes == {"ptq", "qat"}
+    ptq_pipeline = next(
+        pipeline
+        for pipeline in pipelines
+        if pipeline["name"] == "issue365-lora_preference_ptq_quantized_inference"
+    )
+    ptq_steps = {step["id"]: step for step in ptq_pipeline["steps"]}
+    assert ptq_steps["ptq_publish_export"]["args"]["export_kind"] == "adapter"
+    assert ptq_steps["ptq_quantize"]["args"]["source_artifact_kind"] == "adapter_export"
+    assert ptq_steps["ptq_quantize"]["args"]["local_inference_smoke_mode"] == "runtime_generate"
+    assert ptq_steps["ptq_quantize"]["checks"]["equals"] == {
+        "result.local_inference_smoke.status": "passed",
+        "result.local_inference_smoke.evidence_kind": "local_runtime_generate",
+        "result.local_inference_smoke.smoke_mode": "runtime_generate",
+        "result.release_gate.local_inference_smoke_result": "passed",
+    }
+    assert all(step["command"] != "chat.run" for step in ptq_pipeline["steps"])
+    qat_pipeline = next(
+        pipeline
+        for pipeline in pipelines
+        if pipeline["name"] == "issue365-qat_quantized_inference"
+    )
+    qat_steps = {step["id"]: step for step in qat_pipeline["steps"]}
+    assert qat_steps["qat_publish_export"]["args"]["export_kind"] == "adapter"
+    assert qat_steps["qat_quantize"]["args"]["source_artifact_kind"] == "adapter_export"
+    assert qat_steps["qat_quantize"]["args"]["local_inference_smoke_mode"] == "runtime_generate"
+    assert qat_steps["qat_quantize"]["checks"] == ptq_steps["ptq_quantize"]["checks"]
+    assert all(step["command"] != "chat.run" for step in qat_pipeline["steps"])
     assert any("real_local_runtime" in gap for gap in bundle["known_gaps"])
     assert all(case["evidence_tier"] == "planning_matrix" for case in bundle["cases"])
     assert all(case["release_ready"] is False for case in bundle["cases"])


### PR DESCRIPTION
## Summary
- Add `melix pipeline run` routing for post-training model operations: `alignment.train`, `lora.publish`, `quantize`, `convert`, and `upload`.
- Add an Issue 365 CLI acceptance bundle harness covering all 10 required CLI chains, with plan/dry-run evidence kept separate from real-local-runtime release evidence.
- Add selected-case real-mode execution plus a local-filesystem publish backend so local acceptance can publish receipts without Hugging Face credentials.
- Preserve real adapter activation by activating trained/aligned adapter manifests directly, while still recording publish receipts as evidence.
- Normalize successful pipeline result envelopes so downstream steps can use `result.output_path` when commands return artifact-specific paths.
- Fix MLX text runtime stop handling for installed `mlx-lm` versions whose `stream_generate` wrapper accepts `**kwargs` but the downstream generation step rejects unsupported `stop` kwargs.
- Support MLX-LM preference batch comm-group sharding so DPO/ORPO/CPO real-runtime alignment runs work when the upstream trainer passes `mx.distributed.init()`.
- Expose `melix quantize --local-inference-smoke-mode/--local-inference-smoke-prompt` through CLI and pipeline routing, then require PTQ/QAT acceptance to use the quantize manifest's typed `runtime_generate` local smoke gate.
- Add real local runtime evidence for selected LoRA, QLoRA, DoRA, DPO, ORPO, and CPO chains.
- Keep the vendored Swift MLX `ChatSession.clear()` regression test deterministic on CI hosts without the package default `mlx.metallib` by running it under the existing temporary metallib helper and CPU default device.

## Plan or Spec
- `docs/plans/2026-05-05-issue-365-cli-chain-routing.md`
- Refs #365. This remains a CLI-chain routing and acceptance-harness slice; it does not complete the full roadmap.

## Commands Run
```text
swift test --filter 'MelixCLIRunnerTests|MelixCLIParserTests'
Result: Passed, 213 tests in 3 suites.

swift test --enable-code-coverage --filter 'MelixCLIRunnerTests|MelixCLIParserTests'
Result: Passed, 213 tests in 3 suites and wrote Swift coverage data.

python3 scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/MelixPackageTests.xctest/Contents/MacOS/MelixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main Sources/MelixCLICore/MelixCLI.swift Sources/MelixCLICore/MelixCLICommandCodec.swift Sources/MelixCLICore/MelixPipelineRunner.swift tests/MelixCLITests/MelixCLIParserTests.swift tests/MelixCLITests/MelixCLIRunnerTests.swift docs/plans/2026-05-05-issue-365-cli-chain-routing.md
Result: Passed, TOTAL 99.48% (962/967 changed executable lines).

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q tests/integration/test_issue365_acceptance_bundle.py
Result: Passed, 13 tests.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_issue365_acceptance_bundle.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_mlx_backend.py
Result: Passed, 196 tests.

python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-cli-chain-routing-python-coverage.json --diff-from origin/main scripts/issue365_acceptance_bundle.py services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_mlx_backend.py tests/integration/test_issue365_acceptance_bundle.py docs/plans/2026-05-05-issue-365-cli-chain-routing.md
Result: Passed, TOTAL 97.65% (582/596 changed executable lines).

MELIX_SERVICE_INSTANCE_NAME=issue365-real MELIX_HTTP_PORT=12465 MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real" MELIX_HOME="$PWD/.runtime/home-issue365-real" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-swift.sock" bash scripts/dev_up.sh --prefer-built
Result: Passed, started a named real local runtime stack.

MELIX_HOME="$PWD/.runtime/home-issue365-real" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-swift.sock" MELIX_HTTP_PORT=12465 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id lora_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --output-dir .runtime/issue365/real-lora-final-probe --timestamp 2026-05-06T133000Z --json
Result: Passed, selected real case returned release_ready=true and wrote .runtime/issue365/real-lora-final-probe/bundle.json.

MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-swift.sock" bash scripts/dev_down.sh
Result: Passed, stopped the named real local runtime stack.

python3 scripts/issue365_acceptance_bundle.py --execution-mode dry-run --melix-cli .build/arm64-apple-macosx/debug/melix --output-dir .runtime/issue365/acceptance-dry-run-final --timestamp 2026-05-06T140000Z --json
Result: Passed, wrote a dry-run bundle with 10 succeeded cases, 0 failed cases, 0 blocked cases, and release_ready=false.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q tests/integration/test_issue365_acceptance_bundle.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py
Result: Passed, 273 tests with 2 MLX SWIG deprecation warnings.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_issue365_acceptance_bundle.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py
Result: Passed, 273 tests with 2 MLX SWIG deprecation warnings.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-cli-chain-routing-python-coverage.json
Result: Passed, wrote JSON coverage.

python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-cli-chain-routing-python-coverage.json --diff-from origin/main scripts/issue365_acceptance_bundle.py services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/worker/model_ops/preference_training.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py tests/integration/test_issue365_acceptance_bundle.py docs/plans/2026-05-05-issue-365-cli-chain-routing.md
Result: Passed, TOTAL 97.80% (621/635 changed executable lines).

python3 scripts/issue365_acceptance_bundle.py --execution-mode plan --output-dir .runtime/issue365/acceptance-plan-runtime-smoke --timestamp 2026-05-06T170000Z --json
Result: Passed, wrote a plan bundle with 10 planned cases and release_ready=false.

python3 scripts/issue365_acceptance_bundle.py --execution-mode dry-run --melix-cli .build/arm64-apple-macosx/debug/melix --output-dir .runtime/issue365/acceptance-dry-run-runtime-smoke --timestamp 2026-05-06T170500Z --json
Result: Passed, wrote a dry-run bundle with 10 succeeded cases, 0 failed cases, 0 blocked cases, and release_ready=false.

MELIX_SERVICE_INSTANCE_NAME=issue365-real-ptq-runtime-smoke MELIX_HTTP_PORT=12472 MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-ptq-runtime-smoke" MELIX_HOME="$PWD/.runtime/home-issue365-real-ptq-runtime-smoke" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-ptq-runtime-smoke-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-ptq-runtime-smoke-swift.sock" bash scripts/dev_up.sh --prefer-built
Result: Passed, started a named real local runtime stack for the PTQ runtime smoke probe.

MELIX_HOME="$PWD/.runtime/home-issue365-real-ptq-runtime-smoke" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-ptq-runtime-smoke-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-ptq-runtime-smoke-swift.sock" MELIX_HTTP_PORT=12472 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id lora_preference_ptq_quantized_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --preference-dataset-uri "$PWD/.runtime/issue365/input-datasets/preference_pair" --calibration-dataset-uri "$PWD/.runtime/issue365/input-datasets/calibration" --output-dir .runtime/issue365/real-ptq-runtime-smoke-probe --timestamp 2026-05-06T171500Z --json
Result: Failed as expected; the stricter quantize runtime_generate smoke gate failed with status=failed and release_ready=false for the selected case.

MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-ptq-runtime-smoke" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-ptq-runtime-smoke-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-ptq-runtime-smoke-swift.sock" bash scripts/dev_down.sh
Result: Passed, stopped the named PTQ runtime smoke stack.

MELIX_SERVICE_INSTANCE_NAME=issue365-real-qlora MELIX_HTTP_PORT=12466 MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-qlora" MELIX_HOME="$PWD/.runtime/home-issue365-real-qlora" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-qlora-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-qlora-swift.sock" bash scripts/dev_up.sh --prefer-built
Result: Passed, started a named real local runtime stack for QLoRA.

MELIX_HOME="$PWD/.runtime/home-issue365-real-qlora" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-qlora-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-qlora-swift.sock" MELIX_HTTP_PORT=12466 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id qlora_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --output-dir .runtime/issue365/real-qlora-probe --timestamp 2026-05-06T143000Z --json
Result: Passed, selected real QLoRA case returned release_ready=true and wrote .runtime/issue365/real-qlora-probe/bundle.json.

MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-qlora" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-qlora-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-qlora-swift.sock" bash scripts/dev_down.sh
Result: Passed, stopped the named real local QLoRA runtime stack.

MELIX_SERVICE_INSTANCE_NAME=issue365-real-dora MELIX_HTTP_PORT=12467 MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-dora" MELIX_HOME="$PWD/.runtime/home-issue365-real-dora" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dora-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dora-swift.sock" bash scripts/dev_up.sh --prefer-built
Result: Passed, started a named real local runtime stack for DoRA.

MELIX_HOME="$PWD/.runtime/home-issue365-real-dora" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dora-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dora-swift.sock" MELIX_HTTP_PORT=12467 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id dora_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --output-dir .runtime/issue365/real-dora-probe --timestamp 2026-05-06T150000Z --json
Result: Passed, selected real DoRA case returned release_ready=true and wrote .runtime/issue365/real-dora-probe/bundle.json.

MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-dora" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dora-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dora-swift.sock" bash scripts/dev_down.sh
Result: Passed, stopped the named real local DoRA runtime stack.

MELIX_SERVICE_INSTANCE_NAME=issue365-real-dpo MELIX_HTTP_PORT=12469 MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-dpo" MELIX_HOME="$PWD/.runtime/home-issue365-real-dpo" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-swift.sock" bash scripts/dev_up.sh --prefer-built
Result: Passed, started a named real local runtime stack for preference alignment.

MELIX_HOME="$PWD/.runtime/home-issue365-real-dpo" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-swift.sock" MELIX_HTTP_PORT=12469 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id lora_dpo_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --preference-dataset-uri "$PWD/.runtime/issue365/input-datasets/preference_pair" --output-dir .runtime/issue365/real-dpo-probe-pass2 --timestamp 2026-05-06T153500Z --json
Result: Passed, selected real DPO case returned release_ready=true and wrote .runtime/issue365/real-dpo-probe-pass2/bundle.json.

MELIX_HOME="$PWD/.runtime/home-issue365-real-dpo" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-swift.sock" MELIX_HTTP_PORT=12469 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id lora_orpo_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --preference-dataset-uri "$PWD/.runtime/issue365/input-datasets/preference_pair" --output-dir .runtime/issue365/real-orpo-probe --timestamp 2026-05-06T154500Z --json
Result: Passed, selected real ORPO case returned release_ready=true and wrote .runtime/issue365/real-orpo-probe/bundle.json.

MELIX_HOME="$PWD/.runtime/home-issue365-real-dpo" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-swift.sock" MELIX_HTTP_PORT=12469 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id lora_cpo_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --preference-dataset-uri "$PWD/.runtime/issue365/input-datasets/preference_pair" --output-dir .runtime/issue365/real-cpo-probe --timestamp 2026-05-06T155500Z --json
Result: Passed, selected real CPO case returned release_ready=true and wrote .runtime/issue365/real-cpo-probe/bundle.json.

MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-real-dpo" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-real-dpo-swift.sock" bash scripts/dev_down.sh
Result: Passed, stopped the named real local preference runtime stack.

find .runtime -type f \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.webp' \) -print
Result: Passed, no generated screenshot artifacts found.

xcrun swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter WorkerScaffoldTests/testVendoredChatSessionClearUsesAsyncSerialAccess
Result: Passed, 1 selected test with Swift coverage enabled.

python3 scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from HEAD services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
Result: Passed, TOTAL 100.00% (10/10 changed executable lines).

make swift-test-protocol
Result: Passed, 1 generated protocol test. The first local run hit a host sandbox-exec limitation; rerunning the same command with elevated permissions passed.

make swift-test-text-worker
Result: Passed, 189 tests.

make swift-test-control-worker
Result: Passed, 102 selected worker client/registry tests.

git diff --check
Result: Passed.

git rebase origin/main
Result: Passed; duplicate CI hotfix commits from #394 were dropped because the patch contents were already upstream.

git diff --check
Result: Passed.

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr/issue365-cli-chain-routing.md
Result: Passed.
```

## Coverage and Metrics
- Changed-line Swift coverage: 99.48% total, 962/967 changed executable lines.
- Swift CI hotfix changed-line coverage: 100.00% total, 10/10 changed executable lines in `WorkerScaffoldTests.swift`.
- Changed-line Python coverage: 97.80% total, 621/635 changed executable lines.
- Acceptance bundle plan metrics: 10 required Issue 365 cases planned, `release_ready=false`.
- Acceptance bundle dry-run metrics: 10 required Issue 365 cases succeeded, 0 failed, 0 blocked, `release_ready=false`.
- Real local runtime metrics: selected `lora_export_inference`, `qlora_export_inference`, `dora_export_inference`, `lora_dpo_export_inference`, `lora_orpo_export_inference`, and `lora_cpo_export_inference` cases each succeeded with `release_ready=true` for their selected case.
- Real LoRA evidence: `.runtime/issue365/real-lora-final-probe/bundle.json`.
- Real QLoRA evidence: `.runtime/issue365/real-qlora-probe/bundle.json`.
- Real DoRA evidence: `.runtime/issue365/real-dora-probe/bundle.json`.
- Real DPO evidence: `.runtime/issue365/real-dpo-probe-pass2/bundle.json`.
- Real ORPO evidence: `.runtime/issue365/real-orpo-probe/bundle.json`.
- Real CPO evidence: `.runtime/issue365/real-cpo-probe/bundle.json`.
- PTQ runtime smoke probe evidence: `.runtime/issue365/real-ptq-runtime-smoke-probe/bundle.json`; selected `lora_preference_ptq_quantized_inference` failed with `release_ready=false`.
- PTQ quantize manifest evidence: `.runtime/issue365/real-ptq-runtime-smoke-probe/artifacts/ptq/model-ops-0015/quantize.artifact/manifest.json` recorded `local_inference_smoke.evidence_kind=local_runtime_generate`, `smoke_mode=runtime_generate`, `status=failed`, and `release_gate.local_inference_smoke_result=failed`.
- Real local supervised chains proven in this slice: `lora.train -> lora.publish(local_filesystem) -> lora.activate -> chat.run -> eval.run`.
- Real local preference chains proven in this slice: `lora.train -> alignment.train -> lora.publish(local_filesystem) -> lora.activate -> chat.run -> eval.run`.
- Performance metrics: no throughput claim for this PR; runtime evidence is scoped to selected local smoke chains, and the default plan/dry-run harness still avoids model execution.

## Known Gaps
- Issue #365 remains incomplete even though the roadmap issue is currently closed; this PR advances CLI pipeline routing, acceptance evidence, and selected real supervised/preference chains.
- Real local runtime evidence is still missing for 4 chains: `lora_grpo_export_inference`, `lora_rlhf_export_inference`, `lora_preference_ptq_quantized_inference`, and `qat_quantized_inference`.
- The latest PTQ probe is failed evidence, not completion evidence: `runtime_generate` local smoke failed because no safetensors were present in the quantized artifact, so `release_gate.local_inference_smoke_result=failed`.
- Real GRPO candidate generation, scoring, and policy updates are not implemented here.
- RLHF reward-model integration from #366 is not implemented here.
- MLX-native QAT over full model tensors and QAT-aware export are not implemented here.
- Window UI runnable/inspectable acceptance for every business line is still deferred.
- Screenshot cleanup found no generated screenshot artifacts in `.runtime`; tracked branding images, evaluation fixtures, docs, and source files were not removed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
