### PR TITLE
perf: limit training validation preview loading

### DIFF
--- a/docs/plans/2026-05-05-training-dataset-validation-sample-limit.md
+++ b/docs/plans/2026-05-05-training-dataset-validation-sample-limit.md
@@ -1,0 +1,25 @@
+# Training Dataset Validation Sample Limit Optimization
+
+## Goal
+
+Align local training dataset validation preview loading with the existing training sample `sample_limit` behavior so smoke and preview paths do not parse an entire `valid.jsonl` file when callers request only a bounded sample.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset.py`
+- `services/mlx-worker-python/tests/test_training_dataset_builder.py`
+- `infra/perf/pr_scoped_probes.json` if CI-scoped probe registration is needed
+
+## Linux Verification Path
+
+This is a Python-only slice and is locally verifiable on Linux.
+
+## Performance Probe
+
+Use a synthetic local dataset package with one training row and a large `valid.jsonl`, then call `load_training_dataset_package(..., sample_limit=1)` while measuring elapsed time and peak traced allocation. The expected improvement is O(total validation rows) to O(sample_limit) validation JSONL parsing for preview/smoke loads.
+
+## Success Metrics
+
+- Focused pytest passes for training dataset builder coverage.
+- Changed-scope coverage is at least 95% for changed executable Python lines.
+- The local probe returns the same one validation sample while materially reducing elapsed time and/or peak memory versus `origin/main`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -679,6 +679,42 @@
     ]
   },
   {
+    "id": "training-dataset-validation-sample-limit",
+    "name": "Training dataset validation sample-limit loading",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/training_dataset.py",
+      "services/mlx-worker-python/tests/test_training_dataset_builder.py",
+      "scripts/training_dataset_validation_limit_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_load_training_dataset_package_limits_validation_samples services/mlx-worker-python/tests/test_training_dataset_builder.py::test_load_training_dataset_package_stops_reading_validation_after_sample_limit",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_load_training_dataset_package_limits_validation_samples services/mlx-worker-python/tests/test_training_dataset_builder.py::test_load_training_dataset_package_stops_reading_validation_after_sample_limit && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/tests/test_training_dataset_builder.py",
+    "probe_command": "if [ -f scripts/training_dataset_validation_limit_probe.py ]; then\n  PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python scripts/training_dataset_validation_limit_probe.py\nelse\n  PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python - <<'PY'\nimport json\nimport statistics\nimport sys\nimport tempfile\nimport time\nimport tracemalloc\nfrom pathlib import Path\nsys.path[:0] = [str(Path.cwd()), str(Path.cwd() / \"services/mlx-worker-python\")]\nfrom worker.model_ops.training_dataset import load_training_dataset_package\nrows = 50000\nsamples = []\nwith tempfile.TemporaryDirectory(prefix=\"melix-validation-limit-probe-\") as temp_dir:\n    package_path = Path(temp_dir) / \"package\"\n    package_path.mkdir()\n    (package_path / \"manifest.json\").write_text(json.dumps({\"schema_version\": \"melix.training_dataset_package.v1\", \"dataset_id\": \"validation-limit-probe\", \"format\": \"text_completion\", \"sample_count\": 1, \"version\": \"1\", \"validation_sample_count\": rows}) + \"\\n\", encoding=\"utf-8\")\n    (package_path / \"samples.jsonl\").write_text(json.dumps({\"text\": \"train-row\"}) + \"\\n\", encoding=\"utf-8\")\n    with (package_path / \"valid.jsonl\").open(\"w\", encoding=\"utf-8\") as handle:\n        for index in range(rows):\n            handle.write(json.dumps({\"text\": f\"validation-{index}\"}) + \"\\n\")\n    for _ in range(5):\n        tracemalloc.start()\n        started = time.perf_counter()\n        package = load_training_dataset_package(str(package_path), sample_limit=1)\n        elapsed_ms = (time.perf_counter() - started) * 1000.0\n        _, peak_bytes = tracemalloc.get_traced_memory()\n        tracemalloc.stop()\n        samples.append((elapsed_ms, float(peak_bytes), float(package.validation_sample_count)))\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(sample[0] for sample in samples), \"peak_bytes_mean\": statistics.fmean(sample[1] for sample in samples), \"validation_sample_count_mean\": statistics.fmean(sample[2] for sample in samples), \"synthetic_validation_rows\": float(rows)}, sort_keys=True))\nPY\nfi",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "validation_sample_count_mean",
+        "unit": "rows",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "maintenance-bench-report-readback",
     "name": "Maintenance bench report readback",
     "runner": "ubuntu-latest",

--- a/scripts/training_dataset_validation_limit_probe.py
+++ b/scripts/training_dataset_validation_limit_probe.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.model_ops.training_dataset import load_training_dataset_package  # noqa: E402
+
+
+def _write_package(package_path: Path, validation_rows: int) -> None:
+    package_path.mkdir(parents=True, exist_ok=True)
+    (package_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "validation-limit-probe",
+                "format": "text_completion",
+                "sample_count": 1,
+                "version": "1",
+                "validation_sample_count": validation_rows,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (package_path / "samples.jsonl").write_text(
+        json.dumps({"text": "train-row"}) + "\n",
+        encoding="utf-8",
+    )
+    with (package_path / "valid.jsonl").open("w", encoding="utf-8") as handle:
+        for index in range(validation_rows):
+            handle.write(json.dumps({"text": f"validation-{index}"}) + "\n")
+
+
+def main() -> None:
+    validation_rows = 50_000
+    samples: list[dict[str, float]] = []
+    with tempfile.TemporaryDirectory(prefix="melix-validation-limit-probe-") as temp_dir:
+        package_path = Path(temp_dir) / "package"
+        _write_package(package_path, validation_rows)
+        for _ in range(5):
+            tracemalloc.start()
+            started = time.perf_counter()
+            package = load_training_dataset_package(str(package_path), sample_limit=1)
+            elapsed_ms = (time.perf_counter() - started) * 1000.0
+            _, peak_bytes = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            samples.append(
+                {
+                    "elapsed_ms": elapsed_ms,
+                    "peak_bytes": float(peak_bytes),
+                    "validation_sample_count": float(package.validation_sample_count),
+                }
+            )
+
+    result = {
+        "elapsed_ms_mean": statistics.fmean(sample["elapsed_ms"] for sample in samples),
+        "peak_bytes_mean": statistics.fmean(sample["peak_bytes"] for sample in samples),
+        "validation_sample_count_mean": statistics.fmean(
+            sample["validation_sample_count"] for sample in samples
+        ),
+        "synthetic_validation_rows": float(validation_rows),
+    }
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -141,8 +141,12 @@ def test_scope_report_selects_training_dataset_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/model_ops/training_dataset.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "training-dataset-token-percentiles-single-sort"
+    probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert scope["selected_count"] == 2
+    assert probe_ids == {
+        "training-dataset-token-percentiles-single-sort",
+        "training-dataset-validation-sample-limit",
+    }
 
 
 def test_scope_report_selects_startup_signals_probe() -> None:
@@ -918,6 +922,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "pr-scoped-performance-scope-json-read-bytes",
         "pr-scoped-performance-scope-matcher",
         "training-dataset-token-percentiles-single-sort",
+        "training-dataset-validation-sample-limit",
         "maintenance-bench-report-readback",
         "maintenance-percentile-vector-reuse",
         "phase8-metrics-closure-audit-reuse",

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -222,17 +222,16 @@ def test_load_training_dataset_package_stops_reading_after_sample_limit(
     assert package.normalized_samples == [{"text": "alpha"}]
 
 
-
-def test_load_training_dataset_package_stops_reading_validation_after_sample_limit(
+def test_load_training_dataset_package_limits_validation_samples(
     tmp_path: Path,
 ) -> None:
-    package_path = tmp_path / "limited-invalid-validation-tail"
+    package_path = tmp_path / "limited-validation-package"
     package_path.mkdir(parents=True, exist_ok=True)
     (package_path / "manifest.json").write_text(
         json.dumps(
             {
                 "schema_version": "melix.training_dataset_package.v1",
-                "dataset_id": "limited-invalid-validation-tail",
+                "dataset_id": "limited-validation-package",
                 "format": "text_completion",
                 "sample_count": 1,
                 "version": "1",
@@ -247,7 +246,44 @@ def test_load_training_dataset_package_stops_reading_validation_after_sample_lim
         encoding="utf-8",
     )
     (package_path / "valid.jsonl").write_text(
-        '{"text": "validate-alpha"}\n'
+        "\n"
+        '{"text": "holdout-one"}\n'
+        "\n"
+        '{"text": "holdout-two"}\n',
+        encoding="utf-8",
+    )
+
+    package = load_training_dataset_package(str(package_path), sample_limit=1)
+
+    assert package.validation_sample_count == 1
+    assert package.normalized_validation_samples == [{"text": "holdout-one"}]
+
+
+def test_load_training_dataset_package_stops_reading_validation_after_sample_limit(
+    tmp_path: Path,
+) -> None:
+    package_path = tmp_path / "limited-validation-invalid-tail"
+    package_path.mkdir(parents=True, exist_ok=True)
+    (package_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "limited-validation-invalid-tail",
+                "format": "text_completion",
+                "sample_count": 1,
+                "version": "1",
+                "validation_sample_count": 2,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (package_path / "samples.jsonl").write_text(
+        '{"text": "alpha"}\n',
+        encoding="utf-8",
+    )
+    (package_path / "valid.jsonl").write_text(
+        '{"text": "holdout-one"}\n'
         "{not-json\n",
         encoding="utf-8",
     )
@@ -255,7 +291,7 @@ def test_load_training_dataset_package_stops_reading_validation_after_sample_lim
     package = load_training_dataset_package(str(package_path), sample_limit=1)
 
     assert package.validation_sample_count == 1
-    assert package.normalized_validation_samples == [{"text": "validate-alpha"}]
+    assert package.normalized_validation_samples == [{"text": "holdout-one"}]
 
 
 def test_load_training_dataset_package_supports_preference_pair_samples(


### PR DESCRIPTION
## Summary
- Limit `valid.jsonl` preview loading with the existing `sample_limit` path so local package smoke/preview loads do not parse every validation row.
- Add focused regression coverage for validation limiting and invalid tail rows after the limit.
- Register a dedicated `training-dataset-validation-sample-limit` PR-scoped performance probe with a base-compatible fallback command.

## Plan or Spec
- `docs/plans/2026-05-05-training-dataset-validation-sample-limit.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_training_dataset_builder.py::test_load_training_dataset_package_limits_validation_samples \
  services/mlx-worker-python/tests/test_training_dataset_builder.py::test_load_training_dataset_package_stops_reading_validation_after_sample_limit \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 4 passed in 0.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 54 passed in 0.14s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --data-file=/tmp/melix_validation_limit.coverage -m pytest -q ... && coverage json ... && python scripts/changed_scope_coverage.py ...
