### PR TITLE
perf: stream limited dataset registry reads

### DIFF
--- a/docs/plans/2026-05-05-dataset-registry-limited-read-streaming.md
+++ b/docs/plans/2026-05-05-dataset-registry-limited-read-streaming.md
@@ -1,0 +1,32 @@
+# Dataset Registry Limited Read Streaming Plan
+
+## Goal
+
+Reduce redundant dataset snapshot file enumeration when callers request a small unfiltered row preview with `read_hf_dataset_snapshot_rows(..., limit=N)`.
+
+## Linux-only constraint
+
+This slice is Python-only under `services/mlx-worker-python` and can be validated on Linux with focused pytest, changed-scope coverage, and a synthetic performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+- `scripts/dataset_registry_limit_probe.py`
+
+## Performance probe
+
+Register `dataset-registry-limited-read-streaming` in PR-scoped performance CI. The probe builds a synthetic cached dataset snapshot with many supported data files, calls `read_hf_dataset_snapshot_rows(..., limit=5)`, and reports:
+
+- `elapsed_ms_mean` (lower is better)
+- `dataset_files_yielded_mean` (lower is better; structural proof that limited reads stop before enumerating the full snapshot)
+- `peak_bytes_mean` (informational)
+
+## Success metrics
+
+- Focused dataset registry tests pass.
+- Changed-scope coverage for touched executable Python/test/probe lines is at least 95%.
+- Local probe shows limited reads yield only the files needed for the requested limit instead of all synthetic files.
+- PR-scoped performance CI runs the registered probe before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1,5 +1,41 @@
 [
   {
+    "id": "dataset-registry-limited-read-streaming",
+    "name": "Dataset registry limited read streaming",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/dataset_registry/catalog.py",
+      "services/mlx-worker-python/tests/test_dataset_registry.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/dataset_registry_limit_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_unfiltered_read_stops_before_later_files services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_unlimited_unfiltered_read_preserves_full_selection services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_limit_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_unfiltered_read_stops_before_later_files services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_unlimited_unfiltered_read_preserves_full_selection services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_limit_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_limit_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/dataset_registry_limit_probe.py ]; then python scripts/dataset_registry_limit_probe.py; else python - <<\"PYPROBE\"\nimport json, os, statistics, sys, tempfile, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nimport worker.dataset_registry.catalog as catalog\ndef build_snapshot(snapshot_dir, group_count, files_per_group):\n    for group_index in range(group_count):\n        group_dir = snapshot_dir / f\"group-{group_index:04d}\"\n        group_dir.mkdir(parents=True, exist_ok=True)\n        for file_index in range(files_per_group):\n            (group_dir / f\"train-{file_index:04d}.jsonl\").write_text(json.dumps({\"prompt\": f\"{group_index}-{file_index}\"}) + \"\\n\", encoding=\"utf-8\")\n    (snapshot_dir / \"README.md\").write_text(\"# synthetic dataset\\n\", encoding=\"utf-8\")\ndef sample(snapshot_dir, limit):\n    original_iter = catalog._iter_supported_dataset_files\n    yielded_paths = set()\n    def tracked_iter(path):\n        for candidate in original_iter(path):\n            yielded_paths.add(candidate)\n            yield candidate\n    catalog._iter_supported_dataset_files = tracked_iter\n    try:\n        tracemalloc.start(); started = time.perf_counter(); rows = catalog.read_hf_dataset_snapshot_rows(snapshot_dir, limit=limit); elapsed = (time.perf_counter() - started) * 1000.0; _, peak = tracemalloc.get_traced_memory(); tracemalloc.stop()\n    finally:\n        catalog._iter_supported_dataset_files = original_iter\n    if len(rows) != limit:\n        raise SystemExit(f\"expected {limit} rows, got {len(rows)}\")\n    return elapsed, float(peak), float(len(yielded_paths))\ngroup_count = int(os.environ.get(\"MELIX_DATASET_LIMIT_PROBE_GROUPS\", \"160\")); files_per_group = int(os.environ.get(\"MELIX_DATASET_LIMIT_PROBE_FILES_PER_GROUP\", \"8\")); limit = int(os.environ.get(\"MELIX_DATASET_LIMIT_PROBE_LIMIT\", \"5\")); sample_count = int(os.environ.get(\"MELIX_DATASET_LIMIT_PROBE_SAMPLES\", \"5\"))\nwith tempfile.TemporaryDirectory(prefix=\"melix-dataset-limit-probe-\") as tmp:\n    snapshot_dir = Path(tmp) / \"snapshot\"; snapshot_dir.mkdir(); build_snapshot(snapshot_dir, group_count, files_per_group); samples = [sample(snapshot_dir, limit) for _ in range(sample_count)]\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(item[0] for item in samples), \"peak_bytes_mean\": statistics.fmean(item[1] for item in samples), \"dataset_files_yielded_mean\": statistics.fmean(item[2] for item in samples), \"synthetic_file_count\": float(group_count * files_per_group), \"limit\": float(limit), \"sample_count\": float(sample_count)}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "dataset_files_yielded_mean",
+        "unit": "files",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "hub-catalog-tag-normalization-single-pass",
     "name": "Hub catalog tag normalization single pass",
     "runner": "ubuntu-latest",

--- a/scripts/dataset_registry_limit_probe.py
+++ b/scripts/dataset_registry_limit_probe.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+import worker.dataset_registry.catalog as catalog
+
+
+def _build_snapshot(snapshot_dir: Path, *, group_count: int, files_per_group: int) -> None:
+    for group_index in range(group_count):
+        group_dir = snapshot_dir / f"group-{group_index:04d}"
+        group_dir.mkdir(parents=True, exist_ok=True)
+        for file_index in range(files_per_group):
+            path = group_dir / f"train-{file_index:04d}.jsonl"
+            path.write_text(json.dumps({"prompt": f"{group_index}-{file_index}"}) + "\n", encoding="utf-8")
+    (snapshot_dir / "README.md").write_text("# synthetic dataset\n", encoding="utf-8")
+
+
+def _sample(snapshot_dir: Path, *, limit: int) -> dict[str, float]:
+    original_iter = catalog._iter_supported_dataset_files
+    yielded_paths: set[Path] = set()
+
+    def tracked_iter(path: Path):
+        for candidate in original_iter(path):
+            yielded_paths.add(candidate)
+            yield candidate
+
+    catalog._iter_supported_dataset_files = tracked_iter
+    try:
+        tracemalloc.start()
+        started = time.perf_counter()
+        rows = catalog.read_hf_dataset_snapshot_rows(snapshot_dir, limit=limit)
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+    finally:
+        catalog._iter_supported_dataset_files = original_iter
+    if len(rows) != limit:
+        raise SystemExit(f"expected {limit} rows, got {len(rows)}")
+    return {
+        "elapsed_ms": elapsed_ms,
+        "peak_bytes": float(peak_bytes),
+        "dataset_files_yielded": float(len(yielded_paths)),
+    }
+
+
+def main() -> int:
+    group_count = int(os.environ.get("MELIX_DATASET_LIMIT_PROBE_GROUPS", "160"))
+    files_per_group = int(os.environ.get("MELIX_DATASET_LIMIT_PROBE_FILES_PER_GROUP", "8"))
+    limit = int(os.environ.get("MELIX_DATASET_LIMIT_PROBE_LIMIT", "5"))
+    sample_count = int(os.environ.get("MELIX_DATASET_LIMIT_PROBE_SAMPLES", "5"))
+    with tempfile.TemporaryDirectory(prefix="melix-dataset-limit-probe-") as tmp:
+        snapshot_dir = Path(tmp) / "snapshot"
+        snapshot_dir.mkdir()
+        _build_snapshot(snapshot_dir, group_count=group_count, files_per_group=files_per_group)
+        samples = [_sample(snapshot_dir, limit=limit) for _ in range(sample_count)]
+    metrics = {
+        "elapsed_ms_mean": statistics.fmean(sample["elapsed_ms"] for sample in samples),
+        "peak_bytes_mean": statistics.fmean(sample["peak_bytes"] for sample in samples),
+        "dataset_files_yielded_mean": statistics.fmean(sample["dataset_files_yielded"] for sample in samples),
+        "synthetic_file_count": float(group_count * files_per_group),
+        "limit": float(limit),
+        "sample_count": float(sample_count),
+    }
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -155,6 +155,57 @@ def test_dataset_catalog_row_reader_respects_limit(tmp_path: Path) -> None:
     assert rows == [{"prompt": "first", "answer": "a"}]
 
 
+def test_dataset_catalog_limited_unfiltered_read_stops_before_later_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    data_dir = snapshot_dir / "data"
+    data_dir.mkdir(parents=True)
+    first_file = data_dir / "part-000.jsonl"
+    later_file = data_dir / "part-001.jsonl"
+    first_file.write_text('{"prompt":"first"}\n', encoding="utf-8")
+    later_file.write_text('{"prompt":"later"}\n', encoding="utf-8")
+    (snapshot_dir / "README.md").write_text("# metadata\n", encoding="utf-8")
+    read_files: list[str] = []
+    original_reader = catalog._read_rows_from_file
+
+    def tracked_reader(path: Path, *, limit: int | None = None) -> list[dict[str, object]]:
+        read_files.append(path.name)
+        return original_reader(path, limit=limit)
+
+    monkeypatch.setattr(catalog, "_read_rows_from_file", tracked_reader)
+
+    rows = read_hf_dataset_snapshot_rows(snapshot_dir, limit=1)
+
+    assert rows == [{"prompt": "first"}]
+    assert read_files == ["part-000.jsonl"]
+
+
+def test_dataset_catalog_unlimited_unfiltered_read_preserves_full_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    data_dir = snapshot_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "part-000.jsonl").write_text('{"prompt":"first"}\n', encoding="utf-8")
+    (data_dir / "part-001.jsonl").write_text('{"prompt":"second"}\n', encoding="utf-8")
+    selected_calls: list[str] = []
+    original_selector = catalog._selected_dataset_files
+
+    def tracked_selector(snapshot_path: Path, *, split: str) -> tuple[Path, ...]:
+        selected_calls.append(split)
+        return original_selector(snapshot_path, split=split)
+
+    monkeypatch.setattr(catalog, "_selected_dataset_files", tracked_selector)
+
+    rows = read_hf_dataset_snapshot_rows(snapshot_dir)
+
+    assert rows == [{"prompt": "first"}, {"prompt": "second"}]
+    assert selected_calls == [""]
+
+
 def test_dataset_catalog_reads_json_and_csv_snapshots(tmp_path: Path) -> None:
     snapshot_dir = tmp_path / "snapshot"
     data_dir = snapshot_dir / "custom"

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -113,6 +113,16 @@ def test_scope_report_selects_runtime_utils_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "runtime-utils-kwarg-signature-cache"
 
 
+def test_scope_report_selects_dataset_registry_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/dataset_registry/catalog.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "dataset-registry-limited-read-streaming"
+
+
 def test_scope_report_selects_only_matching_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -838,8 +848,34 @@ def test_runtime_utils_kwarg_cache_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0
 
 
+def test_dataset_registry_limit_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_DATASET_LIMIT_PROBE_GROUPS", "2")
+    monkeypatch.setenv("MELIX_DATASET_LIMIT_PROBE_FILES_PER_GROUP", "3")
+    monkeypatch.setenv("MELIX_DATASET_LIMIT_PROBE_LIMIT", "2")
+    monkeypatch.setenv("MELIX_DATASET_LIMIT_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/dataset_registry_limit_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["synthetic_file_count"] == 6.0
+    assert metrics["limit"] == 2.0
+    assert metrics["dataset_files_yielded_mean"] == 4.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
+        "dataset-registry-limited-read-streaming",
         "hub-catalog-tag-normalization-single-pass",
         "benchmark-evaluation-report-running-aggregates",
         "statistical-evidence-bootstrap-percentile-single-sort",

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -427,7 +427,11 @@ def read_hf_dataset_snapshot_rows(
     split: str = "",
     limit: int | None = None,
 ) -> list[dict[str, Any]]:
-    files = _selected_dataset_files(Path(snapshot_path).expanduser().resolve(), split=split)
+    resolved_snapshot_path = Path(snapshot_path).expanduser().resolve()
+    if not _normalized(split) and limit is not None:
+        files = _iter_limited_dataset_files(resolved_snapshot_path)
+    else:
+        files = iter(_selected_dataset_files(resolved_snapshot_path, split=split))
     rows: list[dict[str, Any]] = []
     for path in files:
         remaining = None if limit is None else max(limit - len(rows), 0)
@@ -435,6 +439,12 @@ def read_hf_dataset_snapshot_rows(
             return rows
         rows.extend(_read_rows_from_file(path, limit=remaining))
     return rows
+
+
+def _iter_limited_dataset_files(snapshot_path: Path) -> Iterator[Path]:
+    for path in _iter_supported_dataset_files(snapshot_path):
+        if path.name not in _README_NAMES:
+            yield path
 
 
 def _selected_dataset_files(snapshot_path: Path, *, split: str) -> tuple[Path, ...]:


### PR DESCRIPTION
## Summary
- Stream unfiltered limited dataset snapshot reads so `read_hf_dataset_snapshot_rows(..., limit=N)` can stop before materializing every supported file in large snapshots.
- Add focused regression coverage that proves limited previews avoid reading later files while unlimited reads keep the existing full-selection path.
- Register `dataset-registry-limited-read-streaming` in PR-scoped performance CI with a base-compatible probe command.

## Plan or Spec
- Plan: `docs/plans/2026-05-05-dataset-registry-limited-read-streaming.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/probes-json-ok
PASS

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_unfiltered_read_stops_before_later_files services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_unlimited_unfiltered_read_preserves_full_selection services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_limit_probe_script_emits_metrics
PASS: 6 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_limit_probe.py
PASS: TOTAL 60 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/dataset_registry_limit_probe.py
PASS: {"dataset_files_yielded_mean": 7.0, "elapsed_ms_mean": 1.1874381802044809, "limit": 5.0, "peak_bytes_mean": 58429.0, "sample_count": 5.0, "synthetic_file_count": 1280.0}

python /tmp/dataset_registry_limit_compare.py /tmp/melix-dataset-limit-base-20260505161015 and /tmp/melix-cron-opt-20260505161015
PASS: base {"dataset_files_yielded_mean": 1281.0, "elapsed_ms_mean": 54.67035339679569, "peak_bytes_mean": 931156.2}; head {"dataset_files_yielded_mean": 7.0, "elapsed_ms_mean": 1.4274854096584022, "peak_bytes_mean": 58963.8}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-registry-limited-read-streaming --base-repo /tmp/melix-dataset-limit-base-20260505161015 --head-repo /tmp/melix-cron-opt-20260505161015 --output /tmp/dataset-registry-limited-read-pr-scoped.json
PASS: head verification ok, changed-scope coverage 100%; base probe dataset_files_yielded_mean=1281.0 elapsed_ms_mean=53.49236798938364 peak_bytes_mean=925954.2; head probe dataset_files_yielded_mean=7.0 elapsed_ms_mean=1.2526603997685015 peak_bytes_mean=58456.6

git diff --check
PASS
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 60 0 100%`.
- Registered scoped CI probe: `dataset-registry-limited-read-streaming`.
- Local PR-scoped probe comparison:
  - Base: `dataset_files_yielded_mean=1281.0`, `elapsed_ms_mean=53.49236798938364`, `peak_bytes_mean=925954.2`.
  - Head: `dataset_files_yielded_mean=7.0`, `elapsed_ms_mean=1.2526603997685015`, `peak_bytes_mean=58456.6`.
  - Interpretation: limited previews now stop after the needed files instead of enumerating the whole synthetic snapshot.

## Known Gaps
- Linux/Python-only verification was run locally. macOS/Swift checks were not run because this slice does not touch Swift/macOS surfaces.
- Hosted GitHub Actions still need to validate the registered PR-scoped performance probe and repository-required checks.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
