### PR TITLE
perf: limit validation dataset preview loading

### DIFF
--- a/docs/plans/training-dataset-validation-sample-limit.md
+++ b/docs/plans/training-dataset-validation-sample-limit.md
@@ -1,0 +1,35 @@
+# Training Dataset Validation Sample Limit Optimization
+
+## Goal
+
+Apply `sample_limit` consistently to both `samples.jsonl` and `valid.jsonl` when loading a local training dataset package. Limited preview/smoke paths should not parse or normalize the entire validation split when only a bounded sample is requested.
+
+## Linux Constraint
+
+This is a Python-only slice under `services/mlx-worker-python`, verifiable on Linux with focused pytest, changed-scope coverage, and a local synthetic performance probe.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset.py`
+- `services/mlx-worker-python/tests/test_training_dataset_builder.py`
+
+## Performance Probe
+
+Synthetic local package with one training row and many validation rows. Measure `load_training_dataset_package(..., sample_limit=1)` before/after by comparing current branch against `origin/main` with elapsed time and peak traced allocation.
+
+Success metrics:
+
+- Preserve loaded sample and validation sample output for the first validation row.
+- Avoid parsing invalid/tail validation rows after the limit.
+- Reduce elapsed time and peak traced allocation for large validation files with `sample_limit=1`.
+
+## Verification Commands
+
+- Focused pytest for the new and adjacent sample-limit tests.
+- Changed-scope coverage for touched executable Python/test lines, requiring at least 95%.
+- `git diff --check`.
+- Local base-vs-head performance probe with concrete metrics.
+
+## PR-Scoped Performance CI
+
+`training-dataset-token-percentiles-single-sort` already watches `training_dataset.py` and `test_training_dataset_builder.py`; the focused test/coverage command covers the changed training dataset scope. The local probe records the specific validation-limit metric for this small loader path.

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -222,6 +222,42 @@ def test_load_training_dataset_package_stops_reading_after_sample_limit(
     assert package.normalized_samples == [{"text": "alpha"}]
 
 
+
+def test_load_training_dataset_package_stops_reading_validation_after_sample_limit(
+    tmp_path: Path,
+) -> None:
+    package_path = tmp_path / "limited-invalid-validation-tail"
+    package_path.mkdir(parents=True, exist_ok=True)
+    (package_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "limited-invalid-validation-tail",
+                "format": "text_completion",
+                "sample_count": 1,
+                "version": "1",
+                "validation_sample_count": 2,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (package_path / "samples.jsonl").write_text(
+        '{"text": "alpha"}\n',
+        encoding="utf-8",
+    )
+    (package_path / "valid.jsonl").write_text(
+        '{"text": "validate-alpha"}\n'
+        "{not-json\n",
+        encoding="utf-8",
+    )
+
+    package = load_training_dataset_package(str(package_path), sample_limit=1)
+
+    assert package.validation_sample_count == 1
+    assert package.normalized_validation_samples == [{"text": "validate-alpha"}]
+
+
 def test_load_training_dataset_package_supports_preference_pair_samples(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -278,6 +278,7 @@ def load_training_dataset_package(
         serialized_validation_samples = _iter_dataset_package_jsonl_rows(
             validation_samples_path,
             invalid_json_message="Training dataset validation sample is not valid JSON.",
+            sample_limit=sample_limit,
         )
 
     return _build_training_dataset_package(


### PR DESCRIPTION
## Summary
- Applies `sample_limit` to `valid.jsonl` loading in local training dataset packages.
- Prevents limited preview/smoke loads from parsing and normalizing the entire validation split.
- Adds a regression test proving invalid validation rows after the requested limit are not read.

## Plan or Spec
- `docs/plans/training-dataset-validation-sample-limit.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_load_training_dataset_package_respects_sample_limit_after_skipping_blank_lines services/mlx-worker-python/tests/test_training_dataset_builder.py::test_load_training_dataset_package_stops_reading_after_sample_limit services/mlx-worker-python/tests/test_training_dataset_builder.py::test_load_training_dataset_package_stops_reading_validation_after_sample_limit
# 3 passed in 0.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 180 passed in 64.80s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/tests/test_training_dataset_builder.py
# 180 passed in 149.05s; TOTAL 9 0 100%

python /tmp/training_validation_sample_limit_probe.py <repo> 50000 5 on detached origin/main and head
# origin/main: elapsed_ms_mean=494.7684986051172, peak_bytes_mean=12246205.4, validation_sample_count_mean=50000
# head:        elapsed_ms_mean=0.637795205693692, peak_bytes_mean=29622.4, validation_sample_count_mean=1

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 9 0 100%` for `services/mlx-worker-python/worker/model_ops/training_dataset.py` and `services/mlx-worker-python/tests/test_training_dataset_builder.py`.
- Local synthetic validation-load probe, 50,000 validation rows × 5 samples:
  - `origin/main`: `elapsed_ms_mean=494.7684986051172`, `peak_bytes_mean=12246205.4`, `validation_sample_count_mean=50000`
  - head: `elapsed_ms_mean=0.637795205693692`, `peak_bytes_mean=29622.4`, `validation_sample_count_mean=1`
  - Interpretation: limited validation package loading now stops after the requested sample, cutting the preview workload by ~99.87% elapsed time and ~99.76% traced peak allocation on this synthetic path.
- Registered scoped CI probe selected by touched files: `training-dataset-token-percentiles-single-sort`.

## Known Gaps
- Linux-only local verification; macOS/Swift checks were not run locally.
- This PR does not add a new dedicated scoped-performance probe ID because the touched training-dataset files are already covered by the existing training-dataset scoped probe selection. The local probe captures the specific validation sample-limit behavior.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
