### PR TITLE
perf: streamline multimodal fast-path signatures

### DIFF
--- a/docs/plans/2026-05-05-multimodal-fast-path-signature-metadata-order.md
+++ b/docs/plans/2026-05-05-multimodal-fast-path-signature-metadata-order.md
@@ -1,0 +1,31 @@
+# Multimodal Fast-Path Signature Metadata Ordering Optimization
+
+## Goal
+
+Reduce redundant work in `fast_path_probe_signature(...)` by avoiding iteration and sorting of arbitrary nested metadata dictionaries when the signature only accepts a fixed small metadata-key set.
+
+## Linux-only constraint
+
+This slice is Python-only under `services/mlx-worker-python` and can be verified on Linux with focused pytest, changed-scope coverage, and the existing PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py`
+- `services/mlx-worker-python/tests/test_multimodal_fast_paths.py`
+- `docs/plans/2026-05-05-multimodal-fast-path-signature-metadata-order.md`
+
+## Performance probe
+
+Use the existing registered PR-scoped probe:
+
+- Probe ID: `multimodal-fast-path-signature-top-level-key-cache`
+- Script: `scripts/multimodal_fast_path_signature_probe.py`
+- Primary metric: `elapsed_ms_mean` lower is better
+- Secondary metric: `peak_bytes_mean` informational
+
+## Success metrics
+
+- Preserve exact signature tuple output and nested metadata precedence.
+- Focused pytest passes for multimodal fast-path signature behavior and scoped-probe registry tests.
+- Changed-scope coverage is at least 95% for touched executable Python scope.
+- Local probe shows lower `elapsed_ms_mean` versus an `origin/main` worktree on the same workload.

--- a/services/mlx-worker-python/tests/test_multimodal_fast_paths.py
+++ b/services/mlx-worker-python/tests/test_multimodal_fast_paths.py
@@ -451,3 +451,37 @@ def test_fast_path_probe_signature_reuses_pre_sorted_top_level_keys() -> None:
         "(('model_id', 'melix-dev-vlm'), ('quant_profile_id', 'q8'), "
         "('revision', 'main'), ('tokenizer_hash', 'tok'))"
     )
+
+
+def test_fast_path_probe_signature_probes_fixed_metadata_keys_without_scanning_nested_items() -> None:
+    class FixedKeyMetadata(dict):
+        def items(self):  # type: ignore[override]
+            raise AssertionError("signature should not scan arbitrary nested metadata items")
+
+    loaded_model = _loaded_model(top_level_family_id="stale-family")
+    loaded_model["metadata"] = FixedKeyMetadata(
+        {"unrelated." + str(index): "ignored" for index in range(1000)}
+    )
+    loaded_model["metadata"].update(  # type: ignore[union-attr]
+        {
+            "vision_family_id": "gemma4-v1",
+            "vision_prompt_profile_id": "gemma4-chatml-v1",
+            "melix.vlm.execution_mode": "multimodal",
+            "vision_tokenization_mode": "interleaved",
+            "vision_max_images_per_prompt": 8,
+            "melix.multimodal_adapter_hash": "adapter-a",
+        }
+    )
+
+    signature = fast_path_probe_signature(loaded_model, _request([_image(b"image")]))
+    try:
+        loaded_model["metadata"].items()  # type: ignore[union-attr]
+    except AssertionError as exc:
+        assert "should not scan" in str(exc)
+    else:  # pragma: no cover - defensive guard for the test helper itself.
+        raise AssertionError("test metadata helper did not guard items() scans")
+
+    assert "stale-family" not in signature[2]
+    assert "gemma4-v1" in signature[2]
+    assert "unrelated." not in signature[2]
+    assert "('vision_max_images_per_prompt', '8')" in signature[2]

--- a/services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py
+++ b/services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py
@@ -34,6 +34,7 @@ _FAST_PATH_SIGNATURE_METADATA_KEYS = frozenset(
         "multimodal_adapter_hash",
     }
 )
+_FAST_PATH_SIGNATURE_METADATA_KEYS_SORTED = tuple(sorted(_FAST_PATH_SIGNATURE_METADATA_KEYS))
 _FAST_PATH_SIGNATURE_TOP_LEVEL_KEYS = ("model_id", "revision", "tokenizer_hash", "quant_profile_id")
 _FAST_PATH_SIGNATURE_TOP_LEVEL_KEYS_SORTED = tuple(sorted(_FAST_PATH_SIGNATURE_TOP_LEVEL_KEYS))
 
@@ -265,23 +266,26 @@ def fast_path_probe_signature(
     loaded_model: Any,
     prepared_request: PreparedVisionRequest,
 ) -> tuple[str, ...]:
-    metadata: dict[str, str] = {}
+    metadata_items: tuple[tuple[str, str], ...] = ()
     if isinstance(loaded_model, dict):
-        for key in _FAST_PATH_SIGNATURE_METADATA_KEYS:
+        metadata_pairs: list[tuple[str, str]] = []
+        nested_metadata = loaded_model.get("metadata", {})
+        nested_metadata_is_dict = isinstance(nested_metadata, dict)
+        for key in _FAST_PATH_SIGNATURE_METADATA_KEYS_SORTED:
+            normalized = ""
             value = loaded_model.get(key)
             if isinstance(value, str) and value.strip():
-                metadata[key] = value.strip()
-        nested_metadata = loaded_model.get("metadata", {})
-        if isinstance(nested_metadata, dict):
-            # Nested runtime metadata is authoritative over import-time top-level copies.
-            for key, value in nested_metadata.items():
-                if key not in _FAST_PATH_SIGNATURE_METADATA_KEYS:
-                    continue
-                normalized = str(value).strip()
-                if normalized:
-                    metadata[str(key)] = normalized
-
-    metadata_items = tuple(sorted(metadata.items()))
+                normalized = value.strip()
+            if nested_metadata_is_dict and key in nested_metadata:
+                # Nested runtime metadata is authoritative over import-time top-level copies.
+                # The accepted key set is fixed, so probe those keys directly instead of
+                # scanning and sorting arbitrary metadata payloads on every signature call.
+                nested_normalized = str(nested_metadata[key]).strip()
+                if nested_normalized:
+                    normalized = nested_normalized
+            if normalized:
+                metadata_pairs.append((key, normalized))
+        metadata_items = tuple(metadata_pairs)
     top_level_items: tuple[tuple[str, str], ...] = ()
     if isinstance(loaded_model, dict):
         top_level_items = tuple(


### PR DESCRIPTION
## Summary
- Streamlines `fast_path_probe_signature(...)` by reusing a pre-sorted fixed metadata key tuple instead of scanning and sorting arbitrary nested metadata on every call.
- Preserves nested runtime metadata precedence over import-time top-level copies and keeps the signature tuple shape unchanged.
- Adds a focused regression test that fails if the signature helper scans nested metadata via `items()`.

## Plan or Spec
- Plan: `docs/plans/2026-05-05-multimodal-fast-path-signature-metadata-order.md`
- Registered scoped performance probe: `multimodal-fast-path-signature-top-level-key-cache`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_fast_path_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_fast_path_signature_probe_script_emits_metrics
# 24 passed in 0.10s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_fast_path_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_fast_path_signature_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py services/mlx-worker-python/tests/test_multimodal_fast_paths.py scripts/multimodal_fast_path_signature_probe.py docs/plans/2026-05-05-multimodal-fast-path-signature-metadata-order.md
# TOTAL 31 0 100%

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id multimodal-fast-path-signature-top-level-key-cache --base-repo /tmp/melix-cron-opt-base-20260505203731 --head-repo "$PWD" --output /tmp/melix-multimodal-fast-path-probe-result.json
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 31 0 100%`
- Local PR-scoped probe `multimodal-fast-path-signature-top-level-key-cache`:
  - Base `elapsed_ms_mean`: `9601.254941383377`
  - Head `elapsed_ms_mean`: `8878.457472997252`
  - Delta: ~7.53% lower elapsed time
  - Base `peak_bytes_mean`: `30081.2`
  - Head `peak_bytes_mean`: `30138.8`
  - Workload: 5 samples x 120,000 signatures/sample, 600,000 total signatures

## Known Gaps
- Linux-only local verification. macOS/Swift checks were not run locally.
- Hosted `pr-scoped-performance` and broader repository CI must validate on GitHub before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.

Protocol changes: N/A — no protocol files touched.
Dependency changes: N/A — no dependency files touched.
