### PR TITLE
perf: cache event alignment accepted edges

### DIFF
--- a/docs/plans/event-extraction-alignment-accepted-edge-cache.md
+++ b/docs/plans/event-extraction-alignment-accepted-edge-cache.md
@@ -1,0 +1,52 @@
+# Event Extraction Alignment Accepted-Edge Cache
+
+## Goal
+
+Reduce redundant work in `worker.productization.event_extraction._maximum_weight_event_matching` by precomputing accepted prediction edges for each gold event before the dynamic-programming search.
+
+## Linux-only constraint
+
+This slice is Python-only and can be verified on Linux with focused pytest, changed-scope coverage, and an explicit local performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/productization/event_extraction.py`
+- `services/mlx-worker-python/tests/test_event_extraction.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+- `scripts/event_extraction_alignment_probe.py`
+
+## Probe definition
+
+Register `event-extraction-alignment-accepted-edge-cache` in the PR-scoped performance registry. The probe builds a deterministic sparse alignment matrix and repeatedly calls `_maximum_weight_event_matching`, reporting:
+
+- `elapsed_ms_mean` — lower is better
+- `accepted_edges` — informational structural metric
+- `matrix_size`, `iterations_per_sample`, `sample_count`, `match_count_mean`, and `checksum` for workload integrity
+
+## Success metrics
+
+- Focused tests pass.
+- Changed-scope automated coverage is at least 95%.
+- The local probe produces concrete metrics and the base-vs-head comparison improves `elapsed_ms_mean` without changing the matching checksum.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_uses_global_optimum_not_greedy \
+  services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_precomputes_only_accepted_sparse_edges \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_alignment_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same test selection>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/productization/event_extraction.py \
+  services/mlx-worker-python/tests/test_event_extraction.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/event_extraction_alignment_probe.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/event_extraction_alignment_probe.py
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1736,5 +1736,35 @@
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
     "notes": "Compares startup failure classification log-read work for control-plane-resolved failures versus worker-crash fallback."
