### PR TITLE
ci: provision Python for Swift test shards

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -103,6 +103,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Restore Python dependency cache
+        uses: actions/cache@v4
+        with:
+          path: .uv-cache
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock', 'pyproject.toml', 'services/mlx-worker-python/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
       - name: Restore Swift dependency cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- Adds Python 3.12 and uv setup to the `swift-tests` matrix shards.
- Restores the Python uv cache before Swift shards so `ProcessWorkerBridgeRunner` tests can run fixture workers through `uv run`.
- Fixes the base-branch CI regression where many PRs fail `swift-tests (control-worker)` / `swift-tests (text-worker)` after the Swift CI split omitted Python toolchain provisioning.

## Plan or Spec
- N/A: CI base-branch remediation for an existing workflow regression; governed by `.github/workflows/ci-pr.yml` and the PR evidence rules.

## Commands Run
```text
GH_CONFIG_DIR=/root/.hermes/secrets/legacy-gh-akane gh api repos/Keith-CY/melix/pulls --method GET --paginate -f state=open -f per_page=100
  -> confirmed 37 open PRs; recurring failures: swift-tests (text-worker)=22, swift-tests (control-worker)=20, swift-tests-report=19.

GH_CONFIG_DIR=/root/.hermes/secrets/legacy-gh-akane gh api repos/Keith-CY/melix/actions/jobs/74523759922/logs
  -> confirmed control-worker failure in PythonBridgeWorkerClientTests because ProcessWorkerBridgeRunner returned unavailable for uv-backed fixture tests.

git diff --check
  -> passed.

python3 - <<'PY'
from pathlib import Path
import yaml
yaml.safe_load(Path('.github/workflows/ci-pr.yml').read_text())
print('yaml ok')
PY
  -> yaml ok.

bash -n scripts/ci_progress.sh
  -> passed.

actionlint .github/workflows/ci-pr.yml
  -> not run: actionlint is unavailable in this Linux worktree.

make swift-test
  -> not run: the failing shard is macOS GitHub Actions specific; this Linux host cannot reproduce xcrun swift test macOS runner behavior.
```

## Coverage and Metrics
- N/A: workflow-only CI provisioning change; no executable product code changed and no changed-scope coverage metric applies.
- CI metric from failed PR rollup before the fix: 22 open PRs failing `swift-tests (text-worker)`, 20 failing `swift-tests (control-worker)`, 19 failing `swift-tests-report`.

## Known Gaps
- GitHub Actions must validate the actual macOS `swift-tests` matrix after this PR opens.
- Existing PRs will need a rerun/rebase after this base fix lands.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated.
- [x] Protocol changes include regenerated generated artifacts, or N/A is stated.
- [x] Dependency changes include updated lockfiles, or N/A is stated.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
