### PR TITLE
Add Issue 365 Window acceptance matrix

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift
+++ b/apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift
@@ -19,6 +19,8 @@ private let phase8MatrixConcurrencyLevel: UInt32 = 1
 private let phase8MatrixRequests: UInt32 = 4
 private let phase8EvaluationSampleSize: UInt32 = 4
 private let phase8EvaluationScoringMode = "multiple_choice_accuracy"
+private let phase8WindowUIBusinessLineEvidenceLevel = "window_route_matrix"
+private let phase8WindowUIReleaseReadyBlocker = "real_local_runtime_matrix_not_run"
 
 public enum Phase8WindowUIAcceptanceError: Error, LocalizedError {
     case missingCLIEvidenceBundle(String)
@@ -193,6 +195,49 @@ private struct Phase8WindowUIAcceptanceUIState: Codable, Equatable, Sendable {
     let selectedServerLifecycle: String
 }
 
+private enum Phase8WindowUIBusinessLineKind: Equatable, Sendable {
+    case training(RuntimeLoraTrainingMode)
+    case quantization(RuntimeQuantizationMode)
+}
+
+private struct Phase8WindowUIBusinessLineCase: Equatable, Sendable {
+    let caseID: String
+    let businessLine: String
+    let kind: Phase8WindowUIBusinessLineKind
+}
+
+private struct Phase8WindowUIBusinessLineEvidence: Codable, Equatable, Sendable {
+    let caseID: String
+    let businessLine: String
+    let evidenceLevel: String
+    let selectedSurface: String
+    let selectedToolSection: String
+    let selectedTrainingMode: String
+    let selectedQuantizationMode: String
+    let selectedQuantizationProfileID: String
+    let runnableAction: String
+    let routedCommand: String
+    let visible: Bool
+    let selectable: Bool
+    let runnable: Bool
+    let inspectable: Bool
+    let releaseReady: Bool
+    let releaseReadyBlocker: String
+}
+
+private let phase8WindowUIBusinessLineCases: [Phase8WindowUIBusinessLineCase] = [
+    .init(caseID: "base_lora_export_local_inference", businessLine: "BaseModel -> LoRA -> export -> local inference", kind: .training(.lora)),
+    .init(caseID: "base_qlora_export_local_inference", businessLine: "BaseModel -> QLoRA -> export -> local inference", kind: .training(.qlora)),
+    .init(caseID: "base_dora_export_local_inference", businessLine: "BaseModel -> DoRA -> export -> local inference", kind: .training(.dora)),
+    .init(caseID: "lora_dpo_export_local_inference", businessLine: "BaseModel -> LoRA -> DPO -> export -> local inference", kind: .training(.dpo)),
+    .init(caseID: "lora_orpo_export_local_inference", businessLine: "BaseModel -> LoRA -> ORPO -> export -> local inference", kind: .training(.orpo)),
+    .init(caseID: "lora_cpo_export_local_inference", businessLine: "BaseModel -> LoRA -> CPO -> export -> local inference", kind: .training(.cpo)),
+    .init(caseID: "lora_grpo_export_local_inference", businessLine: "BaseModel -> LoRA -> GRPO -> export -> local inference", kind: .training(.grpo)),
+    .init(caseID: "lora_rlhf_export_local_inference", businessLine: "BaseModel -> LoRA -> RLHF using #366 reward model -> export -> local inference", kind: .training(.rlhf)),
+    .init(caseID: "lora_preference_ptq_local_inference", businessLine: "BaseModel -> LoRA/preference result -> merge/export -> PTQ -> local inference", kind: .quantization(.ptq)),
+    .init(caseID: "qat_quantized_local_inference", businessLine: "BaseModel -> QAT/QAT-aware export -> quantized local inference", kind: .quantization(.qat)),
+]
+
 private struct Phase8WindowUIAcceptanceBundle: Codable, Equatable, Sendable {
     let schemaVersion: String
     let surface: String
@@ -212,6 +257,7 @@ private struct Phase8WindowUIAcceptanceBundle: Codable, Equatable, Sendable {
     let evaluationDataset: String
     let cliEvidenceBundlePath: String
     let screenshotPath: String
+    let businessLines: [Phase8WindowUIBusinessLineEvidence]
     let baseChatAssistantText: String
     let derivedChatAssistantText: String
     let loraTrainJobID: String
@@ -417,6 +463,8 @@ public final class Phase8WindowUIAcceptanceRunner {
             outputURL: exportsRoot.appendingPathComponent("evaluation-samples.jsonl")
         )
 
+        let businessLines = collectBusinessLineEvidence()
+
         await viewModel.refreshDesktopFoundation()
         viewModel.selectSurface(.server)
         viewModel.selectServerSession(id: serverSessionID)
@@ -449,6 +497,7 @@ public final class Phase8WindowUIAcceptanceRunner {
             evaluationDataset: config.evaluationDataset,
             cliEvidenceBundlePath: config.cliEvidenceBundlePath,
             screenshotPath: screenshotURL.path,
+            businessLines: businessLines,
             baseChatAssistantText: baseChatReceipt.assistantText,
             derivedChatAssistantText: derivedChatReceipt.assistantText,
             loraTrainJobID: loraTrainJobID,
@@ -481,6 +530,101 @@ public final class Phase8WindowUIAcceptanceRunner {
             screenshotPath: screenshotURL.path,
             cliEvidenceBundlePath: config.cliEvidenceBundlePath,
             modelID: materializeReceipt.modelID
+        )
+    }
+
+    private func collectBusinessLineEvidence() -> [Phase8WindowUIBusinessLineEvidence] {
+        phase8WindowUIBusinessLineCases.map { businessLine in
+            switch businessLine.kind {
+            case .training(let mode):
+                return collectTrainingBusinessLineEvidence(businessLine, mode: mode)
+            case .quantization(let mode):
+                return collectQuantizationBusinessLineEvidence(businessLine, mode: mode)
+            }
+        }
+    }
+
+    private func collectTrainingBusinessLineEvidence(
+        _ businessLine: Phase8WindowUIBusinessLineCase,
+        mode: RuntimeLoraTrainingMode
+    ) -> Phase8WindowUIBusinessLineEvidence {
+        viewModel.selectSurface(.tools)
+        viewModel.selectToolSection(.training)
+        viewModel.selectedLoraModelID = config.modelID
+        viewModel.loraDatasetURI = config.trainingFixture
+        viewModel.loraAdapterName = "\(phase8AdapterName)-\(mode.rawValue)"
+        viewModel.loraTrainingMode = mode
+        if mode.isAlignmentMode {
+            viewModel.loraReferenceModelPath = "/tmp/melix/reference-model"
+            viewModel.loraKLPenalty = "0.02"
+        }
+        if mode == .grpo {
+            viewModel.loraGRPOCandidateCount = "4"
+        }
+        if mode == .rlhf {
+            viewModel.loraRewardModelManifestPath = "/tmp/melix/reward-model/manifest.json"
+        }
+
+        let visible = RuntimeLoraTrainingMode.allCases.contains(mode)
+        let selectable = viewModel.loraTrainingMode == mode
+        let runnable = viewModel.selectedLoraModelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            && viewModel.loraDatasetURI.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        let inspectable = viewModel.selectedSurface == .tools && viewModel.selectedToolSection == .training
+        let routedCommand = mode.isAlignmentMode ? "alignment.train" : "lora.train"
+
+        return Phase8WindowUIBusinessLineEvidence(
+            caseID: businessLine.caseID,
+            businessLine: businessLine.businessLine,
+            evidenceLevel: phase8WindowUIBusinessLineEvidenceLevel,
+            selectedSurface: viewModel.selectedSurface.rawValue,
+            selectedToolSection: viewModel.selectedToolSection.rawValue,
+            selectedTrainingMode: mode.rawValue,
+            selectedQuantizationMode: "",
+            selectedQuantizationProfileID: "",
+            runnableAction: "Start Training",
+            routedCommand: routedCommand,
+            visible: visible,
+            selectable: selectable,
+            runnable: runnable,
+            inspectable: inspectable,
+            releaseReady: false,
+            releaseReadyBlocker: phase8WindowUIReleaseReadyBlocker
+        )
+    }
+
+    private func collectQuantizationBusinessLineEvidence(
+        _ businessLine: Phase8WindowUIBusinessLineCase,
+        mode: RuntimeQuantizationMode
+    ) -> Phase8WindowUIBusinessLineEvidence {
+        viewModel.selectSurface(.tools)
+        viewModel.selectToolSection(.downloads)
+        viewModel.selectQuantizationMode(mode.rawValue)
+        viewModel.selectQuantizationProfile("q4")
+
+        let visible = RuntimeQuantizationMode.allCases.contains(mode)
+        let selectable = viewModel.selectedQuantizationMode == mode
+        let runnable = viewModel.modelOperationTargetModelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        let inspectable = viewModel.selectedSurface == .tools
+            && viewModel.selectedToolSection == .downloads
+            && viewModel.availableQuantizationProfileIDs.contains(viewModel.selectedQuantizationProfileID)
+
+        return Phase8WindowUIBusinessLineEvidence(
+            caseID: businessLine.caseID,
+            businessLine: businessLine.businessLine,
+            evidenceLevel: phase8WindowUIBusinessLineEvidenceLevel,
+            selectedSurface: viewModel.selectedSurface.rawValue,
+            selectedToolSection: viewModel.selectedToolSection.rawValue,
+            selectedTrainingMode: "",
+            selectedQuantizationMode: mode.rawValue,
+            selectedQuantizationProfileID: viewModel.selectedQuantizationProfileID,
+            runnableAction: "Quantize Model",
+            routedCommand: "model.quantize",
+            visible: visible,
+            selectable: selectable,
+            runnable: runnable,
+            inspectable: inspectable,
+            releaseReady: false,
+            releaseReadyBlocker: phase8WindowUIReleaseReadyBlocker
         )
     }
 

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -2069,6 +2069,20 @@ struct DesktopDownloadsToolSectionView: View {
                     Spacer(minLength: 12)
 
                     Picker(
+                        "Quant Mode",
+                        selection: Binding(
+                            get: { viewModel.selectedQuantizationMode },
+                            set: { viewModel.selectedQuantizationMode = $0 }
+                        )
+                    ) {
+                        ForEach(RuntimeQuantizationMode.allCases) { mode in
+                            Text(mode.title).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 128)
+
+                    Picker(
                         "Quant Profile",
                         selection: Binding(
                             get: { viewModel.selectedQuantizationProfileID },

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -1102,6 +1102,24 @@ public enum RuntimeLoraTrainingMode: String, CaseIterable, Identifiable, Sendabl
     }
 }
 
+public enum RuntimeQuantizationMode: String, CaseIterable, Identifiable, Sendable {
+    case ptq = "ptq"
+    case qat = "qat"
+
+    public var id: String {
+        rawValue
+    }
+
+    public var title: String {
+        switch self {
+        case .ptq:
+            return "PTQ"
+        case .qat:
+            return "QAT"
+        }
+    }
+}
+
 public enum RuntimeLoraTrainingPreset: String, CaseIterable, Identifiable, Sendable {
     case custom = ""
     case debugFast = "debug_fast"
@@ -2056,6 +2074,7 @@ public final class RuntimeViewModel {
     public private(set) var effectiveImageNegativePrompt = ""
     public private(set) var imageDefaultsUpdatedAtUnixMS: Int64 = 0
     public let availableQuantizationProfileIDs = ["q2", "q3", "q4", "q5", "q6", "q7", "q8"]
+    public var selectedQuantizationMode: RuntimeQuantizationMode = .ptq
     public var selectedQuantizationProfileID = "q4"
     public var selectedModelOperationTargetModelID = ""
     public var openCommandCenterAction: (@MainActor @Sendable () -> Void)?
@@ -3069,6 +3088,15 @@ public final class RuntimeViewModel {
             return
         }
         selectedQuantizationProfileID = normalizedProfileID
+        notifyStateChanged()
+    }
+
+    public func selectQuantizationMode(_ modeID: String) {
+        let normalizedModeID = modeID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let mode = RuntimeQuantizationMode(rawValue: normalizedModeID) else {
+            return
+        }
+        selectedQuantizationMode = mode
         notifyStateChanged()
     }
 
@@ -6330,7 +6358,8 @@ public final class RuntimeViewModel {
             outputDir: "/tmp/melix-quantize",
             quantProfileID: selectedQuantizationProfileID,
             weightQuant: selectedQuantizationProfileID,
-            kvQuant: "q8"
+            kvQuant: "q8",
+            ext: quantizationModeExt()
         )
     }
 
@@ -6345,6 +6374,43 @@ public final class RuntimeViewModel {
             outputDir: "/tmp/melix-convert",
             ext: ["target_format": "melix_model_bundle"]
         )
+    }
+
+    private func quantizationModeExt() -> [String: String] {
+        var ext: [String: String] = [
+            "quantization_mode": selectedQuantizationMode.rawValue,
+        ]
+        switch selectedQuantizationMode {
+        case .ptq:
+            ext["source_artifact_kind"] = "base_model"
+        case .qat:
+            ext["source_artifact_kind"] = "merged_adapter"
+            ext["qat_fake_quant"] = "requested"
+            if let sourceArtifactPath = selectedQATSourceArtifactPath() {
+                ext["source_artifact_path"] = sourceArtifactPath
+            }
+        }
+        return ext
+    }
+
+    private func selectedQATSourceArtifactPath() -> String? {
+        if let job = selectedLoraTrainingJob {
+            let adapterPath = loraAdapterManifestPath(for: job).trimmingCharacters(in: .whitespacesAndNewlines)
+            if adapterPath.isEmpty == false {
+                return adapterPath
+            }
+        }
+        if let lastModelOperation {
+            let manifestPath = lastModelOperation.manifestPath.trimmingCharacters(in: .whitespacesAndNewlines)
+            if manifestPath.isEmpty == false {
+                return manifestPath
+            }
+            let outputPath = lastModelOperation.outputPath.trimmingCharacters(in: .whitespacesAndNewlines)
+            if outputPath.isEmpty == false {
+                return outputPath
+            }
+        }
+        return nil
     }
 
     public func downloadPrimaryModel() async {

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -5994,6 +5994,25 @@ struct Phase8WindowUIAcceptanceRunnerTests {
         #expect(config.timestamp.isEmpty == false)
     }
 
+    @Test("phase 8 window ui downloads surface exposes quantization modes")
+    @MainActor
+    func phase8WindowUIDownloadsSurfaceExposesQuantizationModes() async throws {
+        let viewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        await viewModel.start()
+        viewModel.selectSurface(.tools)
+        viewModel.selectToolSection(.downloads)
+        viewModel.selectedQuantizationMode = .qat
+
+        let view = hostView(DesktopDownloadsToolSectionView(viewModel: viewModel))
+
+        #expect(view.subviews.isEmpty == false)
+        #expect(RuntimeQuantizationMode.ptq.id == "ptq")
+        #expect(RuntimeQuantizationMode.ptq.title == "PTQ")
+        #expect(RuntimeQuantizationMode.qat.id == "qat")
+        #expect(RuntimeQuantizationMode.qat.title == "QAT")
+        #expect(viewModel.selectedQuantizationMode == .qat)
+    }
+
     @Test("phase 8 window ui acceptance runner writes a screenshot and evidence bundle")
     @MainActor
     func phase8WindowUIAcceptanceRunnerWritesEvidenceBundle() async throws {
@@ -6196,6 +6215,31 @@ struct Phase8WindowUIAcceptanceRunnerTests {
         )
         #expect(bundleJSON["cli_evidence_bundle_path"] as? String == cliBundlePath.path)
         #expect(bundleJSON["screenshot_path"] as? String == result.screenshotPath)
+        let businessLines = try #require(bundleJSON["business_lines"] as? [[String: Any]])
+        #expect(businessLines.count == 10)
+        let caseIDs = Set(businessLines.compactMap { $0["case_id"] as? String })
+        #expect(caseIDs == Set([
+            "base_lora_export_local_inference",
+            "base_qlora_export_local_inference",
+            "base_dora_export_local_inference",
+            "lora_dpo_export_local_inference",
+            "lora_orpo_export_local_inference",
+            "lora_cpo_export_local_inference",
+            "lora_grpo_export_local_inference",
+            "lora_rlhf_export_local_inference",
+            "lora_preference_ptq_local_inference",
+            "qat_quantized_local_inference",
+        ]))
+        #expect(businessLines.allSatisfy { $0["visible"] as? Bool == true })
+        #expect(businessLines.allSatisfy { $0["selectable"] as? Bool == true })
+        #expect(businessLines.allSatisfy { $0["runnable"] as? Bool == true })
+        #expect(businessLines.allSatisfy { $0["inspectable"] as? Bool == true })
+        #expect(businessLines.allSatisfy { $0["release_ready"] as? Bool == false })
+        let dpoLine = try #require(businessLines.first { $0["case_id"] as? String == "lora_dpo_export_local_inference" })
+        #expect(dpoLine["routed_command"] as? String == "alignment.train")
+        let qatLine = try #require(businessLines.first { $0["case_id"] as? String == "qat_quantized_local_inference" })
+        #expect(qatLine["selected_quantization_mode"] as? String == "qat")
+        #expect(qatLine["routed_command"] as? String == "model.quantize")
 
         let recordedCommands = await workflowRunner.snapshotRecordedCommands()
         #expect(recordedCommands.contains(where: {

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -8101,10 +8101,13 @@ struct RuntimeViewModelTests {
         #expect(viewModel.selectedLoraTrainingJobID == "saved-job")
         viewModel.selectQuantizationProfile("q6")
         viewModel.selectQuantizationProfile("q9")
+        viewModel.selectQuantizationMode(" QAT ")
+        viewModel.selectQuantizationMode("mystery")
         viewModel.selectLoraTrainingJob(id: " alternate-job ")
 
         #expect(viewModel.selectedQuantizationProfileID == "q6")
-        #expect(notifications.value == 2)
+        #expect(viewModel.selectedQuantizationMode == .qat)
+        #expect(notifications.value == 3)
         #expect(viewModel.selectedLoraTrainingJobID == "alternate-job")
 
         viewModel.loraRank = "99"
@@ -9395,6 +9398,153 @@ struct RuntimeViewModelTests {
         #expect(viewModel.lastModelOperation?.artifactBytes == 256)
         #expect(viewModel.lastModelOperation?.smokeTestPassed == true)
         #expect(viewModel.lastModelOperation?.calibrationSampleCount == 32)
+        let request = try #require(await client.recordedModelOperationRequests.last)
+        #expect(request.ext["quantization_mode"] == "ptq")
+        #expect(request.ext["source_artifact_kind"] == "base_model")
+    }
+
+    @Test("quantize action forwards QAT mode with selected adapter source artifact")
+    @MainActor
+    func quantizeActionForwardsQATModeWithSelectedAdapterSourceArtifact() async throws {
+        let client = FakeControlPlaneXPCClient()
+        await client.configureModelOperation(
+            makeNamedModelOperationResult(
+                operation: "quantize",
+                outputPath: "/tmp/melix-quantize/model-ops-qat/quantize.artifact",
+                manifestJSON: #"{"operation":"quantize","quantization_mode":"qat"}"#,
+                quantProfileID: "q4",
+                artifactKind: "quantized_model_bundle",
+                manifestPath: "/tmp/melix-quantize/model-ops-qat/quantize.artifact/manifest.json"
+            ),
+            forNamedOperation: "quantize"
+        )
+        var config = makeDesktopLoraTrainingConfig(adapterName: "qat-adapter")
+        config.derivedModelAlias = "melix-dev-text-qataware"
+        var job = makeDesktopLoraTrainingJobRecord(
+            id: "qat-job",
+            title: "QAT Adapter",
+            config: config,
+            status: .succeeded
+        )
+        job.manifestPath = "/tmp/melix-train/model-ops-qat/train_lora.adapter.json"
+        job.followUpArtifacts.adapterManifestPath = "/tmp/melix-train/model-ops-qat/train_lora.adapter.json"
+        let store = FakeLoraTrainingJobStore(jobs: [job])
+        let viewModel = RuntimeViewModel(client: client, loraTrainingJobStore: store)
+
+        await viewModel.start()
+        viewModel.prepareSelectedLoraTrainingJobFollowUp(.quantization)
+        viewModel.selectedQuantizationMode = .qat
+        await viewModel.quantizePrimaryModel()
+
+        let request = try #require(await client.recordedModelOperationRequests.last)
+        #expect(request.operation == "quantize")
+        #expect(request.modelID == "melix-dev-text-qataware")
+        #expect(request.ext["quantization_mode"] == "qat")
+        #expect(request.ext["source_artifact_kind"] == "merged_adapter")
+        #expect(request.ext["source_artifact_path"] == "/tmp/melix-train/model-ops-qat/train_lora.adapter.json")
+        #expect(request.ext["qat_fake_quant"] == "requested")
+    }
+
+    @Test("quantize action forwards QAT mode with latest operation manifest source artifact")
+    @MainActor
+    func quantizeActionForwardsQATModeWithLatestOperationManifestSourceArtifact() async throws {
+        let client = FakeControlPlaneXPCClient()
+        await client.configureModelOperation(
+            makeNamedModelOperationResult(
+                operation: "convert",
+                outputPath: "/tmp/melix-convert/qat-source/convert.artifact",
+                manifestJSON: #"{"operation":"convert"}"#,
+                artifactKind: "converted_model_bundle",
+                manifestPath: "/tmp/melix-convert/qat-source/convert.artifact/manifest.json"
+            ),
+            forNamedOperation: "convert"
+        )
+        await client.configureModelOperation(
+            makeNamedModelOperationResult(
+                operation: "quantize",
+                outputPath: "/tmp/melix-quantize/qat-from-manifest/quantize.artifact",
+                manifestJSON: #"{"operation":"quantize","quantization_mode":"qat"}"#,
+                artifactKind: "quantized_model_bundle",
+                manifestPath: "/tmp/melix-quantize/qat-from-manifest/quantize.artifact/manifest.json"
+            ),
+            forNamedOperation: "quantize"
+        )
+        let viewModel = RuntimeViewModel(client: client)
+
+        await viewModel.start()
+        await viewModel.convertPrimaryModel()
+        viewModel.selectedQuantizationMode = .qat
+        await viewModel.quantizePrimaryModel()
+
+        let request = try #require(await client.recordedModelOperationRequests.last)
+        #expect(request.operation == "quantize")
+        #expect(request.ext["quantization_mode"] == "qat")
+        #expect(request.ext["source_artifact_kind"] == "merged_adapter")
+        #expect(request.ext["source_artifact_path"] == "/tmp/melix-convert/qat-source/convert.artifact/manifest.json")
+    }
+
+    @Test("quantize action forwards QAT mode with latest operation output source artifact")
+    @MainActor
+    func quantizeActionForwardsQATModeWithLatestOperationOutputSourceArtifact() async throws {
+        let client = FakeControlPlaneXPCClient()
+        await client.configureModelOperation(
+            makeNamedModelOperationResult(
+                operation: "convert",
+                outputPath: "/tmp/melix-convert/qat-output-source/convert.artifact",
+                manifestJSON: #"{"operation":"convert"}"#,
+                artifactKind: "converted_model_bundle"
+            ),
+            forNamedOperation: "convert"
+        )
+        await client.configureModelOperation(
+            makeNamedModelOperationResult(
+                operation: "quantize",
+                outputPath: "/tmp/melix-quantize/qat-from-output/quantize.artifact",
+                manifestJSON: #"{"operation":"quantize","quantization_mode":"qat"}"#,
+                artifactKind: "quantized_model_bundle",
+                manifestPath: "/tmp/melix-quantize/qat-from-output/quantize.artifact/manifest.json"
+            ),
+            forNamedOperation: "quantize"
+        )
+        let viewModel = RuntimeViewModel(client: client)
+
+        await viewModel.start()
+        await viewModel.convertPrimaryModel()
+        viewModel.selectedQuantizationMode = .qat
+        await viewModel.quantizePrimaryModel()
+
+        let request = try #require(await client.recordedModelOperationRequests.last)
+        #expect(request.operation == "quantize")
+        #expect(request.ext["quantization_mode"] == "qat")
+        #expect(request.ext["source_artifact_kind"] == "merged_adapter")
+        #expect(request.ext["source_artifact_path"] == "/tmp/melix-convert/qat-output-source/convert.artifact")
+    }
+
+    @Test("quantize action omits QAT source artifact when no prior artifact exists")
+    @MainActor
+    func quantizeActionOmitsQATSourceArtifactWhenNoPriorArtifactExists() async throws {
+        let client = FakeControlPlaneXPCClient()
+        await client.configureModelOperation(
+            makeNamedModelOperationResult(
+                operation: "quantize",
+                outputPath: "/tmp/melix-quantize/qat-no-source/quantize.artifact",
+                manifestJSON: #"{"operation":"quantize","quantization_mode":"qat"}"#,
+                artifactKind: "quantized_model_bundle",
+                manifestPath: "/tmp/melix-quantize/qat-no-source/quantize.artifact/manifest.json"
+            ),
+            forNamedOperation: "quantize"
+        )
+        let viewModel = RuntimeViewModel(client: client)
+
+        await viewModel.start()
+        viewModel.selectedQuantizationMode = .qat
+        await viewModel.quantizePrimaryModel()
+
+        let request = try #require(await client.recordedModelOperationRequests.last)
+        #expect(request.operation == "quantize")
+        #expect(request.ext["quantization_mode"] == "qat")
+        #expect(request.ext["source_artifact_kind"] == "merged_adapter")
+        #expect(request.ext["source_artifact_path"] == nil)
     }
 
     @Test("convert action stores typed packaging summary")

--- a/docs/plans/2026-05-06-issue-365-window-acceptance-matrix.md
+++ b/docs/plans/2026-05-06-issue-365-window-acceptance-matrix.md
@@ -1,0 +1,95 @@
+# Issue 365 Window Acceptance Matrix Slice
+
+## Goal
+
+Continue https://github.com/Keith-CY/melix/issues/365 by making the native
+Window UI evidence bundle enumerate every required business line and by adding
+an explicit PTQ/QAT mode selector to the Window quantization surface.
+
+Issue 365 is still not complete after this slice. The evidence added here is
+Window UI routing and inspectability evidence. It does not claim final
+real-local-runtime release readiness for any business line.
+
+## Scope
+
+### Included
+
+- Add a Window quantization mode state for `ptq` and `qat`.
+- Show the mode selector beside the existing quantization profile selector.
+- Forward `quantization_mode` and `source_artifact_kind` through Window model
+  operations so PTQ/QAT requests are explicit.
+- Record adapter-derived source artifact hints for QAT when a saved LoRA job is
+  selected.
+- Extend the Phase 8 Window UI acceptance bundle with all 10 Issue 365 business
+  lines:
+  - LoRA, QLoRA, and DoRA supervised adapter workflows.
+  - DPO, ORPO, CPO, GRPO, and RLHF alignment workflows.
+  - PTQ quantized local inference workflow.
+  - QAT/QAT-aware quantized local inference workflow.
+- Mark the matrix evidence as non-release-ready until real local runtime runs
+  succeed for the same cases.
+
+### Excluded
+
+- Real GRPO/RLHF policy updates.
+- Reward-model training artifacts from issue 366.
+- MLX-native full-tensor QAT execution.
+- Full real-runtime CLI or Window acceptance execution for every business line.
+- Screenshot artifact preservation.
+- Closing issue 365.
+
+## Performance And Metrics
+
+This slice only adds UI state, model-operation request metadata, and JSON
+evidence construction during an explicit acceptance run. It does not add
+background polling or new model execution work.
+
+Success metrics:
+
+- Quantization command construction keeps the existing unit-test dispatch path.
+- The Window acceptance bundle contains exactly 10 business-line entries.
+- Each matrix entry records visible/selectable/runnable/inspectable routing
+  state and keeps `release_ready=false`.
+- Changed-scope tests remain green with at least 95 percent changed-line
+  coverage for the touched Swift scope.
+
+## Verification
+
+Targeted commands:
+
+```bash
+swift test --package-path apps/macos-menubar --filter 'Phase8WindowUIAcceptanceRunnerTests|RuntimeViewModelTests'
+git diff --check
+```
+
+Coverage and metrics:
+
+```bash
+swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'Phase8WindowUIAcceptanceRunnerTests|RuntimeViewModelTests'
+python3 scripts/swift_changed_line_coverage.py \
+  --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests \
+  --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata \
+  --diff-from origin/main \
+  apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift \
+  apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift \
+  apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift \
+  apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift \
+  apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+```
+
+Results on 2026-05-06:
+
+- `swift test --package-path apps/macos-menubar --filter 'Phase8WindowUIAcceptanceRunnerTests|RuntimeViewModelTests'`:
+  254 tests passed in 2 suites.
+- `swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'Phase8WindowUIAcceptanceRunnerTests|RuntimeViewModelTests'`:
+  254 tests passed in 2 suites and wrote Swift coverage data.
+- `python3 scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift docs/plans/2026-05-06-issue-365-window-acceptance-matrix.md`:
+  100.00 percent total changed-line coverage, 340/340 executable lines.
+- `git diff --check`: passed.
+
+## Remaining Issue 365 Gaps
+
+- Real local runtime evidence for every CLI and Window business line.
+- Final populated release evidence bundle.
+- GRPO/RLHF policy-update implementation and reward-model artifact integration.
+- MLX-native full QAT backend execution and release-gated evidence.


### PR DESCRIPTION
## Summary
- Add a Window UI PTQ/QAT quantization mode state and segmented selector beside the existing quantization profile selector.
- Forward explicit `quantization_mode`, `source_artifact_kind`, and QAT source artifact hints through Window model-operation requests.
- Extend the Phase 8 Window UI acceptance bundle with all 10 Issue 365 business lines and mark each route as visible, selectable, runnable, inspectable, and not release-ready.
- Add focused Window/UI tests for the business-line matrix, quantization selector body, and QAT source-artifact fallback behavior.
- Stabilize two MLX-backed text-worker tests so CI skips cleanly when the default `mlx.metallib` is unavailable.

## Plan or Spec
- `docs/plans/2026-05-06-issue-365-window-acceptance-matrix.md`
- Refs #365. This is a Window UI routing/evidence slice; it does not complete the full roadmap.

## Commands Run
```text
swift test --package-path apps/macos-menubar --filter 'Phase8WindowUIAcceptanceRunnerTests|RuntimeViewModelTests'
Result: Passed, 254 tests in 2 suites.

swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'Phase8WindowUIAcceptanceRunnerTests|RuntimeViewModelTests'
Result: Passed, 254 tests in 2 suites and wrote Swift coverage data.

python3 scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift docs/plans/2026-05-06-issue-365-window-acceptance-matrix.md
Result: Passed, TOTAL 100.00% (340/340 changed executable lines).

xcrun swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter "WorkerScaffoldTests/testFusedDecodeQuantizerRejectsUnsupportedInputs|WorkerScaffoldTests/testVendoredChatSessionClearUsesAsyncSerialAccess"
Result: Passed, 2 tests in WorkerScaffoldTests.

python3 scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from HEAD services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
Result: Passed, TOTAL 100.00% (28/28 changed executable lines).

git diff --check
Result: Passed.

git rebase origin/main
Result: Passed; duplicate CI hotfix commits from #394 were dropped because the patch contents were already upstream.

git diff --check
Result: Passed.

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr/issue365-window-acceptance-matrix.md
Result: Passed.
```

## Coverage and Metrics
- Changed-line Swift coverage: 100.00% total, 340/340 changed executable lines.
- Text-worker hotfix changed-line Swift coverage: 100.00% total, 28/28 changed executable lines.
- Window acceptance metrics: the bundle now records exactly 10 Issue 365 business-line entries with visible/selectable/runnable/inspectable route state and `release_ready=false`.
- QAT routing metrics: Window quantization requests now distinguish PTQ (`source_artifact_kind=base_model`) from QAT (`source_artifact_kind=merged_adapter`) and forward selected adapter, previous manifest, or previous output source paths when available.
- Performance metrics: N/A for runtime throughput; this slice only adds explicit UI state, request metadata, and JSON evidence construction during an acceptance run.

## Known Gaps
- This PR does not complete issue #365.
- The Window matrix is route/inspectability evidence, not final real-local-runtime Window acceptance for every business line.
- Real local runtime evidence for the remaining CLI/Window chains, reward-model-backed RLHF from #366, release-ready GRPO policy updates, MLX-native full-tensor QAT, and the final populated release bundle remain deferred.
- Screenshot artifacts are not required for this PR body; no generated screenshots are committed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
