### PR TITLE
perf: avoid benchmark queue warm Path construction

### DIFF
--- a/docs/plans/2026-05-06-benchmark-queue-string-cache-key.md
+++ b/docs/plans/2026-05-06-benchmark-queue-string-cache-key.md
@@ -1,0 +1,33 @@
+# Benchmark queue string cache key
+
+## Goal
+
+Reduce warm-cache overhead in the Python benchmark queue record listing path by avoiding per-entry `Path` construction when `os.DirEntry` metadata already proves that the cached decoded record is still valid.
+
+## Scope
+
+- `services/mlx-worker-python/worker/productization/benchmark_queue.py`
+- `services/mlx-worker-python/tests/test_benchmark_queue.py`
+- Registered probe: `benchmark-queue-decoded-record-cache` in `infra/perf/pr_scoped_probes.json`
+
+## Plan
+
+1. Keep `BenchmarkQueueStore.list_records()` on the existing `os.scandir()` path.
+2. Key the decoded-record cache by filesystem string path so `entry.path` can be used directly on the warm list path.
+3. Preserve defensive copies at public return boundaries and existing cache invalidation by metadata key.
+4. Add regression coverage proving the warm list path does not construct `Path` objects after a cache hit.
+5. Run the registered focused tests, changed-scope coverage command, and registered probe locally on Linux before PR creation.
+
+## Performance Probe
+
+The affected path is already covered by the registered PR-scoped probe `benchmark-queue-decoded-record-cache`, including:
+
+- `test_command`
+- `coverage_command`
+- `probe_command`
+
+Primary metrics remain `cold_elapsed_ms`, `warm_elapsed_ms_mean`, and `warm_json_loads_mean`. The expected improvement is in `warm_elapsed_ms_mean`; `warm_json_loads_mean` should remain `0.0` for warm-cache reads.
+
+## Validation Boundary
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime validation is required for this slice.

--- a/services/mlx-worker-python/tests/test_benchmark_queue.py
+++ b/services/mlx-worker-python/tests/test_benchmark_queue.py
@@ -411,6 +411,44 @@ def test_list_records_reuses_cached_decoded_records_for_unchanged_files(
     assert loads == 1
 
 
+def test_list_records_warm_cache_uses_direntry_string_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    queue_root = tmp_path / "queue"
+    queue_root.mkdir()
+    payload = BenchmarkQueueRecord(
+        queue_item_id="queue-1",
+        job_kind="benchmark",
+        model_id="melix-dev-text",
+        suite_ids=("smoke",),
+        parameters={"sample_size": "32"},
+        status="queued",
+        created_at_unix_ms=100,
+        updated_at_unix_ms=100,
+    ).to_dict()
+    (queue_root / "queue-1.json").write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    store = BenchmarkQueueStore()
+
+    first = store.list_records(queue_root=queue_root)
+
+    path_constructions = 0
+    original_path = Path
+
+    def tracked_path(*args: object, **kwargs: object) -> Path:  # pragma: no cover
+        nonlocal path_constructions  # pragma: no cover
+        path_constructions += 1  # pragma: no cover
+        return original_path(*args, **kwargs)  # pragma: no cover
+
+    monkeypatch.setattr("worker.productization.benchmark_queue.Path", tracked_path)
+
+    second = store.list_records(queue_root=queue_root)
+
+    assert [record.queue_item_id for record in first] == ["queue-1"]
+    assert [record.queue_item_id for record in second] == ["queue-1"]
+    assert path_constructions == 0
+
+
 def test_list_records_decodes_uncached_records_from_bytes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/services/mlx-worker-python/worker/productization/benchmark_queue.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_queue.py
@@ -65,7 +65,7 @@ class BenchmarkQueueRecord:
 
 class BenchmarkQueueStore:
     def __init__(self) -> None:
-        self._decoded_record_cache: dict[Path, _RecordCacheEntry] = {}
+        self._decoded_record_cache: dict[str, _RecordCacheEntry] = {}
 
     def enqueue(
         self,
@@ -93,10 +93,9 @@ class BenchmarkQueueStore:
                         continue
                     if not stat.S_ISREG(stat_result.st_mode):
                         continue
-                    path = Path(entry.path)
                     records.append(
                         self._load_record(
-                            path,
+                            entry.path,
                             metadata_key=self._metadata_key_from_stat(stat_result),
                         )
                     )
@@ -142,23 +141,26 @@ class BenchmarkQueueStore:
             json.dumps(persisted_record.to_dict(), indent=2) + "\n",
             encoding="utf-8",
         )
-        self._decoded_record_cache[path] = _RecordCacheEntry(
+        self._decoded_record_cache[os.fspath(path)] = _RecordCacheEntry(
             metadata_key=self._metadata_key(path),
             record=persisted_record,
         )
 
     def _load_record(
         self,
-        path: Path,
+        path: Path | str,
         *,
         metadata_key: tuple[int, int, int, int] | None = None,
     ) -> BenchmarkQueueRecord:
-        current_metadata_key = self._metadata_key(path) if metadata_key is None else metadata_key
-        cached = self._decoded_record_cache.get(path)
+        cache_key = os.fspath(path)
+        current_metadata_key = (
+            self._metadata_key(Path(path)) if metadata_key is None else metadata_key
+        )
+        cached = self._decoded_record_cache.get(cache_key)
         if cached is not None and cached.metadata_key == current_metadata_key:
             return cached.record
-        record = BenchmarkQueueRecord.from_dict(json.loads(path.read_bytes()))
-        self._decoded_record_cache[path] = _RecordCacheEntry(
+        record = BenchmarkQueueRecord.from_dict(json.loads(Path(path).read_bytes()))
+        self._decoded_record_cache[cache_key] = _RecordCacheEntry(
             metadata_key=current_metadata_key,
             record=record,
         )


### PR DESCRIPTION
## Summary
- Avoid per-entry `Path` construction on warm benchmark queue cache hits by keying decoded records with filesystem string paths.
- Preserve existing metadata-key invalidation and public defensive-copy behavior.
- Add regression coverage for the warm-cache no-`Path` construction path.

## Plan or Spec
- `docs/plans/2026-05-06-benchmark-queue-string-cache-key.md`
- Registered PR-scoped probe: `benchmark-queue-decoded-record-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
# 26 passed in 11.81s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_queue.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 26 passed in 36.07s; changed-scope coverage TOTAL 21 0 100%

git diff --check
# exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_benchmark_queue_probe.py
# baseline origin/main: {"cold_elapsed_ms": 5.938487, "cold_json_loads": 128.0, "record_count": 128.0, "warm_elapsed_ms_mean": 1.511, "warm_json_loads_mean": 0.0, "warm_sample_count": 5.0}
# branch: {"cold_elapsed_ms": 5.406029, "cold_json_loads": 128.0, "record_count": 128.0, "warm_elapsed_ms_mean": 0.683207, "warm_json_loads_mean": 0.0, "warm_sample_count": 5.0}
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 21 0 100%`).
- Registered probe metric comparison (`benchmark-queue-decoded-record-cache`, local Linux):
  - `warm_elapsed_ms_mean`: 1.511 ms → 0.683207 ms (delta -0.827793 ms, ~54.8% faster)
  - `cold_elapsed_ms`: 5.938487 ms → 5.406029 ms (delta -0.532458 ms, ~9.0% faster)
  - `warm_json_loads_mean`: 0.0 → 0.0 (unchanged)
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local validation covers the Python benchmark queue path on Linux only; no Swift runtime path is touched.
- CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
