### PR TITLE
perf: cache training target module presets

### DIFF
--- a/docs/plans/2026-05-06-training-config-target-module-cache.md
+++ b/docs/plans/2026-05-06-training-config-target-module-cache.md
@@ -1,0 +1,39 @@
+# Training Config Target Module Cache Optimization
+
+## Goal
+
+Reduce repeated normalization work in LoRA training target-module resolution by reusing normalized family-profile target presets and default target tuples.
+
+## Linux-only Constraint
+
+This slice only touches Python worker code and repository CI probe metadata. It is locally verifiable on Linux with focused pytest, changed-scope coverage, and a command-json performance probe.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/model_ops/training_config.py`
+- `services/mlx-worker-python/tests/test_lora_model_ops.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/training_config_target_modules_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Performance Probe
+
+Register `training-config-target-module-cache` in PR-scoped performance CI. The probe repeatedly resolves static family target presets across dense and MoE profiles and reports:
+
+- `elapsed_ms_mean` — lower is better
+- `peak_bytes_mean` — lower is better
+- `checksum`, `iteration_count`, and `case_count` structural metrics
+
+## Success Metrics
+
+- Preserve exact resolved target-module lists and mutation isolation for returned default lists.
+- Achieve at least 95% changed-scope automated coverage for touched Python files.
+- Show a concrete local base-vs-head improvement for the registered probe before PR creation.
+
+## Verification Commands
+
+- Focused pytest for target-module behavior and PR-scoped probe registration.
+- Changed-scope coverage via `scripts/changed_scope_coverage.py`.
+- Local branch probe: `python scripts/training_config_target_modules_probe.py` through `uv run`.
+- Base-vs-head registered probe through `scripts/pr_scoped_performance_run.py`.
+- `git diff --check`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -871,6 +871,55 @@
     ]
   },
   {
+    "id": "training-config-target-module-cache",
+    "name": "Training config target-module cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/training_config.py",
+      "services/mlx-worker-python/tests/test_lora_model_ops.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/training_config_target_modules_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_training_config_helper_resolution_paths_and_limits services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_config_target_module_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_config_target_modules_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_training_config_helper_resolution_paths_and_limits services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_config_target_module_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_config_target_modules_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/training_config_target_modules_probe.py",
+    "probe_command": "if [ -f scripts/training_config_target_modules_probe.py ]; then\n  PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python scripts/training_config_target_modules_probe.py\nelse\n  PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python - <<'PY'\nimport json, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nsys.path[:0] = [str(Path.cwd()), str(Path.cwd() / \"services/mlx-worker-python\")]\nfrom worker.model_ops import training_config\nSAMPLES = 7\nITERATIONS = 50000\nCASES = ((\"qwen\", \"@attention,q_proj,attention\"), (\"qwen3moe\", \"attention_experts,@experts,q_proj\"), (\"mixtral\", \"\"), (\"gemma\", \"@gated_mlp,gate_proj\"))\nEXPECTED = {(\"qwen\", \"@attention,q_proj,attention\"): (\"q_proj\", \"k_proj\", \"v_proj\", \"o_proj\"), (\"qwen3moe\", \"attention_experts,@experts,q_proj\"): (\"q_proj\", \"k_proj\", \"v_proj\", \"o_proj\", \"gate_proj\", \"up_proj\", \"down_proj\"), (\"mixtral\", \"\"): (\"q_proj\", \"k_proj\", \"v_proj\", \"o_proj\"), (\"gemma\", \"@gated_mlp,gate_proj\"): (\"gate_proj\", \"up_proj\", \"down_proj\")}\ndef run_once():\n    checksum = 0\n    tracemalloc.start()\n    started = time.perf_counter()\n    for _ in range(ITERATIONS):\n        for family_id, raw_value in CASES:\n            resolved = training_config._resolve_target_modules(raw_value, profile=training_config._FAMILY_PROFILES[family_id])\n            if tuple(resolved) != EXPECTED[(family_id, raw_value)]:\n                raise AssertionError((family_id, resolved))\n            checksum += len(resolved)\n    elapsed_ms = (time.perf_counter() - started) * 1000.0\n    _, peak_bytes = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    return elapsed_ms, float(peak_bytes), checksum\nsamples = [run_once() for _ in range(SAMPLES)]\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(sample[0] for sample in samples), \"peak_bytes_mean\": statistics.fmean(sample[1] for sample in samples), \"checksum\": float(samples[-1][2]), \"iteration_count\": float(ITERATIONS), \"case_count\": float(len(CASES))}, sort_keys=True))\nPY\nfi",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "checksum",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "iteration_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "case_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "training-dataset-token-percentiles-single-sort",
     "name": "Training dataset quality/token summary",
     "runner": "ubuntu-latest",

--- a/scripts/training_config_target_modules_probe.py
+++ b/scripts/training_config_target_modules_probe.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import statistics
+import sys
+import time
+import tracemalloc
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.model_ops import training_config  # noqa: E402
+
+SAMPLES = int(os.environ.get("MELIX_TRAINING_CONFIG_TARGET_MODULE_SAMPLES", "7"))
+ITERATIONS = int(os.environ.get("MELIX_TRAINING_CONFIG_TARGET_MODULE_ITERATIONS", "50000"))
+CASES = (
+    ("qwen", "@attention,q_proj,attention"),
+    ("qwen3moe", "attention_experts,@experts,q_proj"),
+    ("mixtral", ""),
+    ("gemma", "@gated_mlp,gate_proj"),
+)
+EXPECTED = {
+    ("qwen", "@attention,q_proj,attention"): ("q_proj", "k_proj", "v_proj", "o_proj"),
+    ("qwen3moe", "attention_experts,@experts,q_proj"): (
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+    ),
+    ("mixtral", ""): ("q_proj", "k_proj", "v_proj", "o_proj"),
+    ("gemma", "@gated_mlp,gate_proj"): ("gate_proj", "up_proj", "down_proj"),
+}
+
+
+def _run_once() -> tuple[float, float, int]:
+    checksum = 0
+    tracemalloc.start()
+    started = time.perf_counter()
+    for _ in range(ITERATIONS):
+        for family_id, raw_value in CASES:
+            resolved = training_config._resolve_target_modules(
+                raw_value,
+                profile=training_config._FAMILY_PROFILES[family_id],
+            )
+            if tuple(resolved) != EXPECTED[(family_id, raw_value)]:
+                raise AssertionError(f"unexpected targets for {family_id}: {resolved!r}")
+            checksum += len(resolved)
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    _, peak_bytes = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return elapsed_ms, float(peak_bytes), checksum
+
+
+def main() -> None:
+    samples = [_run_once() for _ in range(SAMPLES)]
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(sample[0] for sample in samples),
+                "peak_bytes_mean": statistics.fmean(sample[1] for sample in samples),
+                "checksum": float(samples[-1][2]),
+                "iteration_count": float(ITERATIONS),
+                "case_count": float(len(CASES)),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -2528,6 +2528,12 @@ def test_training_config_helper_resolution_paths_and_limits() -> None:
         profile=training_config_module._FAMILY_PROFILES["qwen"],
     )
     assert qwen_targets == ["q_proj", "k_proj", "v_proj", "o_proj"]
