### PR TITLE
perf: stream mlx audio wav pcm writes

### DIFF
--- a/docs/plans/2026-05-05-mlx-audio-wav-streaming-pcm.md
+++ b/docs/plans/2026-05-05-mlx-audio-wav-streaming-pcm.md
@@ -1,0 +1,34 @@
+# MLX Audio WAV PCM Streaming Plan
+
+## Goal
+
+Reduce transient memory pressure in MLX audio text-to-speech WAV serialization by avoiding a fully materialized flat sample list and whole PCM byte buffer before writing WAV frames.
+
+## Linux-only constraint
+
+This is a Python-only worker-runtime slice. It can be validated on Linux with focused pytest, changed-scope coverage, and a synthetic WAV conversion performance probe. It does not require macOS or Swift execution.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py`
+- `services/mlx-worker-python/tests/test_mlx_audio_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/mlx_audio_wav_streaming_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Performance probe
+
+Register `mlx-audio-wav-streaming-pcm` in the PR-scoped performance registry. The probe converts a nested synthetic 240,000-sample mono audio payload to WAV bytes and reports:
+
+- `elapsed_ms_mean`
+- `elapsed_ms_min`
+- `peak_bytes_mean`
+- `sample_count`
+- `wav_bytes`
+
+## Success metrics
+
+- Preserve WAV sample rate, mono channel count, 16-bit sample width, frame count, clamping, and returned bytes.
+- Focused tests pass.
+- Changed-scope automated coverage is at least 95%.
+- Local probe reports the same `wav_bytes` and `sample_count` with lower peak memory than `origin/main`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1778,5 +1778,35 @@
         "direction": "informational"
       }
     ]
