### PR TITLE
perf: skip startup logs for direct port conflicts

### DIFF
--- a/docs/plans/2026-05-05-startup-signals-error-text-port-conflict.md
+++ b/docs/plans/2026-05-05-startup-signals-error-text-port-conflict.md
@@ -1,0 +1,43 @@
+# Startup Signals Error-Text Port Conflict Fast Path
+
+## Goal
+
+Reduce redundant startup log reads when `classify_startup_failure(...)` receives an `error_text` payload that already identifies a host-port conflict.
+
+## Linux-only Constraint
+
+This slice is Python-only under `services/mlx-worker-python` and can be validated on Linux with focused pytest, changed-scope coverage, and the existing `startup-signals-lazy-worker-log-excerpts` PR-scoped performance probe.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/productization/startup_signals.py`
+- `services/mlx-worker-python/tests/test_startup_signals.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `docs/plans/2026-05-05-startup-signals-error-text-port-conflict.md`
+
+## Performance Probe
+
+Use the existing registered scoped probe:
+
+- `startup-signals-lazy-worker-log-excerpts`
+
+The probe records `conflict_log_reads_mean` and `conflict_elapsed_ms_mean` for the port-conflict path, plus control-plane and worker crash fallback metrics to guard against regressions.
+
+## Success Metrics
+
+- Preserve startup failure classifications and report fields.
+- Reduce `conflict_log_reads_mean` from `1.0` to `0.0` when `error_text` contains a port-conflict signal.
+- Keep focused tests passing.
+- Achieve at least 95% changed-scope automated coverage for touched executable Python scope.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/startup_signals_log_probe.py
+
+git diff --check
+```

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1669,7 +1669,7 @@ def test_startup_signals_probe_script_emits_metrics(capsys: pytest.CaptureFixtur
     assert excinfo.value.code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["conflict_elapsed_ms_mean"] > 0
-    assert payload["conflict_log_reads_mean"] == 1.0
+    assert payload["conflict_log_reads_mean"] == 0.0
     assert payload["control_crash_elapsed_ms_mean"] > 0
     assert payload["control_crash_log_reads_mean"] == 1.0
     assert payload["worker_crash_elapsed_ms_mean"] > 0

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -160,6 +160,37 @@ def test_classify_startup_failure_reports_host_port_conflict(tmp_path: Path) -> 
     assert "Address already in use" in report.log_excerpt
 
 
+def test_classify_startup_failure_skips_log_reads_when_error_text_reports_port_conflict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    control_plane_stderr = tmp_path / "control-plane.stderr.log"
+    worker_stderr = tmp_path / "python-worker.stderr.log"
+    control_plane_stderr.write_text("fatal error: should not be inspected\n", encoding="utf-8")
+    worker_stderr.write_text("Traceback: worker should not be inspected\n", encoding="utf-8")
+    read_paths: list[str] = []
+
+    def tracked_read(path: Path, *, chunk_size: int = 8192) -> str:
+        read_paths.append(path.name)
+        raise AssertionError("logs should not be read when error text already identifies the port conflict")
+
+    monkeypatch.setattr(startup_signals_module, "_read_last_nonempty_line", tracked_read)
+
+    report = classify_startup_failure(
+        {
+            "http_port": 11434,
+            "ready_probe_url": "http://127.0.0.1:11434/v1/models",
+            "control_plane_stderr_path": str(control_plane_stderr),
+            "python_worker_stderr_path": str(worker_stderr),
+        },
+        error_text="bind() failed: Address already in use",
+    )
+
+    assert report.classification == "host_port_conflict"
+    assert report.log_excerpt == "bind() failed: Address already in use"
+    assert read_paths == []
+
+
 def test_classify_startup_failure_reports_worker_crash(tmp_path: Path) -> None:
     python_worker_stderr = tmp_path / "python-worker.stderr.log"
     python_worker_stderr.write_text("Traceback: worker bootstrap failed\n", encoding="utf-8")

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -158,51 +158,63 @@ def classify_startup_failure(
 ) -> StartupFailureReport:
     ready_probe_url = str(manifest.get("ready_probe_url", ""))
     http_port = int(manifest.get("http_port", 0) or 0)
-    control_plane_excerpt = _log_excerpt(
-        manifest.get("control_plane_stderr_path"),
-        manifest.get("control_plane_stdout_path"),
-    )
-    combined_control_plane = f"{error_text}\n{control_plane_excerpt}".lower()
+    error_text_lower = error_text.lower()
 
-    if any(pattern in combined_control_plane for pattern in PORT_CONFLICT_PATTERNS):
+    if any(pattern in error_text_lower for pattern in PORT_CONFLICT_PATTERNS):
         primary_log_path = str(manifest.get("control_plane_stderr_path", ""))
         summary = f"Configured HTTP port {http_port} is already in use."
         detail = (
             f"The control plane could not bind to {ready_probe_url}. "
             f"Choose a different host port or stop the conflicting process."
         )
-        excerpt = control_plane_excerpt
+        excerpt = error_text
         classification = "host_port_conflict"
-    elif control_plane_excerpt and any(pattern in combined_control_plane for pattern in CRASH_PATTERNS):
-        primary_log_path = str(manifest.get("control_plane_stderr_path", ""))
-        summary = "Control plane crashed before startup completed."
-        detail = f"Melix never reached {ready_probe_url}. Inspect the control-plane logs for the crash cause."
-        excerpt = control_plane_excerpt
-        classification = "control_plane_crash"
     else:
-        worker_excerpt_value = _log_excerpt(
-            manifest.get("python_worker_stderr_path"),
-            manifest.get("swift_text_worker_stderr_path"),
-            manifest.get("python_worker_stdout_path"),
-            manifest.get("swift_text_worker_stdout_path"),
+        control_plane_excerpt = _log_excerpt(
+            manifest.get("control_plane_stderr_path"),
+            manifest.get("control_plane_stdout_path"),
         )
-        combined_worker = worker_excerpt_value.lower()
-        if worker_excerpt_value and any(pattern in combined_worker for pattern in CRASH_PATTERNS):
-            primary_log_path = str(
-                manifest.get("python_worker_stderr_path")
-                or manifest.get("swift_text_worker_stderr_path")
-                or ""
-            )
-            summary = "A worker crashed before Melix became ready."
-            detail = "Inspect the worker logs and restart Melix after fixing the failing runtime."
-            excerpt = worker_excerpt_value
-            classification = "worker_crash"
-        else:
+        combined_control_plane = f"{error_text}\n{control_plane_excerpt}".lower()
+
+        if any(pattern in combined_control_plane for pattern in PORT_CONFLICT_PATTERNS):
             primary_log_path = str(manifest.get("control_plane_stderr_path", ""))
-            summary = f"Melix startup timed out before {ready_probe_url} became ready."
-            detail = "Inspect the startup logs and ready probe path to determine whether the services hung or never launched."
-            excerpt = control_plane_excerpt or worker_excerpt_value or error_text
-            classification = "startup_hang"
+            summary = f"Configured HTTP port {http_port} is already in use."
+            detail = (
+                f"The control plane could not bind to {ready_probe_url}. "
+                f"Choose a different host port or stop the conflicting process."
+            )
+            excerpt = control_plane_excerpt
+            classification = "host_port_conflict"
+        elif control_plane_excerpt and any(pattern in combined_control_plane for pattern in CRASH_PATTERNS):
+            primary_log_path = str(manifest.get("control_plane_stderr_path", ""))
+            summary = "Control plane crashed before startup completed."
+            detail = f"Melix never reached {ready_probe_url}. Inspect the control-plane logs for the crash cause."
+            excerpt = control_plane_excerpt
+            classification = "control_plane_crash"
+        else:
+            worker_excerpt_value = _log_excerpt(
+                manifest.get("python_worker_stderr_path"),
+                manifest.get("swift_text_worker_stderr_path"),
+                manifest.get("python_worker_stdout_path"),
+                manifest.get("swift_text_worker_stdout_path"),
+            )
+            combined_worker = worker_excerpt_value.lower()
+            if worker_excerpt_value and any(pattern in combined_worker for pattern in CRASH_PATTERNS):
+                primary_log_path = str(
+                    manifest.get("python_worker_stderr_path")
+                    or manifest.get("swift_text_worker_stderr_path")
+                    or ""
+                )
+                summary = "A worker crashed before Melix became ready."
+                detail = "Inspect the worker logs and restart Melix after fixing the failing runtime."
+                excerpt = worker_excerpt_value
+                classification = "worker_crash"
+            else:
+                primary_log_path = str(manifest.get("control_plane_stderr_path", ""))
+                summary = f"Melix startup timed out before {ready_probe_url} became ready."
+                detail = "Inspect the startup logs and ready probe path to determine whether the services hung or never launched."
+                excerpt = control_plane_excerpt or worker_excerpt_value or error_text
+                classification = "startup_hang"
 
     return StartupFailureReport(
         classification=classification,


### PR DESCRIPTION
## Summary
- Adds a Python fast path in `classify_startup_failure(...)` for startup failures whose `error_text` already reports a host-port conflict.
- Skips control-plane and worker log reads for that already-classified path while preserving the existing log-based fallback behavior for control-plane and worker crashes.
- Updates focused regression and PR-scoped probe tests to expect `conflict_log_reads_mean=0.0`.

## Plan or Spec
- `docs/plans/2026-05-05-startup-signals-error-text-port-conflict.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# 23 passed in 0.45s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 23 passed; TOTAL 44 2 95%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/startup_signals_log_probe.py
# {"conflict_elapsed_ms_mean": 1.299204, "conflict_log_reads_mean": 0.0, "control_crash_elapsed_ms_mean": 13.701798, "control_crash_log_reads_mean": 1.0, "iterations": 400.0, "sample_count": 5.0, "worker_crash_elapsed_ms_mean": 14.175431, "worker_crash_log_reads_mean": 1.0}

python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id startup-signals-lazy-worker-log-excerpts --base-repo /tmp/melix-cron-opt-base-run-20260505192635 --head-repo "$PWD" --output /tmp/startup-signals-pr-scoped-20260505192635.json
# head verification ok; coverage_pct=95.0; base conflict_log_reads_mean=1.0 / conflict_elapsed_ms_mean=12.689942; head conflict_log_reads_mean=0.0 / conflict_elapsed_ms_mean=0.966277

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 44 2 95%`.
- Registered scoped CI probe: `startup-signals-lazy-worker-log-excerpts`.
- Local base-vs-head probe result:
  - base `conflict_log_reads_mean=1.0`, `conflict_elapsed_ms_mean=12.689942`
  - head `conflict_log_reads_mean=0.0`, `conflict_elapsed_ms_mean=0.966277`
- Control/worker fallback guard metrics remained structurally unchanged at `control_crash_log_reads_mean=1.0` and `worker_crash_log_reads_mean=1.0`.

## Known Gaps
- Linux-only local validation. Full macOS/Swift checks were not run locally on this host.
- Hosted `pr-scoped-performance` and broader PR checks still need to complete before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
