### PR TITLE
perf: short-circuit duplicate stream tool call ids

### DIFF
--- a/docs/plans/2026-05-06-stream-assembler-duplicate-call-id-short-circuit.md
+++ b/docs/plans/2026-05-06-stream-assembler-duplicate-call-id-short-circuit.md
@@ -1,0 +1,39 @@
+# Stream Assembler Duplicate Call-ID Short-Circuit
+
+## Goal
+
+Reduce redundant work in the Python worker stream assembler when a model replays a tool call fragment with the same model-provided call ID.
+
+## Linux-only constraint
+
+This slice is Python-only under `services/mlx-worker-python`, so it can be validated on Linux with focused pytest, changed-scope coverage, and a local command-json performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/stream_assembler.py`
+- `services/mlx-worker-python/tests/test_stream_assembler.py`
+- `infra/perf/pr_scoped_probes.json`
+- `docs/plans/2026-05-06-stream-assembler-duplicate-call-id-short-circuit.md`
+
+## Optimization
+
+`RequestStreamAssembler._tool_delta(...)` currently canonicalizes `arguments` with `json.dumps(..., sort_keys=True, separators=(",", ":"))` before checking whether a model-provided `id`/`call_id` has already been emitted. For duplicate call-ID replays, the argument serialization is wasted because the duplicate is discarded.
+
+Change the model-provided call-ID path to check `_emitted_tool_keys` before serializing arguments. Preserve the legacy call-ID-less path because it still needs canonical argument JSON for content-based dedupe.
+
+## Performance probe definition
+
+Update the registered `stream-assembler-parser-mode-cache` PR-scoped probe so the command-json workload includes repeated duplicate model-provided call IDs with large argument payloads.
+
+Metrics:
+
+- `elapsed_ms_mean`: lower is better.
+- `json_dumps_calls_mean`: lower is better; expected to drop for duplicate call-ID replay.
+- `duplicate_tool_delta_count`: must remain equal to the duplicate replay count.
+
+## Success metrics
+
+- Focused pytest passes.
+- Changed-scope coverage is at least 95% for touched executable Python lines.
+- Local probe reports lower elapsed time and fewer argument serialization calls on the optimized branch against `origin/main`.
+- `git diff --check` is clean.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -88,7 +88,7 @@
   },
   {
     "id": "stream-assembler-parser-mode-cache",
-    "name": "Stream assembler parser-mode cache",
+    "name": "Stream assembler duplicate call-id short-circuit",
     "runner": "ubuntu-latest",
     "watch_globs": [
       "services/mlx-worker-python/worker/runtime/stream_assembler.py",
@@ -98,7 +98,7 @@
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
     "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
-    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 - <<'PY'\nimport json\nimport statistics\nimport time\nfrom worker.runtime.stream_assembler import RequestStreamAssembler, StreamFragment\n\nchunks = []\nraw = ''\nfor index in range(1200):\n    if index % 120 == 0:\n        piece = '<think>plan</think><tool_call>{\\\"id\\\":\\\"call-%d\\\",\\\"name\\\":\\\"search\\\",\\\"arguments\\\":{\\\"q\\\":\\\"alpha\\\"}}</tool_call>' % index\n    elif index % 17 == 0:\n        piece = 'alpha<tool_ca'\n    else:\n        piece = ' token-%d ' % index\n    raw += piece\n    chunks.append(raw)\n\nelapsed = []\ntool_counts = []\nfor _ in range(8):\n    assembler = RequestStreamAssembler('probe', True, '', 'qwen')\n    started = time.perf_counter()\n    tool_count = 0\n    for chunk in chunks:\n        tool_count += sum(1 for delta in assembler.accept(StreamFragment(raw_text=chunk)) if delta.tool_call is not None)\n    completed = assembler.completed()\n    elapsed.append((time.perf_counter() - started) * 1000.0)\n    tool_counts.append(tool_count)\n    if completed.metrics['tool_call_markup_leak_count'] != 0:\n        raise SystemExit('tool markup leaked')\nif len(set(tool_counts)) != 1 or tool_counts[0] != 10:\n    raise SystemExit(f'unexpected tool counts: {tool_counts!r}')\nprint(json.dumps({'elapsed_ms_mean': statistics.fmean(elapsed), 'raw_char_count': float(len(raw)), 'tool_call_count': float(tool_counts[0])}, sort_keys=True))\nPY",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 - <<'PY'\nimport json\nimport statistics\nimport time\nfrom worker.runtime import stream_assembler\nfrom worker.runtime.stream_assembler import RequestStreamAssembler\n\nbody = json.dumps({\n    \"id\": \"call-duplicate\",\n    \"name\": \"search\",\n    \"arguments\": {\n        \"query\": \"alpha\",\n        \"payload\": [f\"token-{index}\" for index in range(512)],\n        \"nested\": {\"enabled\": True, \"limit\": 8192},\n    },\n})\niterations = 5000\nsample_count = 7\nelapsed = []\ndumps_calls = []\nduplicate_counts = []\noriginal_dumps = stream_assembler.json.dumps\nfor _ in range(sample_count):\n    assembler = RequestStreamAssembler(\"probe-duplicate-call-id\", True, \"\", \"qwen\")\n    calls = 0\n    def counting_dumps(*args, **kwargs):\n        nonlocal_calls[0] += 1\n        return original_dumps(*args, **kwargs)\n    nonlocal_calls = [0]\n    stream_assembler.json.dumps = counting_dumps\n    try:\n        started = time.perf_counter()\n        first = assembler._tool_delta(body)\n        for _index in range(iterations):\n            duplicate = assembler._tool_delta(body)\n            if duplicate is not None:\n                raise SystemExit(\"duplicate call id emitted a tool delta\")\n        elapsed.append((time.perf_counter() - started) * 1000.0)\n    finally:\n        stream_assembler.json.dumps = original_dumps\n    if first is None or first.call_id != \"call-duplicate\":\n        raise SystemExit(\"first call id did not emit\")\n    completed = assembler.completed()\n    duplicate_count = completed.metrics[\"duplicate_tool_delta_count\"]\n    if duplicate_count != iterations:\n        raise SystemExit(f\"unexpected duplicate count: {duplicate_count}\")\n    dumps_calls.append(float(nonlocal_calls[0]))\n    duplicate_counts.append(float(duplicate_count))\nprint(original_dumps({\n    \"elapsed_ms_mean\": round(statistics.fmean(elapsed), 6),\n    \"json_dumps_calls_mean\": round(statistics.fmean(dumps_calls), 3),\n    \"duplicate_tool_delta_count\": round(statistics.fmean(duplicate_counts), 3),\n    \"iteration_count\": float(iterations),\n}, sort_keys=True))\nPY",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
     "metrics": [
@@ -107,6 +107,12 @@
         "unit": "ms",
         "direction": "lower_is_better",
         "warn_pct": 5.0
+      },
+      {
+        "key": "json_dumps_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
       }
     ]
   },

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from worker.runtime import stream_assembler
 from worker.runtime.stream_assembler import RequestStreamAssembler, StreamFragment
 
 
@@ -420,6 +421,38 @@ def test_duplicate_tool_call_fragments_are_skipped_when_raw_stream_replays_out_o
 
     assert [delta.tool_call.tool_name for delta in first if delta.tool_call] == ["search"]
     assert [delta.tool_call for delta in replay if delta.tool_call] == []
+    assert completed.metrics["duplicate_tool_delta_count"] == 1
+    assert completed.metrics["non_monotonic_stream_count"] == 1
+
+
+def test_duplicate_model_call_id_skips_argument_serialization(monkeypatch) -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-duplicate-call-id-fast-path",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+    dumps_calls = 0
+    original_dumps = stream_assembler.json.dumps
+
+    def counting_dumps(*args, **kwargs):
+        nonlocal dumps_calls
+        dumps_calls += 1
+        return original_dumps(*args, **kwargs)
+
+    monkeypatch.setattr(stream_assembler.json, "dumps", counting_dumps)
+    raw_tool_call = (
+        '<tool_call>{"id":"call-duplicate","name":"search","arguments":'
+        '{"query":"alpha","payload":[1,2,3,4,5]}}</tool_call>'
+    )
+
+    first = assembler.accept(StreamFragment(raw_text=raw_tool_call))
+    replay = assembler.accept(StreamFragment(raw_text=f"prefix {raw_tool_call}"))
+    completed = assembler.completed()
+
+    assert [delta.tool_call.call_id for delta in first if delta.tool_call] == ["call-duplicate"]
+    assert [delta.tool_call for delta in replay if delta.tool_call] == []
+    assert dumps_calls == 1
     assert completed.metrics["duplicate_tool_delta_count"] == 1
     assert completed.metrics["non_monotonic_stream_count"] == 1
 

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -302,14 +302,23 @@ class RequestStreamAssembler:
 
         arguments = payload.get("arguments", {})
         call_id = str(payload.get("id") or payload.get("call_id") or "").strip()
-        arguments_fragment = json.dumps(arguments, sort_keys=True, separators=(",", ":"))
         # Prefer model-provided call ids for dedupe so identical repeated calls
-        # can be emitted. Legacy call-id-less fragments keep content dedupe to
-        # suppress non-monotonic replay from older parsers.
-        key = ("call_id", call_id) if call_id else ("legacy", f"{name}\0{arguments_fragment}")
-        if key in self._emitted_tool_keys:
-            self._metrics["duplicate_tool_delta_count"] += 1
-            return None
+        # can be emitted. When a call id has already been seen, skip before
+        # canonicalizing arguments because the fragment will be discarded.
+        if call_id:
+            key = ("call_id", call_id)
+            if key in self._emitted_tool_keys:
+                self._metrics["duplicate_tool_delta_count"] += 1
+                return None
+            arguments_fragment = json.dumps(arguments, sort_keys=True, separators=(",", ":"))
+        else:
+            arguments_fragment = json.dumps(arguments, sort_keys=True, separators=(",", ":"))
+            # Legacy call-id-less fragments keep content dedupe to suppress
+            # non-monotonic replay from older parsers.
+            key = ("legacy", f"{name}\0{arguments_fragment}")
+            if key in self._emitted_tool_keys:
+                self._metrics["duplicate_tool_delta_count"] += 1
+                return None
         self._emitted_tool_keys.add(key)
 
         self._tool_fragment_index += 1


### PR DESCRIPTION
## Summary
- Short-circuits duplicate model-provided stream tool-call IDs before canonicalizing arguments.
- Preserves legacy call-ID-less content dedupe, where canonical argument JSON is still required.
- Updates the registered stream assembler scoped performance probe to measure duplicate call-ID replay and serialization count directly.

## Plan or Spec
- `docs/plans/2026-05-06-stream-assembler-duplicate-call-id-short-circuit.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 27 passed in 0.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id stream-assembler-parser-mode-cache --base-repo /tmp/melix-cron-opt-base-20260506052935 --head-repo "$PWD" --output /tmp/stream-assembler-probe-20260506052935.json
# head verification: 27 passed; changed-scope coverage TOTAL 29 0 100%
# base probe: elapsed_ms_mean=282.145140, json_dumps_calls_mean=5001.0, duplicate_tool_delta_count=5000.0
# head probe: elapsed_ms_mean=119.289788, json_dumps_calls_mean=1.0, duplicate_tool_delta_count=5000.0

git diff --check
# clean

python3 -m json.tool infra/perf/pr_scoped_probes.json >/dev/null
# valid JSON
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 29 0 100%` from the registered `stream-assembler-parser-mode-cache` head verification.
- Local base-vs-head scoped probe (`stream-assembler-parser-mode-cache`):
  - `elapsed_ms_mean`: `282.145140` -> `119.289788` (~57.72% lower).
  - `json_dumps_calls_mean`: `5001.0` -> `1.0`.
  - `duplicate_tool_delta_count`: preserved at `5000.0`.
- Slice type: Python.

## Known Gaps
- Full Swift/macOS checks were not run locally because this cron host is Linux.
- Hosted PR checks, including the relevant `pr-scoped-performance` job, must validate before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
