### PR TITLE
perf: cache MLX audio generate signature

### DIFF
--- a/docs/plans/2026-05-05-mlx-audio-generate-signature-cache.md
+++ b/docs/plans/2026-05-05-mlx-audio-generate-signature-cache.md
@@ -1,0 +1,37 @@
+# MLX Audio Generate Signature Cache Plan
+
+## Goal
+
+Avoid repeated `inspect.signature(...)` calls on the MLX audio TTS `generate` method for every `speak(...)` request. The generate signature is stable for a loaded model, so the runtime can cache the parameter names at `load_model(...)` time and reuse them during request dispatch.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/runtime/audio_runtime_protocols.py`
+- `services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py`
+- `services/mlx-worker-python/tests/test_mlx_audio_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/mlx_audio_generate_signature_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux-Only Constraint
+
+This is a Python-only runtime slice and is verified on Linux with fake MLX audio model objects. It does not require the macOS/Swift surfaces or real MLX audio packages.
+
+## Performance Probe
+
+Registered PR-scoped probe: `mlx-audio-generate-signature-cache`.
+
+The probe runs repeated `MLXAudioSpeechRuntime.speak(...)` calls against a fake TTS model while wrapping `worker.runtime.mlx_audio_runtime.signature` to count per-request signature introspection calls.
+
+## Success Metrics
+
+- `signature_calls_mean` should drop to `0.0` during the repeated `speak(...)` loop on the optimized branch.
+- `elapsed_ms_mean` is recorded as informational because the structural reflection-call metric is the stable signal for this tiny Python hot path.
+- Focused tests and changed-scope coverage must pass with at least 95% coverage for changed executable lines.
+
+## Verification Commands
+
+- Focused pytest for MLX audio and PR-scoped probe tests.
+- Changed-scope coverage over the touched Python/test/script files.
+- Local run of `scripts/mlx_audio_generate_signature_probe.py`.
+- `git diff --check`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1909,5 +1909,36 @@
         "warn_pct": 5.0
       }
     ]
