### PR TITLE
Issue 365: wire reward runtime scoring

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1548,6 +1548,7 @@ public enum MelixCLIParser {
       melix lora list [--model-id MODEL_ID] [--json]
       melix lora train --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) --adapter-name NAME [--target-repo REPO] [--training-mode (lora|qlora|dora)] [--preset PRESET] [--experiment-group GROUP] [--rank N] [--alpha N] [--dropout N] [--target-modules CSV] [--num-layers N] [--batch-size N] [--epochs N] [--max-steps N] [--learning-rate N] [--max-seq-length N] [--sample-limit N] [--gradient-accumulation N] [--resume-adapter PATH | --resume-from-manifest PATH] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-train-split SPLIT] [--hf-valid-split SPLIT] [--text-feature NAME] [--prompt-feature NAME] [--completion-feature NAME] [--chat-feature NAME] [--derived-model-alias NAME] [--response-only] [--mask-prompt] [--gradient-checkpointing] [--json]
       melix alignment train --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) --adapter-name NAME --algorithm dpo|orpo|cpo|grpo|rlhf [--target-repo REPO] [--source-adapter-path PATH] [--grpo-candidate-count N] [--candidate-generation-mode scored_trace|runtime_generate] [--candidate-scoring-mode dataset_score|seed_overlap_proxy|reward_model] [--candidate-generation-max-tokens N] [--reference-model-path PATH] [--reward-model-manifest-path PATH] [--kl-penalty N] [--preset PRESET] [--experiment-group GROUP] [--rank N] [--alpha N] [--dropout N] [--target-modules CSV] [--num-layers N] [--batch-size N] [--epochs N] [--max-steps N] [--learning-rate N] [--max-seq-length N] [--sample-limit N] [--gradient-accumulation N] [--json]
+        note: --source-adapter-path is the upstream/base LoRA adapter to carry into GRPO/RLHF output; it is not checkpoint resumption.
       melix lora dataset inspect --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) [--template TEMPLATE] [--dataset-id ID] [--validation-ratio N] [--sample-limit N] [--preview-count N] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-train-split SPLIT] [--hf-valid-split SPLIT] [--text-feature NAME] [--prompt-feature NAME] [--completion-feature NAME] [--chat-feature NAME] [--json]
       melix lora dataset build --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) [--output-dir PATH] [--template TEMPLATE] [--dataset-id ID] [--validation-ratio N] [--sample-limit N] [--preview-count N] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-train-split SPLIT] [--hf-valid-split SPLIT] [--text-feature NAME] [--prompt-feature NAME] [--completion-feature NAME] [--chat-feature NAME] [--json]
       melix lora activate --model-id MODEL_ID --adapter-path PATH [--activation-mode (fused_derived_model|adapter_backed_runtime)] [--alias NAME] [--json]
@@ -2341,6 +2342,13 @@ public enum MelixCLIParser {
             if candidateScoringMode.isEmpty == false,
                ["dataset_score", "seed_overlap_proxy", "reward_model"].contains(candidateScoringMode) == false {
                 throw MelixCLIError.usage("Invalid value for --candidate-scoring-mode. Expected one of: dataset_score, seed_overlap_proxy, reward_model.")
+            }
+            let loraResumeAdapter = (values.single["--resume-adapter"] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            let loraResumeManifest = (values.single["--resume-from-manifest"] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            if loraResumeAdapter.isEmpty == false || loraResumeManifest.isEmpty == false {
+                throw MelixCLIError.usage(
+                    "--resume-adapter and --resume-from-manifest are only for melix lora train checkpoint resumption. For melix alignment train, use --source-adapter-path for the upstream/base LoRA adapter to carry into GRPO/RLHF output."
+                )
             }
             let datasetSourceKind = datasetURI.isEmpty ? "hf_dataset" : "local_package"
             var parameters: [String: String] = [:]

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1547,7 +1547,7 @@ public enum MelixCLIParser {
       melix chat run (--model-id MODEL_ID | --remote-server-id ID --model MODEL) --message TEXT [--system TEXT] [--server-session-id ID] [--json]
       melix lora list [--model-id MODEL_ID] [--json]
       melix lora train --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) --adapter-name NAME [--target-repo REPO] [--training-mode (lora|qlora|dora)] [--preset PRESET] [--experiment-group GROUP] [--rank N] [--alpha N] [--dropout N] [--target-modules CSV] [--num-layers N] [--batch-size N] [--epochs N] [--max-steps N] [--learning-rate N] [--max-seq-length N] [--sample-limit N] [--gradient-accumulation N] [--resume-adapter PATH | --resume-from-manifest PATH] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-train-split SPLIT] [--hf-valid-split SPLIT] [--text-feature NAME] [--prompt-feature NAME] [--completion-feature NAME] [--chat-feature NAME] [--derived-model-alias NAME] [--response-only] [--mask-prompt] [--gradient-checkpointing] [--json]
-      melix alignment train --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) --adapter-name NAME --algorithm dpo|orpo|cpo|grpo|rlhf [--target-repo REPO] [--grpo-candidate-count N] [--candidate-generation-mode scored_trace|runtime_generate] [--candidate-scoring-mode dataset_score|seed_overlap_proxy|reward_model] [--candidate-generation-max-tokens N] [--reference-model-path PATH] [--reward-model-manifest-path PATH] [--kl-penalty N] [--preset PRESET] [--experiment-group GROUP] [--rank N] [--alpha N] [--dropout N] [--target-modules CSV] [--num-layers N] [--batch-size N] [--epochs N] [--max-steps N] [--learning-rate N] [--max-seq-length N] [--sample-limit N] [--gradient-accumulation N] [--json]
+      melix alignment train --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) --adapter-name NAME --algorithm dpo|orpo|cpo|grpo|rlhf [--target-repo REPO] [--source-adapter-path PATH] [--grpo-candidate-count N] [--candidate-generation-mode scored_trace|runtime_generate] [--candidate-scoring-mode dataset_score|seed_overlap_proxy|reward_model] [--candidate-generation-max-tokens N] [--reference-model-path PATH] [--reward-model-manifest-path PATH] [--kl-penalty N] [--preset PRESET] [--experiment-group GROUP] [--rank N] [--alpha N] [--dropout N] [--target-modules CSV] [--num-layers N] [--batch-size N] [--epochs N] [--max-steps N] [--learning-rate N] [--max-seq-length N] [--sample-limit N] [--gradient-accumulation N] [--json]
       melix lora dataset inspect --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) [--template TEMPLATE] [--dataset-id ID] [--validation-ratio N] [--sample-limit N] [--preview-count N] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-train-split SPLIT] [--hf-valid-split SPLIT] [--text-feature NAME] [--prompt-feature NAME] [--completion-feature NAME] [--chat-feature NAME] [--json]
       melix lora dataset build --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) [--output-dir PATH] [--template TEMPLATE] [--dataset-id ID] [--validation-ratio N] [--sample-limit N] [--preview-count N] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-train-split SPLIT] [--hf-valid-split SPLIT] [--text-feature NAME] [--prompt-feature NAME] [--completion-feature NAME] [--chat-feature NAME] [--json]
       melix lora activate --model-id MODEL_ID --adapter-path PATH [--activation-mode (fused_derived_model|adapter_backed_runtime)] [--alias NAME] [--json]
