### PR TITLE
perf: stream code eval code-block extraction

### DIFF
--- a/docs/plans/2026-05-05-code-eval-code-block-extraction-streaming.md
+++ b/docs/plans/2026-05-05-code-eval-code-block-extraction-streaming.md
@@ -1,0 +1,27 @@
+# Code evaluation code-block extraction streaming plan
+
+## Goal
+
+Avoid materializing every fenced code block when `extract_candidate_code(...)` only needs the final candidate block emitted by a model response.
+
+## Scope
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `scripts/code_eval_code_block_extract_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Linux-only verification path
+
+This is a Python-only worker change and can be verified on Linux with focused pytest, changed-scope coverage, and a synthetic local probe.
+
+## Performance probe
+
+Register `code-eval-code-block-last-match-streaming` in the PR-scoped performance registry. The probe builds a synthetic response with thousands of fenced code blocks and measures `extract_candidate_code(...)` elapsed time and peak traced allocation while asserting that the last block is still selected.
+
+## Success metrics
+
+- Focused tests pass.
+- Changed executable scope coverage is at least 95%.
+- Probe preserves `parsed_code_block` semantics and concrete metrics are reported for elapsed time and peak bytes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1349,6 +1349,36 @@
     ]
   },
   {
+    "id": "code-eval-code-block-last-match-streaming",
+    "name": "Code evaluation code-block last-match streaming",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/engine/code_eval_runner.py",
+      "services/mlx-worker-python/tests/test_code_eval_runner.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/code_eval_code_block_extract_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/code_eval_code_block_extract_probe.py ]; then python scripts/code_eval_code_block_extract_probe.py; else python - <<\"PYPROBE\"\nimport json, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.engine import code_eval_runner\ndef build_response(block_count):\n    return \"\\n\\n\".join(f\"analysis chunk {index}\\n```python\\ndef candidate_{index}():\\n    return {index}\\n```\" for index in range(block_count))\nblock_count = 2500\nresponse = build_response(block_count)\nexpected_code = f\"def candidate_{block_count - 1}():\\n    return {block_count - 1}\"\nelapsed = []\npeaks = []\nlengths = []\nfor _ in range(7):\n    tracemalloc.start()\n    started = time.perf_counter()\n    code, parse_status = code_eval_runner.extract_candidate_code(response)\n    elapsed.append((time.perf_counter() - started) * 1000.0)\n    _, peak = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    peaks.append(float(peak))\n    if parse_status != \"parsed_code_block\" or code != expected_code:\n        raise SystemExit(\"unexpected extracted code block\")\n    lengths.append(float(len(code)))\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed), \"peak_bytes_mean\": statistics.fmean(peaks), \"block_count\": float(block_count), \"sample_count\": 7.0, \"extracted_chars_mean\": statistics.fmean(lengths)}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "code-eval-stdio-tail-single-stat",
     "name": "Code evaluation stdio tail single stat",
     "runner": "ubuntu-latest",

--- a/scripts/code_eval_code_block_extract_probe.py
+++ b/scripts/code_eval_code_block_extract_probe.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.engine import code_eval_runner
+
+
+def _build_response(block_count: int) -> str:
+    blocks = []
+    for index in range(block_count):
+        blocks.append(
+            f"analysis chunk {index}\n```python\ndef candidate_{index}():\n    return {index}\n```"
+        )
+    return "\n\n".join(blocks)
+
+
+def main() -> None:
+    block_count = 2500
+    response = _build_response(block_count)
+    expected_code = f"def candidate_{block_count - 1}():\n    return {block_count - 1}"
+    sample_count = 7
+    elapsed_ms: list[float] = []
+    peak_bytes: list[float] = []
+    extracted_lengths: list[float] = []
+
+    for _ in range(sample_count):
+        tracemalloc.start()
+        started = time.perf_counter()
+        code, parse_status = code_eval_runner.extract_candidate_code(response)
+        elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_bytes.append(float(peak))
+        if parse_status != "parsed_code_block" or code != expected_code:
+            raise RuntimeError("unexpected extracted code block")
+        extracted_lengths.append(float(len(code)))
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed_ms),
+                "peak_bytes_mean": statistics.fmean(peak_bytes),
+                "block_count": float(block_count),
+                "sample_count": float(sample_count),
+                "extracted_chars_mean": statistics.fmean(extracted_lengths),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -17,6 +17,9 @@ def test_extract_candidate_code_handles_empty_plaintext_and_code_blocks() -> Non
         "print('hi')",
         "parsed_code_block",
     )
+    assert code_eval_runner.extract_candidate_code(
+        "first attempt:\n```python\nprint('old')\n```\nfinal answer:\n```python\nprint('new')\n```"
+    ) == ("print('new')", "parsed_code_block")
 
 
 def test_is_code_execution_policy_supported_requires_sandboxed_policy_and_binary(monkeypatch) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -176,8 +176,12 @@ def test_scope_report_selects_code_eval_stdio_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/engine/code_eval_runner.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "code-eval-stdio-tail-single-stat"
+    probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert scope["selected_count"] == 2
+    assert probe_ids == {
+        "code-eval-code-block-last-match-streaming",
+        "code-eval-stdio-tail-single-stat",
+    }
 
 
 def test_scope_report_selects_evaluation_store_probe() -> None:
@@ -850,6 +854,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "changed-scope-coverage-empty-path-short-circuit",
         "changed-scope-coverage-diff-parser",
         "closure-audit-probe-source-short-circuit",
+        "code-eval-code-block-last-match-streaming",
         "code-eval-stdio-tail-single-stat",
         "deterministic-embedding-duplicate-input-cache",
         "deterministic-embedding-project-digest-allocation",
@@ -1266,6 +1271,21 @@ def test_code_eval_stdio_probe_script_emits_metrics(capsys: pytest.CaptureFixtur
     assert metrics["stdio_stat_calls_mean"] == 6000.0
     assert metrics["output_limit_exceeded_mean"] == 1.0
     assert metrics["tail_chars_mean"] > 0
+
+
+def test_code_eval_code_block_extract_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/code_eval_code_block_extract_probe.py"))
+
+    probe_script["main"]()
+    metrics = json.loads(capsys.readouterr().out)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["block_count"] == 2500.0
+    assert metrics["sample_count"] == 7.0
+    assert metrics["extracted_chars_mean"] > 0
 
 
 def test_probe_smokes_return_metrics_against_current_repo() -> None:

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -40,9 +40,11 @@ def extract_candidate_code(raw_response: str) -> tuple[str, str]:
     normalized = raw_response.strip()
     if not normalized:
         return "", "empty_prediction"
-    matches = _CODE_BLOCK_PATTERN.findall(normalized)
-    if matches:
-        return matches[-1].strip(), "parsed_code_block"
+    last_code_block: str | None = None
+    for match in _CODE_BLOCK_PATTERN.finditer(normalized):
+        last_code_block = match.group(1)
+    if last_code_block is not None:
+        return last_code_block.strip(), "parsed_code_block"
     return normalized, "parsed_code"
 
 


### PR DESCRIPTION
## Summary
- Streams code-evaluation fenced-code extraction by tracking only the last regex match instead of materializing every code block with `findall()`.
- Adds a focused regression test for multi-block responses so the final candidate block remains selected.
- Registers `code-eval-code-block-last-match-streaming` in PR-scoped performance CI with a base-compatible probe.

## Plan or Spec
- Plan: `docs/plans/2026-05-05-code-eval-code-block-extraction-streaming.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# 4 passed in 0.10s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py
# TOTAL 18 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/code_eval_code_block_extract_probe.py
# {"block_count": 2500.0, "elapsed_ms_mean": 6.1987838707864285, "extracted_chars_mean": 37.0, "peak_bytes_mean": 1892.0, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-code-block-last-match-streaming --base-repo /tmp/melix-cron-opt-base-20260505-145347 --head-repo "$PWD" --output /tmp/code-eval-code-block-probe-result-v2.json
# head verification ok; base peak_bytes_mean=216870.0, head peak_bytes_mean=1892.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 18 0 100%`.
- Registered scoped CI probe: `code-eval-code-block-last-match-streaming`.
- Local base-vs-head probe: peak traced allocation improved from `216,870` bytes to `1,892` bytes (~99.13% lower) on a 2,500-block synthetic response while preserving extraction of the final code block.
- Local probe elapsed time was informational and regressed in this run (`3.510825 ms` base to `5.354192 ms` head); the slice intentionally gates the memory-pressure win rather than wall-clock speed.

## Known Gaps
- Linux-only local verification; macOS/Swift checks were not run because this is a Python worker slice.
- Touching `infra/perf/pr_scoped_probes.json` may fan out the hosted PR-scoped performance matrix; hosted CI is the final gate before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A — no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A — no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