+  },
+  {
+    "id": "mlx-audio-generate-signature-cache",
+    "name": "MLX audio generate signature cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py",
+      "services/mlx-worker-python/worker/runtime/audio_runtime_protocols.py",
+      "services/mlx-worker-python/tests/test_mlx_audio_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/mlx_audio_generate_signature_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_signature_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_generate_signature_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_signature_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_generate_signature_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py services/mlx-worker-python/worker/runtime/audio_runtime_protocols.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_audio_generate_signature_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/mlx_audio_generate_signature_probe.py ]; then python scripts/mlx_audio_generate_signature_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"CmltcG9ydCBqc29uCmltcG9ydCBvcwppbXBvcnQgc3RhdGlzdGljcwppbXBvcnQgc3lzCmltcG9ydCB0aW1lCmZyb20gZGF0YWNsYXNzZXMgaW1wb3J0IGZpZWxkcwpmcm9tIHBhdGhsaWIgaW1wb3J0IFBhdGgKcmVwb19yb290ID0gUGF0aC5jd2QoKQpzeXMucGF0aC5pbnNlcnQoMCwgc3RyKHJlcG9fcm9vdCkpCnN5cy5wYXRoLmluc2VydCgwLCBzdHIocmVwb19yb290IC8gInNlcnZpY2VzL21seC13b3JrZXItcHl0aG9uIikpCmZyb20gd29ya2VyLnJ1bnRpbWUgaW1wb3J0IG1seF9hdWRpb19ydW50aW1lCmZyb20gd29ya2VyLnJ1bnRpbWUuYXVkaW9fcnVudGltZV9wcm90b2NvbHMgaW1wb3J0IEF1ZGlvUnVudGltZUxvYWRlZE1vZGVsCmZyb20gcGFja2FnZXMucHJvdG9jb2wucHl0aG9uLndvcmtlci52MSBpbXBvcnQgaW5mZXJlbmNlX3BiMgpjbGFzcyBGYWtlQ2h1bms6CiAgICBkZWYgX19pbml0X18oc2VsZik6CiAgICAgICAgc2VsZi5hdWRpbyA9IFswLjEsIC0wLjEsIDAuMF0KICAgICAgICBzZWxmLnNhbXBsZV9yYXRlID0gMjQwMDAKY2xhc3MgRmFrZVRUU01vZGVsOgogICAgZGVmIGdlbmVyYXRlKHNlbGYsIHRleHQsIHZvaWNlPU5vbmUsIGluc3RydWN0PU5vbmUsIHNwZWVkPTEuMCwgdmVyYm9zZT1GYWxzZSk6CiAgICAgICAgXyA9ICh0ZXh0LCB2b2ljZSwgaW5zdHJ1Y3QsIHNwZWVkLCB2ZXJib3NlKQogICAgICAgIHlpZWxkIEZha2VDaHVuaygpCmRlZiBsb2FkZWRfbW9kZWwobW9kZWwpOgogICAga3dhcmdzID0geyJiYWNrZW5kX2lkIjogIm1seF9hdWRpby50dHMiLCAiZmFtaWx5X2lkIjogInF3ZW4zLXR0cyIsICJydW50aW1lX25hbWUiOiAibWx4LWF1ZGlvLXR0cyIsICJtb2RlbCI6IG1vZGVsLCAidm9pY2VfbW9kZSI6ICJoeWJyaWQiLCAic3VwcG9ydHNfaW5zdHJ1Y3Rpb25zIjogVHJ1ZSwgIm91dHB1dF9mb3JtYXRzIjogKCJ3YXYiLCl9CiAgICBmaWVsZF9uYW1lcyA9IHtmaWVsZC5uYW1lIGZvciBmaWVsZCBpbiBmaWVsZHMoQXVkaW9SdW50aW1lTG9hZGVkTW9kZWwpfQogICAgaWYgImdlbmVyYXRlX3BhcmFtZXRlcl9uYW1lcyIgaW4gZmllbGRfbmFtZXM6CiAgICAgICAga3dhcmdzWyJnZW5lcmF0ZV9wYXJhbWV0ZXJfbmFtZXMiXSA9IHR1cGxlKG1seF9hdWRpb19ydW50aW1lLnNpZ25hdHVyZShtb2RlbC5nZW5lcmF0ZSkucGFyYW1ldGVycykKICAgIHJldHVybiBBdWRpb1J1bnRpbWVMb2FkZWRNb2RlbCgqKmt3YXJncykKaXRlcmF0aW9ucyA9IGludChvcy5lbnZpcm9uLmdldCgiTUVMSVhfTUxYX0FVRElPX1NJR05BVFVSRV9QUk9CRV9JVEVSQVRJT05TIiwgIjUwMDAiKSkKc2FtcGxlX2NvdW50ID0gaW50KG9zLmVudmlyb24uZ2V0KCJNRUxJWF9NTFhfQVVESU9fU0lHTkFUVVJFX1BST0JFX1NBTVBMRVMiLCAiNSIpKQplbGFwc2VkX3NhbXBsZXMgPSBbXQpzaWduYXR1cmVfY2FsbF9zYW1wbGVzID0gW10KYnl0ZV9jb3VudCA9IDAKb3JpZ2luYWxfc2lnbmF0dXJlID0gbWx4X2F1ZGlvX3J1bnRpbWUuc2lnbmF0dXJlCmZvciBfIGluIHJhbmdlKHNhbXBsZV9jb3VudCk6CiAgICBzaWduYXR1cmVfY2FsbHMgPSAwCiAgICBkZWYgdHJhY2tlZF9zaWduYXR1cmUoY2FsbGFibGVfb2JqKToKICAgICAgICBub25sb2NhbF9zaWduYXR1cmVfY2FsbHNbMF0gKz0gMQogICAgICAgIHJldHVybiBvcmlnaW5hbF9zaWduYXR1cmUoY2FsbGFibGVfb2JqKQogICAgbm9ubG9jYWxfc2lnbmF0dXJlX2NhbGxzID0gWzBdCiAgICBtb2RlbCA9IEZha2VUVFNNb2RlbCgpCiAgICBtbHhfYXVkaW9fcnVudGltZS5zaWduYXR1cmUgPSB0cmFja2VkX3NpZ25hdHVyZQogICAgdHJ5OgogICAgICAgIGxvYWRlZCA9IGxvYWRlZF9tb2RlbChtb2RlbCkKICAgICAgICBydW50aW1lID0gbWx4X2F1ZGlvX3J1bnRpbWUuTUxYQXVkaW9TcGVlY2hSdW50aW1lKCkKICAgICAgICByZXF1ZXN0ID0gaW5mZXJlbmNlX3BiMi5TcGVha1JlcXVlc3QoaW5wdXQ9InNpZ25hdHVyZSBjYWNoZSBwcm9iZSIsIHZvaWNlPSJhbGxveSIsIGluc3RydWN0aW9ucz0iU3BlYWsgY2FsbWx5LiIsIGZvcm1hdD0id2F2IikKICAgICAgICBub25sb2NhbF9zaWduYXR1cmVfY2FsbHNbMF0gPSAwCiAgICAgICAgc3RhcnRlZF9hdCA9IHRpbWUucGVyZl9jb3VudGVyKCkKICAgICAgICBmb3IgX2luZGV4IGluIHJhbmdlKGl0ZXJhdGlvbnMpOgogICAgICAgICAgICByZXN1bHQgPSBydW50aW1lLnNwZWFrKGxvYWRlZCwgcmVxdWVzdCkKICAgICAgICAgICAgYnl0ZV9jb3VudCArPSBsZW4ocmVzdWx0LmF1ZGlvX2J5dGVzKQogICAgICAgIGVsYXBzZWRfc2FtcGxlcy5hcHBlbmQoKHRpbWUucGVyZl9jb3VudGVyKCkgLSBzdGFydGVkX2F0KSAqIDEwMDAuMCkKICAgICAgICBzaWduYXR1cmVfY2FsbF9zYW1wbGVzLmFwcGVuZChmbG9hdChub25sb2NhbF9zaWduYXR1cmVfY2FsbHNbMF0pKQogICAgZmluYWxseToKICAgICAgICBtbHhfYXVkaW9fcnVudGltZS5zaWduYXR1cmUgPSBvcmlnaW5hbF9zaWduYXR1cmUKaWYgYnl0ZV9jb3VudCA8PSAwOgogICAgcmFpc2UgUnVudGltZUVycm9yKCJtbHgtYXVkaW8gc2lnbmF0dXJlIHByb2JlIHByb2R1Y2VkIG5vIGF1ZGlvIGJ5dGVzIikKcHJpbnQoanNvbi5kdW1wcyh7ImVsYXBzZWRfbXNfbWVhbiI6IHN0YXRpc3RpY3MuZm1lYW4oZWxhcHNlZF9zYW1wbGVzKSwgInNpZ25hdHVyZV9jYWxsc19tZWFuIjogc3RhdGlzdGljcy5mbWVhbihzaWduYXR1cmVfY2FsbF9zYW1wbGVzKSwgIml0ZXJhdGlvbnNfcGVyX3NhbXBsZSI6IGZsb2F0KGl0ZXJhdGlvbnMpLCAic2FtcGxlX2NvdW50IjogZmxvYXQoc2FtcGxlX2NvdW50KSwgImF1ZGlvX2J5dGVzX3RvdGFsIjogZmxvYXQoYnl0ZV9jb3VudCl9LCBzb3J0X2tleXM9VHJ1ZSkpCg==\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "signature_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "informational"
+      }
+    ]
   }
 ]

