### PR TITLE
perf: reuse chunker top-level sample copy

### DIFF
--- a/docs/plans/2026-05-05-training-dataset-chunker-top-level-copy.md
+++ b/docs/plans/2026-05-05-training-dataset-chunker-top-level-copy.md
@@ -1,0 +1,36 @@
+# Training Dataset Chunker Top-Level Copy Optimization
+
+## Goal
+
+Reduce redundant top-level sample key filtering in `worker/model_ops/training_dataset_chunker.py` when a long sample emits many chunks.
+
+## Linux Constraint
+
+This is a Python-only worker slice and is verifiable on Linux with focused pytest, changed-scope coverage, and a local PR-scoped performance probe.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py`
+- `services/mlx-worker-python/tests/test_training_dataset_chunker.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/training_dataset_chunker_top_level_copy_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Performance Probe
+
+Register `training-dataset-chunker-top-level-base-copy` in `infra/perf/pr_scoped_probes.json`.
+
+The probe builds one synthetic sample with many top-level metadata fields and long user content that splits into many chunks. It records:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- `chunk_count`
+- `top_level_key_count`
+- `sample_count`
+
+## Success Metrics
+
+- Behavior preserved: chunk IDs, shallow shared top-level metadata/tools, copied message containers.
+- Focused tests pass.
+- Changed-scope coverage is at least 95% for touched executable Python/test/probe files.
+- Local base-vs-head probe shows reduced or neutral latency/peak memory on the synthetic many-chunk workload.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1878,5 +1878,36 @@
         "warn_pct": 0.0
       }
     ]
