### PR TITLE
perf: short-circuit hub catalog MLX tag checks

### DIFF
--- a/docs/plans/2026-05-05-hub-catalog-tag-normalization-single-pass.md
+++ b/docs/plans/2026-05-05-hub-catalog-tag-normalization-single-pass.md
@@ -34,7 +34,7 @@ The probe also emits `peak_bytes_mean` as observational context, but the CI gate
 ## Success Metrics
 
 - Preserve Hub catalog output semantics for MLX compatibility, quantization summary, and resident-byte estimates.
-- Reduce tag normalization from three lower-case set builds per record to one per record on the optimized path.
+- Avoid card-data tag normalization when an earlier MLX compatibility signal already proves the record is compatible.
 - Keep changed-scope automated coverage at or above 95%.
 
 ## Verification Commands
@@ -44,5 +44,5 @@ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-
 
 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py
 
-PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/hub_catalog_tag_normalization_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py
 ```

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -184,6 +184,26 @@ def test_hub_catalog_raises_hub_payload_invalid_on_malformed_json() -> None:
     assert error.value.code == "hub_payload_invalid"
 
 
+def test_is_mlx_compatible_preserves_card_data_tag_signal_after_fast_paths() -> None:
+    assert _is_mlx_compatible(
+        repo_id="plain/card-tagged-model",
+        tags=["transformers"],
+        library_name="transformers",
+        card_data={"tags": ["MLX"]},
+        lowered_tags={"transformers"},
+    ) is True
+
+
+def test_is_mlx_compatible_keeps_library_name_fast_path() -> None:
+    assert _is_mlx_compatible(
+        repo_id="plain/library-tagged-model",
+        tags=["transformers"],
+        library_name="MLX",
+        card_data={"tags": []},
+        lowered_tags={"transformers"},
+    ) is True
+
+
 def test_search_models_with_mlx_only_false_returns_all_results() -> None:
     payload = [
         {

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -352,18 +352,14 @@ def _is_mlx_compatible(
     lowered_tags: set[str] | None = None,
 ) -> bool:
     lowered_tags = _normalized_lowered_tags(tags, lowered_tags)
-    card_tags = {
-        tag.lower()
-        for tag in _string_list(card_data.get("tags"))
-    }
-    lowered_repo_id = repo_id.lower()
-    if "mlx" in lowered_tags or "mlx" in card_tags:
+    if "mlx" in lowered_tags:
         return True
     if library_name.lower() == "mlx":
         return True
+    lowered_repo_id = repo_id.lower()
     if "mlx" in lowered_repo_id:
         return True
-    return repo_id.startswith("mlx-community/")
+    return "mlx" in {tag.lower() for tag in _string_list(card_data.get("tags"))}
 
 
 def _local_fit_evidence(


### PR DESCRIPTION
## Summary
- Short-circuit Hub catalog MLX compatibility checks before normalizing `cardData.tags` when payload tags, library name, or repo id already prove compatibility.
- Add focused regression tests for the deferred card-data fallback and the library-name fast path.
- Update the governing performance plan to describe this follow-up optimization and use `python3` in the probe command.

## Plan or Spec
- `docs/plans/2026-05-05-hub-catalog-tag-normalization-single-pass.md`

## Commands Run
```text
# Baseline on origin/main before the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
# exit 0; 25 passed in 0.46s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py
# exit 0; {"elapsed_ms_mean": 366.56777600292116, "peak_bytes_mean": 8750033.4, "record_count": 5000.0, "sample_count": 5.0, "tag_normalization_calls_mean": 5000.0}

# Head after the change before rebase
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
# exit 0; 27 passed in 0.14s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py
# exit 0; TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py
# exit 0; {"elapsed_ms_mean": 353.5454047843814, "peak_bytes_mean": 8750033.4, "record_count": 5000.0, "sample_count": 5.0, "tag_normalization_calls_mean": 5000.0}

# Rebased onto origin/main after #444, then re-ran focused verification
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
# exit 0; 28 passed in 0.49s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py
# exit 0; TOTAL 0 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py
# exit 0; {"elapsed_ms_mean": 344.12259818054736, "peak_bytes_mean": 8749543.8, "record_count": 5000.0, "sample_count": 5.0, "tag_normalization_calls_mean": 5000.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 7 0 100%`).
- Registered local probe: `hub-catalog-tag-normalization-single-pass`.
- Local probe delta: pre-rebase `elapsed_ms_mean` improved from `366.5678 ms` to `353.5454 ms` (`-13.0224 ms`, about `3.55%` faster); after rebasing onto `origin/main` the focused probe measured `344.1226 ms`. `tag_normalization_calls_mean` stayed at `5000.0` because this follow-up optimizes the card-data fallback allocation/normalization after the previous one-pass tag-set slice.
- CI PR-scoped performance workflow validated the registered probe after rebase: `hub-catalog-tag-normalization-single-pass` base `349.988 ms`, head `341.326 ms`, delta `-8.662 ms` (`-2.47%`), regressions `0`, verification failures `0`. The same report also ran the overlapping hub-catalog size-hint probe as neutral (`+1.34%`). Full PR CI is still required before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed.
- The structural tag-normalization call metric is unchanged by design for this follow-up; elapsed time is the relevant local metric.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
