### PR TITLE
perf: consolidate remaining Python worker optimizations

### DIFF
--- a/docs/plans/2026-05-06-dataset-preview-limit-short-circuit.md
+++ b/docs/plans/2026-05-06-dataset-preview-limit-short-circuit.md
@@ -1,0 +1,41 @@
+# Dataset preview limit short-circuit optimization
+
+## Goal
+
+Reduce redundant filesystem traversal and path materialization when local Hugging Face dataset previews request only a small number of rows without an explicit split.
+
+## Linux-only constraint
+
+This is a Python-only worker/catalog slice and can be verified on Linux with focused pytest, changed-scope coverage, and a synthetic local probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_registry_preview_limit_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Proposed change
+
+`read_hf_dataset_snapshot_rows(..., limit=N)` currently calls `_selected_dataset_files(...)`, which fully walks and materializes every supported dataset file before row reading begins. For no-split previews with a tiny limit, this makes preview latency and peak allocation scale with total file count even though only the first readable file is needed.
+
+Add a lazy selected-file iterator for the no-split path so the reader can return as soon as the requested row limit is satisfied. Keep explicit split behavior unchanged because split filtering needs to know whether any matching split file exists.
+
+## Performance probe
+
+Register `dataset-registry-preview-limit-short-circuit` in the PR-scoped performance registry. The probe creates a synthetic snapshot with many JSONL files, reads `limit=1`, and reports:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- `file_count`
+- `rows_returned`
+
+Success means the branch preserves row output while materially lowering elapsed time and peak traced allocation for a many-file `limit=1` preview.
+
+## Verification commands
+
+- Focused pytest for dataset registry and PR-scoped probe tests.
+- Changed-scope coverage using `scripts/changed_scope_coverage.py`; require >=95% for touched executable lines.
+- Local probe command from the registered `dataset-registry-preview-limit-short-circuit` probe.
+- `git diff --check`.

--- a/docs/plans/2026-05-06-hub-catalog-size-hint-regex-precompile.md
+++ b/docs/plans/2026-05-06-hub-catalog-size-hint-regex-precompile.md
@@ -1,0 +1,35 @@
+# Hub Catalog Size Hint Regex Precompile
+
+## Goal
+
+Reduce repeated regex compilation overhead in the Hub catalog size-hint parser while preserving accepted size-hint formats.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Linux Constraint
+
+This is a Python-only worker optimization and can be verified on Linux with focused pytest, changed-scope coverage, and a local PR-scoped performance probe.
+
+## Performance Probe
+
+Registered probe: `hub-catalog-size-hint-regex-precompile`
+
+The probe repeatedly calls `_size_hint_from_text(...)` across direct card-data hints, explicit README/model-card hints, and non-matching fallback text. It records:
+
+- `elapsed_ms_mean` — lower is better.
+- `peak_bytes_mean` — informational.
+- `size_hint_calls_mean` — structural workload size.
+- `matched_hint_count` and `checksum` — behavior guard rails.
+
+## Success Metrics
+
+- Focused pytest passes.
+- Changed executable line coverage is at least 95% for the touched Python scope.
+- Local base-vs-head probe shows lower `elapsed_ms_mean` with identical structural guard rails.
+- `git diff --check` passes.

--- a/docs/plans/2026-05-06-mlx-audio-speech-signature-elision.md
+++ b/docs/plans/2026-05-06-mlx-audio-speech-signature-elision.md
@@ -1,0 +1,40 @@
+# MLX Audio Speech Signature Elision
+
+## Goal
+
+Reduce redundant reflection in the MLX audio speech runtime by reusing the speech model capability metadata already computed during `load_model()` instead of calling `inspect.signature(...)` on every `speak(...)` request.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py`
+- `services/mlx-worker-python/tests/test_mlx_audio_runtime.py`
+- `scripts/mlx_audio_speech_signature_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Linux-Only Constraint
+
+This slice is Python-only and uses fake MLX audio modules/models in focused tests and probes, so it can be verified on Linux without the macOS/Swift runtime surfaces.
+
+## Performance Probe Definition
+
+Register `mlx-audio-speech-signature-elision` in the PR-scoped performance registry. The probe runs a synthetic speech workload against `MLXAudioSpeechRuntime.speak(...)` and reports:
+
+- `elapsed_ms_mean`
+- `inspect_signature_calls_mean`
+- `speak_call_count`
+- `output_bytes_total`
+
+## Success Metrics
+
+- Preserve voice/instruction mapping semantics.
+- Drive per-request speech signature calls to `0` on the optimized branch after model load.
+- Improve or maintain elapsed runtime for repeated synthetic `speak(...)` calls.
+- Maintain at least 95% changed-scope automated coverage.
+
+## Verification Commands
+
+- Focused pytest for MLX audio runtime and PR-scoped probe registry tests.
+- Changed-scope coverage via `coverage json` plus `scripts/changed_scope_coverage.py`.
+- Local explicit performance probe via `scripts/mlx_audio_speech_signature_probe.py` and registered PR-scoped performance runner.
+- `git diff --check`.

--- a/docs/plans/2026-05-06-multimodal-image-uri-single-parse.md
+++ b/docs/plans/2026-05-06-multimodal-image-uri-single-parse.md
@@ -1,0 +1,33 @@
+# Multimodal Image URI Single-Parse Optimization
+
+## Goal
+
+Reduce redundant URI parsing in `worker.runtime.multimodal_preprocessing` for image URI inputs while preserving local, file, HTTP/HTTPS, missing-file, and unsupported-scheme behavior.
+
+## Linux-only constraint
+
+This slice is Python-only and runs in `services/mlx-worker-python`, so it can be validated on Linux with focused pytest, changed-scope coverage, and a PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py`
+- `services/mlx-worker-python/tests/test_vision_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/multimodal_image_uri_parse_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Probe
+
+Register `multimodal-preprocessing-image-uri-single-parse` as a command-json PR-scoped probe. The probe builds repeated local file image URI requests, wraps `multimodal_preprocessing.urlparse`, and reports:
+
+- `elapsed_ms_mean` (lower is better)
+- `urlparse_calls_mean` (lower is better, structural metric)
+- `peak_bytes_mean`
+- `prepared_image_count`
+
+## Success metrics
+
+- Behavior remains unchanged for local/file/http URI image inputs and existing failure paths.
+- Focused pytest passes.
+- Changed executable scope coverage is at least 95%.
+- Local probe shows `urlparse_calls_mean` reduced from the legacy two-parses-per-local-URI path to one parse per local URI on the optimized branch.

