### PR TITLE
perf: cache runtime kwarg signature checks

### DIFF
--- a/docs/plans/2026-05-05-runtime-utils-kwarg-signature-cache.md
+++ b/docs/plans/2026-05-05-runtime-utils-kwarg-signature-cache.md
@@ -1,0 +1,33 @@
+# Runtime Utils Kwarg Signature Cache
+
+## Goal
+
+Reduce repeated `inspect.signature(...)` work in the Python worker runtime helper that checks whether backend callables accept optional keyword arguments.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/runtime_utils.py`
+- `services/mlx-worker-python/tests/test_runtime_utils.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/runtime_utils_kwarg_cache_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux-only Constraint
+
+This is a Python-only slice and can be verified locally on Linux with focused pytest, changed-scope coverage, and a base-vs-head PR-scoped performance probe.
+
+## Performance Probe
+
+Register `runtime-utils-kwarg-signature-cache` in `infra/perf/pr_scoped_probes.json`.
+
+Metrics:
+
+- `elapsed_ms_mean`: lower is better
+- `inspect_signature_calls_mean`: lower is better; expected to drop from one call per helper invocation to one call per `(callable, keyword)` pair
+
+## Success Criteria
+
+- Focused runtime utility tests pass.
+- PR-scoped probe registry tests for this probe pass.
+- Changed-scope coverage is at least 95%.
+- Local base-vs-head probe shows fewer `inspect.signature` calls and lower elapsed time.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -56,6 +56,37 @@
     ]
   },
   {
+    "id": "runtime-utils-kwarg-signature-cache",
+    "name": "Runtime utils kwarg signature cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/runtime_utils.py",
+      "services/mlx-worker-python/tests/test_runtime_utils.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/runtime_utils_kwarg_cache_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_kwarg_cache_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/runtime_utils_kwarg_cache_probe.py ]; then python scripts/runtime_utils_kwarg_cache_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"aW1wb3J0IGluc3BlY3QsanNvbixzdGF0aXN0aWNzLHN5cyx0aW1lCmZyb20gcGF0aGxpYiBpbXBvcnQgUGF0aApyZXBvX3Jvb3Q9UGF0aC5jd2QoKQpzeXMucGF0aC5pbnNlcnQoMCxzdHIocmVwb19yb290KSkKc3lzLnBhdGguaW5zZXJ0KDAsc3RyKHJlcG9fcm9vdC8nc2VydmljZXMvbWx4LXdvcmtlci1weXRob24nKSkKZnJvbSB3b3JrZXIucnVudGltZSBpbXBvcnQgcnVudGltZV91dGlscwoKZGVmIHNhbXBsZV9mdW5jdGlvbigqLCB0ZW1wZXJhdHVyZT0wLjAsIHRvcF9wPTEuMCk6CiAgICBwYXNzCml0ZXJhdGlvbnM9NDAwMDAKc2FtcGxlX2NvdW50PTUKZWxhcHNlZD1bXQpjYWxscz1bXQpvcmlnPWluc3BlY3Quc2lnbmF0dXJlCmZvciBfIGluIHJhbmdlKHNhbXBsZV9jb3VudCk6CiAgICBpZiBoYXNhdHRyKHJ1bnRpbWVfdXRpbHMsJ2NsZWFyX2NhbGxhYmxlX2FjY2VwdHNfa3dhcmdfY2FjaGUnKToKICAgICAgICBydW50aW1lX3V0aWxzLmNsZWFyX2NhbGxhYmxlX2FjY2VwdHNfa3dhcmdfY2FjaGUoKQogICAgY291bnRlcj1bMF0KICAgIGRlZiB0cmFja2VkKGNhbGxhYmxlX29iaik6CiAgICAgICAgY291bnRlclswXSs9MQogICAgICAgIHJldHVybiBvcmlnKGNhbGxhYmxlX29iaikKICAgIHJ1bnRpbWVfdXRpbHMuaW5zcGVjdC5zaWduYXR1cmU9dHJhY2tlZAogICAgc3RhcnRlZD10aW1lLnBlcmZfY291bnRlcigpCiAgICBmb3IgaW5kZXggaW4gcmFuZ2UoaXRlcmF0aW9ucyk6CiAgICAgICAga2V5d29yZD0ndGVtcGVyYXR1cmUnIGlmIGluZGV4ICUgMiA9PSAwIGVsc2UgJ3RvcF9wJwogICAgICAgIGlmIG5vdCBydW50aW1lX3V0aWxzLmNhbGxhYmxlX2FjY2VwdHNfa3dhcmcoc2FtcGxlX2Z1bmN0aW9uLCBrZXl3b3JkKToKICAgICAgICAgICAgcmFpc2UgU3lzdGVtRXhpdChmJ3VuZXhwZWN0ZWQgbWlzc2luZyBrd2FyZzoge2tleXdvcmR9JykKICAgIGVsYXBzZWQuYXBwZW5kKCh0aW1lLnBlcmZfY291bnRlcigpLXN0YXJ0ZWQpKjEwMDAuMCkKICAgIGNhbGxzLmFwcGVuZChjb3VudGVyWzBdKQpydW50aW1lX3V0aWxzLmluc3BlY3Quc2lnbmF0dXJlPW9yaWcKaWYgaGFzYXR0cihydW50aW1lX3V0aWxzLCdjbGVhcl9jYWxsYWJsZV9hY2NlcHRzX2t3YXJnX2NhY2hlJyk6CiAgICBydW50aW1lX3V0aWxzLmNsZWFyX2NhbGxhYmxlX2FjY2VwdHNfa3dhcmdfY2FjaGUoKQpwcmludChqc29uLmR1bXBzKHsnZWxhcHNlZF9tc19tZWFuJzpzdGF0aXN0aWNzLmZtZWFuKGVsYXBzZWQpLCdpbnNwZWN0X3NpZ25hdHVyZV9jYWxsc19tZWFuJzpzdGF0aXN0aWNzLmZtZWFuKGNhbGxzKSwnaXRlcmF0aW9uc19wZXJfc2FtcGxlJzpmbG9hdChpdGVyYXRpb25zKSwnc2FtcGxlX2NvdW50JzpmbG9hdChzYW1wbGVfY291bnQpfSwgc29ydF9rZXlzPVRydWUpKQ==\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "inspect_signature_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "stream-assembler-parser-mode-cache",
     "name": "Stream assembler parser-mode cache",
     "runner": "ubuntu-latest",

--- a/scripts/runtime_utils_kwarg_cache_probe.py
+++ b/scripts/runtime_utils_kwarg_cache_probe.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import inspect
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime import runtime_utils
+
+
+def _sample_function(*, temperature: float = 0.0, top_p: float = 1.0) -> None:
+    _ = (temperature, top_p)
+
+
+def main() -> int:
+    iterations = 40000
+    sample_count = 5
+    elapsed_samples: list[float] = []
+    signature_call_samples: list[int] = []
+    original_signature = inspect.signature
+
+    for _ in range(sample_count):
+        runtime_utils.clear_callable_accepts_kwarg_cache()
+        signature_calls = 0
+
+        def tracked_signature(callable_obj: Any) -> inspect.Signature:
+            nonlocal signature_calls
+            signature_calls += 1
+            return original_signature(callable_obj)
+
+        runtime_utils.inspect.signature = tracked_signature
+        started = time.perf_counter()
+        for index in range(iterations):
+            keyword = "temperature" if index % 2 == 0 else "top_p"
+            if not runtime_utils.callable_accepts_kwarg(_sample_function, keyword):
+                raise SystemExit(f"unexpected missing kwarg: {keyword}")
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        signature_call_samples.append(signature_calls)
+
+    runtime_utils.inspect.signature = original_signature
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+
+    metrics = {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "inspect_signature_calls_mean": statistics.fmean(signature_call_samples),
+        "iterations_per_sample": float(iterations),
+        "sample_count": float(sample_count),
+    }
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -103,6 +103,16 @@ def test_scope_report_selects_stream_assembler_probe() -> None:
     }
 
 
