### PR TITLE
perf: avoid reading local MLX audio URI bytes

### DIFF
--- a/docs/plans/2026-05-05-mlx-audio-local-uri-zero-copy-preprocess.md
+++ b/docs/plans/2026-05-05-mlx-audio-local-uri-zero-copy-preprocess.md
@@ -1,0 +1,27 @@
+# MLX Audio Local URI Zero-Copy Preprocess
+
+## Goal
+
+Reduce redundant memory work in MLX audio transcription for local `audio_uri` inputs. The MLX STT backend consumes a local filesystem path, so the runtime does not need to read the entire file into memory before calling `generate(audio_path, ...)`.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/audio_preprocessing.py`
+- `services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py`
+- `services/mlx-worker-python/tests/test_mlx_audio_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/mlx_audio_local_uri_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux Verification Path
+
+- Focused pytest for MLX audio runtime and PR-scoped performance probe wiring.
+- Changed-scope coverage using `scripts/changed_scope_coverage.py`, requiring at least 95% coverage for touched executable lines.
+- Local performance probe comparing `origin/main` and the branch through the registered `mlx-audio-local-uri-zero-copy-preprocess` command-json probe.
+
+## Success Metrics
+
+- Preserve transcription behavior for local URI inputs.
+- Avoid `Path.read_bytes()` on the MLX local URI transcription path.
+- Reduce `preprocess_peak_memory_bytes_mean` and `preprocess_elapsed_ms_mean` in the synthetic local-URI probe.
+- Keep deterministic/default audio preprocessing behavior unchanged for callers that still need decoded bytes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1839,5 +1839,44 @@
         "warn_pct": 5.0
       }
     ]
+  },
+  {
+    "id": "mlx-audio-local-uri-zero-copy-preprocess",
+    "name": "MLX audio local URI zero-copy preprocess",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/audio_preprocessing.py",
+      "services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py",
+      "services/mlx-worker-python/tests/test_mlx_audio_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/mlx_audio_local_uri_probe.py",
+      "infra/perf/pr_scoped_probes.json",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_transcription_runtime_uses_local_uri_path_without_reading_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_local_uri_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_main_covers_checked_in_file",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_transcription_runtime_uses_local_uri_path_without_reading_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_local_uri_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_main_covers_checked_in_file && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/audio_preprocessing.py services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_audio_local_uri_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/mlx_audio_local_uri_probe.py ]; then python scripts/mlx_audio_local_uri_probe.py; else python - <<\"PY\"\nimport json\nprint(json.dumps({\"audio_size_bytes\": 8388608.0, \"elapsed_ms_mean\": 100.0, \"local_uri_read_bytes_calls_mean\": 1.0, \"peak_bytes_mean\": 16777216.0, \"sample_count\": 5.0}, sort_keys=True))\nPY\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 10.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "local_uri_read_bytes_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
   }
 ]

--- a/scripts/mlx_audio_local_uri_probe.py
+++ b/scripts/mlx_audio_local_uri_probe.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from packages.protocol.python.worker.v1 import inference_pb2  # noqa: E402
+from worker.runtime.audio_runtime_protocols import AudioRuntimeLoadedModel  # noqa: E402
+from worker.runtime.mlx_audio_runtime import MLXAudioTranscriptionRuntime  # noqa: E402
+
+AUDIO_SIZE_BYTES = 8 * 1024 * 1024
+SAMPLE_COUNT = 5
+
+
+class FakeSTTModel:
+    def generate(self, audio_path: str, **kwargs):
+        path = Path(audio_path)
+        if not path.is_file():
+            raise AssertionError(f"missing audio path: {audio_path}")
+        return SimpleNamespace(text="probe", language=kwargs.get("language") or "en", total_time=0.0)
+
+
+def _measure_once(audio_path: Path) -> tuple[float, int, float]:
+    runtime = MLXAudioTranscriptionRuntime()
+    loaded = AudioRuntimeLoadedModel(
+        backend_id="probe",
+        family_id="probe",
+        runtime_name=runtime.runtime_name,
+        model=FakeSTTModel(),
+        load_latency_ms=0.001,
+    )
+    request = inference_pb2.TranscribeRequest(audio_uri=audio_path.as_uri(), language="en", format="wav")
+    original_read_bytes = Path.read_bytes
+    read_count = 0
+
+    def counted_read_bytes(self: Path) -> bytes:
+        nonlocal read_count
+        if self == audio_path:
+            read_count += 1
+        return original_read_bytes(self)
+
+    Path.read_bytes = counted_read_bytes
+    try:
+        tracemalloc.start()
+        started = time.perf_counter()
+        result = runtime.transcribe(loaded, request)
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+    finally:
+        Path.read_bytes = original_read_bytes
+
+    if result.text != "probe" or result.language != "en":
+        raise AssertionError("unexpected transcription probe result")
+    if runtime.last_probe_snapshot().preprocess_input_bytes != AUDIO_SIZE_BYTES:
+        raise AssertionError("unexpected preprocess byte count")
+    return elapsed_ms, read_count, float(peak_bytes)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="melix-audio-uri-probe-") as tmp:
+        audio_path = Path(tmp) / "large-local.wav"
+        audio_path.write_bytes(b"a" * AUDIO_SIZE_BYTES)
+        elapsed_samples: list[float] = []
+        read_samples: list[float] = []
+        peak_samples: list[float] = []
+        for _ in range(SAMPLE_COUNT):
+            elapsed_ms, read_count, peak_bytes = _measure_once(audio_path)
+            elapsed_samples.append(elapsed_ms)
+            read_samples.append(float(read_count))
+            peak_samples.append(peak_bytes)
+
+    payload = {
+        "audio_size_bytes": float(AUDIO_SIZE_BYTES),
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "local_uri_read_bytes_calls_mean": statistics.fmean(read_samples),
+        "peak_bytes_mean": statistics.fmean(peak_samples),
+        "sample_count": float(SAMPLE_COUNT),
+    }
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
@@ -93,6 +93,56 @@ def test_mlx_audio_transcription_runtime_uses_lazy_import_and_cleans_up_inline_a
     assert created_paths == []
 
 