+    mixtral_defaults = training_config_module._resolve_target_modules(
+        "",
+        profile=training_config_module._FAMILY_PROFILES["mixtral"],
+    )
+    assert mixtral_defaults == ["q_proj", "k_proj", "v_proj", "o_proj"]
+    mixtral_defaults.append("mutated")
     assert training_config_module._resolve_target_modules(
         "",
         profile=training_config_module._FAMILY_PROFILES["mixtral"],
@@ -2536,6 +2542,18 @@ def test_training_config_helper_resolution_paths_and_limits() -> None:
         "attention_experts",
         profile=training_config_module._FAMILY_PROFILES["qwen3moe"],
     ) == ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
+    assert training_config_module._FAMILY_PROFILES["qwen3moe"][
+        training_config_module._NORMALIZED_TARGET_MODULE_PRESETS_KEY
+    ]["attention_experts"] == ("q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj")
+    custom_profile = {
+        "default_target_modules": [" Custom_Default "],
+        "target_module_presets": {"Preset": [" Custom_Default ", " Second "]},
+    }
+    assert training_config_module._resolve_target_modules("", profile=custom_profile) == ["custom_default"]
+    assert training_config_module._resolve_target_modules("@Preset", profile=custom_profile) == [
+        "custom_default",
+        "second",
+    ]
     assert training_config_module._backend_target_modules(["standalone.module"]) == ["standalone.module"]
 
     bounded = training_config_module.normalize_training_config(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -203,6 +203,36 @@ def test_scope_report_selects_video_preprocessing_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "video-preprocessing-uri-byte-length-reuse"
 
 
+def test_scope_report_selects_training_config_target_module_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/model_ops/training_config.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "training-config-target-module-cache"
+
+
+def test_training_config_target_modules_probe_script_smoke(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_TRAINING_CONFIG_TARGET_MODULE_SAMPLES", "1")
+    monkeypatch.setenv("MELIX_TRAINING_CONFIG_TARGET_MODULE_ITERATIONS", "3")
+
+    runpy.run_path(
+        str(REPO_ROOT / "scripts/training_config_target_modules_probe.py"),
+        run_name="__main__",
+    )
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["checksum"] == 54.0
+    assert metrics["iteration_count"] == 3.0
+    assert metrics["case_count"] == 4.0
+
+
 def test_scope_report_selects_mlx_audio_speech_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -1424,6 +1454,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "pr-scoped-performance-scope-json-read-bytes",
         "pr-scoped-performance-scope-matcher",
         "quantization-qat-source-scan-scandir",
+        "training-config-target-module-cache",
         "training-dataset-token-percentiles-single-sort",
         "training-dataset-validation-sample-limit",
         "training-dataset-chunker-top-level-base-copy",

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -104,6 +104,9 @@ _SUPPORTED_TRAINING_MODES = (
     | _CPT_TRAINING_MODES
 )
 
+_NORMALIZED_TARGET_MODULE_PRESETS_KEY = "_normalized_target_module_presets"
+_NORMALIZED_DEFAULT_TARGET_MODULES_KEY = "_normalized_default_target_modules"
+
 _FAMILY_PROFILES: dict[str, dict[str, object]] = {
     "llama": {
         "family_kind": "dense",
@@ -249,6 +252,22 @@ _FAMILY_PROFILES: dict[str, dict[str, object]] = {
         },
     },
 }
+
+
+def _normalize_target_module_presets(profile: dict[str, object]) -> dict[str, tuple[str, ...]]:
+    return {
+        str(key).strip().lower(): tuple(str(item).strip().lower() for item in value)
+        for key, value in profile.get("target_module_presets", {}).items()
+    }
+
+
+def _normalize_default_target_modules(profile: dict[str, object]) -> tuple[str, ...]:
+    return tuple(str(item).strip().lower() for item in profile["default_target_modules"])
+
+
+for _profile in _FAMILY_PROFILES.values():
+    _profile[_NORMALIZED_TARGET_MODULE_PRESETS_KEY] = _normalize_target_module_presets(_profile)
+    _profile[_NORMALIZED_DEFAULT_TARGET_MODULES_KEY] = _normalize_default_target_modules(_profile)
 
 _ADVANCED_FAMILY_HOOKS: dict[str, dict[str, str]] = {
     "mixtral": {
@@ -901,20 +920,21 @@ def _resolve_family_hooks(source_model: common_pb2.ModelSpec, *, family_id: str)
 
 
 def _resolve_target_modules(raw_value: str, *, profile: dict[str, object]) -> list[str]:
-    presets = {
-        str(key).strip().lower(): [str(item).strip().lower() for item in value]
-        for key, value in profile.get("target_module_presets", {}).items()
-    }
-    default_targets = [str(item).strip().lower() for item in profile["default_target_modules"]]
+    presets = profile.get(_NORMALIZED_TARGET_MODULE_PRESETS_KEY)
+    if not isinstance(presets, dict):
+        presets = _normalize_target_module_presets(profile)
+    default_targets = profile.get(_NORMALIZED_DEFAULT_TARGET_MODULES_KEY)
+    if not isinstance(default_targets, tuple):
+        default_targets = _normalize_default_target_modules(profile)
     requested = [item.strip().lower() for item in raw_value.split(",") if item.strip()]
     if not requested:
-        return default_targets
+        return list(default_targets)
 
     resolved_targets: list[str] = []
     seen: set[str] = set()
     for requested_target in requested:
         target_key = requested_target.lstrip("@")
-        expanded_targets = presets.get(target_key, [requested_target])
+        expanded_targets = presets.get(target_key, (requested_target,))
         for expanded_target in expanded_targets:
             if expanded_target not in seen:
                 seen.add(expanded_target)


### PR DESCRIPTION
## Summary
- Cache normalized LoRA target-module presets/defaults on static family profiles so `_resolve_target_modules()` no longer rebuilds lowercased preset dictionaries on every training config normalization.
- Keep fallback normalization for ad hoc profile dictionaries and preserve fresh mutable return lists for callers.
- Register `training-config-target-module-cache` in PR-scoped performance CI with a base-compatible fallback probe command.

## Plan or Spec
- `docs/plans/2026-05-06-training-config-target-module-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_training_config_helper_resolution_paths_and_limits services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_config_target_module_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_config_target_modules_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 4 passed in 0.72s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_training_config_helper_resolution_paths_and_limits services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_config_target_module_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_config_target_modules_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/training_config_target_modules_probe.py
# 4 passed in 1.09s; TOTAL 38 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/training_config_target_modules_probe.py
# {"case_count": 4.0, "checksum": 900000.0, "elapsed_ms_mean": 1934.986776722196, "iteration_count": 50000.0, "peak_bytes_mean": 1915.142857142857}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-config-target-module-cache --base-repo /tmp/melix-cron-opt-20260506-232458-base-1 --head-repo /tmp/melix-cron-opt-20260506-232458 --output /tmp/training-config-target-module-cache-result.json
# head verification passed; base/head probe passed

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 38 0 100%`.
- Registered scoped CI probe: `training-config-target-module-cache`.
- Local branch probe: `elapsed_ms_mean=1934.987 ms`, `peak_bytes_mean=1915.14`, `checksum=900000`, `iteration_count=50000`, `case_count=4`.
- Local base-vs-head registered probe:
  - base: `elapsed_ms_mean=8984.130 ms`, `peak_bytes_mean=3817.14`
  - head: `elapsed_ms_mean=2089.100 ms`, `peak_bytes_mean=1915.14`
  - improvement: ~76.7% lower elapsed mean, ~49.8% lower peak traced bytes for the synthetic target-module resolution workload.

## Known Gaps
- Linux-only local verification; macOS/Swift checks were not run locally because this slice only touches Python worker/probe metadata.
- Hosted PR-scoped performance and broader CI still need to validate on GitHub before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
