### PR TITLE
perf: short-circuit evaluation compare target lookup

### DIFF
--- a/docs/plans/2026-05-07-evaluation-compare-target-lookup.md
+++ b/docs/plans/2026-05-07-evaluation-compare-target-lookup.md
@@ -1,0 +1,35 @@
+# Evaluation Compare Target Lookup Early Stop
+
+## Goal
+
+Reduce redundant loaded-model lookups in `resolve_compare_target_models()` when evaluation compare requests a small set of target model IDs from a registry with many resident models.
+
+## Scope
+
+- `services/mlx-worker-python/worker/productization/evaluation_compare.py`
+- `services/mlx-worker-python/tests/test_evaluation_core.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux verification path
+
+This is a Python-only optimization and is verifiable on Linux with focused pytest, changed-scope coverage, `git diff --check`, and a registered PR-scoped performance probe.
+
+## Optimization
+
+The current resolver builds a dictionary for every loaded model before checking the requested target IDs. The optimized resolver will:
+
+1. Convert requested target IDs to a set.
+2. Store only loaded models whose IDs are requested.
+3. Stop scanning once all requested targets have been resolved.
+4. Preserve duplicate target ordering and unknown-target errors.
+
+## Probe
+
+Register `evaluation-compare-target-lookup-early-stop` in `infra/perf/pr_scoped_probes.json` with a synthetic registry containing many loaded handles and a small requested target set near the front of the scan. The probe reports elapsed time and `get_loaded_model` calls; lower is better for both.
+
+## Success metrics
+
+- Focused tests pass.
+- Changed executable line coverage is at least 95%.
+- Local probe shows fewer registry lookups and lower elapsed time versus `origin/main`.
+- The registered PR-scoped performance CI probe completes successfully before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -760,6 +760,37 @@
     ]
   },
   {
+    "id": "evaluation-compare-target-lookup-early-stop",
+    "name": "Evaluation compare target lookup early stop",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/evaluation_compare.py",
+      "services/mlx-worker-python/tests/test_evaluation_core.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_resolve_compare_target_models_stops_after_requested_targets services/mlx-worker-python/tests/test_evaluation_core.py::test_resolve_compare_target_models_scans_all_handles_for_unknown_targets services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_compares_base_against_target_models_and_persists_compare_artifacts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_resolve_compare_target_models_stops_after_requested_targets services/mlx-worker-python/tests/test_evaluation_core.py::test_resolve_compare_target_models_scans_all_handles_for_unknown_targets services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_compares_base_against_target_models_and_persists_compare_artifacts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_compare.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 - <<'PYPROBE'\nimport json\nimport sys\nimport time\nfrom pathlib import Path\nfrom types import SimpleNamespace\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / 'services/mlx-worker-python'))\nfrom worker.productization.evaluation_compare import resolve_compare_target_models\nclass Registry:\n    def __init__(self, count=40000):\n        self.handles = [f'handle-{index:05d}' for index in range(count)]\n        self.calls = 0\n        self.models = {}\n        for index, handle in enumerate(self.handles):\n            model_id = f'model-{index:05d}'\n            if index == 7:\n                model_id = 'target-a'\n            elif index == 11:\n                model_id = 'target-b'\n            self.models[handle] = SimpleNamespace(spec=SimpleNamespace(model_id=model_id))\n    def list_loaded_models(self):\n        return self.handles\n    def get_loaded_model(self, handle):\n        self.calls += 1\n        return self.models[handle]\nelapsed = []\ncall_counts = []\nfor _ in range(7):\n    registry = Registry()\n    started = time.perf_counter()\n    resolved = resolve_compare_target_models(registry=registry, target_model_ids=('target-a', 'target-b'))\n    elapsed.append((time.perf_counter() - started) * 1000.0)\n    call_counts.append(float(registry.calls))\n    assert tuple(resolved) == ('target-a', 'target-b')\nprint(json.dumps({'elapsed_ms_mean': round(sum(elapsed) / len(elapsed), 6), 'get_loaded_model_calls_mean': round(sum(call_counts) / len(call_counts), 3), 'loaded_handle_count': 40000.0}, sort_keys=True))\nPYPROBE",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "get_loaded_model_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "evaluation-store-compare-summary-csv-streaming",
     "name": "Evaluation store compare summary CSV streaming",
     "runner": "ubuntu-latest",

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -1672,6 +1672,67 @@ def test_run_local_suite_compares_base_against_target_models_and_persists_compar
     assert "Category Breakdown" in report_markdown
 
 
+def test_resolve_compare_target_models_stops_after_requested_targets() -> None:
+    from worker.productization.evaluation_compare import resolve_compare_target_models
+
+    class TrackingRegistry:
+        def __init__(self) -> None:
+            self.get_calls: list[str] = []
+            self._models = {
+                "handle-00": SimpleNamespace(spec=SimpleNamespace(model_id="base-model")),
+                "handle-01": SimpleNamespace(spec=SimpleNamespace(model_id="target-a")),
+                "handle-02": SimpleNamespace(spec=SimpleNamespace(model_id="target-b")),
+                "handle-03": SimpleNamespace(spec=SimpleNamespace(model_id="unused-after-targets")),
+            }
+
+        def list_loaded_models(self) -> list[str]:
+            return list(self._models)
+
+        def get_loaded_model(self, handle: str):
+            self.get_calls.append(handle)
+            return self._models[handle]
+
+    registry = TrackingRegistry()
+
+    resolved = resolve_compare_target_models(
+        registry=registry,
+        target_model_ids=("target-a", "target-b", "target-a"),
+    )
+
+    assert tuple(resolved) == ("target-a", "target-b")
+    assert registry.get_calls == ["handle-00", "handle-01", "handle-02"]
+
+
+def test_resolve_compare_target_models_scans_all_handles_for_unknown_targets() -> None:
+    from worker.productization.evaluation_compare import resolve_compare_target_models
+
+    class TrackingRegistry:
+        def __init__(self) -> None:
+            self.get_calls: list[str] = []
+            self._models = {
+                "handle-00": SimpleNamespace(spec=SimpleNamespace(model_id="target-a")),
+                "handle-01": SimpleNamespace(spec=SimpleNamespace(model_id="unrelated")),
+                "handle-02": SimpleNamespace(spec=SimpleNamespace(model_id="target-b")),
+            }
+
+        def list_loaded_models(self) -> list[str]:
+            return list(self._models)
+
+        def get_loaded_model(self, handle: str):
+            self.get_calls.append(handle)
+            return self._models[handle]
+
+    registry = TrackingRegistry()
+
+    with pytest.raises(ValueError, match="Unknown comparison target model IDs: missing-target"):
+        resolve_compare_target_models(
+            registry=registry,
+            target_model_ids=("target-a", "missing-target"),
+        )
+
+    assert registry.get_calls == ["handle-00", "handle-01", "handle-02"]
+
+
 def test_run_local_suite_compare_requires_target_model_ids(tmp_path: Path) -> None:
     dataset_root = _write_dataset_package(
         tmp_path=tmp_path,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1406,6 +1406,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "evaluation-latency-percentile-vector-reuse",
         "evaluation-sample-probe-aggregation",
         "evaluation-store-compare-summary-csv-streaming",
+        "evaluation-compare-target-lookup-early-stop",
         "evaluation-store-samples-csv-streaming",
         "job-registry-derived-model-single-pass",
         "job-registry-restore-sort-elision",

--- a/services/mlx-worker-python/worker/productization/evaluation_compare.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_compare.py
@@ -176,14 +176,17 @@ def resolve_compare_target_models(
         raise ValueError("Evaluation compare requires a live registry with loaded target models.")
     if not target_model_ids:
         return {}
+    requested_targets = {model_id for model_id in target_model_ids if model_id}
     loaded_models_by_id: dict[str, Any] = {}
     for handle in registry.list_loaded_models():
         loaded_model = registry.get_loaded_model(handle)
         if loaded_model is None:
             continue
         model_id = str(getattr(getattr(loaded_model, "spec", None), "model_id", "")).strip()
-        if model_id and model_id not in loaded_models_by_id:
+        if model_id in requested_targets and model_id not in loaded_models_by_id:
             loaded_models_by_id[model_id] = loaded_model
+            if len(loaded_models_by_id) == len(requested_targets):
+                break
     unknown_targets = [model_id for model_id in target_model_ids if model_id not in loaded_models_by_id]
     if unknown_targets:
         raise ValueError(f"Unknown comparison target model IDs: {', '.join(unknown_targets)}")


### PR DESCRIPTION
## Summary
- Short-circuit `resolve_compare_target_models()` once all requested comparison targets are found.
- Avoid storing unrelated resident models while preserving duplicate target ordering and unknown-target errors.
- Register `evaluation-compare-target-lookup-early-stop` as a PR-scoped performance probe for hosted base-vs-head validation.

## Plan or Spec
- `docs/plans/2026-05-07-evaluation-compare-target-lookup.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.validated.json
PASS: probe registry JSON parsed successfully.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_resolve_compare_target_models_stops_after_requested_targets services/mlx-worker-python/tests/test_evaluation_core.py::test_resolve_compare_target_models_scans_all_handles_for_unknown_targets services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_compares_base_against_target_models_and_persists_compare_artifacts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
PASS: 4 passed in 0.71s before rebase; 4 passed in 1.71s after rebase through the coverage run.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_resolve_compare_target_models_stops_after_requested_targets services/mlx-worker-python/tests/test_evaluation_core.py::test_resolve_compare_target_models_scans_all_handles_for_unknown_targets services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_compares_base_against_target_models_and_persists_compare_artifacts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_compare.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
PASS: TOTAL 34 0 100% changed-scope coverage.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-compare-target-lookup-early-stop --base-repo /tmp/melix-cron-opt-20260507001151-base-postrebase-1778113231 --head-repo "$PWD" --output /tmp/evaluation_compare_target_lookup_probe_postrebase.json
PASS: base and head probes completed successfully.

git diff --check
PASS: no whitespace errors.
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 34 0 100%`.
- Registered probe: `evaluation-compare-target-lookup-early-stop`.
- Local base-vs-head probe against detached `origin/main` (`af751d4`):
  - `elapsed_ms_mean`: base `22.690563` ms → head `0.034578` ms.
  - `get_loaded_model_calls_mean`: base `40000.0` → head `12.0`.
  - `loaded_handle_count`: `40000.0` for both.

## Known Gaps
- Linux-only local verification; macOS/Swift checks were not run locally.
- Hosted `pr-scoped-performance` and broader repository CI must still validate this PR before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
