### PR TITLE
perf: reduce dataset registry snapshot inference passes

### DIFF
--- a/docs/plans/2026-05-06-dataset-registry-snapshot-inference-single-pass.md
+++ b/docs/plans/2026-05-06-dataset-registry-snapshot-inference-single-pass.md
@@ -1,0 +1,46 @@
+# Dataset Registry Snapshot Inference Single-Pass Optimization
+
+## Goal
+
+Reduce redundant work in Hugging Face dataset snapshot discovery by deriving the file list, total byte count, split names, and config names in one pass over supported dataset files.
+
+## Scope
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_registry_snapshot_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux Constraint
+
+This is a Python worker slice and is locally verifiable on Linux with focused pytest, changed-scope coverage, and an explicit performance probe.
+
+## Performance Probe
+
+Registered scoped CI probe: `dataset-registry-snapshot-inference-single-pass`.
+
+The probe builds a synthetic Hugging Face dataset cache with many supported files, wraps the legacy split/config inference helpers to count calls, and runs `DatasetCatalog.registry_snapshot_payload()` while measuring:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- `legacy_inference_helper_calls_mean`
+- `file_count_mean`
+
+## Success Metrics
+
+- Preserve dataset snapshot payload shape, ordering, split/config inference, and total byte reporting.
+- Drive `legacy_inference_helper_calls_mean` to `0.0` on the optimized branch for snapshot builds.
+- Keep changed-scope automated coverage at or above 95%.
+- Keep the registered scoped CI probe selected for dataset registry changes.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/dataset_registry_snapshot_probe.py
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -67,6 +67,43 @@
     ]
   },
   {
+    "id": "dataset-registry-snapshot-inference-single-pass",
+    "name": "Dataset registry snapshot inference single pass",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/dataset_registry/catalog.py",
+      "services/mlx-worker-python/tests/test_dataset_registry.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/dataset_registry_snapshot_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/dataset_registry_snapshot_probe.py ]; then python scripts/dataset_registry_snapshot_probe.py; else python -c \"import base64; exec(base64.b64decode(\\\"aW1wb3J0IGpzb24KaW1wb3J0IG9zCmltcG9ydCBzdGF0aXN0aWNzCmltcG9ydCBzeXMKaW1wb3J0IHRlbXBmaWxlCmltcG9ydCB0aW1lCmltcG9ydCB0cmFjZW1hbGxvYwpmcm9tIHBhdGhsaWIgaW1wb3J0IFBhdGgKcmVwb19yb290ID0gUGF0aC5jd2QoKQpzeXMucGF0aC5pbnNlcnQoMCwgb3MuZnNwYXRoKHJlcG9fcm9vdCkpCnN5cy5wYXRoLmluc2VydCgwLCBvcy5mc3BhdGgocmVwb19yb290IC8gInNlcnZpY2VzL21seC13b3JrZXItcHl0aG9uIikpCmltcG9ydCB3b3JrZXIuZGF0YXNldF9yZWdpc3RyeS5jYXRhbG9nIGFzIGNhdGFsb2cKZnJvbSB3b3JrZXIuZGF0YXNldF9yZWdpc3RyeS5jYXRhbG9nIGltcG9ydCBEYXRhc2V0Q2F0YWxvZwoKZGVmIHdyaXRlX3Byb2JlX3NuYXBzaG90KGhvbWUsIGZpbGVfY291bnQpOgogICAgY2FjaGVfcmVwb19kaXIgPSBob21lIC8gIi5jYWNoZSIgLyAiaHVnZ2luZ2ZhY2UiIC8gImh1YiIgLyAiZGF0YXNldHMtLW9yZy0tcHJvYmUiCiAgICBzbmFwc2hvdF9kaXIgPSBjYWNoZV9yZXBvX2RpciAvICJzbmFwc2hvdHMiIC8gInNuYXBzaG90LXByb2JlIgogICAgcmVmc19kaXIgPSBjYWNoZV9yZXBvX2RpciAvICJyZWZzIgogICAgcmVmc19kaXIubWtkaXIocGFyZW50cz1UcnVlKQogICAgcmVmc19kaXIuam9pbnBhdGgoIm1haW4iKS53cml0ZV90ZXh0KCJzbmFwc2hvdC1wcm9iZSIsIGVuY29kaW5nPSJ1dGYtOCIpCiAgICBleHBlY3RlZF9maWxlcyA9IDAKICAgIHNwbGl0cyA9ICgidHJhaW4iLCAidmFsaWRhdGlvbiIsICJ0ZXN0IikKICAgIHJvd19wYXlsb2FkID0ganNvbi5kdW1wcyh7InByb21wdCI6ICJoZWxsbyIsICJhbnN3ZXIiOiAid29ybGQifSkgKyAiXG4iCiAgICBmb3IgaW5kZXggaW4gcmFuZ2UoZmlsZV9jb3VudCk6CiAgICAgICAgY29uZmlnID0gZiJjb25maWcte2luZGV4ICUgMTI6MDJkfSIKICAgICAgICBzcGxpdCA9IHNwbGl0c1tpbmRleCAlIGxlbihzcGxpdHMpXQogICAgICAgIGRhdGFfZGlyID0gc25hcHNob3RfZGlyIC8gY29uZmlnCiAgICAgICAgZGF0YV9kaXIubWtkaXIocGFyZW50cz1UcnVlLCBleGlzdF9vaz1UcnVlKQogICAgICAgIChkYXRhX2RpciAvIGYie3NwbGl0fS17aW5kZXg6MDVkfS5qc29ubCIpLndyaXRlX3RleHQocm93X3BheWxvYWQsIGVuY29kaW5nPSJ1dGYtOCIpCiAgICAgICAgZXhwZWN0ZWRfZmlsZXMgKz0gMQogICAgc25hcHNob3RfZGlyLmpvaW5wYXRoKCJSRUFETUUubWQiKS53cml0ZV90ZXh0KCIjIFByb2JlIGRhdGFzZXRcbiIsIGVuY29kaW5nPSJ1dGYtOCIpCiAgICByZXR1cm4gZXhwZWN0ZWRfZmlsZXMgKyAxCgpmaWxlX2NvdW50ID0gMjQwMApzYW1wbGVzID0gNQplbGFwc2VkX3NhbXBsZXMgPSBbXQpwZWFrX3NhbXBsZXMgPSBbXQpoZWxwZXJfY2FsbF9zYW1wbGVzID0gW10KZmlsZV9jb3VudF9zYW1wbGVzID0gW10Kb3JpZ2luYWxfc3BsaXQgPSBjYXRhbG9nLl9pbmZlcnJlZF9zcGxpdApvcmlnaW5hbF9jb25maWcgPSBjYXRhbG9nLl9pbmZlcnJlZF9jb25maWcKZm9yIF8gaW4gcmFuZ2Uoc2FtcGxlcyk6CiAgICB3aXRoIHRlbXBmaWxlLlRlbXBvcmFyeURpcmVjdG9yeShwcmVmaXg9Im1lbGl4LWRhdGFzZXQtcmVnaXN0cnktcHJvYmUtIikgYXMgdG1wOgogICAgICAgIGhvbWUgPSBQYXRoKHRtcCkgLyAiaG9tZSIKICAgICAgICBleHBlY3RlZF9maWxlcyA9IHdyaXRlX3Byb2JlX3NuYXBzaG90KGhvbWUsIGZpbGVfY291bnQpCiAgICAgICAgbm9ubG9jYWxfaGVscGVyID0gWzBdCiAgICAgICAgZGVmIGNvdW50ZWRfc3BsaXQocmVsYXRpdmVfcGF0aCk6CiAgICAgICAgICAgIG5vbmxvY2FsX2hlbHBlclswXSArPSAxCiAgICAgICAgICAgIHJldHVybiBvcmlnaW5hbF9zcGxpdChyZWxhdGl2ZV9wYXRoKQogICAgICAgIGRlZiBjb3VudGVkX2NvbmZpZyhyZWxhdGl2ZV9wYXRoKToKICAgICAgICAgICAgbm9ubG9jYWxfaGVscGVyWzBdICs9IDEKICAgICAgICAgICAgcmV0dXJuIG9yaWdpbmFsX2NvbmZpZyhyZWxhdGl2ZV9wYXRoKQogICAgICAgIGNhdGFsb2cuX2luZmVycmVkX3NwbGl0ID0gY291bnRlZF9zcGxpdAogICAgICAgIGNhdGFsb2cuX2luZmVycmVkX2NvbmZpZyA9IGNvdW50ZWRfY29uZmlnCiAgICAgICAgdHJ5OgogICAgICAgICAgICB0cmFjZW1hbGxvYy5zdGFydCgpCiAgICAgICAgICAgIHN0YXJ0ZWQgPSB0aW1lLnBlcmZfY291bnRlcigpCiAgICAgICAgICAgIHBheWxvYWQgPSBEYXRhc2V0Q2F0YWxvZyhlbnZpcm9ubWVudD17IkhPTUUiOiBvcy5mc3BhdGgoaG9tZSl9KS5yZWdpc3RyeV9zbmFwc2hvdF9wYXlsb2FkKCkKICAgICAgICAgICAgZWxhcHNlZF9tcyA9ICh0aW1lLnBlcmZfY291bnRlcigpIC0gc3RhcnRlZCkgKiAxMDAwLjAKICAgICAgICAgICAgX2N1cnJlbnQsIHBlYWsgPSB0cmFjZW1hbGxvYy5nZXRfdHJhY2VkX21lbW9yeSgpCiAgICAgICAgICAgIHRyYWNlbWFsbG9jLnN0b3AoKQogICAgICAgIGZpbmFsbHk6CiAgICAgICAgICAgIGNhdGFsb2cuX2luZmVycmVkX3NwbGl0ID0gb3JpZ2luYWxfc3BsaXQKICAgICAgICAgICAgY2F0YWxvZy5faW5mZXJyZWRfY29uZmlnID0gb3JpZ2luYWxfY29uZmlnCiAgICAgICAgICAgIGlmIHRyYWNlbWFsbG9jLmlzX3RyYWNpbmcoKToKICAgICAgICAgICAgICAgIHRyYWNlbWFsbG9jLnN0b3AoKQogICAgICAgIGRhdGFzZXRzID0gcGF5bG9hZC5nZXQoImRhdGFzZXRzIiwgW10pCiAgICAgICAgaWYgbGVuKGRhdGFzZXRzKSAhPSAxOgogICAgICAgICAgICByYWlzZSBTeXN0ZW1FeGl0KCJ1bmV4cGVjdGVkIGRhdGFzZXQgY291bnQiKQogICAgICAgIGRhdGFzZXQgPSBkYXRhc2V0c1swXQogICAgICAgIGlmIGxlbihkYXRhc2V0LmdldCgiZmlsZXMiLCBbXSkpICE9IGV4cGVjdGVkX2ZpbGVzOgogICAgICAgICAgICByYWlzZSBTeXN0ZW1FeGl0KCJ1bmV4cGVjdGVkIGRhdGFzZXQgZmlsZSBjb3VudCIpCiAgICAgICAgaWYgZGF0YXNldC5nZXQoInNwbGl0cyIpICE9IFsidGVzdCIsICJ0cmFpbiIsICJ2YWxpZGF0aW9uIl06CiAgICAgICAgICAgIHJhaXNlIFN5c3RlbUV4aXQoInVuZXhwZWN0ZWQgc3BsaXRzIikKICAgICAgICBpZiBsZW4oZGF0YXNldC5nZXQoImNvbmZpZ3MiLCBbXSkpICE9IDEzOgogICAgICAgICAgICByYWlzZSBTeXN0ZW1FeGl0KCJ1bmV4cGVjdGVkIGNvbmZpZ3MiKQogICAgICAgIGVsYXBzZWRfc2FtcGxlcy5hcHBlbmQoZWxhcHNlZF9tcykKICAgICAgICBwZWFrX3NhbXBsZXMuYXBwZW5kKGZsb2F0KHBlYWspKQogICAgICAgIGhlbHBlcl9jYWxsX3NhbXBsZXMuYXBwZW5kKGZsb2F0KG5vbmxvY2FsX2hlbHBlclswXSkpCiAgICAgICAgZmlsZV9jb3VudF9zYW1wbGVzLmFwcGVuZChmbG9hdChleHBlY3RlZF9maWxlcykpCnByaW50KGpzb24uZHVtcHMoeyJlbGFwc2VkX21zX21lYW4iOiBzdGF0aXN0aWNzLmZtZWFuKGVsYXBzZWRfc2FtcGxlcyksICJwZWFrX2J5dGVzX21lYW4iOiBzdGF0aXN0aWNzLmZtZWFuKHBlYWtfc2FtcGxlcyksICJsZWdhY3lfaW5mZXJlbmNlX2hlbHBlcl9jYWxsc19tZWFuIjogc3RhdGlzdGljcy5mbWVhbihoZWxwZXJfY2FsbF9zYW1wbGVzKSwgImZpbGVfY291bnRfbWVhbiI6IHN0YXRpc3RpY3MuZm1lYW4oZmlsZV9jb3VudF9zYW1wbGVzKSwgInNhbXBsZV9jb3VudCI6IGZsb2F0KHNhbXBsZXMpfSwgc29ydF9rZXlzPVRydWUpKQo=\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "legacy_inference_helper_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 10.0
+      }
+    ]
+  },
+  {
     "id": "multimodal-fast-path-signature-top-level-key-cache",
     "name": "Multimodal fast-path signature top-level key cache",
     "runner": "ubuntu-latest",

--- a/scripts/dataset_registry_snapshot_probe.py
+++ b/scripts/dataset_registry_snapshot_probe.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(os.environ.get("MELIX_DATASET_REGISTRY_PROBE_REPO_ROOT", Path(__file__).resolve().parents[1]))
+sys.path.insert(0, os.fspath(REPO_ROOT))
+sys.path.insert(0, os.fspath(REPO_ROOT / "services/mlx-worker-python"))
+
+import worker.dataset_registry.catalog as catalog
+from worker.dataset_registry.catalog import DatasetCatalog
+
+
+def _write_probe_snapshot(home: Path, *, file_count: int) -> tuple[Path, int]:
+    cache_repo_dir = home / ".cache" / "huggingface" / "hub" / "datasets--org--probe"
+    snapshot_dir = cache_repo_dir / "snapshots" / "snapshot-probe"
+    refs_dir = cache_repo_dir / "refs"
+    refs_dir.mkdir(parents=True)
+    refs_dir.joinpath("main").write_text("snapshot-probe", encoding="utf-8")
+    expected_files = 0
+    splits = ("train", "validation", "test")
+    for index in range(file_count):
+        config = f"config-{index % 12:02d}"
+        split = splits[index % len(splits)]
+        data_dir = snapshot_dir / config
+        data_dir.mkdir(parents=True, exist_ok=True)
+        path = data_dir / f"{split}-{index:05d}.jsonl"
+        path.write_text('{"prompt":"hello","answer":"world"}\n', encoding="utf-8")
+        expected_files += 1
+    snapshot_dir.joinpath("README.md").write_text("# Probe dataset\n", encoding="utf-8")
+    expected_files += 1
+    return snapshot_dir, expected_files
+
+
+def run_probe(*, file_count: int = 2400, samples: int = 5) -> dict[str, Any]:
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    helper_call_samples: list[float] = []
+    file_count_samples: list[float] = []
+    original_split = catalog._inferred_split
+    original_config = catalog._inferred_config
+
+    for _ in range(samples):
+        with tempfile.TemporaryDirectory(prefix="melix-dataset-registry-probe-") as tmp:
+            home = Path(tmp) / "home"
+            _snapshot_dir, expected_files = _write_probe_snapshot(home, file_count=file_count)
+            helper_calls = 0
+
+            def counted_split(relative_path: str) -> str:
+                nonlocal helper_calls
+                helper_calls += 1
+                return original_split(relative_path)
+
+            def counted_config(relative_path: str) -> str:
+                nonlocal helper_calls
+                helper_calls += 1
+                return original_config(relative_path)
+
+            catalog._inferred_split = counted_split
+            catalog._inferred_config = counted_config
+            try:
+                tracemalloc.start()
+                started = time.perf_counter()
+                payload = DatasetCatalog(environment={"HOME": os.fspath(home)}).registry_snapshot_payload()
+                elapsed_ms = (time.perf_counter() - started) * 1000.0
+                _current, peak = tracemalloc.get_traced_memory()
+                tracemalloc.stop()
+            finally:
+                catalog._inferred_split = original_split
+                catalog._inferred_config = original_config
+                if tracemalloc.is_tracing():  # pragma: no cover - defensive cleanup after interrupted tracing
+                    tracemalloc.stop()
+
+            datasets = payload.get("datasets", [])
+            if len(datasets) != 1:  # pragma: no cover - probe guard rail
+                raise SystemExit(f"unexpected dataset count: {len(datasets)}")
+            dataset = datasets[0]
+            if len(dataset.get("files", [])) != expected_files:  # pragma: no cover - probe guard rail
+                raise SystemExit("unexpected dataset file count")
+            if dataset.get("splits") != ["test", "train", "validation"]:  # pragma: no cover - probe guard rail
+                raise SystemExit(f"unexpected splits: {dataset.get('splits')!r}")
+            expected_config_count = min(12, file_count) + 1
+            if len(dataset.get("configs", [])) != expected_config_count:  # pragma: no cover - probe guard rail
+                raise SystemExit(f"unexpected configs: {dataset.get('configs')!r}")
+            elapsed_samples.append(elapsed_ms)
+            peak_samples.append(float(peak))
+            helper_call_samples.append(float(helper_calls))
+            file_count_samples.append(float(expected_files))
+
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "peak_bytes_mean": statistics.fmean(peak_samples),
+        "legacy_inference_helper_calls_mean": statistics.fmean(helper_call_samples),
+        "file_count_mean": statistics.fmean(file_count_samples),
+        "sample_count": float(samples),
+    }
+
+
+def main() -> int:
+    file_count = int(os.environ.get("MELIX_DATASET_REGISTRY_PROBE_FILE_COUNT", "2400"))
+    samples = int(os.environ.get("MELIX_DATASET_REGISTRY_PROBE_SAMPLES", "5"))
+    metrics = run_probe(file_count=file_count, samples=samples)
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -59,6 +59,44 @@ def test_dataset_catalog_discovers_default_huggingface_cache_snapshot(tmp_path: 
     assert dataset["restore_command"] == "melix dataset hub download --repo-id org/repo --revision main"
 
 
+def test_dataset_catalog_builds_snapshot_inference_in_one_pass(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    snapshot_dir = _write_hf_dataset_snapshot(home)
+    (snapshot_dir / "custom").mkdir()
+    (snapshot_dir / "custom" / "validation-00000.parquet").write_bytes(b"validation")
+    (snapshot_dir / "custom" / "test.json").write_text("[]", encoding="utf-8")
+
+    def fail_split(_relative_path: str) -> str:
+        raise AssertionError("snapshot build should infer split/config together")
+
+    monkeypatch.setattr(catalog, "_inferred_split", fail_split)
+    monkeypatch.setattr(catalog, "_inferred_config", fail_split)
+
+    payload = DatasetCatalog(environment={"HOME": str(home)}).registry_snapshot_payload()
+
+    dataset = payload["datasets"][0]
+    assert dataset["splits"] == ["test", "train", "validation"]
+    assert dataset["configs"] == ["custom", "default"]
+    assert {file["relative_path"] for file in dataset["files"]} == {
+        "README.md",
+        "custom/test.json",
+        "custom/validation-00000.parquet",
+        "data/train-00000-of-00001.jsonl",
+    }
+
+
+def test_dataset_catalog_inferred_split_and_config_preserves_legacy_helpers() -> None:
+    assert catalog._inferred_split("custom/validation-00000.parquet") == "validation"
+    assert catalog._inferred_config("custom/validation-00000.parquet") == "custom"
+    assert catalog._inferred_split_and_config("data/train-00000-of-00001.jsonl") == ("train", "default")
+    assert catalog._inferred_split_and_config("custom\\test.json") == ("test", "custom")
+    assert catalog._inferred_split_and_config("README.md") == ("", "default")
+    assert catalog._inferred_split_and_config("") == ("", "default")
+
+
 def test_dataset_catalog_reports_unavailable_roots_and_filters_snapshots(tmp_path: Path) -> None:
     home = tmp_path / "home"
     _write_hf_dataset_snapshot(home)

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1048,9 +1048,31 @@ def test_mlx_audio_generate_signature_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0
 
 
+def test_dataset_registry_snapshot_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_DATASET_REGISTRY_PROBE_FILE_COUNT", "3")
+    monkeypatch.setenv("MELIX_DATASET_REGISTRY_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/dataset_registry_snapshot_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["legacy_inference_helper_calls_mean"] == 0.0
+    assert metrics["file_count_mean"] == 4.0
+
+
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
         "dataset-registry-limited-read-streaming",
+        "dataset-registry-snapshot-inference-single-pass",
         "event-extraction-alignment-accepted-edge-cache",
         "hub-catalog-tag-normalization-single-pass",
         "benchmark-evaluation-report-running-aggregates",

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -578,10 +578,21 @@ def _build_dataset_snapshot(
     snapshot_dir: Path,
     revision: str,
 ) -> DatasetSnapshot:
-    files = tuple(_dataset_files(snapshot_dir))
-    total_bytes = sum(file.size_bytes for file in files)
-    splits = tuple(sorted(set(_inferred_split(file.relative_path) for file in files) - {""}))
-    configs = tuple(sorted(set(_inferred_config(file.relative_path) for file in files) - {""}))
+    dataset_files: list[DatasetFile] = []
+    total_bytes = 0
+    split_names: set[str] = set()
+    config_names: set[str] = set()
+    for dataset_file in _dataset_files(snapshot_dir):
+        dataset_files.append(dataset_file)
+        total_bytes += dataset_file.size_bytes
+        split, config = _inferred_split_and_config(dataset_file.relative_path)
+        if split:
+            split_names.add(split)
+        if config:
+            config_names.add(config)
+    files = tuple(dataset_files)
+    splits = tuple(sorted(split_names))
+    configs = tuple(sorted(config_names))
     revision_label = revision or snapshot_dir.name
     return DatasetSnapshot(
         dataset_id=f"{repo_id}@{revision_label}",
@@ -638,24 +649,33 @@ def _dataset_file_format(path: Path) -> str:
 
 
 def _inferred_split(relative_path: str) -> str:
-    path = Path(relative_path)
-    candidates = [path.stem]
-    candidates.extend(part for part in path.parts[:-1] if part not in {"data", "default"})
-    for candidate in candidates:
-        prefix = candidate.split("-", 1)[0].split("_", 1)[0].lower()
-        if prefix in _SPLIT_ALIASES:
-            return _SPLIT_ALIASES[prefix]
-    return ""
+    return _inferred_split_and_config(relative_path)[0]
 
 
 def _inferred_config(relative_path: str) -> str:
-    parts = Path(relative_path).parts
+    return _inferred_split_and_config(relative_path)[1]
+
+
+def _inferred_split_and_config(relative_path: str) -> tuple[str, str]:
+    parts = tuple(part for part in relative_path.replace("\\", "/").split("/") if part)
+    if not parts:
+        return "", "default"
+    filename = parts[-1]
+    stem = filename.rsplit(".", 1)[0]
+    candidates = [stem]
+    candidates.extend(part for part in parts[:-1] if part not in {"data", "default"})
+    split = ""
+    for candidate in candidates:
+        prefix = candidate.split("-", 1)[0].split("_", 1)[0].lower()
+        if prefix in _SPLIT_ALIASES:
+            split = _SPLIT_ALIASES[prefix]
+            break
     if len(parts) < 2:
-        return "default"
+        return split, "default"
     first = parts[0]
     if first in {"data", "train", "test", "validation", "valid", "dev"}:
-        return "default"
-    return first
+        return split, "default"
+    return split, first
 
 
 def _path_matches_split(relative_path: Path, split: str) -> bool:


### PR DESCRIPTION
## Summary
- Reduce redundant split/config inference during Hugging Face dataset registry snapshot discovery by deriving file metadata, total bytes, splits, and configs in one pass over dataset files.
- Preserve existing `_inferred_split` / `_inferred_config` helper compatibility via a shared `_inferred_split_and_config(...)` helper.
- Add a registered PR-scoped performance probe for this dataset registry hot path.

## Plan or Spec
- Plan: `docs/plans/2026-05-06-dataset-registry-snapshot-inference-single-pass.md`
- Scoped CI probe: `dataset-registry-snapshot-inference-single-pass`
- Python-only/Linux-verifiable optimization slice.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics`
  - Result: `21 passed`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-registry-snapshot-inference-single-pass --base-repo /tmp/melix-cron-opt-base-20260506-013555b --head-repo /tmp/melix-cron-opt-20260506-013555 --output /tmp/dataset-registry-pr-scoped-result.json`
  - Result: head verification passed; base and head probes completed successfully.
- `git diff --check`
  - Result: passed.

## Coverage and Metrics
- Changed-scope coverage from registered probe head verification: `TOTAL 71 1 99%`
  - `services/mlx-worker-python/worker/dataset_registry/catalog.py`: 100.00%
  - `services/mlx-worker-python/tests/test_dataset_registry.py`: 95.45%
  - `services/mlx-worker-python/tests/test_pr_scoped_performance.py`: 100.00%
- Local base-vs-head probe metrics (`dataset-registry-snapshot-inference-single-pass`, 2,401 synthetic files, 5 samples):
  - `legacy_inference_helper_calls_mean`: `4802.0` -> `0.0`
  - `elapsed_ms_mean`: `715.5702849966474` -> `701.9745517871343`
  - `peak_bytes_mean`: `858120.2` -> `880690.6`
  - `file_count_mean`: `2401.0` -> `2401.0`
- Primary deterministic win: eliminates redundant legacy split/config helper calls during optimized snapshot builds.

## Known Gaps
- Linux host only; no macOS/Swift local validation was run because this is a Python worker slice.
- Peak traced allocation is slightly higher in the local synthetic probe; the probe records it with a 10% warning threshold while the primary structural metric is eliminated redundant helper calls.

## Evidence Checklist
- [x] Focused tests added/updated and passing.
- [x] Changed-scope coverage is >=95%.
- [x] Explicit local performance probe reports concrete base/head metrics.
- [x] PR-scoped performance probe registered in `infra/perf/pr_scoped_probes.json`.
- [x] Diff hygiene checked with `git diff --check`.