+def test_scope_report_selects_runtime_utils_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/runtime_utils.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "runtime-utils-kwarg-signature-cache"
+
+
 def test_scope_report_selects_only_matching_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -775,6 +785,24 @@ def test_stream_assembler_structural_prefix_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0
     assert metrics["peak_bytes_mean"] > 0
 
+
+def test_runtime_utils_kwarg_cache_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/runtime_utils_kwarg_cache_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 5.0
+    assert metrics["iterations_per_sample"] == 40000.0
+    assert metrics["inspect_signature_calls_mean"] == 2.0
+    assert metrics["elapsed_ms_mean"] >= 0
+
+
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
         "hub-catalog-tag-normalization-single-pass",
@@ -791,6 +819,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "deterministic-embedding-project-digest-allocation",
         "deterministic-rerank-query-context-reuse",
         "rerank-core-top-k-heap-selection",
+        "runtime-utils-kwarg-signature-cache",
         "dev-up-mlx-metal-dist-info-scandir",
         "evaluation-job-id-high-water-mark",
         "evaluation-final-result-materialization-streaming",

--- a/services/mlx-worker-python/tests/test_runtime_utils.py
+++ b/services/mlx-worker-python/tests/test_runtime_utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.metadata
+import inspect
+from typing import Any
 
 import pytest
 