+  },
+  {
+    "id": "event-extraction-alignment-accepted-edge-cache",
+    "name": "Event extraction alignment accepted-edge cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/event_extraction.py",
+      "services/mlx-worker-python/tests/test_event_extraction.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/event_extraction_alignment_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_uses_global_optimum_not_greedy services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_precomputes_only_accepted_sparse_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_alignment_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_uses_global_optimum_not_greedy services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_precomputes_only_accepted_sparse_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_alignment_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_alignment_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/event_extraction_alignment_probe.py ]; then python scripts/event_extraction_alignment_probe.py; else python -c \"import base64; exec(base64.b64decode(\\\"aW1wb3J0IGpzb24sIHN0YXRpc3RpY3MsIHN5cywgdGltZQpmcm9tIHBhdGhsaWIgaW1wb3J0IFBhdGgKcmVwbz1QYXRoLmN3ZCgpCnN5cy5wYXRoLmluc2VydCgwLHN0cihyZXBvKSkKc3lzLnBhdGguaW5zZXJ0KDAsc3RyKHJlcG8vJ3NlcnZpY2VzL21seC13b3JrZXItcHl0aG9uJykpCmZyb20gd29ya2VyLnByb2R1Y3RpemF0aW9uLmV2ZW50X2V4dHJhY3Rpb24gaW1wb3J0IF9tYXhpbXVtX3dlaWdodF9ldmVudF9tYXRjaGluZwpzaXplPTE0CmFjY19wZXI9MgppdGVyYXRpb25zPTIwCnNhbXBsZXM9NQpzY29yZXM9W10KYWNjZXB0ZWQ9W10KZm9yIGdpIGluIHJhbmdlKHNpemUpOgogICAgc2NvcmVfcm93PVswLjBdKnNpemUKICAgIGFjY2VwdGVkX3Jvdz1bRmFsc2VdKnNpemUKICAgIGZvciBlaSBpbiByYW5nZShhY2NfcGVyKToKICAgICAgICBwaT0oZ2kqNStlaSozKSVzaXplCiAgICAgICAgYWNjZXB0ZWRfcm93W3BpXT1UcnVlCiAgICAgICAgc2NvcmVfcm93W3BpXT0wLjUrKCgoZ2krMSkqKGVpKzMpKSU0MSkvMTAwLjAKICAgIHNjb3Jlcy5hcHBlbmQoc2NvcmVfcm93KQogICAgYWNjZXB0ZWQuYXBwZW5kKGFjY2VwdGVkX3JvdykKZXhwZWN0ZWQ9c3VtKHN1bShyb3cpIGZvciByb3cgaW4gYWNjZXB0ZWQpCmVsYXBzZWQ9W10KY2hlY2tzdW09MC4wCm1hdGNoX2NvdW50PTAKZm9yIF8gaW4gcmFuZ2Uoc2FtcGxlcyk6CiAgICBzdGFydGVkPXRpbWUucGVyZl9jb3VudGVyKCkKICAgIGZvciBfIGluIHJhbmdlKGl0ZXJhdGlvbnMpOgogICAgICAgIG1hdGNoZXM9X21heGltdW1fd2VpZ2h0X2V2ZW50X21hdGNoaW5nKHNjb3JlcywgYWNjZXB0ZWQpCiAgICAgICAgY2hlY2tzdW0rPXN1bSgoZysxKSoxMDAwKyhwKzEpKjEwK3MgZm9yIGcscCxzIGluIG1hdGNoZXMpCiAgICAgICAgbWF0Y2hfY291bnQrPWxlbihtYXRjaGVzKQogICAgZWxhcHNlZC5hcHBlbmQoKHRpbWUucGVyZl9jb3VudGVyKCktc3RhcnRlZCkqMTAwMC4wKQpwcmludChqc29uLmR1bXBzKHsnZWxhcHNlZF9tc19tZWFuJzpzdGF0aXN0aWNzLmZtZWFuKGVsYXBzZWQpLCdlbGFwc2VkX21zX21pbic6bWluKGVsYXBzZWQpLCdtYXRyaXhfc2l6ZSc6ZmxvYXQoc2l6ZSksJ2FjY2VwdGVkX2VkZ2VzJzpmbG9hdChleHBlY3RlZCksJ2l0ZXJhdGlvbnNfcGVyX3NhbXBsZSc6ZmxvYXQoaXRlcmF0aW9ucyksJ3NhbXBsZV9jb3VudCc6ZmxvYXQoc2FtcGxlcyksJ21hdGNoX2NvdW50X21lYW4nOm1hdGNoX2NvdW50L3NhbXBsZXMsJ2NoZWNrc3VtJzpjaGVja3N1bX0sIHNvcnRfa2V5cz1UcnVlKSkK\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "accepted_edges",
+        "unit": "edges",
+        "direction": "informational"
+      }
+    ]
   }
 ]

