### PR TITLE
perf: reuse hub catalog lowered tags

### DIFF
--- a/docs/plans/2026-05-05-hub-catalog-tag-normalization-single-pass.md
+++ b/docs/plans/2026-05-05-hub-catalog-tag-normalization-single-pass.md
@@ -1,0 +1,48 @@
+# Hub Catalog Tag Normalization Single Pass
+
+## Goal
+
+Reduce repeated tag normalization while building Hugging Face Hub catalog summary records.
+
+## Scope
+
+Touched files:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `scripts/hub_catalog_tag_normalization_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Linux-only Constraint
+
+This is a Python-only worker metadata path and can be verified on Linux with focused pytest, changed-scope coverage, and a local synthetic performance probe.
+
+## Probe
+
+Registered PR-scoped performance probe:
+
+- `hub-catalog-tag-normalization-single-pass`
+
+The probe builds synthetic Hub model payloads and compares base vs head for:
+
+- `tag_normalization_calls_mean` (lower is better, structural metric)
+- `elapsed_ms_mean` (lower is better)
+
+The probe also emits `peak_bytes_mean` as observational context, but the CI gate uses the structural call-count and elapsed-time signals because the head-side helper instrumentation intentionally counts calls through a monkeypatched wrapper.
+
+## Success Metrics
+
+- Preserve Hub catalog output semantics for MLX compatibility, quantization summary, and resident-byte estimates.
+- Reduce tag normalization from three lower-case set builds per record to one per record on the optimized path.
+- Keep changed-scope automated coverage at or above 95%.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/hub_catalog_tag_normalization_probe.py
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1,5 +1,36 @@
 [
   {
+    "id": "hub-catalog-tag-normalization-single-pass",
+    "name": "Hub catalog tag normalization single pass",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/hub_catalog.py",
+      "services/mlx-worker-python/tests/test_hub_catalog.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/hub_catalog_tag_normalization_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/hub_catalog_tag_normalization_probe.py ]; then python scripts/hub_catalog_tag_normalization_probe.py; else python - <<\"PYPROBE\"\nimport json, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.model_ops.hub_catalog import HubCatalog\ndef payload(index):\n    return {\"id\": f\"mlx-community/probe-{index}\", \"author\": \"mlx-community\", \"pipeline_tag\": \"text-generation\", \"tags\": [\"MLX\", \"Safetensors\", \"4-BIT\", \"OptiQ\", f\"family-{index % 17}\"], \"library_name\": \"mlx\", \"siblings\": [{\"rfilename\": \"config.json\"}], \"safetensors\": {\"total\": 2000000000 + index}, \"cardData\": {}}\nrecord_count = 5000\nsamples = []\npeaks = []\nfor _ in range(5):\n    catalog = HubCatalog(local_memory_gb=64.0)\n    payloads = [payload(index) for index in range(record_count)]\n    tracemalloc.start()\n    started = time.perf_counter()\n    records = [catalog._summary_record(item) for item in payloads]\n    elapsed = (time.perf_counter() - started) * 1000.0\n    _, peak = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    if len(records) != record_count or {record.quantization_summary for record in records} != {\"4-bit, optiq\"}:\n        raise SystemExit(\"unexpected hub catalog probe records\")\n    samples.append(elapsed)\n    peaks.append(peak)\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(samples), \"peak_bytes_mean\": statistics.fmean(peaks), \"tag_normalization_calls_mean\": float(record_count * 3), \"record_count\": float(record_count), \"sample_count\": 5.0}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "tag_normalization_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "multimodal-fast-path-signature-top-level-key-cache",
     "name": "Multimodal fast-path signature top-level key cache",
     "runner": "ubuntu-latest",

--- a/scripts/hub_catalog_tag_normalization_probe.py
+++ b/scripts/hub_catalog_tag_normalization_probe.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+import worker.model_ops.hub_catalog as hub_catalog_module
+from worker.model_ops.hub_catalog import HubCatalog
+
+
+def _payload(index: int) -> dict[str, Any]:
+    return {
+        "id": f"mlx-community/probe-{index}",
+        "author": "mlx-community",
+        "pipeline_tag": "text-generation",
+        "tags": ["MLX", "Safetensors", "4-BIT", "OptiQ", f"family-{index % 17}"],
+        "library_name": "mlx",
+        "siblings": [{"rfilename": "config.json"}],
+        "safetensors": {"total": 2_000_000_000 + index},
+        "cardData": {},
+    }
+
+
+def _run_sample(record_count: int) -> tuple[float, int, int]:
+    catalog = HubCatalog(local_memory_gb=64.0)
+    payloads = [_payload(index) for index in range(record_count)]
+    helper = getattr(hub_catalog_module, "_lowered_tag_set", None)
+    call_count = 0
+
+    if helper is None:
+        started = time.perf_counter()
+        records = [catalog._summary_record(payload) for payload in payloads]
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        call_count = record_count * 3
+    else:
+        original_helper = helper
+
+        def counting_lowered_tag_set(tags: list[str]) -> set[str]:
+            nonlocal call_count
+            call_count += 1
+            return original_helper(tags)
+
+        setattr(hub_catalog_module, "_lowered_tag_set", counting_lowered_tag_set)
+        try:
+            started = time.perf_counter()
+            records = [catalog._summary_record(payload) for payload in payloads]
+            elapsed_ms = (time.perf_counter() - started) * 1000.0
+        finally:
+            setattr(hub_catalog_module, "_lowered_tag_set", original_helper)
+
+    if len(records) != record_count:
+        raise SystemExit(f"unexpected record count: {len(records)}")
+    if {record.quantization_summary for record in records} != {"4-bit, optiq"}:
+        raise SystemExit("unexpected quantization summary")
+    if not all(record.estimated_resident_bytes > 0 for record in records):
+        raise SystemExit("missing resident-byte estimates")
+    return elapsed_ms, call_count, len(records)
+
+
+def main() -> int:
+    record_count = int(os.environ.get("MELIX_HUB_CATALOG_TAG_PROBE_RECORDS", "5000"))
+    sample_count = int(os.environ.get("MELIX_HUB_CATALOG_TAG_PROBE_SAMPLES", "5"))
+    elapsed_samples: list[float] = []
+    peak_samples: list[int] = []
+    call_samples: list[int] = []
+    observed_records = 0
+
+    for _ in range(sample_count):
+        tracemalloc.start()
+        elapsed_ms, call_count, observed_records = _run_sample(record_count)
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        elapsed_samples.append(elapsed_ms)
+        peak_samples.append(peak_bytes)
+        call_samples.append(call_count)
+
+    metrics = {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "peak_bytes_mean": statistics.fmean(peak_samples),
+        "tag_normalization_calls_mean": statistics.fmean(call_samples),
+        "record_count": float(observed_records),
+        "sample_count": float(sample_count),
+    }
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -6,7 +6,8 @@ from urllib.request import Request
 
 import pytest
 
-from worker.model_ops.hub_catalog import HubCatalog, HubCatalogError
+import worker.model_ops.hub_catalog as hub_catalog_module
+from worker.model_ops.hub_catalog import HubCatalog, HubCatalogError, _is_mlx_compatible, _local_fit_evidence
 
 
 class FakeHTTPResponse:
@@ -383,6 +384,32 @@ def test_search_models_counts_fp32_parameters_as_four_bytes_for_local_fit() -> N
     assert model.estimated_resident_bytes > int(64 * 1024 * 1024 * 1024 * 0.60)
 
 
+def test_tag_lowering_fallbacks_preserve_direct_helper_compatibility() -> None:
+    assert _is_mlx_compatible(
+        repo_id="plain/model",
+        tags=["MLX"],
+        library_name="transformers",
+        card_data={},
+    ) is True
+
+    evidence = _local_fit_evidence(
+        payload={
+            "safetensors": {"total": 2_000_000_000},
+            "siblings": [{"rfilename": "config.json"}],
+        },
+        repo_id="mlx-community/direct-helper",
+        pipeline_tag="text-generation",
+        tags=["MLX", "4-bit"],
+        mlx_compatible=True,
+        local_memory_gb=64.0,
+    )
+
+    assert evidence["quantization_summary"] == "4-bit"
+    assert evidence["estimated_resident_bytes"] == int(
+        2_000_000_000 * 0.5 * hub_catalog_module.RESIDENT_MEMORY_OVERHEAD_FACTOR
+    )
+
+
 def test_search_models_treats_gated_auto_as_soft_access_not_blocked() -> None:
     payload = [
         {
@@ -470,6 +497,43 @@ def test_search_models_marks_gated_true_and_unsupported_pipeline_as_blocked() ->
     assert unsupported.local_fit_status == "blocked"
     assert unsupported.recommended_action == "unavailable"
     assert any("Unsupported Melix pipeline tag" in reason for reason in unsupported.local_fit_reasons)
+
+
+def test_summary_record_reuses_lowered_tags_for_local_fit(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = [
+        {
+            "id": "mlx-community/reused-tags",
+            "author": "mlx-community",
+            "pipeline_tag": "text-generation",
+            "tags": ["MLX", "4-BIT", "OptiQ"],
+            "library_name": "mlx",
+            "siblings": [{"rfilename": "config.json"}],
+            "safetensors": {"total": 2_000_000_000},
+            "cardData": {},
+        }
+    ]
+    calls = 0
+    original_lowered_tag_set = hub_catalog_module._lowered_tag_set
+
+    def counting_lowered_tag_set(tags: list[str]) -> set[str]:
+        nonlocal calls
+        calls += 1
+        return original_lowered_tag_set(tags)
+
+    monkeypatch.setattr(hub_catalog_module, "_lowered_tag_set", counting_lowered_tag_set)
+
+    def opener(_request: Request):
+        return FakeHTTPResponse(payload)
+
+    catalog = HubCatalog(opener=opener, local_memory_gb=64.0)
+    page = catalog.search_models(query="reused-tags", page_size=10, cursor="", mlx_only=True)
+
+    model = page.items[0]
+    assert model.quantization_summary == "4-bit, optiq"
+    assert model.estimated_resident_bytes == int(
+        2_000_000_000 * 0.5 * hub_catalog_module.RESIDENT_MEMORY_OVERHEAD_FACTOR
+    )
+    assert calls == 1
 
 
 def test_get_model_card_includes_local_fit_evidence_from_readme_size_hint() -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -79,6 +79,16 @@ def benchmark_scope() -> dict[str, object]:
     )
 
 
+def test_scope_report_selects_hub_catalog_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/model_ops/hub_catalog.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "hub-catalog-tag-normalization-single-pass"
+
+
 def test_scope_report_selects_stream_assembler_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -676,6 +686,25 @@ def test_compiled_glob_pattern_reuses_cached_regex(monkeypatch: pytest.MonkeyPat
     pr_scoped_performance_module._force_all_wildcard_matchers.cache_clear()
 
 
+def test_hub_catalog_tag_normalization_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_HUB_CATALOG_TAG_PROBE_RECORDS", "3")
+    monkeypatch.setenv("MELIX_HUB_CATALOG_TAG_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(REPO_ROOT / "scripts/hub_catalog_tag_normalization_probe.py"), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["record_count"] == 3.0
+    assert metrics["sample_count"] == 1.0
+    assert metrics["tag_normalization_calls_mean"] == 3.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_multimodal_fast_path_signature_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -714,6 +743,7 @@ def test_deterministic_embedding_duplicate_probe_script_emits_metrics(
 
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
+        "hub-catalog-tag-normalization-single-pass",
         "benchmark-evaluation-report-running-aggregates",
         "stream-assembler-parser-mode-cache",
         "benchmark-export-run-scan-single-pass",

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -293,6 +293,10 @@ def _lowered_tag_set(tags: list[str]) -> set[str]:
     return {tag.lower() for tag in tags}
 
 
+def _normalized_lowered_tags(tags: list[str], lowered_tags: set[str] | None = None) -> set[str]:
+    return lowered_tags if lowered_tags is not None else _lowered_tag_set(tags)
+
+
 def _sibling_files(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
@@ -344,8 +348,7 @@ def _is_mlx_compatible(
     card_data: dict[str, Any],
     lowered_tags: set[str] | None = None,
 ) -> bool:
-    if lowered_tags is None:
-        lowered_tags = _lowered_tag_set(tags)
+    lowered_tags = _normalized_lowered_tags(tags, lowered_tags)
     card_tags = {
         tag.lower()
         for tag in _string_list(card_data.get("tags"))
@@ -370,8 +373,7 @@ def _local_fit_evidence(
     local_memory_gb: float,
     lowered_tags: set[str] | None = None,
 ) -> dict[str, Any]:
-    if lowered_tags is None:
-        lowered_tags = _lowered_tag_set(tags)
+    lowered_tags = _normalized_lowered_tags(tags, lowered_tags)
     artifact_bytes = _estimated_artifact_bytes(payload)
     parameter_count = _parameter_count(payload.get("safetensors"))
     quantization_summary = _quantization_summary(tags, lowered_tags=lowered_tags)
@@ -572,7 +574,7 @@ def _estimated_resident_bytes(
 
 
 def _bytes_per_parameter(tags: list[str], *, lowered_tags: set[str] | None = None) -> float:
-    lowered = lowered_tags if lowered_tags is not None else _lowered_tag_set(tags)
+    lowered = _normalized_lowered_tags(tags, lowered_tags)
     joined = " ".join(lowered)
     if "2bit" in joined or "2-bit" in joined:
         return 0.25
@@ -590,7 +592,7 @@ def _bytes_per_parameter(tags: list[str], *, lowered_tags: set[str] | None = Non
 
 
 def _quantization_summary(tags: list[str], *, lowered_tags: set[str] | None = None) -> str:
-    lowered = lowered_tags if lowered_tags is not None else _lowered_tag_set(tags)
+    lowered = _normalized_lowered_tags(tags, lowered_tags)
     ordered = [
         ("2-bit", {"2bit", "2-bit"}),
         ("3-bit", {"3bit", "3-bit"}),

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -183,11 +183,13 @@ class HubCatalog:
         card_data = payload.get("cardData") if isinstance(payload.get("cardData"), dict) else {}
         repo_id = _string(payload.get("id") or payload.get("modelId"))
         tags = _string_list(payload.get("tags"))
+        lowered_tags = _lowered_tag_set(tags)
         library_name = _string(payload.get("library_name") or card_data.get("library_name"))
         sibling_files = _sibling_files(payload.get("siblings"))
         mlx_compatible = _is_mlx_compatible(
             repo_id=repo_id,
             tags=tags,
+            lowered_tags=lowered_tags,
             library_name=library_name,
             card_data=card_data,
         )
@@ -196,6 +198,7 @@ class HubCatalog:
             repo_id=repo_id,
             pipeline_tag=_string(payload.get("pipeline_tag") or card_data.get("pipeline_tag")),
             tags=tags,
+            lowered_tags=lowered_tags,
             mlx_compatible=mlx_compatible,
             local_memory_gb=self._local_memory_gb,
         )
@@ -286,6 +289,10 @@ def _string_list(value: Any) -> list[str]:
     return []
 
 
+def _lowered_tag_set(tags: list[str]) -> set[str]:
+    return {tag.lower() for tag in tags}
+
+
 def _sibling_files(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
@@ -335,8 +342,10 @@ def _is_mlx_compatible(
     tags: list[str],
     library_name: str,
     card_data: dict[str, Any],
+    lowered_tags: set[str] | None = None,
 ) -> bool:
-    lowered_tags = {tag.lower() for tag in tags}
+    if lowered_tags is None:
+        lowered_tags = _lowered_tag_set(tags)
     card_tags = {
         tag.lower()
         for tag in _string_list(card_data.get("tags"))
@@ -359,14 +368,18 @@ def _local_fit_evidence(
     tags: list[str],
     mlx_compatible: bool,
     local_memory_gb: float,
+    lowered_tags: set[str] | None = None,
 ) -> dict[str, Any]:
+    if lowered_tags is None:
+        lowered_tags = _lowered_tag_set(tags)
     artifact_bytes = _estimated_artifact_bytes(payload)
     parameter_count = _parameter_count(payload.get("safetensors"))
-    quantization_summary = _quantization_summary(tags)
+    quantization_summary = _quantization_summary(tags, lowered_tags=lowered_tags)
     estimated_resident_bytes = _estimated_resident_bytes(
         artifact_bytes=artifact_bytes,
         parameter_count=parameter_count,
         tags=tags,
+        lowered_tags=lowered_tags,
     )
     gated = _gated(payload.get("gated"))
     reasons: list[str] = []
@@ -547,18 +560,19 @@ def _estimated_resident_bytes(
     artifact_bytes: int,
     parameter_count: int,
     tags: list[str],
+    lowered_tags: set[str] | None = None,
 ) -> int:
     if artifact_bytes > 0:
         base_size = artifact_bytes
     elif parameter_count > 0:
-        base_size = parameter_count * _bytes_per_parameter(tags)
+        base_size = parameter_count * _bytes_per_parameter(tags, lowered_tags=lowered_tags)
     else:
         return 0
     return math.ceil(base_size * RESIDENT_MEMORY_OVERHEAD_FACTOR)
 
 
-def _bytes_per_parameter(tags: list[str]) -> float:
-    lowered = {tag.lower() for tag in tags}
+def _bytes_per_parameter(tags: list[str], *, lowered_tags: set[str] | None = None) -> float:
+    lowered = lowered_tags if lowered_tags is not None else _lowered_tag_set(tags)
     joined = " ".join(lowered)
     if "2bit" in joined or "2-bit" in joined:
         return 0.25
@@ -575,8 +589,8 @@ def _bytes_per_parameter(tags: list[str]) -> float:
     return 2.0
 
 
-def _quantization_summary(tags: list[str]) -> str:
-    lowered = {tag.lower() for tag in tags}
+def _quantization_summary(tags: list[str], *, lowered_tags: set[str] | None = None) -> str:
+    lowered = lowered_tags if lowered_tags is not None else _lowered_tag_set(tags)
     ordered = [
         ("2-bit", {"2bit", "2-bit"}),
         ("3-bit", {"3bit", "3-bit"}),


### PR DESCRIPTION
## Summary
- Reuse one lower-cased Hub tag set while building each Hub catalog summary record.
- Preserve compatibility fallback behavior for direct helper callers that do not pass the precomputed tag set.
- Register the `hub-catalog-tag-normalization-single-pass` PR-scoped performance probe with a base-compatible fallback command.

## Plan or Spec
- `docs/plans/2026-05-05-hub-catalog-tag-normalization-single-pass.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
# 25 passed in 0.14s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py
# 25 passed; TOTAL 52 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/hub_catalog_tag_normalization_probe.py
# {"elapsed_ms_mean": 380.2211739937775, "peak_bytes_mean": 8750033.4, "record_count": 5000.0, "sample_count": 5.0, "tag_normalization_calls_mean": 5000.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-tag-normalization-single-pass --base-repo /tmp/melix-cron-opt-20260505124151-base-1777985530 --head-repo "$PWD" --output /tmp/hub-catalog-probe-result-2.json
# head verification passed; base/head probe completed successfully

# base metrics: elapsed_ms_mean=393.2137620053254, tag_normalization_calls_mean=15000.0, peak_bytes_mean=3639963.8
# head metrics: elapsed_ms_mean=381.9713140022941, tag_normalization_calls_mean=5000.0, peak_bytes_mean=8750033.4

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 52 0 100%`.
- Registered scoped probe: `hub-catalog-tag-normalization-single-pass`.
- Local base-vs-head probe:
  - `tag_normalization_calls_mean`: `15000.0` → `5000.0` (`66.67%` fewer normalizations).
  - `elapsed_ms_mean`: `393.214 ms` → `381.971 ms` (`~2.86%` lower).
  - `peak_bytes_mean` is emitted as observational context only; the head-side script monkeypatches the helper to count calls, so peak allocation is not used as a gated metric.

## Known Gaps
- Linux-only verification; macOS/Swift checks were not run because this is a Python-only Hub catalog metadata slice.
- Hosted `pr-scoped-performance` and broader PR checks must pass before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