--- a/scripts/mlx_audio_generate_signature_probe.py
+++ b/scripts/mlx_audio_generate_signature_probe.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+from dataclasses import fields
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime import mlx_audio_runtime
+from worker.runtime.audio_runtime_protocols import AudioRuntimeLoadedModel
+from packages.protocol.python.worker.v1 import inference_pb2
+
+
+class FakeChunk:
+    def __init__(self) -> None:
+        self.audio = [0.1, -0.1, 0.0]
+        self.sample_rate = 24_000
+
+
+class FakeTTSModel:
+    def generate(self, text, voice=None, instruct=None, speed=1.0, verbose=False):
+        _ = (text, voice, instruct, speed, verbose)
+        yield FakeChunk()
+
+
+def _loaded_model(model: FakeTTSModel) -> AudioRuntimeLoadedModel:
+    kwargs = {
+        "backend_id": "mlx_audio.tts",
+        "family_id": "qwen3-tts",
+        "runtime_name": "mlx-audio-tts",
+        "model": model,
+        "voice_mode": "hybrid",
+        "supports_instructions": True,
+        "output_formats": ("wav",),
+    }
+    field_names = {field.name for field in fields(AudioRuntimeLoadedModel)}
+    if "generate_parameter_names" in field_names:
+        kwargs["generate_parameter_names"] = tuple(mlx_audio_runtime.signature(model.generate).parameters)
+    return AudioRuntimeLoadedModel(**kwargs)
+
+
+def run_probe() -> dict[str, float]:
+    iterations = int(os.environ.get("MELIX_MLX_AUDIO_SIGNATURE_PROBE_ITERATIONS", "5000"))
+    sample_count = int(os.environ.get("MELIX_MLX_AUDIO_SIGNATURE_PROBE_SAMPLES", "5"))
+    elapsed_samples: list[float] = []
+    signature_call_samples: list[float] = []
+    byte_count = 0
+    original_signature = mlx_audio_runtime.signature
+
+    for _ in range(sample_count):
+        signature_calls = 0
+
+        def tracked_signature(callable_obj):
+            nonlocal signature_calls
+            signature_calls += 1
+            return original_signature(callable_obj)
+
+        model = FakeTTSModel()
+        mlx_audio_runtime.signature = tracked_signature
+        try:
+            loaded_model = _loaded_model(model)
+            runtime = mlx_audio_runtime.MLXAudioSpeechRuntime()
+            request = inference_pb2.SpeakRequest(
+                input="signature cache probe",
+                voice="alloy",
+                instructions="Speak calmly.",
+                format="wav",
+            )
+            signature_calls = 0
+            started_at = time.perf_counter()
+            for _index in range(iterations):
+                result = runtime.speak(loaded_model, request)
+                byte_count += len(result.audio_bytes)
+            elapsed_samples.append((time.perf_counter() - started_at) * 1000.0)
+            signature_call_samples.append(float(signature_calls))
+        finally:
+            mlx_audio_runtime.signature = original_signature
+
+    if byte_count <= 0:
+        raise RuntimeError("mlx-audio signature probe produced no audio bytes")
+
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "signature_calls_mean": statistics.fmean(signature_call_samples),
+        "iterations_per_sample": float(iterations),
+        "sample_count": float(sample_count),
+        "audio_bytes_total": float(byte_count),
+    }
+
+
+def main() -> int:
+    print(json.dumps(run_probe(), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
@@ -204,6 +204,55 @@ def test_mlx_audio_speech_runtime_detects_voice_mode_and_maps_voice_and_instruct
     ]
 
 
+def test_mlx_audio_speech_runtime_reuses_generate_signature_from_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import worker.runtime.mlx_audio_runtime as mlx_audio_runtime
+    from worker.runtime.mlx_audio_runtime import MLXAudioSpeechRuntime
+
+    signature_calls = 0
+    original_signature = mlx_audio_runtime.signature
+
+    class FakeChunk:
+        def __init__(self, audio):
+            self.audio = audio
+            self.sample_rate = 24_000
+
+    class FakeTTSModel:
+        def generate(self, text, voice=None, instruct=None, speed=1.0, verbose=False):
+            yield FakeChunk([0.1, -0.1, 0.0])
+
+    def fake_load_model(model_path: str, strict: bool = True):
+        return FakeTTSModel()
+
+    def tracked_signature(callable_obj):
+        nonlocal signature_calls
+        signature_calls += 1
+        return original_signature(callable_obj)
+
+    _install_fake_mlx_audio(monkeypatch, tts_loader=fake_load_model)
+    monkeypatch.setattr(mlx_audio_runtime, "signature", tracked_signature)
+
+    runtime = MLXAudioSpeechRuntime()
+    loaded = runtime.load_model(WorkerModelCatalog.mlx_qwen3_tts_model())
+    assert loaded.generate_parameter_names == ("text", "voice", "instruct", "speed", "verbose")
+    assert signature_calls == 1
+
+    for index in range(3):
+        result = runtime.speak(
+            loaded,
+            inference_pb2.SpeakRequest(
+                input=f"hello cached signature {index}",
+                voice="alloy",
+                instructions="Speak calmly.",
+                format="wav",
+            ),
+        )
+        assert result.audio_bytes.startswith(b"RIFF")
+
+    assert signature_calls == 1
+
+
 def test_mlx_audio_speech_runtime_falls_back_to_voice_descriptor_only_for_instructional_models(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -143,6 +143,16 @@ def test_scope_report_selects_mlx_audio_wav_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "mlx-audio-wav-streaming-pcm"
 
 
+def test_scope_report_selects_mlx_audio_signature_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "mlx-audio-generate-signature-cache"
+
+
 def test_scope_report_selects_only_matching_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -1013,6 +1023,28 @@ def test_mlx_audio_wav_streaming_probe_script_emits_metrics(
     assert metrics["sample_count"] == 240000.0
     assert metrics["wav_bytes"] == 480044.0
     assert metrics["peak_bytes_mean"] > 0
+    assert metrics["elapsed_ms_mean"] >= 0
+
+
+def test_mlx_audio_generate_signature_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_MLX_AUDIO_SIGNATURE_PROBE_ITERATIONS", "3")
+    monkeypatch.setenv("MELIX_MLX_AUDIO_SIGNATURE_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/mlx_audio_generate_signature_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["iterations_per_sample"] == 3.0
+    assert metrics["signature_calls_mean"] == 0.0
+    assert metrics["audio_bytes_total"] > 0
     assert metrics["elapsed_ms_mean"] >= 0
 
 

--- a/services/mlx-worker-python/worker/runtime/audio_runtime_protocols.py
+++ b/services/mlx-worker-python/worker/runtime/audio_runtime_protocols.py
@@ -52,6 +52,7 @@ class AudioRuntimeLoadedModel:
     voice_mode: str = ""
     supports_instructions: bool = False
     output_formats: tuple[str, ...] = ()
+    generate_parameter_names: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
@@ -241,9 +241,9 @@ class MLXAudioSpeechRuntime:
         except TypeError:
             model = load_model(model_spec.model_path)
 
-        params = signature(model.generate).parameters
-        supports_voice = "voice" in params
-        supports_instructions = "instruct" in params
+        generate_parameter_names = tuple(signature(model.generate).parameters)
+        supports_voice = "voice" in generate_parameter_names
+        supports_instructions = "instruct" in generate_parameter_names
         if supports_voice and supports_instructions:
             voice_mode = "hybrid"
         elif supports_instructions:
@@ -261,6 +261,7 @@ class MLXAudioSpeechRuntime:
             voice_mode=voice_mode,
             supports_instructions=supports_instructions,
             output_formats=("wav",),
+            generate_parameter_names=generate_parameter_names,
         )
 
     def estimate_resident_bytes(self, model_spec) -> int:
@@ -271,7 +272,7 @@ class MLXAudioSpeechRuntime:
         if requested_format != "wav":
             raise ValueError("mlx-audio speech backend only supports wav output.")
 
-        params = signature(loaded_model.model.generate).parameters
+        params = loaded_model.generate_parameter_names or tuple(signature(loaded_model.model.generate).parameters)
         kwargs = {
             "text": request.input,
             "verbose": False,


### PR DESCRIPTION
## Summary
- Cache MLX audio TTS `generate` parameter names on `AudioRuntimeLoadedModel` at model-load time.
- Reuse the cached parameter names in `MLXAudioSpeechRuntime.speak(...)` instead of reflecting on `model.generate` for every speech request.
- Add a focused regression test and a registered PR-scoped performance probe for the reflection-call reduction.

## Plan or Spec
- `docs/plans/2026-05-05-mlx-audio-generate-signature-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_signature_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_generate_signature_probe_script_emits_metrics
# 12 passed in 0.91s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_signature_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_mlx_audio_generate_signature_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py services/mlx-worker-python/worker/runtime/audio_runtime_protocols.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_audio_generate_signature_probe.py
# 12 passed; TOTAL 48 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_MLX_AUDIO_SIGNATURE_PROBE_ITERATIONS=5000 MELIX_MLX_AUDIO_SIGNATURE_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python scripts/mlx_audio_generate_signature_probe.py
# {"audio_bytes_total": 1250000.0, "elapsed_ms_mean": 53.98436279501766, "iterations_per_sample": 5000.0, "sample_count": 5.0, "signature_calls_mean": 0.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_MLX_AUDIO_SIGNATURE_PROBE_ITERATIONS=5000 MELIX_MLX_AUDIO_SIGNATURE_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id mlx-audio-generate-signature-cache --base-repo /tmp/melix-base-mlx-audio-202605052326 --head-repo "$PWD" --output /tmp/mlx-audio-signature-report.json
# head verification passed; base signature_calls_mean=5000.0, head signature_calls_mean=0.0

# git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 48 0 100%`.
- Registered scoped CI probe: `mlx-audio-generate-signature-cache`.
- Local head probe: `signature_calls_mean=0.0`, `elapsed_ms_mean=53.984 ms` for 5 samples × 5000 `speak(...)` calls.
- Local base-vs-head PR-scoped probe comparison:
  - base: `signature_calls_mean=5000.0`, `elapsed_ms_mean=198.977 ms`
  - head: `signature_calls_mean=0.0`, `elapsed_ms_mean=53.400 ms`
- `elapsed_ms_mean` is informational in the registered probe; `signature_calls_mean` is the stable gated metric for this tiny reflection-cache slice.

## Known Gaps
- Full `make py-test`, Swift tests, and integration tests were not run locally on this Linux cron host.
- Hosted CI is expected to provide the repository-level and PR-scoped validation after PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf/schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
