### PR TITLE
perf: speed code eval stdio tail reads

### DIFF
--- a/docs/plans/2026-05-06-code-eval-stdio-osread.md
+++ b/docs/plans/2026-05-06-code-eval-stdio-osread.md
@@ -1,0 +1,48 @@
+# Code evaluation stdio tail OS-read slice
+
+## Scope
+
+This slice is limited to the Python worker code-evaluation stdio tail reader:
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+
+The behavior remains unchanged: missing, raced-away, unreadable, directory, and oversized stdio paths still return the same `(tail, size)` contract used by code evaluation failure reporting.
+
+## Registered probe
+
+The affected path is already covered by the PR-scoped performance probe `code-eval-stdio-tail-single-stat` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes:
+
+- a focused `test_command` for code-evaluation stdio behavior and probe selection,
+- a `coverage_command` that measures changed-scope coverage for the code-eval runner, its tests, and the probe script,
+- a `probe_command` that exercises repeated oversized stdout/stderr tail reads and reports `elapsed_ms_mean` plus `stdio_stat_calls_mean`.
+
+## Optimization
+
+Replace the `Path.stat()` + `Path.open()` + file-object `seek/read` sequence in `_read_limited_stdio()` with one descriptor-based path:
+
+1. `os.open()` the stdio file once,
+2. `os.fstat()` the opened descriptor so size and handle are consistent,
+3. `os.lseek()` only when the file exceeds the retained tail byte limit,
+4. `os.read()` the exact byte count and close the descriptor in `finally`.
+
+This keeps the same single size lookup per file while avoiding Python file-object allocation and reducing the race window between stat and open.
+
+## Verification plan
+
+Run the registered probe's focused local Linux checks:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_returns_timeout_result services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_uses_stderr_when_payload_is_missing services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_skips_parent_test_counting_after_successful_payload services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_text_handles_missing_and_oversized_files services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_handles_open_race services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_ignores_close_errors services/mlx-worker-python/tests/test_code_eval_runner.py::test_output_limit_reuses_limited_stdio_sizes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_stdio_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_returns_timeout_result services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_uses_stderr_when_payload_is_missing services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_skips_parent_test_counting_after_successful_payload services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_text_handles_missing_and_oversized_files services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_handles_open_race services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_ignores_close_errors services/mlx-worker-python/tests/test_code_eval_runner.py::test_output_limit_reuses_limited_stdio_sizes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_stdio_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_stdio_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_stdio_probe.py
+```
+
+## Success criteria
+
+- Focused behavior tests pass on Linux.
+- Changed-scope coverage for touched Python code remains at or above 95%.
+- Local registered probe reports a lower `elapsed_ms_mean` than the origin/main baseline while preserving `stdio_stat_calls_mean == 6000.0` and the same output-limit/tail guard values.
+- PR-scoped performance CI selects and completes `code-eval-stdio-tail-single-stat`.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -344,22 +344,32 @@ def test_read_limited_text_handles_missing_and_oversized_files(tmp_path: Path) -
     assert code_eval_runner._read_limited_stdio(directory_path, 4) == ("", 0)
 
 
-def test_read_limited_stdio_handles_stat_open_race(
+def test_read_limited_stdio_handles_open_race(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     output_path = tmp_path / "output.txt"
     output_path.write_text("secret output", encoding="utf-8")
 
-    original_open = Path.open
+    def fake_open(path, flags, *args, **kwargs):
+        raise FileNotFoundError(str(path))
 
-    def fake_open(self: Path, *args, **kwargs):
-        if self == output_path:
-            raise FileNotFoundError(str(self))
-        return original_open(self, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "open", fake_open)
+    monkeypatch.setattr(code_eval_runner.os, "open", fake_open)
 
     assert code_eval_runner._read_limited_stdio(output_path, 4) == ("", 0)
+
+
+def test_read_limited_stdio_ignores_close_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_path = tmp_path / "output.txt"
+    output_path.write_text("0123456789abcdef", encoding="utf-8")
+
+    def fake_close(fd: int) -> None:
+        raise OSError("close failed")
+
+    monkeypatch.setattr(code_eval_runner.os, "close", fake_close)
+
+    assert code_eval_runner._read_limited_stdio(output_path, 4) == ("cdef", 16)
 
 
 def test_output_limit_reuses_limited_stdio_sizes(monkeypatch) -> None:

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -4,6 +4,7 @@ import ast
 from dataclasses import dataclass
 from functools import lru_cache
 import json
+import os
 from pathlib import Path
 import re
 import shutil
@@ -235,13 +236,26 @@ def _load_payload_file(payload_path: Path) -> dict[str, object] | None:
 
 def _read_limited_stdio(path: Path, byte_limit: int) -> tuple[str, int]:
     try:
-        size = path.stat().st_size
-        with path.open("rb") as file:
-            if size > byte_limit:
-                file.seek(-byte_limit, 2)
-            return file.read().decode("utf-8", errors="replace").strip(), size
+        fd = os.open(path, os.O_RDONLY)
     except OSError:
         return "", 0
+
+    try:
+        size = os.fstat(fd).st_size
+        read_limit = max(int(byte_limit), 0)
+        if size > read_limit:
+            os.lseek(fd, -read_limit, os.SEEK_END)
+            read_size = read_limit
+        else:
+            read_size = size
+        return os.read(fd, read_size).decode("utf-8", errors="replace").strip(), size
+    except OSError:
+        return "", 0
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
 
 
 def _read_limited_text(path: Path, byte_limit: int) -> str:


### PR DESCRIPTION
## Summary
- Replace the code-evaluation stdio tail reader's `Path.stat()` + file-object `open/seek/read` sequence with descriptor-based `os.open`/`os.fstat`/`os.lseek`/`os.read`.
- Keep the same `(tail, size)` contract for missing, raced-away, directory, oversized, and close-error paths.
- Extend the registered PR-scoped probe commands for `code-eval-stdio-tail-single-stat` so the new race/close guard tests are included in CI verification.

## Plan or Spec
- `docs/plans/2026-05-06-code-eval-stdio-osread.md`

## Commands Run
```text
# Baseline probe on origin/main before implementation, run 3 times
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_stdio_probe.py
exit 0; elapsed_ms_mean: 55.8315, 55.5218, 69.5919; stdio_stat_calls_mean=6000.0

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_returns_timeout_result services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_uses_stderr_when_payload_is_missing services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_skips_parent_test_counting_after_successful_payload services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_text_handles_missing_and_oversized_files services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_handles_open_race services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_ignores_close_errors services/mlx-worker-python/tests/test_code_eval_runner.py::test_output_limit_reuses_limited_stdio_sizes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_stdio_probe_script_emits_metrics
exit 0; 10 passed in 0.27s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_returns_timeout_result services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_uses_stderr_when_payload_is_missing services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_skips_parent_test_counting_after_successful_payload services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_text_handles_missing_and_oversized_files services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_handles_open_race services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_ignores_close_errors services/mlx-worker-python/tests/test_code_eval_runner.py::test_output_limit_reuses_limited_stdio_sizes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_stdio_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_stdio_probe.py
exit 0; TOTAL 27 0 100%

# Head local probe, run 3 times
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_stdio_probe.py
exit 0; elapsed_ms_mean: 28.7967, 28.7598, 29.3259; stdio_stat_calls_mean=6000.0

# Registered base-vs-head probe runner
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-stdio-tail-single-stat --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-code-eval-stdio-osread-20260506 --head-repo "$PWD" --output /tmp/code_eval_stdio_osread_probe.json
exit 0; head verification ok; coverage_pct=100.0

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.valid.json
exit 0

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 27 0 100%`.
- Registered probe `code-eval-stdio-tail-single-stat` local base-vs-head result:
  - `old_mean=59.194598405156285 ms`
  - `new_mean=28.211899020243436 ms`
  - `delta_ms=-30.98269938491285 ms`
  - `speedup=2.098214x`
  - `improvement=52.34%`
  - Guard metrics preserved: `stdio_stat_calls_mean=6000.0`, `output_limit_exceeded_mean=1.0`, `tail_chars_mean=5119.0`.
- CI PR-scoped performance must still run the registered probe on GitHub Actions before merge.

## Known Gaps
- Full repository test suite was not run locally; this is a focused Python performance slice.
- Local validation is Linux-only. No Swift runtime behavior is touched.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
