### PR TITLE
perf: skip stream assembler tag scans for plain chunks

### DIFF
--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -72,6 +72,51 @@ def test_next_structural_tag_prefers_the_earliest_tool_tag() -> None:
     assert assembler._next_structural_tag() == (RequestStreamAssembler._TOOL_OPEN, 0)
 
 
+def test_plain_buffer_without_tag_marker_flushes_without_structural_scans(monkeypatch) -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-no-marker-fast-path",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+
+    def fail_structural_scan() -> None:
+        raise AssertionError("plain buffers should not scan for structural tags")
+
+    monkeypatch.setattr(assembler, "_next_structural_tag", fail_structural_scan)
+    deltas = assembler.accept(StreamFragment(raw_text="plain text chunk without markup"))
+    completed = assembler.completed()
+
+    assert [delta.content_text for delta in deltas if delta.content_text] == [
+        "plain text chunk without markup"
+    ]
+    assert completed.assistant_text == "plain text chunk without markup"
+    assert completed.metrics["stream_prefix_hold_chars"] == 0
+    assert completed.metrics["stream_short_reply_flush_count"] == 0
+
+
+def test_plain_buffer_with_marker_still_holds_partial_structural_prefix() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-marker-still-held",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+
+    first = assembler.accept(StreamFragment(raw_text="alpha<tool_ca"))
+    second = assembler.accept(
+        StreamFragment(
+            raw_text='alpha<tool_call>{"name":"search","arguments":{"q":"alpha"}}</tool_call>'
+        )
+    )
+    completed = assembler.completed()
+
+    assert [delta.content_text for delta in first if delta.content_text] == ["alpha"]
+    assert [delta.tool_call.tool_name for delta in second if delta.tool_call] == ["search"]
+    assert completed.assistant_text == "alpha"
+    assert completed.metrics["stream_prefix_hold_chars"] == len("<tool_ca")
+
+
 def test_partial_structural_tag_suffix_checks_all_prefixes_in_one_endswith_call() -> None:
     class RecordingBuffer:
         def __init__(self) -> None:

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -198,6 +198,12 @@ class RequestStreamAssembler:
     def _drain_buffer(self, final: bool) -> list[AssemblyDelta]:
         deltas: list[AssemblyDelta] = []
         while self._buffer:
+            if "<" not in self._buffer:
+                content = self._buffer
+                self._buffer = ""
+                deltas.append(self._content_delta(content))
+                continue
+
             next_tag = self._next_structural_tag()
             if next_tag is None:
                 if not final:


### PR DESCRIPTION
## Summary
- Skips stream assembler structural tag scans for chunks that contain no `<` marker.
- Preserves existing reasoning/tool-call parsing for chunks that may contain structural prefixes.
- Adds focused regression coverage for the no-marker fast path and partial-prefix behavior.

## Plan or Spec
- Governed by `AGENTS.md`, `docs/engineering-standards.md`, and the existing `stream-assembler-parser-mode-cache` scoped performance probe.
- Optimization target: reduce redundant structural tag work in `RequestStreamAssembler._drain_buffer(...)` for plain content chunks.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 30 passed in 0.50s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 25 1 96%

python /tmp/stream_no_marker_probe.py /tmp/melix-cron-opt-base-20260506210300
# {"assistant_char_count": 113890.0, "chunk_count": 5000.0, "elapsed_ms_max": 33.972705, "elapsed_ms_mean": 32.505479, "elapsed_ms_min": 31.15071, "raw_char_count": 113890.0}

python /tmp/stream_no_marker_probe.py /tmp/melix-cron-opt-20260506205829
# {"assistant_char_count": 113890.0, "chunk_count": 5000.0, "elapsed_ms_max": 26.580254, "elapsed_ms_mean": 25.087782, "elapsed_ms_min": 23.746798, "raw_char_count": 113890.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id stream-assembler-parser-mode-cache --base-repo /tmp/melix-cron-opt-base-20260506210300 --head-repo /tmp/melix-cron-opt-20260506205829 --output /tmp/stream-assembler-parser-mode-cache-result.json
# Head verification passed; scoped probe succeeded.
# Registered mixed workload: base elapsed_ms_mean=5.558310862397775, head elapsed_ms_mean=5.808161149616353 (within 5% warning threshold).

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 25 1 96%`.
  - `stream_assembler.py`: 5/5 changed executable lines covered, 100%.
  - `test_stream_assembler.py`: 19/20 changed executable lines covered, 95%.
- Explicit no-marker local probe: `elapsed_ms_mean` improved from `32.505479 ms` on `origin/main` to `25.087782 ms` on this branch for 5,000 cumulative plain chunks, about 22.82% lower.
- Registered scoped CI probe: `stream-assembler-parser-mode-cache`.
  - Local base-vs-head scoped run passed head verification and probe execution.
  - The existing registered mixed workload was effectively flat/slightly noisy (`5.5583 ms` base vs `5.8082 ms` head), still inside the probe's 5% warning threshold; the direct no-marker probe above captures the optimized path.

## Known Gaps
- Linux-only local verification; macOS/Swift checks were not run locally.
- Hosted PR checks are required before merge; auto-merge should only be enabled if all required checks pass.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. N/A: internal hot-path optimization with unchanged external behavior.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