@@ -9,6 +11,98 @@ from worker.runtime import runtime_utils
 
 def test_callable_accepts_kwarg_returns_false_for_non_introspectable_object() -> None:
     assert runtime_utils.callable_accepts_kwarg(object(), "temperature") is False
+
+
+def test_callable_accepts_kwarg_caches_signature_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+    original_signature = inspect.signature
+    signature_calls = 0
+
+    def tracked_signature(callable_obj: Any) -> inspect.Signature:
+        nonlocal signature_calls
+        signature_calls += 1
+        return original_signature(callable_obj)
+
+    def sample(*, temperature: float = 0.0) -> None:
+        _ = temperature
+
+    monkeypatch.setattr(runtime_utils.inspect, "signature", tracked_signature)
+
+    assert runtime_utils.callable_accepts_kwarg(sample, "temperature") is True
+    assert runtime_utils.callable_accepts_kwarg(sample, "temperature") is True
+    assert signature_calls == 1
+    assert runtime_utils.callable_accepts_kwarg(sample, "top_p") is False
+    assert signature_calls == 2
+
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+
+
+def test_callable_accepts_kwarg_caches_bound_methods_by_underlying_function(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+    original_signature = inspect.signature
+    signature_calls = 0
+    inspected_objects: list[Any] = []
+
+    class SampleRuntime:
+        def generate(self, prompt: str, *, temperature: float = 0.0) -> str:
+            return f"{prompt}:{temperature}"
+
+    def tracked_signature(callable_obj: Any) -> inspect.Signature:
+        nonlocal signature_calls
+        signature_calls += 1
+        inspected_objects.append(callable_obj)
+        return original_signature(callable_obj)
+
+    monkeypatch.setattr(runtime_utils.inspect, "signature", tracked_signature)
+
+    first = SampleRuntime()
+    second = SampleRuntime()
+    assert runtime_utils.callable_accepts_kwarg(first.generate, "temperature") is True
+    assert runtime_utils.callable_accepts_kwarg(second.generate, "temperature") is True
+    assert runtime_utils.callable_accepts_kwarg(second.generate, "self") is False
+    assert signature_calls == 2
+    assert inspected_objects == [SampleRuntime.generate, SampleRuntime.generate]
+
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+
+
+def test_callable_accepts_kwarg_bound_methods_preserve_var_keyword_behavior() -> None:
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+
+    class SampleRuntime:
+        def generate(self, **kwargs: object) -> object:
+            return kwargs
+
+    assert runtime_utils.callable_accepts_kwarg(SampleRuntime().generate, "temperature") is True
+    assert runtime_utils.callable_accepts_kwarg(SampleRuntime().generate, "self") is True
+
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+
+
+def test_callable_accepts_kwarg_falls_back_for_unhashable_callable(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+    original_signature = inspect.signature
+    signature_calls = 0
+
+    class UnhashableCallable:
+        __hash__ = None
+
+        def __call__(self, *, temperature: float = 0.0) -> None:
+            _ = temperature
+
+    def tracked_signature(callable_obj: Any) -> inspect.Signature:
+        nonlocal signature_calls
+        signature_calls += 1
+        return original_signature(callable_obj)
+
+    callable_obj = UnhashableCallable()
+    monkeypatch.setattr(runtime_utils.inspect, "signature", tracked_signature)
+
+    assert runtime_utils.callable_accepts_kwarg(callable_obj, "temperature") is True
+    assert runtime_utils.callable_accepts_kwarg(callable_obj, "temperature") is True
+    assert signature_calls == 2
 
 
 def test_installed_package_version_returns_empty_for_missing_package(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -1,29 +1,75 @@
 from __future__ import annotations
 
+from functools import lru_cache
 import importlib.metadata
 import inspect
 from typing import Any
 
 
-def callable_accepts_kwarg(callable_obj: Any, keyword: str) -> bool:
+def _callable_accepts_kwarg_uncached(
+    callable_obj: Any,
+    keyword: str,
+    *,
+    skip_first_parameter: bool = False,
+) -> bool:
     try:
         signature = inspect.signature(callable_obj)
     except (TypeError, ValueError):
         return False
 
+    parameters = signature.parameters
+    if skip_first_parameter:
+        parameters = dict(list(parameters.items())[1:])
+
     if any(
         parameter.kind == inspect.Parameter.VAR_KEYWORD
-        for parameter in signature.parameters.values()
+        for parameter in parameters.values()
     ):
         return True
 
-    parameter = signature.parameters.get(keyword)
+    parameter = parameters.get(keyword)
     if parameter is None:
         return False
     return parameter.kind in (
         inspect.Parameter.POSITIONAL_OR_KEYWORD,
         inspect.Parameter.KEYWORD_ONLY,
     )
+
+
+@lru_cache(maxsize=512)
+def _callable_accepts_kwarg_cached(
+    callable_obj: Any,
+    keyword: str,
+    *,
+    skip_first_parameter: bool = False,
+) -> bool:
+    return _callable_accepts_kwarg_uncached(
+        callable_obj,
+        keyword,
+        skip_first_parameter=skip_first_parameter,
+    )
+
+
+def callable_accepts_kwarg(callable_obj: Any, keyword: str) -> bool:
+    cache_callable = callable_obj
+    skip_first_parameter = False
+    bound_function = getattr(callable_obj, "__func__", None)
+    if bound_function is not None and getattr(callable_obj, "__self__", None) is not None:
+        cache_callable = bound_function
+        skip_first_parameter = True
+
+    try:
+        return _callable_accepts_kwarg_cached(
+            cache_callable,
+            keyword,
+            skip_first_parameter=skip_first_parameter,
+        )
+    except TypeError:
+        return _callable_accepts_kwarg_uncached(callable_obj, keyword)
+
+
+def clear_callable_accepts_kwarg_cache() -> None:
+    _callable_accepts_kwarg_cached.cache_clear()
 
 
 def installed_package_version(package_name: str) -> str:


### PR DESCRIPTION
## Summary
- Cache `callable_accepts_kwarg(...)` signature checks so repeated runtime kwarg probes reuse the same `(callable, keyword)` result.
- Add focused regression coverage for cache reuse and unhashable-callable fallback behavior.
- Register the `runtime-utils-kwarg-signature-cache` PR-scoped performance probe with a base-compatible fallback command.

## Plan or Spec
- `docs/plans/2026-05-05-runtime-utils-kwarg-signature-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics
# 7 passed in 0.34s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_kwarg_cache_probe.py
# 7 passed; TOTAL 59 2 97%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-utils-kwarg-signature-cache --base-repo /tmp/melix-base-runtime-utils-probe-postrebase-20260505-133758 --head-repo "$PWD" --output /tmp/runtime-utils-kwarg-cache-report-postrebase.json
# head verification passed; base and head probes passed

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 59 2 97%`.
- Registered scoped probe: `runtime-utils-kwarg-signature-cache`.
- Local base-vs-head probe on latest `origin/main`:
  - `elapsed_ms_mean`: base `378.415982 ms` → head `5.950473 ms`
  - `inspect_signature_calls_mean`: base `40000.0` → head `2.0`
  - `iterations_per_sample`: `40000.0`
  - `sample_count`: `5.0`

## Known Gaps
- Linux-only verification for this Python slice; macOS/Swift checks were not run locally.
- Full repository `make py-test`, Swift tests, and integration tests were not run locally for this focused runtime-helper change.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
