### PR TITLE
perf: aggregate statistical category breakdown in one pass

### DIFF
--- a/docs/plans/2026-05-06-statistical-evidence-category-breakdown-single-pass.md
+++ b/docs/plans/2026-05-06-statistical-evidence-category-breakdown-single-pass.md
@@ -1,0 +1,39 @@
+# Statistical Evidence Category Breakdown Single-Pass Plan
+
+## Goal
+
+Reduce redundant work and memory pressure in `build_category_breakdown(...)` by replacing per-category retained row lists and follow-up scans with a compact single-pass aggregate.
+
+## Linux-only constraint
+
+This is a Python worker/productization slice under `services/mlx-worker-python`, so it can be verified on Linux with focused pytest, changed-scope coverage, and a local PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/productization/statistical_evidence.py`
+- `services/mlx-worker-python/tests/test_statistical_evidence.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+- `scripts/statistical_evidence_category_breakdown_probe.py`
+
+## Performance probe
+
+Register `statistical-evidence-category-breakdown-single-pass` in the PR-scoped performance registry. The probe builds a synthetic many-row category payload, calls `build_category_breakdown(...)`, and reports:
+
+- `elapsed_ms_mean` — lower is better
+- `peak_bytes_mean` — lower is better
+- structural row/category/checksum metrics to catch semantic drift
+
+## Success metrics
+
+- Preserve category labels, sorted output ordering, sample sizes, rounded base/target accuracy, and delta accuracy.
+- Focused tests pass.
+- Changed-scope coverage for touched executable Python files is at least 95%.
+- Local base-vs-head probe shows lower peak memory and/or elapsed time for the synthetic workload.
+
+## Verification commands
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json ... && python3 scripts/changed_scope_coverage.py ...`
+- `python3 scripts/pr_scoped_performance_run.py --probe-id statistical-evidence-category-breakdown-single-pass ...`
+- `git diff --check`

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1947,6 +1947,38 @@
     ]
   },
   {
+    "id": "statistical-evidence-category-breakdown-single-pass",
+    "name": "Statistical evidence category breakdown single pass",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/statistical_evidence.py",
+      "services/mlx-worker-python/tests/test_statistical_evidence.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json",
+      "scripts/statistical_evidence_category_breakdown_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_category_breakdown_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/statistical_evidence_category_breakdown_probe.py ]; then python3 scripts/statistical_evidence_category_breakdown_probe.py; else python3 - <<\"PY\"\nimport json, os, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd(); sys.path.insert(0, str(repo_root)); sys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.productization.statistical_evidence import build_category_breakdown\nrow_count = int(os.environ.get(\"MELIX_STAT_CATEGORY_ROWS\", \"50000\")); category_count = int(os.environ.get(\"MELIX_STAT_CATEGORY_COUNT\", \"64\")); sample_count = int(os.environ.get(\"MELIX_STAT_CATEGORY_PROBE_SAMPLES\", \"5\"))\nrows = tuple({\"category_label\": f\"category-{index % category_count:03d}\", \"base_correct\": index % 5 in (0, 1), \"target_correct\": index % 7 in (0, 1, 2, 3)} for index in range(row_count))\nelapsed_samples = []; peak_samples = []; checksum = 0.0\nfor _ in range(sample_count):\n    started = time.perf_counter(); breakdown = build_category_breakdown(rows=rows); elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n    checksum += sum(float(payload[\"sample_size\"]) + float(payload[\"base_accuracy\"]) + float(payload[\"target_accuracy\"]) + float(payload[\"delta_accuracy\"]) for payload in breakdown.values())\n    if len(breakdown) != category_count: raise SystemExit(f\"unexpected category count: {len(breakdown)} != {category_count}\")\n    if sum(int(payload[\"sample_size\"]) for payload in breakdown.values()) != row_count: raise SystemExit(\"category breakdown dropped rows\")\n    tracemalloc.start(); memory_breakdown = build_category_breakdown(rows=rows); _, peak = tracemalloc.get_traced_memory(); tracemalloc.stop(); peak_samples.append(float(peak))\n    if memory_breakdown != breakdown: raise SystemExit(\"category breakdown changed between timing and memory passes\")\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed_samples), \"peak_bytes_mean\": statistics.fmean(peak_samples), \"row_count\": float(row_count), \"category_count\": float(category_count), \"sample_count\": float(sample_count), \"checksum\": checksum}, sort_keys=True))\nPY\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "video-preprocessing-uri-byte-length-reuse",
     "name": "Video preprocessing URI byte length reuse",
     "runner": "ubuntu-latest",

--- a/scripts/statistical_evidence_category_breakdown_probe.py
+++ b/scripts/statistical_evidence_category_breakdown_probe.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Measure category-breakdown aggregation for statistical evidence."""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.productization.statistical_evidence import build_category_breakdown
+
+
+def _build_rows(row_count: int, category_count: int) -> tuple[dict[str, object], ...]:
+    return tuple(
+        {
+            "category_label": f"category-{index % category_count:03d}",
+            "base_correct": index % 5 in (0, 1),
+            "target_correct": index % 7 in (0, 1, 2, 3),
+        }
+        for index in range(row_count)
+    )
+
+
+def main() -> int:
+    row_count = int(os.environ.get("MELIX_STAT_CATEGORY_ROWS", "50000"))
+    category_count = int(os.environ.get("MELIX_STAT_CATEGORY_COUNT", "64"))
+    sample_count = int(os.environ.get("MELIX_STAT_CATEGORY_PROBE_SAMPLES", "5"))
+    rows = _build_rows(row_count=row_count, category_count=category_count)
+
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    checksum = 0.0
+    for _ in range(sample_count):
+        started = time.perf_counter()
+        breakdown = build_category_breakdown(rows=rows)
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        checksum += sum(
+            float(payload["sample_size"])
+            + float(payload["base_accuracy"])
+            + float(payload["target_accuracy"])
+            + float(payload["delta_accuracy"])
+            for payload in breakdown.values()
+        )
+        if len(breakdown) != category_count:
+            raise SystemExit(
+                f"unexpected category count: {len(breakdown)} != {category_count}"
+            )
+        if sum(int(payload["sample_size"]) for payload in breakdown.values()) != row_count:
+            raise SystemExit("category breakdown dropped rows")
+
+        tracemalloc.start()
+        memory_breakdown = build_category_breakdown(rows=rows)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_samples.append(float(peak))
+        if memory_breakdown != breakdown:
+            raise SystemExit("category breakdown changed between timing and memory passes")
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+                "peak_bytes_mean": statistics.fmean(peak_samples),
+                "row_count": float(row_count),
+                "category_count": float(category_count),
+                "sample_count": float(sample_count),
+                "checksum": checksum,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -417,8 +417,12 @@ def test_scope_report_selects_statistical_evidence_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/productization/statistical_evidence.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "statistical-evidence-bootstrap-single-sort"
+    selected_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert scope["selected_count"] == 2
+    assert selected_ids == {
+        "statistical-evidence-bootstrap-single-sort",
+        "statistical-evidence-category-breakdown-single-pass",
+    }
 
 
 def test_scope_report_selects_pr_scoped_scope_script_probe() -> None:
@@ -1028,6 +1032,30 @@ def test_statistical_evidence_bootstrap_probe_script_emits_metrics(
     assert metrics["lower_bound_mean"] <= metrics["upper_bound_mean"]
 
 
+def test_statistical_evidence_category_breakdown_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_STAT_CATEGORY_ROWS", "18")
+    monkeypatch.setenv("MELIX_STAT_CATEGORY_COUNT", "3")
+    monkeypatch.setenv("MELIX_STAT_CATEGORY_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/statistical_evidence_category_breakdown_probe.py"),
+            run_name="__main__",
+        )
+
+    assert excinfo.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["row_count"] == 18.0
+    assert metrics["category_count"] == 3.0
+    assert metrics["checksum"] > 0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_training_dataset_chunker_top_level_copy_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -1444,6 +1472,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "pr-scoped-performance-report-results-scandir",
         "model-ops-bundle-artifact-byte-accounting",
         "statistical-evidence-bootstrap-single-sort",
+        "statistical-evidence-category-breakdown-single-pass",
     }
     registry_probe = None
     maintenance_probe = None

--- a/services/mlx-worker-python/tests/test_statistical_evidence.py
+++ b/services/mlx-worker-python/tests/test_statistical_evidence.py
@@ -229,3 +229,41 @@ def test_build_category_breakdown_aggregates_supported_categories_only() -> None
             "delta_accuracy": 0.5,
         },
     }
+
+
+def test_build_category_breakdown_preserves_ordering_and_rounded_totals() -> None:
+    rows = tuple(
+        {
+            "category_label": f" category-{index % 3} ",
+            "base_correct": index % 2 == 0,
+            "target_correct": index % 4 != 0,
+        }
+        for index in range(12)
+    ) + (
+        {"category_label": "   ", "base_correct": True, "target_correct": True},
+        {"base_correct": True, "target_correct": True},
+    )
+
+    breakdown = build_category_breakdown(rows=rows)
+
+    assert list(breakdown) == ["category-0", "category-1", "category-2"]
+    assert breakdown == {
+        "category-0": {
+            "sample_size": 4,
+            "base_accuracy": 0.5,
+            "target_accuracy": 0.75,
+            "delta_accuracy": 0.25,
+        },
+        "category-1": {
+            "sample_size": 4,
+            "base_accuracy": 0.5,
+            "target_accuracy": 0.75,
+            "delta_accuracy": 0.25,
+        },
+        "category-2": {
+            "sample_size": 4,
+            "base_accuracy": 0.5,
+            "target_accuracy": 0.75,
+            "delta_accuracy": 0.25,
+        },
+    }

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -74,25 +74,28 @@ def build_category_breakdown(
     *,
     rows: tuple[dict[str, object], ...],
 ) -> dict[str, dict[str, object]]:
-    grouped: dict[str, list[dict[str, object]]] = {}
+    category_totals: dict[str, list[int]] = {}
     for row in rows:
         category_label = str(row.get("category_label", "")).strip()
         if not category_label:
             continue
-        grouped.setdefault(category_label, []).append(row)
+        totals = category_totals.get(category_label)
+        if totals is None:
+            category_totals[category_label] = [
+                1,
+                int(bool(row.get("base_correct", False))),
+                int(bool(row.get("target_correct", False))),
+            ]
+            continue
+        totals[0] += 1
+        totals[1] += int(bool(row.get("base_correct", False)))
+        totals[2] += int(bool(row.get("target_correct", False)))
 
     breakdown: dict[str, dict[str, object]] = {}
-    for category_label in sorted(grouped):
-        category_rows = grouped[category_label]
-        sample_size = len(category_rows)
-        base_accuracy = _rounded(
-            sum(1 for row in category_rows if bool(row.get("base_correct", False)))
-            / max(sample_size, 1)
-        )
-        target_accuracy = _rounded(
-            sum(1 for row in category_rows if bool(row.get("target_correct", False)))
-            / max(sample_size, 1)
-        )
+    for category_label in sorted(category_totals):
+        sample_size, base_correct, target_correct = category_totals[category_label]
+        base_accuracy = _rounded(base_correct / max(sample_size, 1))
+        target_accuracy = _rounded(target_correct / max(sample_size, 1))
         breakdown[category_label] = {
             "sample_size": sample_size,
             "base_accuracy": base_accuracy,


### PR DESCRIPTION
## Summary
- Replaces statistical-evidence category row retention with compact per-category counters in `build_category_breakdown(...)`.
- Adds focused regression coverage for sorted category output and rounded aggregate values.
- Registers the `statistical-evidence-category-breakdown-single-pass` PR-scoped performance probe with a base-compatible fallback.

## Plan or Spec
- `docs/plans/2026-05-06-statistical-evidence-category-breakdown-single-pass.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics
# 13 passed in 0.09s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_category_breakdown_probe.py
# 13 passed; TOTAL 34 0 100%

