### PR TITLE
perf: cache stream assembler reversed prefixes

### DIFF
--- a/docs/plans/2026-05-05-stream-assembler-reversed-prefix-cache.md
+++ b/docs/plans/2026-05-05-stream-assembler-reversed-prefix-cache.md
@@ -1,0 +1,27 @@
+# Stream assembler reversed prefix cache slice
+
+## Scope
+
+This performance slice is limited to the Python request stream assembler structural-tag partial suffix path in `services/mlx-worker-python/worker/runtime/stream_assembler.py`.
+
+The implementation caches the reversed structural prefix tuples selected at assembler initialization so `_partial_structural_tag_suffix()` can resolve the longest held suffix without allocating a `reversed(...)` iterator on every hot-path call.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `stream-assembler-structural-prefix-cache` in `infra/perf/pr_scoped_probes.json`.
+
+This slice extends that probe to report `partial_suffix_elapsed_ms_mean`, which directly times repeated `_partial_structural_tag_suffix()` resolution for a buffer ending in a held `<tool` prefix. The existing focused `test_command`, `coverage_command`, and `probe_command` remain the validation source for this path.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_structural_tag_prefixes_are_cached_per_parser_mode services/mlx-worker-python/tests/test_stream_assembler.py::test_partial_structural_tag_suffix_checks_all_prefixes_in_one_endswith_call services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_structural_tag_prefixes_are_cached_per_parser_mode services/mlx-worker-python/tests/test_stream_assembler.py::test_partial_structural_tag_suffix_checks_all_prefixes_in_one_endswith_call services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_structural_prefix_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_structural_prefix_probe.py
+```
+
+## Expected metric direction
+
+`partial_suffix_elapsed_ms_mean` is expected to decrease because the per-call reversed-prefix iterator allocation is removed. `elapsed_ms_mean` and `peak_bytes_mean` remain guardrail metrics for the existing broad structural-prefix probe loop.

--- a/scripts/stream_assembler_structural_prefix_probe.py
+++ b/scripts/stream_assembler_structural_prefix_probe.py
@@ -33,7 +33,9 @@ def main() -> None:
     elapsed_samples: list[float] = []
     peak_samples: list[float] = []
     held_suffix_hits = 0
+    partial_suffix_hits = 0
     prefix_identity_hits = 0
+    partial_elapsed_samples: list[float] = []
 
     assembler = _build_assembler()
     expected_prefixes = assembler._structural_tag_prefixes
@@ -51,10 +53,20 @@ def main() -> None:
         tracemalloc.stop()
         peak_samples.append(float(peak))
 
+        started = time.perf_counter()
+        for _index in range(iterations):
+            if assembler._partial_structural_tag_suffix() == "<tool":
+                partial_suffix_hits += 1
+        partial_elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+
     expected_hits = iterations * sample_count
     if held_suffix_hits != expected_hits:
         raise RuntimeError(
             f"unexpected partial suffix hits: {held_suffix_hits} != {expected_hits}"
+        )
+    if partial_suffix_hits != expected_hits:
+        raise RuntimeError(
+            f"unexpected partial suffix resolutions: {partial_suffix_hits} != {expected_hits}"
         )
     if prefix_identity_hits != expected_hits:
         raise RuntimeError(
@@ -66,10 +78,16 @@ def main() -> None:
             {
                 "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
                 "elapsed_ms_min": round(min(elapsed_samples), 6),
+                "partial_suffix_elapsed_ms_mean": round(
+                    statistics.fmean(partial_elapsed_samples),
+                    6,
+                ),
+                "partial_suffix_elapsed_ms_min": round(min(partial_elapsed_samples), 6),
                 "peak_bytes_mean": round(statistics.fmean(peak_samples), 3),
                 "iteration_count": float(iterations),
                 "sample_count": float(sample_count),
                 "held_suffix_hits": float(held_suffix_hits),
+                "partial_suffix_hits": float(partial_suffix_hits),
                 "prefix_identity_hits": float(prefix_identity_hits),
             },
             sort_keys=True,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1059,8 +1059,10 @@ def test_stream_assembler_structural_prefix_probe_script_emits_metrics(
     assert metrics["sample_count"] == 1.0
     assert metrics["iteration_count"] == 3.0
     assert metrics["held_suffix_hits"] == 3.0
+    assert metrics["partial_suffix_hits"] == 3.0
     assert metrics["prefix_identity_hits"] == 3.0
     assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["partial_suffix_elapsed_ms_mean"] >= 0
     assert metrics["peak_bytes_mean"] > 0
 
 

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -31,10 +31,18 @@ def test_structural_tag_prefixes_are_cached_per_parser_mode() -> None:
 
     assert tool_enabled._structural_tag_prefixes == think_prefixes + tool_prefixes
     assert tool_enabled._structural_tag_prefixes is tool_enabled._structural_tag_prefixes
+    assert tool_enabled._structural_tag_prefixes_reversed == tuple(
+        reversed(think_prefixes + tool_prefixes)
+    )
+    assert (
+        tool_enabled._structural_tag_prefixes_reversed
+        is tool_enabled._structural_tag_prefixes_reversed
+    )
     assert tool_disabled._structural_tag_prefixes == think_prefixes
     assert tool_enabled._structural_tag_prefixes is tool_enabled._structural_tag_prefixes
     assert tool_disabled._structural_tag_prefixes is tool_disabled._structural_tag_prefixes
     assert tool_disabled._structural_tag_prefixes is RequestStreamAssembler._THINK_PREFIXES
+    assert tool_disabled._structural_tag_prefixes_reversed is RequestStreamAssembler._THINK_PREFIXES_REVERSED
 
 
 def test_parser_mode_flags_are_computed_once_at_initialization() -> None:

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -46,6 +46,8 @@ class RequestStreamAssembler:
     _TOOL_CLOSE = "</tool_call>"
     _THINK_PREFIXES = tuple("<think>"[:index] for index in range(1, len("<think>")))
     _TOOL_PREFIXES = tuple("<tool_call>"[:index] for index in range(1, len("<tool_call>")))
+    _THINK_PREFIXES_REVERSED = tuple(reversed(_THINK_PREFIXES))
+    _TOOL_PREFIXES_REVERSED = tuple(reversed(_TOOL_PREFIXES))
 
     def __init__(
         self,
@@ -67,9 +69,13 @@ class RequestStreamAssembler:
             self._is_json_structured_output_value and not self._tool_parsing_enabled_value
         )
         self._structural_tag_prefixes_value = self._THINK_PREFIXES
+        self._structural_tag_prefixes_reversed_value = self._THINK_PREFIXES_REVERSED
         if self._tool_parsing_enabled_value:
             self._request_context_mode_value = "tool_parser"
             self._structural_tag_prefixes_value = self._THINK_PREFIXES + self._TOOL_PREFIXES
+            self._structural_tag_prefixes_reversed_value = (
+                self._TOOL_PREFIXES_REVERSED + self._THINK_PREFIXES_REVERSED
+            )
         elif self._is_json_structured_output_value:
             self._request_context_mode_value = "structured_json"
         elif self._reasoning_enabled:
@@ -146,6 +152,10 @@ class RequestStreamAssembler:
     @property
     def _structural_tag_prefixes(self) -> tuple[str, ...]:
         return self._structural_tag_prefixes_value
+
+    @property
+    def _structural_tag_prefixes_reversed(self) -> tuple[str, ...]:
+        return self._structural_tag_prefixes_reversed_value
 
     def _unseen_delta(self, raw: str) -> str:
         if raw.startswith(self._raw_seen):
@@ -266,7 +276,7 @@ class RequestStreamAssembler:
         return self._buffer.endswith(self._structural_tag_prefixes)
 
     def _partial_structural_tag_suffix(self) -> str:
-        for prefix in reversed(self._structural_tag_prefixes):
+        for prefix in self._structural_tag_prefixes_reversed:
             if self._buffer.endswith(prefix):
                 return prefix
         return ""


### PR DESCRIPTION
## Summary
- Cache the stream assembler's reversed structural-prefix tuple per parser mode.
- Use the cached reversed tuple when resolving `_partial_structural_tag_suffix()` so the hot path does not allocate a `reversed(...)` iterator per call.
- Extend the registered stream-assembler structural-prefix probe with `partial_suffix_elapsed_ms_mean` for direct CI validation of this slice.

## Plan or Spec
- `docs/plans/2026-05-05-stream-assembler-reversed-prefix-cache.md`

## Commands Run
```text
# focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_structural_tag_prefixes_are_cached_per_parser_mode services/mlx-worker-python/tests/test_stream_assembler.py::test_partial_structural_tag_suffix_checks_all_prefixes_in_one_endswith_call services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_script_emits_metrics
Result: 5 passed in 0.11s

# changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_structural_tag_prefixes_are_cached_per_parser_mode services/mlx-worker-python/tests/test_stream_assembler.py::test_partial_structural_tag_suffix_checks_all_prefixes_in_one_endswith_call services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_structural_prefix_probe.py
Result: 5 passed; aggregate changed-line coverage TOTAL 22 1 95%

# registered probe command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_structural_prefix_probe.py
Result: {"elapsed_ms_mean": 574.667686, "elapsed_ms_min": 534.691197, "held_suffix_hits": 1750000.0, "iteration_count": 250000.0, "partial_suffix_elapsed_ms_mean": 183.916839, "partial_suffix_elapsed_ms_min": 173.605118, "partial_suffix_hits": 1750000.0, "peak_bytes_mean": 168.0, "prefix_identity_hits": 1750000.0, "sample_count": 7.0}

# git hygiene
git diff --check
Result: exit 0
```

## Coverage and Metrics
- Changed-scope coverage: aggregate `TOTAL 22 1 95%`.
- Local comparison probe for `_partial_structural_tag_suffix()` over 250,000 iterations x 7 samples x 3 runs:
  - baseline mean: `225.999294 ms`
  - new mean: `190.626798 ms`
  - delta: `-35.372496 ms`
  - speedup: `1.1856x` (`15.65%` lower)
- Registered local probe after the change: `partial_suffix_elapsed_ms_mean=183.916839 ms`.
- CI PR-scoped performance workflow is required for the registered probe report before merge.

## Known Gaps
- None for the Python slice. Swift/macOS runtime effects are not involved.
- The CI registered probe report is still required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
