### PR TITLE
perf: reuse video URI byte length metadata

### DIFF
--- a/docs/plans/2026-05-06-video-preprocessing-uri-byte-length-reuse.md
+++ b/docs/plans/2026-05-06-video-preprocessing-uri-byte-length-reuse.md
@@ -1,0 +1,39 @@
+# Video Preprocessing URI Byte-Length Reuse
+
+## Goal
+
+Reduce redundant work in the Python video URI preprocessing hot path by reading `media.byte_length` once per URI input and reusing that value for both the prepared metadata payload and URI identity hash construction.
+
+## Scope
+
+Touched files:
+
+- `services/mlx-worker-python/worker/runtime/video_preprocessing.py`
+- `services/mlx-worker-python/tests/test_video_preprocessing.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/video_preprocessing_uri_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux-only Verification Path
+
+This is a Python-only optimization and can be verified on Linux with focused pytest, changed-scope coverage, and a local performance probe.
+
+## Performance Probe
+
+Register `video-preprocessing-uri-byte-length-reuse` in the PR-scoped performance registry. The probe repeatedly calls `prepare_video_input(...)` for URI-backed video input using a counting media stub.
+
+Primary success metric:
+
+- `byte_length_getattrs_per_call` drops from `2.0` on `origin/main` to `1.0` on the branch.
+
+Secondary metric:
+
+- `elapsed_ms_mean` should not regress beyond the probe warning threshold.
+
+## Success Criteria
+
+- Focused video preprocessing tests pass.
+- PR-scoped performance registry tests for the new probe pass.
+- Changed executable coverage for touched Python/test/probe files is at least 95%.
+- Local probe emits concrete metrics showing one `byte_length` read per URI preprocessing call.
+- `git diff --check` passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1762,6 +1762,37 @@
     ]
   },
   {
+    "id": "video-preprocessing-uri-byte-length-reuse",
+    "name": "Video preprocessing URI byte length reuse",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/video_preprocessing.py",
+      "services/mlx-worker-python/tests/test_video_preprocessing.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/video_preprocessing_uri_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/video_preprocessing_uri_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/video_preprocessing_uri_probe.py ]; then python scripts/video_preprocessing_uri_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"aW1wb3J0IGpzb24sIHN0YXRpc3RpY3MsIHN5cywgdGltZQpmcm9tIHBhdGhsaWIgaW1wb3J0IFBhdGgKcmVwb19yb290ID0gUGF0aC5jd2QoKQpzeXMucGF0aC5pbnNlcnQoMCwgc3RyKHJlcG9fcm9vdCkpCnN5cy5wYXRoLmluc2VydCgwLCBzdHIocmVwb19yb290IC8gInNlcnZpY2VzL21seC13b3JrZXItcHl0aG9uIikpCmZyb20gd29ya2VyLnJ1bnRpbWUudmlkZW9fcHJlcHJvY2Vzc2luZyBpbXBvcnQgcHJlcGFyZV92aWRlb19pbnB1dApjbGFzcyBDb3VudGluZ01lZGlhOgogICAgZGVmIF9faW5pdF9fKHNlbGYpOgogICAgICAgIHNlbGYuYnl0ZV9sZW5ndGhfcmVhZHMgPSAwCiAgICBkZWYgX19nZXRhdHRyaWJ1dGVfXyhzZWxmLCBuYW1lKToKICAgICAgICBpZiBuYW1lID09ICJieXRlX2xlbmd0aCI6CiAgICAgICAgICAgIHJlYWRzID0gb2JqZWN0Ll9fZ2V0YXR0cmlidXRlX18oc2VsZiwgImJ5dGVfbGVuZ3RoX3JlYWRzIikKICAgICAgICAgICAgb2JqZWN0Ll9fc2V0YXR0cl9fKHNlbGYsICJieXRlX2xlbmd0aF9yZWFkcyIsIHJlYWRzICsgMSkKICAgICAgICAgICAgcmV0dXJuIDQwOTYKICAgICAgICByZXR1cm4gb2JqZWN0Ll9fZ2V0YXR0cmlidXRlX18oc2VsZiwgbmFtZSkKICAgIGRlZiBfX2dldGF0dHJfXyhzZWxmLCBuYW1lKToKICAgICAgICByZXR1cm4gIiIgaWYgbmFtZSBpbiB7Im1pbWVfdHlwZSIsICJmb3JtYXQiLCAiZmlsZW5hbWUifSBlbHNlIDAKY2xhc3MgQ291bnRpbmdWaWRlb1BhcnQ6CiAgICBkZWYgX19pbml0X18oc2VsZiwgbWVkaWEpOgogICAgICAgIHNlbGYubWVkaWEgPSBtZWRpYQogICAgICAgIHNlbGYudmlkZW9fYnl0ZXMgPSBiIiIKICAgICAgICBzZWxmLnZpZGVvX3VyaSA9ICJodHRwczovL2V4YW1wbGUuY29tL21lZGlhL3Byb2JlLm1vdiIKaXRlcmF0aW9ucyA9IDUwMDAwCnNhbXBsZV9jb3VudCA9IDUKZWxhcHNlZCA9IFtdCnJlYWRzID0gW10KY2hlY2tzdW0gPSAwCmZvciBfIGluIHJhbmdlKHNhbXBsZV9jb3VudCk6CiAgICBtZWRpYSA9IENvdW50aW5nTWVkaWEoKQogICAgcGFydCA9IENvdW50aW5nVmlkZW9QYXJ0KG1lZGlhKQogICAgc3RhcnRlZCA9IHRpbWUucGVyZl9jb3VudGVyKCkKICAgIGZvciBfaW5kZXggaW4gcmFuZ2UoaXRlcmF0aW9ucyk6CiAgICAgICAgcHJlcGFyZWQgPSBwcmVwYXJlX3ZpZGVvX2lucHV0KHBhcnQpCiAgICAgICAgY2hlY2tzdW0gKz0gcHJlcGFyZWQuYnl0ZV9sZW5ndGggKyBsZW4ocHJlcGFyZWQuc2hhMjU2X2hleCkKICAgIGVsYXBzZWQuYXBwZW5kKCh0aW1lLnBlcmZfY291bnRlcigpIC0gc3RhcnRlZCkgKiAxMDAwLjApCiAgICByZWFkcy5hcHBlbmQoZmxvYXQobWVkaWEuYnl0ZV9sZW5ndGhfcmVhZHMpIC8gZmxvYXQoaXRlcmF0aW9ucykpCmlmIGNoZWNrc3VtIDw9IDA6CiAgICByYWlzZSBTeXN0ZW1FeGl0KCJ1bmV4cGVjdGVkIGVtcHR5IHZpZGVvIHByZXByb2Nlc3NpbmcgcHJvYmUgY2hlY2tzdW0iKQpwcmludChqc29uLmR1bXBzKHsiZWxhcHNlZF9tc19tZWFuIjogc3RhdGlzdGljcy5mbWVhbihlbGFwc2VkKSwgImJ5dGVfbGVuZ3RoX2dldGF0dHJzX3Blcl9jYWxsIjogc3RhdGlzdGljcy5mbWVhbihyZWFkcyksICJpdGVyYXRpb25zX3Blcl9zYW1wbGUiOiBmbG9hdChpdGVyYXRpb25zKSwgInNhbXBsZV9jb3VudCI6IGZsb2F0KHNhbXBsZV9jb3VudCl9LCBzb3J0X2tleXM9VHJ1ZSkp\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "byte_length_getattrs_per_call",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "startup-signals-lazy-worker-log-excerpts",
     "name": "Startup signals lazy worker log excerpts",
     "runner": "ubuntu-latest",

--- a/scripts/video_preprocessing_uri_probe.py
+++ b/scripts/video_preprocessing_uri_probe.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime.video_preprocessing import prepare_video_input
+
+
+class CountingMedia:
+    def __init__(self) -> None:
+        self.byte_length_reads = 0
+
+    def __getattribute__(self, name: str):
+        if name == "byte_length":
+            byte_length_reads = object.__getattribute__(self, "byte_length_reads")
+            object.__setattr__(self, "byte_length_reads", byte_length_reads + 1)
+            return 4096
+        return object.__getattribute__(self, name)
+
+    def __getattr__(self, name: str):
+        return "" if name in {"mime_type", "format", "filename"} else 0
+
+
+class CountingVideoPart:
+    def __init__(self, media: CountingMedia) -> None:
+        self.media = media
+        self.video_bytes = b""
+        self.video_uri = "https://example.com/media/probe.mov"
+
+
+def run_probe(iterations: int = 50_000, sample_count: int = 5) -> dict[str, float]:
+    elapsed_samples: list[float] = []
+    byte_length_reads: list[float] = []
+    checksum = 0
+    for _ in range(sample_count):
+        media = CountingMedia()
+        part = CountingVideoPart(media)
+        started = time.perf_counter()
+        for _index in range(iterations):
+            prepared = prepare_video_input(part)
+            checksum += prepared.byte_length + len(prepared.sha256_hex)
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        byte_length_reads.append(float(media.byte_length_reads) / float(iterations))
+    if checksum <= 0:
+        raise RuntimeError("unexpected empty video preprocessing probe checksum")
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "byte_length_getattrs_per_call": statistics.fmean(byte_length_reads),
+        "iterations_per_sample": float(iterations),
+        "sample_count": float(sample_count),
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(run_probe(), sort_keys=True))
+    raise SystemExit(0)

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -153,6 +153,16 @@ def test_scope_report_selects_mlx_audio_signature_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "mlx-audio-generate-signature-cache"
 
 
+def test_scope_report_selects_video_preprocessing_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/video_preprocessing.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "video-preprocessing-uri-byte-length-reuse"
+
+
 def test_scope_report_selects_only_matching_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -1067,6 +1077,23 @@ def test_dataset_registry_snapshot_probe_script_emits_metrics(
     assert metrics["peak_bytes_mean"] > 0
     assert metrics["legacy_inference_helper_calls_mean"] == 0.0
     assert metrics["file_count_mean"] == 4.0
+
+
+def test_video_preprocessing_uri_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/video_preprocessing_uri_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 5.0
+    assert metrics["iterations_per_sample"] == 50000.0
+    assert metrics["byte_length_getattrs_per_call"] == 1.0
+    assert metrics["elapsed_ms_mean"] >= 0
 
 
 def test_registered_probes_expose_focused_commands() -> None:

--- a/services/mlx-worker-python/tests/test_video_preprocessing.py
+++ b/services/mlx-worker-python/tests/test_video_preprocessing.py
@@ -94,6 +94,39 @@ def test_prepare_video_input_accepts_local_uri_and_mime_type_resolution() -> Non
     assert len(prepared.sha256_hex) == 64
 
 
+class _CountingMedia:
+    def __init__(self) -> None:
+        self.byte_length_reads = 0
+
+    def __getattribute__(self, name: str):
+        if name == "byte_length":
+            byte_length_reads = object.__getattribute__(self, "byte_length_reads")
+            object.__setattr__(self, "byte_length_reads", byte_length_reads + 1)
+            return 123
+        return object.__getattribute__(self, name)
+
+    def __getattr__(self, name: str):
+        return "" if name in {"mime_type", "format", "filename"} else 0
+
+
+class _CountingVideoPart:
+    def __init__(self, media: _CountingMedia) -> None:
+        self.media = media
+        self.video_bytes = b""
+        self.video_uri = "https://example.com/media/demo.mov"
+
+
+def test_prepare_video_input_reuses_uri_byte_length_for_metadata_and_identity_hash() -> None:
+    media = _CountingMedia()
+    part = _CountingVideoPart(media)
+
+    prepared = prepare_video_input(part)
+
+    assert prepared.byte_length == 123
+    assert media.byte_length_reads == 1
+    assert len(prepared.sha256_hex) == 64
+
+
 def test_prepare_video_input_infers_format_from_plain_local_path() -> None:
     part = common_pb2.MessagePart(
         video_uri="/tmp/local-demo.m4v",

--- a/services/mlx-worker-python/worker/runtime/video_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/video_preprocessing.py
@@ -84,6 +84,7 @@ def prepare_video_input(part) -> PreparedVideoInput:
     resolved_filename = (
         filename or _filename_from_reference(parsed_reference) or f"remote-video.{resolved_format}"
     )
+    byte_length = int(getattr(media, "byte_length", 0) or 0)
     return PreparedVideoInput(
         source_kind="uri",
         reference=uri,
@@ -91,7 +92,7 @@ def prepare_video_input(part) -> PreparedVideoInput:
         mime_type=mime_type,
         format=resolved_format,
         filename=resolved_filename,
-        byte_length=int(getattr(media, "byte_length", 0) or 0),
+        byte_length=byte_length,
         duration_ms=duration_ms,
         frame_budget=frame_budget,
         start_ms=start_ms,
@@ -101,7 +102,7 @@ def prepare_video_input(part) -> PreparedVideoInput:
             mime_type=mime_type,
             format_name=resolved_format,
             filename=resolved_filename,
-            byte_length=int(getattr(media, "byte_length", 0) or 0),
+            byte_length=byte_length,
             duration_ms=duration_ms,
             frame_budget=frame_budget,
             start_ms=start_ms,


### PR DESCRIPTION
## Summary
- Reuse the URI video `byte_length` metadata value inside `prepare_video_input(...)` instead of reading and converting it once for the prepared payload and again for the URI identity hash.
- Add a focused regression test with a counting media stub to lock the single-read behavior.
- Register the `video-preprocessing-uri-byte-length-reuse` PR-scoped performance probe with a base-compatible fallback command.

## Plan or Spec
- Plan: `docs/plans/2026-05-06-video-preprocessing-uri-byte-length-reuse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_video_preprocessing.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics
# 17 passed in 7.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
  services/mlx-worker-python/tests/test_video_preprocessing.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics && \
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && \
python scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/runtime/video_preprocessing.py \
  services/mlx-worker-python/tests/test_video_preprocessing.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/video_preprocessing_uri_probe.py
