### PR TITLE
perf: avoid full sort for dialogue diagnostics

### DIFF
--- a/docs/plans/2026-05-06-event-dialogue-diagnostics-top-k.md
+++ b/docs/plans/2026-05-06-event-dialogue-diagnostics-top-k.md
@@ -1,0 +1,40 @@
+# Event Dialogue Diagnostics Top-K Probe Plan
+
+## Goal
+
+Reduce redundant work in event-extraction dialogue diagnostics by avoiding a full sort when the summary only keeps the five slowest dialogue traces.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/engine/evaluation_core.py`
+- `services/mlx-worker-python/tests/test_event_extraction.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux-Only Constraint
+
+This is a Python worker optimization and can be verified on Linux with focused pytest, changed-scope coverage, and the PR-scoped performance harness.
+
+## Performance Probe Definition
+
+Register `evaluation-dialogue-diagnostics-top-k` in `infra/perf/pr_scoped_probes.json`.
+
+The probe builds a large synthetic dialogue trace list, repeatedly calls `EvaluationCore._event_extraction_dialogue_diagnostics(...)`, and reports:
+
+- `elapsed_ms_mean` — lower is better.
+- `sorted_calls_mean` — lower is better; expected to drop from one full `sorted(...)` call per diagnostics pass to zero.
+- `trace_count` and `iteration_count` — structural workload metrics.
+
+## Success Metrics
+
+- Preserve the exact five slowest-dialogue payloads and ordering.
+- Focused tests pass.
+- Changed executable line coverage is at least 95%.
+- Local base-vs-head scoped probe shows zero full-sort calls and improved elapsed time.
+
+## Verification Commands
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json ... && python scripts/changed_scope_coverage.py ...`
+- `python scripts/pr_scoped_performance_run.py --probe evaluation-dialogue-diagnostics-top-k --base-ref origin/main --head-ref HEAD --output /tmp/...json`
+- `git diff --check`

--- a/services/mlx-worker-python/tests/test_event_extraction.py
+++ b/services/mlx-worker-python/tests/test_event_extraction.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import json
 from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
@@ -22,6 +23,34 @@ from worker.productization.event_extraction import (
     RemoteEventExtractionTarget,
     write_event_prediction_rows,
 )
+
+
+def test_event_dialogue_diagnostics_keeps_top_five_without_full_sort(monkeypatch) -> None:
+    traces = [
+        {"dialogue_id": f"dlg-{index}", "line_number": index, "status": "ok", "total_duration_ms": float(index)}
+        for index in range(30)
+    ]
+    traces[3]["provider_usage"] = {"prompt_tokens": 2.0, "ignored_bool": True}
+
+    def fail_sorted(*args, **kwargs):  # pragma: no cover - exercised only on regression
+        if args and args[0] is traces:
+            raise AssertionError("slowest dialogue diagnostics should not fully sort all traces")
+        return original_sorted(*args, **kwargs)
+
+    original_sorted = builtins.sorted
+    monkeypatch.setattr(builtins, "sorted", fail_sorted)
+
+    diagnostics = EvaluationCore._event_extraction_dialogue_diagnostics(traces)
+
+    assert diagnostics["provider_usage_totals"] == {"prompt_tokens": 2}
+    assert diagnostics["dialogue_status_counts"] == {"ok": 30, "failed": 0, "aborted": 0}
+    assert diagnostics["slowest_dialogues"] == [
+        {"dialogue_id": "dlg-29", "line_number": 29, "duration_ms": 29.0, "status": "ok"},
+        {"dialogue_id": "dlg-28", "line_number": 28, "duration_ms": 28.0, "status": "ok"},
+        {"dialogue_id": "dlg-27", "line_number": 27, "duration_ms": 27.0, "status": "ok"},
+        {"dialogue_id": "dlg-26", "line_number": 26, "duration_ms": 26.0, "status": "ok"},
+        {"dialogue_id": "dlg-25", "line_number": 25, "duration_ms": 25.0, "status": "ok"},
+    ]
 
 
 def test_default_event_extraction_prompt_spec_uses_baseline_v6_feedback_rules() -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1071,6 +1071,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "runtime-utils-kwarg-signature-cache",
         "mlx-audio-wav-streaming-pcm",
         "dev-up-mlx-metal-dist-info-scandir",
+        "evaluation-dialogue-diagnostics-top-k",
         "evaluation-job-id-high-water-mark",
         "evaluation-dialogue-diagnostics-top-k",
         "evaluation-final-result-materialization-streaming",


### PR DESCRIPTION
## Summary
- Replaces the event-extraction dialogue diagnostics full-trace sort with `heapq.nlargest(5, ...)` so only the retained slowest-dialogue window is selected.
- Adds a regression test that fails if the slowest-dialogue path fully sorts the original trace list.
- Registers the `evaluation-dialogue-diagnostics-top-k` PR-scoped performance probe for hosted base-vs-head validation.

## Plan or Spec
- Plan: `docs/plans/2026-05-06-event-dialogue-diagnostics-top-k.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_event_dialogue_diagnostics_keeps_top_five_without_full_sort services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 3 passed in 0.78s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_event_dialogue_diagnostics_keeps_top_five_without_full_sort services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 3 passed in 0.26s; TOTAL 13 0 100%

python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-dialogue-diagnostics-top-k --base-repo /tmp/melix-cron-opt-20260506010759-base --head-repo /tmp/melix-cron-opt-20260506010759 --output /tmp/evaluation-dialogue-diagnostics-top-k.json
# head verification ok; base/head probe ok

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Local `evaluation-dialogue-diagnostics-top-k` probe (`trace_count=30000`, `iteration_count=18`):
  - `elapsed_ms_mean`: base `857.541314` ms → head `797.019196` ms (~7.06% lower).
  - `sorted_calls_mean`: base `1.0` → head `0.0` for the original trace-list sort.
  - `slowest_count`: base/head `5.0`.

## Known Gaps
- Linux-only local verification; macOS/Swift checks were not run locally because this slice only changes Python worker diagnostics and PR-scoped CI registry/test metadata.
- Full repository `make py-test`, `make swift-test`, and integration tests were not run locally; hosted CI remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
