### PR TITLE
perf: fast-parse hub catalog next cursor

### DIFF
--- a/docs/plans/2026-05-06-hub-catalog-next-cursor-fast-parse.md
+++ b/docs/plans/2026-05-06-hub-catalog-next-cursor-fast-parse.md
@@ -1,0 +1,34 @@
+# Hub catalog next cursor fast parse optimization
+
+## Goal
+
+Reduce per-page overhead in Hugging Face Hub pagination by avoiding full URL and query parsing when Melix only needs the `cursor` value from the RFC 5988 `Link` header's `rel="next"` entry.
+
+## Linux-only constraint
+
+This slice is Python-only under `services/mlx-worker-python` and is locally verifiable on Linux with focused pytest, changed-scope coverage, and a command-json PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_next_cursor_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Performance probe
+
+Registered probe: `hub-catalog-next-cursor-fast-parse`
+
+The probe parses synthetic Hub `Link` headers repeatedly and emits:
+
+- `elapsed_ms_mean` — lower is better
+- `cursor_parse_calls_mean` — structural call-count metric
+- `peak_bytes_mean` — lower is better / memory-pressure signal
+
+## Success metrics
+
+- Focused tests pass.
+- Changed-scope coverage is at least 95% for touched executable Python scope.
+- Local base-vs-head probe preserves cursor parsing correctness and improves elapsed time and/or peak allocation.
+- `git diff --check` passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -67,6 +67,43 @@
     ]
   },
   {
+    "id": "hub-catalog-next-cursor-fast-parse",
+    "name": "Hub catalog next cursor fast parse",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/hub_catalog.py",
+      "services/mlx-worker-python/tests/test_hub_catalog.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/hub_catalog_next_cursor_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_next_cursor_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/hub_catalog_next_cursor_probe.py ]; then python scripts/hub_catalog_next_cursor_probe.py; else python - <<\"PYPROBE\"\nimport json, os, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.model_ops.hub_catalog import _next_cursor_from_link\ndef link_header(index):\n    cursor = f\"page/{index}+batch {index % 17}\"\n    encoded = cursor.replace(\"/\", \"%2F\").replace(\"+\", \"%2B\").replace(\" \", \"+\")\n    return (f\"<https://huggingface.co/api/models?cursor=prev-{index}>; rel=\\\"prev\\\", <https://huggingface.co/api/models?limit=50&full=true&cursor={encoded}&cardData=true>; rel=\\\"next\\\"\", cursor)\ndef run_sample(iterations):\n    checksum = 0\n    started = time.perf_counter()\n    for index in range(iterations):\n        header, expected = link_header(index)\n        parsed = _next_cursor_from_link(header)\n        if parsed != expected:\n            raise SystemExit(f\"unexpected cursor at {index}: {parsed!r} != {expected!r}\")\n        checksum += len(parsed) + ord(parsed[0])\n    return (time.perf_counter() - started) * 1000.0, checksum\niterations = int(os.environ.get(\"MELIX_HUB_CATALOG_CURSOR_ITERATIONS\", \"50000\"))\nsample_count = int(os.environ.get(\"MELIX_HUB_CATALOG_CURSOR_SAMPLES\", \"5\"))\nelapsed = []\npeaks = []\nchecksum = 0\nfor _ in range(sample_count):\n    tracemalloc.start()\n    elapsed_ms, checksum = run_sample(iterations)\n    _, peak = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    elapsed.append(elapsed_ms)\n    peaks.append(peak)\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed), \"peak_bytes_mean\": statistics.fmean(peaks), \"cursor_parse_calls_mean\": float(iterations), \"checksum\": float(checksum), \"sample_count\": float(sample_count)}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "cursor_parse_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 20.0
+      }
+    ]
+  },
+  {
     "id": "dataset-registry-snapshot-inference-single-pass",
     "name": "Dataset registry snapshot inference single pass",
     "runner": "ubuntu-latest",

--- a/scripts/hub_catalog_next_cursor_probe.py
+++ b/scripts/hub_catalog_next_cursor_probe.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.model_ops.hub_catalog import _next_cursor_from_link
+
+
+def _link_header(index: int) -> tuple[str, str]:
+    cursor = f"page/{index}+batch {index % 17}"
+    encoded = cursor.replace("/", "%2F").replace("+", "%2B").replace(" ", "+")
+    header = (
+        f'<https://huggingface.co/api/models?cursor=prev-{index}>; rel="prev", '
+        f'<https://huggingface.co/api/models?limit=50&full=true&cursor={encoded}&cardData=true>; rel="next"'
+    )
+    return header, cursor
+
+
+def _run_sample(iterations: int) -> tuple[float, int]:
+    checksum = 0
+    started = time.perf_counter()
+    for index in range(iterations):
+        header, expected = _link_header(index)
+        parsed = _next_cursor_from_link(header)
+        if parsed != expected:
+            raise SystemExit(f"unexpected cursor at {index}: {parsed!r} != {expected!r}")
+        checksum += len(parsed) + ord(parsed[0])
+    return (time.perf_counter() - started) * 1000.0, checksum
+
+
+def main() -> int:
+    iterations = int(os.environ.get("MELIX_HUB_CATALOG_CURSOR_ITERATIONS", "50000"))
+    sample_count = int(os.environ.get("MELIX_HUB_CATALOG_CURSOR_SAMPLES", "5"))
+    elapsed_samples: list[float] = []
+    peak_samples: list[int] = []
+    checksum = 0
+
+    for _ in range(sample_count):
+        tracemalloc.start()
+        elapsed_ms, checksum = _run_sample(iterations)
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        elapsed_samples.append(elapsed_ms)
+        peak_samples.append(peak_bytes)
+
+    metrics = {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "peak_bytes_mean": statistics.fmean(peak_samples),
+        "cursor_parse_calls_mean": float(iterations),
+        "checksum": float(checksum),
+        "sample_count": float(sample_count),
+    }
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -184,6 +184,37 @@ def test_hub_catalog_raises_hub_payload_invalid_on_malformed_json() -> None:
     assert error.value.code == "hub_payload_invalid"
 
 
+def test_next_cursor_from_link_extracts_encoded_next_cursor_without_full_query_parse() -> None:
+    assert not hasattr(hub_catalog_module, "urlparse")
+    assert not hasattr(hub_catalog_module, "parse_qs")
+    link_header = (
+        '<https://huggingface.co/api/models?cursor=ignored>; rel="prev", '
+        '<https://huggingface.co/api/models?limit=10&cursor=abc%2Fdef+ghi&full=true#page>; rel="next"'
+    )
+
+    assert hub_catalog_module._next_cursor_from_link(link_header) == "abc/def ghi"
+
+
+def test_next_cursor_from_link_returns_empty_for_missing_or_malformed_next_cursor() -> None:
+    assert hub_catalog_module._next_cursor_from_link('<https://huggingface.co/api/models?cursor=prev>; rel="prev"') == ""
+    assert hub_catalog_module._next_cursor_from_link('<https://huggingface.co/api/models>; rel="next"') == ""
+    assert hub_catalog_module._next_cursor_from_link('<https://huggingface.co/api/models?limit=10>; rel="next"') == ""
+    assert hub_catalog_module._next_cursor_from_link('https://huggingface.co/api/models?cursor=broken; rel="next"') == ""
+
+
+def test_search_models_uses_next_cursor_from_link_header() -> None:
+    response = FakeHTTPResponse([{"id": "mlx-community/example", "tags": ["mlx"], "siblings": [], "cardData": {}}])
+    response.headers["Link"] = '<https://huggingface.co/api/models?limit=1&cursor=page%2B2>; rel="next"'
+
+    def opener(_request: Request):
+        return response
+
+    catalog = HubCatalog(opener=opener)
+    page = catalog.search_models(query="mlx", page_size=1, cursor="", mlx_only=False)
+
+    assert page.next_cursor == "page+2"
+
+
 def test_search_models_with_mlx_only_false_returns_all_results() -> None:
     payload = [
         {

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -96,9 +96,10 @@ def test_scope_report_selects_hub_catalog_probe() -> None:
     )
 
     probe_ids = {probe["id"] for probe in scope["selected_probes"]}
-    assert scope["selected_count"] == 2
+    assert scope["selected_count"] == 3
     assert probe_ids == {
         "hub-catalog-tag-normalization-single-pass",
+        "hub-catalog-next-cursor-fast-parse",
         "hub-catalog-size-hint-regex-precompile",
     }
 
@@ -926,6 +927,25 @@ def test_hub_catalog_size_hint_probe_script_emits_metrics(
     assert metrics["peak_bytes_mean"] > 0
 
 
+def test_hub_catalog_next_cursor_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_HUB_CATALOG_CURSOR_ITERATIONS", "8")
+    monkeypatch.setenv("MELIX_HUB_CATALOG_CURSOR_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(REPO_ROOT / "scripts/hub_catalog_next_cursor_probe.py"), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["cursor_parse_calls_mean"] == 8.0
+    assert metrics["checksum"] > 0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_statistical_evidence_bootstrap_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -1227,6 +1247,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "dataset-registry-snapshot-inference-single-pass",
         "event-extraction-alignment-accepted-edge-cache",
         "hub-catalog-tag-normalization-single-pass",
+        "hub-catalog-next-cursor-fast-parse",
         "hub-catalog-size-hint-regex-precompile",
         "benchmark-evaluation-report-running-aggregates",
         "stream-assembler-parser-mode-cache",

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Callable
 from urllib.error import HTTPError, URLError
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import unquote_plus, urlencode
 from urllib.request import Request, urlopen
 
 from worker.productization.device_identity import collect_device_identity
@@ -265,8 +265,22 @@ def _next_cursor_from_link(link_header: str) -> str:
         if not part.startswith("<") or ">" not in part:
             continue
         next_url = part[1:part.index(">")]
-        query = parse_qs(urlparse(next_url).query)
-        return _string(query.get("cursor", [""])[0])
+        return _cursor_query_value(next_url)
+    return ""
+
+
+def _cursor_query_value(url: str) -> str:
+    query_start = url.find("?")
+    if query_start < 0:
+        return ""
+    query = url[query_start + 1:]
+    fragment_start = query.find("#")
+    if fragment_start >= 0:
+        query = query[:fragment_start]
+    for parameter in query.split("&"):
+        key, separator, value = parameter.partition("=")
+        if separator and key == "cursor":
+            return unquote_plus(value)
     return ""
 
 


### PR DESCRIPTION
## Summary
- Fast-parse the Hub catalog pagination `Link` header's `rel="next"` cursor without materializing a full parsed URL/query map.
- Add focused cursor parsing regressions and a base-compatible PR-scoped performance probe for the hot path.

## Plan or Spec
- `docs/plans/2026-05-06-hub-catalog-next-cursor-fast-parse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics
# 29 passed in 0.16s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_next_cursor_probe.py
# 29 passed; TOTAL 46 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-next-cursor-fast-parse --base-repo /tmp/melix-cron-opt-base-20260506090524 --head-repo /tmp/melix-cron-opt-20260506090524 --output /tmp/hub-catalog-next-cursor-probe.json
# head verification passed; base/head probe completed successfully

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.pretty.json && git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 46 0 100%`.
- Registered scoped probe: `hub-catalog-next-cursor-fast-parse`.
- Local base-vs-head probe (`50,000` cursor parses x `5` samples):
  - `elapsed_ms_mean`: base `3630.932095` ms -> head `1839.572903` ms (~49.34% lower, ~1.97x faster)
  - `peak_bytes_mean`: base `95090.4` bytes -> head `14792.4` bytes (~84.44% lower)
  - `checksum`: base/head `6509477.0`, preserving parsed cursor outputs
  - `cursor_parse_calls_mean`: base/head `50000.0`

## Known Gaps
- Linux/Python slice only; macOS/Swift checks were not run locally on this Linux host.
- Hosted CI remains the final gate for the registered `pr-scoped-performance` run and broader repository checks.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
