### PR TITLE
perf: stream MLX audio flat arrays into WAV

### DIFF
--- a/docs/plans/2026-05-06-mlx-audio-flat-array-streaming.md
+++ b/docs/plans/2026-05-06-mlx-audio-flat-array-streaming.md
@@ -1,0 +1,33 @@
+# MLX Audio Flat Array Streaming Plan
+
+## Context
+
+This Linux-verifiable Python slice targets `services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py`.
+The WAV encoder already writes PCM frames in bounded chunks, but `_iter_samples(...)` still calls
+`tolist()` before iteration for array-like audio payloads. NumPy/MLX-style arrays commonly expose a
+`.flat` iterator that can stream samples without materializing a full Python list first.
+
+## Proposed Change
+
+- Prefer a `.flat` iterator for non-list/tuple array-like audio payloads before falling back to
+  `tolist()`.
+- Preserve scalar, nested `list`/`tuple`, and legacy `tolist()` behavior.
+- Extend the focused WAV streaming test to assert flat array-like inputs do not call `tolist()`.
+- Update the existing `mlx-audio-wav-streaming-pcm` probe script workload so branch-side probe runs
+  exercise the `.flat` streaming path while retaining the existing metrics contract.
+
+## Verification Plan
+
+- Focused pytest:
+  `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_wav_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_wav_streaming_probe_script_emits_metrics`
+- Changed-scope coverage with the registered `mlx-audio-wav-streaming-pcm` coverage command.
+- Local performance probe:
+  `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/mlx_audio_wav_streaming_probe.py`
+- Diff hygiene: `git diff --check`.
+
+## Success Metrics
+
+- Changed executable scope coverage is at least 95%.
+- The `mlx-audio-wav-streaming-pcm` local probe emits concrete `elapsed_ms_mean` and
+  `peak_bytes_mean` numbers without changing WAV byte size or sample count.
+- Hosted PR-scoped performance CI validates the registered `mlx-audio-wav-streaming-pcm` probe before merge.

--- a/scripts/mlx_audio_wav_streaming_probe.py
+++ b/scripts/mlx_audio_wav_streaming_probe.py
@@ -19,6 +19,14 @@ class ArrayLikeSegment:
     def __init__(self, values):
         self._values = values
 
+    @property
+    def flat(self):
+        for value in self._values:
+            if isinstance(value, (list, tuple)):
+                yield from value
+            else:
+                yield value
+
     def tolist(self):
         return self._values
 
@@ -32,7 +40,9 @@ def _build_audio(sample_count: int):
             segments.append(chunk)
         else:
             midpoint = len(chunk) // 2
-            segments.append(ArrayLikeSegment((chunk[:midpoint], tuple(chunk[midpoint:]))))
+            segments.append(
+                ArrayLikeSegment((chunk[:midpoint], chunk[midpoint], tuple(chunk[midpoint + 1 :])))
+            )
     return segments
 
 

--- a/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
@@ -603,6 +603,25 @@ def test_audio_to_wav_bytes_does_not_materialize_flat_sample_list(monkeypatch: p
         assert handle.getnframes() == 9000
         assert handle.getframerate() == 24_000
 
+    class FlatArrayLike:
+        def __init__(self) -> None:
+            self.tolist_calls = 0
+            self.flat = (0.1 for _ in range(4))
+
+        def tolist(self):
+            self.tolist_calls += 1
+            raise AssertionError("flat audio arrays should stream without tolist materialization")
+
+    flat_audio = FlatArrayLike()
+    flat_wav_bytes = mlx_audio_runtime._audio_to_wav_bytes(flat_audio, sample_rate=12_000)
+
+    assert flat_audio.tolist_calls == 0
+    with pytest.raises(AssertionError, match="flat audio arrays"):
+        flat_audio.tolist()
+    with wave.open(BytesIO(flat_wav_bytes), "rb") as handle:
+        assert handle.getnframes() == 4
+        assert handle.getframerate() == 12_000
+
 
 def test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts(
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
@@ -38,13 +38,22 @@ def _normalize_language(value) -> str:
 
 
 def _iter_samples(value):
-    if hasattr(value, "tolist"):
-        value = value.tolist()
     if isinstance(value, (float, int)):
         yield float(value)
         return
+    flat_values = getattr(value, "flat", None)
+    if flat_values is not None and not isinstance(value, (list, tuple)):
+        for item in flat_values:
+            yield float(item)
+        return
+    if hasattr(value, "tolist"):
+        value = value.tolist()
     for item in value:
-        if isinstance(item, (list, tuple)) or hasattr(item, "tolist"):
+        if (
+            isinstance(item, (list, tuple))
+            or hasattr(item, "flat")
+            or hasattr(item, "tolist")
+        ):
             yield from _iter_samples(item)
         else:
             yield float(item)


### PR DESCRIPTION
## Summary
- Stream MLX/NumPy-style flat audio arrays through `_iter_samples(...)` before falling back to `tolist()`.
- Preserve existing scalar, nested list/tuple, and legacy `tolist()` behavior for WAV encoding.
- Update the registered `mlx-audio-wav-streaming-pcm` probe script workload to exercise flat array-like segments.

## Plan or Spec
- Plan: `docs/plans/2026-05-06-mlx-audio-flat-array-streaming.md`
- Registered scoped probe: `mlx-audio-wav-streaming-pcm`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_wav_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_wav_streaming_probe_script_emits_metrics
# 6 passed in 5.55s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_wav_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_wav_streaming_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_audio_wav_streaming_probe.py
# 6 passed in 18.65s; TOTAL 30 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/mlx_audio_wav_streaming_probe.py
# {"elapsed_ms_mean": 745.839551, "elapsed_ms_min": 721.963998, "peak_bytes_mean": 659638.0, "sample_count": 240000.0, "wav_bytes": 480044.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id mlx-audio-wav-streaming-pcm --base-repo /tmp/melix-cron-opt-base-20260506181104 --head-repo "$PWD" --output /tmp/mlx-audio-wav-probe-20260506181104.json
# head verification ok; coverage 100%; base elapsed_ms_mean=760.848811 peak_bytes_mean=659622.0; head elapsed_ms_mean=723.337624 peak_bytes_mean=659638.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed executable scope coverage: `TOTAL 30 0 100%`.
- Local registered probe `mlx-audio-wav-streaming-pcm`:
  - base: `elapsed_ms_mean=760.848811`, `peak_bytes_mean=659622.0`, `sample_count=240000.0`, `wav_bytes=480044.0`
  - head: `elapsed_ms_mean=723.337624`, `peak_bytes_mean=659638.0`, `sample_count=240000.0`, `wav_bytes=480044.0`
- Direct head probe run: `elapsed_ms_mean=745.839551`, `elapsed_ms_min=721.963998`, `peak_bytes_mean=659638.0`, `sample_count=240000.0`, `wav_bytes=480044.0`.

## Known Gaps
- Linux-only local verification; macOS/Swift checks were not run locally.
- Hosted PR-scoped performance CI remains the merge gate for the registered probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
