### PR TITLE
perf: parse CLI JSON output before trimming

### DIFF
--- a/Sources/MelixCLICore/MelixCLIJSON.swift
+++ b/Sources/MelixCLICore/MelixCLIJSON.swift
@@ -113,13 +113,11 @@ enum MelixCLIJSON {
     }
 
     static func jsonValue(from text: String) -> Any {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let data = trimmed.data(using: .utf8),
-              let value = try? JSONSerialization.jsonObject(with: data)
-        else {
-            return ["text": trimmed]
+        let data = Data(text.utf8)
+        if let value = try? JSONSerialization.jsonObject(with: data) {
+            return value
         }
-        return value
+        return ["text": text.trimmingCharacters(in: .whitespacesAndNewlines)]
     }
 
     static func metricsObject(

--- a/docs/plans/2026-05-06-swift-cli-json-value-parse-before-trim.md
+++ b/docs/plans/2026-05-06-swift-cli-json-value-parse-before-trim.md
@@ -1,0 +1,40 @@
+# Swift CLI JSON Value Parse Before Trim
+
+## Goal
+
+Reduce avoidable string allocation in the `--output json-v1` CLI envelope path while preserving the existing fallback behavior for plain-text command output.
+
+## Slice
+
+`MelixCLIJSON.jsonValue(from:)` previously trimmed command output before attempting JSON parsing. `JSONSerialization` accepts leading and trailing whitespace, so JSON command output can be parsed directly from UTF-8 bytes and only pay the trimming cost on the non-JSON fallback path.
+
+This slice keeps scope limited to:
+
+- `Sources/MelixCLICore/MelixCLIJSON.swift`
+- `tests/MelixCLITests/MelixCLIRunnerTests.swift`
+- `infra/perf/pr_scoped_probes.json`
+
+## Registered Probe
+
+The affected Swift path is covered by the existing registered PR-scoped probe:
+
+- `swift-cli-json-envelope-encoding`
+- runner: `macos-15`
+- test/coverage/probe command: focused `MelixCLIRunnerTests` filter for JSON v1 envelope behavior and metric patching
+
+This slice keeps the existing focused filter unchanged and adds the direct-parse/fallback assertions inside `jsonV1WrapsCommandResultsInAStableEnvelope`, which is already part of the registered test, coverage, and probe commands.
+
+## Verification Plan
+
+Local Linux cannot run Swift in this scheduled environment because `swift` is not installed. Local verification is limited to static repository checks and JSON registry parsing. The registered macOS CI probe is the source of truth for Swift runtime performance validation.
+
+Required CI evidence before merge:
+
+1. focused Swift test command from `swift-cli-json-envelope-encoding` passes on macOS,
+2. focused coverage command replays the same tests,
+3. registered probe emits `elapsed_ms_mean`, and
+4. PR checks are green.
+
+## Expected Performance Direction
+
+For JSON command output, this avoids building a trimmed `String` before converting back to bytes for JSON parsing. Plain-text fallback output still trims exactly as before.

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -141,6 +141,11 @@ struct MelixCLIRunnerTests {
         #expect((metrics["melix.cli.parse_ms"] as? Double) != nil)
         #expect((metrics["melix.cli.command_ms"] as? Double) != nil)
         #expect((metrics["melix.cli.json_encode_ms"] as? Double) != nil)
+
+        let paddedJSON = try #require(MelixCLIJSON.jsonValue(from: "  {\"health_status\":\"healthy\"}\n") as? [String: Any])
+        let fallbackText = try #require(MelixCLIJSON.jsonValue(from: "  plain text\n") as? [String: String])
+        #expect(paddedJSON["health_status"] as? String == "healthy")
+        #expect(fallbackText["text"] == "plain text")
     }
 
     @Test("json v1 error envelopes are machine readable")


### PR DESCRIPTION
## Summary
- Parse `MelixCLIJSON.jsonValue(from:)` directly from UTF-8 bytes before falling back to trimmed plain text.
- Keep fallback text semantics unchanged for non-JSON command output.
- Add regression assertions to the existing focused JSON v1 envelope test.

## Plan or Spec
- `docs/plans/2026-05-06-swift-cli-json-value-parse-before-trim.md`
- Registered PR-scoped probe: `swift-cli-json-envelope-encoding` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Sync and branch
cd /root/.hermes/profiles/coder/workspace/melix && git fetch origin && git reset --hard origin/main
git worktree add -b perf/swift-cli-json-envelope-data-patch-20260506 /root/.hermes/profiles/coder/workspace/worktrees/melix-swift-cli-json-envelope-data-patch-20260506 origin/main

# Local static/registry verification
python3 - <<'PY'
import json
from pathlib import Path
probes=json.loads(Path('infra/perf/pr_scoped_probes.json').read_text())
probe=next(p for p in probes if p['id']=='swift-cli-json-envelope-encoding')
print('registry ok', probe['id'], probe['runner'])
PY
# outcome: registry ok swift-cli-json-envelope-encoding macos-15

git diff --check
# outcome: exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json /tmp/melix_changed_files_swift_json_value.json --output /tmp/melix_scope_swift_json_value.json
python3 - <<'PY'
import json
scope=json.load(open('/tmp/melix_scope_swift_json_value.json'))
ids=[p['id'] for p in scope.get('selected_probes', [])]
print('selected_count', len(ids))
print(ids)
assert ids == ['swift-cli-json-envelope-encoding']
PY
# outcome: selected_count 1; ['swift-cli-json-envelope-encoding']

if command -v swift >/dev/null 2>&1; then swift test --filter 'MelixCLIRunnerTests/(jsonV1WrapsCommandResultsInAStableEnvelope|jsonV1ErrorEnvelopesAreMachineReadable|jsonMetricPatchingRejectsMissingPlaceholders|jsonMetricPatchingPreservesUserArtifactStringsThatLookLikeTheOldSentinel)'; else echo 'swift unavailable locally; macOS CI registered probe required'; fi
# outcome: swift unavailable locally; macOS CI registered probe required
```

## Coverage and Metrics
- Local Linux coverage: not runnable because `swift` is not installed in this environment.
- Changed-scope coverage command is registered as `swift test --filter 'MelixCLIRunnerTests/(jsonV1WrapsCommandResultsInAStableEnvelope|jsonV1ErrorEnvelopesAreMachineReadable|jsonMetricPatchingRejectsMissingPlaceholders|jsonMetricPatchingPreservesUserArtifactStringsThatLookLikeTheOldSentinel)'` and must run on macOS CI.
- Registered probe: `swift-cli-json-envelope-encoding` (`macos-15`, `elapsed_ms_mean`, lower is better). CI is required for Swift runtime performance validation.

## Known Gaps
- Swift is unavailable on local Linux, so local runtime performance and coverage are not claimed. The registered macOS PR-scoped performance workflow is the source of truth for this Swift slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run. Local static/registry checks ran; Swift focused tests are registered for macOS CI.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
