### PR TITLE
perf: scan QAT source artifacts with scandir

### DIFF
--- a/docs/plans/2026-05-06-quantization-qat-source-scan-scandir.md
+++ b/docs/plans/2026-05-06-quantization-qat-source-scan-scandir.md
@@ -1,0 +1,40 @@
+# Quantization QAT Source Scan Scandir
+
+## Goal
+
+Reduce Python QAT fake-quant source artifact scan overhead by replacing the directory `Path.rglob("*")` materialization with an explicit `os.scandir()` stack while preserving deterministic file ordering and existing invalid-source behavior.
+
+## Scope
+
+- `services/mlx-worker-python/worker/model_ops/quantization_pipeline.py`
+- `services/mlx-worker-python/tests/test_quantization_pipeline.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/quantization_qat_source_scan_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Probe Registration
+
+Registered probe: `quantization-qat-source-scan-scandir`.
+
+The probe includes:
+
+- `test_command` for focused quantization and PR-scoped registry tests.
+- `coverage_command` for changed-scope coverage across the touched Python source, tests, and probe script.
+- `probe_command` using `command_json` to measure the QAT source scan against a synthetic nested merged-adapter artifact tree.
+
+## Optimization
+
+`_source_artifact_files_for_qat(...)` keeps the single-file fast path unchanged. For directory inputs it walks entries with `os.scandir()`, appends directory entries to an explicit stack, collects file paths, and sorts the final list before returning so downstream QAT hashing remains deterministic.
+
+Directory symlinks are not followed during stack expansion. Per-entry `OSError` and root scan failures continue to be ignored until the existing empty-source validation raises `invalid_qat_source_artifact`.
+
+## Linux-only Verification Path
+
+This is a Python-only worker optimization and is locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered PR-scoped performance probe.
+
+## Success Metrics
+
+- Focused tests pass.
+- Changed-scope coverage is at least 95% for touched executable Python lines.
+- Registered probe reports `rglob_calls_mean == 0.0` and a successful deterministic file count.
+- `elapsed_ms_mean` should not regress beyond the registered 5% warning threshold in PR-scoped CI.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2286,5 +2286,41 @@
         "warn_pct": 0.0
       }
     ]
+  },
+  {
+    "id": "quantization-qat-source-scan-scandir",
+    "name": "Quantization QAT source scan scandir",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/quantization_pipeline.py",
+      "services/mlx-worker-python/tests/test_quantization_pipeline.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/quantization_qat_source_scan_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_uses_scandir_stack_without_path_rglob services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_skips_bad_scandir_entries_and_empty_roots services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_qat_source_scan_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_uses_scandir_stack_without_path_rglob services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_skips_bad_scandir_entries_and_empty_roots services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_qat_source_scan_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/quantization_qat_source_scan_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_QAT_SOURCE_SCAN_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python python3 \"${PWD}/scripts/quantization_qat_source_scan_probe.py\" || PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_QAT_SOURCE_SCAN_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python python3 \"${PWD}/../head/scripts/quantization_qat_source_scan_probe.py\"",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "rglob_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      }
+    ]
   }
 ]

--- a/scripts/quantization_qat_source_scan_probe.py
+++ b/scripts/quantization_qat_source_scan_probe.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(os.environ.get("MELIX_QAT_SOURCE_SCAN_REPO_ROOT") or Path(__file__).resolve().parents[1])
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.model_ops import quantization_pipeline
+from worker.model_ops.quantization_pipeline import _source_artifact_files_for_qat
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    return int(raw) if raw else default
+
+
+def _write_source_tree(root: Path, *, file_count: int) -> list[Path]:
+    expected: list[Path] = []
+    for index in range(file_count):
+        parent = root / f"shard-{index % 32:02d}" / f"block-{index % 8:02d}"
+        parent.mkdir(parents=True, exist_ok=True)
+        suffix = ".safetensors" if index % 2 else ".json"
+        path = parent / f"artifact-{index:05d}{suffix}"
+        path.write_bytes((f"melix-qatsource-{index}\n" * 2).encode("utf-8"))
+        expected.append(path)
+    (root / "empty-dir").mkdir(parents=True, exist_ok=True)
+    return sorted(expected)
+
+
+def main() -> int:
+    file_count = _int_env("MELIX_QAT_SOURCE_SCAN_PROBE_FILES", 4000)
+    sample_count = _int_env("MELIX_QAT_SOURCE_SCAN_PROBE_SAMPLES", 5)
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    scandir_samples: list[float] = []
+    rglob_samples: list[float] = []
+
+    with tempfile.TemporaryDirectory(prefix="melix-qat-source-scan-probe-") as temp_dir:
+        source_root = Path(temp_dir) / "merged-adapter"
+        expected = _write_source_tree(source_root, file_count=file_count)
+        original_scandir = quantization_pipeline.os.scandir
+        original_rglob = Path.rglob
+
+        for _ in range(sample_count):
+            scandir_calls = 0
+            rglob_calls = 0
+
+            def tracked_scandir(path: str | bytes | os.PathLike[str] | os.PathLike[bytes] | int):
+                nonlocal scandir_calls
+                scandir_calls += 1
+                return original_scandir(path)
+
+            def tracked_rglob(self: Path, pattern: str):
+                nonlocal rglob_calls
+                rglob_calls += 1
+                return original_rglob(self, pattern)
+
+            quantization_pipeline.os.scandir = tracked_scandir
+            Path.rglob = tracked_rglob  # type: ignore[method-assign]
+            try:
+                tracemalloc.start()
+                started = time.perf_counter()
+                files = _source_artifact_files_for_qat(source_root)
+                elapsed_ms = (time.perf_counter() - started) * 1000.0
+                _, peak = tracemalloc.get_traced_memory()
+                tracemalloc.stop()
+            finally:
+                quantization_pipeline.os.scandir = original_scandir
+                Path.rglob = original_rglob  # type: ignore[method-assign]
+                if tracemalloc.is_tracing():
+                    tracemalloc.stop()
+
+            if files != expected:
+                raise SystemExit("unexpected QAT source file ordering/count")
+            elapsed_samples.append(elapsed_ms)
+            peak_samples.append(float(peak))
+            scandir_samples.append(float(scandir_calls))
+            rglob_samples.append(float(rglob_calls))
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+                "elapsed_ms_min": round(min(elapsed_samples), 6),
+                "peak_bytes_mean": round(statistics.fmean(peak_samples), 3),
+                "scandir_calls_mean": round(statistics.fmean(scandir_samples), 3),
+                "rglob_calls_mean": round(statistics.fmean(rglob_samples), 3),
+                "file_count": float(file_count),
+                "sample_count": float(sample_count),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -252,6 +252,15 @@ def test_scope_report_selects_training_dataset_chunker_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "training-dataset-chunker-top-level-base-copy"
 
 
+def test_scope_report_selects_quantization_qat_source_scan_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/model_ops/quantization_pipeline.py"],
+    )
+
+    assert "quantization-qat-source-scan-scandir" in _selected_probe_ids(scope)
+
+
 def test_scope_report_selects_startup_signals_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -1300,6 +1309,28 @@ def test_video_preprocessing_uri_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0
 
 
+def test_quantization_qat_source_scan_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_QAT_SOURCE_SCAN_PROBE_FILES", "4")
+    monkeypatch.setenv("MELIX_QAT_SOURCE_SCAN_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/quantization_qat_source_scan_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["file_count"] == 4.0
+    assert metrics["rglob_calls_mean"] == 0.0
+    assert metrics["scandir_calls_mean"] >= 1.0
+    assert metrics["elapsed_ms_mean"] >= 0
+
+
 def test_mlx_audio_speech_signature_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -1392,6 +1423,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "package-macos-resolve-fallback-scandir",
         "pr-scoped-performance-scope-json-read-bytes",
         "pr-scoped-performance-scope-matcher",
+        "quantization-qat-source-scan-scandir",
         "training-dataset-token-percentiles-single-sort",
         "training-dataset-validation-sample-limit",
         "training-dataset-chunker-top-level-base-copy",

--- a/services/mlx-worker-python/tests/test_quantization_pipeline.py
+++ b/services/mlx-worker-python/tests/test_quantization_pipeline.py
@@ -17,6 +17,7 @@ from worker.model_ops.quantization_pipeline import (
     OQQuantizationPipeline,
     _local_source_path_for_mlx_lm_convert,
     _smoke_required_files_for_backend,
+    _source_artifact_files_for_qat,
     _sum_bundle_file_bytes,
 )
 from worker.model_ops.quantization_profiles import (
@@ -1195,6 +1196,67 @@ def test_mlx_lm_bundle_byte_sum_handles_nested_and_unreadable_entries(
 
     monkeypatch.setattr(quantization_pipeline_module.os, "scandir", failed_scandir)
     assert _sum_bundle_file_bytes(bundle_path) == 0
+
+
+def test_qat_source_artifact_files_uses_scandir_stack_without_path_rglob(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_path = tmp_path / "merged-adapter"
+    nested_path = source_path / "nested"
+    nested_path.mkdir(parents=True)
+    root_file = source_path / "adapter_config.json"
+    nested_file = nested_path / "adapters.safetensors"
+    root_file.write_text(json.dumps({"fine_tune_type": "lora"}) + "\n", encoding="utf-8")
+    nested_file.write_bytes(b"melix-qatsource-weights")
+
+    def fail_rglob(self: Path, pattern: str):
+        raise AssertionError("QAT source scan should avoid Path.rglob allocation")
+
+    monkeypatch.setattr(Path, "rglob", fail_rglob)
+    with pytest.raises(AssertionError):
+        list(source_path.rglob("*"))
+
+    assert _source_artifact_files_for_qat(source_path) == sorted([root_file, nested_file])
+
+
+def test_qat_source_artifact_files_skips_bad_scandir_entries_and_empty_roots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_path = tmp_path / "bad-source"
+    source_path.mkdir()
+
+    class BadEntry:
+        path = os.fspath(source_path / "bad")
+
+        def is_file(self) -> bool:
+            raise OSError("entry stat failed")
+
+        def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+            raise AssertionError("is_dir should not run after is_file fails")
+
+    class BadScandir:
+        def __enter__(self) -> list[BadEntry]:
+            return [BadEntry()]
+
+        def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+            return None
+
+    monkeypatch.setattr(quantization_pipeline_module.os, "scandir", lambda _: BadScandir())
+
+    with pytest.raises(ModelOperationError) as error:
+        _source_artifact_files_for_qat(source_path)
+    assert error.value.code == "invalid_qat_source_artifact"
+
+    def failed_scandir(_: object) -> object:
+        raise OSError("root failed")
+
+    monkeypatch.setattr(quantization_pipeline_module.os, "scandir", failed_scandir)
+
+    with pytest.raises(ModelOperationError) as root_error:
+        _source_artifact_files_for_qat(source_path)
+    assert root_error.value.code == "invalid_qat_source_artifact"
 
 
 def test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -1175,7 +1175,24 @@ def _run_qat_fake_quant_training(
 def _source_artifact_files_for_qat(source_path: Path) -> list[Path]:
     if source_path.is_file():
         return [source_path]
-    source_files = sorted(path for path in source_path.rglob("*") if path.is_file())
+    source_file_paths: list[str] = []
+    stack = [os.fspath(source_path)]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_file():
+                            source_file_paths.append(entry.path)
+                        elif entry.is_dir(follow_symlinks=False):
+                            stack.append(entry.path)
+                    except OSError:
+                        continue
+        except OSError:
+            continue
+    source_file_paths.sort()
+    source_files = [Path(path) for path in source_file_paths]
     if not source_files:
         raise ModelOperationError(
             code="invalid_qat_source_artifact",


### PR DESCRIPTION
## Summary
- Replace QAT fake-quant source directory `Path.rglob("*")` materialization with an explicit `os.scandir()` stack that sorts string paths before final `Path` construction.
- Register the `quantization-qat-source-scan-scandir` PR-scoped performance probe and add focused regression coverage for the scan path and error handling.
- Update the probe command so base/head CI comparisons can run the new probe script from the head checkout while importing the target repository under measurement.

## Plan or Spec
- `docs/plans/2026-05-06-quantization-qat-source-scan-scandir.md`

## Commands Run
```text
# Baseline on origin/main helper (same synthetic 4k-file nested tree)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 - <<'PY'
...
PY
# exit 0; {"elapsed_ms_mean": 128.815067, "file_count": 4000.0, "peak_bytes_mean": 1984904.4, "rglob_calls_mean": 1.0, "sample_count": 5.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_uses_scandir_stack_without_path_rglob services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_skips_bad_scandir_entries_and_empty_roots services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_qat_source_scan_probe_script_emits_metrics
# exit 0; 6 passed in 0.79s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_uses_scandir_stack_without_path_rglob services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_skips_bad_scandir_entries_and_empty_roots services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_qat_source_scan_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/quantization_qat_source_scan_probe.py
# exit 0; TOTAL 0 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_QAT_SOURCE_SCAN_PROBE_FILES=10 MELIX_QAT_SOURCE_SCAN_PROBE_SAMPLES=1 uv run --project services/mlx-worker-python python3 scripts/quantization_qat_source_scan_probe.py
# exit 0; {"elapsed_ms_mean": 0.391776, "elapsed_ms_min": 0.391776, "file_count": 10.0, "peak_bytes_mean": 4395.0, "rglob_calls_mean": 0.0, "sample_count": 1.0, "scandir_calls_mean": 22.0}

