### PR TITLE
Bridge Window acceptance to Issue 365 runtime evidence

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift
+++ b/apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift
@@ -298,12 +298,12 @@ private let phase8WindowUIBusinessLineCases: [Phase8WindowUIBusinessLineCase] = 
     ),
 ]
 
-struct Phase8Issue365CLIEvidenceBundle: Decodable, Equatable, Sendable {
+internal struct Phase8Issue365CLIEvidenceBundle: Decodable, Equatable, Sendable {
     let executionMode: String
     let releaseReady: Bool
     let cases: [Phase8Issue365CLIEvidenceCase]
 
-    var caseByID: [String: Phase8Issue365CLIEvidenceCase] {
+    func makeCaseIndex() -> [String: Phase8Issue365CLIEvidenceCase] {
         var indexedCases: [String: Phase8Issue365CLIEvidenceCase] = [:]
         for evidenceCase in cases where evidenceCase.caseID.isEmpty == false {
             indexedCases[evidenceCase.caseID] = evidenceCase
@@ -325,7 +325,7 @@ struct Phase8Issue365CLIEvidenceBundle: Decodable, Equatable, Sendable {
     }
 }
 
-struct Phase8Issue365CLIEvidenceCase: Decodable, Equatable, Sendable {
+internal struct Phase8Issue365CLIEvidenceCase: Decodable, Equatable, Sendable {
     let caseID: String
     let status: String
     let evidenceTier: String
@@ -347,7 +347,7 @@ struct Phase8Issue365CLIEvidenceCase: Decodable, Equatable, Sendable {
     }
 }
 
-struct Phase8WindowUIBusinessLineReleaseGate: Equatable, Sendable {
+internal struct Phase8WindowUIBusinessLineReleaseGate: Equatable, Sendable {
     let evidenceLevel: String
     let cliExecutionMode: String
     let cliCaseStatus: String
@@ -357,12 +357,13 @@ struct Phase8WindowUIBusinessLineReleaseGate: Equatable, Sendable {
     let releaseReadyBlocker: String
 }
 
-enum Phase8WindowUIReleaseGateResolver {
+internal enum Phase8WindowUIReleaseGateResolver {
     static func releaseGate(
         cliCaseID: String,
-        cliEvidenceBundle: Phase8Issue365CLIEvidenceBundle
+        cliEvidenceBundle: Phase8Issue365CLIEvidenceBundle,
+        cliCaseIndex: [String: Phase8Issue365CLIEvidenceCase]? = nil
     ) -> Phase8WindowUIBusinessLineReleaseGate {
-        let cliCase = cliEvidenceBundle.caseByID[cliCaseID]
+        let cliCase = (cliCaseIndex ?? cliEvidenceBundle.makeCaseIndex())[cliCaseID]
         let cliExecutionMode = cliEvidenceBundle.executionMode
         let cliCaseStatus = cliCase?.status ?? ""
         let cliCaseEvidenceTier = cliCase?.evidenceTier ?? ""
@@ -380,6 +381,8 @@ enum Phase8WindowUIReleaseGateResolver {
             )
         }
 
+        // Prefer the top-level bundle blocker before per-case diagnosis when
+        // the real CLI matrix itself is not release-ready.
         guard cliEvidenceBundle.releaseReady else {
             return .init(
                 evidenceLevel: phase8WindowUIBusinessLineEvidenceLevel,
@@ -733,19 +736,28 @@ public final class Phase8WindowUIAcceptanceRunner {
     private func collectBusinessLineEvidence(
         cliEvidenceBundle: Phase8Issue365CLIEvidenceBundle
     ) -> [Phase8WindowUIBusinessLineEvidence] {
-        phase8WindowUIBusinessLineCases.map { businessLine in
+        let cliCaseIndex = cliEvidenceBundle.makeCaseIndex()
+        return phase8WindowUIBusinessLineCases.map { businessLine in
             switch businessLine.kind {
             case .training(let mode):
                 return collectTrainingBusinessLineEvidence(
                     businessLine,
                     mode: mode,
-                    releaseGate: releaseGate(for: businessLine, cliEvidenceBundle: cliEvidenceBundle)
+                    releaseGate: releaseGate(
+                        for: businessLine,
+                        cliEvidenceBundle: cliEvidenceBundle,
+                        cliCaseIndex: cliCaseIndex
+                    )
                 )
             case .quantization(let mode):
                 return collectQuantizationBusinessLineEvidence(
                     businessLine,
                     mode: mode,
-                    releaseGate: releaseGate(for: businessLine, cliEvidenceBundle: cliEvidenceBundle)
+                    releaseGate: releaseGate(
+                        for: businessLine,
+                        cliEvidenceBundle: cliEvidenceBundle,
+                        cliCaseIndex: cliCaseIndex
+                    )
                 )
             }
         }
@@ -753,11 +765,13 @@ public final class Phase8WindowUIAcceptanceRunner {
 
     private func releaseGate(
         for businessLine: Phase8WindowUIBusinessLineCase,
-        cliEvidenceBundle: Phase8Issue365CLIEvidenceBundle
+        cliEvidenceBundle: Phase8Issue365CLIEvidenceBundle,
+        cliCaseIndex: [String: Phase8Issue365CLIEvidenceCase]
     ) -> Phase8WindowUIBusinessLineReleaseGate {
         Phase8WindowUIReleaseGateResolver.releaseGate(
             cliCaseID: businessLine.cliCaseID,
-            cliEvidenceBundle: cliEvidenceBundle
+            cliEvidenceBundle: cliEvidenceBundle,
+            cliCaseIndex: cliCaseIndex
         )
     }
 

--- a/apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift
+++ b/apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift
@@ -20,7 +20,11 @@ private let phase8MatrixRequests: UInt32 = 4
 private let phase8EvaluationSampleSize: UInt32 = 4
 private let phase8EvaluationScoringMode = "multiple_choice_accuracy"
 private let phase8WindowUIBusinessLineEvidenceLevel = "window_route_matrix"
+private let phase8WindowUIBusinessLineRealCLIEvidenceLevel = "window_route_matrix_with_real_cli_runtime"
 private let phase8WindowUIReleaseReadyBlocker = "real_local_runtime_matrix_not_run"
+private let phase8WindowUIUnreadyCLIBundleBlocker = "real_local_runtime_bundle_not_release_ready"
+private let phase8WindowUIMissingCLICaseBlocker = "real_local_runtime_case_missing"
+private let phase8WindowUIUnreadyCLICaseBlocker = "real_local_runtime_case_not_release_ready"
 
 public enum Phase8WindowUIAcceptanceError: Error, LocalizedError {
     case missingCLIEvidenceBundle(String)
@@ -202,12 +206,14 @@ private enum Phase8WindowUIBusinessLineKind: Equatable, Sendable {
 
 private struct Phase8WindowUIBusinessLineCase: Equatable, Sendable {
     let caseID: String
+    let cliCaseID: String
     let businessLine: String
     let kind: Phase8WindowUIBusinessLineKind
 }
 
 private struct Phase8WindowUIBusinessLineEvidence: Codable, Equatable, Sendable {
     let caseID: String
+    let cliCaseID: String
     let businessLine: String
     let evidenceLevel: String
     let selectedSurface: String
@@ -221,22 +227,206 @@ private struct Phase8WindowUIBusinessLineEvidence: Codable, Equatable, Sendable 
     let selectable: Bool
     let runnable: Bool
     let inspectable: Bool
+    let cliExecutionMode: String
+    let cliCaseStatus: String
+    let cliCaseEvidenceTier: String
+    let cliCaseReleaseReady: Bool
     let releaseReady: Bool
     let releaseReadyBlocker: String
 }
 
 private let phase8WindowUIBusinessLineCases: [Phase8WindowUIBusinessLineCase] = [
-    .init(caseID: "base_lora_export_local_inference", businessLine: "BaseModel -> LoRA -> export -> local inference", kind: .training(.lora)),
-    .init(caseID: "base_qlora_export_local_inference", businessLine: "BaseModel -> QLoRA -> export -> local inference", kind: .training(.qlora)),
-    .init(caseID: "base_dora_export_local_inference", businessLine: "BaseModel -> DoRA -> export -> local inference", kind: .training(.dora)),
-    .init(caseID: "lora_dpo_export_local_inference", businessLine: "BaseModel -> LoRA -> DPO -> export -> local inference", kind: .training(.dpo)),
-    .init(caseID: "lora_orpo_export_local_inference", businessLine: "BaseModel -> LoRA -> ORPO -> export -> local inference", kind: .training(.orpo)),
-    .init(caseID: "lora_cpo_export_local_inference", businessLine: "BaseModel -> LoRA -> CPO -> export -> local inference", kind: .training(.cpo)),
-    .init(caseID: "lora_grpo_export_local_inference", businessLine: "BaseModel -> LoRA -> GRPO -> export -> local inference", kind: .training(.grpo)),
-    .init(caseID: "lora_rlhf_export_local_inference", businessLine: "BaseModel -> LoRA -> RLHF using #366 reward model -> export -> local inference", kind: .training(.rlhf)),
-    .init(caseID: "lora_preference_ptq_local_inference", businessLine: "BaseModel -> LoRA/preference result -> merge/export -> PTQ -> local inference", kind: .quantization(.ptq)),
-    .init(caseID: "qat_quantized_local_inference", businessLine: "BaseModel -> QAT/QAT-aware export -> quantized local inference", kind: .quantization(.qat)),
+    .init(
+        caseID: "base_lora_export_local_inference",
+        cliCaseID: "lora_export_inference",
+        businessLine: "BaseModel -> LoRA -> export -> local inference",
+        kind: .training(.lora)
+    ),
+    .init(
+        caseID: "base_qlora_export_local_inference",
+        cliCaseID: "qlora_export_inference",
+        businessLine: "BaseModel -> QLoRA -> export -> local inference",
+        kind: .training(.qlora)
+    ),
+    .init(
+        caseID: "base_dora_export_local_inference",
+        cliCaseID: "dora_export_inference",
+        businessLine: "BaseModel -> DoRA -> export -> local inference",
+        kind: .training(.dora)
+    ),
+    .init(
+        caseID: "lora_dpo_export_local_inference",
+        cliCaseID: "lora_dpo_export_inference",
+        businessLine: "BaseModel -> LoRA -> DPO -> export -> local inference",
+        kind: .training(.dpo)
+    ),
+    .init(
+        caseID: "lora_orpo_export_local_inference",
+        cliCaseID: "lora_orpo_export_inference",
+        businessLine: "BaseModel -> LoRA -> ORPO -> export -> local inference",
+        kind: .training(.orpo)
+    ),
+    .init(
+        caseID: "lora_cpo_export_local_inference",
+        cliCaseID: "lora_cpo_export_inference",
+        businessLine: "BaseModel -> LoRA -> CPO -> export -> local inference",
+        kind: .training(.cpo)
+    ),
+    .init(
+        caseID: "lora_grpo_export_local_inference",
+        cliCaseID: "lora_grpo_export_inference",
+        businessLine: "BaseModel -> LoRA -> GRPO -> export -> local inference",
+        kind: .training(.grpo)
+    ),
+    .init(
+        caseID: "lora_rlhf_export_local_inference",
+        cliCaseID: "lora_rlhf_export_inference",
+        businessLine: "BaseModel -> LoRA -> RLHF using #366 reward model -> export -> local inference",
+        kind: .training(.rlhf)
+    ),
+    .init(
+        caseID: "lora_preference_ptq_local_inference",
+        cliCaseID: "lora_preference_ptq_quantized_inference",
+        businessLine: "BaseModel -> LoRA/preference result -> merge/export -> PTQ -> local inference",
+        kind: .quantization(.ptq)
+    ),
+    .init(
+        caseID: "qat_quantized_local_inference",
+        cliCaseID: "qat_quantized_inference",
+        businessLine: "BaseModel -> QAT/QAT-aware export -> quantized local inference",
+        kind: .quantization(.qat)
+    ),
 ]
+
+struct Phase8Issue365CLIEvidenceBundle: Decodable, Equatable, Sendable {
+    let executionMode: String
+    let releaseReady: Bool
+    let cases: [Phase8Issue365CLIEvidenceCase]
+
+    var caseByID: [String: Phase8Issue365CLIEvidenceCase] {
+        var indexedCases: [String: Phase8Issue365CLIEvidenceCase] = [:]
+        for evidenceCase in cases where evidenceCase.caseID.isEmpty == false {
+            indexedCases[evidenceCase.caseID] = evidenceCase
+        }
+        return indexedCases
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case executionMode = "execution_mode"
+        case releaseReady = "release_ready"
+        case cases
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.executionMode = try container.decodeIfPresent(String.self, forKey: .executionMode) ?? ""
+        self.releaseReady = try container.decodeIfPresent(Bool.self, forKey: .releaseReady) ?? false
+        self.cases = try container.decodeIfPresent([Phase8Issue365CLIEvidenceCase].self, forKey: .cases) ?? []
+    }
+}
+
+struct Phase8Issue365CLIEvidenceCase: Decodable, Equatable, Sendable {
+    let caseID: String
+    let status: String
+    let evidenceTier: String
+    let releaseReady: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case caseID = "case_id"
+        case status
+        case evidenceTier = "evidence_tier"
+        case releaseReady = "release_ready"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.caseID = try container.decodeIfPresent(String.self, forKey: .caseID) ?? ""
+        self.status = try container.decodeIfPresent(String.self, forKey: .status) ?? ""
+        self.evidenceTier = try container.decodeIfPresent(String.self, forKey: .evidenceTier) ?? ""
+        self.releaseReady = try container.decodeIfPresent(Bool.self, forKey: .releaseReady) ?? false
+    }
+}
+
+struct Phase8WindowUIBusinessLineReleaseGate: Equatable, Sendable {
+    let evidenceLevel: String
+    let cliExecutionMode: String
+    let cliCaseStatus: String
+    let cliCaseEvidenceTier: String
+    let cliCaseReleaseReady: Bool
+    let releaseReady: Bool
+    let releaseReadyBlocker: String
+}
+
+enum Phase8WindowUIReleaseGateResolver {
+    static func releaseGate(
+        cliCaseID: String,
+        cliEvidenceBundle: Phase8Issue365CLIEvidenceBundle
+    ) -> Phase8WindowUIBusinessLineReleaseGate {
+        let cliCase = cliEvidenceBundle.caseByID[cliCaseID]
+        let cliExecutionMode = cliEvidenceBundle.executionMode
+        let cliCaseStatus = cliCase?.status ?? ""
+        let cliCaseEvidenceTier = cliCase?.evidenceTier ?? ""
+        let cliCaseReleaseReady = cliCase?.releaseReady ?? false
+
+        guard cliExecutionMode == "real" else {
+            return .init(
+                evidenceLevel: phase8WindowUIBusinessLineEvidenceLevel,
+                cliExecutionMode: cliExecutionMode,
+                cliCaseStatus: cliCaseStatus,
+                cliCaseEvidenceTier: cliCaseEvidenceTier,
+                cliCaseReleaseReady: cliCaseReleaseReady,
+                releaseReady: false,
+                releaseReadyBlocker: phase8WindowUIReleaseReadyBlocker
+            )
+        }
+
+        guard cliEvidenceBundle.releaseReady else {
+            return .init(
+                evidenceLevel: phase8WindowUIBusinessLineEvidenceLevel,
+                cliExecutionMode: cliExecutionMode,
+                cliCaseStatus: cliCaseStatus,
+                cliCaseEvidenceTier: cliCaseEvidenceTier,
+                cliCaseReleaseReady: cliCaseReleaseReady,
+                releaseReady: false,
+                releaseReadyBlocker: phase8WindowUIUnreadyCLIBundleBlocker
+            )
+        }
+
+        guard cliCase != nil else {
+            return .init(
+                evidenceLevel: phase8WindowUIBusinessLineEvidenceLevel,
+                cliExecutionMode: cliExecutionMode,
+                cliCaseStatus: "",
+                cliCaseEvidenceTier: "",
+                cliCaseReleaseReady: false,
+                releaseReady: false,
+                releaseReadyBlocker: "\(phase8WindowUIMissingCLICaseBlocker):\(cliCaseID)"
+            )
+        }
+
+        guard cliCaseStatus == "succeeded", cliCaseReleaseReady else {
+            return .init(
+                evidenceLevel: phase8WindowUIBusinessLineEvidenceLevel,
+                cliExecutionMode: cliExecutionMode,
+                cliCaseStatus: cliCaseStatus,
+                cliCaseEvidenceTier: cliCaseEvidenceTier,
+                cliCaseReleaseReady: cliCaseReleaseReady,
+                releaseReady: false,
+                releaseReadyBlocker: "\(phase8WindowUIUnreadyCLICaseBlocker):\(cliCaseID)"
+            )
+        }
+
+        return .init(
+            evidenceLevel: phase8WindowUIBusinessLineRealCLIEvidenceLevel,
+            cliExecutionMode: cliExecutionMode,
+            cliCaseStatus: cliCaseStatus,
+            cliCaseEvidenceTier: cliCaseEvidenceTier,
+            cliCaseReleaseReady: cliCaseReleaseReady,
+            releaseReady: true,
+            releaseReadyBlocker: ""
+        )
+    }
+}
 
 private struct Phase8WindowUIAcceptanceBundle: Codable, Equatable, Sendable {
     let schemaVersion: String
@@ -339,6 +529,7 @@ public final class Phase8WindowUIAcceptanceRunner {
         guard fileManager.fileExists(atPath: cliBundleURL.path) else {
             throw Phase8WindowUIAcceptanceError.missingCLIEvidenceBundle(cliBundleURL.path)
         }
+        let cliEvidenceBundle = try loadCLIEvidenceBundle(from: cliBundleURL)
 
         let bundleRoot = URL(fileURLWithPath: config.melixHome, isDirectory: true)
             .appendingPathComponent("acceptance", isDirectory: true)
@@ -463,7 +654,7 @@ public final class Phase8WindowUIAcceptanceRunner {
             outputURL: exportsRoot.appendingPathComponent("evaluation-samples.jsonl")
         )
 
-        let businessLines = collectBusinessLineEvidence()
+        let businessLines = collectBusinessLineEvidence(cliEvidenceBundle: cliEvidenceBundle)
 
         await viewModel.refreshDesktopFoundation()
         viewModel.selectSurface(.server)
@@ -533,20 +724,47 @@ public final class Phase8WindowUIAcceptanceRunner {
         )
     }
 
-    private func collectBusinessLineEvidence() -> [Phase8WindowUIBusinessLineEvidence] {
+    private func loadCLIEvidenceBundle(from bundleURL: URL) throws -> Phase8Issue365CLIEvidenceBundle {
+        let decoder = JSONDecoder()
+        let data = try Data(contentsOf: bundleURL)
+        return try decoder.decode(Phase8Issue365CLIEvidenceBundle.self, from: data)
+    }
+
+    private func collectBusinessLineEvidence(
+        cliEvidenceBundle: Phase8Issue365CLIEvidenceBundle
+    ) -> [Phase8WindowUIBusinessLineEvidence] {
         phase8WindowUIBusinessLineCases.map { businessLine in
             switch businessLine.kind {
             case .training(let mode):
-                return collectTrainingBusinessLineEvidence(businessLine, mode: mode)
+                return collectTrainingBusinessLineEvidence(
+                    businessLine,
+                    mode: mode,
+                    releaseGate: releaseGate(for: businessLine, cliEvidenceBundle: cliEvidenceBundle)
+                )
             case .quantization(let mode):
-                return collectQuantizationBusinessLineEvidence(businessLine, mode: mode)
+                return collectQuantizationBusinessLineEvidence(
+                    businessLine,
+                    mode: mode,
+                    releaseGate: releaseGate(for: businessLine, cliEvidenceBundle: cliEvidenceBundle)
+                )
             }
         }
     }
 
+    private func releaseGate(
+        for businessLine: Phase8WindowUIBusinessLineCase,
+        cliEvidenceBundle: Phase8Issue365CLIEvidenceBundle
+    ) -> Phase8WindowUIBusinessLineReleaseGate {
+        Phase8WindowUIReleaseGateResolver.releaseGate(
+            cliCaseID: businessLine.cliCaseID,
+            cliEvidenceBundle: cliEvidenceBundle
+        )
+    }
+
     private func collectTrainingBusinessLineEvidence(
         _ businessLine: Phase8WindowUIBusinessLineCase,
-        mode: RuntimeLoraTrainingMode
+        mode: RuntimeLoraTrainingMode,
+        releaseGate: Phase8WindowUIBusinessLineReleaseGate
     ) -> Phase8WindowUIBusinessLineEvidence {
         viewModel.selectSurface(.tools)
         viewModel.selectToolSection(.training)
@@ -574,8 +792,9 @@ public final class Phase8WindowUIAcceptanceRunner {
 
         return Phase8WindowUIBusinessLineEvidence(
             caseID: businessLine.caseID,
+            cliCaseID: businessLine.cliCaseID,
             businessLine: businessLine.businessLine,
-            evidenceLevel: phase8WindowUIBusinessLineEvidenceLevel,
+            evidenceLevel: releaseGate.evidenceLevel,
             selectedSurface: viewModel.selectedSurface.rawValue,
             selectedToolSection: viewModel.selectedToolSection.rawValue,
             selectedTrainingMode: mode.rawValue,
@@ -587,14 +806,19 @@ public final class Phase8WindowUIAcceptanceRunner {
             selectable: selectable,
             runnable: runnable,
             inspectable: inspectable,
-            releaseReady: false,
-            releaseReadyBlocker: phase8WindowUIReleaseReadyBlocker
+            cliExecutionMode: releaseGate.cliExecutionMode,
+            cliCaseStatus: releaseGate.cliCaseStatus,
+            cliCaseEvidenceTier: releaseGate.cliCaseEvidenceTier,
+            cliCaseReleaseReady: releaseGate.cliCaseReleaseReady,
+            releaseReady: releaseGate.releaseReady,
+            releaseReadyBlocker: releaseGate.releaseReadyBlocker
         )
     }
 
     private func collectQuantizationBusinessLineEvidence(
         _ businessLine: Phase8WindowUIBusinessLineCase,
-        mode: RuntimeQuantizationMode
+        mode: RuntimeQuantizationMode,
+        releaseGate: Phase8WindowUIBusinessLineReleaseGate
     ) -> Phase8WindowUIBusinessLineEvidence {
         viewModel.selectSurface(.tools)
         viewModel.selectToolSection(.downloads)
@@ -610,8 +834,9 @@ public final class Phase8WindowUIAcceptanceRunner {
 
         return Phase8WindowUIBusinessLineEvidence(
             caseID: businessLine.caseID,
+            cliCaseID: businessLine.cliCaseID,
             businessLine: businessLine.businessLine,
-            evidenceLevel: phase8WindowUIBusinessLineEvidenceLevel,
+            evidenceLevel: releaseGate.evidenceLevel,
             selectedSurface: viewModel.selectedSurface.rawValue,
             selectedToolSection: viewModel.selectedToolSection.rawValue,
             selectedTrainingMode: "",
@@ -623,8 +848,12 @@ public final class Phase8WindowUIAcceptanceRunner {
             selectable: selectable,
             runnable: runnable,
             inspectable: inspectable,
-            releaseReady: false,
-            releaseReadyBlocker: phase8WindowUIReleaseReadyBlocker
+            cliExecutionMode: releaseGate.cliExecutionMode,
+            cliCaseStatus: releaseGate.cliCaseStatus,
+            cliCaseEvidenceTier: releaseGate.cliCaseEvidenceTier,
+            cliCaseReleaseReady: releaseGate.cliCaseReleaseReady,
+            releaseReady: releaseGate.releaseReady,
+            releaseReadyBlocker: releaseGate.releaseReadyBlocker
         )
     }
 

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -6013,6 +6013,100 @@ struct Phase8WindowUIAcceptanceRunnerTests {
         #expect(viewModel.selectedQuantizationMode == .qat)
     }
 
+    @Test("phase 8 window ui release gate requires top-level and case-level real CLI evidence")
+    func phase8WindowUIReleaseGateRequiresRealCLIEvidence() throws {
+        let dryRunBundle = try decodePhase8Issue365CLIBundle(
+            #"""
+            {
+              "execution_mode": "dry-run",
+              "release_ready": false,
+              "cases": [
+                {
+                  "case_id": "lora_export_inference",
+                  "status": "planned",
+                  "evidence_tier": "deterministic_dry_run",
+                  "release_ready": false
+                }
+              ]
+            }
+            """#
+        )
+        let dryRunGate = Phase8WindowUIReleaseGateResolver.releaseGate(
+            cliCaseID: "lora_export_inference",
+            cliEvidenceBundle: dryRunBundle
+        )
+        #expect(dryRunGate.releaseReady == false)
+        #expect(dryRunGate.releaseReadyBlocker == "real_local_runtime_matrix_not_run")
+        #expect(dryRunGate.cliExecutionMode == "dry-run")
+        #expect(dryRunGate.cliCaseStatus == "planned")
+        #expect(dryRunGate.cliCaseEvidenceTier == "deterministic_dry_run")
+
+        let unreadyBundle = try decodePhase8Issue365CLIBundle(
+            #"""
+            {
+              "execution_mode": "real",
+              "release_ready": false,
+              "cases": [
+                {
+                  "case_id": "lora_export_inference",
+                  "status": "succeeded",
+                  "evidence_tier": "real_local_runtime",
+                  "release_ready": true
+                }
+              ]
+            }
+            """#
+        )
+        let unreadyGate = Phase8WindowUIReleaseGateResolver.releaseGate(
+            cliCaseID: "lora_export_inference",
+            cliEvidenceBundle: unreadyBundle
+        )
+        #expect(unreadyGate.releaseReady == false)
+        #expect(unreadyGate.releaseReadyBlocker == "real_local_runtime_bundle_not_release_ready")
+        #expect(unreadyGate.cliCaseReleaseReady == true)
+
+        let missingCaseBundle = try decodePhase8Issue365CLIBundle(
+            #"""
+            {
+              "execution_mode": "real",
+              "release_ready": true,
+              "cases": []
+            }
+            """#
+        )
+        let missingCaseGate = Phase8WindowUIReleaseGateResolver.releaseGate(
+            cliCaseID: "lora_export_inference",
+            cliEvidenceBundle: missingCaseBundle
+        )
+        #expect(missingCaseGate.releaseReady == false)
+        #expect(missingCaseGate.releaseReadyBlocker == "real_local_runtime_case_missing:lora_export_inference")
+        #expect(missingCaseGate.cliCaseStatus == "")
+
+        let failedCaseBundle = try decodePhase8Issue365CLIBundle(
+            #"""
+            {
+              "execution_mode": "real",
+              "release_ready": true,
+              "cases": [
+                {
+                  "case_id": "lora_export_inference",
+                  "status": "failed",
+                  "evidence_tier": "real_local_runtime",
+                  "release_ready": false
+                }
+              ]
+            }
+            """#
+        )
+        let failedCaseGate = Phase8WindowUIReleaseGateResolver.releaseGate(
+            cliCaseID: "lora_export_inference",
+            cliEvidenceBundle: failedCaseBundle
+        )
+        #expect(failedCaseGate.releaseReady == false)
+        #expect(failedCaseGate.releaseReadyBlocker == "real_local_runtime_case_not_release_ready:lora_export_inference")
+        #expect(failedCaseGate.cliCaseStatus == "failed")
+    }
+
     @Test("phase 8 window ui acceptance runner writes a screenshot and evidence bundle")
     @MainActor
     func phase8WindowUIAcceptanceRunnerWritesEvidenceBundle() async throws {
@@ -6029,7 +6123,7 @@ struct Phase8WindowUIAcceptanceRunnerTests {
             at: cliBundlePath.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        try Data("{\"ok\":true}\n".utf8).write(to: cliBundlePath)
+        try Data(makeIssue365ReleaseReadyCLIBundleJSON().utf8).write(to: cliBundlePath)
         let materializedModelID = "melix-dev-qwen-local"
         let derivedModelID = "\(materializedModelID)-lora-adapter"
 
@@ -6234,10 +6328,22 @@ struct Phase8WindowUIAcceptanceRunnerTests {
         #expect(businessLines.allSatisfy { $0["selectable"] as? Bool == true })
         #expect(businessLines.allSatisfy { $0["runnable"] as? Bool == true })
         #expect(businessLines.allSatisfy { $0["inspectable"] as? Bool == true })
-        #expect(businessLines.allSatisfy { $0["release_ready"] as? Bool == false })
+        #expect(businessLines.allSatisfy { $0["release_ready"] as? Bool == true })
+        #expect(businessLines.allSatisfy { $0["release_ready_blocker"] as? String == "" })
+        #expect(businessLines.allSatisfy { $0["evidence_level"] as? String == "window_route_matrix_with_real_cli_runtime" })
+        #expect(businessLines.allSatisfy { $0["cli_execution_mode"] as? String == "real" })
+        #expect(businessLines.allSatisfy { $0["cli_case_status"] as? String == "succeeded" })
+        #expect(businessLines.allSatisfy { $0["cli_case_evidence_tier"] as? String == "real_local_runtime" })
+        #expect(businessLines.allSatisfy { $0["cli_case_release_ready"] as? Bool == true })
+        let loraLine = try #require(
+            businessLines.first { $0["case_id"] as? String == "base_lora_export_local_inference" }
+        )
+        #expect(loraLine["cli_case_id"] as? String == "lora_export_inference")
         let dpoLine = try #require(businessLines.first { $0["case_id"] as? String == "lora_dpo_export_local_inference" })
+        #expect(dpoLine["cli_case_id"] as? String == "lora_dpo_export_inference")
         #expect(dpoLine["routed_command"] as? String == "alignment.train")
         let qatLine = try #require(businessLines.first { $0["case_id"] as? String == "qat_quantized_local_inference" })
+        #expect(qatLine["cli_case_id"] as? String == "qat_quantized_inference")
         #expect(qatLine["selected_quantization_mode"] as? String == "qat")
         #expect(qatLine["routed_command"] as? String == "model.quantize")
 
@@ -6900,6 +7006,91 @@ private final class RecordingPhase8WindowUIRenderer: Phase8WindowUIRendering {
         )
         try Data("png".utf8).write(to: outputURL)
     }
+}
+
+private func makeIssue365ReleaseReadyCLIBundleJSON() -> String {
+    #"""
+    {
+      "schema_version": "melix.issue365.acceptance_bundle.v1",
+      "execution_mode": "real",
+      "release_ready": true,
+      "known_gaps": [],
+      "summary": {
+        "case_count": 10,
+        "succeeded_count": 10,
+        "failed_count": 0,
+        "blocked_count": 0,
+        "release_ready_case_count": 10,
+        "release_ready": true
+      },
+      "cases": [
+        {
+          "case_id": "lora_export_inference",
+          "status": "succeeded",
+          "evidence_tier": "real_local_runtime",
+          "release_ready": true
+        },
+        {
+          "case_id": "qlora_export_inference",
+          "status": "succeeded",
+          "evidence_tier": "real_local_runtime",
+          "release_ready": true
+        },
+        {
+          "case_id": "dora_export_inference",
+          "status": "succeeded",
+          "evidence_tier": "real_local_runtime",
+          "release_ready": true
+        },
+        {
+          "case_id": "lora_dpo_export_inference",
+          "status": "succeeded",
+          "evidence_tier": "real_local_runtime",
+          "release_ready": true
+        },
+        {
+          "case_id": "lora_orpo_export_inference",
+          "status": "succeeded",
+          "evidence_tier": "real_local_runtime",
+          "release_ready": true
+        },
+        {
+          "case_id": "lora_cpo_export_inference",
+          "status": "succeeded",
+          "evidence_tier": "real_local_runtime",
+          "release_ready": true
+        },
+        {
+          "case_id": "lora_grpo_export_inference",
+          "status": "succeeded",
+          "evidence_tier": "real_local_runtime",
+          "release_ready": true
+        },
+        {
+          "case_id": "lora_rlhf_export_inference",
+          "status": "succeeded",
+          "evidence_tier": "real_local_runtime",
+          "release_ready": true
+        },
+        {
+          "case_id": "lora_preference_ptq_quantized_inference",
+          "status": "succeeded",
+          "evidence_tier": "real_local_runtime",
+          "release_ready": true
+        },
+        {
+          "case_id": "qat_quantized_inference",
+          "status": "succeeded",
+          "evidence_tier": "real_local_runtime",
+          "release_ready": true
+        }
+      ]
+    }
+    """#
+}
+
+private func decodePhase8Issue365CLIBundle(_ json: String) throws -> Phase8Issue365CLIEvidenceBundle {
+    try JSONDecoder().decode(Phase8Issue365CLIEvidenceBundle.self, from: Data(json.utf8))
 }
 
 @MainActor

--- a/docs/plans/2026-05-06-issue-365-window-acceptance-matrix.md
+++ b/docs/plans/2026-05-06-issue-365-window-acceptance-matrix.md
@@ -4,11 +4,20 @@
 
 Continue https://github.com/Keith-CY/melix/issues/365 by making the native
 Window UI evidence bundle enumerate every required business line and by adding
-an explicit PTQ/QAT mode selector to the Window quantization surface.
+an explicit PTQ/QAT mode selector to the Window quantization surface. The
+follow-up real-evidence bridge makes the Window UI bundle consume the same
+Issue 365 CLI acceptance bundle so each Window business line can chain to the
+matching real local runtime case.
 
 Issue 365 is still not complete after this slice. The evidence added here is
-Window UI routing and inspectability evidence. It does not claim final
-real-local-runtime release readiness for any business line.
+Window UI routing and inspectability evidence plus a chained CLI real-runtime
+release gate. A Window business line is only marked `release_ready=true` when
+the configured CLI bundle is `execution_mode=real`, the top-level CLI bundle is
+`release_ready=true`, and the matching CLI case is `status=succeeded` with
+`release_ready=true`. This does not mean every business line was independently
+clicked through in the Window UI; it means the Window route is visible,
+selectable, runnable, and inspectable while the same business line is backed by
+the release-ready CLI real-runtime case.
 
 ## Scope
 
@@ -26,15 +35,28 @@ real-local-runtime release readiness for any business line.
   - DPO, ORPO, CPO, GRPO, and RLHF alignment workflows.
   - PTQ quantized local inference workflow.
   - QAT/QAT-aware quantized local inference workflow.
-- Mark the matrix evidence as non-release-ready until real local runtime runs
-  succeed for the same cases.
+- Map each Window business-line case to the corresponding Issue 365 CLI case:
+  - `base_lora_export_local_inference` -> `lora_export_inference`
+  - `base_qlora_export_local_inference` -> `qlora_export_inference`
+  - `base_dora_export_local_inference` -> `dora_export_inference`
+  - `lora_dpo_export_local_inference` -> `lora_dpo_export_inference`
+  - `lora_orpo_export_local_inference` -> `lora_orpo_export_inference`
+  - `lora_cpo_export_local_inference` -> `lora_cpo_export_inference`
+  - `lora_grpo_export_local_inference` -> `lora_grpo_export_inference`
+  - `lora_rlhf_export_local_inference` -> `lora_rlhf_export_inference`
+  - `lora_preference_ptq_local_inference` -> `lora_preference_ptq_quantized_inference`
+  - `qat_quantized_local_inference` -> `qat_quantized_inference`
+- Keep the matrix evidence non-release-ready when the CLI bundle is missing
+  real execution mode, is not top-level release-ready, lacks the mapped case,
+  or has a mapped case that is not succeeded and release-ready.
 
 ### Excluded
 
 - Real GRPO/RLHF policy updates.
 - Reward-model training artifacts from issue 366.
 - MLX-native full-tensor QAT execution.
-- Full real-runtime CLI or Window acceptance execution for every business line.
+- Independent Window click-through execution for every business line beyond the
+  existing route/runnable/inspectable checks.
 - Screenshot artifact preservation.
 - Closing issue 365.
 
@@ -49,7 +71,11 @@ Success metrics:
 - Quantization command construction keeps the existing unit-test dispatch path.
 - The Window acceptance bundle contains exactly 10 business-line entries.
 - Each matrix entry records visible/selectable/runnable/inspectable routing
-  state and keeps `release_ready=false`.
+  state and the mapped CLI case id/status/evidence tier.
+- Matrix entries only use
+  `evidence_level=window_route_matrix_with_real_cli_runtime` and
+  `release_ready=true` when the mapped real CLI case is release-ready under a
+  top-level release-ready real CLI bundle.
 - Changed-scope tests remain green with at least 95 percent changed-line
   coverage for the touched Swift scope.
 
@@ -89,7 +115,8 @@ Results on 2026-05-06:
 
 ## Remaining Issue 365 Gaps
 
-- Real local runtime evidence for every CLI and Window business line.
 - Final populated release evidence bundle.
 - GRPO/RLHF policy-update implementation and reward-model artifact integration.
 - MLX-native full QAT backend execution and release-gated evidence.
+- Independent Window click-through execution for every business line beyond the
+  route-level acceptance checks.


### PR DESCRIPTION
## Summary
- Chain Phase 8 Window UI business-line evidence to the Issue 365 CLI real-runtime acceptance bundle.
- Add explicit Window-to-CLI case ids and release-gate fields so Window evidence is only release-ready when the mapped real CLI case is succeeded and release-ready.
- Update the active Window acceptance matrix plan to document the evidence boundary and remaining Issue 365 gaps.
- Address review follow-up by precomputing the CLI case index once per acceptance run, documenting bundle-level blocker priority, and making the CLI evidence access levels explicit.

## Plan or Spec
- `docs/plans/2026-05-06-issue-365-window-acceptance-matrix.md`

## Commands Run
```text
swift test --package-path apps/macos-menubar --filter 'Phase8WindowUIAcceptanceRunnerTests|RuntimeViewModelTests'
Result: pass; 255 tests in 2 suites passed.

swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'Phase8WindowUIAcceptanceRunnerTests|RuntimeViewModelTests'
Result: pass; 255 tests in 2 suites passed.

python3 scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/codex/issue365-reward-runtime-evidence apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift docs/plans/2026-05-06-issue-365-window-acceptance-matrix.md
Result: pass; TOTAL 100.00%, 314/314 changed executable lines covered.

git diff --check
Result: pass; no whitespace errors.

jq '{execution_mode, release_ready, known_gaps, summary}' /Users/ChenYu/Documents/Github/melix/.worktrees/issue365-reward-runtime-evidence/.runtime/issue365/full-real-runtime-bundle-r2/bundle.json
Result: pass; execution_mode=real, release_ready=true, known_gaps=[], 10/10 cases succeeded and release-ready.

swift test --package-path apps/macos-menubar --filter Phase8WindowUIAcceptanceRunnerTests
Result: pass; 7 tests in 1 suite passed.

swift test --package-path apps/macos-menubar --enable-code-coverage --filter Phase8WindowUIAcceptanceRunnerTests
Result: pass; 7 tests in 1 suite passed.

python3 scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from HEAD apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift
Result: pass; TOTAL 100.00%, 18/18 changed executable lines covered.
```

## Coverage and Metrics
- Changed-line coverage: 100.00% (314/314 changed executable lines).
- Review follow-up changed-line coverage: 100.00% (18/18 changed executable lines, measured with `--diff-from HEAD`).
- Business-line evidence mapping: 10 Window UI cases mapped to 10 Issue 365 CLI real-runtime cases.
- CLI evidence consumed for local verification: `.worktrees/issue365-reward-runtime-evidence/.runtime/issue365/full-real-runtime-bundle-r2/bundle.json`, with `execution_mode=real`, top-level `release_ready=true`, `succeeded_count=10`, `failed_count=0`, `blocked_count=0`, and `known_gaps=[]`.
- Performance probes: N/A for this slice. The changed code decodes one local acceptance JSON bundle and evaluates a fixed 10-case in-memory release gate during an acceptance run; no long-running runtime path or operator interaction latency path is changed.

## Known Gaps
- Issue 365 is not complete until the stacked PR sequence lands and the final completion audit confirms every acceptance item.
- This Window evidence proves route visibility, selectability, runnability, inspectability, and chained real CLI runtime readiness. It does not prove independent Window click-through execution for every business line.
- GRPO/RLHF policy updates and reward-model training artifacts remain outside this Issue 365 slice unless the roadmap boundary is explicitly expanded.
- MLX-native full QAT backend execution remains deferred from this Window evidence bridge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