--- a/scripts/event_extraction_alignment_probe.py
+++ b/scripts/event_extraction_alignment_probe.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return int(raw)
+
+
+def _build_sparse_matrix(size: int, accepted_per_row: int) -> tuple[list[list[float]], list[list[bool]]]:
+    scores: list[list[float]] = []
+    accepted: list[list[bool]] = []
+    for gold_index in range(size):
+        score_row = [0.0] * size
+        accepted_row = [False] * size
+        for edge_index in range(accepted_per_row):
+            pred_index = (gold_index * 5 + edge_index * 3) % size
+            accepted_row[pred_index] = True
+            # Keep a deterministic spread of positive weights with stable tie behavior.
+            score_row[pred_index] = 0.5 + (((gold_index + 1) * (edge_index + 3)) % 41) / 100.0
+        scores.append(score_row)
+        accepted.append(accepted_row)
+    return scores, accepted
+
+
+def main() -> int:
+    repo_root = Path.cwd()
+    sys.path.insert(0, str(repo_root))
+    sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
+
+    from worker.productization.event_extraction import (  # noqa: PLC0415
+        _accepted_event_matching_edges,
+        _maximum_weight_event_matching,
+    )
+
+    size = _int_env("MELIX_EVENT_ALIGNMENT_PROBE_SIZE", 14)
+    accepted_per_row = _int_env("MELIX_EVENT_ALIGNMENT_PROBE_ACCEPTED_PER_ROW", 2)
+    iterations = _int_env("MELIX_EVENT_ALIGNMENT_PROBE_ITERATIONS", 20)
+    sample_count = _int_env("MELIX_EVENT_ALIGNMENT_PROBE_SAMPLES", 5)
+    scores, accepted = _build_sparse_matrix(size, accepted_per_row)
+    expected_edge_count = sum(sum(row) for row in accepted)
+    edge_count = sum(len(row) for row in _accepted_event_matching_edges(scores, accepted))
+    if edge_count != expected_edge_count:
+        raise RuntimeError(f"unexpected accepted edge count: {edge_count} != {expected_edge_count}")
+
+    expected_matches = _maximum_weight_event_matching(scores, accepted)
+    expected_checksum = sum((gold + 1) * 1000 + (pred + 1) * 10 + score for gold, pred, score in expected_matches)
+
+    elapsed_samples: list[float] = []
+    checksum = 0.0
+    match_count = 0
+    for _sample_index in range(sample_count):
+        started = time.perf_counter()
+        for _iteration in range(iterations):
+            matches = _maximum_weight_event_matching(scores, accepted)
+            checksum += sum((gold + 1) * 1000 + (pred + 1) * 10 + score for gold, pred, score in matches)
+            match_count += len(matches)
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+
+    expected_total_checksum = expected_checksum * iterations * sample_count
+    if abs(checksum - expected_total_checksum) > 1e-6:
+        raise RuntimeError(f"unexpected matching checksum: {checksum} != {expected_total_checksum}")
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+                "elapsed_ms_min": min(elapsed_samples),
+                "matrix_size": float(size),
+                "accepted_edges": float(edge_count),
+                "iterations_per_sample": float(iterations),
+                "sample_count": float(sample_count),
+                "match_count_mean": match_count / sample_count,
+                "checksum": checksum,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_event_extraction.py
+++ b/services/mlx-worker-python/tests/test_event_extraction.py
@@ -1653,6 +1653,29 @@ def test_event_alignment_uses_global_optimum_not_greedy() -> None:
     assert matches == [(0, 1, 0.80), (1, 0, 0.80)]
 
 
+def test_event_alignment_precomputes_only_accepted_sparse_edges() -> None:
+    scores = [
+        [0.91, 0.0, 0.0, 0.77],
+        [0.0, 0.82, 0.0, 0.0],
+        [0.80, 0.0, 0.79, 0.0],
+    ]
+    accepted = [
+        [True, False, False, True],
+        [False, True, False, False],
+        [True, False, True, False],
+    ]
+
+    edges = event_extraction_module._accepted_event_matching_edges(scores, accepted)
+    matches = event_extraction_module._maximum_weight_event_matching(scores, accepted)
+
+    assert edges == (
+        ((0, 0.91), (3, 0.77)),
+        ((1, 0.82),),
+        ((0, 0.80), (2, 0.79)),
+    )
+    assert matches == [(0, 0, 0.91), (1, 1, 0.82), (2, 2, 0.79)]
+
+
 def test_event_alignment_reuses_normalized_action_values(monkeypatch) -> None:
     calls = 0
     original = event_extraction_module._normalize_event_field

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -79,6 +79,16 @@ def benchmark_scope() -> dict[str, object]:
     )
 
 
