### PR TITLE
Add Issue 365 QAT-aware MLX export

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1534,7 +1534,7 @@ public enum MelixCLIParser {
       melix chat run (--model-id MODEL_ID | --remote-server-id ID --model MODEL) --message TEXT [--system TEXT] [--server-session-id ID] [--json]
       melix lora list [--model-id MODEL_ID] [--json]
       melix lora train --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) --adapter-name NAME [--target-repo REPO] [--training-mode (lora|qlora|dora)] [--preset PRESET] [--experiment-group GROUP] [--rank N] [--alpha N] [--dropout N] [--target-modules CSV] [--num-layers N] [--batch-size N] [--epochs N] [--max-steps N] [--learning-rate N] [--max-seq-length N] [--sample-limit N] [--gradient-accumulation N] [--resume-adapter PATH | --resume-from-manifest PATH] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-train-split SPLIT] [--hf-valid-split SPLIT] [--text-feature NAME] [--prompt-feature NAME] [--completion-feature NAME] [--chat-feature NAME] [--derived-model-alias NAME] [--response-only] [--mask-prompt] [--gradient-checkpointing] [--json]
-      melix alignment train --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) --adapter-name NAME --algorithm dpo|orpo|cpo|grpo|rlhf [--target-repo REPO] [--grpo-candidate-count N] [--reference-model-path PATH] [--reward-model-manifest-path PATH] [--kl-penalty N] [--preset PRESET] [--experiment-group GROUP] [--rank N] [--alpha N] [--dropout N] [--target-modules CSV] [--num-layers N] [--batch-size N] [--epochs N] [--max-steps N] [--learning-rate N] [--max-seq-length N] [--sample-limit N] [--gradient-accumulation N] [--json]
+      melix alignment train --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) --adapter-name NAME --algorithm dpo|orpo|cpo|grpo|rlhf [--target-repo REPO] [--grpo-candidate-count N] [--candidate-generation-mode scored_trace|runtime_generate] [--candidate-scoring-mode dataset_score|seed_overlap_proxy|reward_model] [--candidate-generation-max-tokens N] [--reference-model-path PATH] [--reward-model-manifest-path PATH] [--kl-penalty N] [--preset PRESET] [--experiment-group GROUP] [--rank N] [--alpha N] [--dropout N] [--target-modules CSV] [--num-layers N] [--batch-size N] [--epochs N] [--max-steps N] [--learning-rate N] [--max-seq-length N] [--sample-limit N] [--gradient-accumulation N] [--json]
       melix lora dataset inspect --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) [--template TEMPLATE] [--dataset-id ID] [--validation-ratio N] [--sample-limit N] [--preview-count N] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-train-split SPLIT] [--hf-valid-split SPLIT] [--text-feature NAME] [--prompt-feature NAME] [--completion-feature NAME] [--chat-feature NAME] [--json]
       melix lora dataset build --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) [--output-dir PATH] [--template TEMPLATE] [--dataset-id ID] [--validation-ratio N] [--sample-limit N] [--preview-count N] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-train-split SPLIT] [--hf-valid-split SPLIT] [--text-feature NAME] [--prompt-feature NAME] [--completion-feature NAME] [--chat-feature NAME] [--json]
       melix lora activate --model-id MODEL_ID --adapter-path PATH [--activation-mode (fused_derived_model|adapter_backed_runtime)] [--alias NAME] [--json]
