### PR TITLE
perf: cache code eval sandbox profile keys

### DIFF
--- a/docs/plans/2026-05-06-code-eval-sandbox-profile-key-cache.md
+++ b/docs/plans/2026-05-06-code-eval-sandbox-profile-key-cache.md
@@ -1,0 +1,31 @@
+# Code Eval Sandbox Profile Key Cache
+
+## Goal
+
+Reduce repeated Python-environment introspection while building code-evaluation sandbox profiles. The dynamic temporary-root clauses still differ per evaluation run, but the static profile cache key is process-environment derived and should not rebuild `sysconfig.get_paths()` for every `_sandbox_profile(...)` call.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `scripts/code_eval_stdio_probe.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Linux Constraint
+
+This is a Python-only slice under `services/mlx-worker-python`, so local Linux verification uses focused pytest, changed-scope coverage, and an explicit PR-scoped performance probe run. It does not require macOS/Swift local validation.
+
+## Probe Definition
+
+Reuse the existing registered PR-scoped probe:
+
+- `code-eval-stdio-tail-single-stat`
+
+The probe already measures sandbox profile generation. This slice extends the probe script with a structural `sandbox_profile_sysconfig_get_paths_calls_mean` metric so the optimization has a deterministic signal in addition to elapsed wall time.
+
+## Success Metrics
+
+- Focused tests pass.
+- Changed-scope coverage for touched executable Python/test/script lines is at least 95%.
+- Local probe shows reduced sandbox profile elapsed time and reduced `sysconfig.get_paths()` calls versus `origin/main`.
+- `git diff --check` passes.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -468,8 +468,10 @@ def test_sandbox_profile_reuses_static_runtime_fragments(
     monkeypatch,
 ) -> None:
     code_eval_runner._sandbox_static_profile_fragments.cache_clear()
+    code_eval_runner._cached_sandbox_static_profile_key.cache_clear()
     runtime_calls = 0
     executable_calls = 0
+    get_paths_calls = 0
 
     def fake_runtime_paths() -> tuple[Path, ...]:
         nonlocal runtime_calls
@@ -481,8 +483,14 @@ def test_sandbox_profile_reuses_static_runtime_fragments(
         executable_calls += 1
         return (tmp_path / "python",)
 
+    def fake_get_paths() -> dict[str, str]:
+        nonlocal get_paths_calls
+        get_paths_calls += 1
+        return {"stdlib": str(tmp_path / "stdlib")}
+
     monkeypatch.setattr(code_eval_runner, "_sandbox_runtime_read_paths", fake_runtime_paths)
     monkeypatch.setattr(code_eval_runner, "_sandbox_executable_paths", fake_executable_paths)
+    monkeypatch.setattr(code_eval_runner.sysconfig, "get_paths", fake_get_paths)
 
     first_root = tmp_path / "eval-a"
     second_root = tmp_path / "eval-b"
@@ -491,12 +499,14 @@ def test_sandbox_profile_reuses_static_runtime_fragments(
 
     assert runtime_calls == 1
     assert executable_calls == 1
+    assert get_paths_calls == 1
     assert str(first_root) in first_profile
     assert str(second_root) not in first_profile
     assert str(second_root) in second_profile
     assert str(tmp_path / "python-runtime") in second_profile
 
     code_eval_runner._sandbox_static_profile_fragments.cache_clear()
+    code_eval_runner._cached_sandbox_static_profile_key.cache_clear()
 
 
 def test_sandbox_profile_cache_key_tracks_python_environment(
@@ -504,6 +514,7 @@ def test_sandbox_profile_cache_key_tracks_python_environment(
     monkeypatch,
 ) -> None:
     code_eval_runner._sandbox_static_profile_fragments.cache_clear()
+    code_eval_runner._cached_sandbox_static_profile_key.cache_clear()
     runtime_calls = 0
 
     def fake_runtime_paths() -> tuple[Path, ...]:
@@ -526,6 +537,7 @@ def test_sandbox_profile_cache_key_tracks_python_environment(
     assert "runtime-2" in third_profile
 
     code_eval_runner._sandbox_static_profile_fragments.cache_clear()
+    code_eval_runner._cached_sandbox_static_profile_key.cache_clear()
 
 
 def test_sandbox_allow_path_variants_falls_back_when_resolve_raises() -> None:

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -313,12 +313,25 @@ class _SandboxStaticProfileFragments:
 
 
 def _sandbox_static_profile_key() -> tuple[object, ...]:
+    return _cached_sandbox_static_profile_key(_sandbox_static_profile_environment_fingerprint())
+
+
+def _sandbox_static_profile_environment_fingerprint() -> tuple[str, str, str, str, str]:
     return (
         sys.executable,
         sys.prefix,
         sys.exec_prefix,
         sys.base_prefix,
         sys.base_exec_prefix,
+    )
+
+
+@lru_cache(maxsize=1)
+def _cached_sandbox_static_profile_key(
+    environment_fingerprint: tuple[str, str, str, str, str],
+) -> tuple[object, ...]:
+    return (
+        *environment_fingerprint,
         tuple(sorted((key, value or "") for key, value in sysconfig.get_paths().items())),
     )
 


### PR DESCRIPTION
## Summary
- Cache the code-eval sandbox static profile key behind a cheap Python environment fingerprint.
- Preserve per-evaluation temp-root sandbox clauses while avoiding repeated `sysconfig.get_paths()` / interpreter-path introspection for stable runtime metadata.
- Add focused regression coverage for cache reuse and environment invalidation.

## Plan or Spec
- Plan: `docs/plans/2026-05-06-code-eval-sandbox-profile-key-cache.md`
- Scope: Python-only optimization in `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
- Verification path: existing registered scoped probe `code-eval-stdio-tail-single-stat` watches this code-eval path and includes the new focused sandbox-profile cache tests.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_returns_timeout_result services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_uses_stderr_when_payload_is_missing services/mlx-worker-python/tests/test_code_eval_runner.py::test_run_python_code_evaluation_skips_parent_test_counting_after_successful_payload services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_text_handles_missing_and_oversized_files services/mlx-worker-python/tests/test_code_eval_runner.py::test_output_limit_reuses_limited_stdio_sizes services/mlx-worker-python/tests/test_code_eval_runner.py::test_sandbox_profile_reuses_static_runtime_fragments services/mlx-worker-python/tests/test_code_eval_runner.py::test_sandbox_profile_cache_key_tracks_python_environment services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_stdio_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...same focused selection... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-stdio-tail-single-stat --base-repo /tmp/melix-base-codeeval-20260506135200 --head-repo "$PWD" --output /tmp/code-eval-stdio-probe-result-after-amend.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `10 passed in 0.80s`.
- Focused coverage rerun: `10 passed in 1.08s`.
- Changed-scope coverage after the amend: `TOTAL 0 0 100%` from `scripts/changed_scope_coverage.py` on the committed diff state; before the amend, the same focused command covered all measurable changed executable lines (`43/43`, `100%`) while the now-reverted probe instrumentation files were still in the diff.
- Registered local scoped probe: `code-eval-stdio-tail-single-stat`.
  - Base (`origin/main`): `sandbox_profile_elapsed_ms_mean=245.582799 ms`, `elapsed_ms_mean=30.094337 ms`, `stdio_stat_calls_mean=6000.0`, `sandbox_profile_static_builds_mean=1.0`.
  - Head: `sandbox_profile_elapsed_ms_mean=68.622973 ms`, `elapsed_ms_mean=29.735311 ms`, `stdio_stat_calls_mean=6000.0`, `sandbox_profile_static_builds_mean=1.0`.
  - Interpretation: sandbox-profile construction portion improved by ~72.06% while stdio tail behavior stayed unchanged.
- Hosted `pr-scoped-performance` for head `1b858346c3a7841758ddf21b09184b33411c6c70`: `scope`, `probes (code-eval-code-block-last-match-streaming, ...)`, `probes (code-eval-stdio-tail-single-stat, ...)`, and `report` all passed.

## Known Gaps
- Linux host only: full Swift/macOS validation was not run locally.
- Broader `ci-pr` checks are still hosted-only and may continue after the scoped performance report finishes.

## Evidence Checklist
- [x] Plan/spec linked.
- [x] Focused tests passed.
- [x] Changed-scope coverage measured for touched Python/test scope.
- [x] Explicit performance probe run with base-vs-head metrics.
- [x] Registered scoped CI probe identified: `code-eval-stdio-tail-single-stat`.
- [x] `git diff --check` passed.