+  },
+  {
+    "id": "mlx-audio-wav-streaming-pcm",
+    "name": "MLX audio WAV PCM streaming",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py",
+      "services/mlx-worker-python/tests/test_mlx_audio_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/mlx_audio_wav_streaming_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_wav_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_wav_streaming_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_wav_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_wav_streaming_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_audio_wav_streaming_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/mlx_audio_wav_streaming_probe.py ]; then python scripts/mlx_audio_wav_streaming_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"aW1wb3J0IGpzb24sIHN0YXRpc3RpY3MsIHN5cywgdGltZSwgdHJhY2VtYWxsb2MKZnJvbSBwYXRobGliIGltcG9ydCBQYXRoCnJlcG9fcm9vdCA9IFBhdGguY3dkKCkKc3lzLnBhdGguaW5zZXJ0KDAsIHN0cihyZXBvX3Jvb3QpKQpzeXMucGF0aC5pbnNlcnQoMCwgc3RyKHJlcG9fcm9vdCAvICdzZXJ2aWNlcy9tbHgtd29ya2VyLXB5dGhvbicpKQpmcm9tIHdvcmtlci5ydW50aW1lLm1seF9hdWRpb19ydW50aW1lIGltcG9ydCBfYXVkaW9fdG9fd2F2X2J5dGVzCmNsYXNzIEFycmF5TGlrZVNlZ21lbnQ6CiAgICBkZWYgX19pbml0X18oc2VsZiwgdmFsdWVzKTogc2VsZi5fdmFsdWVzID0gdmFsdWVzCiAgICBkZWYgdG9saXN0KHNlbGYpOiByZXR1cm4gc2VsZi5fdmFsdWVzCmRlZiBidWlsZF9hdWRpbyhzYW1wbGVfY291bnQpOgogICAgc2VnbWVudHM9W107IGN5Y2xlPSgtMC43NSwtMC4yNSwwLjAsMC4yNSwwLjc1KQogICAgZm9yIG9mZnNldCBpbiByYW5nZSgwLCBzYW1wbGVfY291bnQsIDUxMik6CiAgICAgICAgY2h1bms9W2N5Y2xlWyhvZmZzZXQraSklbGVuKGN5Y2xlKV0gZm9yIGkgaW4gcmFuZ2UobWluKDUxMiwgc2FtcGxlX2NvdW50LW9mZnNldCkpXQogICAgICAgIGlmIChvZmZzZXQvLzUxMiklMiA9PSAwOiBzZWdtZW50cy5hcHBlbmQoY2h1bmspCiAgICAgICAgZWxzZToKICAgICAgICAgICAgbWlkcG9pbnQ9bGVuKGNodW5rKS8vMjsgc2VnbWVudHMuYXBwZW5kKEFycmF5TGlrZVNlZ21lbnQoKGNodW5rWzptaWRwb2ludF0sIHR1cGxlKGNodW5rW21pZHBvaW50Ol0pKSkpCiAgICByZXR1cm4gc2VnbWVudHMKc2FtcGxlX2NvdW50PTI0MDAwMDsgc2FtcGxlX3JhdGU9MjQwMDA7IGF1ZGlvPWJ1aWxkX2F1ZGlvKHNhbXBsZV9jb3VudCkKZWxhcHNlZD1bXTsgcGVha3M9W107IHNpemVzPVtdCmZvciBfIGluIHJhbmdlKDUpOgogICAgdHJhY2VtYWxsb2Muc3RhcnQoKTsgc3RhcnRlZD10aW1lLnBlcmZfY291bnRlcigpOyB3YXZfYnl0ZXM9X2F1ZGlvX3RvX3dhdl9ieXRlcyhhdWRpbywgc2FtcGxlX3JhdGU9c2FtcGxlX3JhdGUpOyBlbGFwc2VkLmFwcGVuZCgodGltZS5wZXJmX2NvdW50ZXIoKS1zdGFydGVkKSoxMDAwLjApOyBfLCBwZWFrPXRyYWNlbWFsbG9jLmdldF90cmFjZWRfbWVtb3J5KCk7IHRyYWNlbWFsbG9jLnN0b3AoKTsgcGVha3MuYXBwZW5kKGZsb2F0KHBlYWspKTsgc2l6ZXMuYXBwZW5kKGxlbih3YXZfYnl0ZXMpKQpleHBlY3RlZD00NCtzYW1wbGVfY291bnQqMgppZiBzZXQoc2l6ZXMpICE9IHtleHBlY3RlZH06IHJhaXNlIFN5c3RlbUV4aXQoZid1bmV4cGVjdGVkIHdhdiBzaXplczoge3NpemVzIXJ9ICE9IHtleHBlY3RlZH0nKQpwcmludChqc29uLmR1bXBzKHsnZWxhcHNlZF9tc19tZWFuJzogcm91bmQoc3RhdGlzdGljcy5mbWVhbihlbGFwc2VkKSwgNiksICdlbGFwc2VkX21zX21pbic6IHJvdW5kKG1pbihlbGFwc2VkKSwgNiksICdwZWFrX2J5dGVzX21lYW4nOiByb3VuZChzdGF0aXN0aWNzLmZtZWFuKHBlYWtzKSwgMyksICdzYW1wbGVfY291bnQnOiBmbG9hdChzYW1wbGVfY291bnQpLCAnd2F2X2J5dGVzJzogZmxvYXQoZXhwZWN0ZWQpfSwgc29ydF9rZXlzPVRydWUpKQo=\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
   }
 ]

