### PR TITLE
perf: cache code eval sandbox profile keys

### DIFF
--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -468,8 +468,10 @@ def test_sandbox_profile_reuses_static_runtime_fragments(
     monkeypatch,
 ) -> None:
     code_eval_runner._sandbox_static_profile_fragments.cache_clear()
+    code_eval_runner._sandbox_static_profile_key_cache_clear()
     runtime_calls = 0
     executable_calls = 0
+    get_paths_calls = 0
 
     def fake_runtime_paths() -> tuple[Path, ...]:
         nonlocal runtime_calls
@@ -481,8 +483,14 @@ def test_sandbox_profile_reuses_static_runtime_fragments(
         executable_calls += 1
         return (tmp_path / "python",)
 
+    def fake_get_paths() -> dict[str, str]:
+        nonlocal get_paths_calls
+        get_paths_calls += 1
+        return {"stdlib": str(tmp_path / "stdlib")}
+
     monkeypatch.setattr(code_eval_runner, "_sandbox_runtime_read_paths", fake_runtime_paths)
     monkeypatch.setattr(code_eval_runner, "_sandbox_executable_paths", fake_executable_paths)
+    monkeypatch.setattr(code_eval_runner.sysconfig, "get_paths", fake_get_paths)
 
     first_root = tmp_path / "eval-a"
     second_root = tmp_path / "eval-b"
@@ -491,12 +499,14 @@ def test_sandbox_profile_reuses_static_runtime_fragments(
 
     assert runtime_calls == 1
     assert executable_calls == 1
+    assert get_paths_calls == 1
     assert str(first_root) in first_profile
     assert str(second_root) not in first_profile
     assert str(second_root) in second_profile
     assert str(tmp_path / "python-runtime") in second_profile
 
     code_eval_runner._sandbox_static_profile_fragments.cache_clear()
+    code_eval_runner._sandbox_static_profile_key_cache_clear()
 
 
 def test_sandbox_profile_cache_key_tracks_python_environment(
@@ -504,6 +514,7 @@ def test_sandbox_profile_cache_key_tracks_python_environment(
     monkeypatch,
 ) -> None:
     code_eval_runner._sandbox_static_profile_fragments.cache_clear()
+    code_eval_runner._sandbox_static_profile_key_cache_clear()
     runtime_calls = 0
 
     def fake_runtime_paths() -> tuple[Path, ...]:
@@ -526,6 +537,7 @@ def test_sandbox_profile_cache_key_tracks_python_environment(
     assert "runtime-2" in third_profile
 
     code_eval_runner._sandbox_static_profile_fragments.cache_clear()
+    code_eval_runner._sandbox_static_profile_key_cache_clear()
 
 
 def test_sandbox_allow_path_variants_falls_back_when_resolve_raises() -> None:

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -312,15 +312,38 @@ class _SandboxStaticProfileFragments:
     runtime_read_filters: str
 
 
-def _sandbox_static_profile_key() -> tuple[object, ...]:
+_SANDBOX_STATIC_PROFILE_KEY_CACHE: tuple[tuple[object, ...], tuple[object, ...]] | None = None
+
+
+def _sandbox_static_profile_environment_fingerprint() -> tuple[object, ...]:
     return (
         sys.executable,
         sys.prefix,
         sys.exec_prefix,
         sys.base_prefix,
         sys.base_exec_prefix,
+        id(sysconfig.get_paths),
+    )
+
+
+def _sandbox_static_profile_key() -> tuple[object, ...]:
+    global _SANDBOX_STATIC_PROFILE_KEY_CACHE
+    fingerprint = _sandbox_static_profile_environment_fingerprint()
+    if _SANDBOX_STATIC_PROFILE_KEY_CACHE is not None:
+        cached_fingerprint, cached_key = _SANDBOX_STATIC_PROFILE_KEY_CACHE
+        if cached_fingerprint == fingerprint:
+            return cached_key
+    key = (
+        *fingerprint[:-1],
         tuple(sorted((key, value or "") for key, value in sysconfig.get_paths().items())),
     )
+    _SANDBOX_STATIC_PROFILE_KEY_CACHE = (fingerprint, key)
+    return key
+
+
+def _sandbox_static_profile_key_cache_clear() -> None:
+    global _SANDBOX_STATIC_PROFILE_KEY_CACHE
+    _SANDBOX_STATIC_PROFILE_KEY_CACHE = None
 
 
 @lru_cache(maxsize=8)


### PR DESCRIPTION
## Summary
- Cache the code-eval sandbox static profile key behind a cheap process-environment fingerprint.
- Avoid rebuilding/sorting `sysconfig.get_paths()` for every `_sandbox_profile(...)` call when only the per-evaluation `temp_root` changes.
- Extend focused sandbox-profile tests to assert the sysconfig path map is read once across repeated profile builds while preserving environment invalidation.

## Plan or Spec
- `docs/plans/2026-05-05-code-eval-sandbox-profile-cache.md`
- Registered scoped CI probe: `code-eval-stdio-tail-single-stat`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_returns_timeout_result \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_uses_stderr_when_payload_is_missing \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_skips_parent_test_counting_after_successful_payload \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_text_handles_missing_and_oversized_files \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_output_limit_reuses_limited_stdio_sizes \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_sandbox_profile_reuses_static_runtime_fragments \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_sandbox_profile_cache_key_tracks_python_environment \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_stdio_probe_script_emits_metrics
# 10 passed in 0.93s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused nodes>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_stdio_probe.py
# TOTAL 23 0 100%

git diff --check
# passed

Detached origin/main vs head local probe:
PYTHONPATH="$DIR:$DIR/services/mlx-worker-python" uv run --project "$DIR/services/mlx-worker-python" python "$DIR/scripts/code_eval_stdio_probe.py"
# origin/main sandbox_profile_elapsed_ms_mean=249.61740979924798, sandbox_profile_static_builds_mean=1.0
# head sandbox_profile_elapsed_ms_mean=66.86333280522376, sandbox_profile_static_builds_mean=1.0
```

## Coverage and Metrics
- Changed executable scope coverage: `TOTAL 23 0 100%`.
- Local probe (`scripts/code_eval_stdio_probe.py`, detached `origin/main` vs branch):
  - `sandbox_profile_elapsed_ms_mean`: 249.617 ms -> 66.863 ms (~73.21% lower).
  - `sandbox_profile_static_builds_mean`: 1.0 -> 1.0.
  - stdio-tail metrics were informational/no target for this slice (`stdio_stat_calls_mean=6000.0` on both paths; elapsed noise is unrelated to the sandbox-profile change).

## Known Gaps
- Linux-only local verification; macOS/Swift tests were not run on this host.
- Hosted `pr-scoped-performance` remains the merge gate for the registered `code-eval-stdio-tail-single-stat` probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or no externally visible behavior changed.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
