### PR TITLE
perf: skip startup log exists preflight

### DIFF
--- a/docs/plans/2026-05-06-startup-log-exists-elision.md
+++ b/docs/plans/2026-05-06-startup-log-exists-elision.md
@@ -1,0 +1,27 @@
+# Startup Log Exists Check Elision
+
+## Goal
+
+Reduce redundant filesystem work in startup failure classification by avoiding a separate `Path.exists()` probe before reading log excerpts.
+
+## Scope
+
+- `services/mlx-worker-python/worker/productization/startup_signals.py`
+- `services/mlx-worker-python/tests/test_startup_signals.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/startup_signals_log_probe.py`
+
+## Linux Verification Path
+
+This is a Python-only slice and can be verified on Linux with focused pytest, changed-scope coverage, and the existing `startup-signals-lazy-worker-log-excerpts` PR-scoped performance probe.
+
+## Performance Probe
+
+Use `scripts/startup_signals_log_probe.py` and the registered `startup-signals-lazy-worker-log-excerpts` probe. The local structural metric is `*_log_path_exists_checks_mean`; success means startup classification no longer calls `Path.exists()` while preserving log-read counts and classifications.
+
+## Success Metrics
+
+- Focused startup-signal tests pass.
+- Changed-scope automated coverage is at least 95%.
+- Local probe reports `control_crash_log_path_exists_checks_mean=0.0` and `worker_crash_log_path_exists_checks_mean=0.0` on the optimized branch.
+- Existing log-read metrics remain unchanged (`control_crash_log_reads_mean=1.0`, `worker_crash_log_reads_mean=1.0`).

--- a/scripts/startup_signals_log_probe.py
+++ b/scripts/startup_signals_log_probe.py
@@ -37,16 +37,24 @@ def _measure_case(
     error_text: str,
     expected_classification: str,
     iterations: int,
-) -> tuple[float, float]:
+) -> tuple[float, float, float]:
     original_reader: Callable[..., str] = startup_signals._read_last_nonempty_line
+    original_exists = Path.exists
     read_count = 0
+    exists_count = 0
 
     def tracked_reader(path: Path, *, chunk_size: int = 8192) -> str:
         nonlocal read_count
         read_count += 1
         return original_reader(path, chunk_size=chunk_size)
 
+    def tracked_exists(path: Path) -> bool:
+        nonlocal exists_count  # pragma: no cover
+        exists_count += 1  # pragma: no cover
+        return original_exists(path)  # pragma: no cover
+
     startup_signals._read_last_nonempty_line = tracked_reader
+    Path.exists = tracked_exists
     try:
         started = time.perf_counter()
         for _ in range(iterations):
