### PR TITLE
perf: bound hub cursor relation scan

### DIFF
--- a/docs/plans/2026-05-06-hub-catalog-next-cursor-bounded-search.md
+++ b/docs/plans/2026-05-06-hub-catalog-next-cursor-bounded-search.md
@@ -1,0 +1,36 @@
+# Hub Catalog Next-Cursor Bounded Relation Search
+
+## Scope
+
+This performance slice is Python-only and targets the Hugging Face Hub catalog
+pagination helper in `services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+The affected helper scans RFC-style `Link` header segments and extracts the
+encoded `cursor` value from the `rel="next"` segment.
+
+## Registered probe
+
+Use the existing `hub-catalog-next-cursor-fast-parse` PR-scoped performance
+probe in `infra/perf/pr_scoped_probes.json`. It includes focused test,
+coverage, and probe commands for:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_next_cursor_probe.py`
+
+## Optimization hypothesis
+
+The current segment scanner already avoids full `urllib.parse.urlparse` and
+`parse_qs`, but relation detection still materializes the relation slice before
+checking for `rel="next"`. Replace that substring allocation with a bounded
+`str.find(...)` over the same segment range.
+
+Expected effect: preserve cursor behavior while reducing per-segment allocation
+and improving `elapsed_ms_mean` / `peak_bytes_mean` in the registered probe.
+
+## Verification
+
+Run the focused cursor tests, changed-scope coverage for the touched Python
+scope, and the registered local probe before opening the PR. The CI PR-scoped
+performance workflow must also complete the registered probe successfully before
+merge.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -267,8 +267,9 @@ def _next_cursor_from_link(link_header: str) -> str:
         if url_end < 0:
             return ""
         next_url_start = link_header.find("<", url_end + 1)
+        relation_start = url_end + 1
         relation_end = next_url_start if next_url_start >= 0 else len(link_header)
-        if 'rel="next"' in link_header[url_end + 1 : relation_end]:
+        if link_header.find('rel="next"', relation_start, relation_end) >= 0:
             return _cursor_query_value(link_header[url_start + 1 : url_end])
         search_start = relation_end
 


### PR DESCRIPTION
## Summary
- Bound the hub catalog `Link` relation search with `str.find(..., start, end)` instead of materializing the relation substring before checking for `rel="next"`.
- Keeps the existing cursor extraction behavior while reducing allocation on the registered next-cursor parsing hot path.

## Plan or Spec
- `docs/plans/2026-05-06-hub-catalog-next-cursor-bounded-search.md`
- Registered probe: `hub-catalog-next-cursor-fast-parse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# baseline before edit, origin/main at 5a7d551, focused cursor tests/probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py::test_next_cursor_from_link_extracts_encoded_next_cursor_without_full_query_parse services/mlx-worker-python/tests/test_hub_catalog.py::test_next_cursor_from_link_scans_segments_without_splitting_on_url_commas services/mlx-worker-python/tests/test_hub_catalog.py::test_next_cursor_from_link_returns_empty_for_missing_or_malformed_next_cursor services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics
# exit 0; 4 passed in 0.49s
MELIX_HUB_CATALOG_CURSOR_ITERATIONS=50000 MELIX_HUB_CATALOG_CURSOR_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_next_cursor_probe.py
# exit 0; {"elapsed_ms_mean": 1554.27791622933, "peak_bytes_mean": 11133.6, ...}

# focused registered tests after edit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics
# exit 0; 34 passed in 0.17s

# changed-scope coverage after edit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_next_cursor_probe.py
# exit 0; TOTAL 2 0 100%

# registered local probe after edit
MELIX_HUB_CATALOG_CURSOR_ITERATIONS=50000 MELIX_HUB_CATALOG_CURSOR_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_next_cursor_probe.py
# exit 0; {"elapsed_ms_mean": 1610.0880770012736, "peak_bytes_mean": 11096.0, ...}

# larger baseline/head comparison, 100k iterations x 7 samples
MELIX_HUB_CATALOG_CURSOR_ITERATIONS=100000 MELIX_HUB_CATALOG_CURSOR_SAMPLES=7 PYTHONPATH="$BASE_WT:$BASE_WT/services/mlx-worker-python" uv run --project "$BASE_WT/services/mlx-worker-python" python3 "$BASE_WT/scripts/hub_catalog_next_cursor_probe.py"
# base exit 0; {"elapsed_ms_mean": 3084.2260346980765, "peak_bytes_mean": 8839.285714285714, ...}
MELIX_HUB_CATALOG_CURSOR_ITERATIONS=100000 MELIX_HUB_CATALOG_CURSOR_SAMPLES=7 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_next_cursor_probe.py
# head exit 0; {"elapsed_ms_mean": 2843.660181454782, "peak_bytes_mean": 8852.714285714286, ...}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%` for the touched hub catalog lines and registered probe scope.
- Local registered probe, 50k iterations x 5 samples: baseline `elapsed_ms_mean=1554.278ms`, head `elapsed_ms_mean=1610.088ms` (single run noisy, +55.810ms / -3.6% slower); baseline `peak_bytes_mean=11133.6`, head `peak_bytes_mean=11096.0` (-37.6 bytes).
- Larger local comparison, 100k iterations x 7 samples: baseline `elapsed_ms_mean=3084.226ms`, head `elapsed_ms_mean=2843.660ms`, speedup `1.085x`, delta `-240.566ms` (-7.8%); peak bytes baseline `8839.286`, head `8852.714` (+13.429 bytes / +0.15%).
- GitHub Actions PR-scoped performance workflow is required to validate the registered probe before merge.

## Known Gaps
- Local validation is Linux/Python only. No Swift runtime behavior is touched.
- The 50k sample was noisy for elapsed time, so the acceptance evidence emphasizes the larger repeated local comparison plus required CI registered probe validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
