### PR TITLE
perf: reuse parsed image URI in preprocessing

### DIFF
--- a/docs/plans/multimodal-preprocessing-uri-parse-elision.md
+++ b/docs/plans/multimodal-preprocessing-uri-parse-elision.md
@@ -1,0 +1,34 @@
+# Multimodal Preprocessing URI Parse Elision
+
+## Goal
+
+Reduce redundant URI parsing in the Python multimodal preprocessing path for local image URI inputs.
+
+## Linux-only constraint
+
+This slice is Python-only under `services/mlx-worker-python` and can be verified on Linux with focused pytest, changed-scope coverage, and a synthetic local performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py`
+- `services/mlx-worker-python/tests/test_vision_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/multimodal_preprocessing_uri_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Probe definition
+
+Register `multimodal-preprocessing-local-uri-parse-elision` in the PR-scoped performance registry.
+
+The probe repeatedly prepares a vision request with a local `file://` image URI and records:
+
+- `elapsed_ms_mean` — lower is better
+- `urlparse_calls_mean` — lower is better and should drop from two parses per local URI to one parse per local URI
+- `iteration_count` and `sample_count` — workload shape
+
+## Success metrics
+
+- Focused pytest for the touched scope passes.
+- Changed-scope coverage for touched executable Python files is at least 95%.
+- The local probe reports `urlparse_calls_mean == iteration_count` on the optimized branch.
+- `git diff --check` passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -92,6 +92,37 @@
     ]
   },
   {
+    "id": "multimodal-preprocessing-local-uri-parse-elision",
+    "name": "Multimodal preprocessing local URI parse elision",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py",
+      "services/mlx-worker-python/tests/test_vision_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/multimodal_preprocessing_uri_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_path_from_uri_preserves_direct_helper_behavior services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_missing_remote_and_unsupported_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_vlm_response_from_file_image_uri services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_preprocessing_uri_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_path_from_uri_preserves_direct_helper_behavior services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_missing_remote_and_unsupported_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_vlm_response_from_file_image_uri services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_preprocessing_uri_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/multimodal_preprocessing_uri_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/multimodal_preprocessing_uri_probe.py ]; then python scripts/multimodal_preprocessing_uri_probe.py; else python - <<\"PYPROBE\"\nimport json, statistics, sys, time\nfrom pathlib import Path\nfrom tempfile import TemporaryDirectory\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom packages.protocol.python.worker.v1 import common_pb2\nfrom worker.runtime import multimodal_preprocessing\nfrom worker.runtime.multimodal_preprocessing import prepare_vision_request\ndef sample(iterations):\n    with TemporaryDirectory() as directory:\n        image_path = Path(directory) / \"probe-image.txt\"\n        image_path.write_bytes(b\"synthetic local image bytes\")\n        message = common_pb2.ChatMessage(role=\"user\", parts=[common_pb2.MessagePart(text=\"Describe the image.\"), common_pb2.MessagePart(image_uri=image_path.as_uri(), media=common_pb2.MediaMetadata(media_type=common_pb2.MEDIA_TYPE_IMAGE, source_kind=common_pb2.MEDIA_SOURCE_URI))])\n        original = multimodal_preprocessing.urlparse\n        calls = 0\n        def tracked(uri):\n            nonlocal calls\n            calls += 1\n            return original(uri)\n        multimodal_preprocessing.urlparse = tracked\n        try:\n            started = time.perf_counter()\n            for _ in range(iterations):\n                request = prepare_vision_request([message])\n                if request.images[0].bytes_data != b\"synthetic local image bytes\":\n                    raise RuntimeError(\"unexpected image bytes\")\n            elapsed_ms = (time.perf_counter() - started) * 1000.0\n        finally:\n            multimodal_preprocessing.urlparse = original\n    return elapsed_ms, calls\niterations = 5000\nsample_count = 5\nelapsed = []\ncalls = []\nfor _ in range(sample_count):\n    elapsed_ms, call_count = sample(iterations)\n    elapsed.append(elapsed_ms)\n    calls.append(float(call_count))\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed), \"elapsed_ms_min\": min(elapsed), \"urlparse_calls_mean\": statistics.fmean(calls), \"iteration_count\": float(iterations), \"sample_count\": float(sample_count)}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "urlparse_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "runtime-utils-kwarg-signature-cache",
     "name": "Runtime utils kwarg signature cache",
     "runner": "ubuntu-latest",

--- a/scripts/multimodal_preprocessing_uri_probe.py
+++ b/scripts/multimodal_preprocessing_uri_probe.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from packages.protocol.python.worker.v1 import common_pb2  # noqa: E402
+from worker.runtime import multimodal_preprocessing  # noqa: E402
+from worker.runtime.multimodal_preprocessing import prepare_vision_request  # noqa: E402
+
+
+def _sample(iterations: int) -> tuple[float, int]:
+    with TemporaryDirectory() as directory:
+        image_path = Path(directory) / "probe-image.txt"
+        image_path.write_bytes(b"synthetic local image bytes")
+        image_uri = image_path.as_uri()
+        message = common_pb2.ChatMessage(
+            role="user",
+            parts=[
+                common_pb2.MessagePart(text="Describe the image."),
+                common_pb2.MessagePart(
+                    image_uri=image_uri,
+                    media=common_pb2.MediaMetadata(
+                        media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                        source_kind=common_pb2.MEDIA_SOURCE_URI,
+                    ),
+                ),
+            ],
+        )
+        original_urlparse = multimodal_preprocessing.urlparse
+        urlparse_calls = 0
+
+        def tracked_urlparse(uri: str):
+            nonlocal urlparse_calls
+            urlparse_calls += 1
+            return original_urlparse(uri)
+
+        multimodal_preprocessing.urlparse = tracked_urlparse
+        try:
+            started = time.perf_counter()
+            for _ in range(iterations):
+                request = prepare_vision_request([message])
+                if request.images[0].bytes_data != b"synthetic local image bytes":
+                    raise RuntimeError("unexpected image bytes")
+            elapsed_ms = (time.perf_counter() - started) * 1000.0
+        finally:
+            multimodal_preprocessing.urlparse = original_urlparse
+    return elapsed_ms, urlparse_calls
+
+
+def main() -> None:
+    iterations = int(os.environ.get("MELIX_PROBE_ITERATIONS", "5000"))
+    sample_count = int(os.environ.get("MELIX_PROBE_SAMPLES", "5"))
+    elapsed_samples: list[float] = []
+    urlparse_call_samples: list[float] = []
+    for _ in range(sample_count):
+        elapsed_ms, urlparse_calls = _sample(iterations)
+        elapsed_samples.append(elapsed_ms)
+        urlparse_call_samples.append(float(urlparse_calls))
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+                "elapsed_ms_min": min(elapsed_samples),
+                "urlparse_calls_mean": statistics.fmean(urlparse_call_samples),
+                "iteration_count": float(iterations),
+                "sample_count": float(sample_count),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -268,6 +268,16 @@ def test_scope_report_selects_multimodal_fast_path_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "multimodal-fast-path-signature-top-level-key-cache"
 
 
+def test_scope_report_selects_multimodal_preprocessing_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "multimodal-preprocessing-local-uri-parse-elision"
+
+
 def test_scope_report_selects_worker_registry_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -845,6 +855,25 @@ def test_multimodal_fast_path_signature_probe_script_emits_metrics(
     assert metrics["peak_bytes_mean"] > 0
 
 
+def test_multimodal_preprocessing_uri_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_PROBE_ITERATIONS", "3")
+    monkeypatch.setenv("MELIX_PROBE_SAMPLES", "1")
+
+    runpy.run_path(
+        str(REPO_ROOT / "scripts/multimodal_preprocessing_uri_probe.py"),
+        run_name="__main__",
+    )
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["iteration_count"] == 3.0
+    assert metrics["sample_count"] == 1.0
+    assert metrics["urlparse_calls_mean"] == 3.0
+    assert metrics["elapsed_ms_mean"] >= 0
+
+
 def test_deterministic_embedding_duplicate_probe_script_emits_metrics(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -979,6 +1008,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "mlx-vlm-gemma4-weight-presence-single-pass",
         "model-registry-plain-local-manifest-stat-elision",
         "multimodal-fast-path-signature-top-level-key-cache",
+        "multimodal-preprocessing-local-uri-parse-elision",
         "package-macos-resolve-fallback-scandir",
         "pr-scoped-performance-scope-json-read-bytes",
         "pr-scoped-performance-scope-matcher",

--- a/services/mlx-worker-python/tests/test_vision_runtime.py
+++ b/services/mlx-worker-python/tests/test_vision_runtime.py
@@ -17,6 +17,8 @@ from worker.runtime import multimodal_preprocessing
 from worker.runtime.multimodal_fast_paths import fast_path_probe_signature
 from worker.runtime.multimodal_preprocessing import (
     MultimodalPreprocessError,
+    _bytes_from_image_uri,
+    _path_from_uri,
     _prepare_image_part,
     prepare_vision_request,
 )
@@ -1311,6 +1313,37 @@ def test_prepare_vision_request_rejects_missing_remote_and_unsupported_inputs(
                 )
             ]
         )
+
+
+def test_path_from_uri_preserves_direct_helper_behavior(tmp_path: Path) -> None:
+    image_path = tmp_path / "direct-helper-image.txt"
+    image_path.write_bytes(b"direct image bytes")
+
+    assert _path_from_uri(str(image_path)) == image_path
+
+
+def test_bytes_from_local_image_uri_reuses_single_parsed_uri(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    image_path = tmp_path / "single-parse-image.txt"
+    image_path.write_bytes(b"local image bytes")
+    calls: list[str] = []
+    original_urlparse = multimodal_preprocessing.urlparse
+
+    def tracked_urlparse(uri: str):
+        calls.append(uri)
+        return original_urlparse(uri)
+
+    monkeypatch.setattr(multimodal_preprocessing, "urlparse", tracked_urlparse)
+
+    bytes_data, reference, mime_type, format_name, filename = _bytes_from_image_uri(image_path.as_uri())
+
+    assert bytes_data == b"local image bytes"
+    assert reference == image_path.as_uri()
+    assert mime_type == ""
+    assert format_name == "txt"
+    assert filename == image_path.name
+    assert calls == [image_path.as_uri()]
 
 
 def test_prepare_image_part_rejects_parts_without_any_image_payload() -> None:

--- a/services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py
@@ -156,8 +156,7 @@ def _prepare_image_part(part) -> PreparedImageInput:
     raise MultimodalPreprocessError("No image input provided.")
 
 
-def _path_from_uri(uri: str) -> Path:
-    parsed = urlparse(uri)
+def _path_from_parsed_uri(uri: str, parsed) -> Path:
     if parsed.scheme in {"", "file"}:
         if parsed.scheme == "file":
             candidate = Path(unquote(parsed.path))
@@ -169,10 +168,14 @@ def _path_from_uri(uri: str) -> Path:
     raise MultimodalPreprocessError(f"Unsupported image URI scheme: {parsed.scheme}")
 
 
+def _path_from_uri(uri: str) -> Path:
+    return _path_from_parsed_uri(uri, urlparse(uri))
+
+
 def _bytes_from_image_uri(uri: str) -> tuple[bytes, str, str, str, str]:
     parsed = urlparse(uri)
     if parsed.scheme in {"", "file"}:
-        path = _path_from_uri(uri)
+        path = _path_from_parsed_uri(uri, parsed)
         return (
             path.read_bytes(),
             uri,


### PR DESCRIPTION
## Summary
- Reuses the already parsed local image URI inside `multimodal_preprocessing._bytes_from_image_uri(...)` instead of parsing the same URI again via `_path_from_uri(...)`.
- Adds focused regression coverage that proves local file image URIs now call `urlparse` once per image.
- Registers a PR-scoped performance probe for the local image URI preprocessing path.

## Plan or Spec
- `docs/plans/multimodal-preprocessing-uri-parse-elision.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_vision_runtime.py::test_path_from_uri_preserves_direct_helper_behavior \
  services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri \
  services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_missing_remote_and_unsupported_inputs \
  services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_vlm_response_from_file_image_uri \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_preprocessing_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_preprocessing_uri_probe_script_emits_metrics
# 7 passed in 0.41s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused selection>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py \
  services/mlx-worker-python/tests/test_vision_runtime.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/multimodal_preprocessing_uri_probe.py
# TOTAL 37 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/multimodal_preprocessing_uri_probe.py
# {"elapsed_ms_mean": 229.4785417849198, "elapsed_ms_min": 219.12895399145782, "iteration_count": 5000.0, "sample_count": 5.0, "urlparse_calls_mean": 5000.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py \
  --registry infra/perf/pr_scoped_probes.json \
  --probe-id multimodal-preprocessing-local-uri-parse-elision \
  --base-repo /tmp/melix-base-uri-parse-20260505-212033 \
  --head-repo "$PWD" \
  --output /tmp/multimodal-preprocessing-uri-pr-scoped-result.json
# base: elapsed_ms_mean=252.1028979914263, urlparse_calls_mean=10000.0
# head: elapsed_ms_mean=220.84724499145523, urlparse_calls_mean=5000.0
# head verification coverage: TOTAL 37 0 100%

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 37 0 100%`.
- Registered scoped CI probe: `multimodal-preprocessing-local-uri-parse-elision`.
- Local direct probe on head: `elapsed_ms_mean=229.4785 ms`, `urlparse_calls_mean=5000.0` for `5000` iterations × `5` samples.
- Local PR-scoped base-vs-head probe:
  - base (`origin/main`): `elapsed_ms_mean=252.1029 ms`, `urlparse_calls_mean=10000.0`
  - head: `elapsed_ms_mean=220.8472 ms`, `urlparse_calls_mean=5000.0`
  - structural improvement: local URI parse calls reduced by 50% for the synthetic workload.

## Known Gaps
- Linux-only verification was run; macOS/Swift checks were not run locally because this slice is Python-only and the host is Linux.
- Hosted CI is still required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
