### PR TITLE
perf: reuse deterministic image edit input digests

### DIFF
--- a/docs/plans/2026-05-06-deterministic-image-edit-digest-reuse.md
+++ b/docs/plans/2026-05-06-deterministic-image-edit-digest-reuse.md
@@ -1,0 +1,55 @@
+# Deterministic Image Edit Digest Reuse
+
+## Goal
+
+Reduce redundant hashing in the deterministic image edit runtime by computing edit source and mask digests once per request instead of once per generated variant.
+
+## Linux-only constraint
+
+This slice only touches the Python worker runtime and PR-scoped performance harness, so it is locally verifiable on Linux with focused pytest, changed-scope coverage, and a command-json performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py`
+- `services/mlx-worker-python/tests/test_image_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/deterministic_image_edit_digest_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Probe definition
+
+Registered probe: `deterministic-image-edit-digest-reuse`
+
+The probe runs `scripts/deterministic_image_edit_digest_probe.py`, which executes an eight-variant image edit using large source and mask buffers. It reports:
+
+- `elapsed_ms_mean` (lower is better)
+- `digest_calls_mean` (lower is better)
+- `image_count`
+- `payload_checksum`
+- `sample_count`
+
+## Success metrics
+
+- Focused tests pass.
+- Changed executable coverage for touched scope is at least 95%.
+- Probe preserves output shape/checksum and reduces tracked source/mask digest calls from the old per-variant path to the request-local digest path.
+- `git diff --check` passes.
+
+## Verification commands
+
+Use:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_image_runtime.py::test_image_edit_persists_lineage_and_generated_artifact \
+  services/mlx-worker-python/tests/test_image_runtime.py::test_image_edit_reuses_input_digests_across_variants \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_image_edit_digest_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_image_edit_digest_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same tests>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json <touched files>
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/deterministic_image_edit_digest_probe.py
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -247,6 +247,37 @@
     ]
   },
   {
+    "id": "deterministic-image-edit-digest-reuse",
+    "name": "Deterministic image edit digest reuse",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py",
+      "services/mlx-worker-python/tests/test_image_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/deterministic_image_edit_digest_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_image_runtime.py::test_image_edit_persists_lineage_and_generated_artifact services/mlx-worker-python/tests/test_image_runtime.py::test_image_edit_reuses_input_digests_across_variants services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_image_edit_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_image_edit_digest_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_image_runtime.py::test_image_edit_persists_lineage_and_generated_artifact services/mlx-worker-python/tests/test_image_runtime.py::test_image_edit_reuses_input_digests_across_variants services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_image_edit_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_image_edit_digest_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py services/mlx-worker-python/tests/test_image_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_image_edit_digest_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/deterministic_image_edit_digest_probe.py ]; then python scripts/deterministic_image_edit_digest_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"ZnJvbSBfX2Z1dHVyZV9fIGltcG9ydCBhbm5vdGF0aW9ucwoKaW1wb3J0IGpzb24KaW1wb3J0IHN0YXRpc3RpY3MKaW1wb3J0IHRlbXBmaWxlCmltcG9ydCB0aW1lCmZyb20gcGF0aGxpYiBpbXBvcnQgUGF0aApmcm9tIHRocmVhZGluZyBpbXBvcnQgRXZlbnQKCmZyb20gcGFja2FnZXMucHJvdG9jb2wucHl0aG9uLndvcmtlci52MSBpbXBvcnQgY29tbW9uX3BiMiwgaW5mZXJlbmNlX3BiMgpmcm9tIHdvcmtlci5ydW50aW1lIGltcG9ydCBkZXRlcm1pbmlzdGljX2ltYWdlX2dlbmVyYXRpb25fcnVudGltZSBhcyBpbWFnZV9ydW50aW1lCmZyb20gd29ya2VyLnJ1bnRpbWUuZGV0ZXJtaW5pc3RpY19pbWFnZV9nZW5lcmF0aW9uX3J1bnRpbWUgaW1wb3J0IERldGVybWluaXN0aWNJbWFnZUdlbmVyYXRpb25SdW50aW1lCgoKZGVmIF9ydW5fb25jZShzYW1wbGU6IGludCkgLT4gZGljdFtzdHIsIGZsb2F0XToKICAgIHNvdXJjZV9ieXRlcyA9IChiIlNPVVJDRV9JTUFHRV9CTE9DS18lMDRkIiAlIHNhbXBsZSkgKiAyMjBfMDAwCiAgICBtYXNrX2J5dGVzID0gKGIiTUFTS19JTUFHRV9CTE9DS18lMDRkIiAlIHNhbXBsZSkgKiAyMjBfMDAwCiAgICBvcmlnaW5hbF9zaGEyNTYgPSBpbWFnZV9ydW50aW1lLmhhc2hsaWIuc2hhMjU2CiAgICB0cmFja2VkX2lucHV0cyA9IHtzb3VyY2VfYnl0ZXMsIG1hc2tfYnl0ZXN9CiAgICBkaWdlc3RfY2FsbHMgPSAwCgogICAgZGVmIGNvdW50aW5nX3NoYTI1NihwYXlsb2FkOiBieXRlcyA9IGIiIik6CiAgICAgICAgbm9ubG9jYWwgZGlnZXN0X2NhbGxzCiAgICAgICAgaWYgcGF5bG9hZCBpbiB0cmFja2VkX2lucHV0czoKICAgICAgICAgICAgZGlnZXN0X2NhbGxzICs9IDEKICAgICAgICByZXR1cm4gb3JpZ2luYWxfc2hhMjU2KHBheWxvYWQpCgogICAgcnVudGltZSA9IERldGVybWluaXN0aWNJbWFnZUdlbmVyYXRpb25SdW50aW1lKCkKICAgIHJlcXVlc3QgPSBpbmZlcmVuY2VfcGIyLkltYWdlRWRpdFJlcXVlc3QoCiAgICAgICAgaWQ9Y29tbW9uX3BiMi5SZXF1ZXN0SWRlbnRpdHkocmVxdWVzdF9pZD1mImRpZ2VzdC1wcm9iZS17c2FtcGxlfSIpLAogICAgICAgIHByb21wdD0iYWRkIGRldGFpbCB3aXRob3V0IGNoYW5naW5nIGNvbXBvc2l0aW9uIiwKICAgICAgICBpbWFnZT1zb3VyY2VfYnl0ZXMsCiAgICAgICAgbWFzaz1tYXNrX2J5dGVzLAogICAgICAgIHNpemU9IjUxMng1MTIiLAogICAgICAgIHJlc3BvbnNlX2Zvcm1hdD0icG5nIiwKICAgICAgICBuPTgsCiAgICApCiAgICB3aXRoIHRlbXBmaWxlLlRlbXBvcmFyeURpcmVjdG9yeSgpIGFzIHJhd190bXA6CiAgICAgICAgaW1hZ2VfcnVudGltZS5oYXNobGliLnNoYTI1NiA9IGNvdW50aW5nX3NoYTI1NgogICAgICAgIHN0YXJ0ZWQgPSB0aW1lLnBlcmZfY291bnRlcigpCiAgICAgICAgdHJ5OgogICAgICAgICAgICByZXN1bHQgPSBydW50aW1lLmVkaXRfaW1hZ2UoCiAgICAgICAgICAgICAgICB7Im1vZGVsX2lkIjogIm1lbGl4LWRldi1pbWFnZSJ9LAogICAgICAgICAgICAgICAgcmVxdWVzdCwKICAgICAgICAgICAgICAgIGpvYl9pZD1mImRpZ2VzdC1wcm9iZS17c2FtcGxlfSIsCiAgICAgICAgICAgICAgICBpbWFnZXNfcm9vdD1QYXRoKHJhd190bXApLAogICAgICAgICAgICAgICAgY2FuY2VsX2V2ZW50PUV2ZW50KCksCiAgICAgICAgICAgICkKICAgICAgICBmaW5hbGx5OgogICAgICAgICAgICBlbGFwc2VkX21zID0gKHRpbWUucGVyZl9jb3VudGVyKCkgLSBzdGFydGVkKSAqIDEwMDAuMAogICAgICAgICAgICBpbWFnZV9ydW50aW1lLmhhc2hsaWIuc2hhMjU2ID0gb3JpZ2luYWxfc2hhMjU2CgogICAgcGF5bG9hZF9jaGVja3N1bSA9IHN1bShzdW0oaW1hZ2UpIGZvciBpbWFnZSBpbiByZXN1bHQuaW1hZ2VzKQogICAgcmV0dXJuIHsKICAgICAgICAiZWxhcHNlZF9tcyI6IGVsYXBzZWRfbXMsCiAgICAgICAgImRpZ2VzdF9jYWxscyI6IGZsb2F0KGRpZ2VzdF9jYWxscyksCiAgICAgICAgImltYWdlX2NvdW50IjogZmxvYXQobGVuKHJlc3VsdC5pbWFnZXMpKSwKICAgICAgICAicGF5bG9hZF9jaGVja3N1bSI6IGZsb2F0KHBheWxvYWRfY2hlY2tzdW0pLAogICAgfQoKCmRlZiBtYWluKCkgLT4gTm9uZToKICAgIHNhbXBsZXMgPSBbX3J1bl9vbmNlKGluZGV4KSBmb3IgaW5kZXggaW4gcmFuZ2UoNSldCiAgICBwcmludCgKICAgICAgICBqc29uLmR1bXBzKAogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAiZWxhcHNlZF9tc19tZWFuIjogc3RhdGlzdGljcy5mbWVhbihzYW1wbGVbImVsYXBzZWRfbXMiXSBmb3Igc2FtcGxlIGluIHNhbXBsZXMpLAogICAgICAgICAgICAgICAgImRpZ2VzdF9jYWxsc19tZWFuIjogc3RhdGlzdGljcy5mbWVhbihzYW1wbGVbImRpZ2VzdF9jYWxscyJdIGZvciBzYW1wbGUgaW4gc2FtcGxlcyksCiAgICAgICAgICAgICAgICAiaW1hZ2VfY291bnQiOiBzYW1wbGVzWy0xXVsiaW1hZ2VfY291bnQiXSwKICAgICAgICAgICAgICAgICJwYXlsb2FkX2NoZWNrc3VtIjogc2FtcGxlc1stMV1bInBheWxvYWRfY2hlY2tzdW0iXSwKICAgICAgICAgICAgICAgICJzYW1wbGVfY291bnQiOiBmbG9hdChsZW4oc2FtcGxlcykpLAogICAgICAgICAgICB9LAogICAgICAgICAgICBzb3J0X2tleXM9VHJ1ZSwKICAgICAgICApCiAgICApCgoKaWYgX19uYW1lX18gPT0gIl9fbWFpbl9fIjoKICAgIG1haW4oKQo=\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 10.0
+      },
+      {
+        "key": "digest_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "deterministic-embedding-duplicate-input-cache",
     "name": "Deterministic embedding duplicate input cache",
     "runner": "ubuntu-latest",

--- a/scripts/deterministic_image_edit_digest_probe.py
+++ b/scripts/deterministic_image_edit_digest_probe.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import statistics
+import tempfile
+import time
+from pathlib import Path
+from threading import Event
+
+from packages.protocol.python.worker.v1 import common_pb2, inference_pb2
+from worker.runtime import deterministic_image_generation_runtime as image_runtime
+from worker.runtime.deterministic_image_generation_runtime import DeterministicImageGenerationRuntime
+
+
+def _run_once(sample: int) -> dict[str, float]:
+    source_bytes = (b"SOURCE_IMAGE_BLOCK_%04d" % sample) * 220_000
+    mask_bytes = (b"MASK_IMAGE_BLOCK_%04d" % sample) * 220_000
+    original_sha256 = image_runtime.hashlib.sha256
+    tracked_inputs = {source_bytes, mask_bytes}
+    digest_calls = 0
+
+    def counting_sha256(payload: bytes = b""):
+        nonlocal digest_calls
+        if payload in tracked_inputs:
+            digest_calls += 1
+        return original_sha256(payload)
+
+    runtime = DeterministicImageGenerationRuntime()
+    request = inference_pb2.ImageEditRequest(
+        id=common_pb2.RequestIdentity(request_id=f"digest-probe-{sample}"),
+        prompt="add detail without changing composition",
+        image=source_bytes,
+        mask=mask_bytes,
+        size="512x512",
+        response_format="png",
+        n=8,
+    )
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        image_runtime.hashlib.sha256 = counting_sha256
+        started = time.perf_counter()
+        try:
+            result = runtime.edit_image(
+                {"model_id": "melix-dev-image"},
+                request,
+                job_id=f"digest-probe-{sample}",
+                images_root=Path(raw_tmp),
+                cancel_event=Event(),
+            )
+        finally:
+            elapsed_ms = (time.perf_counter() - started) * 1000.0
+            image_runtime.hashlib.sha256 = original_sha256
+
+    payload_checksum = sum(sum(image) for image in result.images)
+    return {
+        "elapsed_ms": elapsed_ms,
+        "digest_calls": float(digest_calls),
+        "image_count": float(len(result.images)),
+        "payload_checksum": float(payload_checksum),
+    }
+
+
+def main() -> None:
+    samples = [_run_once(index) for index in range(5)]
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(sample["elapsed_ms"] for sample in samples),
+                "digest_calls_mean": statistics.fmean(sample["digest_calls"] for sample in samples),
+                "image_count": samples[-1]["image_count"],
+                "payload_checksum": samples[-1]["payload_checksum"],
+                "sample_count": float(len(samples)),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_image_runtime.py
+++ b/services/mlx-worker-python/tests/test_image_runtime.py
@@ -182,6 +182,51 @@ def test_image_edit_persists_lineage_and_generated_artifact(tmp_path: Path) -> N
     assert Path(generated_artifact.storage_uri).read_bytes() == response.images[0]
 
 
+def test_image_edit_reuses_input_digests_across_variants(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime_service, inference_service, _ = build_services(tmp_path)
+    model_handle = load_model(runtime_service, WorkerModelCatalog.dev_image_model())
+    source_path = tmp_path / "edit-source.png"
+    mask_path = tmp_path / "edit-mask.png"
+    source_path.write_bytes(b"SOURCE_IMAGE")
+    mask_path.write_bytes(b"MASK_IMAGE")
+    digest_payloads: list[bytes] = []
+
+    def record_digest(payload: bytes) -> str:
+        digest_payloads.append(payload)
+        if payload == b"SOURCE_IMAGE":
+            return "source-once"
+        if payload == b"MASK_IMAGE":
+            return "mask-once"
+        return "unexpected"
+
+    monkeypatch.setattr(
+        DeterministicImageGenerationRuntime,
+        "_edit_input_digest",
+        staticmethod(record_digest),
+    )
+
+    response = inference_service.ImageEdit(
+        inference_pb2.ImageEditRequest(
+            id=common_pb2.RequestIdentity(request_id="image-edit-digests"),
+            model_handle=model_handle,
+            prompt="add stars",
+            image_uri=source_path.as_uri(),
+            mask_uri=mask_path.as_uri(),
+            size="256x256",
+            response_format="png",
+            n=4,
+        ),
+        context=None,
+    )
+
+    assert response.error.code == ""
+    assert len(response.images) == 4
+    assert digest_payloads == [b"SOURCE_IMAGE", b"MASK_IMAGE"]
+    for payload in response.images:
+        assert b"SOURCE_SHA=source-once" in payload
+        assert b"MASK_SHA=mask-once" in payload
+
+
 def test_image_iterate_and_variation_preserve_lineage_metadata(tmp_path: Path) -> None:
     runtime_service, inference_service, _ = build_services(tmp_path)
     model_handle = load_model(runtime_service, WorkerModelCatalog.dev_image_model())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -476,6 +476,32 @@ def test_deterministic_embedding_project_digest_probe_script_smoke(capsys: pytes
     assert metrics["dimensions"] == 4096.0
 
 
+def test_scope_report_selects_deterministic_image_edit_digest_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "deterministic-image-edit-digest-reuse"
+
+
+def test_deterministic_image_edit_digest_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runpy.run_path(
+        str(REPO_ROOT / "scripts/deterministic_image_edit_digest_probe.py"),
+        run_name="__main__",
+    )
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 5.0
+    assert metrics["image_count"] == 8.0
+    assert metrics["digest_calls_mean"] == 4.0
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["payload_checksum"] > 0
+
+
 def test_scope_report_selects_rerank_core_top_k_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -1145,6 +1171,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "code-eval-stdio-tail-single-stat",
         "deterministic-embedding-duplicate-input-cache",
         "deterministic-embedding-project-digest-allocation",
+        "deterministic-image-edit-digest-reuse",
         "deterministic-rerank-query-context-reuse",
         "rerank-core-top-k-heap-selection",
         "runtime-utils-kwarg-signature-cache",

--- a/services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py
@@ -152,6 +152,9 @@ class DeterministicImageGenerationRuntime:
             label="image edit mask",
         )
 
+        source_digest = self._edit_input_digest(source_bytes)
+        mask_digest = self._edit_input_digest(mask_bytes) if mask_bytes is not None else "none"
+
         artifacts: list[common_pb2.ImageArtifactMetadata] = []
         artifact_publish_ms = 0.0
         lineage_ext = self._lineage_ext(
@@ -211,8 +214,8 @@ class DeterministicImageGenerationRuntime:
                 variant=index,
                 model_id=str(loaded_model.get("model_id", "image-model")),
                 strength=float(request.strength or 0.0),
-                source_bytes=source_bytes,
-                mask_bytes=mask_bytes,
+                source_digest=source_digest,
+                mask_digest=mask_digest,
             )
             artifact_path = output_dir / f"output-{index}.{image_format}"
             artifact_publish_ms += self._write_bytes(artifact_path, payload)
@@ -410,6 +413,10 @@ class DeterministicImageGenerationRuntime:
         return cls._normalized_format(suffix or "png")
 
     @staticmethod
+    def _edit_input_digest(payload: bytes) -> str:
+        return hashlib.sha256(payload).hexdigest()[:12]
+
+    @staticmethod
     def _render_edit_payload(
         *,
         prompt: str,
@@ -418,11 +425,9 @@ class DeterministicImageGenerationRuntime:
         variant: int,
         model_id: str,
         strength: float,
-        source_bytes: bytes,
-        mask_bytes: bytes | None,
+        source_digest: str,
+        mask_digest: str,
     ) -> bytes:
-        source_digest = hashlib.sha256(source_bytes).hexdigest()[:12]
-        mask_digest = hashlib.sha256(mask_bytes).hexdigest()[:12] if mask_bytes is not None else "none"
         payload = (
             f"MELIX_IMAGE_EDIT\n"
             f"MODEL={model_id}\n"


### PR DESCRIPTION
## Summary
- Reuse deterministic image edit source/mask digests once per request instead of hashing the same input bytes once per generated variant.
- Add a focused regression test proving four edit variants reuse the same source/mask digest results.
- Register the `deterministic-image-edit-digest-reuse` PR-scoped performance probe with a base-compatible fallback command.

## Plan or Spec
- Plan: `docs/plans/2026-05-06-deterministic-image-edit-digest-reuse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_image_runtime.py::test_image_edit_persists_lineage_and_generated_artifact services/mlx-worker-python/tests/test_image_runtime.py::test_image_edit_reuses_input_digests_across_variants services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_image_edit_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_image_edit_digest_probe_script_emits_metrics
# 5 passed in 0.75s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_image_runtime.py::test_image_edit_persists_lineage_and_generated_artifact services/mlx-worker-python/tests/test_image_runtime.py::test_image_edit_reuses_input_digests_across_variants services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_image_edit_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_image_edit_digest_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py services/mlx-worker-python/tests/test_image_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_image_edit_digest_probe.py
# 5 passed; TOTAL 40 1 98%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/deterministic_image_edit_digest_probe.py
# {"digest_calls_mean": 4.0, "elapsed_ms_mean": 25.92352321371436, "image_count": 8.0, "payload_checksum": 108012.0, "sample_count": 5.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-image-edit-digest-reuse --base-repo /tmp/melix-cron-opt-base-20260506032616 --head-repo "$PWD" --output /tmp/deterministic-image-edit-digest-reuse.json
# head verification passed; base probe ok; head probe ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 40 1 98%`.
  - Runtime changed lines: `100.00%`.
  - Focused image-runtime test changed lines: `95.65%`.
  - PR-scoped performance test changed lines: `100.00%`.
- Registered local base-vs-head probe: `deterministic-image-edit-digest-reuse`.
  - Base (`origin/main`): `digest_calls_mean=18.0`, `elapsed_ms_mean=72.6214558002539`, `image_count=8.0`, `payload_checksum=108012.0`.
  - Head: `digest_calls_mean=4.0`, `elapsed_ms_mean=25.944124022498727`, `image_count=8.0`, `payload_checksum=108012.0`.
  - Interpretation: source/mask digest calls drop by ~77.8% while preserving output checksum; elapsed mean is ~64.3% lower on the synthetic eight-variant edit workload.

## Known Gaps
- Linux-only local verification was run; macOS/Swift checks were not run locally because this slice only changes Python worker/runtime and CI probe files.
- Hosted CI is still required before merge, especially the PR-scoped performance workflow for the registered probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