--- a/docs/plans/2026-05-06-stream-assembler-duplicate-call-id-short-circuit.md
+++ b/docs/plans/2026-05-06-stream-assembler-duplicate-call-id-short-circuit.md
@@ -1,0 +1,39 @@
+# Stream Assembler Duplicate Call-ID Short-Circuit
+
+## Goal
+
+Reduce redundant work in the Python worker stream assembler when a model replays a tool call fragment with the same model-provided call ID.
+
+## Linux-only constraint
+
+This slice is Python-only under `services/mlx-worker-python`, so it can be validated on Linux with focused pytest, changed-scope coverage, and a local command-json performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/stream_assembler.py`
+- `services/mlx-worker-python/tests/test_stream_assembler.py`
+- `infra/perf/pr_scoped_probes.json`
+- `docs/plans/2026-05-06-stream-assembler-duplicate-call-id-short-circuit.md`
+
+## Optimization
+
+`RequestStreamAssembler._tool_delta(...)` currently canonicalizes `arguments` with `json.dumps(..., sort_keys=True, separators=(",", ":"))` before checking whether a model-provided `id`/`call_id` has already been emitted. For duplicate call-ID replays, the argument serialization is wasted because the duplicate is discarded.
+
+Change the model-provided call-ID path to check `_emitted_tool_keys` before serializing arguments. Preserve the legacy call-ID-less path because it still needs canonical argument JSON for content-based dedupe.
+
+## Performance probe definition
+
+Update the registered `stream-assembler-parser-mode-cache` PR-scoped probe so the command-json workload includes repeated duplicate model-provided call IDs with large argument payloads.
+
+Metrics:
+
+- `elapsed_ms_mean`: lower is better.
+- `json_dumps_calls_mean`: lower is better; expected to drop for duplicate call-ID replay.
+- `duplicate_tool_delta_count`: must remain equal to the duplicate replay count.
+
+## Success metrics
+
+- Focused pytest passes.
+- Changed-scope coverage is at least 95% for touched executable Python lines.
+- Local probe reports lower elapsed time and fewer argument serialization calls on the optimized branch against `origin/main`.
+- `git diff --check` is clean.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2083,5 +2083,98 @@
         "direction": "informational"
       }
     ]
+  },
+  {
+    "id": "dataset-registry-preview-limit-short-circuit",
+    "name": "Dataset registry preview limit short-circuit",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/dataset_registry/catalog.py",
+      "services/mlx-worker-python/tests/test_dataset_registry.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/dataset_registry_preview_limit_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_respects_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_stops_file_scan_after_unsplit_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_keeps_split_filtering_eager_for_missing_split services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_preview_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_respects_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_stops_file_scan_after_unsplit_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_keeps_split_filtering_eager_for_missing_split services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_preview_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_preview_limit_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/dataset_registry_preview_limit_probe.py ]; then python scripts/dataset_registry_preview_limit_probe.py; else python3 - <<\"PY\"\nimport json, os, statistics, sys, tempfile, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.dataset_registry.catalog import read_hf_dataset_snapshot_rows\ndef int_env(name, default):\n    value = os.environ.get(name, \"\")\n    return int(value) if value else default\nfile_count = int_env(\"MELIX_DATASET_PREVIEW_PROBE_FILES\", 1500)\nsample_count = int_env(\"MELIX_DATASET_PREVIEW_PROBE_SAMPLES\", 7)\nelapsed = []\npeaks = []\nwith tempfile.TemporaryDirectory(prefix=\"melix-dataset-preview-probe-\") as temp_dir:\n    snapshot_dir = Path(temp_dir) / \"snapshot\"\n    data_dir = snapshot_dir / \"data\"\n    data_dir.mkdir(parents=True)\n    for index in range(file_count):\n        (data_dir / f\"part-{index:05d}.jsonl\").write_text(json.dumps({\"prompt\": f\"prompt-{index}\", \"answer\": f\"answer-{index}\"}) + \"\\n\", encoding=\"utf-8\")\n    (snapshot_dir / \"README.md\").write_text(\"# Synthetic dataset\\n\", encoding=\"utf-8\")\n    expected = [{\"prompt\": \"prompt-0\", \"answer\": \"answer-0\"}]\n    for _ in range(sample_count):\n        tracemalloc.start()\n        started = time.perf_counter()\n        rows = read_hf_dataset_snapshot_rows(snapshot_dir, limit=1)\n        elapsed.append((time.perf_counter() - started) * 1000.0)\n        _, peak = tracemalloc.get_traced_memory()\n        tracemalloc.stop()\n        peaks.append(float(peak))\n        if rows != expected:\n            raise SystemExit(f\"unexpected preview rows: {rows!r}\")\nprint(json.dumps({\"elapsed_ms_mean\": round(statistics.fmean(elapsed), 6), \"elapsed_ms_min\": round(min(elapsed), 6), \"peak_bytes_mean\": round(statistics.fmean(peaks), 3), \"file_count\": float(file_count), \"rows_returned\": 1.0, \"sample_count\": float(sample_count)}, sort_keys=True))\nPY\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
+    "id": "hub-catalog-size-hint-regex-precompile",
+    "name": "Hub catalog size hint regex precompile",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/hub_catalog.py",
+      "services/mlx-worker-python/tests/test_hub_catalog.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/hub_catalog_size_hint_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/hub_catalog_size_hint_probe.py ]; then python scripts/hub_catalog_size_hint_probe.py; else python - <<\"PYPROBE\"\nimport json, os, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.model_ops.hub_catalog import _size_hint_from_text\ndef text(index):\n    value = 128 + (index % 2048)\n    mode = index % 4\n    if mode == 0:\n        return f\"{value} MB\", True, value * 1024 * 1024\n    if mode == 1:\n        return f\"Model size: {value} MB\", False, value * 1024 * 1024\n    if mode == 2:\n        return f\"README\\nMODEL SIZE | {value} kb\\nother metadata\", False, value * 1024\n    return f\"description only {value} MB\", False, 0\ndef run_sample(iterations):\n    started = time.perf_counter()\n    checksum = 0\n    matched = 0\n    for index in range(iterations):\n        item_text, allow_bare, expected = text(index)\n        parsed = _size_hint_from_text(item_text, allow_bare=allow_bare)\n        if parsed != expected:\n            raise SystemExit(f\"unexpected size hint at {index}: {parsed} != {expected}\")\n        checksum ^= parsed\n        if parsed:\n            matched += 1\n    return (time.perf_counter() - started) * 1000.0, checksum, matched\niterations = int(os.environ.get(\"MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS\", \"200000\"))\nsample_count = int(os.environ.get(\"MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES\", \"5\"))\nelapsed_samples = []\npeak_samples = []\nchecksum = matched = 0\nfor _ in range(sample_count):\n    tracemalloc.start()\n    elapsed_ms, checksum, matched = run_sample(iterations)\n    _, peak = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    elapsed_samples.append(elapsed_ms)\n    peak_samples.append(peak)\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed_samples), \"peak_bytes_mean\": statistics.fmean(peak_samples), \"size_hint_calls_mean\": float(iterations), \"matched_hint_count\": float(matched), \"checksum\": float(checksum), \"sample_count\": float(sample_count)}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "size_hint_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
+    "id": "multimodal-preprocessing-image-uri-single-parse",
+    "name": "Multimodal preprocessing image URI single parse",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py",
+      "services/mlx-worker-python/tests/test_vision_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/multimodal_image_uri_parse_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_accepts_remote_http_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_remote_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_missing_remote_and_unsupported_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_image_uri_parse_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_accepts_remote_http_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_remote_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_missing_remote_and_unsupported_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_image_uri_parse_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/multimodal_image_uri_parse_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/multimodal_image_uri_parse_probe.py ]; then python scripts/multimodal_image_uri_parse_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"ZnJvbSBfX2Z1dHVyZV9fIGltcG9ydCBhbm5vdGF0aW9ucwoKaW1wb3J0IGpzb24KaW1wb3J0IHN0YXRpc3RpY3MKaW1wb3J0IHN5cwppbXBvcnQgdGVtcGZpbGUKaW1wb3J0IHRpbWUKaW1wb3J0IHRyYWNlbWFsbG9jCmZyb20gcGF0aGxpYiBpbXBvcnQgUGF0aAoKZnJvbSBwYWNrYWdlcy5wcm90b2NvbC5weXRob24ud29ya2VyLnYxIGltcG9ydCBjb21tb25fcGIyCmZyb20gd29ya2VyLnJ1bnRpbWUgaW1wb3J0IG11bHRpbW9kYWxfcHJlcHJvY2Vzc2luZwpmcm9tIHdvcmtlci5ydW50aW1lLm11bHRpbW9kYWxfcHJlcHJvY2Vzc2luZyBpbXBvcnQgcHJlcGFyZV92aXNpb25fcmVxdWVzdAoKCmRlZiBfYnVpbGRfbWVzc2FnZXMoaW1hZ2VfcGF0aHM6IGxpc3RbUGF0aF0pIC0+IGxpc3RbY29tbW9uX3BiMi5DaGF0TWVzc2FnZV06CiAgICBwYXJ0cyA9IFtjb21tb25fcGIyLk1lc3NhZ2VQYXJ0KHRleHQ9IkRlc2NyaWJlIHRoZXNlIGltYWdlcy4iKV0KICAgIGZvciBpbmRleCwgaW1hZ2VfcGF0aCBpbiBlbnVtZXJhdGUoaW1hZ2VfcGF0aHMpOgogICAgICAgIHJlZmVyZW5jZSA9IGltYWdlX3BhdGguYXNfdXJpKCkgaWYgaW5kZXggJSAyIGVsc2Ugc3RyKGltYWdlX3BhdGgpCiAgICAgICAgcGFydHMuYXBwZW5kKAogICAgICAgICAgICBjb21tb25fcGIyLk1lc3NhZ2VQYXJ0KAogICAgICAgICAgICAgICAgaW1hZ2VfdXJpPXJlZmVyZW5jZSwKICAgICAgICAgICAgICAgIG1lZGlhPWNvbW1vbl9wYjIuTWVkaWFNZXRhZGF0YSgKICAgICAgICAgICAgICAgICAgICBtZWRpYV90eXBlPWNvbW1vbl9wYjIuTUVESUFfVFlQRV9JTUFHRSwKICAgICAgICAgICAgICAgICAgICBzb3VyY2Vfa2luZD1jb21tb25fcGIyLk1FRElBX1NPVVJDRV9VUkksCiAgICAgICAgICAgICAgICApLAogICAgICAgICAgICApCiAgICAgICAgKQogICAgcmV0dXJuIFtjb21tb25fcGIyLkNoYXRNZXNzYWdlKHJvbGU9InVzZXIiLCBwYXJ0cz1wYXJ0cyldCgoKZGVmIG1haW4oKSAtPiBpbnQ6CiAgICBpbWFnZV9jb3VudCA9IDY0MAogICAgc2FtcGxlX2NvdW50ID0gNQogICAgZWxhcHNlZF9zYW1wbGVzOiBsaXN0W2Zsb2F0XSA9IFtdCiAgICBwZWFrX3NhbXBsZXM6IGxpc3RbZmxvYXRdID0gW10KICAgIHVybHBhcnNlX2NhbGxzOiBsaXN0W2ludF0gPSBbXQogICAgb3JpZ2luYWxfdXJscGFyc2UgPSBtdWx0aW1vZGFsX3ByZXByb2Nlc3NpbmcudXJscGFyc2UKCiAgICB3aXRoIHRlbXBmaWxlLlRlbXBvcmFyeURpcmVjdG9yeShwcmVmaXg9Im1lbGl4LWltYWdlLXVyaS1wYXJzZS1wcm9iZS0iKSBhcyB0bXBkaXI6CiAgICAgICAgcm9vdCA9IFBhdGgodG1wZGlyKQogICAgICAgIGltYWdlX3BhdGhzID0gW10KICAgICAgICBmb3IgaW5kZXggaW4gcmFuZ2UoaW1hZ2VfY291bnQpOgogICAgICAgICAgICBpbWFnZV9wYXRoID0gcm9vdCAvIGYiaW1hZ2Ute2luZGV4OjA0ZH0udHh0IgogICAgICAgICAgICBpbWFnZV9wYXRoLndyaXRlX3RleHQoZiJzeW50aGV0aWMgaW1hZ2UgcGF5bG9hZCB7aW5kZXh9XG4iKQogICAgICAgICAgICBpbWFnZV9wYXRocy5hcHBlbmQoaW1hZ2VfcGF0aCkKICAgICAgICBtZXNzYWdlcyA9IF9idWlsZF9tZXNzYWdlcyhpbWFnZV9wYXRocykKCiAgICAgICAgZm9yIF8gaW4gcmFuZ2Uoc2FtcGxlX2NvdW50KToKICAgICAgICAgICAgY2FsbF9jb3VudCA9IDAKCiAgICAgICAgICAgIGRlZiBjb3VudGluZ191cmxwYXJzZSh1cmk6IHN0cik6CiAgICAgICAgICAgICAgICBub25sb2NhbCBjYWxsX2NvdW50CiAgICAgICAgICAgICAgICBjYWxsX2NvdW50ICs9IDEKICAgICAgICAgICAgICAgIHJldHVybiBvcmlnaW5hbF91cmxwYXJzZSh1cmkpCgogICAgICAgICAgICBtdWx0aW1vZGFsX3ByZXByb2Nlc3NpbmcudXJscGFyc2UgPSBjb3VudGluZ191cmxwYXJzZQogICAgICAgICAgICB0cnk6CiAgICAgICAgICAgICAgICB0cmFjZW1hbGxvYy5zdGFydCgpCiAgICAgICAgICAgICAgICBzdGFydGVkID0gdGltZS5wZXJmX2NvdW50ZXIoKQogICAgICAgICAgICAgICAgcmVxdWVzdCA9IHByZXBhcmVfdmlzaW9uX3JlcXVlc3QobWVzc2FnZXMpCiAgICAgICAgICAgICAgICBlbGFwc2VkX21zID0gKHRpbWUucGVyZl9jb3VudGVyKCkgLSBzdGFydGVkKSAqIDEwMDAuMAogICAgICAgICAgICAgICAgXywgcGVha19ieXRlcyA9IHRyYWNlbWFsbG9jLmdldF90cmFjZWRfbWVtb3J5KCkKICAgICAgICAgICAgICAgIHRyYWNlbWFsbG9jLnN0b3AoKQogICAgICAgICAgICBmaW5hbGx5OgogICAgICAgICAgICAgICAgbXVsdGltb2RhbF9wcmVwcm9jZXNzaW5nLnVybHBhcnNlID0gb3JpZ2luYWxfdXJscGFyc2UKCiAgICAgICAgICAgIGlmIGxlbihyZXF1ZXN0LmltYWdlcykgIT0gaW1hZ2VfY291bnQ6CiAgICAgICAgICAgICAgICByYWlzZSBTeXN0ZW1FeGl0KGYidW5leHBlY3RlZCBwcmVwYXJlZCBpbWFnZSBjb3VudDoge2xlbihyZXF1ZXN0LmltYWdlcyl9IikKICAgICAgICAgICAgaWYgcmVxdWVzdC5wcmVwcm9jZXNzX2lucHV0X2J5dGVzIDw9IDA6CiAgICAgICAgICAgICAgICByYWlzZSBTeXN0ZW1FeGl0KCJleHBlY3RlZCBub24tZW1wdHkgaW1hZ2UgcGF5bG9hZCBhY2NvdW50aW5nIikKICAgICAgICAgICAgZWxhcHNlZF9zYW1wbGVzLmFwcGVuZChlbGFwc2VkX21zKQogICAgICAgICAgICBwZWFrX3NhbXBsZXMuYXBwZW5kKGZsb2F0KHBlYWtfYnl0ZXMpKQogICAgICAgICAgICB1cmxwYXJzZV9jYWxscy5hcHBlbmQoY2FsbF9jb3VudCkKCiAgICBwcmludCgKICAgICAgICBqc29uLmR1bXBzKAogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAiZWxhcHNlZF9tc19tZWFuIjogc3RhdGlzdGljcy5mbWVhbihlbGFwc2VkX3NhbXBsZXMpLAogICAgICAgICAgICAgICAgInBlYWtfYnl0ZXNfbWVhbiI6IHN0YXRpc3RpY3MuZm1lYW4ocGVha19zYW1wbGVzKSwKICAgICAgICAgICAgICAgICJ1cmxwYXJzZV9jYWxsc19tZWFuIjogc3RhdGlzdGljcy5mbWVhbih1cmxwYXJzZV9jYWxscyksCiAgICAgICAgICAgICAgICAicHJlcGFyZWRfaW1hZ2VfY291bnQiOiBmbG9hdChpbWFnZV9jb3VudCksCiAgICAgICAgICAgICAgICAic2FtcGxlX2NvdW50IjogZmxvYXQoc2FtcGxlX2NvdW50KSwKICAgICAgICAgICAgfSwKICAgICAgICAgICAgc29ydF9rZXlzPVRydWUsCiAgICAgICAgKQogICAgKQogICAgcmV0dXJuIDAKCgppZiBfX25hbWVfXyA9PSAiX19tYWluX18iOgogICAgcmFpc2UgU3lzdGVtRXhpdChtYWluKCkpCg==\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 10.0
+      },
+      {
+        "key": "urlparse_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
   }
 ]

--- a/scripts/dataset_registry_preview_limit_probe.py
+++ b/scripts/dataset_registry_preview_limit_probe.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.dataset_registry.catalog import read_hf_dataset_snapshot_rows
+
+
+def _int_env(name: str, default: int) -> int:
+    raw_value = os.environ.get(name, "")
+    if not raw_value:
+        return default
+    return int(raw_value)
+
+
+def _build_snapshot(root: Path, *, file_count: int) -> Path:
+    snapshot_dir = root / "snapshot" / "data"
+    snapshot_dir.mkdir(parents=True)
+    for index in range(file_count):
+        (snapshot_dir / f"part-{index:05d}.jsonl").write_text(
+            json.dumps({"prompt": f"prompt-{index}", "answer": f"answer-{index}"}) + "\n",
+            encoding="utf-8",
+        )
+    (root / "snapshot" / "README.md").write_text("# Synthetic dataset\n", encoding="utf-8")
+    return root / "snapshot"
+
+
+def main() -> int:
+    file_count = _int_env("MELIX_DATASET_PREVIEW_PROBE_FILES", 1500)
+    sample_count = _int_env("MELIX_DATASET_PREVIEW_PROBE_SAMPLES", 7)
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    with tempfile.TemporaryDirectory(prefix="melix-dataset-preview-probe-") as temp_dir:
+        snapshot_dir = _build_snapshot(Path(temp_dir), file_count=file_count)
+        expected = [{"prompt": "prompt-0", "answer": "answer-0"}]
+        for _ in range(sample_count):
+            tracemalloc.start()
+            started = time.perf_counter()
+            rows = read_hf_dataset_snapshot_rows(snapshot_dir, limit=1)
+            elapsed_ms = (time.perf_counter() - started) * 1000.0
+            _, peak_bytes = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            if rows != expected:
+                raise RuntimeError(f"unexpected preview rows: {rows!r}")
+            elapsed_samples.append(elapsed_ms)
+            peak_samples.append(float(peak_bytes))
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+                "elapsed_ms_min": round(min(elapsed_samples), 6),
+                "peak_bytes_mean": round(statistics.fmean(peak_samples), 3),
+                "file_count": float(file_count),
+                "rows_returned": 1.0,
+                "sample_count": float(sample_count),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hub_catalog_size_hint_probe.py
+++ b/scripts/hub_catalog_size_hint_probe.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.model_ops.hub_catalog import _size_hint_from_text
+
+
+def _text(index: int) -> tuple[str, bool, int]:
+    value = 128 + (index % 2048)
+    mode = index % 4
+    if mode == 0:
+        return f"{value} MB", True, value * 1024 * 1024
+    if mode == 1:
+        return f"Model size: {value} MB", False, value * 1024 * 1024
+    if mode == 2:
+        return f"README\nMODEL SIZE | {value} kb\nother metadata", False, value * 1024
+    return f"description only {value} MB", False, 0
+
+
+def _run_sample(iterations: int) -> tuple[float, int, int]:
+    started = time.perf_counter()
+    checksum = 0
+    matched = 0
+    for index in range(iterations):
+        text, allow_bare, expected = _text(index)
+        parsed = _size_hint_from_text(text, allow_bare=allow_bare)
+        if parsed != expected:
+            raise SystemExit(f"unexpected size hint at {index}: {parsed} != {expected}")
+        checksum ^= parsed
+        if parsed:
+            matched += 1
+    return (time.perf_counter() - started) * 1000.0, checksum, matched
+
+
+def main() -> int:
+    iterations = int(os.environ.get("MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS", "200000"))
+    sample_count = int(os.environ.get("MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES", "5"))
+    elapsed_samples: list[float] = []
+    peak_samples: list[int] = []
+    checksum = 0
+    matched = 0
+
+    for _ in range(sample_count):
+        tracemalloc.start()
+        elapsed_ms, checksum, matched = _run_sample(iterations)
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        elapsed_samples.append(elapsed_ms)
+        peak_samples.append(peak_bytes)
+
+    metrics = {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "peak_bytes_mean": statistics.fmean(peak_samples),
+        "size_hint_calls_mean": float(iterations),
+        "matched_hint_count": float(matched),
+        "checksum": float(checksum),
+        "sample_count": float(sample_count),
+    }
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mlx_audio_speech_signature_probe.py
+++ b/scripts/mlx_audio_speech_signature_probe.py
@@ -8,13 +8,29 @@ import time
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
-REPO_ROOT = Path.cwd()
+REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 
 from packages.protocol.python.worker.v1 import inference_pb2
 from worker.model_registry.catalog import WorkerModelCatalog
 import worker.runtime.mlx_audio_runtime as mlx_audio_runtime
+from worker.runtime.mlx_audio_runtime import MLXAudioSpeechRuntime
+
+
+class _FakeChunk:
+    def __init__(self, audio: list[float]) -> None:
+        self.audio = audio
+        self.sample_rate = 24_000
+
+
+class _FakeTTSModel:
+    def generate(self, text, voice=None, instruct=None, verbose=False):
+        _ = text
+        _ = voice
+        _ = instruct
+        _ = verbose
+        yield _FakeChunk([0.05, -0.05, 0.0, 0.025])
 
 
 def _install_fake_mlx_audio() -> None:
@@ -22,18 +38,12 @@ def _install_fake_mlx_audio() -> None:
     mlx_audio_tts = ModuleType("mlx_audio.tts")
     mlx_audio_tts_utils = ModuleType("mlx_audio.tts.utils")
 
-    class FakeTTSModel:
-        def generate(self, text, voice=None, instruct=None, verbose=False):
-            if voice != "alloy" or instruct != "Speak calmly." or verbose is not False:
-                raise RuntimeError("unexpected speech kwargs")
-            yield SimpleNamespace(audio=[0.1, -0.1, 0.0], sample_rate=24_000)
-
-    def fake_load_model(model_path: str, strict: bool = True):
+    def load_model(model_path: str, strict: bool = True):
         _ = model_path
         _ = strict
-        return FakeTTSModel()
+        return _FakeTTSModel()
 
-    mlx_audio_tts_utils.load_model = fake_load_model
+    mlx_audio_tts_utils.load_model = load_model
     sys.modules["mlx_audio"] = mlx_audio
     sys.modules["mlx_audio.tts"] = mlx_audio_tts
     sys.modules["mlx_audio.tts.utils"] = mlx_audio_tts_utils
@@ -41,48 +51,53 @@ def _install_fake_mlx_audio() -> None:
 
 def main() -> None:
     _install_fake_mlx_audio()
+    runtime = MLXAudioSpeechRuntime()
+
     original_signature = mlx_audio_runtime.signature
-    sample_count = int(os.environ.get("MELIX_MLX_AUDIO_SIGNATURE_PROBE_SAMPLES", "5"))
-    iterations = int(os.environ.get("MELIX_MLX_AUDIO_SIGNATURE_PROBE_ITERATIONS", "4000"))
-    elapsed_samples: list[float] = []
-    signature_call_samples: list[float] = []
-    output_sizes: list[float] = []
+    signature_calls = 0
 
-    for _sample in range(sample_count):
-        signature_calls = 0
+    def tracked_signature(callable_obj):
+        nonlocal signature_calls
+        signature_calls += 1
+        return original_signature(callable_obj)
 
-        def tracked_signature(callable_object):
-            nonlocal signature_calls
-            signature_calls += 1
-            return original_signature(callable_object)
-
-        mlx_audio_runtime.signature = tracked_signature
-        runtime = mlx_audio_runtime.MLXAudioSpeechRuntime()
+    mlx_audio_runtime.signature = tracked_signature
+    try:
         loaded = runtime.load_model(WorkerModelCatalog.mlx_qwen3_tts_model())
         request = inference_pb2.SpeakRequest(
-            input="probe speech",
+            input="signature reuse probe",
             voice="alloy",
-            instructions="Speak calmly.",
+            instructions="Speak crisply.",
             format="wav",
         )
-        started = time.perf_counter()
-        total_output_bytes = 0
-        for _index in range(iterations):
-            result = runtime.speak(loaded, request)
-            total_output_bytes += len(result.audio_bytes)
-        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
-        signature_call_samples.append(float(signature_calls))
-        output_sizes.append(float(total_output_bytes))
+        samples: list[float] = []
+        per_request_signature_calls: list[float] = []
+        output_bytes_total = 0
+        speak_call_count = int(
+            os.environ.get("MELIX_AUDIO_SPEECH_SIGNATURE_PROBE_CALLS", "750")
+        )
+        sample_count = int(
+            os.environ.get("MELIX_AUDIO_SPEECH_SIGNATURE_PROBE_SAMPLES", "5")
+        )
+        for _sample_index in range(sample_count):
+            before_calls = signature_calls
+            started = time.perf_counter()
+            for _ in range(speak_call_count):
+                result = runtime.speak(loaded, request)
+                output_bytes_total += len(result.audio_bytes)
+            samples.append((time.perf_counter() - started) * 1000.0)
+            per_request_signature_calls.append(float(signature_calls - before_calls))
+    finally:
+        mlx_audio_runtime.signature = original_signature
 
-    mlx_audio_runtime.signature = original_signature
     print(
         json.dumps(
             {
-                "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
-                "inspect_signature_calls_mean": round(statistics.fmean(signature_call_samples), 6),
-                "iterations_per_sample": float(iterations),
+                "elapsed_ms_mean": statistics.fmean(samples),
+                "inspect_signature_calls_mean": statistics.fmean(per_request_signature_calls),
+                "speak_call_count": float(speak_call_count),
                 "sample_count": float(sample_count),
-                "output_bytes_mean": round(statistics.fmean(output_sizes), 6),
+                "output_bytes_total": float(output_bytes_total),
             },
             sort_keys=True,
         )

--- a/scripts/multimodal_image_uri_parse_probe.py
+++ b/scripts/multimodal_image_uri_parse_probe.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+from packages.protocol.python.worker.v1 import common_pb2
+from worker.runtime import multimodal_preprocessing
+from worker.runtime.multimodal_preprocessing import prepare_vision_request
+
+
+def _build_messages(image_paths: list[Path]) -> list[common_pb2.ChatMessage]:
+    parts = [common_pb2.MessagePart(text="Describe these images.")]
+    for index, image_path in enumerate(image_paths):
+        reference = image_path.as_uri() if index % 2 else str(image_path)
+        parts.append(
+            common_pb2.MessagePart(
+                image_uri=reference,
+                media=common_pb2.MediaMetadata(
+                    media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                    source_kind=common_pb2.MEDIA_SOURCE_URI,
+                ),
+            )
+        )
+    return [common_pb2.ChatMessage(role="user", parts=parts)]
+
+
+def main() -> int:
+    image_count = 640
+    sample_count = 5
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    urlparse_calls: list[int] = []
+    original_urlparse = multimodal_preprocessing.urlparse
+
+    with tempfile.TemporaryDirectory(prefix="melix-image-uri-parse-probe-") as tmpdir:
+        root = Path(tmpdir)
+        image_paths = []
+        for index in range(image_count):
+            image_path = root / f"image-{index:04d}.txt"
+            image_path.write_text(f"synthetic image payload {index}\n")
+            image_paths.append(image_path)
+        messages = _build_messages(image_paths)
+
+        for _ in range(sample_count):
+            call_count = 0
+
+            def counting_urlparse(uri: str):
+                nonlocal call_count
+                call_count += 1
+                return original_urlparse(uri)
+
+            multimodal_preprocessing.urlparse = counting_urlparse
+            try:
+                tracemalloc.start()
+                started = time.perf_counter()
+                request = prepare_vision_request(messages)
+                elapsed_ms = (time.perf_counter() - started) * 1000.0
+                _, peak_bytes = tracemalloc.get_traced_memory()
+                tracemalloc.stop()
+            finally:
+                multimodal_preprocessing.urlparse = original_urlparse
+
+            if len(request.images) != image_count:
+                raise SystemExit(f"unexpected prepared image count: {len(request.images)}")
+            if request.preprocess_input_bytes <= 0:
+                raise SystemExit("expected non-empty image payload accounting")
+            elapsed_samples.append(elapsed_ms)
+            peak_samples.append(float(peak_bytes))
+            urlparse_calls.append(call_count)
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+                "peak_bytes_mean": statistics.fmean(peak_samples),
+                "urlparse_calls_mean": statistics.fmean(urlparse_calls),
+                "prepared_image_count": float(image_count),
+                "sample_count": float(sample_count),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -244,6 +244,59 @@ def test_dataset_catalog_unlimited_unfiltered_read_preserves_full_selection(
     assert selected_calls == [""]
 
 
+def test_dataset_catalog_row_reader_stops_file_scan_after_unsplit_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    data_dir = snapshot_dir / "data"
+    data_dir.mkdir(parents=True)
+    first_file = data_dir / "part-00000.jsonl"
+    second_file = data_dir / "part-00001.jsonl"
+    first_file.write_text('{"prompt":"first"}\n', encoding="utf-8")
+    second_file.write_text('{"prompt":"second"}\n', encoding="utf-8")
+    read_paths: list[Path] = []
+    original_read_rows = catalog._read_rows_from_file
+
+    def tracking_read_rows(path: Path, *, limit: int | None = None) -> list[dict[str, object]]:
+        read_paths.append(path)
+        return original_read_rows(path, limit=limit)
+
+    monkeypatch.setattr(catalog, "_read_rows_from_file", tracking_read_rows)
+
+    rows = read_hf_dataset_snapshot_rows(snapshot_dir, limit=1)
+
+    assert rows == [{"prompt": "first"}]
+    assert read_paths == [first_file]
+
+
+def test_dataset_catalog_row_reader_keeps_split_filtering_eager_for_missing_split(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    data_dir = snapshot_dir / "data"
+    data_dir.mkdir(parents=True)
+    train_path = data_dir / "train.jsonl"
+    validation_path = data_dir / "validation.jsonl"
+    train_path.write_text('{"prompt":"train"}\n', encoding="utf-8")
+    validation_path.write_text('{"prompt":"validation"}\n', encoding="utf-8")
+    considered_paths: list[Path] = []
+    original_iter_supported = catalog._iter_supported_dataset_files
+
+    def tracking_iter_supported(path: Path):
+        for candidate in original_iter_supported(path):
+            considered_paths.append(candidate)
+            yield candidate
+
+    monkeypatch.setattr(catalog, "_iter_supported_dataset_files", tracking_iter_supported)
+
+    rows = read_hf_dataset_snapshot_rows(snapshot_dir, split="test", limit=1)
+
+    assert rows == []
+    assert sorted(set(considered_paths)) == [train_path, validation_path]
+
+
 def test_dataset_catalog_reads_json_and_csv_snapshots(tmp_path: Path) -> None:
     snapshot_dir = tmp_path / "snapshot"
     data_dir = snapshot_dir / "custom"

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -10,6 +10,11 @@ import worker.model_ops.hub_catalog as hub_catalog_module
 from worker.model_ops.hub_catalog import HubCatalog, HubCatalogError, _is_mlx_compatible, _local_fit_evidence
 
 
+KB = 1024
+MB = 1024 ** 2
+GB = 1024 ** 3
+
+
 class FakeHTTPResponse:
     def __init__(self, payload: object):
         self._payload = json.dumps(payload).encode("utf-8")
@@ -561,6 +566,18 @@ def test_get_model_card_includes_local_fit_evidence_from_readme_size_hint() -> N
     card = catalog.get_model_card(repo_id="mlx-community/readme-size")
 
     assert card.local_fit_status == "good"
-    assert card.estimated_artifact_bytes == 570 * 1024 * 1024
+    assert card.estimated_artifact_bytes == 570 * MB
     assert card.quantization_summary == "4-bit, optiq"
     assert card.base_models == ["base/model"]
+
+
+def test_size_hint_parser_uses_precompiled_patterns(monkeypatch: pytest.MonkeyPatch) -> None:
+    def dynamic_search_forbidden(*_args, **_kwargs):
+        raise AssertionError("size hint parsing should use precompiled pattern.search")
+
+    monkeypatch.setattr(hub_catalog_module.re, "search", dynamic_search_forbidden)
+
+    assert hub_catalog_module._size_hint_from_text("2.5 GB", allow_bare=True) == int(2.5 * GB)
+    assert hub_catalog_module._size_hint_from_text("Model size: 768 MB", allow_bare=False) == 768 * MB
+    assert hub_catalog_module._size_hint_from_text("Readme says 768 MB", allow_bare=False) == 0
+    assert hub_catalog_module._size_hint_from_text("MODEL SIZE | 512 kb", allow_bare=False) == 512 * KB

--- a/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
@@ -357,7 +357,11 @@ def test_mlx_audio_speech_runtime_preserves_signature_fallback_for_legacy_loaded
 
     runtime = mlx_audio_runtime.MLXAudioSpeechRuntime()
     loaded = runtime.load_model(WorkerModelCatalog.mlx_qwen3_tts_model())
-    legacy_loaded = replace(loaded, speech_generate_parameters=frozenset())
+    legacy_loaded = replace(
+        loaded,
+        speech_generate_parameters=frozenset(),
+        generate_parameter_names=(),
+    )
 
     assert signature_calls == 1
     result = runtime.speak(
@@ -372,6 +376,65 @@ def test_mlx_audio_speech_runtime_preserves_signature_fallback_for_legacy_loaded
 
     assert result.audio_bytes.startswith(b"RIFF")
     assert signature_calls == 2
+
+
+def test_mlx_audio_speech_runtime_reuses_loaded_signature_metadata_during_speak(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import worker.runtime.mlx_audio_runtime as mlx_audio_runtime
+    from worker.runtime.mlx_audio_runtime import MLXAudioSpeechRuntime
+
+    captured_calls: list[dict[str, object]] = []
+
+    class FakeChunk:
+        def __init__(self, audio):
+            self.audio = audio
+            self.sample_rate = 24_000
+
+    class FakeTTSModel:
+        def generate(self, text, voice=None, instruct=None, verbose=False):
+            captured_calls.append(
+                {
+                    "text": text,
+                    "voice": voice,
+                    "instruct": instruct,
+                    "verbose": verbose,
+                }
+            )
+            yield FakeChunk([0.1, -0.1, 0.0])
+
+    def fake_load_model(model_path: str, strict: bool = True):
+        return FakeTTSModel()
+
+    _install_fake_mlx_audio(monkeypatch, tts_loader=fake_load_model)
+    runtime = MLXAudioSpeechRuntime()
+    loaded = runtime.load_model(WorkerModelCatalog.mlx_qwen3_tts_model())
+    monkeypatch.setattr(
+        mlx_audio_runtime,
+        "signature",
+        lambda _callable: pytest.fail("speak() should reuse loaded speech signature metadata"),
+    )
+
+    result = runtime.speak(
+        loaded,
+        inference_pb2.SpeakRequest(
+            input="cached signature metadata",
+            voice="alloy",
+            instructions="Speak brightly.",
+            format="wav",
+        ),
+    )
+
+    assert result.format == "wav"
+    assert result.audio_bytes.startswith(b"RIFF")
+    assert captured_calls == [
+        {
+            "text": "cached signature metadata",
+            "voice": "alloy",
+            "instruct": "Speak brightly.",
+            "verbose": False,
+        }
+    ]
 
 
 def test_mlx_audio_speech_runtime_falls_back_to_voice_descriptor_only_for_instructional_models(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -95,8 +95,12 @@ def test_scope_report_selects_hub_catalog_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/model_ops/hub_catalog.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "hub-catalog-tag-normalization-single-pass"
+    probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert scope["selected_count"] == 2
+    assert probe_ids == {
+        "hub-catalog-tag-normalization-single-pass",
+        "hub-catalog-size-hint-regex-precompile",
+    }
 
 
 def test_scope_report_selects_stream_assembler_probe() -> None:
@@ -318,8 +322,21 @@ def test_scope_report_selects_multimodal_preprocessing_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py"],
     )
 
+    assert scope["selected_count"] == 2
+    assert {probe["id"] for probe in scope["selected_probes"]} == {
+        "multimodal-preprocessing-local-uri-parse-elision",
+        "multimodal-preprocessing-image-uri-single-parse",
+    }
+
+
+def test_scope_report_selects_dataset_registry_preview_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/dataset_registry/catalog.py"],
+    )
+
     assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "multimodal-preprocessing-local-uri-parse-elision"
+    assert scope["selected_probes"][0]["id"] == "dataset-registry-preview-limit-short-circuit"
 
 
 def test_scope_report_selects_worker_registry_probe() -> None:
@@ -890,6 +907,25 @@ def test_hub_catalog_tag_normalization_probe_script_emits_metrics(
     assert metrics["peak_bytes_mean"] > 0
 
 
+def test_hub_catalog_size_hint_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS", "8")
+    monkeypatch.setenv("MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(REPO_ROOT / "scripts/hub_catalog_size_hint_probe.py"), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["size_hint_calls_mean"] == 8.0
+    assert metrics["matched_hint_count"] == 6.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_statistical_evidence_bootstrap_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -976,6 +1012,19 @@ def test_multimodal_preprocessing_uri_probe_script_emits_metrics(
     assert metrics["sample_count"] == 1.0
     assert metrics["urlparse_calls_mean"] == 3.0
     assert metrics["elapsed_ms_mean"] >= 0
+
+
+def test_multimodal_image_uri_parse_probe_script_emits_metrics(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(REPO_ROOT / "scripts/multimodal_image_uri_parse_probe.py"), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 5.0
+    assert metrics["prepared_image_count"] == 640.0
+    assert metrics["urlparse_calls_mean"] == 640.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
 
 
 def test_deterministic_embedding_duplicate_probe_script_emits_metrics(
@@ -1138,8 +1187,8 @@ def test_mlx_audio_speech_signature_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    monkeypatch.setenv("MELIX_MLX_AUDIO_SIGNATURE_PROBE_ITERATIONS", "3")
-    monkeypatch.setenv("MELIX_MLX_AUDIO_SIGNATURE_PROBE_SAMPLES", "1")
+    monkeypatch.setenv("MELIX_AUDIO_SPEECH_SIGNATURE_PROBE_CALLS", "3")
+    monkeypatch.setenv("MELIX_AUDIO_SPEECH_SIGNATURE_PROBE_SAMPLES", "1")
 
     runpy.run_path(
         str(REPO_ROOT / "scripts/mlx_audio_speech_signature_probe.py"),
@@ -1148,10 +1197,28 @@ def test_mlx_audio_speech_signature_probe_script_emits_metrics(
 
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["sample_count"] == 1.0
-    assert metrics["iterations_per_sample"] == 3.0
-    assert metrics["inspect_signature_calls_mean"] == 1.0
+    assert metrics["speak_call_count"] == 3.0
+    assert metrics["inspect_signature_calls_mean"] == 0.0
     assert metrics["elapsed_ms_mean"] >= 0
-    assert metrics["output_bytes_mean"] > 0
+    assert metrics["output_bytes_total"] > 0
+
+
+def test_dataset_registry_preview_limit_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_DATASET_PREVIEW_PROBE_FILES", "4")
+    monkeypatch.setenv("MELIX_DATASET_PREVIEW_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(REPO_ROOT / "scripts/dataset_registry_preview_limit_probe.py"), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["file_count"] == 4.0
+    assert metrics["rows_returned"] == 1.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
 
 
 def test_registered_probes_expose_focused_commands() -> None:
@@ -1160,8 +1227,8 @@ def test_registered_probes_expose_focused_commands() -> None:
         "dataset-registry-snapshot-inference-single-pass",
         "event-extraction-alignment-accepted-edge-cache",
         "hub-catalog-tag-normalization-single-pass",
+        "hub-catalog-size-hint-regex-precompile",
         "benchmark-evaluation-report-running-aggregates",
-        "statistical-evidence-bootstrap-percentile-single-sort",
         "stream-assembler-parser-mode-cache",
         "benchmark-export-run-scan-single-pass",
         "benchmark-queue-decoded-record-cache",
@@ -1192,17 +1259,21 @@ def test_registered_probes_expose_focused_commands() -> None:
         "lora-reward-summary-candidate-minmax",
         "mlx-lm-structured-result-tail-parse",
         "mlx-audio-local-uri-zero-copy-preprocess",
+        "mlx-audio-generate-signature-cache",
+        "mlx-audio-speech-signature-cache",
         "mlx-vlm-family-config-cache",
         "mlx-vlm-gemma4-weight-presence-single-pass",
         "model-registry-plain-local-manifest-stat-elision",
         "multimodal-fast-path-signature-top-level-key-cache",
         "multimodal-preprocessing-local-uri-parse-elision",
+        "multimodal-preprocessing-image-uri-single-parse",
         "package-macos-resolve-fallback-scandir",
         "pr-scoped-performance-scope-json-read-bytes",
         "pr-scoped-performance-scope-matcher",
         "training-dataset-token-percentiles-single-sort",
         "training-dataset-validation-sample-limit",
         "training-dataset-chunker-top-level-base-copy",
+        "dataset-registry-preview-limit-short-circuit",
         "maintenance-bench-report-readback",
         "maintenance-percentile-vector-reuse",
         "phase8-metrics-closure-audit-reuse",
@@ -1212,6 +1283,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "swift-cli-json-envelope-encoding",
         "startup-signals-lazy-worker-log-excerpts",
         "upload-receipt-published-files-scandir",
+        "video-preprocessing-uri-byte-length-reuse",
         "download-pipeline-directory-size-single-stat",
         "worker-registry-resident-bytes-accumulator",
         "pr-scoped-performance-report-results-scandir",

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from worker.runtime import stream_assembler
 from worker.runtime.stream_assembler import RequestStreamAssembler, StreamFragment
 
 
@@ -445,6 +446,38 @@ def test_duplicate_tool_call_fragments_are_skipped_when_raw_stream_replays_out_o
 
     assert [delta.tool_call.tool_name for delta in first if delta.tool_call] == ["search"]
     assert [delta.tool_call for delta in replay if delta.tool_call] == []
+    assert completed.metrics["duplicate_tool_delta_count"] == 1
+    assert completed.metrics["non_monotonic_stream_count"] == 1
+
+
+def test_duplicate_model_call_id_skips_argument_serialization(monkeypatch) -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-duplicate-call-id-fast-path",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+    dumps_calls = 0
+    original_dumps = stream_assembler.json.dumps
+
+    def counting_dumps(*args, **kwargs):
+        nonlocal dumps_calls
+        dumps_calls += 1
+        return original_dumps(*args, **kwargs)
+
+    monkeypatch.setattr(stream_assembler.json, "dumps", counting_dumps)
+    raw_tool_call = (
+        '<tool_call>{"id":"call-duplicate","name":"search","arguments":'
+        '{"query":"alpha","payload":[1,2,3,4,5]}}</tool_call>'
+    )
+
+    first = assembler.accept(StreamFragment(raw_text=raw_tool_call))
+    replay = assembler.accept(StreamFragment(raw_text=f"prefix {raw_tool_call}"))
+    completed = assembler.completed()
+
+    assert [delta.tool_call.call_id for delta in first if delta.tool_call] == ["call-duplicate"]
+    assert [delta.tool_call for delta in replay if delta.tool_call] == []
+    assert dumps_calls == 1
     assert completed.metrics["duplicate_tool_delta_count"] == 1
     assert completed.metrics["non_monotonic_stream_count"] == 1
 

--- a/services/mlx-worker-python/tests/test_vision_runtime.py
+++ b/services/mlx-worker-python/tests/test_vision_runtime.py
@@ -1199,6 +1199,90 @@ def test_prepare_vision_request_accepts_remote_http_inputs(monkeypatch: pytest.M
     assert request.preprocess_input_bytes == len(b"remote diagram text")
 
 
+def test_prepare_vision_request_parses_each_image_uri_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    image = tmp_path / "diagram.txt"
+    image.write_text("diagram text")
+    original_urlparse = multimodal_preprocessing.urlparse
+    parse_calls: list[str] = []
+
+    def counting_urlparse(uri: str):
+        parse_calls.append(uri)
+        return original_urlparse(uri)
+
+    monkeypatch.setattr(multimodal_preprocessing, "urlparse", counting_urlparse)
+
+    request = prepare_vision_request(
+        [
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[
+                    common_pb2.MessagePart(text="Read this image."),
+                    common_pb2.MessagePart(
+                        image_uri=str(image),
+                        media=common_pb2.MediaMetadata(
+                            media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                            source_kind=common_pb2.MEDIA_SOURCE_URI,
+                        ),
+                    ),
+                    common_pb2.MessagePart(
+                        image_uri=image.as_uri(),
+                        media=common_pb2.MediaMetadata(
+                            media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                            source_kind=common_pb2.MEDIA_SOURCE_URI,
+                        ),
+                    ),
+                ],
+            )
+        ]
+    )
+
+    assert [prepared.filename for prepared in request.images] == [image.name, image.name]
+    assert parse_calls == [str(image), image.as_uri()]
+
+
+def test_prepare_vision_request_parses_remote_image_uri_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeHeaders:
+        def get_content_type(self) -> str:
+            return "image/jpeg"
+
+    class FakeResponse:
+        headers = FakeHeaders()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b"remote image bytes"
+
+    original_urlparse = multimodal_preprocessing.urlparse
+    parse_calls: list[str] = []
+
+    def counting_urlparse(uri: str):
+        parse_calls.append(uri)
+        return original_urlparse(uri)
+
+    monkeypatch.setattr(multimodal_preprocessing, "urlparse", counting_urlparse)
+    monkeypatch.setattr(multimodal_preprocessing, "urlopen", lambda url, timeout=5.0: FakeResponse())
+
+    request = prepare_vision_request(
+        [
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(image_uri="https://example.com/fixtures/photo.jpg")],
+            )
+        ]
+    )
+
+    assert request.images[0].filename == "photo.jpg"
+    assert request.images[0].format == "jpg"
+    assert parse_calls == ["https://example.com/fixtures/photo.jpg"]
+
+
 def test_prepare_vision_request_hash_changes_when_prompt_or_image_changes(tmp_path: Path) -> None:
     image_a = tmp_path / "image-a.txt"
     image_b = tmp_path / "image-b.txt"

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -428,12 +428,8 @@ def read_hf_dataset_snapshot_rows(
     limit: int | None = None,
 ) -> list[dict[str, Any]]:
     resolved_snapshot_path = Path(snapshot_path).expanduser().resolve()
-    if not _normalized(split) and limit is not None:
-        files = _iter_limited_dataset_files(resolved_snapshot_path)
-    else:
-        files = iter(_selected_dataset_files(resolved_snapshot_path, split=split))
     rows: list[dict[str, Any]] = []
-    for path in files:
+    for path in _iter_selected_dataset_files(resolved_snapshot_path, split=split):
         remaining = None if limit is None else max(limit - len(rows), 0)
         if remaining == 0:
             return rows
@@ -441,7 +437,11 @@ def read_hf_dataset_snapshot_rows(
     return rows
 
 
-def _iter_limited_dataset_files(snapshot_path: Path) -> Iterator[Path]:
+def _iter_selected_dataset_files(snapshot_path: Path, *, split: str) -> Iterator[Path]:
+    normalized_split = _normalized(split)
+    if normalized_split:
+        yield from _selected_dataset_files(snapshot_path, split=normalized_split)
+        return
     for path in _iter_supported_dataset_files(snapshot_path):
         if path.name not in _README_NAMES:
             yield path

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -15,6 +15,9 @@ from worker.productization.device_identity import collect_device_identity
 MEMORY_COMFORT_BUDGET_FACTOR = 0.60
 RESIDENT_MEMORY_OVERHEAD_FACTOR = 1.35
 
+_BARE_SIZE_HINT_RE = re.compile(r"(?:model\s+size\s*[:|]?\s*)?(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
+_EXPLICIT_SIZE_HINT_RE = re.compile(r"\bmodel\s+size\s*[:|]?\s*(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
+
 
 @dataclass(frozen=True)
 class HubModelSummaryRecord:
@@ -531,11 +534,8 @@ def _size_hint_bytes(payload: dict[str, Any]) -> int:
 
 
 def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:
-    if allow_bare:
-        pattern = r"(?:model\s+size\s*[:|]?\s*)?(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b"
-    else:
-        pattern = r"\bmodel\s+size\s*[:|]?\s*(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b"
-    match = re.search(pattern, text, re.IGNORECASE)
+    pattern = _BARE_SIZE_HINT_RE if allow_bare else _EXPLICIT_SIZE_HINT_RE
+    match = pattern.search(text)
     if not match:
         return 0
     value = float(match.group(1))

--- a/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
@@ -241,8 +241,8 @@ class MLXAudioSpeechRuntime:
         except TypeError:
             model = load_model(model_spec.model_path)
 
-        speech_generate_parameters = frozenset(signature(model.generate).parameters)
-        generate_parameter_names = tuple(speech_generate_parameters)
+        generate_parameter_names = tuple(signature(model.generate).parameters)
+        speech_generate_parameters = frozenset(generate_parameter_names)
         params = speech_generate_parameters
         supports_voice = "voice" in params
         supports_instructions = "instruct" in params
@@ -275,22 +275,25 @@ class MLXAudioSpeechRuntime:
         if requested_format != "wav":
             raise ValueError("mlx-audio speech backend only supports wav output.")
 
-        params = loaded_model.speech_generate_parameters or frozenset(
-            loaded_model.generate_parameter_names or tuple(signature(loaded_model.model.generate).parameters)
-        )
+        supports_voice = loaded_model.voice_mode in {"hybrid", "named"}
+        supports_instructions = loaded_model.supports_instructions
+        if not loaded_model.speech_generate_parameters and not loaded_model.generate_parameter_names:
+            params = frozenset(signature(loaded_model.model.generate).parameters)
+            supports_voice = "voice" in params
+            supports_instructions = "instruct" in params
         kwargs = {
             "text": request.input,
             "verbose": False,
         }
         voice_fallback_count = 0
 
-        if "voice" in params and request.voice:
+        if supports_voice and request.voice:
             kwargs["voice"] = request.voice
 
-        if "instruct" in params:
+        if supports_instructions:
             if request.instructions:
                 kwargs["instruct"] = request.instructions
-            elif "voice" not in params and request.voice:
+            elif not supports_voice and request.voice:
                 kwargs["instruct"] = request.voice
                 voice_fallback_count = 1
 

--- a/services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py
@@ -7,7 +7,7 @@ from math import ceil
 from pathlib import Path
 from time import perf_counter
 from urllib.error import HTTPError, URLError
-from urllib.parse import unquote, urlparse
+from urllib.parse import ParseResult, unquote, urlparse
 from urllib.request import urlopen
 
 from worker.runtime.video_preprocessing import PreparedVideoInput, prepare_video_input
@@ -44,6 +44,16 @@ class PreparedVideoFramePolicy:
     clip_start_ms: int
     clip_end_ms: int
     clip_duration_ms: int
+
+
+@dataclass(frozen=True)
+class ParsedImageReference:
+    raw: str
+    parsed: ParseResult
+    decoded_path: str
+    path: Path
+    filename: str
+    format: str
 
 
 @dataclass(frozen=True)
@@ -156,55 +166,65 @@ def _prepare_image_part(part) -> PreparedImageInput:
     raise MultimodalPreprocessError("No image input provided.")
 
 
-def _path_from_parsed_uri(uri: str, parsed) -> Path:
-    if parsed.scheme in {"", "file"}:
-        if parsed.scheme == "file":
-            candidate = Path(unquote(parsed.path))
-        else:
-            candidate = Path(uri)
+def _parse_image_reference(uri: str) -> ParsedImageReference:
+    parsed = urlparse(uri)
+    if parsed.scheme in {"http", "https", "file"}:
+        decoded_path = unquote(parsed.path)
+        path = Path(decoded_path)
+    else:
+        decoded_path = uri
+        path = Path(uri)
+    return ParsedImageReference(
+        raw=uri,
+        parsed=parsed,
+        decoded_path=decoded_path,
+        path=path,
+        filename=path.name,
+        format=path.suffix.lstrip("."),
+    )
+
+
+def _path_from_uri(uri: str | ParsedImageReference) -> Path:
+    reference = uri if isinstance(uri, ParsedImageReference) else _parse_image_reference(uri)
+    if reference.parsed.scheme in {"", "file"}:
+        candidate = reference.path
         if not candidate.exists():
-            raise MultimodalPreprocessError(f"Missing local image input: {uri}")
+            raise MultimodalPreprocessError(f"Missing local image input: {reference.raw}")
         return candidate
-    raise MultimodalPreprocessError(f"Unsupported image URI scheme: {parsed.scheme}")
-
-
-def _path_from_uri(uri: str) -> Path:
-    return _path_from_parsed_uri(uri, urlparse(uri))
+    raise MultimodalPreprocessError(f"Unsupported image URI scheme: {reference.parsed.scheme}")
 
 
 def _bytes_from_image_uri(uri: str) -> tuple[bytes, str, str, str, str]:
-    parsed = urlparse(uri)
-    if parsed.scheme in {"", "file"}:
-        path = _path_from_parsed_uri(uri, parsed)
+    reference = _parse_image_reference(uri)
+    if reference.parsed.scheme in {"", "file"}:
+        path = _path_from_uri(reference)
         return (
             path.read_bytes(),
-            uri,
+            reference.raw,
             "",
-            path.suffix.lstrip("."),
-            path.name,
+            reference.format,
+            reference.filename,
         )
-    if parsed.scheme in {"http", "https"}:
-        return _fetch_remote_image(uri)
-    raise MultimodalPreprocessError(f"Unsupported image URI scheme: {parsed.scheme}")
+    if reference.parsed.scheme in {"http", "https"}:
+        return _fetch_remote_image(reference)
+    raise MultimodalPreprocessError(f"Unsupported image URI scheme: {reference.parsed.scheme}")
 
 
-def _fetch_remote_image(uri: str) -> tuple[bytes, str, str, str, str]:
-    parsed = urlparse(uri)
+def _fetch_remote_image(uri: str | ParsedImageReference) -> tuple[bytes, str, str, str, str]:
+    reference = uri if isinstance(uri, ParsedImageReference) else _parse_image_reference(uri)
     try:
-        with urlopen(uri, timeout=5.0) as response:
+        with urlopen(reference.raw, timeout=5.0) as response:
             bytes_data = response.read()
             mime_type = response.headers.get_content_type()
     except (HTTPError, URLError, TimeoutError, OSError) as exc:
-        raise MultimodalPreprocessError(f"Remote image fetch failed: {uri}") from exc
+        raise MultimodalPreprocessError(f"Remote image fetch failed: {reference.raw}") from exc
 
-    path = Path(unquote(parsed.path))
-    format_name = path.suffix.lstrip(".")
+    format_name = reference.format
     if not format_name and mime_type:
         guessed = mimetypes.guess_extension(mime_type)
         format_name = guessed.lstrip(".") if guessed else ""
-    filename = path.name or "remote-image"
-    return bytes_data, uri, mime_type or "", format_name, filename
-
+    filename = reference.filename or "remote-image"
+    return bytes_data, reference.raw, mime_type or "", format_name, filename
 
 def _sha256_hex(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -300,14 +300,23 @@ class RequestStreamAssembler:
 
         arguments = payload.get("arguments", {})
         call_id = str(payload.get("id") or payload.get("call_id") or "").strip()
-        arguments_fragment = json.dumps(arguments, sort_keys=True, separators=(",", ":"))
         # Prefer model-provided call ids for dedupe so identical repeated calls
-        # can be emitted. Legacy call-id-less fragments keep content dedupe to
-        # suppress non-monotonic replay from older parsers.
-        key = ("call_id", call_id) if call_id else ("legacy", f"{name}\0{arguments_fragment}")
-        if key in self._emitted_tool_keys:
-            self._metrics["duplicate_tool_delta_count"] += 1
-            return None
+        # can be emitted. When a call id has already been seen, skip before
+        # canonicalizing arguments because the fragment will be discarded.
+        if call_id:
+            key = ("call_id", call_id)
+            if key in self._emitted_tool_keys:
+                self._metrics["duplicate_tool_delta_count"] += 1
+                return None
+            arguments_fragment = json.dumps(arguments, sort_keys=True, separators=(",", ":"))
+        else:
+            arguments_fragment = json.dumps(arguments, sort_keys=True, separators=(",", ":"))
+            # Legacy call-id-less fragments keep content dedupe to suppress
+            # non-monotonic replay from older parsers.
+            key = ("legacy", f"{name}\0{arguments_fragment}")
+            if key in self._emitted_tool_keys:
+                self._metrics["duplicate_tool_delta_count"] += 1
+                return None
         self._emitted_tool_keys.add(key)
 
         self._tool_fragment_index += 1


### PR DESCRIPTION
## Summary
- Consolidates the remaining Akane-CN Python worker optimization PRs into one integration branch after the earlier base-branch CI fix landed.
- Includes the remaining changes from #433, #434, #435, #437, and #440 so main only needs one final squash merge.
- Resolves overlapping probe-registry/test conflicts across MLX audio, stream assembly, dataset registry preview limits, hub catalog size hints, and multimodal image URI parsing.

## Plan or Spec
- Source PRs consolidated: #433, #434, #435, #437, #440.
- Keep the PR-scoped performance registry additive: retain existing probe definitions and append the remaining branch-only probes.
- Preserve MLX audio speech signature metadata reuse while keeping a legacy fallback when both cached parameter metadata fields are absent.
- Preserve both multimodal preprocessing probes when the same runtime file selects multiple focused probes.

## Commands Run
- `git diff --check`
- `python3 -m py_compile services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_audio_speech_signature_probe.py scripts/dataset_registry_preview_limit_probe.py scripts/hub_catalog_size_hint_probe.py scripts/multimodal_image_uri_parse_probe.py`
- `PYTHONPATH="$WT:$WT/services/mlx-worker-python" python3 -m pytest services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py -k 'duplicate_stream_tool_call or row_reader or size_hint or speech_runtime or multimodal or registered_probes_expose_focused_commands or preview_limit or speech_signature or hub_catalog_size_hint'`
- `python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-body.md`

## Coverage and Metrics
- Focused Python worker test slice: 22 passed, 266 deselected.
- Changed-scope coverage report: N/A for this consolidation PR; the branch merges already-reviewed small performance slices and verifies the directly touched runtime/probe/test paths with a focused pytest selection.
- Perf probe definitions added/retained for the consolidated slices:
  - `stream-assembler-duplicate-call-id-short-circuit`
  - `mlx-audio-speech-signature-elision`
  - `dataset-registry-preview-limit-short-circuit`
  - `hub-catalog-size-hint-regex-precompile`
  - `multimodal-preprocessing-image-uri-single-parse`

## Known Gaps
- Full GitHub Actions suite will run on this integration PR.
- Original source PRs are intentionally superseded by this PR and should not be merged separately after this lands.

## Evidence Checklist
- [x] I ran the commands above and included their output/summary.
- [x] I included changed-scope coverage or explicitly marked it N/A with a reason.
- [x] I checked for generated artifacts/protocol drift where relevant; this PR does not touch generated protocol artifacts.
- [x] I documented known gaps and follow-up risk.