+  },
+  {
+    "id": "training-dataset-chunker-top-level-base-copy",
+    "name": "Training dataset chunker top-level base copy",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py",
+      "services/mlx-worker-python/tests/test_training_dataset_chunker.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/training_dataset_chunker_top_level_copy_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_filter_top_level_keys_once_per_source_sample services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_chunker_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_dataset_chunker_top_level_copy_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_filter_top_level_keys_once_per_source_sample services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_chunker_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_dataset_chunker_top_level_copy_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py services/mlx-worker-python/tests/test_training_dataset_chunker.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/training_dataset_chunker_top_level_copy_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/training_dataset_chunker_top_level_copy_probe.py ]; then python scripts/training_dataset_chunker_top_level_copy_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"CmltcG9ydCBqc29uLCBvcywgc3RhdGlzdGljcywgc3lzLCB0aW1lLCB0cmFjZW1hbGxvYwpmcm9tIHBhdGhsaWIgaW1wb3J0IFBhdGgKcmVwb19yb290ID0gUGF0aC5jd2QoKQpzeXMucGF0aC5pbnNlcnQoMCwgc3RyKHJlcG9fcm9vdCkpCnN5cy5wYXRoLmluc2VydCgwLCBzdHIocmVwb19yb290IC8gInNlcnZpY2VzL21seC13b3JrZXItcHl0aG9uIikpCmZyb20gd29ya2VyLm1vZGVsX29wcy50cmFpbmluZ19kYXRhc2V0X2NodW5rZXIgaW1wb3J0IGNodW5rX2xvbmdfc2FtcGxlcwpjbGFzcyBUOgogICAgZGVmIF9faW5pdF9fKHNlbGYsIG92ZXJoZWFkX3Blcl9tZXNzYWdlPTUpOiBzZWxmLm92ZXJoZWFkX3Blcl9tZXNzYWdlID0gb3ZlcmhlYWRfcGVyX21lc3NhZ2UKICAgIGRlZiBhcHBseV9jaGF0X3RlbXBsYXRlKHNlbGYsIG1lc3NhZ2VzLCAqLCB0b29scz1Ob25lLCBhZGRfZ2VuZXJhdGlvbl9wcm9tcHQ9RmFsc2UsIHJldHVybl9kaWN0PUZhbHNlKToKICAgICAgICB0b3RhbCA9IDAKICAgICAgICBmb3IgbWVzc2FnZSBpbiBtZXNzYWdlczoKICAgICAgICAgICAgdG90YWwgKz0gc2VsZi5vdmVyaGVhZF9wZXJfbWVzc2FnZSArIGxlbigobWVzc2FnZS5nZXQoImNvbnRlbnQiLCAiIikgb3IgIiIpLnNwbGl0KCkpCiAgICAgICAgaWYgdG9vbHM6IHRvdGFsICs9IGxlbih0b29scykgKiAzCiAgICAgICAgaWYgYWRkX2dlbmVyYXRpb25fcHJvbXB0OiB0b3RhbCArPSBzZWxmLm92ZXJoZWFkX3Blcl9tZXNzYWdlCiAgICAgICAgcmV0dXJuIGxpc3QocmFuZ2UodG90YWwpKQpkZWYgd29yZHMoY291bnQpOiByZXR1cm4gIiAiLmpvaW4oZiJ3e2luZGV4fSIgZm9yIGluZGV4IGluIHJhbmdlKGNvdW50KSkKZGVmIGJ1aWxkX3NhbXBsZSh0b3BfbGV2ZWxfa2V5X2NvdW50LCB3b3JkX2NvdW50KToKICAgIHNhbXBsZSA9IHsiaWQiOiAiY2h1bmtlci1wcm9iZSIsICJtZXNzYWdlcyI6IFt7InJvbGUiOiAidXNlciIsICJjb250ZW50Ijogd29yZHMod29yZF9jb3VudCl9LCB7InJvbGUiOiAiYXNzaXN0YW50IiwgImNvbnRlbnQiOiAiYWNrIn1dLCAidG9vbHMiOiBbeyJ0eXBlIjogImZ1bmN0aW9uIiwgImZ1bmN0aW9uIjogeyJuYW1lIjogImxvb2t1cCJ9fV19CiAgICBmb3IgaW5kZXggaW4gcmFuZ2UodG9wX2xldmVsX2tleV9jb3VudCk6IHNhbXBsZVtmIm1ldGFkYXRhX3tpbmRleDowM2R9Il0gPSB7InJhbmsiOiBpbmRleCwgImxhYmVscyI6IFtmImxhYmVsLXtpbmRleH0iLCBmImJ1Y2tldC17aW5kZXggJSAxMX0iXX0KICAgIHJldHVybiBzYW1wbGUKc2FtcGxlX2NvdW50ID0gaW50KG9zLmVudmlyb24uZ2V0KCJNRUxJWF9DSFVOS0VSX1BST0JFX1NBTVBMRVMiLCAiNyIpKQp0b3BfbGV2ZWxfa2V5X2NvdW50ID0gaW50KG9zLmVudmlyb24uZ2V0KCJNRUxJWF9DSFVOS0VSX1BST0JFX1RPUF9LRVlTIiwgIjEyMCIpKQp3b3JkX2NvdW50ID0gaW50KG9zLmVudmlyb24uZ2V0KCJNRUxJWF9DSFVOS0VSX1BST0JFX1dPUkRTIiwgIjgwMDAiKSkKY2h1bmtfc2l6ZSA9IGludChvcy5lbnZpcm9uLmdldCgiTUVMSVhfQ0hVTktFUl9QUk9CRV9DSFVOS19TSVpFIiwgIjYwIikpCmVsYXBzZWQ9W107IHBlYWtzPVtdOyBjaHVua3M9W107IHRva2VuaXplcj1UKCkKZm9yIF8gaW4gcmFuZ2Uoc2FtcGxlX2NvdW50KToKICAgIHNhbXBsZT1idWlsZF9zYW1wbGUodG9wX2xldmVsX2tleV9jb3VudCwgd29yZF9jb3VudCkKICAgIHRyYWNlbWFsbG9jLnN0YXJ0KCk7IHN0YXJ0ZWQ9dGltZS5wZXJmX2NvdW50ZXIoKQogICAgY2h1bmtlZCwgc3RhdHMgPSBjaHVua19sb25nX3NhbXBsZXMoW3NhbXBsZV0sIGNodW5rX3NpemU9Y2h1bmtfc2l6ZSwgdG9rZW5pemVyPXRva2VuaXplcikKICAgIGVsYXBzZWQuYXBwZW5kKCh0aW1lLnBlcmZfY291bnRlcigpLXN0YXJ0ZWQpKjEwMDAuMCk7IF8sIHBlYWs9dHJhY2VtYWxsb2MuZ2V0X3RyYWNlZF9tZW1vcnkoKTsgdHJhY2VtYWxsb2Muc3RvcCgpOyBwZWFrcy5hcHBlbmQocGVhaykKICAgIGlmIHN0YXRzLmNodW5rX2NvdW50ICE9IGxlbihjaHVua2VkKSBvciBzdGF0cy5jaHVua19jb3VudCA8PSAxOiByYWlzZSBSdW50aW1lRXJyb3IoImNodW5rZXIgcHJvYmUgZGlkIG5vdCBwcm9kdWNlIG11bHRpcGxlIHZhbGlkIGNodW5rcyIpCiAgICBpZiBhbnkoY2h1bmsuZ2V0KCJ0b29scyIpIGlzIG5vdCBzYW1wbGVbInRvb2xzIl0gZm9yIGNodW5rIGluIGNodW5rZWQpOiByYWlzZSBSdW50aW1lRXJyb3IoImNodW5rZXIgcHJvYmUgbG9zdCBzaGFyZWQgdG9wLWxldmVsIHRvb2xzIHBheWxvYWQiKQogICAgY2h1bmtzLmFwcGVuZChzdGF0cy5jaHVua19jb3VudCkKcHJpbnQoanNvbi5kdW1wcyh7ImVsYXBzZWRfbXNfbWVhbiI6IHJvdW5kKHN0YXRpc3RpY3MuZm1lYW4oZWxhcHNlZCksIDYpLCAicGVha19ieXRlc19tZWFuIjogcm91bmQoc3RhdGlzdGljcy5mbWVhbihwZWFrcyksIDMpLCAiY2h1bmtfY291bnQiOiBmbG9hdChjaHVua3NbMF0pLCAidG9wX2xldmVsX2tleV9jb3VudCI6IGZsb2F0KHRvcF9sZXZlbF9rZXlfY291bnQgKyAzKSwgInNhbXBsZV9jb3VudCI6IGZsb2F0KHNhbXBsZV9jb3VudCl9LCBzb3J0X2tleXM9VHJ1ZSkpCg==\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
   }
 ]