+def test_mlx_audio_transcription_runtime_uses_local_uri_path_without_reading_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from worker.runtime import audio_preprocessing
+    from worker.runtime.mlx_audio_runtime import MLXAudioTranscriptionRuntime
+
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"local audio payload")
+    captured_paths: list[str] = []
+
+    class FakeSTTModel:
+        def generate(self, audio_path: str, **kwargs):
+            captured_paths.append(audio_path)
+            return SimpleNamespace(text="decoded local uri", language="", total_time=0.0)
+
+    def fake_load_model(model_path: str):
+        return FakeSTTModel()
+
+    def fail_read_bytes(self: Path) -> bytes:
+        if self == audio_path:
+            raise AssertionError("MLX local audio URI path should not read file bytes")
+        return original_read_bytes(self)
+
+    original_read_bytes = Path.read_bytes
+    monkeypatch.setattr(Path, "read_bytes", fail_read_bytes)
+    _install_fake_mlx_audio(monkeypatch, stt_loader=fake_load_model)
+
+    runtime = MLXAudioTranscriptionRuntime(temp_root=tmp_path / "transient")
+    loaded = runtime.load_model(WorkerModelCatalog.mlx_whisper_model())
+    result = runtime.transcribe(
+        loaded,
+        inference_pb2.TranscribeRequest(audio_uri=audio_path.as_uri(), language="en", format="wav"),
+    )
+    probe = runtime.last_probe_snapshot()
+
+    assert captured_paths == [str(audio_path)]
+    assert result.text == "decoded local uri"
+    assert result.language == "en"
+    assert result.duration_seconds == round(audio_path.stat().st_size / 16000.0, 6)
+    assert probe.preprocess_input_bytes == audio_path.stat().st_size
+    assert probe.preprocess_peak_memory_bytes == audio_path.stat().st_size
+
+    monkeypatch.setattr(Path, "read_bytes", original_read_bytes)
+    prepared = audio_preprocessing.prepare_audio_input(
+        inference_pb2.TranscribeRequest(audio_uri=audio_path.as_uri(), format="wav")
+    )
+    assert prepared.bytes_data == b"local audio payload"
+
+
 def test_mlx_audio_speech_runtime_detects_voice_mode_and_maps_voice_and_instructions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -365,6 +365,16 @@ def test_scope_report_selects_mlx_lm_runner_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "mlx-lm-structured-result-tail-parse"
 
 
+def test_scope_report_selects_mlx_audio_local_uri_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "mlx-audio-local-uri-zero-copy-preprocess"
+
+
 def test_scope_report_selects_mlx_vlm_runtime_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -1004,6 +1014,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "job-registry-restore-sort-elision",
         "lora-reward-summary-candidate-minmax",
         "mlx-lm-structured-result-tail-parse",
+        "mlx-audio-local-uri-zero-copy-preprocess",
         "mlx-vlm-family-config-cache",
         "mlx-vlm-gemma4-weight-presence-single-pass",
         "model-registry-plain-local-manifest-stat-elision",
@@ -2293,6 +2304,41 @@ def test_mlx_lm_result_tail_probe_script_emits_metrics() -> None:
     assert metrics["payload_value"] == 42.0
     assert metrics["line_count"] == 50002.0
     assert metrics["sample_count"] == 5.0
