### PR TITLE
perf: skip noncandidate rerank order checks

### DIFF
--- a/docs/plans/2026-05-06-rerank-order-match-first-token-skip.md
+++ b/docs/plans/2026-05-06-rerank-order-match-first-token-skip.md
@@ -1,0 +1,28 @@
+# Rerank order-match first-token skip
+
+## Scope
+
+This Linux-safe optimization narrows the deterministic rerank order-aware hot path in `services/mlx-worker-python/worker/runtime/rerank_backends.py`. The current contiguous-query and ordered-pair helpers still perform unnecessary per-position work on document tokens whose first token cannot possibly match the query phrase or an adjacent query pair.
+
+## Files
+
+- `services/mlx-worker-python/worker/runtime/rerank_backends.py`
+- `services/mlx-worker-python/tests/test_rerank_runtime.py`
+
+## Goal
+
+Reduce redundant sequence comparison and adjacent-pair tuple construction for long rerank documents with sparse query-token starts, while preserving existing deterministic score semantics.
+
+## Linux constraint
+
+This slice is Python-only and can be verified on Linux with focused pytest, changed-scope coverage, and a local base-vs-head PR-scoped performance probe.
+
+## Registered probe
+
+Use the existing registered PR-scoped performance probe `deterministic-rerank-query-context-reuse`, which already watches the touched rerank runtime/backend files and runs a synthetic multi-document rerank workload.
+
+## Success metrics
+
+- Focused rerank tests pass.
+- Changed-scope coverage is at least 95% for changed executable lines.
+- The registered `deterministic-rerank-query-context-reuse` probe is equal or faster than `origin/main` while preserving structural metrics (`query_context_builds_mean`, `tokenize_calls_mean`).

--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -9,6 +9,7 @@ from worker.engine.rerank_core import RerankCore
 from worker.grpc_server import WorkerInferenceService, WorkerRuntimeService
 from worker.model_registry.catalog import WorkerModelCatalog
 from worker.registry import WorkerRegistry
+from worker.runtime import rerank_backends
 from worker.runtime.deterministic_rerank_runtime import DeterministicRerankRuntime
 from worker.runtime.mlx_text_runtime import MLXTextRuntime
 from worker.runtime.rerank_backends import (
@@ -599,6 +600,58 @@ def test_contiguous_query_scan_does_not_allocate_document_slices() -> None:
     )
     with pytest.raises(AssertionError, match="without slicing"):
         NoSliceTokens(("swift", "runtime"))[0:1]
+
+
+def test_contiguous_query_scan_skips_full_comparison_until_first_token_matches(monkeypatch) -> None:
+    calls: list[int] = []
+    original_sequence_matches_at = rerank_backends._sequence_matches_at
+
+    def tracking_sequence_matches_at(haystack, needle, start):
+        calls.append(start)
+        return original_sequence_matches_at(haystack, needle, start)
+
+    monkeypatch.setattr(rerank_backends, "_sequence_matches_at", tracking_sequence_matches_at)
+
+    assert JinaV3RerankFamilyAdapter._contains_contiguous_query(
+        ("padding", "runtime", "control", "swift", "runtime"),
+        ("swift", "runtime"),
+    )
+    assert calls == [3]
+
+    calls.clear()
+    assert not JinaV3RerankFamilyAdapter._contains_contiguous_query(
+        ("padding", "runtime", "control", "worker"),
+        ("swift", "runtime"),
+    )
+    assert calls == []
+
+
+def test_ordered_pair_bonus_skips_second_token_reads_for_noncandidate_pair_starts() -> None:
+    class CountingTokens:
+        def __init__(self, tokens: tuple[str, ...]) -> None:
+            self.tokens = tokens
+            self.accessed_indexes: list[int] = []
+
+        def __len__(self) -> int:
+            return len(self.tokens)
+
+        def __getitem__(self, index: int) -> str:
+            self.accessed_indexes.append(index)
+            return self.tokens[index]
+
+    padding = tuple(f"padding-{index}" for index in range(20))
+    document_tokens = CountingTokens(padding + ("swift", "runtime"))
+
+    assert (
+        JinaV3RerankFamilyAdapter._ordered_pair_bonus(
+            ("swift", "runtime"),
+            document_tokens,
+            query_pairs=frozenset({("swift", "runtime")}),
+            query_pair_start_tokens=frozenset({"swift"}),
+        )
+        == 0.15
+    )
+    assert document_tokens.accessed_indexes == list(range(21)) + [21]
 
 
 @pytest.mark.parametrize(

--- a/services/mlx-worker-python/worker/runtime/rerank_backends.py
+++ b/services/mlx-worker-python/worker/runtime/rerank_backends.py
@@ -69,6 +69,7 @@ class RerankQueryContext:
     query_tokens: tuple[str, ...]
     query_token_set: frozenset[str]
     ordered_pairs: frozenset[tuple[str, str]]
+    ordered_pair_start_tokens: frozenset[str]
     tie_breaker_seed: object
 
 
@@ -95,11 +96,13 @@ class RerankFamilyAdapter:
         if query_token_set is None:
             query_token_set = set(query_tokens)
         normalized_query_tokens = tuple(query_tokens)
+        ordered_pairs = frozenset(_build_adjacent_pairs(normalized_query_tokens))
         return RerankQueryContext(
             query=query,
             query_tokens=normalized_query_tokens,
             query_token_set=frozenset(query_token_set),
-            ordered_pairs=frozenset(_build_adjacent_pairs(normalized_query_tokens)),
+            ordered_pairs=ordered_pairs,
+            ordered_pair_start_tokens=frozenset(pair[0] for pair in ordered_pairs),
             tie_breaker_seed=backend.build_tie_breaker_seed(query),
         )
 
@@ -217,6 +220,7 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
                 reusable_query_tokens,
                 document_tokens,
                 query_pairs=query_context.ordered_pairs,
+                query_pair_start_tokens=query_context.ordered_pair_start_tokens,
             )
         has_all_query_terms = overlap_count >= len(reusable_query_token_set)
         if has_all_query_terms:
@@ -242,16 +246,22 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
         document_tokens: Sequence[str],
         *,
         query_pairs: frozenset[tuple[str, str]] | None = None,
+        query_pair_start_tokens: frozenset[str] | None = None,
     ) -> float:
         if len(query_tokens) < 2 or len(document_tokens) < 2:
             return 0.0
 
         if query_pairs is None:
             query_pairs = frozenset(_build_adjacent_pairs(query_tokens))
+        if query_pair_start_tokens is None:
+            query_pair_start_tokens = frozenset(pair[0] for pair in query_pairs)
         matched_pairs: set[tuple[str, str]] = set()
         query_pair_count = len(query_pairs)
         for index in range(len(document_tokens) - 1):
-            pair = (document_tokens[index], document_tokens[index + 1])
+            first_token = document_tokens[index]
+            if first_token not in query_pair_start_tokens:
+                continue
+            pair = (first_token, document_tokens[index + 1])
             if pair not in query_pairs:
                 continue
             matched_pairs.add(pair)
@@ -270,8 +280,11 @@ class JinaV3RerankFamilyAdapter(RerankFamilyAdapter):
         if not query_tokens or len(query_tokens) > len(document_tokens):
             return False
         query_length = len(query_tokens)
+        first_query_token = query_tokens[0]
         last_start = len(document_tokens) - query_length
         for start in range(last_start + 1):
+            if document_tokens[start] != first_query_token:
+                continue
             if _sequence_matches_at(document_tokens, query_tokens, start):
                 return True
         return False
@@ -332,6 +345,7 @@ class CausalLMRerankFamilyAdapter(RerankFamilyAdapter):
                 reusable_query_tokens,
                 document_tokens,
                 query_pairs=query_context.ordered_pairs,
+                query_pair_start_tokens=query_context.ordered_pair_start_tokens,
             )
         if overlap_count >= len(reusable_query_token_set):
             exact_order, prefix_match = JinaV3RerankFamilyAdapter._query_order_matches(


### PR DESCRIPTION
## Summary
- Skips full contiguous-query comparison for rerank document positions whose first token cannot match the query phrase.
- Reuses query-pair first-token metadata so ordered-pair scoring skips second-token reads for impossible adjacent-pair starts.
- Adds focused regression coverage for the first-token skip behavior and the ordered-pair read reduction.

## Plan or Spec
- `docs/plans/2026-05-06-rerank-order-match-first-token-skip.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py
# 36 passed in 0.80s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/tests/test_rerank_runtime.py
# 36 passed in 0.57s
# TOTAL 38 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-rerank-query-context-reuse --base-repo /tmp/melix-cron-opt-20260506192759-base-193920 --head-repo /tmp/melix-cron-opt-20260506192759 --output /tmp/rerank-probe.json
# head verification: 40 passed in 39.24s; TOTAL 38 0 100%
# base elapsed_ms_mean=82.077225; head elapsed_ms_mean=74.65687
# query_context_builds_mean=1.0 on both; tokenize_calls_mean=2049.0 on both

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 38 0 100%` across `rerank_backends.py` and `test_rerank_runtime.py`.
- Registered scoped CI probe: `deterministic-rerank-query-context-reuse`.
- Local base-vs-head probe: `elapsed_ms_mean` improved from `82.077225 ms` to `74.65687 ms` (~9.04% lower) with structural metrics unchanged (`query_context_builds_mean=1.0`, `tokenize_calls_mean=2049.0`).

## Known Gaps
- Linux-only local verification. Full macOS/Swift checks were not run locally on this host.
- Hosted GitHub Actions remains the merge gate after PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