--- a/scripts/mlx_audio_wav_streaming_probe.py
+++ b/scripts/mlx_audio_wav_streaming_probe.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime.mlx_audio_runtime import _audio_to_wav_bytes  # noqa: E402
+
+
+class ArrayLikeSegment:
+    def __init__(self, values):
+        self._values = values
+
+    def tolist(self):
+        return self._values
+
+
+def _build_audio(sample_count: int):
+    segments = []
+    value_cycle = (-0.75, -0.25, 0.0, 0.25, 0.75)
+    for offset in range(0, sample_count, 512):
+        chunk = [value_cycle[(offset + index) % len(value_cycle)] for index in range(min(512, sample_count - offset))]
+        if (offset // 512) % 2 == 0:
+            segments.append(chunk)
+        else:
+            midpoint = len(chunk) // 2
+            segments.append(ArrayLikeSegment((chunk[:midpoint], tuple(chunk[midpoint:]))))
+    return segments
+
+
+def main() -> int:
+    sample_count = 240_000
+    sample_rate = 24_000
+    audio = _build_audio(sample_count)
+    elapsed_samples = []
+    peak_samples = []
+    wav_sizes = []
+    for _ in range(5):
+        tracemalloc.start()
+        started = time.perf_counter()
+        wav_bytes = _audio_to_wav_bytes(audio, sample_rate=sample_rate)
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_samples.append(float(peak))
+        wav_sizes.append(len(wav_bytes))
+    expected_wav_size = 44 + sample_count * 2
+    if set(wav_sizes) != {expected_wav_size}:
+        raise RuntimeError(f"unexpected wav sizes: {wav_sizes!r} != {expected_wav_size}")
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+                "elapsed_ms_min": round(min(elapsed_samples), 6),
+                "peak_bytes_mean": round(statistics.fmean(peak_samples), 3),
+                "sample_count": float(sample_count),
+                "wav_bytes": float(expected_wav_size),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from io import BytesIO
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+import wave
 
 import pytest
 
@@ -268,6 +270,69 @@ def test_mlx_audio_processor_validation_accepts_local_processor_config(
 
     assert loaded.backend_id == "mlx_audio.stt"
     assert captured_paths == [str(model_dir)]
+
+
+def test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values() -> None:
+    from worker.runtime.mlx_audio_runtime import _audio_to_wav_bytes
+
+    class ArrayLike:
+        def tolist(self):
+            return [0.5, (2.0, -2.0)]
+
+    wav_bytes = _audio_to_wav_bytes([[0.0, ArrayLike()], (-0.5,)], sample_rate=16_000)
+
+    with wave.open(BytesIO(wav_bytes), "rb") as handle:
+        assert handle.getnchannels() == 1
+        assert handle.getsampwidth() == 2
+        assert handle.getframerate() == 16_000
+        assert handle.getnframes() == 5
+        frames = handle.readframes(5)
+
+    decoded = [
+        int.from_bytes(frames[index : index + 2], byteorder="little", signed=True)
+        for index in range(0, len(frames), 2)
+    ]
+    assert decoded == [0, 16383, 32767, -32767, -16383]
+
+    scalar_wav_bytes = _audio_to_wav_bytes(0.25, sample_rate=8_000)
+    with wave.open(BytesIO(scalar_wav_bytes), "rb") as handle:
+        assert handle.getframerate() == 8_000
+        assert handle.getnframes() == 1
+        assert int.from_bytes(handle.readframes(1), byteorder="little", signed=True) == 8191
+
+
+def test_audio_to_wav_bytes_does_not_materialize_flat_sample_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    import worker.runtime.mlx_audio_runtime as mlx_audio_runtime
+
+    calls: list[int] = []
+    original_writeframesraw = wave.Wave_write.writeframesraw
+
+    def tracked_writeframesraw(self, data):
+        calls.append(len(data))
+        return original_writeframesraw(self, data)
+
+    monkeypatch.setattr(wave.Wave_write, "writeframesraw", tracked_writeframesraw)
+
+    wav_bytes = mlx_audio_runtime._audio_to_wav_bytes((0.1 for _ in range(9000)), sample_rate=24_000)
+
+    assert calls == [18000]
+    with wave.open(BytesIO(wav_bytes), "rb") as handle:
+        assert handle.getnframes() == 9000
+        assert handle.getframerate() == 24_000
+
+
+def test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import worker.runtime.mlx_audio_runtime as mlx_audio_runtime
+
+    monkeypatch.setattr(mlx_audio_runtime.sys, "byteorder", "big")
+
+    wav_bytes = mlx_audio_runtime._audio_to_wav_bytes((0.1 for _ in range(66000)), sample_rate=24_000)
+
+    assert wav_bytes.startswith(b"RIFF")
+    with wave.open(BytesIO(wav_bytes), "rb") as handle:
+        assert handle.getnframes() == 66000
 
 
 def test_worker_load_model_returns_actionable_audio_processor_validation_error(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -133,6 +133,16 @@ def test_scope_report_selects_dataset_registry_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "dataset-registry-limited-read-streaming"
 
 
+def test_scope_report_selects_mlx_audio_wav_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "mlx-audio-wav-streaming-pcm"
+
+
 def test_scope_report_selects_only_matching_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -914,6 +924,23 @@ def test_dataset_registry_limit_probe_script_emits_metrics(
     assert metrics["peak_bytes_mean"] > 0
 
 
+def test_mlx_audio_wav_streaming_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/mlx_audio_wav_streaming_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 240000.0
+    assert metrics["wav_bytes"] == 480044.0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["elapsed_ms_mean"] >= 0
+
+
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
         "dataset-registry-limited-read-streaming",
@@ -935,6 +962,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "deterministic-rerank-query-context-reuse",
         "rerank-core-top-k-heap-selection",
         "runtime-utils-kwarg-signature-cache",
+        "mlx-audio-wav-streaming-pcm",
         "dev-up-mlx-metal-dist-info-scandir",
         "evaluation-job-id-high-water-mark",
         "evaluation-dialogue-diagnostics-top-k",

--- a/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from threading import Lock
 from time import perf_counter
+import array
+import sys
 import wave
 
 from worker.runtime.audio_preprocessing import prepare_audio_input
@@ -35,36 +37,40 @@ def _normalize_language(value) -> str:
     return "" if normalized.lower() == "none" else normalized
 
 
-def _flatten_samples(value) -> list[float]:
+def _iter_samples(value):
     if hasattr(value, "tolist"):
         value = value.tolist()
     if isinstance(value, (float, int)):
-        return [float(value)]
-    flattened: list[float] = []
+        yield float(value)
+        return
     for item in value:
-        if isinstance(item, (list, tuple)):
-            flattened.extend(_flatten_samples(item))
-        elif hasattr(item, "tolist"):
-            flattened.extend(_flatten_samples(item.tolist()))
+        if isinstance(item, (list, tuple)) or hasattr(item, "tolist"):
+            yield from _iter_samples(item)
         else:
-            flattened.append(float(item))
-    return flattened
+            yield float(item)
 
 
 def _audio_to_wav_bytes(audio, sample_rate: int) -> bytes:
-    samples = _flatten_samples(audio)
-    pcm = bytearray()
-    for sample in samples:
-        clamped = max(-1.0, min(1.0, float(sample)))
-        scaled = int(clamped * 32767.0)
-        pcm.extend(int(scaled).to_bytes(2, byteorder="little", signed=True))
+    chunk = array.array("h")
+    chunk_sample_limit = 65536
 
     with BytesIO() as buffer:
         with wave.open(buffer, "wb") as handle:
             handle.setnchannels(1)
             handle.setsampwidth(2)
             handle.setframerate(int(sample_rate))
-            handle.writeframes(bytes(pcm))
+            for sample in _iter_samples(audio):
+                clamped = max(-1.0, min(1.0, float(sample)))
+                chunk.append(int(clamped * 32767.0))
+                if len(chunk) >= chunk_sample_limit:
+                    if sys.byteorder != "little":
+                        chunk.byteswap()
+                    handle.writeframesraw(chunk.tobytes())
+                    chunk = array.array("h")
+            if chunk:
+                if sys.byteorder != "little":
+                    chunk.byteswap()
+                handle.writeframesraw(chunk.tobytes())
         return buffer.getvalue()
 
 


### PR DESCRIPTION
## Summary
- Streams MLX audio TTS PCM frames into the WAV writer in bounded chunks instead of materializing a flat sample list and full PCM bytearray first.
- Adds focused WAV serialization regression tests for nested samples, scalar samples, chunked writes, clamping, and big-endian byte-swap behavior.
- Registers the `mlx-audio-wav-streaming-pcm` PR-scoped performance probe.

## Plan or Spec
- `docs/plans/2026-05-05-mlx-audio-wav-streaming-pcm.md`

## Commands Run
```text
# Focused test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values \
  services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list \
  services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_wav_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_wav_streaming_probe_script_emits_metrics
# Result: 6 passed in 13.80s (same command under coverage)

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <focused nodes above>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py \
  services/mlx-worker-python/tests/test_mlx_audio_runtime.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/mlx_audio_wav_streaming_probe.py
# Result: TOTAL 76 0 100%

# Explicit local base-vs-head probe
# Base (detached origin/main d04a057): python /tmp/melix_probe_fallback.py
# Head: PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/mlx_audio_wav_streaming_probe.py

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.validated.json
# Result: valid JSON

git diff --check
# Result: passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 76 0 100%`.
- Registered scoped CI probe: `mlx-audio-wav-streaming-pcm`.
- Local probe workload: nested 240,000-sample mono audio payload converted to WAV.
- Base (`origin/main` d04a057): `elapsed_ms_mean=659.079775`, `peak_bytes_mean=3576508.6`, `wav_bytes=480044.0`.
- Head (`0ead0b3`): `elapsed_ms_mean=756.678457`, `peak_bytes_mean=659622.0`, `wav_bytes=480044.0`.
- Interpretation: peak traced allocation dropped by ~81.55% (~2.92 MB less) while preserving WAV byte size and sample count. Elapsed time is intentionally informational for this memory-pressure slice and showed a local ~14.81% regression.

## Known Gaps
- Linux-only local verification; macOS/Swift checks were not run locally.
- The local probe optimizes memory pressure first. Hosted `pr-scoped-performance` should be treated as the final CI gate for this registered probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
