### PR TITLE
Fix runtime kwarg capability detection

### DIFF
--- a/docs/plans/2026-05-07-runtime-kwarg-capability-semantics.md
+++ b/docs/plans/2026-05-07-runtime-kwarg-capability-semantics.md
@@ -28,7 +28,7 @@ Touched files:
 
 `worker.runtime.runtime_utils` owns a single cached callable kwarg capability analysis result. Runtime callers choose between:
 
-- `callable_declares_kwarg(...)` when a backend library must explicitly understand a keyword.
+- `callable_declares_kwarg(...)` when a backend library must explicitly declare a keyword-accessible parameter.
 - `callable_accepts_kwarg(...)` when forwarding to an adapter that safely accepts arbitrary `**kwargs`.
 
 Text stop-sequence forwarding, VLM MTP/video capability detection, and audio speech parameter detection use the explicit-declaration path. Engine/runtime adapter optional arguments keep using the accept-any-kwargs path.

--- a/docs/plans/2026-05-07-runtime-kwarg-capability-semantics.md
+++ b/docs/plans/2026-05-07-runtime-kwarg-capability-semantics.md
@@ -1,0 +1,50 @@
+# Runtime Kwarg Capability Semantics
+
+## Goal
+
+Make runtime callable kwarg checks explicit enough to preserve hot-path signature caching without conflating two different semantics:
+
+- a callable explicitly declares a keyword parameter
+- a callable can accept arbitrary `**kwargs`
+
+## Scope
+
+Touched files:
+
+- `services/mlx-worker-python/worker/runtime/runtime_utils.py`
+- `services/mlx-worker-python/worker/runtime/mlx_text_runtime.py`
+- `services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py`
+- `services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py`
+- `services/mlx-worker-python/tests/test_runtime_utils.py`
+- `services/mlx-worker-python/tests/test_mlx_backend.py`
+- `services/mlx-worker-python/tests/test_mlx_vlm_runtime.py`
+- `services/mlx-worker-python/tests/test_mlx_audio_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/mlx_text_stop_kwarg_signature_probe.py`
+- `scripts/mlx_audio_generate_signature_probe.py`
+- `scripts/mlx_audio_speech_signature_probe.py`
+
+## Design
+
+`worker.runtime.runtime_utils` owns a single cached callable kwarg capability analysis result. Runtime callers choose between:
+
+- `callable_declares_kwarg(...)` when a backend library must explicitly understand a keyword.
+- `callable_accepts_kwarg(...)` when forwarding to an adapter that safely accepts arbitrary `**kwargs`.
+
+Text stop-sequence forwarding, VLM MTP/video capability detection, and audio speech parameter detection use the explicit-declaration path. Engine/runtime adapter optional arguments keep using the accept-any-kwargs path.
+
+## Performance Probes
+
+Existing scoped probes remain authoritative:
+
+- `runtime-utils-kwarg-signature-cache`
+- `mlx-text-stop-kwarg-signature-cache`
+- `mlx-audio-generate-signature-cache`
+- `mlx-audio-speech-signature-cache`
+
+## Success Metrics
+
+- `make py-test` passes on `origin/main` plus this fix.
+- Focused runtime utility, text backend, VLM backend, and audio runtime tests pass.
+- Signature inspections remain cached per callable instead of per generation/speech request.
+- Variadic `**kwargs` backends are not treated as explicitly supporting backend-specific kwargs such as text `stop`, VLM `video`, or MTP `draft_*` arguments.

--- a/scripts/mlx_audio_generate_signature_probe.py
+++ b/scripts/mlx_audio_generate_signature_probe.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 
 from worker.runtime import mlx_audio_runtime
+from worker.runtime import runtime_utils
 from worker.runtime.audio_runtime_protocols import AudioRuntimeLoadedModel
 from packages.protocol.python.worker.v1 import inference_pb2
 
@@ -41,8 +42,11 @@ def _loaded_model(model: FakeTTSModel) -> AudioRuntimeLoadedModel:
         "output_formats": ("wav",),
     }
     field_names = {field.name for field in fields(AudioRuntimeLoadedModel)}
+    generate_signature = runtime_utils.callable_kwarg_signature(model.generate)
+    if "speech_generate_parameters" in field_names:
+        kwargs["speech_generate_parameters"] = generate_signature.declared_kwargs
     if "generate_parameter_names" in field_names:
-        kwargs["generate_parameter_names"] = tuple(mlx_audio_runtime.signature(model.generate).parameters)
+        kwargs["generate_parameter_names"] = generate_signature.parameter_names
     return AudioRuntimeLoadedModel(**kwargs)
 
 
@@ -52,9 +56,10 @@ def run_probe() -> dict[str, float]:
     elapsed_samples: list[float] = []
     signature_call_samples: list[float] = []
     byte_count = 0
-    original_signature = mlx_audio_runtime.signature
+    original_signature = runtime_utils.inspect.signature
 
     for _ in range(sample_count):
+        runtime_utils.clear_callable_accepts_kwarg_cache()
         signature_calls = 0
 
         def tracked_signature(callable_obj):
@@ -63,7 +68,7 @@ def run_probe() -> dict[str, float]:
             return original_signature(callable_obj)
 
         model = FakeTTSModel()
-        mlx_audio_runtime.signature = tracked_signature
+        runtime_utils.inspect.signature = tracked_signature
         try:
             loaded_model = _loaded_model(model)
             runtime = mlx_audio_runtime.MLXAudioSpeechRuntime()
@@ -81,7 +86,8 @@ def run_probe() -> dict[str, float]:
             elapsed_samples.append((time.perf_counter() - started_at) * 1000.0)
             signature_call_samples.append(float(signature_calls))
         finally:
-            mlx_audio_runtime.signature = original_signature
+            runtime_utils.inspect.signature = original_signature
+            runtime_utils.clear_callable_accepts_kwarg_cache()
 
     if byte_count <= 0:
         raise RuntimeError("mlx-audio signature probe produced no audio bytes")

--- a/scripts/mlx_audio_generate_signature_probe.py
+++ b/scripts/mlx_audio_generate_signature_probe.py
@@ -44,7 +44,7 @@ def _loaded_model(model: FakeTTSModel) -> AudioRuntimeLoadedModel:
     field_names = {field.name for field in fields(AudioRuntimeLoadedModel)}
     generate_signature = runtime_utils.callable_kwarg_signature(model.generate)
     if "speech_generate_parameters" in field_names:
-        kwargs["speech_generate_parameters"] = generate_signature.declared_kwargs
+        kwargs["speech_generate_parameters"] = generate_signature.keyword_accessible_params
     if "generate_parameter_names" in field_names:
         kwargs["generate_parameter_names"] = generate_signature.parameter_names
     return AudioRuntimeLoadedModel(**kwargs)
@@ -59,7 +59,7 @@ def run_probe() -> dict[str, float]:
     original_signature = runtime_utils.inspect.signature
 
     for _ in range(sample_count):
-        runtime_utils.clear_callable_accepts_kwarg_cache()
+        runtime_utils.clear_callable_kwarg_signature_cache()
         signature_calls = 0
 
         def tracked_signature(callable_obj):
@@ -87,7 +87,7 @@ def run_probe() -> dict[str, float]:
             signature_call_samples.append(float(signature_calls))
         finally:
             runtime_utils.inspect.signature = original_signature
-            runtime_utils.clear_callable_accepts_kwarg_cache()
+            runtime_utils.clear_callable_kwarg_signature_cache()
 
     if byte_count <= 0:
         raise RuntimeError("mlx-audio signature probe produced no audio bytes")

--- a/scripts/mlx_audio_speech_signature_probe.py
+++ b/scripts/mlx_audio_speech_signature_probe.py
@@ -63,7 +63,7 @@ def main() -> None:
 
     runtime_utils.inspect.signature = tracked_signature
     try:
-        runtime_utils.clear_callable_accepts_kwarg_cache()
+        runtime_utils.clear_callable_kwarg_signature_cache()
         loaded = runtime.load_model(WorkerModelCatalog.mlx_qwen3_tts_model())
         request = inference_pb2.SpeakRequest(
             input="signature reuse probe",
@@ -90,7 +90,7 @@ def main() -> None:
             per_request_signature_calls.append(float(signature_calls - before_calls))
     finally:
         runtime_utils.inspect.signature = original_signature
-        runtime_utils.clear_callable_accepts_kwarg_cache()
+        runtime_utils.clear_callable_kwarg_signature_cache()
 
     print(
         json.dumps(

--- a/scripts/mlx_audio_speech_signature_probe.py
+++ b/scripts/mlx_audio_speech_signature_probe.py
@@ -14,7 +14,7 @@ sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 
 from packages.protocol.python.worker.v1 import inference_pb2
 from worker.model_registry.catalog import WorkerModelCatalog
-import worker.runtime.mlx_audio_runtime as mlx_audio_runtime
+from worker.runtime import runtime_utils
 from worker.runtime.mlx_audio_runtime import MLXAudioSpeechRuntime
 
 
@@ -53,7 +53,7 @@ def main() -> None:
     _install_fake_mlx_audio()
     runtime = MLXAudioSpeechRuntime()
 
-    original_signature = mlx_audio_runtime.signature
+    original_signature = runtime_utils.inspect.signature
     signature_calls = 0
 
     def tracked_signature(callable_obj):
@@ -61,8 +61,9 @@ def main() -> None:
         signature_calls += 1
         return original_signature(callable_obj)
 
-    mlx_audio_runtime.signature = tracked_signature
+    runtime_utils.inspect.signature = tracked_signature
     try:
+        runtime_utils.clear_callable_accepts_kwarg_cache()
         loaded = runtime.load_model(WorkerModelCatalog.mlx_qwen3_tts_model())
         request = inference_pb2.SpeakRequest(
             input="signature reuse probe",
@@ -88,7 +89,8 @@ def main() -> None:
             samples.append((time.perf_counter() - started) * 1000.0)
             per_request_signature_calls.append(float(signature_calls - before_calls))
     finally:
-        mlx_audio_runtime.signature = original_signature
+        runtime_utils.inspect.signature = original_signature
+        runtime_utils.clear_callable_accepts_kwarg_cache()
 
     print(
         json.dumps(

--- a/scripts/mlx_text_stop_kwarg_signature_probe.py
+++ b/scripts/mlx_text_stop_kwarg_signature_probe.py
@@ -67,7 +67,7 @@ def main() -> int:
 
     try:
         for _ in range(sample_count):
-            runtime_utils.clear_callable_accepts_kwarg_cache()
+            runtime_utils.clear_callable_kwarg_signature_cache()
             signature_calls = 0
             stream_signature_calls = 0
 
@@ -100,7 +100,7 @@ def main() -> int:
         if hasattr(mlx_text_runtime, "inspect"):
             mlx_text_runtime.inspect.signature = original_text_signature
         inspect.signature = original_signature
-        runtime_utils.clear_callable_accepts_kwarg_cache()
+        runtime_utils.clear_callable_kwarg_signature_cache()
 
     metrics = {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),

--- a/scripts/mlx_text_stop_kwarg_signature_probe.py
+++ b/scripts/mlx_text_stop_kwarg_signature_probe.py
@@ -68,12 +68,6 @@ def main() -> int:
     try:
         for _ in range(sample_count):
             runtime_utils.clear_callable_accepts_kwarg_cache()
-            backend = AutoMLXBackend(
-                load_fn=_fake_load,
-                stream_generate_fn=_fake_stream_generate,
-                sampler_factory=_fake_sampler_factory,
-            )
-            loaded_model = backend.load_model(model_spec)
             signature_calls = 0
             stream_signature_calls = 0
 
@@ -87,6 +81,12 @@ def main() -> int:
             runtime_utils.inspect.signature = tracked_signature
             if hasattr(mlx_text_runtime, "inspect"):
                 mlx_text_runtime.inspect.signature = tracked_signature
+            backend = AutoMLXBackend(
+                load_fn=_fake_load,
+                stream_generate_fn=_fake_stream_generate,
+                sampler_factory=_fake_sampler_factory,
+            )
+            loaded_model = backend.load_model(model_spec)
             started = time.perf_counter()
             for _iteration in range(iterations):
                 chunks = list(backend.generate_tokens(loaded_model, "prompt", sampling, cancel_event=_NeverCancelled()))

--- a/scripts/runtime_utils_kwarg_cache_probe.py
+++ b/scripts/runtime_utils_kwarg_cache_probe.py
@@ -27,7 +27,7 @@ def main() -> int:
     original_signature = inspect.signature
 
     for _ in range(sample_count):
-        runtime_utils.clear_callable_accepts_kwarg_cache()
+        runtime_utils.clear_callable_kwarg_signature_cache()
         signature_calls = 0
 
         def tracked_signature(callable_obj: Any) -> inspect.Signature:
@@ -45,7 +45,7 @@ def main() -> int:
         signature_call_samples.append(signature_calls)
 
     runtime_utils.inspect.signature = original_signature
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
 
     metrics = {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),

--- a/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
@@ -208,10 +208,12 @@ def test_mlx_audio_speech_runtime_reuses_generate_signature_from_load(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import worker.runtime.mlx_audio_runtime as mlx_audio_runtime
+    from worker.runtime import runtime_utils
     from worker.runtime.mlx_audio_runtime import MLXAudioSpeechRuntime
 
     signature_calls = 0
-    original_signature = mlx_audio_runtime.signature
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+    original_signature = runtime_utils.inspect.signature
 
     class FakeChunk:
         def __init__(self, audio):
@@ -231,12 +233,13 @@ def test_mlx_audio_speech_runtime_reuses_generate_signature_from_load(
         return original_signature(callable_obj)
 
     _install_fake_mlx_audio(monkeypatch, tts_loader=fake_load_model)
-    monkeypatch.setattr(mlx_audio_runtime, "signature", tracked_signature)
+    monkeypatch.setattr(runtime_utils.inspect, "signature", tracked_signature)
 
     runtime = MLXAudioSpeechRuntime()
     loaded = runtime.load_model(WorkerModelCatalog.mlx_qwen3_tts_model())
     assert loaded.generate_parameter_names == ("text", "voice", "instruct", "speed", "verbose")
     assert signature_calls == 1
+    runtime_utils.clear_callable_accepts_kwarg_cache()
 
     for index in range(3):
         result = runtime.speak(
@@ -257,6 +260,7 @@ def test_mlx_audio_speech_runtime_reuses_cached_generate_signature(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import worker.runtime.mlx_audio_runtime as mlx_audio_runtime
+    from worker.runtime import runtime_utils
 
     captured_calls: list[dict[str, object]] = []
 
@@ -276,14 +280,15 @@ def test_mlx_audio_speech_runtime_reuses_cached_generate_signature(
         return FakeTTSModel()
 
     signature_calls = 0
-    original_signature = mlx_audio_runtime.signature
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+    original_signature = runtime_utils.inspect.signature
 
     def tracked_signature(callable_object):
         nonlocal signature_calls
         signature_calls += 1
         return original_signature(callable_object)
 
-    monkeypatch.setattr(mlx_audio_runtime, "signature", tracked_signature)
+    monkeypatch.setattr(runtime_utils.inspect, "signature", tracked_signature)
     _install_fake_mlx_audio(monkeypatch, tts_loader=fake_load_model)
 
     runtime = mlx_audio_runtime.MLXAudioSpeechRuntime()
@@ -318,6 +323,7 @@ def test_mlx_audio_speech_runtime_reuses_cached_generate_signature(
             "verbose": False,
         },
     ]
+    runtime_utils.clear_callable_accepts_kwarg_cache()
 
 
 def test_mlx_audio_speech_runtime_preserves_signature_fallback_for_legacy_loaded_models(
@@ -325,6 +331,7 @@ def test_mlx_audio_speech_runtime_preserves_signature_fallback_for_legacy_loaded
 ) -> None:
     from dataclasses import replace
     import worker.runtime.mlx_audio_runtime as mlx_audio_runtime
+    from worker.runtime import runtime_utils
 
     class FakeChunk:
         def __init__(self, audio):
@@ -345,14 +352,15 @@ def test_mlx_audio_speech_runtime_preserves_signature_fallback_for_legacy_loaded
         return FakeTTSModel()
 
     signature_calls = 0
-    original_signature = mlx_audio_runtime.signature
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+    original_signature = runtime_utils.inspect.signature
 
     def tracked_signature(callable_object):
         nonlocal signature_calls
         signature_calls += 1
         return original_signature(callable_object)
 
-    monkeypatch.setattr(mlx_audio_runtime, "signature", tracked_signature)
+    monkeypatch.setattr(runtime_utils.inspect, "signature", tracked_signature)
     _install_fake_mlx_audio(monkeypatch, tts_loader=fake_load_model)
 
     runtime = mlx_audio_runtime.MLXAudioSpeechRuntime()
@@ -375,13 +383,14 @@ def test_mlx_audio_speech_runtime_preserves_signature_fallback_for_legacy_loaded
     )
 
     assert result.audio_bytes.startswith(b"RIFF")
-    assert signature_calls == 2
+    assert signature_calls == 1
+    runtime_utils.clear_callable_accepts_kwarg_cache()
 
 
 def test_mlx_audio_speech_runtime_reuses_loaded_signature_metadata_during_speak(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import worker.runtime.mlx_audio_runtime as mlx_audio_runtime
+    from worker.runtime import runtime_utils
     from worker.runtime.mlx_audio_runtime import MLXAudioSpeechRuntime
 
     captured_calls: list[dict[str, object]] = []
@@ -407,10 +416,11 @@ def test_mlx_audio_speech_runtime_reuses_loaded_signature_metadata_during_speak(
         return FakeTTSModel()
 
     _install_fake_mlx_audio(monkeypatch, tts_loader=fake_load_model)
+    runtime_utils.clear_callable_accepts_kwarg_cache()
     runtime = MLXAudioSpeechRuntime()
     loaded = runtime.load_model(WorkerModelCatalog.mlx_qwen3_tts_model())
     monkeypatch.setattr(
-        mlx_audio_runtime,
+        runtime_utils.inspect,
         "signature",
         lambda _callable: pytest.fail("speak() should reuse loaded speech signature metadata"),
     )
@@ -435,6 +445,52 @@ def test_mlx_audio_speech_runtime_reuses_loaded_signature_metadata_during_speak(
             "verbose": False,
         }
     ]
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+
+
+def test_mlx_audio_speech_runtime_does_not_treat_variadic_kwargs_as_voice_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from worker.runtime.mlx_audio_runtime import MLXAudioSpeechRuntime
+
+    captured_calls: list[dict[str, object]] = []
+
+    class FakeChunk:
+        def __init__(self, audio):
+            self.audio = audio
+            self.sample_rate = 24_000
+
+    class FakeVariadicModel:
+        def generate(self, **kwargs):
+            captured_calls.append(dict(kwargs))
+            yield FakeChunk([0.1, -0.1])
+
+    def fake_load_model(model_path: str, strict: bool = True):
+        _ = model_path
+        _ = strict
+        return FakeVariadicModel()
+
+    _install_fake_mlx_audio(monkeypatch, tts_loader=fake_load_model)
+
+    runtime = MLXAudioSpeechRuntime()
+    loaded = runtime.load_model(WorkerModelCatalog.mlx_qwen3_tts_model())
+
+    assert loaded.voice_mode == "plain"
+    assert loaded.supports_instructions is False
+    assert loaded.generate_parameter_names == ()
+
+    result = runtime.speak(
+        loaded,
+        inference_pb2.SpeakRequest(
+            input="plain variadic audio",
+            voice="alloy",
+            instructions="Speak calmly.",
+            format="wav",
+        ),
+    )
+
+    assert result.audio_bytes.startswith(b"RIFF")
+    assert captured_calls == [{"text": "plain variadic audio", "verbose": False}]
 
 
 def test_mlx_audio_speech_runtime_falls_back_to_voice_descriptor_only_for_instructional_models(

--- a/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
@@ -212,7 +212,7 @@ def test_mlx_audio_speech_runtime_reuses_generate_signature_from_load(
     from worker.runtime.mlx_audio_runtime import MLXAudioSpeechRuntime
 
     signature_calls = 0
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
     original_signature = runtime_utils.inspect.signature
 
     class FakeChunk:
@@ -239,7 +239,7 @@ def test_mlx_audio_speech_runtime_reuses_generate_signature_from_load(
     loaded = runtime.load_model(WorkerModelCatalog.mlx_qwen3_tts_model())
     assert loaded.generate_parameter_names == ("text", "voice", "instruct", "speed", "verbose")
     assert signature_calls == 1
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
 
     for index in range(3):
         result = runtime.speak(
@@ -280,7 +280,7 @@ def test_mlx_audio_speech_runtime_reuses_cached_generate_signature(
         return FakeTTSModel()
 
     signature_calls = 0
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
     original_signature = runtime_utils.inspect.signature
 
     def tracked_signature(callable_object):
@@ -323,7 +323,7 @@ def test_mlx_audio_speech_runtime_reuses_cached_generate_signature(
             "verbose": False,
         },
     ]
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
 
 
 def test_mlx_audio_speech_runtime_preserves_signature_fallback_for_legacy_loaded_models(
@@ -338,12 +338,18 @@ def test_mlx_audio_speech_runtime_preserves_signature_fallback_for_legacy_loaded
             self.audio = audio
             self.sample_rate = 24_000
 
+    captured_calls: list[dict[str, object]] = []
+
     class FakeTTSModel:
         def generate(self, text, voice=None, instruct=None, verbose=False):
-            _ = text
-            _ = voice
-            _ = instruct
-            _ = verbose
+            captured_calls.append(
+                {
+                    "text": text,
+                    "voice": voice,
+                    "instruct": instruct,
+                    "verbose": verbose,
+                }
+            )
             yield FakeChunk([0.1, -0.1])
 
     def fake_load_model(model_path: str, strict: bool = True):
@@ -352,7 +358,7 @@ def test_mlx_audio_speech_runtime_preserves_signature_fallback_for_legacy_loaded
         return FakeTTSModel()
 
     signature_calls = 0
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
     original_signature = runtime_utils.inspect.signature
 
     def tracked_signature(callable_object):
@@ -367,6 +373,8 @@ def test_mlx_audio_speech_runtime_preserves_signature_fallback_for_legacy_loaded
     loaded = runtime.load_model(WorkerModelCatalog.mlx_qwen3_tts_model())
     legacy_loaded = replace(
         loaded,
+        voice_mode="",
+        supports_instructions=False,
         speech_generate_parameters=frozenset(),
         generate_parameter_names=(),
     )
@@ -384,7 +392,15 @@ def test_mlx_audio_speech_runtime_preserves_signature_fallback_for_legacy_loaded
 
     assert result.audio_bytes.startswith(b"RIFF")
     assert signature_calls == 1
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    assert captured_calls == [
+        {
+            "text": "legacy cached payload",
+            "voice": "alloy",
+            "instruct": "Speak calmly.",
+            "verbose": False,
+        }
+    ]
+    runtime_utils.clear_callable_kwarg_signature_cache()
 
 
 def test_mlx_audio_speech_runtime_reuses_loaded_signature_metadata_during_speak(
@@ -416,7 +432,7 @@ def test_mlx_audio_speech_runtime_reuses_loaded_signature_metadata_during_speak(
         return FakeTTSModel()
 
     _install_fake_mlx_audio(monkeypatch, tts_loader=fake_load_model)
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
     runtime = MLXAudioSpeechRuntime()
     loaded = runtime.load_model(WorkerModelCatalog.mlx_qwen3_tts_model())
     monkeypatch.setattr(
@@ -445,12 +461,13 @@ def test_mlx_audio_speech_runtime_reuses_loaded_signature_metadata_during_speak(
             "verbose": False,
         }
     ]
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
 
 
 def test_mlx_audio_speech_runtime_does_not_treat_variadic_kwargs_as_voice_support(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from worker.runtime import runtime_utils
     from worker.runtime.mlx_audio_runtime import MLXAudioSpeechRuntime
 
     captured_calls: list[dict[str, object]] = []
@@ -478,6 +495,12 @@ def test_mlx_audio_speech_runtime_does_not_treat_variadic_kwargs_as_voice_suppor
     assert loaded.voice_mode == "plain"
     assert loaded.supports_instructions is False
     assert loaded.generate_parameter_names == ()
+
+    monkeypatch.setattr(
+        runtime_utils.inspect,
+        "signature",
+        lambda _callable: pytest.fail("plain voice_mode should skip legacy signature fallback"),
+    )
 
     result = runtime.speak(
         loaded,

--- a/services/mlx-worker-python/tests/test_mlx_backend.py
+++ b/services/mlx-worker-python/tests/test_mlx_backend.py
@@ -490,7 +490,7 @@ def test_auto_backend_does_not_pass_stop_to_variadic_stream_generate() -> None:
     assert "stop" not in seen["kwargs"]
     assert "stop_words" not in seen["kwargs"]
     assert "stop_sequences" not in seen["kwargs"]
-    assert mlx_text_runtime_module._callable_declares_kwarg(42, "stop") is False
+    assert runtime_utils.callable_declares_kwarg(42, "stop") is False
     assert [chunk.text for chunk in chunks] == ["done"]
 
 

--- a/services/mlx-worker-python/tests/test_mlx_backend.py
+++ b/services/mlx-worker-python/tests/test_mlx_backend.py
@@ -236,7 +236,7 @@ def test_auto_backend_uses_mlx_load_stream_and_sampler_hooks() -> None:
 
 
 def test_auto_backend_reuses_cached_stop_kwarg_signature(monkeypatch: pytest.MonkeyPatch) -> None:
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
     signature_calls: dict[str, int] = {}
     original_signature = runtime_utils.inspect.signature
 
@@ -278,7 +278,7 @@ def test_auto_backend_reuses_cached_stop_kwarg_signature(monkeypatch: pytest.Mon
 
     assert seen_stop_values == [["</turn>", "</s>"], ["</turn>", "</s>"]]
     assert signature_calls.get("fake_stream_generate") == 1
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
 
 
 def test_auto_backend_scores_reward_responses_with_mlx_generation() -> None:

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -19,13 +19,13 @@ from worker.runtime.multimodal_preprocessing import (
     PreparedVisionRequest,
 )
 from worker.runtime import mlx_vlm_runtime as mlx_vlm_runtime_module
+from worker.runtime import runtime_utils
 from worker.runtime.mlx_vlm_runtime import (
     AutoMLXVLMBackend,
     MLXVLMRuntime,
     RuntimeUnavailableError,
     _CallableTokenizerProcessor,
     _Gemma4TextBackedModelShim,
-    _callable_has_named_kwarg,
     _gemma4_loaded_execution_mode,
     _gemma4_multimodal_weight_presence,
     _mlx_peak_memory_gb,
@@ -540,6 +540,95 @@ def test_mlx_vlm_runtime_records_video_fallback_when_backend_omits_video_argumen
     assert "does not accept video=" in caplog.text
 
 
+def test_mlx_vlm_runtime_does_not_treat_variadic_kwargs_as_video_support(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stream_calls: list[dict[str, object]] = []
+
+    def fake_load(model_path: str, revision: str = "main"):
+        _ = model_path
+        _ = revision
+        model = SimpleNamespace(
+            config=SimpleNamespace(model_type="qwen2_vl"),
+            vision_tower=object(),
+            embed_vision=object(),
+        )
+        processor = SimpleNamespace(image_processor=object())
+        return model, processor
+
+    def fake_apply_chat_template(processor, config, prompt: str, num_images: int = 0):
+        _ = processor
+        _ = config
+        _ = num_images
+        return f"formatted::{prompt}"
+
+    def fake_stream_generate(*args, **kwargs):
+        _ = args
+        stream_calls.append(dict(kwargs))
+        yield SimpleNamespace(text="variadic fallback summary", generation_tokens=1)
+
+    runtime = MLXVLMRuntime(
+        backend=AutoMLXVLMBackend(
+            load_fn=fake_load,
+            stream_generate_fn=fake_stream_generate,
+            apply_chat_template_fn=fake_apply_chat_template,
+        )
+    )
+    loaded_model = runtime.load_model(imported_gemma4_vlm_model())
+    prepared = PreparedVisionRequest(
+        prompt_text="Describe the video.",
+        images=[],
+        videos=[
+            PreparedVideoInput(
+                source_kind="inline",
+                reference="inline:video",
+                bytes_data=b"fake-video-payload",
+                mime_type="video/mp4",
+                format="mp4",
+                filename="sample.mp4",
+                byte_length=len(b"fake-video-payload"),
+                duration_ms=1000,
+                frame_budget=4,
+                start_ms=0,
+                end_ms=1000,
+                sha256_hex="beef",
+            )
+        ],
+        video_frame_policies=[
+            PreparedVideoFramePolicy(
+                reference="inline:video",
+                sampling_strategy="uniform",
+                requested_frame_budget=4,
+                effective_frame_count=4,
+                clip_start_ms=0,
+                clip_end_ms=1000,
+                clip_duration_ms=1000,
+            )
+        ],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=len(b"fake-video-payload"),
+        preprocess_peak_memory_bytes=len(b"fake-video-payload"),
+        prompt_hash_hex="11" * 32,
+        multimodal_hash_hex="22" * 32,
+    )
+
+    caplog.set_level("WARNING", logger=mlx_vlm_runtime_module.__name__)
+    events = list(
+        runtime.generate_tokens(
+            loaded_model,
+            prepared,
+            common_pb2.SamplingConfig(max_output_tokens=8),
+            Event(),
+        )
+    )
+
+    assert [event.text for event in events] == ["variadic fallback summary"]
+    assert "video" not in stream_calls[0]
+    assert stream_calls[0]["image"] is None
+    assert runtime.last_probe_snapshot().multimodal_fallback_reason == "backend_video_kwarg_unsupported"
+    assert "does not accept video=" in caplog.text
+
+
 def test_mlx_vlm_runtime_plans_fast_path_when_generate_is_called_directly() -> None:
     def fake_load(model_path: str, revision: str = "main"):
         _ = model_path
@@ -988,16 +1077,38 @@ def test_callables_and_text_backed_shims_expose_upstream_compatible_surfaces() -
     assert tokenizer_calls == [(("prompt",), {"padding": True})]
 
 
-def test_callable_has_named_kwarg_requires_explicit_parameter() -> None:
+def test_callable_declares_kwarg_requires_explicit_parameter() -> None:
     def explicit(*, draft_model):
         _ = draft_model
 
     def variadic(**kwargs):
         _ = kwargs
 
-    assert _callable_has_named_kwarg(explicit, "draft_model") is True
-    assert _callable_has_named_kwarg(variadic, "draft_model") is False
-    assert _callable_has_named_kwarg(object(), "draft_model") is False
+    assert runtime_utils.callable_declares_kwarg(explicit, "draft_model") is True
+    assert runtime_utils.callable_declares_kwarg(variadic, "draft_model") is False
+    assert runtime_utils.callable_declares_kwarg(object(), "draft_model") is False
+    assert runtime_utils.callable_accepts_kwarg(variadic, "draft_model") is True
+
+
+def test_auto_mlx_vlm_backend_mtp_detection_requires_declared_draft_kwargs() -> None:
+    drafter_calls: list[dict[str, object]] = []
+
+    def fake_load_drafter(*args, **kwargs):
+        drafter_calls.append({"args": args, "kwargs": kwargs})
+        return {"draft_model_id": args[0]}
+
+    backend = AutoMLXVLMBackend(
+        load_fn=lambda model_path, revision="main": (object(), object()),
+        stream_generate_fn=lambda *args, **kwargs: iter(()),
+        apply_chat_template_fn=lambda *args, **kwargs: "",
+        batch_generate_fn=lambda *args, **kwargs: [],
+        generate_step_fn=lambda *args, **kwargs: iter(()),
+        load_drafter_fn=fake_load_drafter,
+    )
+
+    assert backend.supports_mtp_speculative() is False
+    assert backend.load_drafter("draft-model", kind="mtp") == {"draft_model_id": "draft-model"}
+    assert drafter_calls == [{"args": ("draft-model",), "kwargs": {}}]
 
 
 def test_mlx_peak_memory_prefers_current_api() -> None:
@@ -1508,14 +1619,14 @@ def test_auto_mlx_vlm_backend_detects_installed_optional_mtp_api() -> None:
     assert backend.stream_generate_fn is not None
     assert backend.apply_chat_template_fn is not None
     generate_step_support = backend.generate_step_fn is not None and (
-        _callable_has_named_kwarg(backend.generate_step_fn, "draft_model")
-        and _callable_has_named_kwarg(backend.generate_step_fn, "draft_kind")
-        and _callable_has_named_kwarg(backend.generate_step_fn, "draft_block_size")
+        runtime_utils.callable_declares_kwarg(backend.generate_step_fn, "draft_model")
+        and runtime_utils.callable_declares_kwarg(backend.generate_step_fn, "draft_kind")
+        and runtime_utils.callable_declares_kwarg(backend.generate_step_fn, "draft_block_size")
     )
     batch_generate_support = backend.batch_generate_fn is not None and (
-        _callable_has_named_kwarg(backend.batch_generate_fn, "draft_model")
-        and _callable_has_named_kwarg(backend.batch_generate_fn, "draft_kind")
-        and _callable_has_named_kwarg(backend.batch_generate_fn, "draft_block_size")
+        runtime_utils.callable_declares_kwarg(backend.batch_generate_fn, "draft_model")
+        and runtime_utils.callable_declares_kwarg(backend.batch_generate_fn, "draft_kind")
+        and runtime_utils.callable_declares_kwarg(backend.batch_generate_fn, "draft_block_size")
     )
     assert backend.supports_mtp_speculative() is (
         backend.load_drafter_fn is not None and (generate_step_support or batch_generate_support)

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1147,7 +1147,7 @@ def test_runtime_utils_kwarg_cache_probe_script_emits_metrics(
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["sample_count"] == 5.0
     assert metrics["iterations_per_sample"] == 40000.0
-    assert metrics["inspect_signature_calls_mean"] == 2.0
+    assert metrics["inspect_signature_calls_mean"] == 1.0
     assert metrics["elapsed_ms_mean"] >= 0
 
 
@@ -1169,7 +1169,7 @@ def test_mlx_text_stop_kwarg_signature_probe_script_emits_metrics(
     assert metrics["sample_count"] == 1.0
     assert metrics["iterations_per_sample"] == 12.0
     assert metrics["stream_signature_calls_mean"] == 1.0
-    assert metrics["inspect_signature_calls_mean"] == 3.0
+    assert metrics["inspect_signature_calls_mean"] == 2.0
     assert metrics["elapsed_ms_mean"] >= 0
 
 

--- a/services/mlx-worker-python/tests/test_runtime_utils.py
+++ b/services/mlx-worker-python/tests/test_runtime_utils.py
@@ -15,7 +15,7 @@ def test_callable_accepts_kwarg_returns_false_for_non_introspectable_object() ->
 
 
 def test_callable_kwarg_signature_caches_structured_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
     original_signature = inspect.signature
     signature_calls = 0
 
@@ -37,17 +37,17 @@ def test_callable_kwarg_signature_caches_structured_lookup(monkeypatch: pytest.M
     assert runtime_utils.callable_declares_kwarg(sample, "top_p") is False
     capabilities = runtime_utils.callable_kwarg_signature(sample)
     assert capabilities.parameter_names == ("temperature",)
-    assert capabilities.declared_kwargs == frozenset({"temperature"})
+    assert capabilities.keyword_accessible_params == frozenset({"temperature"})
     assert capabilities.accepts_var_keyword is False
     assert signature_calls == 1
 
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
 
 
 def test_callable_accepts_kwarg_caches_bound_methods_by_underlying_function(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
     original_signature = inspect.signature
     signature_calls = 0
     inspected_objects: list[Any] = []
@@ -73,11 +73,11 @@ def test_callable_accepts_kwarg_caches_bound_methods_by_underlying_function(
     assert signature_calls == 1
     assert inspected_objects == [SampleRuntime.generate]
 
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
 
 
 def test_callable_accepts_kwarg_bound_methods_preserve_parameter_scan_behavior() -> None:
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
 
     class SampleRuntime:
         def generate(
@@ -102,18 +102,22 @@ def test_callable_accepts_kwarg_bound_methods_preserve_parameter_scan_behavior()
     assert runtime_utils.callable_declares_kwarg(method, "max_tokens") is True
     assert runtime_utils.callable_declares_kwarg(method, "temperature") is True
     assert runtime_utils.callable_declares_kwarg(method, "top_p") is True
-    assert runtime_utils.callable_kwarg_signature(method).parameter_names == (
+    capabilities = runtime_utils.callable_kwarg_signature(method)
+    assert capabilities.parameter_names == (
         "prompt",
         "max_tokens",
         "temperature",
         "top_p",
     )
+    assert capabilities.keyword_accessible_params == frozenset(
+        {"prompt", "max_tokens", "temperature", "top_p"}
+    )
 
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
 
 
 def test_callable_accepts_kwarg_bound_methods_preserve_var_keyword_behavior() -> None:
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
 
     class SampleRuntime:
         def generate(self, **kwargs: object) -> object:
@@ -125,11 +129,11 @@ def test_callable_accepts_kwarg_bound_methods_preserve_var_keyword_behavior() ->
     assert runtime_utils.callable_declares_kwarg(SampleRuntime().generate, "self") is False
     assert runtime_utils.callable_kwarg_signature(SampleRuntime().generate).accepts_var_keyword is True
 
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
 
 
 def test_first_declared_kwarg_ignores_variadic_kwargs() -> None:
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
 
     def explicit(*, stop_words: list[str] | None = None, **kwargs: object) -> None:
         _ = (stop_words, kwargs)
@@ -142,11 +146,11 @@ def test_first_declared_kwarg_ignores_variadic_kwargs() -> None:
     assert runtime_utils.callable_accepts_kwarg(variadic, "stop") is True
     assert runtime_utils.callable_declares_kwarg(variadic, "stop") is False
 
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
 
 
 def test_callable_accepts_kwarg_falls_back_for_unhashable_callable(monkeypatch: pytest.MonkeyPatch) -> None:
-    runtime_utils.clear_callable_accepts_kwarg_cache()
+    runtime_utils.clear_callable_kwarg_signature_cache()
     original_signature = inspect.signature
     signature_calls = 0
 

--- a/services/mlx-worker-python/tests/test_runtime_utils.py
+++ b/services/mlx-worker-python/tests/test_runtime_utils.py
@@ -11,9 +11,10 @@ from worker.runtime import runtime_utils
 
 def test_callable_accepts_kwarg_returns_false_for_non_introspectable_object() -> None:
     assert runtime_utils.callable_accepts_kwarg(object(), "temperature") is False
+    assert runtime_utils.callable_declares_kwarg(object(), "temperature") is False
 
 
-def test_callable_accepts_kwarg_caches_signature_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_callable_kwarg_signature_caches_structured_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
     runtime_utils.clear_callable_accepts_kwarg_cache()
     original_signature = inspect.signature
     signature_calls = 0
@@ -31,8 +32,14 @@ def test_callable_accepts_kwarg_caches_signature_lookup(monkeypatch: pytest.Monk
     assert runtime_utils.callable_accepts_kwarg(sample, "temperature") is True
     assert runtime_utils.callable_accepts_kwarg(sample, "temperature") is True
     assert signature_calls == 1
+    assert runtime_utils.callable_declares_kwarg(sample, "temperature") is True
     assert runtime_utils.callable_accepts_kwarg(sample, "top_p") is False
-    assert signature_calls == 2
+    assert runtime_utils.callable_declares_kwarg(sample, "top_p") is False
+    capabilities = runtime_utils.callable_kwarg_signature(sample)
+    assert capabilities.parameter_names == ("temperature",)
+    assert capabilities.declared_kwargs == frozenset({"temperature"})
+    assert capabilities.accepts_var_keyword is False
+    assert signature_calls == 1
 
     runtime_utils.clear_callable_accepts_kwarg_cache()
 
@@ -62,8 +69,9 @@ def test_callable_accepts_kwarg_caches_bound_methods_by_underlying_function(
     assert runtime_utils.callable_accepts_kwarg(first.generate, "temperature") is True
     assert runtime_utils.callable_accepts_kwarg(second.generate, "temperature") is True
     assert runtime_utils.callable_accepts_kwarg(second.generate, "self") is False
-    assert signature_calls == 2
-    assert inspected_objects == [SampleRuntime.generate, SampleRuntime.generate]
+    assert runtime_utils.callable_declares_kwarg(second.generate, "self") is False
+    assert signature_calls == 1
+    assert inspected_objects == [SampleRuntime.generate]
 
     runtime_utils.clear_callable_accepts_kwarg_cache()
 
@@ -90,6 +98,16 @@ def test_callable_accepts_kwarg_bound_methods_preserve_parameter_scan_behavior()
     assert runtime_utils.callable_accepts_kwarg(method, "temperature") is True
     assert runtime_utils.callable_accepts_kwarg(method, "top_p") is True
     assert runtime_utils.callable_accepts_kwarg(method, "missing") is False
+    assert runtime_utils.callable_declares_kwarg(method, "prompt") is True
+    assert runtime_utils.callable_declares_kwarg(method, "max_tokens") is True
+    assert runtime_utils.callable_declares_kwarg(method, "temperature") is True
+    assert runtime_utils.callable_declares_kwarg(method, "top_p") is True
+    assert runtime_utils.callable_kwarg_signature(method).parameter_names == (
+        "prompt",
+        "max_tokens",
+        "temperature",
+        "top_p",
+    )
 
     runtime_utils.clear_callable_accepts_kwarg_cache()
 
@@ -103,6 +121,26 @@ def test_callable_accepts_kwarg_bound_methods_preserve_var_keyword_behavior() ->
 
     assert runtime_utils.callable_accepts_kwarg(SampleRuntime().generate, "temperature") is True
     assert runtime_utils.callable_accepts_kwarg(SampleRuntime().generate, "self") is True
+    assert runtime_utils.callable_declares_kwarg(SampleRuntime().generate, "temperature") is False
+    assert runtime_utils.callable_declares_kwarg(SampleRuntime().generate, "self") is False
+    assert runtime_utils.callable_kwarg_signature(SampleRuntime().generate).accepts_var_keyword is True
+
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+
+
+def test_first_declared_kwarg_ignores_variadic_kwargs() -> None:
+    runtime_utils.clear_callable_accepts_kwarg_cache()
+
+    def explicit(*, stop_words: list[str] | None = None, **kwargs: object) -> None:
+        _ = (stop_words, kwargs)
+
+    def variadic(**kwargs: object) -> None:
+        _ = kwargs
+
+    assert runtime_utils.first_declared_kwarg(explicit, ("stop", "stop_words", "stop_sequences")) == "stop_words"
+    assert runtime_utils.first_declared_kwarg(variadic, ("stop", "stop_words", "stop_sequences")) == ""
+    assert runtime_utils.callable_accepts_kwarg(variadic, "stop") is True
+    assert runtime_utils.callable_declares_kwarg(variadic, "stop") is False
 
     runtime_utils.clear_callable_accepts_kwarg_cache()
 

--- a/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from inspect import signature
 from io import BytesIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -19,6 +18,7 @@ from worker.runtime.audio_runtime_protocols import (
     SpeechResult,
     TranscriptionResult,
 )
+from worker.runtime.runtime_utils import callable_kwarg_signature
 
 
 _AUDIO_PROCESSOR_CONFIG_FILES = (
@@ -250,17 +250,19 @@ class MLXAudioSpeechRuntime:
         except TypeError:
             model = load_model(model_spec.model_path)
 
-        generate_parameter_names = tuple(signature(model.generate).parameters)
-        speech_generate_parameters = frozenset(generate_parameter_names)
-        params = speech_generate_parameters
-        supports_voice = "voice" in params
-        supports_instructions = "instruct" in params
+        generate_signature = callable_kwarg_signature(model.generate)
+        generate_parameter_names = generate_signature.parameter_names
+        speech_generate_parameters = generate_signature.declared_kwargs
+        supports_voice = generate_signature.declares("voice")
+        supports_instructions = generate_signature.declares("instruct")
         if supports_voice and supports_instructions:
             voice_mode = "hybrid"
         elif supports_instructions:
             voice_mode = "instructional"
-        else:
+        elif supports_voice:
             voice_mode = "named"
+        else:
+            voice_mode = "plain"
 
         return AudioRuntimeLoadedModel(
             backend_id=backend_id,
@@ -287,9 +289,9 @@ class MLXAudioSpeechRuntime:
         supports_voice = loaded_model.voice_mode in {"hybrid", "named"}
         supports_instructions = loaded_model.supports_instructions
         if not loaded_model.speech_generate_parameters and not loaded_model.generate_parameter_names:
-            params = frozenset(signature(loaded_model.model.generate).parameters)
-            supports_voice = "voice" in params
-            supports_instructions = "instruct" in params
+            generate_signature = callable_kwarg_signature(loaded_model.model.generate)
+            supports_voice = generate_signature.declares("voice")
+            supports_instructions = generate_signature.declares("instruct")
         kwargs = {
             "text": request.input,
             "verbose": False,

--- a/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
@@ -252,7 +252,7 @@ class MLXAudioSpeechRuntime:
 
         generate_signature = callable_kwarg_signature(model.generate)
         generate_parameter_names = generate_signature.parameter_names
-        speech_generate_parameters = generate_signature.declared_kwargs
+        speech_generate_parameters = generate_signature.keyword_accessible_params
         supports_voice = generate_signature.declares("voice")
         supports_instructions = generate_signature.declares("instruct")
         if supports_voice and supports_instructions:
@@ -288,7 +288,11 @@ class MLXAudioSpeechRuntime:
 
         supports_voice = loaded_model.voice_mode in {"hybrid", "named"}
         supports_instructions = loaded_model.supports_instructions
-        if not loaded_model.speech_generate_parameters and not loaded_model.generate_parameter_names:
+        if (
+            not loaded_model.voice_mode
+            and not loaded_model.speech_generate_parameters
+            and not loaded_model.generate_parameter_names
+        ):
             generate_signature = callable_kwarg_signature(loaded_model.model.generate)
             supports_voice = generate_signature.declares("voice")
             supports_instructions = generate_signature.declares("instruct")

--- a/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
@@ -12,6 +12,7 @@ from typing import Any
 from worker.runtime.mlx_executor import MLXRuntimeExecutor
 from worker.runtime.runtime_utils import (
     callable_accepts_kwarg as _callable_accepts_kwarg,
+    first_declared_kwarg as _first_declared_kwarg,
     installed_package_version as _installed_package_version,
 )
 from worker.runtime.text_family_adapters import resolve_text_family_config
@@ -139,6 +140,7 @@ _TEXT_STOP_SEQUENCE_KEYS = (
     "melix.turn_boundary.stop_sequences",
     "stop_sequences",
 )
+_STREAM_STOP_KWARG_NAMES = ("stop", "stop_words", "stop_sequences")
 
 
 def _split_stop_sequence_value(value: Any) -> list[str]:
@@ -366,12 +368,14 @@ class AutoMLXBackend:
         stream_generate_fn=None,
         sampler_factory=None,
     ) -> None:
+        self._stream_stop_kwarg = ""
         if load_fn is not None and stream_generate_fn is not None and sampler_factory is not None:
             self._available = True
             self._error = None
             self._load_fn = load_fn
             self._stream_generate_fn = stream_generate_fn
             self._sampler_factory = sampler_factory
+            self._stream_stop_kwarg = _first_declared_kwarg(stream_generate_fn, _STREAM_STOP_KWARG_NAMES)
             self.runtime_name = "mlx-lm"
             return
 
@@ -402,6 +406,7 @@ class AutoMLXBackend:
             self._load_fn = load
             self._stream_generate_fn = stream_generate
             self._sampler_factory = make_sampler
+            self._stream_stop_kwarg = _first_declared_kwarg(stream_generate, _STREAM_STOP_KWARG_NAMES)
 
     def load_model(self, model_spec) -> dict[str, Any]:
         if not self._available:
@@ -486,11 +491,8 @@ class AutoMLXBackend:
         max_tokens = int(sampling.max_output_tokens) if int(sampling.max_output_tokens) > 0 else 256
         stop_contract = resolve_text_stop_contract(loaded_model, sampling, execution_ext)
         stream_kwargs: dict[str, Any] = {}
-        if stop_contract.sequences:
-            for kwarg_name in ("stop", "stop_words", "stop_sequences"):
-                if _callable_accepts_kwarg(self._stream_generate_fn, kwarg_name):
-                    stream_kwargs[kwarg_name] = list(stop_contract.sequences)
-                    break
+        if stop_contract.sequences and self._stream_stop_kwarg:
+            stream_kwargs[self._stream_stop_kwarg] = list(stop_contract.sequences)
 
         for response in self._stream_generate_fn(
             loaded_model["model"],

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
 import hashlib
-import inspect
 import importlib.util
 import logging
 import os
@@ -18,7 +17,7 @@ from worker.runtime.mlx_text_runtime import RuntimeTokenEvent
 from worker.runtime.multimodal_fast_paths import MultimodalFastPathController, fast_path_probe_signature
 from worker.runtime.multimodal_preprocessing import PreparedVisionRequest, prepare_vision_request, rebuild_multimodal_hash
 from worker.runtime.runtime_utils import (
-    callable_accepts_kwarg as _callable_accepts_kwarg,
+    callable_declares_kwarg as _callable_declares_kwarg,
     installed_package_version as _installed_package_version,
 )
 from worker.runtime.temp_media_lifecycle import TempMediaSession
@@ -85,20 +84,6 @@ def _gemma4_multimodal_weight_presence(weight_names: Iterable[str]) -> tuple[boo
         if has_vision and has_audio:
             break
     return has_vision, has_audio
-
-
-def _callable_has_named_kwarg(callable_obj: Any, keyword: str) -> bool:
-    try:
-        signature = inspect.signature(callable_obj)
-    except (TypeError, ValueError):
-        return False
-    parameter = signature.parameters.get(keyword)
-    if parameter is None:
-        return False
-    return parameter.kind in (
-        inspect.Parameter.POSITIONAL_OR_KEYWORD,
-        inspect.Parameter.KEYWORD_ONLY,
-    )
 
 
 def _mlx_peak_memory_gb(mx_module: Any) -> float:
@@ -227,17 +212,17 @@ class AutoMLXVLMBackend:
         if self.load_drafter_fn is None:
             return False
         if self.generate_step_fn is not None and (
-            _callable_has_named_kwarg(self.generate_step_fn, "draft_model")
-            and _callable_has_named_kwarg(self.generate_step_fn, "draft_kind")
-            and _callable_has_named_kwarg(self.generate_step_fn, "draft_block_size")
+            _callable_declares_kwarg(self.generate_step_fn, "draft_model")
+            and _callable_declares_kwarg(self.generate_step_fn, "draft_kind")
+            and _callable_declares_kwarg(self.generate_step_fn, "draft_block_size")
         ):
             return True
         if self.batch_generate_fn is None:
             return False
         return (
-            _callable_has_named_kwarg(self.batch_generate_fn, "draft_model")
-            and _callable_has_named_kwarg(self.batch_generate_fn, "draft_kind")
-            and _callable_has_named_kwarg(self.batch_generate_fn, "draft_block_size")
+            _callable_declares_kwarg(self.batch_generate_fn, "draft_model")
+            and _callable_declares_kwarg(self.batch_generate_fn, "draft_kind")
+            and _callable_declares_kwarg(self.batch_generate_fn, "draft_block_size")
         )
 
     def load_drafter(self, model_id: str, *, kind: str = "mtp") -> Any:
@@ -248,7 +233,7 @@ class AutoMLXVLMBackend:
         cached = self._drafter_cache.get(cache_key)
         if cached is not None:
             return cached
-        if _callable_accepts_kwarg(self.load_drafter_fn, "kind"):
+        if _callable_declares_kwarg(self.load_drafter_fn, "kind"):
             drafter = self.load_drafter_fn(model_id, kind=kind)
         else:
             drafter = self.load_drafter_fn(model_id)
@@ -625,7 +610,7 @@ class MLXVLMRuntime:
                     "verbose": False,
                 }
                 if media_paths.video_paths:
-                    if _callable_accepts_kwarg(self._backend.stream_generate_fn, "video"):
+                    if _callable_declares_kwarg(self._backend.stream_generate_fn, "video"):
                         stream_kwargs["video"] = list(media_paths.video_paths)
                     else:
                         logger.warning(

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -1,73 +1,103 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from functools import lru_cache
 import importlib.metadata
 import inspect
 from typing import Any
 
 
-def _callable_accepts_kwarg_uncached(
+@dataclass(frozen=True)
+class CallableKwargSignature:
+    parameter_names: tuple[str, ...]
+    declared_kwargs: frozenset[str]
+    accepts_var_keyword: bool
+
+    def declares(self, keyword: str) -> bool:
+        return keyword in self.declared_kwargs
+
+    def accepts(self, keyword: str) -> bool:
+        return self.declares(keyword) or self.accepts_var_keyword
+
+
+_EMPTY_KWARG_SIGNATURE = CallableKwargSignature((), frozenset(), False)
+
+
+def _callable_kwarg_signature_uncached(
     callable_obj: Any,
-    keyword: str,
     *,
     skip_first_parameter: bool = False,
-) -> bool:
+) -> CallableKwargSignature:
     try:
         signature = inspect.signature(callable_obj)
     except (TypeError, ValueError):
-        return False
+        return _EMPTY_KWARG_SIGNATURE
 
-    matching_parameter: inspect.Parameter | None = None
+    declared_kwargs: set[str] = set()
+    parameter_names: list[str] = []
+    accepts_var_keyword = False
     for index, (name, parameter) in enumerate(signature.parameters.items()):
         if skip_first_parameter and index == 0:
             continue
         if parameter.kind == inspect.Parameter.VAR_KEYWORD:
-            return True
-        if name == keyword:
-            matching_parameter = parameter
+            accepts_var_keyword = True
+        elif parameter.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
+            declared_kwargs.add(name)
+            parameter_names.append(name)
+    return CallableKwargSignature(tuple(parameter_names), frozenset(declared_kwargs), accepts_var_keyword)
 
-    if matching_parameter is None:
-        return False
-    return matching_parameter.kind in (
-        inspect.Parameter.POSITIONAL_OR_KEYWORD,
-        inspect.Parameter.KEYWORD_ONLY,
-    )
+
+def _callable_cache_target(callable_obj: Any) -> tuple[Any, bool]:
+    bound_function = getattr(callable_obj, "__func__", None)
+    if bound_function is not None and getattr(callable_obj, "__self__", None) is not None:
+        return bound_function, True
+    return callable_obj, False
 
 
 @lru_cache(maxsize=512)
-def _callable_accepts_kwarg_cached(
+def _callable_kwarg_signature_cached(
     callable_obj: Any,
-    keyword: str,
     *,
     skip_first_parameter: bool = False,
-) -> bool:
-    return _callable_accepts_kwarg_uncached(
+) -> CallableKwargSignature:
+    return _callable_kwarg_signature_uncached(
         callable_obj,
-        keyword,
         skip_first_parameter=skip_first_parameter,
     )
 
 
-def callable_accepts_kwarg(callable_obj: Any, keyword: str) -> bool:
-    cache_callable = callable_obj
-    skip_first_parameter = False
-    bound_function = getattr(callable_obj, "__func__", None)
-    if bound_function is not None and getattr(callable_obj, "__self__", None) is not None:
-        cache_callable = bound_function
-        skip_first_parameter = True
-
+def callable_kwarg_signature(callable_obj: Any) -> CallableKwargSignature:
+    cache_callable, skip_first_parameter = _callable_cache_target(callable_obj)
     try:
-        return _callable_accepts_kwarg_cached(
+        return _callable_kwarg_signature_cached(
             cache_callable,
-            keyword,
             skip_first_parameter=skip_first_parameter,
         )
     except TypeError:
-        return _callable_accepts_kwarg_uncached(callable_obj, keyword)
+        return _callable_kwarg_signature_uncached(callable_obj)
+
+
+def callable_declares_kwarg(callable_obj: Any, keyword: str) -> bool:
+    return callable_kwarg_signature(callable_obj).declares(keyword)
+
+
+def callable_accepts_kwarg(callable_obj: Any, keyword: str) -> bool:
+    return callable_kwarg_signature(callable_obj).accepts(keyword)
+
+
+def first_declared_kwarg(callable_obj: Any, keywords: tuple[str, ...]) -> str:
+    capabilities = callable_kwarg_signature(callable_obj)
+    for keyword in keywords:
+        if capabilities.declares(keyword):
+            return keyword
+    return ""
 
 
 def clear_callable_accepts_kwarg_cache() -> None:
-    _callable_accepts_kwarg_cached.cache_clear()
+    _callable_kwarg_signature_cached.cache_clear()
 
 
 def installed_package_version(package_name: str) -> str:

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -10,11 +10,11 @@ from typing import Any
 @dataclass(frozen=True)
 class CallableKwargSignature:
     parameter_names: tuple[str, ...]
-    declared_kwargs: frozenset[str]
+    keyword_accessible_params: frozenset[str]
     accepts_var_keyword: bool
 
     def declares(self, keyword: str) -> bool:
-        return keyword in self.declared_kwargs
+        return keyword in self.keyword_accessible_params
 
     def accepts(self, keyword: str) -> bool:
         return self.declares(keyword) or self.accepts_var_keyword
@@ -33,7 +33,7 @@ def _callable_kwarg_signature_uncached(
     except (TypeError, ValueError):
         return _EMPTY_KWARG_SIGNATURE
 
-    declared_kwargs: set[str] = set()
+    keyword_accessible_params: set[str] = set()
     parameter_names: list[str] = []
     accepts_var_keyword = False
     for index, (name, parameter) in enumerate(signature.parameters.items()):
@@ -45,9 +45,13 @@ def _callable_kwarg_signature_uncached(
             inspect.Parameter.POSITIONAL_OR_KEYWORD,
             inspect.Parameter.KEYWORD_ONLY,
         ):
-            declared_kwargs.add(name)
+            keyword_accessible_params.add(name)
             parameter_names.append(name)
-    return CallableKwargSignature(tuple(parameter_names), frozenset(declared_kwargs), accepts_var_keyword)
+    return CallableKwargSignature(
+        tuple(parameter_names),
+        frozenset(keyword_accessible_params),
+        accepts_var_keyword,
+    )
 
 
 def _callable_cache_target(callable_obj: Any) -> tuple[Any, bool]:
@@ -96,7 +100,7 @@ def first_declared_kwarg(callable_obj: Any, keywords: tuple[str, ...]) -> str:
     return ""
 
 
-def clear_callable_accepts_kwarg_cache() -> None:
+def clear_callable_kwarg_signature_cache() -> None:
     _callable_kwarg_signature_cached.cache_clear()
 
 


### PR DESCRIPTION
## Summary
- Add a shared cached kwarg capability model in `runtime_utils` that separates explicitly declared kwargs from arbitrary `**kwargs` acceptance.
- Route text stop forwarding, VLM video/MTP detection, and audio speech generate metadata through the explicit-declaration semantics.
- Update signature-cache probes and regression tests so variadic-only runtime callables no longer receive backend-specific kwargs by accident.
- Address review feedback by renaming the cache clearer and keyword-accessible parameter set, and by limiting audio legacy fallback to loaded models with unset `voice_mode`.

## Plan or Spec
- `docs/plans/2026-05-07-runtime-kwarg-capability-semantics.md`

## Commands Run
```text
python3 -m py_compile services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
# passed

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_mlx_backend.py::test_auto_backend_does_not_pass_stop_to_variadic_stream_generate services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_does_not_treat_variadic_kwargs_as_video_support services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_auto_mlx_vlm_backend_mtp_detection_requires_declared_draft_kwargs services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_speech_runtime_does_not_treat_variadic_kwargs_as_voice_support services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_generate_signature_probe_script_emits_metrics -q
# 13 passed in 0.48s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_speech_runtime_does_not_treat_variadic_kwargs_as_voice_support services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_speech_runtime_preserves_signature_fallback_for_legacy_loaded_models services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_speech_runtime_reuses_loaded_signature_metadata_during_speak services/mlx-worker-python/tests/test_mlx_backend.py::test_auto_backend_does_not_pass_stop_to_variadic_stream_generate services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_auto_mlx_vlm_backend_mtp_detection_requires_declared_draft_kwargs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_generate_signature_probe_script_emits_metrics -q
# 15 passed in 0.37s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_speech_runtime_preserves_signature_fallback_for_legacy_loaded_models services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_speech_runtime_does_not_treat_variadic_kwargs_as_voice_support -q
# 2 passed in 0.15s

make py-test
# 1965 passed, 5 skipped, 2 warnings in 101.54s

make package-smoke
# 30 passed in 0.12s
# packaging_target_profile_count=3
# packaging_target_distinct_packaging_kind_count=3

make py-coverage
# 1965 passed, 5 skipped, 2 warnings in 133.67s
# TOTAL 21958 statements, 857 missed, 96% coverage

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx coverage run -a --source=scripts scripts/runtime_utils_kwarg_cache_probe.py
# inspect_signature_calls_mean=1.0, iterations_per_sample=40000.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" MELIX_MLX_TEXT_STOP_KWARG_PROBE_ITERATIONS=1 MELIX_MLX_TEXT_STOP_KWARG_PROBE_SAMPLES=1 uv run --project services/mlx-worker-python --extra mlx coverage run -a --source=scripts scripts/mlx_text_stop_kwarg_signature_probe.py
# inspect_signature_calls_mean=2.0, stream_signature_calls_mean=1.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" MELIX_MLX_AUDIO_SIGNATURE_PROBE_ITERATIONS=1 MELIX_MLX_AUDIO_SIGNATURE_PROBE_SAMPLES=1 uv run --project services/mlx-worker-python --extra mlx coverage run -a --source=scripts scripts/mlx_audio_generate_signature_probe.py
# signature_calls_mean=0.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" MELIX_AUDIO_SPEECH_SIGNATURE_PROBE_CALLS=1 MELIX_AUDIO_SPEECH_SIGNATURE_PROBE_SAMPLES=1 uv run --project services/mlx-worker-python --extra mlx coverage run -a --source=scripts scripts/mlx_audio_speech_signature_probe.py
# inspect_signature_calls_mean=0.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx coverage json -o .runtime/coverage/runtime-kwarg-capabilities.json
# wrote coverage JSON

python3 scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/runtime-kwarg-capabilities.json --diff-from origin/main services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py scripts/runtime_utils_kwarg_cache_probe.py scripts/mlx_text_stop_kwarg_signature_probe.py scripts/mlx_audio_generate_signature_probe.py scripts/mlx_audio_speech_signature_probe.py
# TOTAL 100.00% 86/86
```

## Coverage and Metrics
- Full Python coverage: 96% overall from `make py-coverage`.
- Changed-line coverage for runtime/probe executable lines: 100.00% (86/86).
- Runtime kwarg cache probe expectation: one structured signature inspection per callable.
- Text stop kwarg probe expectation: stream signature inspected once and cached before repeated generation.
- Audio generate/speech probe expectation: no per-request signature inspection after loaded model metadata is available.

## Known Gaps
- `make bootstrap`, `make proto`, `make swift-test`, and `make integration-test` were not run because this is a Python runtime capability fix with no protocol or Swift changes.
- `uv run` rewrites `uv.lock` in this local environment; `uv.lock` was restored and is intentionally not part of this dependency-free change.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