+def test_scope_report_selects_event_extraction_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/event_extraction.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "event-extraction-alignment-accepted-edge-cache"
+
+
 def test_scope_report_selects_hub_catalog_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -739,6 +749,28 @@ def test_compiled_glob_pattern_reuses_cached_regex(monkeypatch: pytest.MonkeyPat
     pr_scoped_performance_module._force_all_wildcard_matchers.cache_clear()
 
 
+def test_event_extraction_alignment_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_EVENT_ALIGNMENT_PROBE_SIZE", "5")
+    monkeypatch.setenv("MELIX_EVENT_ALIGNMENT_PROBE_ACCEPTED_PER_ROW", "2")
+    monkeypatch.setenv("MELIX_EVENT_ALIGNMENT_PROBE_ITERATIONS", "2")
+    monkeypatch.setenv("MELIX_EVENT_ALIGNMENT_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(REPO_ROOT / "scripts/event_extraction_alignment_probe.py"), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["matrix_size"] == 5.0
+    assert metrics["accepted_edges"] == 10.0
+    assert metrics["iterations_per_sample"] == 2.0
+    assert metrics["sample_count"] == 1.0
+    assert metrics["match_count_mean"] > 0
+    assert metrics["elapsed_ms_mean"] >= 0
+
+
 def test_hub_catalog_tag_normalization_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -885,6 +917,7 @@ def test_dataset_registry_limit_probe_script_emits_metrics(
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
         "dataset-registry-limited-read-streaming",
+        "event-extraction-alignment-accepted-edge-cache",
         "hub-catalog-tag-normalization-single-pass",
         "benchmark-evaluation-report-running-aggregates",
         "statistical-evidence-bootstrap-percentile-single-sort",

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2130,12 +2130,26 @@ def _character_bigrams(value: str) -> dict[str, int]:
     return counts
 
 
+def _accepted_event_matching_edges(
+    scores: list[list[float]],
+    accepted: list[list[bool]],
+) -> tuple[tuple[tuple[int, float], ...], ...]:
+    return tuple(
+        tuple(
+            (pred_index, float(score))
+            for pred_index, score in enumerate(score_row)
+            if pred_index < len(accepted_row) and accepted_row[pred_index]
+        )
+        for score_row, accepted_row in zip(scores, accepted, strict=False)
+    )
+
+
 def _maximum_weight_event_matching(
     scores: list[list[float]],
     accepted: list[list[bool]],
 ) -> list[tuple[int, int, float]]:
     gold_count = len(scores)
-    pred_count = max((len(row) for row in scores), default=0)
+    accepted_edges = _accepted_event_matching_edges(scores, accepted)
     memo: dict[tuple[int, int], tuple[float, tuple[tuple[int, int, float], ...]]] = {}
 
     def better(
@@ -2156,13 +2170,10 @@ def _maximum_weight_event_matching(
             return (0.0, ())
 
         best = solve(gold_index + 1, used_pred_mask)
-        for pred_index in range(pred_count):
+        for pred_index, score in accepted_edges[gold_index]:
             if used_pred_mask & (1 << pred_index):
                 continue
-            if pred_index >= len(scores[gold_index]) or not accepted[gold_index][pred_index]:
-                continue
             next_score, next_pairs = solve(gold_index + 1, used_pred_mask | (1 << pred_index))
-            score = float(scores[gold_index][pred_index])
             pair = (gold_index, pred_index, _round_metric(score))
             candidate = (score + next_score, (pair,) + next_pairs)
             if better(candidate, best):


### PR DESCRIPTION
## Summary
- Precompute accepted prediction edges before event-alignment dynamic programming so sparse alignment matrices do not rescan every prediction column at every DP state.
- Add a focused regression test for accepted-edge construction and optimal matching output.
- Register the `event-extraction-alignment-accepted-edge-cache` PR-scoped performance probe with a base-compatible command fallback.

## Plan or Spec
- `docs/plans/event-extraction-alignment-accepted-edge-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_uses_global_optimum_not_greedy services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_precomputes_only_accepted_sparse_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_alignment_probe_script_emits_metrics
# 5 passed in 0.14s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_uses_global_optimum_not_greedy services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_precomputes_only_accepted_sparse_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_alignment_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_alignment_probe.py
# TOTAL 30 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/event_extraction_alignment_probe.py
# {"accepted_edges": 28.0, "checksum": 10605974.000000017, "elapsed_ms_mean": 3011.3893271889538, "elapsed_ms_min": 2862.299649976194, "iterations_per_sample": 20.0, "match_count_mean": 280.0, "matrix_size": 14.0, "sample_count": 5.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id event-extraction-alignment-accepted-edge-cache --base-repo /tmp/melix-event-base-20260505174255-e --head-repo "$PWD" --output /tmp/event-pr-scoped.json
# head verification: 5 passed; changed-scope coverage 100%
# base elapsed_ms_mean=4323.4887719969265; head elapsed_ms_mean=2896.0395818110555; checksum unchanged

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 30 0 100%`.
- Local direct probe: `elapsed_ms_mean=3011.3893271889538`, `accepted_edges=28`, `checksum=10605974.000000017`.
- Local base-vs-head PR-scoped probe: `elapsed_ms_mean` improved from `4323.4887719969265` on `origin/main` to `2896.0395818110555` on head (~33.0% lower); `checksum` stayed `10605974.000000017`.
- Registered scoped CI probe: `event-extraction-alignment-accepted-edge-cache`.

## Known Gaps
- Full `make py-test`, Swift tests, and integration tests were not run locally; this is a focused Python optimization slice on a Linux host.
- Hosted GitHub Actions remain the source of truth for full CI and PR-scoped performance validation after the PR opens.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