# Local CI-shape registered probe smoke with real sibling base/head checkouts
MELIX_QAT_SOURCE_SCAN_PROBE_FILES=400 MELIX_QAT_SOURCE_SCAN_PROBE_SAMPLES=3 python3 "$PROBE_DIR/head/scripts/pr_scoped_performance_run.py" --registry "$PROBE_DIR/head/infra/perf/pr_scoped_probes.json" --probe-id quantization-qat-source-scan-scandir --base-repo "$PROBE_DIR/base" --head-repo "$PROBE_DIR/head" --output "$PROBE_DIR/result.json"
# exit 0; base elapsed_ms_mean=19.309868, head elapsed_ms_mean=3.638619; base rglob_calls_mean=1.0, head rglob_calls_mean=0.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 0 0 100%` after rebasing onto `origin/main`.
- Local branch probe smoke: `elapsed_ms_mean=0.391776`, `rglob_calls_mean=0.0`, `scandir_calls_mean=22.0`, `file_count=10`, `sample_count=1`.
- Local CI-shape registered probe smoke (400 files, 3 samples): base `elapsed_ms_mean=19.309868`, head `elapsed_ms_mean=3.638619`, delta `-15.671249 ms` (`~5.31x` faster); base `rglob_calls_mean=1.0`, head `rglob_calls_mean=0.0`; base `peak_bytes_mean=401187.333`, head `peak_bytes_mean=139417.333`.
- Earlier 4k-file local baseline helper: base `elapsed_ms_mean=128.815067`, head `elapsed_ms_mean=28.97864`, delta `-99.836427 ms` (`~4.45x` faster).
- CI is required for the registered PR-scoped performance workflow/report before merge.

## Known Gaps
- This is a Python-only Linux-verifiable slice; no Swift runtime validation was performed or required.
- The existing `model-ops-bundle-artifact-byte-accounting` probe also matches `quantization_pipeline.py`; this PR adds a second registered probe specifically for the QAT source scan path.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
