### PR TITLE
perf: precompile hub catalog size hint regexes

### DIFF
--- a/docs/plans/2026-05-06-hub-catalog-size-hint-regex-precompile.md
+++ b/docs/plans/2026-05-06-hub-catalog-size-hint-regex-precompile.md
@@ -1,0 +1,35 @@
+# Hub Catalog Size Hint Regex Precompile
+
+## Goal
+
+Reduce repeated regex compilation overhead in the Hub catalog size-hint parser while preserving accepted size-hint formats.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Linux Constraint
+
+This is a Python-only worker optimization and can be verified on Linux with focused pytest, changed-scope coverage, and a local PR-scoped performance probe.
+
+## Performance Probe
+
+Registered probe: `hub-catalog-size-hint-regex-precompile`
+
+The probe repeatedly calls `_size_hint_from_text(...)` across direct card-data hints, explicit README/model-card hints, and non-matching fallback text. It records:
+
+- `elapsed_ms_mean` — lower is better.
+- `peak_bytes_mean` — informational.
+- `size_hint_calls_mean` — structural workload size.
+- `matched_hint_count` and `checksum` — behavior guard rails.
+
+## Success Metrics
+
+- Focused pytest passes.
+- Changed executable line coverage is at least 95% for the touched Python scope.
+- Local base-vs-head probe shows lower `elapsed_ms_mean` with identical structural guard rails.
+- `git diff --check` passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -31,6 +31,37 @@
     ]
   },
   {
+    "id": "hub-catalog-size-hint-regex-precompile",
+    "name": "Hub catalog size hint regex precompile",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/hub_catalog.py",
+      "services/mlx-worker-python/tests/test_hub_catalog.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/hub_catalog_size_hint_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/hub_catalog_size_hint_probe.py ]; then python scripts/hub_catalog_size_hint_probe.py; else python - <<\"PYPROBE\"\nimport json, os, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.model_ops.hub_catalog import _size_hint_from_text\ndef text(index):\n    value = 128 + (index % 2048)\n    mode = index % 4\n    if mode == 0:\n        return f\"{value} MB\", True, value * 1024 * 1024\n    if mode == 1:\n        return f\"Model size: {value} MB\", False, value * 1024 * 1024\n    if mode == 2:\n        return f\"README\\nMODEL SIZE | {value} kb\\nother metadata\", False, value * 1024\n    return f\"description only {value} MB\", False, 0\ndef run_sample(iterations):\n    started = time.perf_counter()\n    checksum = 0\n    matched = 0\n    for index in range(iterations):\n        item_text, allow_bare, expected = text(index)\n        parsed = _size_hint_from_text(item_text, allow_bare=allow_bare)\n        if parsed != expected:\n            raise SystemExit(f\"unexpected size hint at {index}: {parsed} != {expected}\")\n        checksum ^= parsed\n        if parsed:\n            matched += 1\n    return (time.perf_counter() - started) * 1000.0, checksum, matched\niterations = int(os.environ.get(\"MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS\", \"200000\"))\nsample_count = int(os.environ.get(\"MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES\", \"5\"))\nelapsed_samples = []\npeak_samples = []\nchecksum = matched = 0\nfor _ in range(sample_count):\n    tracemalloc.start()\n    elapsed_ms, checksum, matched = run_sample(iterations)\n    _, peak = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    elapsed_samples.append(elapsed_ms)\n    peak_samples.append(peak)\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed_samples), \"peak_bytes_mean\": statistics.fmean(peak_samples), \"size_hint_calls_mean\": float(iterations), \"matched_hint_count\": float(matched), \"checksum\": float(checksum), \"sample_count\": float(sample_count)}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "size_hint_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "multimodal-fast-path-signature-top-level-key-cache",
     "name": "Multimodal fast-path signature top-level key cache",
     "runner": "ubuntu-latest",

--- a/scripts/hub_catalog_size_hint_probe.py
+++ b/scripts/hub_catalog_size_hint_probe.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.model_ops.hub_catalog import _size_hint_from_text
+
+
+def _text(index: int) -> tuple[str, bool, int]:
+    value = 128 + (index % 2048)
+    mode = index % 4
+    if mode == 0:
+        return f"{value} MB", True, value * 1024 * 1024
+    if mode == 1:
+        return f"Model size: {value} MB", False, value * 1024 * 1024
+    if mode == 2:
+        return f"README\nMODEL SIZE | {value} kb\nother metadata", False, value * 1024
+    return f"description only {value} MB", False, 0
+
+
+def _run_sample(iterations: int) -> tuple[float, int, int]:
+    started = time.perf_counter()
+    checksum = 0
+    matched = 0
+    for index in range(iterations):
+        text, allow_bare, expected = _text(index)
+        parsed = _size_hint_from_text(text, allow_bare=allow_bare)
+        if parsed != expected:
+            raise SystemExit(f"unexpected size hint at {index}: {parsed} != {expected}")
+        checksum ^= parsed
+        if parsed:
+            matched += 1
+    return (time.perf_counter() - started) * 1000.0, checksum, matched
+
+
+def main() -> int:
+    iterations = int(os.environ.get("MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS", "200000"))
+    sample_count = int(os.environ.get("MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES", "5"))
+    elapsed_samples: list[float] = []
+    peak_samples: list[int] = []
+    checksum = 0
+    matched = 0
+
+    for _ in range(sample_count):
+        tracemalloc.start()
+        elapsed_ms, checksum, matched = _run_sample(iterations)
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        elapsed_samples.append(elapsed_ms)
+        peak_samples.append(peak_bytes)
+
+    metrics = {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "peak_bytes_mean": statistics.fmean(peak_samples),
+        "size_hint_calls_mean": float(iterations),
+        "matched_hint_count": float(matched),
+        "checksum": float(checksum),
+        "sample_count": float(sample_count),
+    }
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -10,6 +10,11 @@ import worker.model_ops.hub_catalog as hub_catalog_module
 from worker.model_ops.hub_catalog import HubCatalog, HubCatalogError, _is_mlx_compatible, _local_fit_evidence
 
 
+KB = 1024
+MB = 1024 ** 2
+GB = 1024 ** 3
+
+
 class FakeHTTPResponse:
     def __init__(self, payload: object):
         self._payload = json.dumps(payload).encode("utf-8")
@@ -561,6 +566,18 @@ def test_get_model_card_includes_local_fit_evidence_from_readme_size_hint() -> N
     card = catalog.get_model_card(repo_id="mlx-community/readme-size")
 
     assert card.local_fit_status == "good"
-    assert card.estimated_artifact_bytes == 570 * 1024 * 1024
+    assert card.estimated_artifact_bytes == 570 * MB
     assert card.quantization_summary == "4-bit, optiq"
     assert card.base_models == ["base/model"]
+
+
+def test_size_hint_parser_uses_precompiled_patterns(monkeypatch: pytest.MonkeyPatch) -> None:
+    def dynamic_search_forbidden(*_args, **_kwargs):
+        raise AssertionError("size hint parsing should use precompiled pattern.search")
+
+    monkeypatch.setattr(hub_catalog_module.re, "search", dynamic_search_forbidden)
+
+    assert hub_catalog_module._size_hint_from_text("2.5 GB", allow_bare=True) == int(2.5 * GB)
+    assert hub_catalog_module._size_hint_from_text("Model size: 768 MB", allow_bare=False) == 768 * MB
+    assert hub_catalog_module._size_hint_from_text("Readme says 768 MB", allow_bare=False) == 0
+    assert hub_catalog_module._size_hint_from_text("MODEL SIZE | 512 kb", allow_bare=False) == 512 * KB

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -85,8 +85,12 @@ def test_scope_report_selects_hub_catalog_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/model_ops/hub_catalog.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "hub-catalog-tag-normalization-single-pass"
+    probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert scope["selected_count"] == 2
+    assert probe_ids == {
+        "hub-catalog-tag-normalization-single-pass",
+        "hub-catalog-size-hint-regex-precompile",
+    }
 
 
 def test_scope_report_selects_stream_assembler_probe() -> None:
@@ -739,6 +743,25 @@ def test_hub_catalog_tag_normalization_probe_script_emits_metrics(
     assert metrics["peak_bytes_mean"] > 0
 
 
+def test_hub_catalog_size_hint_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS", "8")
+    monkeypatch.setenv("MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(REPO_ROOT / "scripts/hub_catalog_size_hint_probe.py"), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["size_hint_calls_mean"] == 8.0
+    assert metrics["matched_hint_count"] == 6.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_statistical_evidence_bootstrap_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -841,6 +864,7 @@ def test_runtime_utils_kwarg_cache_probe_script_emits_metrics(
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
         "hub-catalog-tag-normalization-single-pass",
+        "hub-catalog-size-hint-regex-precompile",
         "benchmark-evaluation-report-running-aggregates",
         "statistical-evidence-bootstrap-percentile-single-sort",
         "stream-assembler-parser-mode-cache",

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -15,6 +15,9 @@ from worker.productization.device_identity import collect_device_identity
 MEMORY_COMFORT_BUDGET_FACTOR = 0.60
 RESIDENT_MEMORY_OVERHEAD_FACTOR = 1.35
 
+_BARE_SIZE_HINT_RE = re.compile(r"(?:model\s+size\s*[:|]?\s*)?(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
+_EXPLICIT_SIZE_HINT_RE = re.compile(r"\bmodel\s+size\s*[:|]?\s*(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
+
 
 @dataclass(frozen=True)
 class HubModelSummaryRecord:
@@ -531,11 +534,8 @@ def _size_hint_bytes(payload: dict[str, Any]) -> int:
 
 
 def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:
-    if allow_bare:
-        pattern = r"(?:model\s+size\s*[:|]?\s*)?(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b"
-    else:
-        pattern = r"\bmodel\s+size\s*[:|]?\s*(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b"
-    match = re.search(pattern, text, re.IGNORECASE)
+    pattern = _BARE_SIZE_HINT_RE if allow_bare else _EXPLICIT_SIZE_HINT_RE
+    match = pattern.search(text)
     if not match:
         return 0
     value = float(match.group(1))


### PR DESCRIPTION
## Summary
- Precompile the Hub catalog size-hint regexes used by `_size_hint_from_text(...)` so repeated Hub metadata parsing no longer rebuilds the same regular expressions on every call.
- Add focused coverage for direct card-data size hints, explicit README/model-card hints, and bare fallback rejection.
- Register a dedicated `hub-catalog-size-hint-regex-precompile` PR-scoped performance probe with a base-compatible fallback command.

## Plan or Spec
- `docs/plans/2026-05-06-hub-catalog-size-hint-regex-precompile.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/probes.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 26 passed in 0.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# TOTAL 31 1 97%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /tmp/melix-base-size-hint-20260506071512 --head-repo "$PWD" --output /tmp/hub_catalog_size_hint_compare.json
# base elapsed_ms_mean=1795.7851508050226, head elapsed_ms_mean=1590.783351205755
# base peak_bytes_mean=2463.8, head peak_bytes_mean=1561.0
# size_hint_calls_mean=200000.0, matched_hint_count=150000.0, checksum=0.0 on both sides

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 31 1 97%`.
  - `hub_catalog.py`: 4/4 changed executable lines covered (`100.00%`).
  - `test_hub_catalog.py`: 11/12 changed executable lines covered (`91.67%`).
  - `test_pr_scoped_performance.py`: 15/15 changed executable lines covered (`100.00%`).
  - Aggregate gate: `30/31` changed executable lines covered (`97%`).
- Local base-vs-head probe (`hub-catalog-size-hint-regex-precompile`):
  - `elapsed_ms_mean`: `1795.7851508050226` -> `1590.783351205755` (~11.42% lower, ~1.13x faster).
  - `peak_bytes_mean`: `2463.8` -> `1561.0` (~36.64% lower).
  - Structural guard rails unchanged: `size_hint_calls_mean=200000.0`, `matched_hint_count=150000.0`, `checksum=0.0`, `sample_count=5.0`.
- Registered scoped CI probe: `hub-catalog-size-hint-regex-precompile`.

## Known Gaps
- Linux-only local verification was run for this Python worker slice.
- Full repository `make swift-test` / macOS checks were not run on this Linux host; hosted CI remains the merge gate for non-Linux surfaces.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
