### PR TITLE
perf: short-circuit dataset preview file scans

### DIFF
--- a/docs/plans/2026-05-06-dataset-preview-limit-short-circuit.md
+++ b/docs/plans/2026-05-06-dataset-preview-limit-short-circuit.md
@@ -1,0 +1,41 @@
+# Dataset preview limit short-circuit optimization
+
+## Goal
+
+Reduce redundant filesystem traversal and path materialization when local Hugging Face dataset previews request only a small number of rows without an explicit split.
+
+## Linux-only constraint
+
+This is a Python-only worker/catalog slice and can be verified on Linux with focused pytest, changed-scope coverage, and a synthetic local probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_registry_preview_limit_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Proposed change
+
+`read_hf_dataset_snapshot_rows(..., limit=N)` currently calls `_selected_dataset_files(...)`, which fully walks and materializes every supported dataset file before row reading begins. For no-split previews with a tiny limit, this makes preview latency and peak allocation scale with total file count even though only the first readable file is needed.
+
+Add a lazy selected-file iterator for the no-split path so the reader can return as soon as the requested row limit is satisfied. Keep explicit split behavior unchanged because split filtering needs to know whether any matching split file exists.
+
+## Performance probe
+
+Register `dataset-registry-preview-limit-short-circuit` in the PR-scoped performance registry. The probe creates a synthetic snapshot with many JSONL files, reads `limit=1`, and reports:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- `file_count`
+- `rows_returned`
+
+Success means the branch preserves row output while materially lowering elapsed time and peak traced allocation for a many-file `limit=1` preview.
+
+## Verification commands
+
+- Focused pytest for dataset registry and PR-scoped probe tests.
+- Changed-scope coverage using `scripts/changed_scope_coverage.py`; require >=95% for touched executable lines.
+- Local probe command from the registered `dataset-registry-preview-limit-short-circuit` probe.
+- `git diff --check`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1,5 +1,36 @@
 [
   {
+    "id": "dataset-registry-preview-limit-short-circuit",
+    "name": "Dataset registry preview limit short-circuit",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/dataset_registry/catalog.py",
+      "services/mlx-worker-python/tests/test_dataset_registry.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/dataset_registry_preview_limit_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_respects_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_stops_file_scan_after_unsplit_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_keeps_split_filtering_eager_for_missing_split services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_preview_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_respects_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_stops_file_scan_after_unsplit_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_keeps_split_filtering_eager_for_missing_split services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_preview_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_preview_limit_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/dataset_registry_preview_limit_probe.py ]; then python scripts/dataset_registry_preview_limit_probe.py; else python3 - <<\"PY\"\nimport json, os, statistics, sys, tempfile, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.dataset_registry.catalog import read_hf_dataset_snapshot_rows\ndef int_env(name, default):\n    value = os.environ.get(name, \"\")\n    return int(value) if value else default\nfile_count = int_env(\"MELIX_DATASET_PREVIEW_PROBE_FILES\", 1500)\nsample_count = int_env(\"MELIX_DATASET_PREVIEW_PROBE_SAMPLES\", 7)\nelapsed = []\npeaks = []\nwith tempfile.TemporaryDirectory(prefix=\"melix-dataset-preview-probe-\") as temp_dir:\n    snapshot_dir = Path(temp_dir) / \"snapshot\"\n    data_dir = snapshot_dir / \"data\"\n    data_dir.mkdir(parents=True)\n    for index in range(file_count):\n        (data_dir / f\"part-{index:05d}.jsonl\").write_text(json.dumps({\"prompt\": f\"prompt-{index}\", \"answer\": f\"answer-{index}\"}) + \"\\n\", encoding=\"utf-8\")\n    (snapshot_dir / \"README.md\").write_text(\"# Synthetic dataset\\n\", encoding=\"utf-8\")\n    expected = [{\"prompt\": \"prompt-0\", \"answer\": \"answer-0\"}]\n    for _ in range(sample_count):\n        tracemalloc.start()\n        started = time.perf_counter()\n        rows = read_hf_dataset_snapshot_rows(snapshot_dir, limit=1)\n        elapsed.append((time.perf_counter() - started) * 1000.0)\n        _, peak = tracemalloc.get_traced_memory()\n        tracemalloc.stop()\n        peaks.append(float(peak))\n        if rows != expected:\n            raise SystemExit(f\"unexpected preview rows: {rows!r}\")\nprint(json.dumps({\"elapsed_ms_mean\": round(statistics.fmean(elapsed), 6), \"elapsed_ms_min\": round(min(elapsed), 6), \"peak_bytes_mean\": round(statistics.fmean(peaks), 3), \"file_count\": float(file_count), \"rows_returned\": 1.0, \"sample_count\": float(sample_count)}, sort_keys=True))\nPY\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "hub-catalog-tag-normalization-single-pass",
     "name": "Hub catalog tag normalization single pass",
     "runner": "ubuntu-latest",

--- a/scripts/dataset_registry_preview_limit_probe.py
+++ b/scripts/dataset_registry_preview_limit_probe.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.dataset_registry.catalog import read_hf_dataset_snapshot_rows
+
+
+def _int_env(name: str, default: int) -> int:
+    raw_value = os.environ.get(name, "")
+    if not raw_value:
+        return default
+    return int(raw_value)
+
+
+def _build_snapshot(root: Path, *, file_count: int) -> Path:
+    snapshot_dir = root / "snapshot" / "data"
+    snapshot_dir.mkdir(parents=True)
+    for index in range(file_count):
+        (snapshot_dir / f"part-{index:05d}.jsonl").write_text(
+            json.dumps({"prompt": f"prompt-{index}", "answer": f"answer-{index}"}) + "\n",
+            encoding="utf-8",
+        )
+    (root / "snapshot" / "README.md").write_text("# Synthetic dataset\n", encoding="utf-8")
+    return root / "snapshot"
+
+
+def main() -> int:
+    file_count = _int_env("MELIX_DATASET_PREVIEW_PROBE_FILES", 1500)
+    sample_count = _int_env("MELIX_DATASET_PREVIEW_PROBE_SAMPLES", 7)
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    with tempfile.TemporaryDirectory(prefix="melix-dataset-preview-probe-") as temp_dir:
+        snapshot_dir = _build_snapshot(Path(temp_dir), file_count=file_count)
+        expected = [{"prompt": "prompt-0", "answer": "answer-0"}]
+        for _ in range(sample_count):
+            tracemalloc.start()
+            started = time.perf_counter()
+            rows = read_hf_dataset_snapshot_rows(snapshot_dir, limit=1)
+            elapsed_ms = (time.perf_counter() - started) * 1000.0
+            _, peak_bytes = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            if rows != expected:
+                raise RuntimeError(f"unexpected preview rows: {rows!r}")
+            elapsed_samples.append(elapsed_ms)
+            peak_samples.append(float(peak_bytes))
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+                "elapsed_ms_min": round(min(elapsed_samples), 6),
+                "peak_bytes_mean": round(statistics.fmean(peak_samples), 3),
+                "file_count": float(file_count),
+                "rows_returned": 1.0,
+                "sample_count": float(sample_count),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -155,6 +155,59 @@ def test_dataset_catalog_row_reader_respects_limit(tmp_path: Path) -> None:
     assert rows == [{"prompt": "first", "answer": "a"}]
 
 
+def test_dataset_catalog_row_reader_stops_file_scan_after_unsplit_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    data_dir = snapshot_dir / "data"
+    data_dir.mkdir(parents=True)
+    first_file = data_dir / "part-00000.jsonl"
+    second_file = data_dir / "part-00001.jsonl"
+    first_file.write_text('{"prompt":"first"}\n', encoding="utf-8")
+    second_file.write_text('{"prompt":"second"}\n', encoding="utf-8")
+    read_paths: list[Path] = []
+    original_read_rows = catalog._read_rows_from_file
+
+    def tracking_read_rows(path: Path, *, limit: int | None = None) -> list[dict[str, object]]:
+        read_paths.append(path)
+        return original_read_rows(path, limit=limit)
+
+    monkeypatch.setattr(catalog, "_read_rows_from_file", tracking_read_rows)
+
+    rows = read_hf_dataset_snapshot_rows(snapshot_dir, limit=1)
+
+    assert rows == [{"prompt": "first"}]
+    assert read_paths == [first_file]
+
+
+def test_dataset_catalog_row_reader_keeps_split_filtering_eager_for_missing_split(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    data_dir = snapshot_dir / "data"
+    data_dir.mkdir(parents=True)
+    train_path = data_dir / "train.jsonl"
+    validation_path = data_dir / "validation.jsonl"
+    train_path.write_text('{"prompt":"train"}\n', encoding="utf-8")
+    validation_path.write_text('{"prompt":"validation"}\n', encoding="utf-8")
+    considered_paths: list[Path] = []
+    original_iter_supported = catalog._iter_supported_dataset_files
+
+    def tracking_iter_supported(path: Path):
+        for candidate in original_iter_supported(path):
+            considered_paths.append(candidate)
+            yield candidate
+
+    monkeypatch.setattr(catalog, "_iter_supported_dataset_files", tracking_iter_supported)
+
+    rows = read_hf_dataset_snapshot_rows(snapshot_dir, split="test", limit=1)
+
+    assert rows == []
+    assert sorted(set(considered_paths)) == [train_path, validation_path]
+
+
 def test_dataset_catalog_reads_json_and_csv_snapshots(tmp_path: Path) -> None:
     snapshot_dir = tmp_path / "snapshot"
     data_dir = snapshot_dir / "custom"

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -135,6 +135,16 @@ def test_scope_report_selects_training_dataset_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "training-dataset-token-percentiles-single-sort"
 
 
+def test_scope_report_selects_dataset_registry_preview_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/dataset_registry/catalog.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "dataset-registry-preview-limit-short-circuit"
+
+
 def test_scope_report_selects_startup_signals_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -739,6 +749,24 @@ def test_hub_catalog_tag_normalization_probe_script_emits_metrics(
     assert metrics["peak_bytes_mean"] > 0
 
 
+def test_dataset_registry_preview_limit_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_DATASET_PREVIEW_PROBE_FILES", "4")
+    monkeypatch.setenv("MELIX_DATASET_PREVIEW_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(REPO_ROOT / "scripts/dataset_registry_preview_limit_probe.py"), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["file_count"] == 4.0
+    assert metrics["rows_returned"] == 1.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_statistical_evidence_bootstrap_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -840,6 +868,7 @@ def test_runtime_utils_kwarg_cache_probe_script_emits_metrics(
 
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
+        "dataset-registry-preview-limit-short-circuit",
         "hub-catalog-tag-normalization-single-pass",
         "benchmark-evaluation-report-running-aggregates",
         "statistical-evidence-bootstrap-percentile-single-sort",

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -427,14 +427,24 @@ def read_hf_dataset_snapshot_rows(
     split: str = "",
     limit: int | None = None,
 ) -> list[dict[str, Any]]:
-    files = _selected_dataset_files(Path(snapshot_path).expanduser().resolve(), split=split)
+    resolved_snapshot_path = Path(snapshot_path).expanduser().resolve()
     rows: list[dict[str, Any]] = []
-    for path in files:
+    for path in _iter_selected_dataset_files(resolved_snapshot_path, split=split):
         remaining = None if limit is None else max(limit - len(rows), 0)
         if remaining == 0:
             return rows
         rows.extend(_read_rows_from_file(path, limit=remaining))
     return rows
+
+
+def _iter_selected_dataset_files(snapshot_path: Path, *, split: str) -> Iterator[Path]:
+    normalized_split = _normalized(split)
+    if normalized_split:
+        yield from _selected_dataset_files(snapshot_path, split=normalized_split)
+        return
+    for path in _iter_supported_dataset_files(snapshot_path):
+        if path.name not in _README_NAMES:
+            yield path
 
 
 def _selected_dataset_files(snapshot_path: Path, *, split: str) -> tuple[Path, ...]:


### PR DESCRIPTION
## Summary
- Short-circuits no-split local dataset preview reads so `read_hf_dataset_snapshot_rows(..., limit=N)` can stop scanning files once the requested rows are returned.
- Keeps explicit split filtering eager to preserve missing-split semantics.
- Registers a dedicated PR-scoped performance probe for dataset preview limit reads.

## Plan or Spec
- `docs/plans/2026-05-06-dataset-preview-limit-short-circuit.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/probes.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_respects_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_stops_file_scan_after_unsplit_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_keeps_split_filtering_eager_for_missing_split services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_preview_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics
# 7 passed in 0.13s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_respects_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_stops_file_scan_after_unsplit_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_keeps_split_filtering_eager_for_missing_split services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_preview_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_preview_limit_probe.py
# TOTAL 60 0 100%

./scripts/dataset_registry_preview_limit_probe.py
# {"elapsed_ms_mean": 3.666055, "elapsed_ms_min": 3.491308, "file_count": 1500.0, "peak_bytes_mean": 426266.0, "rows_returned": 1.0, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-registry-preview-limit-short-circuit --base-repo /tmp/melix-cron-opt-base-20260506060234 --head-repo "$PWD" --output /tmp/dataset-preview-pr-scoped.json
# Head verification passed; base/head probe both ok.

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 60 0 100%`.
- Registered scoped CI probe: `dataset-registry-preview-limit-short-circuit`.
- Local direct head probe: `elapsed_ms_mean=3.666055`, `peak_bytes_mean=426266.0`, `file_count=1500.0`, `rows_returned=1.0`.
- Local base-vs-head PR-scoped probe:
  - Base: `elapsed_ms_mean=35.372563`, `peak_bytes_mean=856192.0`.
  - Head: `elapsed_ms_mean=3.855719`, `peak_bytes_mean=402373.0`.
  - Improvement: ~89.1% lower mean elapsed time and ~53.0% lower peak traced allocation for the synthetic no-split `limit=1` preview.

## Known Gaps
- Linux-only local validation; macOS/Swift checks were not run because this is a Python dataset-registry slice.
- Hosted GitHub Actions / PR-scoped performance must still validate on the PR before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