@@ -58,7 +66,8 @@ def _measure_case(
         elapsed_ms = (time.perf_counter() - started) * 1000.0
     finally:
         startup_signals._read_last_nonempty_line = original_reader
-    return elapsed_ms, float(read_count)
+        Path.exists = original_exists
+    return elapsed_ms, float(read_count), float(exists_count)
 
 
 def main() -> int:
@@ -66,15 +75,18 @@ def main() -> int:
     samples = 5
     conflict_elapsed: list[float] = []
     conflict_reads: list[float] = []
+    conflict_exists: list[float] = []
     control_elapsed: list[float] = []
     control_reads: list[float] = []
+    control_exists: list[float] = []
     worker_elapsed: list[float] = []
     worker_reads: list[float] = []
+    worker_exists: list[float] = []
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         manifest = _write_logs(Path(tmp_dir))
         for _ in range(samples):
-            elapsed, reads = _measure_case(
+            elapsed, reads, exists = _measure_case(
                 manifest,
                 error_text="bind() failed: Address already in use",
                 expected_classification="host_port_conflict",
@@ -82,8 +94,9 @@ def main() -> int:
             )
             conflict_elapsed.append(elapsed)
             conflict_reads.append(reads / iterations)
+            conflict_exists.append(exists / iterations)
 
-            elapsed, reads = _measure_case(
+            elapsed, reads, exists = _measure_case(
                 manifest,
                 error_text="handshake failed",
                 expected_classification="control_plane_crash",
@@ -91,10 +104,11 @@ def main() -> int:
             )
             control_elapsed.append(elapsed)
             control_reads.append(reads / iterations)
+            control_exists.append(exists / iterations)
 
             worker_manifest = dict(manifest)
             worker_manifest.pop("control_plane_stderr_path")
-            elapsed, reads = _measure_case(
+            elapsed, reads, exists = _measure_case(
                 worker_manifest,
                 error_text="handshake failed",
                 expected_classification="worker_crash",
@@ -102,17 +116,21 @@ def main() -> int:
             )
             worker_elapsed.append(elapsed)
             worker_reads.append(reads / iterations)
+            worker_exists.append(exists / iterations)
 
     print(
         json.dumps(
             {
                 "conflict_elapsed_ms_mean": round(statistics.fmean(conflict_elapsed), 6),
+                "conflict_log_path_exists_checks_mean": round(statistics.fmean(conflict_exists), 6),
                 "conflict_log_reads_mean": round(statistics.fmean(conflict_reads), 6),
                 "control_crash_elapsed_ms_mean": round(statistics.fmean(control_elapsed), 6),
+                "control_crash_log_path_exists_checks_mean": round(statistics.fmean(control_exists), 6),
                 "control_crash_log_reads_mean": round(statistics.fmean(control_reads), 6),
                 "iterations": float(iterations),
                 "sample_count": float(samples),
                 "worker_crash_elapsed_ms_mean": round(statistics.fmean(worker_elapsed), 6),
+                "worker_crash_log_path_exists_checks_mean": round(statistics.fmean(worker_exists), 6),
                 "worker_crash_log_reads_mean": round(statistics.fmean(worker_reads), 6),
             },
             sort_keys=True,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2146,10 +2146,13 @@ def test_startup_signals_probe_script_emits_metrics(capsys: pytest.CaptureFixtur
     assert excinfo.value.code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["conflict_elapsed_ms_mean"] > 0
+    assert payload["conflict_log_path_exists_checks_mean"] == 0.0
     assert payload["conflict_log_reads_mean"] == 0.0
     assert payload["control_crash_elapsed_ms_mean"] > 0
+    assert payload["control_crash_log_path_exists_checks_mean"] == 0.0
     assert payload["control_crash_log_reads_mean"] == 1.0
     assert payload["worker_crash_elapsed_ms_mean"] > 0
+    assert payload["worker_crash_log_path_exists_checks_mean"] == 0.0
     assert payload["worker_crash_log_reads_mean"] == 1.0
     assert payload["sample_count"] == 5.0
 

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -346,6 +346,24 @@ def test_classify_startup_failure_reports_control_plane_crash(tmp_path: Path) ->
     assert report.to_dict()["classification"] == "control_plane_crash"
 
 
+def test_log_excerpt_skips_missing_paths_without_exists_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    missing_log = tmp_path / "missing.stderr.log"
+    existing_log = tmp_path / "control-plane.stderr.log"
+    existing_log.write_text("booting\nready\n", encoding="utf-8")
+
+    def fail_exists(self: Path) -> bool:
+        raise AssertionError(  # pragma: no cover
+            f"_log_excerpt should not preflight paths with exists(): {self}"
+        )
+
+    monkeypatch.setattr(Path, "exists", fail_exists)
+
+    assert startup_signals_module._log_excerpt(missing_log, existing_log) == "ready"
+
+
 def test_read_last_nonempty_line_ignores_trailing_blank_lines(tmp_path: Path) -> None:
     log_path = tmp_path / "control-plane.stderr.log"
     log_path.write_text("booting\nready\n\n", encoding="utf-8")

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -230,9 +230,10 @@ def _log_excerpt(*paths: object) -> str:
         if not path:
             continue
         resolved = Path(str(path)).expanduser()
-        if resolved.exists() is False:
+        try:
+            excerpt = _read_last_nonempty_line(resolved)
+        except OSError:
             continue
-        excerpt = _read_last_nonempty_line(resolved)
         if excerpt:
             excerpts.append(excerpt)
     return " | ".join(excerpts)


### PR DESCRIPTION
## Summary
- Remove the redundant `Path.exists()` preflight before startup log excerpt reads.
- Let the optimized log reader handle missing paths through `OSError`, preserving classification and log-read behavior while avoiding an extra filesystem check.
- Extend the startup-signals probe script with structural `*_log_path_exists_checks_mean` metrics for local evidence.

## Plan or Spec
- `docs/plans/2026-05-06-startup-log-exists-elision.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# 26 passed in 0.60s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py
# 26 passed; TOTAL 28 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py
# {"conflict_elapsed_ms_mean": 0.949299, "conflict_log_path_exists_checks_mean": 0.0, "conflict_log_reads_mean": 0.0, "control_crash_elapsed_ms_mean": 10.603429, "control_crash_log_path_exists_checks_mean": 0.0, "control_crash_log_reads_mean": 1.0, "iterations": 400.0, "sample_count": 5.0, "worker_crash_elapsed_ms_mean": 10.909451, "worker_crash_log_path_exists_checks_mean": 0.0, "worker_crash_log_reads_mean": 1.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id startup-signals-lazy-worker-log-excerpts --base-repo /tmp/melix-base-startup-20260506224901 --head-repo "$PWD" --output /tmp/startup-signals-probe.json
# head verification ok; base probe ok; head probe ok
# base control_crash_elapsed_ms_mean=15.114824, worker_crash_elapsed_ms_mean=14.538485
# head control_crash_elapsed_ms_mean=11.055752, worker_crash_elapsed_ms_mean=11.175687

 git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 28 0 100%`.
- Registered scoped CI probe: `startup-signals-lazy-worker-log-excerpts`.
- Local structural metrics: `conflict_log_path_exists_checks_mean=0.0`, `control_crash_log_path_exists_checks_mean=0.0`, `worker_crash_log_path_exists_checks_mean=0.0` on the optimized branch.
- Local existing probe comparison: control-plane crash path improved from `15.114824 ms` to `11.055752 ms`; worker crash path improved from `14.538485 ms` to `11.175687 ms`; log-read counts remained unchanged.

## Known Gaps
- Full repository tests were not run; this is a focused Linux-verifiable Python slice.
- Hosted GitHub CI is still the authoritative validation for the registered `startup-signals-lazy-worker-log-excerpts` probe after PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
