### PR TITLE
perf: streamline runtime kwarg parameter scan

### DIFF
--- a/docs/plans/2026-05-06-runtime-utils-bound-kwarg-scan.md
+++ b/docs/plans/2026-05-06-runtime-utils-bound-kwarg-scan.md
@@ -1,0 +1,37 @@
+# Runtime Utils Bound Kwarg Parameter Scan Optimization
+
+## Goal
+
+Avoid materializing a temporary `list(parameters.items())` plus sliced `dict` in `worker.runtime.runtime_utils.callable_accepts_kwarg(...)` when checking bound methods through the underlying unbound function.
+
+## Linux-only constraint
+
+This slice is Python-only and can be verified on Linux with focused pytest, changed-scope coverage, and a local synthetic probe. No Swift/macOS behavior is changed.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/runtime_utils.py`
+- `services/mlx-worker-python/tests/test_runtime_utils.py`
+- `docs/plans/2026-05-06-runtime-utils-bound-kwarg-scan.md`
+
+## Performance probe definition
+
+Use the already-registered scoped CI probe selected by `runtime_utils.py` changes:
+
+- `runtime-utils-kwarg-signature-cache`
+
+For local evidence, run a file-backed synthetic bound-method cold-cache probe against a detached `origin/main` worktree and this branch. The probe repeatedly clears the kwarg cache and checks two keywords on a bound method with many parameters, recording elapsed time and peak traced allocation.
+
+## Success metrics
+
+- Behavior-preserving focused tests pass.
+- Changed-scope coverage for touched executable Python lines is at least 95%.
+- Local bound-method probe shows lower elapsed time and/or lower peak allocation while preserving expected boolean results.
+- Existing scoped CI probe `runtime-utils-kwarg-signature-cache` is selected for the PR.
+
+## Verification commands
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics`
+- Coverage command matching `runtime-utils-kwarg-signature-cache`.
+- Local `/tmp/runtime_utils_bound_kwarg_probe.py` run against detached `origin/main` and head.
+- `git diff --check`

--- a/services/mlx-worker-python/tests/test_runtime_utils.py
+++ b/services/mlx-worker-python/tests/test_runtime_utils.py
@@ -68,6 +68,32 @@ def test_callable_accepts_kwarg_caches_bound_methods_by_underlying_function(
     runtime_utils.clear_callable_accepts_kwarg_cache()
 
 
+def test_callable_accepts_kwarg_bound_methods_preserve_parameter_scan_behavior() -> None:
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+
+    class SampleRuntime:
+        def generate(
+            self,
+            prompt: str,
+            max_tokens: int = 128,
+            *,
+            temperature: float = 0.0,
+            top_p: float = 1.0,
+        ) -> str:
+            return f"{prompt}:{max_tokens}:{temperature}:{top_p}"
+
+    method = SampleRuntime().generate
+
+    assert runtime_utils.callable_accepts_kwarg(method, "self") is False
+    assert runtime_utils.callable_accepts_kwarg(method, "prompt") is True
+    assert runtime_utils.callable_accepts_kwarg(method, "max_tokens") is True
+    assert runtime_utils.callable_accepts_kwarg(method, "temperature") is True
+    assert runtime_utils.callable_accepts_kwarg(method, "top_p") is True
+    assert runtime_utils.callable_accepts_kwarg(method, "missing") is False
+
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+
+
 def test_callable_accepts_kwarg_bound_methods_preserve_var_keyword_behavior() -> None:
     runtime_utils.clear_callable_accepts_kwarg_cache()
 

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -17,20 +17,18 @@ def _callable_accepts_kwarg_uncached(
     except (TypeError, ValueError):
         return False
 
-    parameters = signature.parameters
-    if skip_first_parameter:
-        parameters = dict(list(parameters.items())[1:])
+    matching_parameter: inspect.Parameter | None = None
+    for index, (name, parameter) in enumerate(signature.parameters.items()):
+        if skip_first_parameter and index == 0:
+            continue
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+        if name == keyword:
+            matching_parameter = parameter
 
-    if any(
-        parameter.kind == inspect.Parameter.VAR_KEYWORD
-        for parameter in parameters.values()
-    ):
-        return True
-
-    parameter = parameters.get(keyword)
-    if parameter is None:
+    if matching_parameter is None:
         return False
-    return parameter.kind in (
+    return matching_parameter.kind in (
         inspect.Parameter.POSITIONAL_OR_KEYWORD,
         inspect.Parameter.KEYWORD_ONLY,
     )


### PR DESCRIPTION
## Summary
- Streamlines `callable_accepts_kwarg(...)` bound-method parameter checks so the cold path no longer builds a temporary `list(parameters.items())` plus sliced `dict` just to skip `self`.
- Adds focused regression coverage for bound-method positional, keyword-only, missing-keyword, and skipped-`self` behavior.

## Plan or Spec
- `docs/plans/2026-05-06-runtime-utils-bound-kwarg-scan.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics
# 10 passed in 0.45s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_kwarg_cache_probe.py
# TOTAL 23 1 96%

python /tmp/runtime_utils_bound_kwarg_probe.py /tmp/melix-cron-opt-20260506-095053-base-2
# {"elapsed_ms_mean": 1506.2653614274625, "iterations_per_sample": 12000.0, "peak_bytes_mean": 4467.428571428572, "sample_count": 7.0}

python /tmp/runtime_utils_bound_kwarg_probe.py /tmp/melix-cron-opt-20260506-095053
# {"elapsed_ms_mean": 1435.2269921218976, "iterations_per_sample": 12000.0, "peak_bytes_mean": 3978.285714285714, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-utils-kwarg-signature-cache --base-repo /tmp/melix-cron-opt-20260506-095053-base-2 --head-repo /tmp/melix-cron-opt-20260506-095053 --output /tmp/runtime-utils-kwarg-signature-cache-result.json
# head verification ok; coverage 96%; base elapsed_ms_mean=12.669555423781276, head elapsed_ms_mean=12.733350787311792; inspect_signature_calls_mean=2.0 for both

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 23 1 96%`.
- Local bound-method cold-cache probe: elapsed mean improved from `1506.265 ms` to `1435.227 ms` (~4.72% lower); peak traced allocation improved from `4467.43` bytes to `3978.29` bytes (~10.95% lower).
- Registered scoped probe: `runtime-utils-kwarg-signature-cache` selected for `runtime_utils.py` changes; local base-vs-head run completed successfully with unchanged `inspect_signature_calls_mean=2.0` and head elapsed within the probe tolerance.

## Known Gaps
- Linux-only verification; macOS/Swift checks were not run because this is a Python worker-only runtime utility slice.
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; hosted CI remains the broader gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