@@ -2307,6 +2307,20 @@ public enum MelixCLIParser {
             if ["dpo", "orpo", "cpo", "grpo", "rlhf"].contains(algorithm) == false {
                 throw MelixCLIError.usage("Invalid value for --algorithm. Expected one of: dpo, orpo, cpo, grpo, rlhf.")
             }
+            let candidateGenerationMode = (values.single["--candidate-generation-mode"] ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            if candidateGenerationMode.isEmpty == false,
+               ["scored_trace", "runtime_generate"].contains(candidateGenerationMode) == false {
+                throw MelixCLIError.usage("Invalid value for --candidate-generation-mode. Expected one of: scored_trace, runtime_generate.")
+            }
+            let candidateScoringMode = (values.single["--candidate-scoring-mode"] ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            if candidateScoringMode.isEmpty == false,
+               ["dataset_score", "seed_overlap_proxy", "reward_model"].contains(candidateScoringMode) == false {
+                throw MelixCLIError.usage("Invalid value for --candidate-scoring-mode. Expected one of: dataset_score, seed_overlap_proxy, reward_model.")
+            }
             let datasetSourceKind = datasetURI.isEmpty ? "hf_dataset" : "local_package"
             var parameters: [String: String] = [:]
             for option in [
@@ -2332,6 +2346,7 @@ public enum MelixCLIParser {
                 "--completion-feature",
                 "--text-feature",
                 "--grpo-candidate-count",
+                "--candidate-generation-max-tokens",
                 "--reference-model-path",
                 "--reward-model-manifest-path",
                 "--kl-penalty",
@@ -2339,6 +2354,12 @@ public enum MelixCLIParser {
                 if let value = values.single[option] {
                     parameters[normalizedParameterKey(option)] = value
                 }
+            }
+            if candidateGenerationMode.isEmpty == false {
+                parameters["candidate_generation_mode"] = candidateGenerationMode
+            }
+            if candidateScoringMode.isEmpty == false {
+                parameters["candidate_scoring_mode"] = candidateScoringMode
             }
             if let presetID = values.single["--preset"] {
                 parameters["preset_id"] = presetID
@@ -4921,6 +4942,9 @@ public actor MelixCLIRunner {
                 appendOption("--sample-limit", value: ext["sample_limit"], into: &arguments)
                 appendOption("--gradient-accumulation", value: ext["gradient_accumulation"], into: &arguments)
                 appendOption("--grpo-candidate-count", value: ext["grpo_candidate_count"], into: &arguments)
+                appendOption("--candidate-generation-mode", value: ext["candidate_generation_mode"], into: &arguments)
+                appendOption("--candidate-scoring-mode", value: ext["candidate_scoring_mode"], into: &arguments)
+                appendOption("--candidate-generation-max-tokens", value: ext["candidate_generation_max_tokens"], into: &arguments)
                 appendOption("--reference-model-path", value: ext["reference_model_path"], into: &arguments)
                 appendOption("--reward-model-manifest-path", value: ext["reward_model_manifest_path"], into: &arguments)
                 appendOption("--kl-penalty", value: ext["kl_penalty"], into: &arguments)

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -2,6 +2,17 @@ import Foundation
 import MelixControlPlaneCore
 import MelixControlPlaneProtocol
 
+enum MelixQuantizationAllowedValues {
+    static let quantizationModes = ["ptq", "qat"]
+    static let sourceArtifactKinds = ["base_model", "merged_adapter", "adapter_export"]
+    static let quantizationBackends = ["manifest_only", "mlx_lm_convert"]
+    static let mlxLMQModes = ["affine", "mxfp4", "nvfp4", "mxfp8"]
+
+    static func renderedList(_ values: [String]) -> String {
+        values.joined(separator: ", ")
+    }
+}
+
 public struct LoraListOptions: Equatable, Sendable {
     public let modelID: String
     public let json: Bool
@@ -878,6 +889,8 @@ public struct QuantizeOptions: Equatable, Sendable {
     public let localInferenceSmokePrompt: String
     public let json: Bool
 
+    // The parser and pipeline runner pass optional enum-like fields already
+    // trimmed and lowercased; this initializer preserves direct caller input.
     public init(
         modelID: String,
         outputDir: String = "",
@@ -1636,20 +1649,26 @@ public enum MelixCLIParser {
         let quantizationMode = (values.single["--quantization-mode"] ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        if !quantizationMode.isEmpty, ["ptq", "qat"].contains(quantizationMode) == false {
-            throw MelixCLIError.usage("Invalid value for --quantization-mode. Expected one of: ptq, qat.")
+        if !quantizationMode.isEmpty, MelixQuantizationAllowedValues.quantizationModes.contains(quantizationMode) == false {
+            throw MelixCLIError.usage(
+                "Invalid value for --quantization-mode. Expected one of: \(MelixQuantizationAllowedValues.renderedList(MelixQuantizationAllowedValues.quantizationModes))."
+            )
         }
         let sourceArtifactKind = (values.single["--source-artifact-kind"] ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        if !sourceArtifactKind.isEmpty, ["base_model", "merged_adapter", "adapter_export"].contains(sourceArtifactKind) == false {
-            throw MelixCLIError.usage("Invalid value for --source-artifact-kind. Expected one of: base_model, merged_adapter, adapter_export.")
+        if !sourceArtifactKind.isEmpty, MelixQuantizationAllowedValues.sourceArtifactKinds.contains(sourceArtifactKind) == false {
+            throw MelixCLIError.usage(
+                "Invalid value for --source-artifact-kind. Expected one of: \(MelixQuantizationAllowedValues.renderedList(MelixQuantizationAllowedValues.sourceArtifactKinds))."
+            )
         }
         let quantizationBackend = (values.single["--quantization-backend"] ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        if !quantizationBackend.isEmpty, ["manifest_only", "mlx_lm_convert"].contains(quantizationBackend) == false {
-            throw MelixCLIError.usage("Invalid value for --quantization-backend. Expected one of: manifest_only, mlx_lm_convert.")
+        if !quantizationBackend.isEmpty, MelixQuantizationAllowedValues.quantizationBackends.contains(quantizationBackend) == false {
+            throw MelixCLIError.usage(
+                "Invalid value for --quantization-backend. Expected one of: \(MelixQuantizationAllowedValues.renderedList(MelixQuantizationAllowedValues.quantizationBackends))."
+            )
         }
         let mlxLMQBits = (values.single["--mlx-lm-q-bits"] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         if !mlxLMQBits.isEmpty, Int(mlxLMQBits) == nil {
@@ -1662,8 +1681,10 @@ public enum MelixCLIParser {
         let mlxLMQMode = (values.single["--mlx-lm-q-mode"] ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        if !mlxLMQMode.isEmpty, ["affine", "mxfp4", "nvfp4", "mxfp8"].contains(mlxLMQMode) == false {
-            throw MelixCLIError.usage("Invalid value for --mlx-lm-q-mode. Expected one of: affine, mxfp4, nvfp4, mxfp8.")
+        if !mlxLMQMode.isEmpty, MelixQuantizationAllowedValues.mlxLMQModes.contains(mlxLMQMode) == false {
+            throw MelixCLIError.usage(
+                "Invalid value for --mlx-lm-q-mode. Expected one of: \(MelixQuantizationAllowedValues.renderedList(MelixQuantizationAllowedValues.mlxLMQModes))."
+            )
         }
         let localInferenceSmokeMode = (values.single["--local-inference-smoke-mode"] ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -681,6 +681,9 @@ public enum MelixCLICommandCodec {
     private static func appendAlignmentParameters(_ parameters: [String: String], into arguments: inout [String]) {
         let mapping: [(String, String)] = [
             ("grpo_candidate_count", "--grpo-candidate-count"),
+            ("candidate_generation_mode", "--candidate-generation-mode"),
+            ("candidate_scoring_mode", "--candidate-scoring-mode"),
+            ("candidate_generation_max_tokens", "--candidate-generation-max-tokens"),
             ("reference_model_path", "--reference-model-path"),
             ("reward_model_manifest_path", "--reward-model-manifest-path"),
             ("kl_penalty", "--kl-penalty"),

--- a/Sources/MelixCLICore/MelixPipelineRunner.swift
+++ b/Sources/MelixCLICore/MelixPipelineRunner.swift
@@ -1169,8 +1169,10 @@ private enum MelixPipelineCommandBuilder {
         let mode = (string("quantization_mode", args) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        guard mode.isEmpty || ["ptq", "qat"].contains(mode) else {
-            throw MelixCLIError.usage("Pipeline command argument quantization_mode must be one of: ptq, qat.")
+        guard mode.isEmpty || MelixQuantizationAllowedValues.quantizationModes.contains(mode) else {
+            throw MelixCLIError.usage(
+                "Pipeline command argument quantization_mode must be one of: \(MelixQuantizationAllowedValues.renderedList(MelixQuantizationAllowedValues.quantizationModes))."
+            )
         }
         return mode
     }
@@ -1179,8 +1181,10 @@ private enum MelixPipelineCommandBuilder {
         let kind = (string("source_artifact_kind", args) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        guard kind.isEmpty || ["base_model", "merged_adapter", "adapter_export"].contains(kind) else {
-            throw MelixCLIError.usage("Pipeline command argument source_artifact_kind must be one of: base_model, merged_adapter, adapter_export.")
+        guard kind.isEmpty || MelixQuantizationAllowedValues.sourceArtifactKinds.contains(kind) else {
+            throw MelixCLIError.usage(
+                "Pipeline command argument source_artifact_kind must be one of: \(MelixQuantizationAllowedValues.renderedList(MelixQuantizationAllowedValues.sourceArtifactKinds))."
+            )
         }
         return kind
     }
@@ -1189,8 +1193,10 @@ private enum MelixPipelineCommandBuilder {
         let backend = (string("quantization_backend", args) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        guard backend.isEmpty || ["manifest_only", "mlx_lm_convert"].contains(backend) else {
-            throw MelixCLIError.usage("Pipeline command argument quantization_backend must be one of: manifest_only, mlx_lm_convert.")
+        guard backend.isEmpty || MelixQuantizationAllowedValues.quantizationBackends.contains(backend) else {
+            throw MelixCLIError.usage(
+                "Pipeline command argument quantization_backend must be one of: \(MelixQuantizationAllowedValues.renderedList(MelixQuantizationAllowedValues.quantizationBackends))."
+            )
         }
         return backend
     }
@@ -1199,8 +1205,10 @@ private enum MelixPipelineCommandBuilder {
         let mode = (string("mlx_lm_q_mode", args) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        guard mode.isEmpty || ["affine", "mxfp4", "nvfp4", "mxfp8"].contains(mode) else {
-            throw MelixCLIError.usage("Pipeline command argument mlx_lm_q_mode must be one of: affine, mxfp4, nvfp4, mxfp8.")
+        guard mode.isEmpty || MelixQuantizationAllowedValues.mlxLMQModes.contains(mode) else {
+            throw MelixCLIError.usage(
+                "Pipeline command argument mlx_lm_q_mode must be one of: \(MelixQuantizationAllowedValues.renderedList(MelixQuantizationAllowedValues.mlxLMQModes))."
+            )
         }
         return mode
     }

--- a/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
+++ b/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
@@ -69,6 +69,10 @@ local runtime acceptance requirements.
 - Publish the PTQ fused derived model from
   `lora.activate.result.derived_model_path` via `merged_model_path` so the real
   pipeline uses the activation result field that the runtime actually returns.
+- Route the QAT-aware acceptance case through the same fused merged export shape,
+  run a two-layer `debug_fast` QLoRA probe for bounded runtime cost, record
+  Melix fake-quant/QAT evidence, and request `quantization_backend=mlx_lm_convert`
+  so the final quantized bundle can be loaded for real local runtime smoke.
 - Route PTQ/QAT acceptance through the quantized bundle manifest's
   `local_inference_smoke` and `release_gate.local_inference_smoke_result`
   checks instead of treating `quantized_model_bundle` directories as generic
@@ -81,7 +85,8 @@ local runtime acceptance requirements.
   dataset, reward-model, or runtime evidence bundle for all cases.
 - GRPO candidate generation from a live policy runtime.
 - RLHF reward-model integration from issue 366.
-- QAT trainer/export implementation.
+- MLX-native full-tensor QAT trainer implementation. This slice covers
+  QAT-aware export evidence plus a real MLX-LM converted final bundle.
 - Native Window UI acceptance.
 - Closing issue 365.
 
@@ -334,6 +339,22 @@ MLX-LM conversion backend:
   `tokenizer_config.json`, and `manifest.json`.
 - `MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/issue365-ptq-backend-real" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-ptq-backend-real-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-ptq-backend-real-swift.sock" bash scripts/dev_down.sh`:
   stopped the named PTQ backend runtime stack.
+
+Results on 2026-05-06 after routing the QAT acceptance case through fused
+merged export and QAT-aware MLX-LM conversion:
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q tests/integration/test_issue365_acceptance_bundle.py`:
+  13 passed.
+- `python3 scripts/issue365_acceptance_bundle.py --execution-mode plan --case-id qat_quantized_inference --output-dir .runtime/issue365/qat-aware-plan-r2 --timestamp 2026-05-06T181500Z --json`:
+  wrote a selected-case plan bundle with four steps:
+  `qat_train -> qat_fuse_merged_model -> qat_publish_export -> qat_quantize`.
+- `MELIX_HOME="$PWD/.runtime/home-issue365-qat-aware-clean" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-qat-aware-clean-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-qat-aware-clean-swift.sock" MELIX_HTTP_PORT=12476 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id qat_quantized_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --calibration-dataset-uri "$PWD/.runtime/issue365/input-datasets/calibration" --output-dir .runtime/issue365/qat-aware-real-probe-r5 --timestamp 2026-05-06T183000Z --json`:
+  selected real QAT case passed with `release_ready=true`; the quantize receipt
+  recorded `execution_backend=mlx_lm_convert`, `real_weight_conversion=true`,
+  `source_artifact_kind=merged_adapter`, and
+  `release_gate.local_inference_smoke_result=passed`.
+- `find .runtime -type f \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.webp' \) -print`:
+  passed with no generated screenshot artifacts found.
 
 Results on 2026-05-05 after adding the acceptance bundle harness:
 

--- a/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
+++ b/docs/plans/2026-05-05-issue-365-cli-chain-routing.md
@@ -66,6 +66,11 @@ local runtime acceptance requirements.
   plus the MLX-LM quantization knobs, and route the PTQ acceptance case through
   a fused merged export with `quantization_backend=mlx_lm_convert` instead of
   exercising only the manifest-only quantization path.
+- Add public `melix alignment train` and command-codec routing for
+  `--candidate-generation-mode`, `--candidate-scoring-mode`, and
+  `--candidate-generation-max-tokens` so Issue 365 GRPO acceptance can request
+  live policy-runtime candidate generation and reward-model scoring instead of
+  silently falling back to scored-trace replay.
 - Publish the PTQ fused derived model from
   `lora.activate.result.derived_model_path` via `merged_model_path` so the real
   pipeline uses the activation result field that the runtime actually returns.
@@ -83,7 +88,9 @@ local runtime acceptance requirements.
 - Real local runtime acceptance for every business line. This slice can preflight
   and run real-mode cases, but it does not provide the required local model,
   dataset, reward-model, or runtime evidence bundle for all cases.
-- GRPO candidate generation from a live policy runtime.
+- Release-ready GRPO candidate generation from a live policy runtime. This
+  slice now makes the CLI and acceptance harness request that mode, but it does
+  not provide a final passing real-runtime GRPO release bundle.
 - RLHF reward-model integration from issue 366.
 - MLX-native full-tensor QAT trainer implementation. This slice covers
   QAT-aware export evidence plus a real MLX-LM converted final bundle.
@@ -120,6 +127,9 @@ Success metrics:
 - Quantized PTQ/QAT real-mode subsets must not be marked successful unless the
   quantize step reports `local_runtime_generate` smoke evidence with
   `status=passed` and `release_gate.local_inference_smoke_result=passed`.
+- The GRPO real-mode case must require `candidate_generation_mode=runtime_generate`,
+  `candidate_scoring_mode=reward_model`, and a reward-model manifest before it
+  can be treated as release-ready.
 
 ## Verification
 
@@ -378,20 +388,21 @@ Results on 2026-05-05 after adding the acceptance bundle harness:
 
 ## Remaining Issue 365 Gaps
 
-- Real GRPO policy-runtime candidate generation, scoring, and policy updates.
+- Passing real GRPO policy-runtime candidate generation, reward-model scoring,
+  and policy updates. The CLI and acceptance harness now route the required
+  runtime/scoring controls, but the real release bundle still has to pass.
 - RLHF reward-model inference and PPO/reward-guided update integration from
   issue 366.
-- QAT training and QAT-aware quantized export.
 - Full CLI chain tests backed by real local runtime evidence for every listed
   business line.
 - Real local runtime evidence now exists for `lora_export_inference`,
   `qlora_export_inference`, `dora_export_inference`,
   `lora_dpo_export_inference`, `lora_orpo_export_inference`,
   `lora_cpo_export_inference`, and
-  `lora_preference_ptq_quantized_inference`, but the remaining three CLI
-  chains still require real local runtime evidence:
-  `lora_grpo_export_inference`, `lora_rlhf_export_inference`, and
-  `qat_quantized_inference`.
+  `lora_preference_ptq_quantized_inference`, plus stacked QAT evidence in
+  PR #446. After #446 lands, the remaining two CLI chains still require real
+  local runtime evidence:
+  `lora_grpo_export_inference` and `lora_rlhf_export_inference`.
 - Window UI runnable/inspectable acceptance for every listed business line.
 - Final release evidence that separates deterministic/unit/scored-trace results
   from real local runtime results.

--- a/docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md
+++ b/docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md
@@ -3,7 +3,8 @@
 ## Goal
 
 Continue https://github.com/Keith-CY/melix/issues/365 by adding an opt-in real
-MLX-LM weight conversion backend for PTQ quantization jobs.
+MLX-LM weight conversion backend for PTQ quantization jobs and QAT-aware final
+exports.
 
 Issue 365 is still not complete after this slice. Existing quantization slices
 recorded lineage, release-gate, QAT-mode, and runtime-smoke evidence, but the
@@ -12,9 +13,10 @@ slice adds a separate backend that can invoke `mlx_lm.convert(..., quantize=True
 for local source artifacts while preserving the existing deterministic backend
 for fast tests and unsupported environments. It also tightens the QAT-aware
 export evidence block so QAT requests preserve adapter-derived source lineage,
-fake-quant settings, optional QAT training-manifest lineage, and calibration
-lineage. A follow-up extension in this branch adds a deterministic Melix
-fake-quant optimizer execution path for QAT requests: it reads the
+fake-quant settings, optional QAT training-manifest lineage, calibration
+lineage, and, when requested, a real MLX-LM converted bundle that can pass
+local runtime smoke. A follow-up extension in this branch adds a deterministic
+Melix fake-quant optimizer execution path for QAT requests: it reads the
 adapter-derived source artifact, computes fake-quant error proxies, writes a
 QAT training trace and manifest, and links those artifacts from the quantized
 bundle manifest.
@@ -26,8 +28,10 @@ bundle manifest.
 - Add `quantization_backend=mlx_lm_convert` as an explicit opt-in backend.
 - Keep the current deterministic bundle writer as `manifest_only`.
 - Validate MLX conversion inputs before long-running conversion starts.
-- Reject unsupported QAT requests for the MLX-LM conversion backend because
-  `mlx_lm.convert` is a PTQ conversion path, not QAT training.
+- Allow QAT-aware requests to run Melix fake-quant evidence and then use the
+  MLX-LM conversion backend for a loadable final quantized export from an
+  adapter-derived merged source artifact. This is QAT-aware export evidence, not
+  MLX-native full-tensor QAT training.
 - Derive MLX-LM quantization parameters from the Melix quantization profile and
   optional explicit ext fields.
 - Record `execution_backend` and `real_weight_conversion` in
@@ -44,6 +48,9 @@ bundle manifest.
 ### Excluded
 
 - MLX-native QAT training over full model tensors.
+- Claiming that `mlx_lm.convert` itself performs QAT. The MLX-LM conversion
+  step remains the final quantized export backend after Melix records QAT-aware
+  fake-quant evidence.
 - End-to-end release evidence for every issue 365 business line.
 - Remote Hugging Face downloads during tests.
 - Full CLI chain and Window UI acceptance.
@@ -60,9 +67,13 @@ small trace/manifest/artifact bundle.
 Success metrics:
 
 - Existing manifest-only quantization tests remain compatible.
-- MLX-LM backend tests prove real-conversion routing with a fake converter.
+- MLX-LM backend tests prove real-conversion routing with a fake converter for
+  PTQ and QAT-aware export requests.
 - QAT tests prove fake-quant optimizer execution artifacts and metrics are
   written and linked from `melix.quantized_bundle.v1`.
+- The Issue 365 QAT acceptance case keeps the supervised probe to two layers
+  under `debug_fast` so real-runtime evidence measures the export path without
+  turning the acceptance probe into a full-model QAT benchmark.
 - Changed-line coverage remains at least 95 percent.
 
 ## Verification
@@ -96,12 +107,26 @@ Results on 2026-05-06 after QAT fake-quant optimizer extension:
 - `python3 -m compileall -q services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py`: passed.
 - `git diff --check`: passed.
 
+Results on 2026-05-06 after adding QAT-aware MLX-LM final export:
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py tests/integration/test_issue365_acceptance_bundle.py`:
+  68 passed.
+- `python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-qat-runtime-python-coverage.json --diff-from codex/issue365-ptq-runtime services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py scripts/issue365_acceptance_bundle.py tests/integration/test_issue365_acceptance_bundle.py docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md docs/plans/2026-05-05-issue-365-cli-chain-routing.md`:
+  100.00 percent total changed-line coverage, 51/51 executable lines.
+- `MELIX_HOME="$PWD/.runtime/home-issue365-qat-aware-clean" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-qat-aware-clean-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-qat-aware-clean-swift.sock" MELIX_HTTP_PORT=12476 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id qat_quantized_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --calibration-dataset-uri "$PWD/.runtime/issue365/input-datasets/calibration" --output-dir .runtime/issue365/qat-aware-real-probe-r5 --timestamp 2026-05-06T183000Z --json`:
+  selected real QAT case passed with `release_ready=true`; the quantize receipt
+  recorded `execution_backend=mlx_lm_convert`, `real_weight_conversion=true`,
+  `source_artifact_kind=merged_adapter`, QAT metadata from
+  `melix_fake_quant_optimizer`, and `local_inference_smoke.status=passed`.
+- `python3 -m compileall -q services/mlx-worker-python/worker/model_ops/quantization_pipeline.py scripts/issue365_acceptance_bundle.py services/mlx-worker-python/tests/test_quantization_pipeline.py tests/integration/test_issue365_acceptance_bundle.py`:
+  passed.
+- `git diff --check`: passed.
+
 ## Remaining Issue 365 Gaps
 
 - Real GRPO candidate generation and reward-guided policy update integration.
 - RLHF reward-model-backed policy optimization from issue 366.
-- MLX-native QAT training over full model tensors and real local-runtime release
-  evidence for QAT artifacts.
+- MLX-native QAT training over full model tensors.
 - Full CLI chain tests with real local runtime evidence for every business
   line.
 - Window UI runnable and inspectable acceptance for every business line.

--- a/scripts/issue365_acceptance_bundle.py
+++ b/scripts/issue365_acceptance_bundle.py
@@ -442,6 +442,7 @@ def _ptq_case() -> Issue365PipelineCase:
 
 def _qat_case() -> Issue365PipelineCase:
     train_step = "qat_train"
+    fuse_step = "qat_fuse_merged_model"
     publish_step = "qat_publish_export"
     quantize_step = "qat_quantize"
     return Issue365PipelineCase(
@@ -468,7 +469,19 @@ def _qat_case() -> Issue365PipelineCase:
                     "training_mode": "qlora",
                     "preset_id": "debug_fast",
                     "max_steps": 2,
+                    "total_layers": 2,
+                    "num_layers": 2,
                     "qat_fake_quant": "enabled",
+                },
+            },
+            {
+                "id": fuse_step,
+                "command": "lora.activate",
+                "args": {
+                    "model_id": "${inputs.model_id}",
+                    "adapter_path": f"${{steps.{train_step}.result.output_path}}",
+                    "derived_model_alias": "issue365-qat-merged",
+                    "activation_mode": "fused_derived_model",
                 },
             },
             {
@@ -477,8 +490,8 @@ def _qat_case() -> Issue365PipelineCase:
                 "args": {
                     "model_id": "${inputs.model_id}",
                     "target_repo": "melix/issue365-qat-export",
-                    "manifest_path": f"${{steps.{train_step}.result.output_path}}",
-                    "export_kind": "adapter",
+                    "merged_model_path": f"${{steps.{fuse_step}.result.derived_model_path}}",
+                    "export_kind": "merged",
                     "publish_backend": "local_filesystem",
                     "local_publish_root": "${inputs.local_publish_root}",
                 },
@@ -493,8 +506,10 @@ def _qat_case() -> Issue365PipelineCase:
                     "weight_quant": "q4",
                     "kv_quant": "q8",
                     "quantization_mode": "qat",
-                    "source_artifact_kind": "adapter_export",
+                    "source_artifact_kind": "merged_adapter",
                     "source_artifact_path": f"${{steps.{publish_step}.result.output_path}}",
+                    "quantization_backend": "mlx_lm_convert",
+                    "mlx_lm_q_mode": "affine",
                     "calibration_dataset_uri": "${inputs.calibration_dataset_uri}",
                     "quality_delta": 0,
                     "latency_delta": 0,

--- a/scripts/issue365_acceptance_bundle.py
+++ b/scripts/issue365_acceptance_bundle.py
@@ -407,6 +407,7 @@ def _ptq_case() -> Issue365PipelineCase:
                     "derived_model_alias": "issue365-ptq-merged",
                     "activation_mode": "fused_derived_model",
                 },
+                "checks": {"required_result_fields": ["derived_model_path"]},
             },
             {
                 "id": publish_step,
@@ -489,6 +490,7 @@ def _qat_case() -> Issue365PipelineCase:
                     "derived_model_alias": "issue365-qat-merged",
                     "activation_mode": "fused_derived_model",
                 },
+                "checks": {"required_result_fields": ["derived_model_path"]},
             },
             {
                 "id": publish_step,

--- a/scripts/issue365_acceptance_bundle.py
+++ b/scripts/issue365_acceptance_bundle.py
@@ -191,7 +191,13 @@ def issue365_pipeline_cases() -> tuple[Issue365PipelineCase, ...]:
         _alignment_case(
             "grpo",
             "${inputs.prompt_candidate_dataset_uri}",
-            extra_alignment_args={"grpo_candidate_count": 4},
+            extra_alignment_args={
+                "grpo_candidate_count": 4,
+                "candidate_generation_mode": "runtime_generate",
+                "candidate_scoring_mode": "reward_model",
+                "candidate_generation_max_tokens": 16,
+                "reward_model_manifest_path": "${inputs.reward_model_manifest_path}",
+            },
             requirement="BaseModel -> LoRA -> GRPO -> export -> local inference.",
         ),
         _alignment_case(
@@ -571,7 +577,7 @@ def _alignment_required_inputs(algorithm: str) -> tuple[str, ...]:
     if algorithm in {"dpo", "orpo", "cpo"}:
         return ("sft_dataset_uri", "preference_dataset_uri")
     if algorithm == "grpo":
-        return ("sft_dataset_uri", "prompt_candidate_dataset_uri")
+        return ("sft_dataset_uri", "prompt_candidate_dataset_uri", "reward_model_manifest_path")
     if algorithm == "rlhf":
         return ("sft_dataset_uri", "reward_scored_dataset_uri", "reward_model_manifest_path")
     raise ValueError(f"Unsupported alignment algorithm: {algorithm}")

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -69,6 +69,17 @@ from worker.productization.pr_scoped_performance import (
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 REGISTRY_PATH = REPO_ROOT / "infra/perf/pr_scoped_probes.json"
+DATASET_REGISTRY_SELECTED_PROBE_IDS = [
+    "dataset-registry-limited-read-streaming",
+    "dataset-registry-snapshot-inference-single-pass",
+    "dataset-registry-preview-limit-short-circuit",
+]
+MLX_AUDIO_RUNTIME_SELECTED_PROBE_IDS = [
+    "mlx-audio-speech-signature-cache",
+    "mlx-audio-wav-streaming-pcm",
+    "mlx-audio-local-uri-zero-copy-preprocess",
+    "mlx-audio-generate-signature-cache",
+]
 SCOPE_MATCHER_SELECTED_PROBE_IDS = [
     "benchmark-export-run-scan-single-pass",
     "evaluation-job-id-high-water-mark",
@@ -77,6 +88,10 @@ SCOPE_MATCHER_SELECTED_PROBE_IDS = [
     "evaluation-dialogue-diagnostics-top-k",
     "download-pipeline-directory-size-single-stat",
 ]
+
+
+def _selected_probe_ids(scope: dict[str, object]) -> list[str]:
+    return [probe["id"] for probe in _dict_list(scope["selected_probes"])]
 
 
 @pytest.fixture()
@@ -142,12 +157,8 @@ def test_scope_report_selects_dataset_registry_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/dataset_registry/catalog.py"],
     )
 
-    assert scope["selected_count"] == 3
-    assert {probe["id"] for probe in scope["selected_probes"]} == {
-        "dataset-registry-limited-read-streaming",
-        "dataset-registry-snapshot-inference-single-pass",
-        "dataset-registry-preview-limit-short-circuit",
-    }
+    assert scope["selected_count"] == len(DATASET_REGISTRY_SELECTED_PROBE_IDS)
+    assert _selected_probe_ids(scope) == DATASET_REGISTRY_SELECTED_PROBE_IDS
 
 
 def test_scope_report_selects_mlx_audio_wav_probe() -> None:
@@ -156,8 +167,9 @@ def test_scope_report_selects_mlx_audio_wav_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "mlx-audio-wav-streaming-pcm"
+    assert scope["selected_count"] == len(MLX_AUDIO_RUNTIME_SELECTED_PROBE_IDS)
+    assert _selected_probe_ids(scope) == MLX_AUDIO_RUNTIME_SELECTED_PROBE_IDS
+    assert "mlx-audio-wav-streaming-pcm" in _selected_probe_ids(scope)
 
 
 def test_scope_report_selects_mlx_audio_signature_probe() -> None:
@@ -166,8 +178,9 @@ def test_scope_report_selects_mlx_audio_signature_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "mlx-audio-generate-signature-cache"
+    assert scope["selected_count"] == len(MLX_AUDIO_RUNTIME_SELECTED_PROBE_IDS)
+    assert _selected_probe_ids(scope) == MLX_AUDIO_RUNTIME_SELECTED_PROBE_IDS
+    assert "mlx-audio-generate-signature-cache" in _selected_probe_ids(scope)
 
 
 def test_scope_report_selects_video_preprocessing_probe() -> None:
@@ -186,8 +199,9 @@ def test_scope_report_selects_mlx_audio_speech_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "mlx-audio-speech-signature-cache"
+    assert scope["selected_count"] == len(MLX_AUDIO_RUNTIME_SELECTED_PROBE_IDS)
+    assert _selected_probe_ids(scope) == MLX_AUDIO_RUNTIME_SELECTED_PROBE_IDS
+    assert "mlx-audio-speech-signature-cache" in _selected_probe_ids(scope)
 
 
 def test_scope_report_selects_only_matching_probe() -> None:
@@ -449,8 +463,9 @@ def test_scope_report_selects_mlx_audio_local_uri_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "mlx-audio-local-uri-zero-copy-preprocess"
+    assert scope["selected_count"] == len(MLX_AUDIO_RUNTIME_SELECTED_PROBE_IDS)
+    assert _selected_probe_ids(scope) == MLX_AUDIO_RUNTIME_SELECTED_PROBE_IDS
+    assert "mlx-audio-local-uri-zero-copy-preprocess" in _selected_probe_ids(scope)
 
 
 def test_scope_report_selects_mlx_vlm_runtime_probe() -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -69,6 +69,14 @@ from worker.productization.pr_scoped_performance import (
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 REGISTRY_PATH = REPO_ROOT / "infra/perf/pr_scoped_probes.json"
+SCOPE_MATCHER_SELECTED_PROBE_IDS = [
+    "benchmark-export-run-scan-single-pass",
+    "evaluation-job-id-high-water-mark",
+    "evaluation-sample-probe-aggregation",
+    "evaluation-latency-percentile-vector-reuse",
+    "evaluation-dialogue-diagnostics-top-k",
+    "download-pipeline-directory-size-single-stat",
+]
 
 
 @pytest.fixture()
@@ -751,14 +759,11 @@ def test_scope_report_large_changed_set_preserves_exact_selection_semantics() ->
 
     assert scope["force_all"] is False
     assert scope["changed_files"] == sorted({path for path in changed_files if path})
-    assert [probe["id"] for probe in scope["selected_probes"]] == [
-        "benchmark-export-run-scan-single-pass",
-        "evaluation-job-id-high-water-mark",
-        "evaluation-sample-probe-aggregation",
-        "evaluation-latency-percentile-vector-reuse",
-        "download-pipeline-directory-size-single-stat",
-    ]
-    assert scope["selected_count"] == 5
+    assert (
+        [probe["id"] for probe in scope["selected_probes"]]
+        == SCOPE_MATCHER_SELECTED_PROBE_IDS
+    )
+    assert scope["selected_count"] == len(SCOPE_MATCHER_SELECTED_PROBE_IDS)
 
 
 def test_match_probe_indexes_deduplicates_repeated_watch_globs() -> None:
@@ -1309,6 +1314,9 @@ def test_registered_probes_expose_focused_commands() -> None:
         "rerank-core-top-k-heap-selection",
         "runtime-utils-kwarg-signature-cache",
         "mlx-audio-wav-streaming-pcm",
+        "mlx-audio-generate-signature-cache",
+        "mlx-audio-speech-signature-cache",
+        "video-preprocessing-uri-byte-length-reuse",
         "dev-up-mlx-metal-dist-info-scandir",
         "evaluation-dialogue-diagnostics-top-k",
         "evaluation-job-id-high-water-mark",
@@ -1809,7 +1817,9 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     assert evaluation_store_metrics["csv_line_count"] == 10001.0
     assert scope_matcher_metrics["build_scope_report_ms_mean"] > 0
     assert scope_matcher_metrics["changed_file_count"] == float(len(_build_large_scope_probe_changed_files()))
-    assert scope_matcher_metrics["selected_probe_count_mean"] == 6.0
+    assert scope_matcher_metrics["selected_probe_count_mean"] == float(
+        len(SCOPE_MATCHER_SELECTED_PROBE_IDS)
+    )
     assert scope_matcher_metrics["force_all_selected_mean"] == 0.0
     assert training_dataset_metrics["elapsed_ms_mean"] > 0
     assert training_dataset_metrics["peak_bytes_mean"] > 0
@@ -2179,7 +2189,9 @@ def test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe() -> None:
 
     assert metrics["build_scope_report_ms_mean"] > 0
     assert metrics["changed_file_count"] == float(len(_build_large_scope_probe_changed_files()))
-    assert metrics["selected_probe_count_mean"] == 6.0
+    assert metrics["selected_probe_count_mean"] == float(
+        len(SCOPE_MATCHER_SELECTED_PROBE_IDS)
+    )
     assert metrics["force_all_selected_mean"] == 0.0
 
 

--- a/services/mlx-worker-python/tests/test_quantization_pipeline.py
+++ b/services/mlx-worker-python/tests/test_quantization_pipeline.py
@@ -727,10 +727,32 @@ def test_quantize_job_rejects_unknown_quantization_backend(tmp_path: Path) -> No
     assert events[-1].failed.error.details["quantization_backend"] == "shell-script"
 
 
-def test_quantize_job_rejects_qat_for_mlx_lm_convert_backend(tmp_path: Path) -> None:
+def test_quantize_job_runs_qat_aware_mlx_lm_convert_backend(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     service = build_service(tmp_path)
     source_artifact_path = tmp_path / "merged-model"
     source_artifact_path.mkdir()
+    (source_artifact_path / "config.json").write_text("{}\n", encoding="utf-8")
+    (source_artifact_path / "model.safetensors").write_bytes(b"melix-merged-source")
+
+    convert_calls: list[dict[str, object]] = []
+
+    def fake_mlx_lm_convert(**kwargs: object) -> None:
+        convert_calls.append(kwargs)
+        output_path = kwargs["output_path"]
+        assert isinstance(output_path, Path)
+        output_path.mkdir(parents=True)
+        (output_path / "config.json").write_text("{}\n", encoding="utf-8")
+        (output_path / "tokenizer.json").write_text("{}\n", encoding="utf-8")
+        (output_path / "model.safetensors").write_bytes(b"real-mlx-qat-aware-weights")
+
+    monkeypatch.setattr(
+        OQQuantizationPipeline,
+        "_mlx_lm_convert",
+        staticmethod(fake_mlx_lm_convert),
+    )
 
     events = list(
         service.ConvertModel(
@@ -740,21 +762,53 @@ def test_quantize_job_rejects_qat_for_mlx_lm_convert_backend(tmp_path: Path) -> 
                 weight_quant="q4",
                 kv_quant="q8",
                 generate_manifest=True,
+                run_smoke_test=True,
                 ext={
                     "operation": "quantize",
                     "quantization_backend": "mlx_lm_convert",
                     "quantization_mode": "qat",
                     "source_artifact_kind": "merged_adapter",
                     "source_artifact_path": str(source_artifact_path),
+                    "qat_fake_quant": "enabled",
+                    "qat_training_steps": "2",
+                    "mlx_lm_q_mode": "affine",
                 },
             ),
             context=None,
         )
     )
 
-    assert events[-1].failed.error.code == "unsupported_quantization_backend"
-    assert events[-1].failed.error.details["quantization_backend"] == "mlx_lm_convert"
-    assert events[-1].failed.error.details["quantization_mode"] == "qat"
+    assert events[-1].HasField("completed")
+    assert len(convert_calls) == 1
+    assert convert_calls[0]["source_path"] == source_artifact_path.resolve()
+    manifest_payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+    bundle_path = Path(events[-1].completed.output_path)
+    qat = manifest_payload["qat"]
+    qat_files = [
+        Path(qat["training_manifest_path"]),
+        Path(qat["training_trace_path"]),
+        Path(qat["fake_quant_artifact_path"]),
+    ]
+    expected_artifact_bytes = sum(
+        (bundle_path / file_name).stat().st_size
+        for file_name in ("config.json", "tokenizer.json", "model.safetensors")
+    ) + sum(path.stat().st_size for path in qat_files)
+
+    assert manifest_payload["quantization_mode"] == "qat"
+    assert manifest_payload["execution_backend"] == "mlx_lm_convert"
+    assert manifest_payload["real_weight_conversion"] is True
+    assert manifest_payload["source_artifact_kind"] == "merged_adapter"
+    assert manifest_payload["artifact_bytes"] == expected_artifact_bytes
+    assert manifest_payload["release_gate"]["local_inference_smoke_result"] == "passed"
+    assert manifest_payload["local_inference_smoke"]["checked_files"] == [
+        "config.json",
+        "tokenizer.json",
+        "model.safetensors",
+    ]
+    assert qat["training_backend"] == "melix_fake_quant_optimizer"
+    assert qat["training_steps"] == 2
+    assert qat["source_file_count"] == 2
+    assert all(path.is_file() for path in qat_files)
 
 
 def test_quantize_job_rejects_mlx_lm_convert_without_local_source(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -132,6 +132,30 @@ class OQQuantizationPipeline:
         bundle_path = (output_dir / job_id / "quantize.artifact").resolve()
         qat_training_result: QATFakeQuantTrainingResult | None = None
         qat_metadata: dict[str, Any] | None = None
+
+        def run_qat_training() -> QATFakeQuantTrainingResult:
+            return _run_qat_fake_quant_training(
+                request=request,
+                job_id=job_id,
+                source_artifact_kind=source_artifact_kind,
+                source_artifact_path=source_artifact_path,
+                profile=profile,
+                calibration_evidence=calibration_evidence,
+                bundle_path=bundle_path,
+            )
+
+        def compute_qat_metadata(
+            training_result: QATFakeQuantTrainingResult | None,
+        ) -> dict[str, Any] | None:
+            return _qat_metadata_for_request(
+                request,
+                quantization_mode=quantization_mode,
+                source_artifact_kind=source_artifact_kind,
+                source_artifact_path=source_artifact_path,
+                calibration_evidence=calibration_evidence,
+                qat_training_result=training_result,
+            )
+
         if quantization_backend == _MLX_LM_CONVERT_QUANTIZATION_BACKEND:
             artifact_bytes = self._write_mlx_lm_quantized_bundle(
                 request=request,
@@ -140,36 +164,13 @@ class OQQuantizationPipeline:
                 bundle_path=bundle_path,
             )
             if quantization_mode == "qat":
-                qat_training_result = _run_qat_fake_quant_training(
-                    request=request,
-                    job_id=job_id,
-                    source_artifact_kind=source_artifact_kind,
-                    source_artifact_path=source_artifact_path,
-                    profile=profile,
-                    calibration_evidence=calibration_evidence,
-                    bundle_path=bundle_path,
-                )
+                qat_training_result = run_qat_training()
                 artifact_bytes += qat_training_result.artifact_bytes
         else:
             bundle_path.mkdir(parents=True, exist_ok=True)
             if quantization_mode == "qat":
-                qat_training_result = _run_qat_fake_quant_training(
-                    request=request,
-                    job_id=job_id,
-                    source_artifact_kind=source_artifact_kind,
-                    source_artifact_path=source_artifact_path,
-                    profile=profile,
-                    calibration_evidence=calibration_evidence,
-                    bundle_path=bundle_path,
-                )
-            qat_metadata = _qat_metadata_for_request(
-                request,
-                quantization_mode=quantization_mode,
-                source_artifact_kind=source_artifact_kind,
-                source_artifact_path=source_artifact_path,
-                calibration_evidence=calibration_evidence,
-                qat_training_result=qat_training_result,
-            )
+                qat_training_result = run_qat_training()
+            qat_metadata = compute_qat_metadata(qat_training_result)
 
             files = {
                 bundle_path / "config.json": {
@@ -209,14 +210,7 @@ class OQQuantizationPipeline:
             )
 
         if quantization_mode == "qat" and qat_metadata is None:
-            qat_metadata = _qat_metadata_for_request(
-                request,
-                quantization_mode=quantization_mode,
-                source_artifact_kind=source_artifact_kind,
-                source_artifact_path=source_artifact_path,
-                calibration_evidence=calibration_evidence,
-                qat_training_result=qat_training_result,
-            )
+            qat_metadata = compute_qat_metadata(qat_training_result)
         smoke_evidence = _not_requested_smoke_evidence(
             bundle_path=bundle_path,
             smoke_mode=smoke_mode,

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -131,24 +131,7 @@ class OQQuantizationPipeline:
 
         bundle_path = (output_dir / job_id / "quantize.artifact").resolve()
         qat_training_result: QATFakeQuantTrainingResult | None = None
-        if quantization_mode == "qat":
-            qat_training_result = _run_qat_fake_quant_training(
-                request=request,
-                job_id=job_id,
-                source_artifact_kind=source_artifact_kind,
-                source_artifact_path=source_artifact_path,
-                profile=profile,
-                calibration_evidence=calibration_evidence,
-                bundle_path=bundle_path,
-            )
-        qat_metadata = _qat_metadata_for_request(
-            request,
-            quantization_mode=quantization_mode,
-            source_artifact_kind=source_artifact_kind,
-            source_artifact_path=source_artifact_path,
-            calibration_evidence=calibration_evidence,
-            qat_training_result=qat_training_result,
-        )
+        qat_metadata: dict[str, Any] | None = None
         if quantization_backend == _MLX_LM_CONVERT_QUANTIZATION_BACKEND:
             artifact_bytes = self._write_mlx_lm_quantized_bundle(
                 request=request,
@@ -156,8 +139,37 @@ class OQQuantizationPipeline:
                 profile=profile,
                 bundle_path=bundle_path,
             )
+            if quantization_mode == "qat":
+                qat_training_result = _run_qat_fake_quant_training(
+                    request=request,
+                    job_id=job_id,
+                    source_artifact_kind=source_artifact_kind,
+                    source_artifact_path=source_artifact_path,
+                    profile=profile,
+                    calibration_evidence=calibration_evidence,
+                    bundle_path=bundle_path,
+                )
+                artifact_bytes += qat_training_result.artifact_bytes
         else:
             bundle_path.mkdir(parents=True, exist_ok=True)
+            if quantization_mode == "qat":
+                qat_training_result = _run_qat_fake_quant_training(
+                    request=request,
+                    job_id=job_id,
+                    source_artifact_kind=source_artifact_kind,
+                    source_artifact_path=source_artifact_path,
+                    profile=profile,
+                    calibration_evidence=calibration_evidence,
+                    bundle_path=bundle_path,
+                )
+            qat_metadata = _qat_metadata_for_request(
+                request,
+                quantization_mode=quantization_mode,
+                source_artifact_kind=source_artifact_kind,
+                source_artifact_path=source_artifact_path,
+                calibration_evidence=calibration_evidence,
+                qat_training_result=qat_training_result,
+            )
 
             files = {
                 bundle_path / "config.json": {
@@ -196,6 +208,15 @@ class OQQuantizationPipeline:
                 ).encode("utf-8"),
             )
 
+        if quantization_mode == "qat" and qat_metadata is None:
+            qat_metadata = _qat_metadata_for_request(
+                request,
+                quantization_mode=quantization_mode,
+                source_artifact_kind=source_artifact_kind,
+                source_artifact_path=source_artifact_path,
+                calibration_evidence=calibration_evidence,
+                qat_training_result=qat_training_result,
+            )
         smoke_evidence = _not_requested_smoke_evidence(
             bundle_path=bundle_path,
             smoke_mode=smoke_mode,
@@ -725,19 +746,6 @@ def _validate_quantization_source(
             code="missing_source_artifact_path",
             message="Adapter-derived quantization requires source_artifact_path.",
             details={"source_artifact_kind": source_artifact_kind},
-        )
-    if (
-        quantization_backend == _MLX_LM_CONVERT_QUANTIZATION_BACKEND
-        and quantization_mode != "ptq"
-    ):
-        raise ModelOperationError(
-            code="unsupported_quantization_backend",
-            message="MLX-LM conversion backend supports PTQ only.",
-            details={
-                "quantization_backend": quantization_backend,
-                "quantization_mode": quantization_mode,
-                "supported_quantization_mode": "ptq",
-            },
         )
     if quantization_mode == "qat" and source_artifact_kind == "base_model":
         raise ModelOperationError(

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -564,6 +564,9 @@ struct MelixCLIParserTests {
                 parameters: [
                     "hf_dataset_path": "org/preference",
                     "grpo_candidate_count": "4",
+                    "candidate_generation_mode": "runtime_generate",
+                    "candidate_scoring_mode": "reward_model",
+                    "candidate_generation_max_tokens": "16",
                     "kl_penalty": "0.02",
                 ],
                 json: true
@@ -572,6 +575,12 @@ struct MelixCLIParserTests {
         let alignmentArguments = try MelixCLICommandCodec.arguments(for: alignmentCommand)
         #expect(alignmentArguments.contains("--hf-dataset-path"))
         #expect(alignmentArguments.contains("org/preference"))
+        #expect(alignmentArguments.contains("--candidate-generation-mode"))
+        #expect(alignmentArguments.contains("runtime_generate"))
+        #expect(alignmentArguments.contains("--candidate-scoring-mode"))
+        #expect(alignmentArguments.contains("reward_model"))
+        #expect(alignmentArguments.contains("--candidate-generation-max-tokens"))
+        #expect(alignmentArguments.contains("16"))
         #expect(try MelixCLIParser.parse(alignmentArguments) == alignmentCommand)
     }
 
@@ -1343,6 +1352,9 @@ struct MelixCLIParserTests {
             "--adapter-name", "aligned-adapter",
             "--algorithm", "grpo",
             "--grpo-candidate-count", "4",
+            "--candidate-generation-mode", " Runtime_Generate ",
+            "--candidate-scoring-mode", " Reward_Model ",
+            "--candidate-generation-max-tokens", "16",
             "--reference-model-path", "/tmp/reference-model",
             "--reward-model-manifest-path", "/tmp/reward/manifest.json",
             "--sample-limit", "8",
@@ -1361,6 +1373,9 @@ struct MelixCLIParserTests {
         #expect(options.adapterName == "aligned-adapter")
         #expect(options.algorithm == "grpo")
         #expect(options.parameters["grpo_candidate_count"] == "4")
+        #expect(options.parameters["candidate_generation_mode"] == "runtime_generate")
+        #expect(options.parameters["candidate_scoring_mode"] == "reward_model")
+        #expect(options.parameters["candidate_generation_max_tokens"] == "16")
         #expect(options.parameters["reference_model_path"] == "/tmp/reference-model")
         #expect(options.parameters["reward_model_manifest_path"] == "/tmp/reward/manifest.json")
         #expect(options.parameters["sample_limit"] == "8")
@@ -1379,6 +1394,32 @@ struct MelixCLIParserTests {
                 "--algorithm", "ppo",
             ],
             equals: .usage("Invalid value for --algorithm. Expected one of: dpo, orpo, cpo, grpo, rlhf.")
+        )
+    }
+
+    @Test("alignment train rejects unsupported candidate generation controls")
+    func alignmentTrainRejectsUnsupportedCandidateGenerationControls() throws {
+        try assertError(
+            for: [
+                "alignment", "train",
+                "--model-id", "melix-dev-text",
+                "--dataset-uri", "/tmp/data.jsonl",
+                "--adapter-name", "aligned-adapter",
+                "--algorithm", "grpo",
+                "--candidate-generation-mode", "remote",
+            ],
+            equals: .usage("Invalid value for --candidate-generation-mode. Expected one of: scored_trace, runtime_generate.")
+        )
+        try assertError(
+            for: [
+                "alignment", "train",
+                "--model-id", "melix-dev-text",
+                "--dataset-uri", "/tmp/data.jsonl",
+                "--adapter-name", "aligned-adapter",
+                "--algorithm", "grpo",
+                "--candidate-scoring-mode", "dataset",
+            ],
+            equals: .usage("Invalid value for --candidate-scoring-mode. Expected one of: dataset_score, seed_overlap_proxy, reward_model.")
         )
     }
 

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -1175,6 +1175,8 @@ struct MelixCLIRunnerTests {
                 "adapter_name": "issue365-dpo",
                 "algorithm": " DPO ",
                 "reference_model_path": "${steps.train_lora.result.output_path}",
+                "candidate_generation_mode": "scored_trace",
+                "candidate_scoring_mode": "dataset_score",
                 "max_steps": 2
               },
               "checks": {
@@ -1334,6 +1336,10 @@ struct MelixCLIRunnerTests {
         #expect(Array(operationCommands[1].prefix(2)) == ["alignment", "train"])
         #expect(operationCommands[1].contains("--reference-model-path"))
         #expect(operationCommands[1].contains("/tmp/melix/train_lora/issue365-sft.adapter.json"))
+        #expect(operationCommands[1].contains("--candidate-generation-mode"))
+        #expect(operationCommands[1].contains("scored_trace"))
+        #expect(operationCommands[1].contains("--candidate-scoring-mode"))
+        #expect(operationCommands[1].contains("dataset_score"))
         #expect(operationCommands[1].contains("--algorithm"))
         #expect(operationCommands[1].contains("dpo"))
         #expect(operationCommands[1].contains(where: { $0.contains("dataset_source_kind") }) == false)
@@ -4943,6 +4949,9 @@ struct MelixCLIRunnerTests {
                     algorithm: "grpo",
                     parameters: [
                         "grpo_candidate_count": "4",
+                        "candidate_generation_mode": "runtime_generate",
+                        "candidate_scoring_mode": "reward_model",
+                        "candidate_generation_max_tokens": "16",
                         "reference_model_path": "/tmp/reference-model",
                         "reward_model_manifest_path": "/tmp/reward/manifest.json",
                     ],
@@ -4961,6 +4970,9 @@ struct MelixCLIRunnerTests {
         #expect(call.ext["training_mode"] == "grpo")
         #expect(call.ext["alignment_algorithm"] == "grpo")
         #expect(call.ext["grpo_candidate_count"] == "4")
+        #expect(call.ext["candidate_generation_mode"] == "runtime_generate")
+        #expect(call.ext["candidate_scoring_mode"] == "reward_model")
+        #expect(call.ext["candidate_generation_max_tokens"] == "16")
         #expect(call.ext["reference_model_path"] == "/tmp/reference-model")
         #expect(call.ext["reward_model_manifest_path"] == "/tmp/reward/manifest.json")
     }

--- a/tests/integration/test_issue365_acceptance_bundle.py
+++ b/tests/integration/test_issue365_acceptance_bundle.py
@@ -181,8 +181,17 @@ def test_issue365_acceptance_bundle_plan_covers_required_cli_matrix(tmp_path: Pa
         if pipeline["name"] == "issue365-qat_quantized_inference"
     )
     qat_steps = {step["id"]: step for step in qat_pipeline["steps"]}
-    assert qat_steps["qat_publish_export"]["args"]["export_kind"] == "adapter"
-    assert qat_steps["qat_quantize"]["args"]["source_artifact_kind"] == "adapter_export"
+    assert qat_steps["qat_train"]["args"]["total_layers"] == 2
+    assert qat_steps["qat_train"]["args"]["num_layers"] == 2
+    assert qat_steps["qat_fuse_merged_model"]["command"] == "lora.activate"
+    assert qat_steps["qat_fuse_merged_model"]["args"]["activation_mode"] == "fused_derived_model"
+    assert qat_steps["qat_publish_export"]["args"]["merged_model_path"] == (
+        "${steps.qat_fuse_merged_model.result.derived_model_path}"
+    )
+    assert qat_steps["qat_publish_export"]["args"]["export_kind"] == "merged"
+    assert qat_steps["qat_quantize"]["args"]["source_artifact_kind"] == "merged_adapter"
+    assert qat_steps["qat_quantize"]["args"]["quantization_backend"] == "mlx_lm_convert"
+    assert qat_steps["qat_quantize"]["args"]["mlx_lm_q_mode"] == "affine"
     assert qat_steps["qat_quantize"]["args"]["local_inference_smoke_mode"] == "runtime_generate"
     assert qat_steps["qat_quantize"]["checks"] == ptq_steps["ptq_quantize"]["checks"]
     assert all(step["command"] != "chat.run" for step in qat_pipeline["steps"])

--- a/tests/integration/test_issue365_acceptance_bundle.py
+++ b/tests/integration/test_issue365_acceptance_bundle.py
@@ -172,6 +172,7 @@ def test_issue365_acceptance_bundle_plan_covers_required_cli_matrix(tmp_path: Pa
     ptq_steps = {step["id"]: step for step in ptq_pipeline["steps"]}
     assert ptq_steps["ptq_fuse_merged_model"]["command"] == "lora.activate"
     assert ptq_steps["ptq_fuse_merged_model"]["args"]["activation_mode"] == "fused_derived_model"
+    assert ptq_steps["ptq_fuse_merged_model"]["checks"]["required_result_fields"] == ["derived_model_path"]
     assert ptq_steps["ptq_publish_export"]["args"]["merged_model_path"] == (
         "${steps.ptq_fuse_merged_model.result.derived_model_path}"
     )
@@ -197,6 +198,7 @@ def test_issue365_acceptance_bundle_plan_covers_required_cli_matrix(tmp_path: Pa
     assert qat_steps["qat_train"]["args"]["num_layers"] == 2
     assert qat_steps["qat_fuse_merged_model"]["command"] == "lora.activate"
     assert qat_steps["qat_fuse_merged_model"]["args"]["activation_mode"] == "fused_derived_model"
+    assert qat_steps["qat_fuse_merged_model"]["checks"]["required_result_fields"] == ["derived_model_path"]
     assert qat_steps["qat_publish_export"]["args"]["merged_model_path"] == (
         "${steps.qat_fuse_merged_model.result.derived_model_path}"
     )

--- a/tests/integration/test_issue365_acceptance_bundle.py
+++ b/tests/integration/test_issue365_acceptance_bundle.py
@@ -145,6 +145,18 @@ def test_issue365_acceptance_bundle_plan_covers_required_cli_matrix(tmp_path: Pa
         if step["command"] == "alignment.train"
     }
     assert alignment_algorithms == {"dpo", "orpo", "cpo", "grpo", "rlhf"}
+    grpo_pipeline = next(
+        pipeline
+        for pipeline in pipelines
+        if pipeline["name"] == "issue365-lora_grpo_export_inference"
+    )
+    grpo_steps = {step["id"]: step for step in grpo_pipeline["steps"]}
+    assert grpo_steps["grpo_align"]["args"]["candidate_generation_mode"] == "runtime_generate"
+    assert grpo_steps["grpo_align"]["args"]["candidate_scoring_mode"] == "reward_model"
+    assert grpo_steps["grpo_align"]["args"]["reward_model_manifest_path"] == (
+        "${inputs.reward_model_manifest_path}"
+    )
+    assert grpo_steps["grpo_align"]["args"]["candidate_generation_max_tokens"] == 16
 
     quantization_modes = {
         step["args"]["quantization_mode"]
@@ -290,6 +302,37 @@ def test_issue365_acceptance_bundle_real_preflight_blocks_missing_local_inputs(
     rlhf = next(case for case in bundle["cases"] if case["case_id"] == "lora_rlhf_export_inference")
     blocker_codes = {blocker["code"] for blocker in rlhf["real_runtime_preflight"]["blockers"]}
     assert {"missing_sft_dataset_uri", "missing_reward_scored_dataset_uri", "missing_reward_model_manifest_path"} <= blocker_codes
+
+
+def test_issue365_acceptance_bundle_real_preflight_blocks_grpo_without_reward_model(
+    tmp_path: Path,
+) -> None:
+    melix_cli = _write_executable(tmp_path / "melix")
+    sft = tmp_path / "datasets" / "sft"
+    prompt_candidate = tmp_path / "datasets" / "prompt_candidate"
+    sft.mkdir(parents=True)
+    prompt_candidate.mkdir(parents=True)
+    executor = RecordingExecutor(statuses=["succeeded"])
+
+    bundle = issue365_acceptance_bundle.build_acceptance_bundle(
+        issue365_acceptance_bundle.Issue365AcceptanceConfig(
+            repo_root=Path(__file__).resolve().parents[2],
+            output_dir=tmp_path / "bundle",
+            execution_mode="real",
+            melix_cli=str(melix_cli),
+            sft_dataset_uri=str(sft),
+            prompt_candidate_dataset_uri=str(prompt_candidate),
+            reward_model_manifest_path=str(tmp_path / "missing-reward-model.json"),
+            case_ids=("lora_grpo_export_inference",),
+            timestamp="2026-05-05T000000Z",
+        ),
+        executor=executor,
+    )
+
+    assert executor.commands == []
+    assert bundle["summary"]["blocked_count"] == 1
+    blockers = bundle["cases"][0]["real_runtime_preflight"]["blockers"]
+    assert {blocker["code"] for blocker in blockers} == {"missing_reward_model_manifest_path"}
 
 
 def test_issue365_acceptance_bundle_real_case_filter_runs_only_selected_ready_case(


### PR DESCRIPTION
## Summary
- Add QAT-aware MLX-LM final export support for Issue 365 quantization jobs.
- Route the QAT acceptance case through `lora.train -> lora.activate(fused_derived_model) -> lora.publish(merged) -> quantize(qat, mlx_lm_convert)`.
- Preserve Melix fake-quant/QAT evidence while producing a runtime-loadable quantized bundle with real local inference smoke.
- Route Issue 365 GRPO acceptance through public CLI candidate-generation and scoring controls so real-mode runs can require policy-runtime generation plus reward-model scoring.
- Consolidate QAT fake-quant training and metadata construction through shared local helpers in the quantization pipeline.
- Refresh PR-scoped performance probe expectations so the model-ops bundle probe CI matches the current registered replay probes and scope-matcher selection set.
- Preserve stable MLX audio speech generate parameter ordering while keeping the legacy signature fallback test meaningful.
- Address review follow-up by sharing quantization allowed values between the CLI parser and pipeline runner, documenting the `QuantizeOptions` normalization invariant, and requiring `derived_model_path` from the QAT/PTQ fuse steps.

## Plan or Spec
- `docs/plans/2026-05-05-issue-365-mlx-quantization-convert.md`
- `docs/plans/2026-05-05-issue-365-cli-chain-routing.md`

## Commands Run
```text
swift build --package-path services/mlx-text-worker-swift
Result: passed. Existing third-party MLX deprecation and Swift concurrency warnings remain.

swift build --package-path services/control-plane-swift
Result: passed.

swift test --filter MelixCLIParserTests
Result: 70 passed.

swift test --filter MelixCLIRunnerTests
Result: 160 passed. Existing try-await store.save warnings remain.

swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
Result: passed; 230 tests in 3 suites passed. Existing try-await store.save warnings remain.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py
Result: 55 passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q tests/integration/test_issue365_acceptance_bundle.py
Result: 14 passed.

python3 scripts/issue365_acceptance_bundle.py --execution-mode plan --case-id qat_quantized_inference --output-dir .runtime/issue365/qat-aware-plan-r2 --timestamp 2026-05-06T181500Z --json
Result: passed; selected QAT plan now has qat_train, qat_fuse_merged_model, qat_publish_export, qat_quantize.

python3 scripts/issue365_acceptance_bundle.py --execution-mode plan --output-dir .runtime/issue365/grpo-runtime-routing-plan --timestamp 2026-05-06T200000Z --json
Result: passed; all 10 Issue 365 cases planned and release_ready=false because real inputs are not present.

python3 scripts/issue365_acceptance_bundle.py --execution-mode dry-run --melix-cli .build/arm64-apple-macosx/debug/melix --output-dir .runtime/issue365/grpo-runtime-routing-dry-run --timestamp 2026-05-06T200500Z --json
Result: passed; all 10 dry-run cases succeeded and release_ready=false.

MELIX_HOME="$PWD/.runtime/home-issue365-qat-aware-real" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-qat-aware-real-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-qat-aware-real-swift.sock" MELIX_HTTP_PORT=12475 ./.build/arm64-apple-macosx/debug/melix model hub download --repo-id mlx-community/Qwen3.5-0.8B-OptiQ-4bit --json
Result: passed; default acceptance model was present at /Users/ChenYu/.cache/huggingface/hub/models--mlx-community--Qwen3.5-0.8B-OptiQ-4bit/snapshots/40d69f3d88f45e9c38aea318c318ebc9ded5b783.

MELIX_HOME="$PWD/.runtime/home-issue365-qat-aware-real" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-qat-aware-real-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-qat-aware-real-swift.sock" MELIX_HTTP_PORT=12475 ./.build/arm64-apple-macosx/debug/melix model roots rescan --json
Result: passed; registry discovered mlx-community/Qwen3.5-0.8B-OptiQ-4bit as a text model.

MELIX_HOME="$PWD/.runtime/home-issue365-qat-aware-clean" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-qat-aware-clean-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-qat-aware-clean-swift.sock" MELIX_HTTP_PORT=12476 python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id qat_quantized_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --calibration-dataset-uri "$PWD/.runtime/issue365/input-datasets/calibration" --output-dir .runtime/issue365/qat-aware-real-probe-r5 --timestamp 2026-05-06T183000Z --json
Result: passed; selected real QAT case release_ready=true.

jq '{status, result: {output_path: .result.output_path, artifact_path: .result.artifact_path, quantization_mode: .result.quantization_mode, execution_backend: .result.execution_backend, real_weight_conversion: .result.real_weight_conversion, source_artifact_kind: .result.source_artifact_kind, local_inference_smoke: .result.local_inference_smoke, release_gate: .result.release_gate, qat: .result.qat}}' .runtime/issue365/qat-aware-real-probe-r5/receipts/qat_quantized_inference/steps/004-qat_quantize.json
Result: confirmed quantization_mode=qat, execution_backend=mlx_lm_convert, real_weight_conversion=true, source_artifact_kind=merged_adapter, local_inference_smoke.status=passed, release_gate.local_inference_smoke_result=passed, and qat.training_backend=melix_fake_quant_optimizer.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py
Result: 159 passed after rebasing onto the latest `origin/main`.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py
Result: 15 passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_quantization_pipeline.py tests/integration/test_issue365_acceptance_bundle.py services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_model_writes_manifest_once_after_in_memory_byte_convergence services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_pipeline_counts_artifact_bytes_without_rescanning_bundle_directory
Result: 238 passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
Result: wrote JSON coverage.

python3 scripts/python_changed_line_coverage.py --coverage-json coverage.json --diff-from codex/issue365-ptq-runtime services/mlx-worker-python/tests/test_pr_scoped_performance.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/worker/model_ops/quantization_pipeline.py scripts/issue365_acceptance_bundle.py tests/integration/test_issue365_acceptance_bundle.py
Result: 100.00% total changed-line coverage, 100/100 executable lines.

python3 scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from codex/issue365-ptq-runtime Sources/MelixCLICore/MelixCLI.swift Sources/MelixCLICore/MelixCLICommandCodec.swift tests/MelixCLITests/MelixCLIParserTests.swift tests/MelixCLITests/MelixCLIRunnerTests.swift
Result: 100.00% total changed-line coverage, 78/78 executable lines.

python3 -m compileall -q services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py services/mlx-worker-python/worker/model_ops/quantization_pipeline.py scripts/issue365_acceptance_bundle.py services/mlx-worker-python/tests/test_quantization_pipeline.py tests/integration/test_issue365_acceptance_bundle.py
Result: passed.

find .runtime -type f '(' -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.webp' ')' -print
Result: no generated screenshot artifacts found.

git diff --check
Result: passed.

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-evidence/pr-qat-runtime-body.md
Result: passed.

uv run pytest tests/integration/test_issue365_acceptance_bundle.py -q
Result: 14 passed.

swift test --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
Result: passed; 230 tests in 3 suites passed. Existing try-await store.save warnings remain.

PYTHONPATH="$PWD" uv run coverage run -m pytest tests/integration/test_issue365_acceptance_bundle.py -q
Result: 14 passed.

uv run coverage json -o .runtime/coverage-issue365-qat-review.json
Result: passed; wrote .runtime/coverage-issue365-qat-review.json.

python3 scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage-issue365-qat-review.json --diff-from HEAD scripts/issue365_acceptance_bundle.py
Result: 100.00% total changed-line coverage, 0/0 executable lines; changed script lines were static check-field literals reported as skipped-non-executable.

swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
Result: passed; 230 tests in 3 suites passed. Existing try-await store.save warnings remain.

python3 scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from HEAD Sources/MelixCLICore/MelixCLI.swift Sources/MelixCLICore/MelixPipelineRunner.swift
Result: 100.00% total changed-line coverage, 35/35 executable lines.
```

## Coverage and Metrics
- Python changed-line coverage for this stacked slice: 100.00%, 100/100 executable changed lines, measured with `--diff-from codex/issue365-ptq-runtime`.
- Swift changed-line coverage for the touched CLI parser/runner slice: 100.00%, 78/78 executable changed lines, measured with `--diff-from codex/issue365-ptq-runtime`; review follow-up Swift changed-line coverage is 100.00% (35/35 executable lines, measured with `--diff-from HEAD`).
- Review follow-up Python coverage: N/A for executable-line accounting because the changed acceptance-bundle lines are static check-field literals reported as skipped-non-executable; behavior is covered by `tests/integration/test_issue365_acceptance_bundle.py`.
- Real QAT selected-case runtime metrics: pipeline total 139982.574792 ms; `qat_train` 4350.060459 ms; `qat_fuse_merged_model` 2792.478334 ms; `qat_publish_export` 688.994041 ms; `qat_quantize` 132145.379042 ms.
- Quantize receipt metrics: `local_inference_smoke.latency_ms=2255.954`, `generated_token_count=1`, `source_file_count=8`, `source_byte_count=618238955`, `calibration_sample_count=2`, `training_steps=1`.

## Known Gaps
- This PR is stacked on `codex/issue365-ptq-runtime` / PR #442.
- This is QAT-aware export evidence plus a real MLX-LM converted final bundle; it is not MLX-native full-tensor QAT training.
- Issue #365 still needs a passing real GRPO policy-runtime generation/reward-model scoring/policy-update bundle, RLHF reward-model-backed integration from issue #366, Window UI runtime acceptance, and the final all-business-line release evidence bundle.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