# TOTAL 21 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-validation-sample-limit --base-repo /tmp/melix-base-validation-limit-20260505171000 --head-repo "$PWD" --output /tmp/melix_validation_limit_pr_probe.json
# head verification: 2 passed; coverage TOTAL 18 0 100%; base/head probes succeeded

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-token-percentiles-single-sort --base-repo /tmp/melix-base-validation-limit-20260505171000 --head-repo "$PWD" --output /tmp/melix_training_dataset_token_probe.json
# head verification: 181 passed; coverage TOTAL 21 0 100%; base/head probes succeeded

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 21 0 100%` for the local focused coverage run.
- Registered probe: `training-dataset-validation-sample-limit`
  - `origin/main`: `elapsed_ms_mean=522.451`, `peak_bytes_mean=12496242.4`, `validation_sample_count_mean=50000.0`
  - branch: `elapsed_ms_mean=0.527`, `peak_bytes_mean=29529.4`, `validation_sample_count_mean=1.0`
  - synthetic validation rows: `50000`
- Existing overlapping probe: `training-dataset-token-percentiles-single-sort`
  - `origin/main`: `elapsed_ms_mean=323.846`, `peak_bytes_mean=2202484.0`
  - branch: `elapsed_ms_mean=338.902`, `peak_bytes_mean=2202484.0`
  - The elapsed delta is within the probe's 5% warning threshold; this slice does not modify that token-summary path.

## Known Gaps
- Linux-only local verification. macOS/Swift checks were not run locally.
- Updating `infra/perf/pr_scoped_probes.json` can fan out the hosted `pr-scoped-performance` matrix; hosted CI remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