# 17 passed in 17.58s; TOTAL 37 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/video_preprocessing_uri_probe.py
# {"byte_length_getattrs_per_call": 1.0, "elapsed_ms_mean": 1405.8563898084685, "iterations_per_sample": 50000.0, "sample_count": 5.0}

python -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.valid.json
# passed

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py \
  --registry infra/perf/pr_scoped_probes.json \
  --probe-id video-preprocessing-uri-byte-length-reuse \
  --base-repo /tmp/melix-cron-opt-20260506021450-base \
  --head-repo /tmp/melix-cron-opt-20260506021450 \
  --output /tmp/video-preprocessing-uri-probe-result.json
# head verification passed; base probe and head probe completed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 37 0 100%`.
- Local direct probe on head: `byte_length_getattrs_per_call=1.0`, `elapsed_ms_mean=1405.856 ms`, `iterations_per_sample=50000`, `sample_count=5`.
- Local PR-scoped base-vs-head probe (`video-preprocessing-uri-byte-length-reuse`):
  - base: `byte_length_getattrs_per_call=2.0`, `elapsed_ms_mean=1327.624 ms`
  - head: `byte_length_getattrs_per_call=1.0`, `elapsed_ms_mean=1388.223 ms`
  - structural redundant-read metric improved by 50%; elapsed was ~4.56% slower locally, within the registered 5% warning threshold.

## Known Gaps
- Full `make py-test`, Swift, and integration suites were not run on this Linux cron host.
- Editing `infra/perf/pr_scoped_probes.json` may fan out the hosted `pr-scoped-performance` matrix; hosted CI is the final validation gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