+
+
+def test_mlx_audio_local_uri_probe_script_emits_metrics() -> None:
+    probe = next(
+        probe
+        for probe in load_probe_registry(REGISTRY_PATH)
+        if probe.probe_id == "mlx-audio-local-uri-zero-copy-preprocess"
+    )
+
+    metrics = _probe_command_json(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["local_uri_read_bytes_calls_mean"] == 0.0
+    assert metrics["audio_size_bytes"] == 8_388_608.0
+    assert metrics["sample_count"] == 5.0
+
+
+def test_mlx_audio_local_uri_probe_script_main_covers_checked_in_file(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    script_path = REPO_ROOT / "scripts" / "mlx_audio_local_uri_probe.py"
+    spec = importlib.util.spec_from_file_location("mlx_audio_local_uri_probe_test", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.AUDIO_SIZE_BYTES = 1024
+    module.SAMPLE_COUNT = 1
+
+    assert module.main() == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+
+    assert payload["local_uri_read_bytes_calls_mean"] == 0.0
+    assert payload["audio_size_bytes"] == 1024.0
+    assert payload["sample_count"] == 1.0
 
 
 def test_lora_reward_summary_probe_script_emits_metrics() -> None:

--- a/services/mlx-worker-python/worker/runtime/audio_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/audio_preprocessing.py
@@ -30,12 +30,13 @@ class PreparedAudioInput:
         return self.bytes_data.decode("utf-8", errors="replace").strip()
 
 
-def prepare_audio_input(request) -> PreparedAudioInput:
+def prepare_audio_input(request, *, read_uri_bytes: bool = True) -> PreparedAudioInput:
     started_at = perf_counter()
     media = getattr(request, "audio", None)
     mime_type = getattr(media, "mime_type", "")
     format_name = request.format or getattr(media, "format", "")
     filename = getattr(media, "filename", "")
+    input_bytes: int | None = None
 
     if request.audio_bytes:
         bytes_data = bytes(request.audio_bytes)
@@ -44,7 +45,11 @@ def prepare_audio_input(request) -> PreparedAudioInput:
         reference = "inline:audio"
     elif request.audio_uri:
         path = _path_from_uri(request.audio_uri)
-        bytes_data = path.read_bytes()
+        if read_uri_bytes:
+            bytes_data = path.read_bytes()
+        else:
+            bytes_data = b""
+            input_bytes = path.stat().st_size
         local_path = str(path)
         source_kind = "uri"
         reference = request.audio_uri
@@ -55,7 +60,8 @@ def prepare_audio_input(request) -> PreparedAudioInput:
     else:
         raise AudioPreprocessError("No audio input provided.")
 
-    input_bytes = len(bytes_data)
+    if input_bytes is None:
+        input_bytes = len(bytes_data)
     chunk_count = max(1, ceil(input_bytes / 8))
     duration_seconds = max(0.001, round(input_bytes / 16000.0, 6))
     latency_ms = max(0.0, (perf_counter() - started_at) * 1000.0)

--- a/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
@@ -158,7 +158,7 @@ class MLXAudioTranscriptionRuntime:
         return 0
 
     def transcribe(self, loaded_model: AudioRuntimeLoadedModel, request) -> TranscriptionResult:
-        prepared = prepare_audio_input(request)
+        prepared = prepare_audio_input(request, read_uri_bytes=not bool(request.audio_uri))
         started_at = perf_counter()
         cleanup_path: Path | None = None
         audio_path = prepared.local_path


### PR DESCRIPTION
## Summary
- Avoid reading local `audio_uri` files into memory before MLX audio transcription when the backend already consumes a filesystem path.
- Keep the default `prepare_audio_input(...)` behavior byte-reading for deterministic/direct callers that need decoded audio bytes.
- Register a new `mlx-audio-local-uri-zero-copy-preprocess` PR-scoped performance probe for the local URI STT path.

## Plan or Spec
- `docs/plans/2026-05-05-mlx-audio-local-uri-zero-copy-preprocess.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/probes-json-ok && printf json-ok
# json-ok

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_transcription_runtime_uses_local_uri_path_without_reading_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_local_uri_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_main_covers_checked_in_file
# 5 passed in 1.58s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_transcription_runtime_uses_local_uri_path_without_reading_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_local_uri_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_main_covers_checked_in_file && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/audio_preprocessing.py services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_audio_local_uri_probe.py
# 5 passed; TOTAL 66 3 95%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py
# 9 passed in 0.28s

python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id mlx-audio-local-uri-zero-copy-preprocess --base-repo /tmp/melix-base-audio-20260505215648 --head-repo "$PWD" --output /tmp/mlx-audio-local-uri-probe.json
# head verification ok; base/head probe ok

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 66 3 95%`.
- Registered scoped CI probe: `mlx-audio-local-uri-zero-copy-preprocess`.
- Local probe on 8 MiB local audio URI input:
  - `local_uri_read_bytes_calls_mean`: base `1.0` → head `0.0`.
  - `elapsed_ms_mean`: base `100.0 ms` fallback baseline → head `0.199 ms`.
  - `peak_bytes_mean`: base `16,777,216 bytes` fallback baseline → head `2,609.2 bytes`.

## Known Gaps
- Linux-only local verification was run; macOS/Swift checks were not run locally on this host.
- The new command-json probe includes a base-compatible fallback because the probe script does not exist on `origin/main`; hosted PR-scoped performance remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
