### PR TITLE
perf: skip empty hub catalog size hint regex

### DIFF
--- a/docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md
+++ b/docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md
@@ -1,0 +1,34 @@
+# Hub Catalog Empty Size-Hint Fast Path
+
+## Goal
+
+Avoid redundant regex work when Hub catalog metadata has no model-size hint text.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+
+## Linux-Only Constraint
+
+This slice is Python-only and can be verified locally on Linux with focused pytest, changed-scope coverage, and the existing PR-scoped performance probe.
+
+## Performance Probe
+
+Use the existing registered probe:
+
+- `hub-catalog-tag-normalization-single-pass`
+
+The probe builds a large synthetic Hub catalog page with empty `cardData`, which exercises the hot no-size-hint path.
+
+## Success Metrics
+
+- Focused Hub catalog tests pass.
+- Changed executable line coverage for touched Python scope is at least 95%.
+- The local base-vs-head probe reports no behavior drift and ideally lower elapsed time for the empty-card workload.
+
+## Implementation Plan
+
+1. Add an early return to `_size_hint_from_text(...)` for empty text before selecting/searching the regex pattern.
+2. Add a focused regression test that proves empty text returns `0` without invoking either compiled regex object.
+3. Run focused pytest, changed-scope coverage, `git diff --check`, and the existing local probe before opening the PR.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -7,7 +7,13 @@ from urllib.request import Request
 import pytest
 
 import worker.model_ops.hub_catalog as hub_catalog_module
-from worker.model_ops.hub_catalog import HubCatalog, HubCatalogError, _is_mlx_compatible, _local_fit_evidence
+from worker.model_ops.hub_catalog import (
+    HubCatalog,
+    HubCatalogError,
+    _is_mlx_compatible,
+    _local_fit_evidence,
+    _size_hint_from_text,
+)
 
 
 KB = 1024
@@ -333,6 +339,14 @@ def test_search_models_marks_large_mlx_model_as_heavy_not_blocked() -> None:
     assert model.recommended_action == "review_risk"
     assert model.estimated_resident_bytes > int(64 * 1024 * 1024 * 1024 * 0.60)
     assert any("memory comfort budget" in reason for reason in model.local_fit_reasons)
+
+
+def test_size_hint_from_empty_text_skips_regex_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(hub_catalog_module, "_BARE_SIZE_HINT_RE", object())
+    monkeypatch.setattr(hub_catalog_module, "_EXPLICIT_SIZE_HINT_RE", object())
+
+    assert _size_hint_from_text("", allow_bare=True) == 0
+    assert _size_hint_from_text("", allow_bare=False) == 0
 
 
 def test_search_models_ignores_sibling_sizes_without_weight_or_config_filenames() -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -534,6 +534,8 @@ def _size_hint_bytes(payload: dict[str, Any]) -> int:
 
 
 def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:
+    if not text:
+        return 0
     pattern = _BARE_SIZE_HINT_RE if allow_bare else _EXPLICIT_SIZE_HINT_RE
     match = pattern.search(text)
     if not match:


### PR DESCRIPTION
## Summary
- Skip Hub catalog size-hint regex searches when the source text is empty.
- Add a focused regression test that replaces both size-hint regex objects with plain objects and proves the empty path returns before `.search(...)` would be needed.
- Keep the slice Python-only and reuse the existing Hub catalog PR-scoped performance probe.

## Plan or Spec
- Plan: `docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md`
- Existing scoped probe: `hub-catalog-tag-normalization-single-pass`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
# 27 passed in 0.20s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py
# 27 passed in 0.24s; TOTAL 8 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-tag-normalization-single-pass --base-repo /tmp/melix-base-hub-20260506-102452 --head-repo "$PWD" --output /tmp/hub-catalog-tag-normalization-single-pass-20260506.json
# head verification ok; base/head probe metrics recorded below

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 8 0 100%`.
- Local base-vs-head probe (`hub-catalog-tag-normalization-single-pass`):
  - `elapsed_ms_mean`: base `350.040788 ms`, head `342.778706 ms` (~2.07% lower).
  - `peak_bytes_mean`: base `8,756,339.0`, head `8,749,543.8` (~0.08% lower; informational in probe output).
  - `record_count`: base/head `5000.0`.
  - `tag_normalization_calls_mean`: base/head `5000.0`.

## Known Gaps
- Linux-only local verification; macOS/Swift checks were not run because this is a Python-only Hub catalog slice.
- Hosted CI must still validate the PR-scoped performance probe before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