python3 scripts/statistical_evidence_category_breakdown_probe.py
# {"category_count": 64.0, "checksum": 250365.72000000003, "elapsed_ms_mean": 63.33129657432437, "peak_bytes_mean": 18361.6, "row_count": 50000.0, "sample_count": 5.0}

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id statistical-evidence-category-breakdown-single-pass --base-repo /tmp/melix-base-stat-cat-20260506-213536-v2 --head-repo "$PWD" --output /tmp/stat-category-compare-2.json
# head verification passed; base elapsed_ms_mean=20.011157635599375, peak_bytes_mean=451161.6; head elapsed_ms_mean=19.699157983995974, peak_bytes_mean=16432.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 34 0 100%`.
- Registered scoped probe: `statistical-evidence-category-breakdown-single-pass`.
- Local base-vs-head probe (`50,000` rows, `64` categories, `5` samples):
  - `elapsed_ms_mean`: `20.011157635599375` → `19.699157983995974` (~1.56% lower).
  - `peak_bytes_mean`: `451161.6` → `16432.0` (~96.36% lower).
  - Structural metrics preserved: `row_count=50000.0`, `category_count=64.0`, `checksum=250365.72` on both base and head.

## Known Gaps
- Full repository test suite, Swift tests, and macOS-only checks were not run locally on this Linux host.
- Hosted `pr-scoped-performance` is the final validation gate for the registered probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