@@ -2368,6 +2368,7 @@ public enum MelixCLIParser {
                 "--text-feature",
                 "--grpo-candidate-count",
                 "--candidate-generation-max-tokens",
+                "--source-adapter-path",
                 "--reference-model-path",
                 "--reward-model-manifest-path",
                 "--kl-penalty",
@@ -4966,6 +4967,7 @@ public actor MelixCLIRunner {
                 appendOption("--candidate-generation-mode", value: ext["candidate_generation_mode"], into: &arguments)
                 appendOption("--candidate-scoring-mode", value: ext["candidate_scoring_mode"], into: &arguments)
                 appendOption("--candidate-generation-max-tokens", value: ext["candidate_generation_max_tokens"], into: &arguments)
+                appendOption("--source-adapter-path", value: ext["source_adapter_path"], into: &arguments)
                 appendOption("--reference-model-path", value: ext["reference_model_path"], into: &arguments)
                 appendOption("--reward-model-manifest-path", value: ext["reward_model_manifest_path"], into: &arguments)
                 appendOption("--kl-penalty", value: ext["kl_penalty"], into: &arguments)

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -684,6 +684,7 @@ public enum MelixCLICommandCodec {
             ("candidate_generation_mode", "--candidate-generation-mode"),
             ("candidate_scoring_mode", "--candidate-scoring-mode"),
             ("candidate_generation_max_tokens", "--candidate-generation-max-tokens"),
+            ("source_adapter_path", "--source-adapter-path"),
             ("reference_model_path", "--reference-model-path"),
             ("reward_model_manifest_path", "--reward-model-manifest-path"),
             ("kl_penalty", "--kl-penalty"),

--- a/docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
+++ b/docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
@@ -45,8 +45,9 @@ readiness.
   mean/percentiles, candidate group margin/variance, update count, selected
   candidate count, KL penalty, and reward-model lineage where applicable.
 - Preserve source LoRA adapter weights/config when a GRPO/RLHF alignment run is
-  resumed from an upstream base LoRA adapter so adapter-backed publish/activate
-  and local inference smoke tests load the expected artifacts.
+  supplied an upstream base LoRA adapter through `source_adapter_path`, which is
+  lineage propagation rather than checkpoint resumption, so adapter-backed
+  publish/activate and local inference smoke tests load the expected artifacts.
 - Keep final acceptance honest by marking scored-trace execution as
   deterministic and runtime generation as runtime-generated scored-trace
   execution, and reward-model scoring as reward-runtime scored-trace execution,
@@ -84,8 +85,8 @@ Success metrics:
 - GRPO/RLHF acceptance bundles can pass real local runtime evidence through
   LoRA training, alignment, publish, adapter-backed activation, chat, and
   evaluation when provided a local reward-model manifest and local text model.
-- Resumed alignment adapters preserve the source adapter artifacts required by
-  adapter-backed runtime loading.
+- Alignment runs supplied with `source_adapter_path` preserve the source adapter
+  artifacts required by adapter-backed runtime loading.
 - The production MaintenanceCore default path passes a reward runtime into the
   default LoRA training runner.
 - The MLX-LM reward scorer must use a deterministic scalar-score sampling shape

--- a/docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
+++ b/docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
@@ -44,6 +44,9 @@ readiness.
 - Record policy-update metrics derived from scored samples, including reward
   mean/percentiles, candidate group margin/variance, update count, selected
   candidate count, KL penalty, and reward-model lineage where applicable.
+- Preserve source LoRA adapter weights/config when a GRPO/RLHF alignment run is
+  resumed from an upstream base LoRA adapter so adapter-backed publish/activate
+  and local inference smoke tests load the expected artifacts.
 - Keep final acceptance honest by marking scored-trace execution as
   deterministic and runtime generation as runtime-generated scored-trace
   execution, and reward-model scoring as reward-runtime scored-trace execution,
@@ -54,7 +57,8 @@ readiness.
 - Reward-model training and standalone reward-model artifact generation from
   issue 366.
 - PPO/GRPO gradient updates through MLX-LM.
-- End-to-end real local runtime release evidence.
+- End-to-end real local runtime release evidence across every issue 365
+  business line.
 - Window UI acceptance.
 - Closing issue 365.
 
@@ -77,6 +81,11 @@ Success metrics:
   generated-candidate evidence without being marked release-ready.
 - GRPO/RLHF jobs can opt into reward-runtime scoring and record reward model
   backend, reward model id, and per-response score evidence.
+- GRPO/RLHF acceptance bundles can pass real local runtime evidence through
+  LoRA training, alignment, publish, adapter-backed activation, chat, and
+  evaluation when provided a local reward-model manifest and local text model.
+- Resumed alignment adapters preserve the source adapter artifacts required by
+  adapter-backed runtime loading.
 - The production MaintenanceCore default path passes a reward runtime into the
   default LoRA training runner.
 - The MLX-LM reward scorer must use a deterministic scalar-score sampling shape
@@ -136,11 +145,18 @@ reward scoring:
 - `python3 -m compileall -q services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py`: passed.
 - `git diff --check`: passed.
 
+Results on 2026-05-06 after review follow-up, source adapter propagation, and
+real GRPO/RLHF reward-runtime evidence:
+
+- `find .runtime -type f \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.webp' \) -print`: no screenshot files found.
+- `swift test --filter 'MelixCLIParserTests/parsesAlignmentTrainCommand|MelixCLIRunnerTests/alignmentTrainForwardsExpectedOperationPayload|MelixCLIRunnerTests/subprocessBackedLegacyAlignmentTrainingModeUsesAlignmentTrain'`: 3 tests passed; the build also linked the worktree-local `melix` CLI.
+- `MELIX_HOME="$PWD/.runtime/home-issue365-reward-real" .build/arm64-apple-macosx/debug/melix pipeline run --file .runtime/issue365/real-grpo-reward-runtime-probe-r5/pipelines/lora_grpo_export_inference.pipeline.json --receipt-dir .runtime/issue365/real-grpo-reward-runtime-probe-r6-dry/receipts --trace-id dry-source-adapter --format json-v1 --dry-run`: passed; `002-grpo_align.json` planned `--source-adapter-path ${steps.grpo_base_lora.result.output_path}`.
+- `MELIX_HOME="$PWD/.runtime/home-issue365-reward-real" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-reward-real-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-reward-real-swift.sock" MELIX_HTTP_PORT=12477 MELIX_DEV_TEXT_MODEL_PATH="/Users/ChenYu/.cache/huggingface/hub/models--mlx-community--Qwen3.5-0.8B-OptiQ-4bit/snapshots/40d69f3d88f45e9c38aea318c318ebc9ded5b783" python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id lora_grpo_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --model-id "mlx-community/Qwen3.5-0.8B-OptiQ-4bit" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --prompt-candidate-dataset-uri "$PWD/.runtime/issue365/input-datasets/prompt_candidate" --reward-model-manifest-path "$PWD/.runtime/issue365/reward-model/manifest.json" --output-dir .runtime/issue365/real-grpo-reward-runtime-probe-r6 --timestamp 2026-05-06T210500Z --json`: passed; `lora_grpo_export_inference` release-ready with no missing evidence.
+- `MELIX_HOME="$PWD/.runtime/home-issue365-reward-real" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-reward-real-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-reward-real-swift.sock" MELIX_HTTP_PORT=12477 MELIX_DEV_TEXT_MODEL_PATH="/Users/ChenYu/.cache/huggingface/hub/models--mlx-community--Qwen3.5-0.8B-OptiQ-4bit/snapshots/40d69f3d88f45e9c38aea318c318ebc9ded5b783" python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id lora_rlhf_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --model-id "mlx-community/Qwen3.5-0.8B-OptiQ-4bit" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --reward-scored-dataset-uri "$PWD/.runtime/issue365/input-datasets/reward_scored" --reward-model-manifest-path "$PWD/.runtime/issue365/reward-model/manifest.json" --output-dir .runtime/issue365/real-rlhf-reward-runtime-probe-r1 --timestamp 2026-05-06T210700Z --json`: passed; `lora_rlhf_export_inference` release-ready with no missing evidence.
+
 ## Remaining Issue 365 Gaps
 
 - Reward-model training and PPO/RL policy updates from issue 366.
-- Passing real local-runtime release evidence for reward-model scoring with a
-  local reward-model manifest.
 - PTQ/QAT real local inference release evidence.
 - Full CLI chain tests for every business line.
 - Window UI runnable and inspectable acceptance for every business line.

--- a/docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
+++ b/docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
@@ -31,6 +31,12 @@ readiness.
   traces, training metrics, and `melix.alignment_run.v1`.
 - Support explicit `candidate_scoring_mode=reward_model` for GRPO/RLHF when a
   reward runtime and readable reward-model manifest are provided.
+- Wire the default worker runtime into the RL alignment runner as the production
+  reward runtime so CLI/acceptance runs can request reward-model scoring without
+  relying on test-only runner injection.
+- Add a generic MLX-LM text reward scorer that loads the reward-model manifest
+  target, prompts the local model for a scalar score, and parses a `0..1` score
+  for GRPO/RLHF reward-model scoring evidence.
 - Support `rlhf` from `reward_scored` datasets with an existing reward model
   manifest reference.
 - Produce adapter weights/config artifacts and checkpoint lineage for scored
@@ -71,6 +77,10 @@ Success metrics:
   generated-candidate evidence without being marked release-ready.
 - GRPO/RLHF jobs can opt into reward-runtime scoring and record reward model
   backend, reward model id, and per-response score evidence.
+- The production MaintenanceCore default path passes a reward runtime into the
+  default LoRA training runner.
+- The MLX-LM reward scorer must use a deterministic scalar-score sampling shape
+  and fail when the model output does not contain a parseable score.
 - Alignment manifests include scored policy-update metrics.
 - Adapter manifests preserve alignment backlinks and checkpoint lineage.
 - Changed-scope coverage remains at least 95 percent.
@@ -80,16 +90,16 @@ Success metrics:
 Targeted commands:
 
 ```bash
-PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py
 git diff --check
 ```
 
 Coverage and metrics:
 
 ```bash
-PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_dataset_builder.py
 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/ChenYu/Documents/Github/melix/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/issue365-rl-alignment-runner-coverage.json
-python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-rl-alignment-runner-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
+python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue365-rl-alignment-runner-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py docs/plans/2026-05-05-issue-365-rl-alignment-runner.md
 ```
 
 Results on 2026-05-05 before runtime-generation extension:
@@ -116,11 +126,21 @@ Results on 2026-05-05 after reward-runtime scoring extension:
 - `python3 -m compileall -q services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py`: passed.
 - `git diff --check`: passed.
 
+Results on 2026-05-06 after production reward-runtime wiring and generic MLX-LM
+reward scoring:
+
+- `swift build`: passed and produced the worktree-local `melix` CLI.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_training_dataset_builder.py`: 248 passed, 9 skipped.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`: passed.
+- `python3 scripts/python_changed_line_coverage.py --coverage-json coverage.json --diff-from codex/issue365-qat-runtime services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py`: 100.00% total changed-line coverage (96/96).
+- `python3 -m compileall -q services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py`: passed.
+- `git diff --check`: passed.
+
 ## Remaining Issue 365 Gaps
 
 - Reward-model training and PPO/RL policy updates from issue 366.
-- Real local-runtime release evidence for reward-model scoring outside the
-  scripted reward-runtime tests.
+- Passing real local-runtime release evidence for reward-model scoring with a
+  local reward-model manifest.
 - PTQ/QAT real local inference release evidence.
 - Full CLI chain tests for every business line.
 - Window UI runnable and inspectable acceptance for every business line.

--- a/services/mlx-worker-python/tests/test_lora_experiment_store.py
+++ b/services/mlx-worker-python/tests/test_lora_experiment_store.py
@@ -298,6 +298,24 @@ def test_rebuild_index_falls_back_to_manifest_when_run_record_is_invalid(tmp_pat
     assert payload["runs"][0]["created_at_unix_ms"] == 222
 
 
+def test_rebuild_index_skips_empty_failed_job_directories(tmp_path: Path) -> None:
+    jobs_root = tmp_path / "model-ops"
+    _write_manifest(
+        jobs_root,
+        run_id="model-ops-0002",
+        adapter_name="successful-adapter",
+        updated_at_unix_ms=333,
+        created_at_unix_ms=222,
+    )
+    failed_dir = jobs_root / "train_lora" / "model-ops-0001"
+    failed_dir.mkdir(parents=True)
+
+    payload = LoraExperimentStore().rebuild_index(jobs_root)
+
+    assert [run["run_id"] for run in payload["runs"]] == ["model-ops-0002"]
+    assert payload["runs"][0]["adapter_name"] == "successful-adapter"
+
+
 def test_load_index_uses_existing_index_and_rebuilds_when_missing(tmp_path: Path) -> None:
     jobs_root = tmp_path / "model-ops"
     store = LoraExperimentStore()

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -183,6 +183,70 @@ def test_mlx_lm_runner_routes_alignment_rl_to_scored_trace_backend(tmp_path: Pat
     assert result.metrics.policy_update_trace_path.endswith("policy_updates.jsonl")
 
 
+def test_mlx_lm_runner_alignment_rl_preserves_source_adapter_artifacts(tmp_path: Path) -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"training_mode": "grpo", "grpo_candidate_count": "2"},
+        dataset_format="prompt_candidate",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    normalized_dataset_dir = tmp_path / "normalized"
+    normalized_dataset_dir.mkdir()
+    (normalized_dataset_dir / "train.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": "Draft two summaries.",
+                "candidates": [
+                    {"text": "Short summary.", "score": 0.7},
+                    {"text": "Verbose summary.", "score": 0.4},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    source_adapter_dir = tmp_path / "source-adapter"
+    source_adapter_dir.mkdir()
+    source_weights = source_adapter_dir / "adapters.safetensors"
+    source_weights.write_bytes(b"real-mlx-lora-weights")
+    (source_adapter_dir / "adapter_config.json").write_text(
+        json.dumps(
+            {
+                "adapter_path": str(source_adapter_dir),
+                "fine_tune_type": "lora",
+                "num_layers": 2,
+                "lora_parameters": {"keys": ["self_attn.q_proj"], "rank": 8},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-grpo-source-adapter",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=normalized_dataset_dir,
+        config=config,
+        dataset_format="prompt_candidate",
+        resume_source_path=source_weights,
+    )
+
+    result = mlx_lm_runner_module.MLXLMRunner().train(request)
+    adapter_config = json.loads(result.adapter_config_path.read_text(encoding="utf-8"))
+
+    assert result.weights_path.read_bytes() == b"real-mlx-lora-weights"
+    assert Path(result.metrics.latest_checkpoint_path).read_bytes() == b"real-mlx-lora-weights"
+    assert adapter_config["adapter_path"] == str(tmp_path / "adapter-output")
+    assert adapter_config["num_layers"] == 2
+    assert adapter_config["lora_parameters"]["keys"] == ["self_attn.q_proj"]
+    assert adapter_config["alignment_algorithm"] == "grpo"
+    assert adapter_config["alignment_source_adapter_weights_path"] == str(source_weights)
+    assert result.metrics.resume_source_path == str(source_weights)
+
+
 def test_mlx_lm_runner_generates_grpo_candidates_with_policy_runtime(tmp_path: Path) -> None:
     class ScriptedPolicyBackend:
         runtime_name = "scripted-policy-runtime"
@@ -2057,6 +2121,9 @@ def test_resolve_resume_context_handles_manifest_directory_and_missing_sources(t
         "resume_manifest_path": manifest.resolve(),
         "resume_source_job_id": "run-42",
     }
+
+    source_adapter_context = _resolve_resume_context({"source_adapter_path": str(manifest)})
+    assert source_adapter_context == manifest_context
 
     directory_context = _resolve_resume_context({"resume_source_path": str(checkpoint.parent.parent)})
     assert directory_context == {

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -19,6 +19,7 @@ from worker.model_ops import training_config as training_config_module
 from worker.model_ops import training_dataset as training_dataset_module
 from worker.model_ops.adapter_activation_pipeline import AdapterActivationPipeline
 from worker.model_ops.lora_training_pipeline import (
+    LoRATrainingPipeline,
     _content_hash,
     _int_ext,
     _latest_checkpoint_from_directory,
@@ -563,6 +564,7 @@ def test_alignment_rl_reward_model_scoring_helpers_cover_trace_and_error_paths(
                 "schema_version": "melix.reward_model_adapter.v1",
                 "reward_model_id": "fallback-reward",
                 "reward_head_type": "scalar",
+                "score_prompt_template": "Prompt={prompt}\nResponse={response}\nScore:",
             }
         )
         + "\n",
@@ -573,6 +575,7 @@ def test_alignment_rl_reward_model_scoring_helpers_cover_trace_and_error_paths(
     assert reward_model_spec.model_id == "fallback-reward"
     assert reward_model_spec.model_path == str(manifest_path.parent)
     assert reward_model_spec.ext["melix.reward_model.reward_head_type"] == "scalar"
+    assert reward_model_spec.ext["melix.reward_model.score_prompt_template"].startswith("Prompt=")
 
     with pytest.raises(ModelOperationError) as missing_manifest:
         _load_reward_model_manifest(tmp_path / "missing" / "manifest.json")
@@ -703,6 +706,87 @@ def test_text_runtime_score_response_delegates_backend_and_executor() -> None:
 
     with pytest.raises(RuntimeUnavailableError):
         MLXTextRuntime(backend=MissingScoreBackend()).score_response({}, "Prompt.", "Response.")
+
+
+def test_lora_training_pipeline_wires_reward_runtime_into_default_runner(tmp_path: Path) -> None:
+    class RewardBackend:
+        runtime_name = "pipeline-reward-runtime"
+
+        def __init__(self) -> None:
+            self.loaded_model_path = ""
+            self.responses: list[str] = []
+
+        def load_model(self, model_spec):
+            self.loaded_model_path = model_spec.model_path
+            return {"model_id": model_spec.model_id, "model_path": model_spec.model_path}
+
+        def score_response(self, loaded_model, prompt: str, response: str, execution_ext=None):
+            del loaded_model, prompt, execution_ext
+            self.responses.append(response)
+            return 0.82
+
+    reward_model_dir = tmp_path / "reward-model"
+    reward_model_dir.mkdir()
+    reward_manifest_path = reward_model_dir / "manifest.json"
+    reward_manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.reward_model_adapter.v1",
+                "reward_model_id": "pipeline-reward",
+                "model_path": str(reward_model_dir),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    dataset_dir = _write_dataset_package(
+        tmp_path / "reward-scored-dataset",
+        manifest_payload={
+            "schema_version": "melix.training_dataset_package.v1",
+            "dataset_id": "reward-scored",
+            "format": "reward_scored",
+            "sample_count": 1,
+            "version": "1",
+        },
+        sample_lines=[
+            json.dumps(
+                {
+                    "prompt": "Assess the response.",
+                    "response": "Helpful response.",
+                    "reward_score": 0.3,
+                }
+            )
+        ],
+    )
+    reward_backend = RewardBackend()
+    pipeline = LoRATrainingPipeline(
+        policy_runtime=MLXTextRuntime(backend=RewardBackend()),
+        reward_runtime=MLXTextRuntime(backend=reward_backend),
+    )
+
+    result = pipeline.run(
+        job_id="reward-runtime-pipeline",
+        request_ext={
+            "operation": "train_lora",
+            "training_mode": "rlhf",
+            "adapter_name": "reward-runtime-adapter",
+            "dataset_uri": str(dataset_dir),
+            "reward_model_manifest_path": str(reward_manifest_path),
+            "candidate_scoring_mode": "reward_model",
+        },
+        source_model=_text_model(model_path=str(tmp_path / "policy-model")),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    alignment_payload = json.loads(
+        Path(result.manifest["alignment_run_manifest_path"]).read_text(encoding="utf-8")
+    )
+    assert reward_backend.loaded_model_path == str(reward_model_dir)
+    assert reward_backend.responses == ["Helpful response."]
+    assert alignment_payload["training_backend"] == "reward_model_scored_trace"
+    assert alignment_payload["metrics"]["reward_scoring_backend"] == "pipeline-reward-runtime"
+    assert alignment_payload["metrics"]["reward_mean"] == pytest.approx(0.82)
 
 
 @pytest.mark.parametrize(

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -247,6 +247,23 @@ def test_mlx_lm_runner_alignment_rl_preserves_source_adapter_artifacts(tmp_path:
     assert result.metrics.resume_source_path == str(source_weights)
 
 
+def test_alignment_rl_rejects_missing_source_adapter_weights(tmp_path: Path) -> None:
+    from worker.model_ops.rl_alignment_training import _alignment_adapter_weights_bytes
+
+    missing_weights = tmp_path / "missing-adapters.safetensors"
+    with pytest.raises(ModelOperationError) as exc:
+        _alignment_adapter_weights_bytes(
+            source_weights_path=missing_weights,
+            job_id="train-grpo-missing-source",
+            base_model_id="melix-dev-text",
+            alignment_algorithm="grpo",
+            trace_rows=[],
+        )
+
+    assert exc.value.code == "invalid_resume_source"
+    assert exc.value.details["source_weights_path"] == str(missing_weights)
+
+
 def test_mlx_lm_runner_generates_grpo_candidates_with_policy_runtime(tmp_path: Path) -> None:
     class ScriptedPolicyBackend:
         runtime_name = "scripted-policy-runtime"

--- a/services/mlx-worker-python/tests/test_mlx_backend.py
+++ b/services/mlx-worker-python/tests/test_mlx_backend.py
@@ -234,6 +234,91 @@ def test_auto_backend_uses_mlx_load_stream_and_sampler_hooks() -> None:
     assert chunks[-1].dflash_rollback_count == 2
 
 
+def test_auto_backend_scores_reward_responses_with_mlx_generation() -> None:
+    seen: dict[str, object] = {}
+
+    def fake_load(model_source: str, **kwargs):
+        seen["load"] = (model_source, kwargs)
+        return object(), FakeTokenizer()
+
+    def fake_sampler_factory(*, temp: float, top_p: float, top_k: int):
+        seen["sampler"] = {"temp": temp, "top_p": top_p, "top_k": top_k}
+        return "score-sampler"
+
+    def fake_stream_generate(model, tokenizer, prompt: str, max_tokens: int, sampler):
+        seen["stream"] = {
+            "model": model,
+            "tokenizer": tokenizer,
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "sampler": sampler,
+        }
+        yield FakeGenerationResponse(text="Score: ", prompt_tokens=8, generation_tokens=1)
+        yield FakeGenerationResponse(text="87", prompt_tokens=8, generation_tokens=2)
+
+    backend = AutoMLXBackend(
+        load_fn=fake_load,
+        stream_generate_fn=fake_stream_generate,
+        sampler_factory=fake_sampler_factory,
+    )
+    model_spec = WorkerModelCatalog.dev_text_model(environment={"MELIX_DEV_TEXT_MODEL_PATH": "mlx-community/reward"})
+    model_spec.ext["melix.reward_model.score_prompt_template"] = (
+        "Prompt={prompt}\nResponse={response}\nReturn score:"
+    )
+    loaded_model = backend.load_model(model_spec)
+
+    score = backend.score_response(loaded_model, "Explain safely.", "Helpful answer.")
+
+    assert score == pytest.approx(0.87)
+    assert seen["load"] == ("mlx-community/reward", {"lazy": False})
+    assert seen["sampler"] == {"temp": 0.0, "top_p": 1.0, "top_k": 1}
+    assert seen["stream"] == {
+        "model": loaded_model["model"],
+        "tokenizer": loaded_model["tokenizer"],
+        "prompt": "Prompt=Explain safely.\nResponse=Helpful answer.\nReturn score:",
+        "max_tokens": 8,
+        "sampler": "score-sampler",
+    }
+
+
+def test_reward_score_prompt_and_parser_cover_fallbacks() -> None:
+    prompt = mlx_text_runtime_module._reward_score_prompt(
+        {"metadata": {"melix.reward_model.scoring_prompt_template": "Metadata {prompt} {response}"}},
+        prompt="Prompt",
+        response="Response",
+        execution_ext={
+            "melix.reward_model.score_prompt_template": "Override {prompt} => {response}",
+        },
+    )
+    assert prompt == "Override Prompt => Response"
+
+    default_prompt = mlx_text_runtime_module._reward_score_prompt(
+        object(),
+        prompt="Explain safely.",
+        response="Helpful answer.",
+        execution_ext=None,
+    )
+    assert "Explain safely." in default_prompt
+    assert "Helpful answer." in default_prompt
+    assert mlx_text_runtime_module._parse_reward_score_text("0.42") == pytest.approx(0.42)
+
+    with pytest.raises(RuntimeUnavailableError):
+        mlx_text_runtime_module._parse_reward_score_text("no numeric score")
+
+
+def test_auto_backend_score_response_reports_unavailable_runtime() -> None:
+    backend = AutoMLXBackend(
+        load_fn=lambda model_source, **kwargs: (object(), FakeTokenizer()),
+        stream_generate_fn=lambda *args, **kwargs: iter(()),
+        sampler_factory=lambda **kwargs: "unused",
+    )
+    backend._available = False
+    backend._error = ModuleNotFoundError("mlx-lm is not installed")
+
+    with pytest.raises(RuntimeUnavailableError, match="mlx-lm is not installed"):
+        backend.score_response({}, "Prompt", "Response")
+
+
 def test_text_stop_contract_merges_request_metadata_and_tokenizer_eos() -> None:
     contract = resolve_text_stop_contract(
         {

--- a/services/mlx-worker-python/tests/test_mlx_backend.py
+++ b/services/mlx-worker-python/tests/test_mlx_backend.py
@@ -265,6 +265,7 @@ def test_auto_backend_scores_reward_responses_with_mlx_generation() -> None:
     model_spec.ext["melix.reward_model.score_prompt_template"] = (
         "Prompt={prompt}\nResponse={response}\nReturn score:"
     )
+    model_spec.ext["melix.reward_model.score_max_tokens"] = "12"
     loaded_model = backend.load_model(model_spec)
 
     score = backend.score_response(loaded_model, "Explain safely.", "Helpful answer.")
@@ -276,7 +277,7 @@ def test_auto_backend_scores_reward_responses_with_mlx_generation() -> None:
         "model": loaded_model["model"],
         "tokenizer": loaded_model["tokenizer"],
         "prompt": "Prompt=Explain safely.\nResponse=Helpful answer.\nReturn score:",
-        "max_tokens": 8,
+        "max_tokens": 12,
         "sampler": "score-sampler",
     }
 
@@ -300,10 +301,20 @@ def test_reward_score_prompt_and_parser_cover_fallbacks() -> None:
     )
     assert "Explain safely." in default_prompt
     assert "Helpful answer." in default_prompt
+    assert mlx_text_runtime_module._reward_score_max_tokens(
+        {"metadata": {"melix.reward_model.max_tokens": "12"}},
+        execution_ext={"melix.reward_model.score_max_tokens": "18"},
+    ) == 18
+    assert mlx_text_runtime_module._reward_score_max_tokens(
+        {"metadata": {"melix.reward_model.score_max_tokens": "not-an-int"}},
+        execution_ext=None,
+    ) == 8
     assert mlx_text_runtime_module._parse_reward_score_text("0.42") == pytest.approx(0.42)
 
     with pytest.raises(RuntimeUnavailableError):
         mlx_text_runtime_module._parse_reward_score_text("no numeric score")
+    with pytest.raises(RuntimeUnavailableError):
+        mlx_text_runtime_module._parse_reward_score_text("-0.5")
 
 
 def test_auto_backend_score_response_reports_unavailable_runtime() -> None:

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -232,7 +232,8 @@ class MaintenanceCore:
         self._download_pipeline = download_pipeline or DownloadPipeline()
         self._local_import_pipeline = local_import_pipeline or LocalImportPipeline()
         self._lora_training_pipeline = lora_training_pipeline or LoRATrainingPipeline(
-            policy_runtime=registry.runtime
+            policy_runtime=registry.runtime,
+            reward_runtime=registry.runtime,
         )
         self._adapter_activation_pipeline = adapter_activation_pipeline or AdapterActivationPipeline()
         self._upload_receipt_pipeline = upload_receipt_pipeline or UploadReceiptPipeline()

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -560,6 +560,7 @@ def _resolve_resume_context(ext: dict[str, str]) -> dict[str, Any]:
                 "resume_from_path",
                 "resume_adapter_file",
                 "resume_manifest_path",
+                "source_adapter_path",
             )
             if ext.get(key, "").strip()
         ),

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -38,10 +38,11 @@ class LoRATrainingPipeline:
         self,
         runner: MLXLMRunner | None = None,
         policy_runtime: Any | None = None,
+        reward_runtime: Any | None = None,
         hf_dataset_fetcher: HFDatasetFetcher | None = None,
         experiment_store: LoraExperimentStore | None = None,
     ) -> None:
-        self._runner = runner or MLXLMRunner(policy_runtime=policy_runtime)
+        self._runner = runner or MLXLMRunner(policy_runtime=policy_runtime, reward_runtime=reward_runtime)
         self._hf_dataset_fetcher = hf_dataset_fetcher
         self._experiment_store = experiment_store or LoraExperimentStore()
 

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -656,6 +656,8 @@ def _reward_model_spec_from_manifest(
         "adapter_manifest_path",
         "adapter_weights_path",
         "base_model_id",
+        "score_prompt_template",
+        "scoring_prompt_template",
     ):
         value = manifest_payload.get(key)
         if value is not None and str(value).strip():

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -144,19 +144,8 @@ def train_alignment_rl_trace(
     latest_checkpoint_path = checkpoint_dir / "adapters.safetensors"
 
     _write_jsonl(policy_update_trace_path, policy_updates.trace_rows)
-    adapter_config = {
+    adapter_config = _load_resume_adapter_config(request.resume_source_path) or {
         "fine_tune_type": "lora",
-        "alignment_algorithm": alignment.alignment_algorithm,
-        "execution_backend": policy_updates.execution_backend,
-        "policy_update_trace_path": str(policy_update_trace_path),
-        "reward_model_manifest_path": alignment.reward_model_manifest_path,
-        "reference_model_path": alignment.reference_model_path,
-        "kl_penalty": alignment.kl_penalty,
-        "grpo_candidate_count": alignment.grpo_candidate_count,
-        "candidate_generation_mode": policy_updates.candidate_generation_mode,
-        "candidate_generation_backend": policy_updates.candidate_generation_backend,
-        "candidate_scoring_mode": policy_updates.candidate_scoring_mode,
-        "reward_scoring_backend": policy_updates.reward_scoring_backend,
         "lora_parameters": {
             "rank": request.config.rank,
             "dropout": request.config.dropout,
@@ -164,15 +153,34 @@ def train_alignment_rl_trace(
             "keys": request.config.expanded_target_modules,
         },
     }
+    if "adapter_path" in adapter_config:
+        adapter_config["adapter_path"] = str(request.adapter_output_dir)
+    adapter_config.update(
+        {
+            "alignment_algorithm": alignment.alignment_algorithm,
+            "execution_backend": policy_updates.execution_backend,
+            "policy_update_trace_path": str(policy_update_trace_path),
+            "reward_model_manifest_path": alignment.reward_model_manifest_path,
+            "reference_model_path": alignment.reference_model_path,
+            "kl_penalty": alignment.kl_penalty,
+            "grpo_candidate_count": alignment.grpo_candidate_count,
+            "candidate_generation_mode": policy_updates.candidate_generation_mode,
+            "candidate_generation_backend": policy_updates.candidate_generation_backend,
+            "candidate_scoring_mode": policy_updates.candidate_scoring_mode,
+            "reward_scoring_backend": policy_updates.reward_scoring_backend,
+            "alignment_source_adapter_weights_path": (
+                str(request.resume_source_path) if request.resume_source_path is not None else ""
+            ),
+        }
+    )
     adapter_config_path.write_text(json.dumps(adapter_config, indent=2) + "\n", encoding="utf-8")
-    weights_payload = {
-        "schema_version": "melix.scored_alignment_adapter.v1",
-        "job_id": request.job_id,
-        "base_model_id": request.base_model_id,
-        "alignment_algorithm": alignment.alignment_algorithm,
-        "policy_update_digest": _trace_digest(policy_updates.trace_rows),
-    }
-    weights_bytes = json.dumps(weights_payload, sort_keys=True).encode("utf-8")
+    weights_bytes = _alignment_adapter_weights_bytes(
+        source_weights_path=request.resume_source_path,
+        job_id=request.job_id,
+        base_model_id=request.base_model_id,
+        alignment_algorithm=alignment.alignment_algorithm,
+        trace_rows=policy_updates.trace_rows,
+    )
     weights_path.write_bytes(weights_bytes)
     latest_checkpoint_path.write_bytes(weights_bytes)
 
@@ -211,6 +219,40 @@ def train_alignment_rl_trace(
         ),
         execution_backend=policy_updates.execution_backend,
     )
+
+
+def _load_resume_adapter_config(resume_source_path: Path | None) -> dict[str, Any] | None:
+    if resume_source_path is None:
+        return None
+    config_path = resume_source_path.parent / "adapter_config.json"
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return dict(payload) if isinstance(payload, dict) else None
+
+
+def _alignment_adapter_weights_bytes(
+    *,
+    source_weights_path: Path | None,
+    job_id: str,
+    base_model_id: str,
+    alignment_algorithm: str,
+    trace_rows: list[dict[str, Any]],
+) -> bytes:
+    if source_weights_path is not None:
+        try:
+            return source_weights_path.read_bytes()
+        except OSError:
+            pass
+    weights_payload = {
+        "schema_version": "melix.scored_alignment_adapter.v1",
+        "job_id": job_id,
+        "base_model_id": base_model_id,
+        "alignment_algorithm": alignment_algorithm,
+        "policy_update_digest": _trace_digest(trace_rows),
+    }
+    return json.dumps(weights_payload, sort_keys=True).encode("utf-8")
 
 
 def _load_training_rows(path: Path) -> list[dict[str, Any]]:

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -243,8 +243,12 @@ def _alignment_adapter_weights_bytes(
     if source_weights_path is not None:
         try:
             return source_weights_path.read_bytes()
-        except OSError:
-            pass
+        except OSError as exc:
+            raise ModelOperationError(
+                code="invalid_resume_source",
+                message="Source adapter weights are missing or unreadable.",
+                details={"source_weights_path": str(source_weights_path)},
+            ) from exc
     weights_payload = {
         "schema_version": "melix.scored_alignment_adapter.v1",
         "job_id": job_id,

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -80,7 +80,7 @@ class LoraExperimentStore:
 
             manifest_path = run_dir / "train_lora.adapter.json"
             payload = self._load_payload(manifest_path)
-            if not payload:
+            if payload == {}:
                 continue
             run_id = str(payload.get("job_id", "")).strip() or manifest_path.parent.name
             if run_id in runs_by_id:

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -80,6 +80,8 @@ class LoraExperimentStore:
 
             manifest_path = run_dir / "train_lora.adapter.json"
             payload = self._load_payload(manifest_path)
+            if not payload:
+                continue
             run_id = str(payload.get("job_id", "")).strip() or manifest_path.parent.name
             if run_id in runs_by_id:
                 continue

--- a/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
@@ -7,6 +7,7 @@ import importlib.util
 import inspect
 import json
 from pathlib import Path
+import re
 from typing import Any
 
 from worker.runtime.mlx_executor import MLXRuntimeExecutor
@@ -53,6 +54,9 @@ class RuntimeToolCallEvent:
     arguments_json_fragment: str
 
 
+_REWARD_SCORE_RE = re.compile(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)")
+
+
 @dataclass(frozen=True)
 class ResolvedTextStopContract:
     sequences: tuple[str, ...]
@@ -62,6 +66,49 @@ class ResolvedTextStopContract:
 
 def _normalized_ext_value(model_spec, key: str) -> str:
     return str(getattr(model_spec, "ext", {}).get(key, "") or "").strip()
+
+
+def _reward_score_prompt(
+    loaded_model: Any,
+    *,
+    prompt: str,
+    response: str,
+    execution_ext: dict[str, str] | None,
+) -> str:
+    ext: dict[str, str] = {}
+    if isinstance(loaded_model, dict):
+        for key in ("model_ext", "metadata", "ext"):
+            raw_ext = loaded_model.get(key)
+            if isinstance(raw_ext, dict):
+                ext.update({str(raw_key): str(raw_value) for raw_key, raw_value in raw_ext.items()})
+    if execution_ext:
+        ext.update({str(key): str(value) for key, value in execution_ext.items()})
+
+    template = (
+        ext.get("melix.reward_model.score_prompt_template")
+        or ext.get("melix.reward_model.scoring_prompt_template")
+        or ""
+    )
+    if template.strip():
+        return template.replace("{prompt}", prompt).replace("{response}", response)
+
+    return (
+        "Score the assistant response for helpfulness and correctness on a 0 to 1 scale.\n"
+        "Return only one decimal number between 0 and 1.\n\n"
+        f"User prompt:\n{prompt}\n\n"
+        f"Assistant response:\n{response}\n\n"
+        "Score:"
+    )
+
+
+def _parse_reward_score_text(text: str) -> float:
+    for match in _REWARD_SCORE_RE.finditer(text):
+        value = float(match.group(0))
+        if 0.0 <= value <= 1.0:
+            return value
+        if 1.0 < value <= 100.0:
+            return value / 100.0
+    raise RuntimeUnavailableError("Reward model did not return a numeric score between 0 and 1.")
 
 
 _TEXT_STOP_SEQUENCE_KEYS = (
@@ -376,6 +423,35 @@ class AutoMLXBackend:
 
     def estimate_resident_bytes(self, model_spec) -> int:
         return 0
+
+    def score_response(
+        self,
+        loaded_model,
+        prompt: str,
+        response: str,
+        execution_ext: dict[str, str] | None = None,
+    ) -> float:
+        if not self._available:
+            raise RuntimeUnavailableError("mlx-lm is not installed") from self._error
+        self._ensure_runtime()
+        sampler = self._sampler_factory(temp=0.0, top_p=1.0, top_k=1)
+        score_prompt = _reward_score_prompt(
+            loaded_model,
+            prompt=prompt,
+            response=response,
+            execution_ext=execution_ext,
+        )
+        score_text = "".join(
+            str(getattr(chunk, "text", ""))
+            for chunk in self._stream_generate_fn(
+                loaded_model["model"],
+                loaded_model["tokenizer"],
+                score_prompt,
+                max_tokens=8,
+                sampler=sampler,
+            )
+        )
+        return _parse_reward_score_text(score_text)
 
     def generate_tokens(
         self,

--- a/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
@@ -68,6 +68,20 @@ def _normalized_ext_value(model_spec, key: str) -> str:
     return str(getattr(model_spec, "ext", {}).get(key, "") or "").strip()
 
 
+def _reward_score_ext(
+    loaded_model: Any,
+    execution_ext: dict[str, str] | None,
+) -> dict[str, str]:
+    ext: dict[str, str] = {}
+    if isinstance(loaded_model, dict):
+        for key in ("model_ext", "metadata", "ext"):
+            if isinstance(raw_ext := loaded_model.get(key), dict):
+                ext.update({str(raw_key): str(raw_value) for raw_key, raw_value in raw_ext.items()})
+    if execution_ext:
+        ext.update({str(raw_key): str(raw_value) for raw_key, raw_value in execution_ext.items()})
+    return ext
+
+
 def _reward_score_prompt(
     loaded_model: Any,
     *,
@@ -75,14 +89,7 @@ def _reward_score_prompt(
     response: str,
     execution_ext: dict[str, str] | None,
 ) -> str:
-    ext: dict[str, str] = {}
-    if isinstance(loaded_model, dict):
-        for key in ("model_ext", "metadata", "ext"):
-            if isinstance(raw_ext := loaded_model.get(key), dict):
-                ext.update({str(raw_key): str(raw_value) for raw_key, raw_value in raw_ext.items()})
-    if execution_ext:
-        ext.update(execution_ext)
-
+    ext = _reward_score_ext(loaded_model, execution_ext)
     template = (
         ext.get("melix.reward_model.score_prompt_template")
         or ext.get("melix.reward_model.scoring_prompt_template")
@@ -98,6 +105,24 @@ def _reward_score_prompt(
         f"Assistant response:\n{response}\n\n"
         "Score:"
     )
+
+
+def _reward_score_max_tokens(
+    loaded_model: Any,
+    execution_ext: dict[str, str] | None,
+) -> int:
+    ext = _reward_score_ext(loaded_model, execution_ext)
+    for key in ("melix.reward_model.score_max_tokens", "melix.reward_model.max_tokens"):
+        raw_value = str(ext.get(key, "") or "").strip()
+        if not raw_value:
+            continue
+        try:
+            value = int(raw_value)
+        except ValueError:
+            continue
+        if value > 0:
+            return value
+    return 8
 
 
 def _parse_reward_score_text(text: str) -> float:
@@ -446,7 +471,7 @@ class AutoMLXBackend:
                 loaded_model["model"],
                 loaded_model["tokenizer"],
                 score_prompt,
-                max_tokens=8,
+                max_tokens=_reward_score_max_tokens(loaded_model, execution_ext),
                 sampler=sampler,
             )
         )

--- a/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
@@ -78,11 +78,10 @@ def _reward_score_prompt(
     ext: dict[str, str] = {}
     if isinstance(loaded_model, dict):
         for key in ("model_ext", "metadata", "ext"):
-            raw_ext = loaded_model.get(key)
-            if isinstance(raw_ext, dict):
+            if isinstance(raw_ext := loaded_model.get(key), dict):
                 ext.update({str(raw_key): str(raw_value) for raw_key, raw_value in raw_ext.items()})
     if execution_ext:
-        ext.update({str(key): str(value) for key, value in execution_ext.items()})
+        ext.update(execution_ext)
 
     template = (
         ext.get("melix.reward_model.score_prompt_template")

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -1343,6 +1343,7 @@ struct MelixCLIParserTests {
     @Test("parses alignment train with preference and RL parameters")
     func parsesAlignmentTrainCommand() throws {
         #expect(MelixCLIParser.usageText.contains("melix alignment train"))
+        #expect(MelixCLIParser.usageText.contains("--source-adapter-path is the upstream/base LoRA adapter"))
 
         let command = try MelixCLIParser.parse([
             "alignment",
@@ -1422,6 +1423,21 @@ struct MelixCLIParserTests {
                 "--candidate-scoring-mode", "dataset",
             ],
             equals: .usage("Invalid value for --candidate-scoring-mode. Expected one of: dataset_score, seed_overlap_proxy, reward_model.")
+        )
+    }
+
+    @Test("alignment train rejects LoRA checkpoint resume flags")
+    func alignmentTrainRejectsLoraCheckpointResumeFlags() throws {
+        try assertError(
+            for: [
+                "alignment", "train",
+                "--model-id", "melix-dev-text",
+                "--dataset-uri", "/tmp/data.jsonl",
+                "--adapter-name", "aligned-adapter",
+                "--algorithm", "grpo",
+                "--resume-adapter", "/tmp/lora-checkpoint",
+            ],
+            equals: .usage("--resume-adapter and --resume-from-manifest are only for melix lora train checkpoint resumption. For melix alignment train, use --source-adapter-path for the upstream/base LoRA adapter to carry into GRPO/RLHF output.")
         )
     }
 

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -1355,6 +1355,7 @@ struct MelixCLIParserTests {
             "--candidate-generation-mode", " Runtime_Generate ",
             "--candidate-scoring-mode", " Reward_Model ",
             "--candidate-generation-max-tokens", "16",
+            "--source-adapter-path", "/tmp/source/train_lora.adapter.json",
             "--reference-model-path", "/tmp/reference-model",
             "--reward-model-manifest-path", "/tmp/reward/manifest.json",
             "--sample-limit", "8",
@@ -1376,6 +1377,7 @@ struct MelixCLIParserTests {
         #expect(options.parameters["candidate_generation_mode"] == "runtime_generate")
         #expect(options.parameters["candidate_scoring_mode"] == "reward_model")
         #expect(options.parameters["candidate_generation_max_tokens"] == "16")
+        #expect(options.parameters["source_adapter_path"] == "/tmp/source/train_lora.adapter.json")
         #expect(options.parameters["reference_model_path"] == "/tmp/reference-model")
         #expect(options.parameters["reward_model_manifest_path"] == "/tmp/reward/manifest.json")
         #expect(options.parameters["sample_limit"] == "8")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -4952,6 +4952,7 @@ struct MelixCLIRunnerTests {
                         "candidate_generation_mode": "runtime_generate",
                         "candidate_scoring_mode": "reward_model",
                         "candidate_generation_max_tokens": "16",
+                        "source_adapter_path": "/tmp/source/train_lora.adapter.json",
                         "reference_model_path": "/tmp/reference-model",
                         "reward_model_manifest_path": "/tmp/reward/manifest.json",
                     ],
@@ -4973,6 +4974,7 @@ struct MelixCLIRunnerTests {
         #expect(call.ext["candidate_generation_mode"] == "runtime_generate")
         #expect(call.ext["candidate_scoring_mode"] == "reward_model")
         #expect(call.ext["candidate_generation_max_tokens"] == "16")
+        #expect(call.ext["source_adapter_path"] == "/tmp/source/train_lora.adapter.json")
         #expect(call.ext["reference_model_path"] == "/tmp/reference-model")
         #expect(call.ext["reward_model_manifest_path"] == "/tmp/reward/manifest.json")
     }
@@ -5534,6 +5536,7 @@ struct MelixCLIRunnerTests {
                 "sample_limit": "8",
                 "gradient_accumulation": "4",
                 "grpo_candidate_count": "4",
+                "source_adapter_path": "/tmp/source/train_lora.adapter.json",
             ]
         )
 
@@ -5548,6 +5551,8 @@ struct MelixCLIRunnerTests {
         #expect(commands[0].contains("8"))
         #expect(commands[0].contains("--gradient-accumulation"))
         #expect(commands[0].contains("4"))
+        #expect(commands[0].contains("--source-adapter-path"))
+        #expect(commands[0].contains("/tmp/source/train_lora.adapter.json"))
     }
 
     @Test("subprocess-backed lora publish builds explicit adapter and merged publish arguments")


### PR DESCRIPTION
## Summary
- Wire the worker default text runtime into `LoRATrainingPipeline` as the production reward runtime so GRPO/RLHF reward-model scoring does not depend on test-only runner injection.
- Add generic MLX-LM scalar reward scoring support, adopt the Gemini review cleanup in the reward prompt extension merge path, and preserve source LoRA adapter weights/config when alignment is supplied an upstream base adapter through `source_adapter_path`.
- Forward `--source-adapter-path` through `melix alignment train`, pipeline dry-run/subprocess command generation, and Swift parser tests so adapter-backed publish/activate/chat works in real runtime probes.
- Harden LoRA experiment index rebuilds so empty failed job directories do not break later model-ops runs.
- Address review follow-up by making reward score token budget metadata-configurable, rejecting missing source adapter weights before writing stubs, explicitly testing negative reward-score rejection, and making the empty manifest payload branch intentional.
- Address stacked review follow-up by documenting that `alignment train --source-adapter-path` carries upstream/base LoRA adapter lineage into GRPO/RLHF output and is not a checkpoint-resume alias, plus rejecting LoRA checkpoint resume flags on `alignment train`.

## Plan or Spec
- Governing plan: `docs/plans/2026-05-05-issue-365-rl-alignment-runner.md`
- This is a stacked follow-up on `codex/issue365-qat-runtime` for issue #365. It narrows the GRPO/RLHF reward-runtime evidence gap but does not close issue #365.

## Commands Run
```text
find .runtime -type f \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.webp' \) -print
Result: passed; no screenshot files found.

swift test --filter 'MelixCLIParserTests/parsesAlignmentTrainCommand|MelixCLIRunnerTests/alignmentTrainForwardsExpectedOperationPayload|MelixCLIRunnerTests/subprocessBackedLegacyAlignmentTrainingModeUsesAlignmentTrain'
Result: 3 tests passed; the debug melix CLI was linked.

MELIX_HOME="$PWD/.runtime/home-issue365-reward-real" .build/arm64-apple-macosx/debug/melix pipeline run --file .runtime/issue365/real-grpo-reward-runtime-probe-r5/pipelines/lora_grpo_export_inference.pipeline.json --receipt-dir .runtime/issue365/real-grpo-reward-runtime-probe-r6-dry/receipts --trace-id dry-source-adapter --format json-v1 --dry-run
Result: passed; 002-grpo_align.json planned --source-adapter-path ${steps.grpo_base_lora.result.output_path}.

MELIX_HOME="$PWD/.runtime/home-issue365-reward-real" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-reward-real-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-reward-real-swift.sock" MELIX_HTTP_PORT=12477 MELIX_DEV_TEXT_MODEL_PATH="/Users/ChenYu/.cache/huggingface/hub/models--mlx-community--Qwen3.5-0.8B-OptiQ-4bit/snapshots/40d69f3d88f45e9c38aea318c318ebc9ded5b783" python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id lora_grpo_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --model-id "mlx-community/Qwen3.5-0.8B-OptiQ-4bit" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --prompt-candidate-dataset-uri "$PWD/.runtime/issue365/input-datasets/prompt_candidate" --reward-model-manifest-path "$PWD/.runtime/issue365/reward-model/manifest.json" --output-dir .runtime/issue365/real-grpo-reward-runtime-probe-r6 --timestamp 2026-05-06T210500Z --json
Result: passed; lora_grpo_export_inference release-ready with no missing evidence.

MELIX_HOME="$PWD/.runtime/home-issue365-reward-real" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-reward-real-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-reward-real-swift.sock" MELIX_HTTP_PORT=12477 MELIX_DEV_TEXT_MODEL_PATH="/Users/ChenYu/.cache/huggingface/hub/models--mlx-community--Qwen3.5-0.8B-OptiQ-4bit/snapshots/40d69f3d88f45e9c38aea318c318ebc9ded5b783" python3 scripts/issue365_acceptance_bundle.py --execution-mode real --case-id lora_rlhf_export_inference --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --model-id "mlx-community/Qwen3.5-0.8B-OptiQ-4bit" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --reward-scored-dataset-uri "$PWD/.runtime/issue365/input-datasets/reward_scored" --reward-model-manifest-path "$PWD/.runtime/issue365/reward-model/manifest.json" --output-dir .runtime/issue365/real-rlhf-reward-runtime-probe-r1 --timestamp 2026-05-06T210700Z --json
Result: passed; lora_rlhf_export_inference release-ready with no missing evidence.

MELIX_SERVICE_INSTANCE_NAME=i365fr3 MELIX_HTTP_PORT=12480 MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/i365fr3" MELIX_HOME="$PWD/.runtime/home-issue365-full-real" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-fr3-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-fr3-swift.sock" MELIX_DEV_TEXT_MODEL_PATH="/Users/ChenYu/.cache/huggingface/hub/models--mlx-community--Qwen3.5-0.8B-OptiQ-4bit/snapshots/40d69f3d88f45e9c38aea318c318ebc9ded5b783" bash scripts/dev_up.sh --prefer-built
Result: passed outside the sandbox after sandboxed startup hit Unix socket bind restrictions; local stack ready on http://127.0.0.1:12480.

MELIX_HOME="$PWD/.runtime/home-issue365-full-real" MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/i365fr3" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-fr3-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-fr3-swift.sock" MELIX_HTTP_PORT=12480 MELIX_DEV_TEXT_MODEL_PATH="/Users/ChenYu/.cache/huggingface/hub/models--mlx-community--Qwen3.5-0.8B-OptiQ-4bit/snapshots/40d69f3d88f45e9c38aea318c318ebc9ded5b783" python3 scripts/issue365_acceptance_bundle.py --execution-mode real --melix-cli "$PWD/.build/arm64-apple-macosx/debug/melix" --model-id "mlx-community/Qwen3.5-0.8B-OptiQ-4bit" --sft-dataset-uri "$PWD/services/mlx-worker-python/fixtures/training/melix-dev-dataset.v1" --preference-dataset-uri "$PWD/.runtime/issue365/input-datasets/preference_pair" --prompt-candidate-dataset-uri "$PWD/.runtime/issue365/input-datasets/prompt_candidate" --reward-scored-dataset-uri "$PWD/.runtime/issue365/input-datasets/reward_scored" --calibration-dataset-uri "$PWD/.runtime/issue365/input-datasets/calibration" --reward-model-manifest-path "$PWD/.runtime/issue365/reward-model/manifest.json" --output-dir .runtime/issue365/full-real-runtime-bundle-r2 --timestamp 2026-05-06T122729Z --json
Result: passed; full Issue 365 real-local-runtime CLI matrix release_ready=true with 10/10 succeeded cases and known_gaps=[].

MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/i365fr3" MELIX_WORKER_SOCKET_PATH="/tmp/mx365-fr3-python.sock" MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH="/tmp/mx365-fr3-swift.sock" bash scripts/dev_down.sh
Result: passed; local stack stopped.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_lora_experiment_store.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_training_dataset_builder.py
Result: 274 passed, 2 warnings.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage json -o coverage.json
Result: passed; wrote coverage.json.

python3 scripts/python_changed_line_coverage.py --coverage-json coverage.json --diff-from origin/codex/issue365-qat-runtime services/mlx-worker-python/tests/test_lora_experiment_store.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/productization/lora_experiment_store.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
Result: 97.33% total changed-line coverage (146/150).

python3 -m compileall -q services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/productization/lora_experiment_store.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_lora_experiment_store.py
Result: passed.

git diff --check
Result: passed.

swift build
Result: passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run pytest services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_lora_experiment_store.py -q -k 'reward_score or score_response or alignment_rl_rejects_missing_source_adapter_weights or preserves_source_adapter_artifacts or rebuild_index_skips_empty_failed_job_directories'
Result: 7 passed, 145 deselected.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run coverage run -m pytest services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_lora_experiment_store.py -q -k 'reward_score or score_response or alignment_rl_rejects_missing_source_adapter_weights or preserves_source_adapter_artifacts or rebuild_index_skips_empty_failed_job_directories'
Result: 7 passed, 145 deselected.

uv run coverage json -o .runtime/coverage-issue365-reward-review.json
Result: passed; wrote .runtime/coverage-issue365-reward-review.json.

python3 scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage-issue365-reward-review.json --diff-from HEAD services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/productization/lora_experiment_store.py
Result: 100.00% total changed-line coverage, 21/21 executable lines.

swift test --filter MelixCLIParserTests
Result: passed; 71 tests in 1 suite.

swift test --enable-code-coverage --filter MelixCLIParserTests
Result: passed; 71 tests in 1 suite.

python3 scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from HEAD Sources/MelixCLICore/MelixCLI.swift tests/MelixCLITests/MelixCLIParserTests.swift
Result: 100.00% total changed-line coverage, 21/21 executable lines.
```

## Coverage and Metrics
- Python changed-line coverage for this stacked branch against `origin/codex/issue365-qat-runtime`: 97.33% (146/150), above the 95% repository threshold. The uncovered changed lines are defensive fallback branches for unreadable resume adapter config/weights.
- Review follow-up changed-line coverage: 100.00% (21/21 executable lines, measured with `--diff-from HEAD`).
- Source-adapter CLI semantics follow-up changed-line coverage: 100.00% (21/21 executable Swift lines, measured with `--diff-from HEAD`).
- Real GRPO runtime acceptance: `lora_grpo_export_inference` passed LoRA training, `alignment.train`, publish, adapter-backed activation, `chat.run`, and `eval.run`; release-ready with no missing evidence.
- Real RLHF runtime acceptance: `lora_rlhf_export_inference` passed LoRA training, `alignment.train`, publish, adapter-backed activation, `chat.run`, and `eval.run`; release-ready with no missing evidence.
- Full Issue 365 real CLI acceptance on the stacked #442/#446/#451 branch: `.runtime/issue365/full-real-runtime-bundle-r2/bundle.json` reports `release_ready=true`, `succeeded_count=10`, `failed_count=0`, `blocked_count=0`, and `known_gaps=[]`.
- The full matrix covered `lora_export_inference`, `qlora_export_inference`, `dora_export_inference`, `lora_dpo_export_inference`, `lora_orpo_export_inference`, `lora_cpo_export_inference`, `lora_grpo_export_inference`, `lora_rlhf_export_inference`, `lora_preference_ptq_quantized_inference`, and `qat_quantized_inference`.
- Performance probes and target metrics are defined in `docs/plans/2026-05-05-issue-365-rl-alignment-runner.md`: reward runtime loads once per job, scoring uses deterministic scalar sampling, adapter artifacts are preserved for resumed alignment, and jobs record reward backend/model/score evidence.

## Known Gaps
- Issue #365 remains open in substance despite being closed on GitHub until the stacked #442/#446/#451 implementation and evidence land.
- Reward-model training and PPO/RL policy updates remain tracked by issue #366.
- Window UI real-runtime acceptance and final release evidence bundle separation remain out of scope for this PR.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
