### PR TITLE
perf: scan hub catalog cursor links without splitting

### DIFF
--- a/docs/plans/2026-05-06-hub-catalog-cursor-fast-parse.md
+++ b/docs/plans/2026-05-06-hub-catalog-cursor-fast-parse.md
@@ -1,0 +1,33 @@
+# Hub Catalog Cursor Fast Parse Optimization
+
+## Goal
+
+Reduce transient allocation and redundant string splitting while parsing Hugging Face `Link` headers for the `rel="next"` cursor in `worker/model_ops/hub_catalog.py`.
+
+## Scope
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+
+## Linux-only constraint
+
+This is a Python worker slice and can be verified locally on Linux with focused pytest, changed-scope coverage, and the existing PR-scoped performance probe.
+
+## Performance probe
+
+Registered probe: `hub-catalog-next-cursor-fast-parse`
+
+Probe command:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/hub_catalog_next_cursor_probe.py
+```
+
+Success metric: lower `elapsed_ms_mean` for repeated cursor parsing while preserving `cursor_parse_calls_mean`, checksum, and decoded cursor values. Peak traced bytes should not materially regress.
+
+## Implementation plan
+
+1. Replace `link_header.split(",")` with a single forward scan over `<...>` link segments so URLs containing commas do not force full header list materialization.
+2. Replace query `split("&")` with bounded index scanning for `cursor=` between `?`, `&`, and `#` delimiters.
+3. Add focused regression coverage for comma-containing next URLs and cursor parameters without values.
+4. Verify with focused tests, changed-scope coverage, local probe, and `git diff --check`.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -236,10 +236,20 @@ def test_next_cursor_from_link_extracts_encoded_next_cursor_without_full_query_p
     assert hub_catalog_module._next_cursor_from_link(link_header) == "abc/def ghi"
 
 
+def test_next_cursor_from_link_scans_segments_without_splitting_on_url_commas() -> None:
+    link_header = (
+        '<https://huggingface.co/api/models?cursor=prev>; rel="prev", '
+        '<https://huggingface.co/api/models?note=a,b&cursor=page%2C2&full=true>; rel="next"'
+    )
+
+    assert hub_catalog_module._next_cursor_from_link(link_header) == "page,2"
+
+
 def test_next_cursor_from_link_returns_empty_for_missing_or_malformed_next_cursor() -> None:
     assert hub_catalog_module._next_cursor_from_link('<https://huggingface.co/api/models?cursor=prev>; rel="prev"') == ""
     assert hub_catalog_module._next_cursor_from_link('<https://huggingface.co/api/models>; rel="next"') == ""
     assert hub_catalog_module._next_cursor_from_link('<https://huggingface.co/api/models?limit=10>; rel="next"') == ""
+    assert hub_catalog_module._next_cursor_from_link('<https://huggingface.co/api/models?cursor>; rel="next"') == ""
     assert hub_catalog_module._next_cursor_from_link('https://huggingface.co/api/models?cursor=broken; rel="next"') == ""
 
 

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -258,29 +258,37 @@ class HubCatalog:
 
 
 def _next_cursor_from_link(link_header: str) -> str:
-    for raw_part in link_header.split(","):
-        part = raw_part.strip()
-        if 'rel="next"' not in part:
-            continue
-        if not part.startswith("<") or ">" not in part:
-            continue
-        next_url = part[1:part.index(">")]
-        return _cursor_query_value(next_url)
-    return ""
+    search_start = 0
+    while True:
+        url_start = link_header.find("<", search_start)
+        if url_start < 0:
+            return ""
+        url_end = link_header.find(">", url_start + 1)
+        if url_end < 0:
+            return ""
+        next_url_start = link_header.find("<", url_end + 1)
+        relation_end = next_url_start if next_url_start >= 0 else len(link_header)
+        if 'rel="next"' in link_header[url_end + 1 : relation_end]:
+            return _cursor_query_value(link_header[url_start + 1 : url_end])
+        search_start = relation_end
 
 
 def _cursor_query_value(url: str) -> str:
     query_start = url.find("?")
     if query_start < 0:
         return ""
-    query = url[query_start + 1:]
-    fragment_start = query.find("#")
-    if fragment_start >= 0:
-        query = query[:fragment_start]
-    for parameter in query.split("&"):
-        key, separator, value = parameter.partition("=")
-        if separator and key == "cursor":
-            return unquote_plus(value)
+    query_end = url.find("#", query_start + 1)
+    if query_end < 0:
+        query_end = len(url)
+    parameter_start = query_start + 1
+    while parameter_start < query_end:
+        parameter_end = url.find("&", parameter_start, query_end)
+        if parameter_end < 0:
+            parameter_end = query_end
+        value_start = parameter_start + len("cursor=")
+        if url.startswith("cursor=", parameter_start):
+            return unquote_plus(url[value_start:parameter_end])
+        parameter_start = parameter_end + 1
     return ""
 
 


### PR DESCRIPTION
## Summary
- Replaces full `Link` header and query-string splitting in the Hub catalog next-cursor parser with bounded index scanning.
- Preserves decoded cursor behavior while avoiding list materialization and handling comma-containing next-link URLs.
- Adds focused regression coverage for comma-bearing next URLs and malformed cursor parameters.

## Plan or Spec
- Plan: `docs/plans/2026-05-06-hub-catalog-cursor-fast-parse.md`
- Existing scoped CI probe: `hub-catalog-next-cursor-fast-parse`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics
# 34 passed in 0.54s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o /tmp/melix-hub-cursor-coverage.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/melix-hub-cursor-coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py
# TOTAL 29 1 97%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/hub_catalog_next_cursor_probe.py
# {"checksum": 6509477.0, "cursor_parse_calls_mean": 50000.0, "elapsed_ms_mean": 1461.407596617937, "peak_bytes_mean": 13212.6, "sample_count": 5.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-next-cursor-fast-parse --base-repo /tmp/melix-base-hub-cursor-20260506165630 --head-repo /tmp/melix-cron-opt-20260506165630 --output /tmp/melix-hub-cursor-probe.json
# head verification ok; base/head probe ok

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 29 1 97%`.
  - `services/mlx-worker-python/worker/model_ops/hub_catalog.py`: 24/25 changed executable lines covered (`96.00%`).
  - `services/mlx-worker-python/tests/test_hub_catalog.py`: 4/4 changed executable lines covered (`100.00%`).
- Local direct head probe: `elapsed_ms_mean=1461.4076`, `peak_bytes_mean=13212.6`, `cursor_parse_calls_mean=50000.0`, checksum unchanged at `6509477.0`.
- Local registered base-vs-head probe (`hub-catalog-next-cursor-fast-parse`):
  - Base: `elapsed_ms_mean=1775.1098`, `peak_bytes_mean=12856.0`, `cursor_parse_calls_mean=50000.0`.
  - Head: `elapsed_ms_mean=1445.5720`, `peak_bytes_mean=11086.6`, `cursor_parse_calls_mean=50000.0`.
  - Interpretation: ~18.56% lower mean elapsed time and ~13.76% lower mean peak traced bytes for the synthetic cursor parser workload.

## Known Gaps
- Linux-only local verification was run for this Python worker slice.
- Full macOS/Swift test suites were not run locally on this Linux host.
- Hosted `pr-scoped-performance` / broader PR CI remains the merge gate after PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