--- a/scripts/training_dataset_chunker_top_level_copy_probe.py
+++ b/scripts/training_dataset_chunker_top_level_copy_probe.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Synthetic probe for training-dataset chunker top-level copy reuse."""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.model_ops.training_dataset_chunker import chunk_long_samples
+
+
+class _ProbeTokenizer:
+    def __init__(self, *, overhead_per_message: int = 5) -> None:
+        self.overhead_per_message = overhead_per_message
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        add_generation_prompt: bool = False,
+        return_dict: bool = False,
+    ) -> list[int]:
+        total = 0
+        for message in messages:
+            content = message.get("content", "") or ""
+            total += self.overhead_per_message + len(content.split())
+        if tools:
+            total += len(tools) * 3
+        if add_generation_prompt:
+            total += self.overhead_per_message
+        return list(range(total))
+
+
+def _words(count: int) -> str:
+    return " ".join(f"w{index}" for index in range(count))
+
+
+def _build_sample(*, top_level_key_count: int, word_count: int) -> dict[str, object]:
+    sample: dict[str, object] = {
+        "id": "chunker-probe",
+        "messages": [
+            {"role": "user", "content": _words(word_count)},
+            {"role": "assistant", "content": "ack"},
+        ],
+        "tools": [{"type": "function", "function": {"name": "lookup"}}],
+    }
+    for index in range(top_level_key_count):
+        sample[f"metadata_{index:03d}"] = {
+            "rank": index,
+            "labels": [f"label-{index}", f"bucket-{index % 11}"],
+        }
+    return sample
+
+
+def main() -> int:
+    sample_count = int(os.environ.get("MELIX_CHUNKER_PROBE_SAMPLES", "7"))
+    top_level_key_count = int(os.environ.get("MELIX_CHUNKER_PROBE_TOP_KEYS", "120"))
+    word_count = int(os.environ.get("MELIX_CHUNKER_PROBE_WORDS", "8000"))
+    chunk_size = int(os.environ.get("MELIX_CHUNKER_PROBE_CHUNK_SIZE", "60"))
+
+    tokenizer = _ProbeTokenizer()
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    chunk_counts: list[int] = []
+
+    for _ in range(sample_count):
+        sample = _build_sample(
+            top_level_key_count=top_level_key_count,
+            word_count=word_count,
+        )
+        tracemalloc.start()
+        started = time.perf_counter()
+        chunked, stats = chunk_long_samples([sample], chunk_size=chunk_size, tokenizer=tokenizer)
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_samples.append(float(peak))
+        if stats.chunk_count != len(chunked) or stats.chunk_count <= 1:
+            raise RuntimeError("chunker probe did not produce multiple valid chunks")
+        if any(chunk.get("tools") is not sample["tools"] for chunk in chunked):
+            raise RuntimeError("chunker probe lost shared top-level tools payload")
+        chunk_counts.append(stats.chunk_count)
+
+    metrics = {
+        "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+        "peak_bytes_mean": round(statistics.fmean(peak_samples), 3),
+        "chunk_count": float(chunk_counts[0]),
+        "top_level_key_count": float(top_level_key_count + 3),
+        "sample_count": float(sample_count),
+    }
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -169,6 +169,18 @@ def test_scope_report_selects_training_dataset_probe() -> None:
     }
 
 
+def test_scope_report_selects_training_dataset_chunker_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=[
+            "services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py"
+        ],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "training-dataset-chunker-top-level-base-copy"
+
+
 def test_scope_report_selects_startup_signals_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -845,6 +857,30 @@ def test_statistical_evidence_bootstrap_probe_script_emits_metrics(
     assert metrics["lower_bound_mean"] <= metrics["upper_bound_mean"]
 
 
+def test_training_dataset_chunker_top_level_copy_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_CHUNKER_PROBE_SAMPLES", "1")
+    monkeypatch.setenv("MELIX_CHUNKER_PROBE_TOP_KEYS", "4")
+    monkeypatch.setenv("MELIX_CHUNKER_PROBE_WORDS", "240")
+    monkeypatch.setenv("MELIX_CHUNKER_PROBE_CHUNK_SIZE", "60")
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/training_dataset_chunker_top_level_copy_probe.py"),
+            run_name="__main__",
+        )
+
+    assert excinfo.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["top_level_key_count"] == 7.0
+    assert metrics["chunk_count"] > 1.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_multimodal_fast_path_signature_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -1025,6 +1061,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "pr-scoped-performance-scope-matcher",
         "training-dataset-token-percentiles-single-sort",
         "training-dataset-validation-sample-limit",
+        "training-dataset-chunker-top-level-base-copy",
         "maintenance-bench-report-readback",
         "maintenance-percentile-vector-reuse",
         "phase8-metrics-closure-audit-reuse",

--- a/services/mlx-worker-python/tests/test_training_dataset_chunker.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_chunker.py
@@ -62,6 +62,18 @@ class _TrackingStr(str):
         raise AssertionError("message payload should not be deep-copied")
 
 
+class _ItemsCountingDict(dict):
+    """Dict that records how often top-level item filtering is requested."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.items_calls = 0
+
+    def items(self):  # type: ignore[override]
+        self.items_calls += 1
+        return super().items()
+
+
 def test_short_single_turn_sample_passes_through_unchanged() -> None:
     tokenizer = _FakeTokenizer()
     sample = {
@@ -279,6 +291,33 @@ def test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads(
             assert message is not source_message
     chunked[0]["messages"][0]["content"] = "mutated"
     assert sample["messages"][0]["content"] == user_content
+
+
+def test_chunked_outputs_filter_top_level_keys_once_per_source_sample() -> None:
+    tokenizer = _FakeTokenizer()
+    metadata = {f"tag-{idx}": idx for idx in range(80)}
+    tools = [{"type": "function", "function": {"name": "lookup"}}]
+    sample = _ItemsCountingDict(
+        {
+            "id": "chunked-top-level-scan",
+            "metadata": metadata,
+            "tools": tools,
+            "messages": [
+                {"role": "user", "content": _words(600)},
+                {"role": "assistant", "content": "ack"},
+            ],
+        }
+    )
+
+    chunked, stats = chunk_long_samples([sample], chunk_size=80, tokenizer=tokenizer)
+
+    assert stats.chunk_count == len(chunked) >= 8
+    assert sample.items_calls == 1
+    for idx, emitted in enumerate(chunked):
+        assert emitted["id"] == f"chunked-top-level-scan#chunk-{idx}"
+        assert emitted["metadata"] is metadata
+        assert emitted["tools"] is tools
+        assert emitted["messages"] is not sample["messages"]
 
 
 def test_multi_turn_single_pair_exceeds_chunk_size_falls_through_to_segmentation() -> None:

--- a/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
@@ -356,12 +356,16 @@ def _chunk_sample(
         )
 
     chunks: list[dict] = []
+    # Preserve any non-messages keys from the source sample (id, tools,
+    # metadata) once per source sample, then shallow-copy that small top-level
+    # base for each emitted chunk. Large long-context samples can emit hundreds
+    # of chunks, so rebuilding this filtered dict inside the chunk loop repeats
+    # the same key scan and metadata reference assignments unnecessarily.
+    output_base = {k: v for k, v in sample.items() if k != "messages"}
     for idx, chunk in enumerate(chunked_messages):
-        # Preserve any non-messages keys from the source sample (id, tools,
-        # metadata) via a shallow top-level copy, then copy only the message
-        # dict containers so each chunk has an independent message list
-        # without re-copying immutable string payloads.
-        out = {k: v for k, v in sample.items() if k != "messages"}
+        # Copy only the message dict containers so each chunk has an independent
+        # message list without re-copying immutable string payloads.
+        out = output_base.copy()
         out["messages"] = _copy_messages(chunk)
         if sample_id:
             out["id"] = f"{sample_id}#chunk-{idx}"


### PR DESCRIPTION
## Summary
- Reuses a single shallow non-`messages` base dict per source sample in the training dataset chunker instead of rebuilding the filtered top-level sample dict for every emitted chunk.
- Adds a focused regression test that tracks top-level `items()` calls for many-chunk samples while preserving copied message containers and shared metadata/tools payloads.
- Registers the `training-dataset-chunker-top-level-base-copy` PR-scoped performance probe with a base-compatible fallback path.

## Plan or Spec
- Plan: `docs/plans/2026-05-05-training-dataset-chunker-top-level-copy.md`
- No protocol, dependency, or generated-artifact changes.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_filter_top_level_keys_once_per_source_sample services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_chunker_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_dataset_chunker_top_level_copy_probe_script_emits_metrics
# 5 passed in 0.07s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_filter_top_level_keys_once_per_source_sample services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_chunker_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_dataset_chunker_top_level_copy_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py services/mlx-worker-python/tests/test_training_dataset_chunker.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/training_dataset_chunker_top_level_copy_probe.py
# 5 passed in 0.14s
# TOTAL 40 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/training_dataset_chunker_top_level_copy_probe.py
# {"chunk_count": 174.0, "elapsed_ms_mean": 43.991409, "peak_bytes_mean": 774473.714, "sample_count": 7.0, "top_level_key_count": 123.0}

python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-chunker-top-level-base-copy --base-repo /tmp/melix-base-chunker-20260505224000 --head-repo /tmp/melix-cron-opt-20260505223546 --output /tmp/chunker-probe-report.json
# head verification: test_ok=True coverage_ok=True
# base: elapsed_ms_mean=46.412918 peak_bytes_mean=772173.714 chunk_count=174.0
# head: elapsed_ms_mean=44.84538 peak_bytes_mean=774473.714 chunk_count=174.0

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 40 0 100%`.
- Registered scoped CI probe: `training-dataset-chunker-top-level-base-copy`.
- Local base-vs-head probe:
  - `elapsed_ms_mean`: `46.412918` → `44.84538` ms (~3.38% lower).
  - `peak_bytes_mean`: `772173.714` → `774473.714` bytes (~0.30% higher, within the 5% warning threshold).
  - `chunk_count`: unchanged at `174.0`.
  - `top_level_key_count`: `123.0`.

## Known Gaps
- Linux-only verification. macOS/Swift checks were not run locally because this slice is Python-only.
- Editing `infra/perf/pr_scoped_probes.json` may fan out the hosted `pr-scoped-performance` workflow beyond this single probe; hosted CI remains the final gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
