### PR TITLE
perf: normalize hub size hint fields once

### DIFF
--- a/docs/plans/2026-05-07-hub-catalog-size-hint-text-normalization.md
+++ b/docs/plans/2026-05-07-hub-catalog-size-hint-text-normalization.md
@@ -1,0 +1,36 @@
+# Hub Catalog Size Hint Text Normalization
+
+## Goal
+
+Reduce repeated Python-level text normalization work in Hub catalog size-hint parsing while preserving accepted model-size hint behavior.
+
+## Scope
+
+Touched files:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+
+## Optimization Slice
+
+`_size_hint_bytes(...)` now normalizes each candidate payload text field once before joining the candidate fields for the existing explicit size-hint regex scan. The previous generator filtered with `_string(value)` and then yielded `_string(value)` again, doubling normalization calls for non-empty `description`, `readme`, and `cardData.description` fields. The slice also avoids a duplicate `payload.get("cardData")` lookup while preserving the existing joined-field fallback semantics.
+
+## Registered Probe
+
+Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.
+
+The existing registered probe has focused `test_command`, `coverage_command`, and `probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+
+The registered probe remains unchanged for apples-to-apples CI comparison and verifies that the shared Hub catalog size-hint path does not regress. The optimized `_size_hint_bytes(...)` payload path is measured locally with a paired base/head payload microprobe because changing the registered probe workload in the same optimization PR would compare different workloads between base and head.
+
+## Success Metrics
+
+- Focused pytest passes.
+- Changed-scope coverage is at least 95% for touched executable lines.
+- Local base-vs-head payload microprobe shows lower `elapsed_ms_mean` with unchanged guard-rail metrics (`checksum`, `matched_hint_count`, `sample_count`).
+- `git diff --check` passes.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -540,6 +540,29 @@ def test_search_models_treats_gated_auto_as_soft_access_not_blocked() -> None:
     assert model.recommended_action == "download"
 
 
+def test_size_hint_bytes_normalizes_each_payload_text_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[object] = []
+    original = hub_catalog_module._string
+
+    def tracked(value: object) -> str:
+        calls.append(value)
+        return original(value)
+
+    monkeypatch.setattr(hub_catalog_module, "_string", tracked)
+
+    assert (
+        hub_catalog_module._size_hint_bytes(
+            {
+                "description": "Model",
+                "readme": "size: 512 MB",
+                "cardData": {"description": "extra notes"},
+            }
+        )
+        == 512 * MB
+    )
+    assert calls == [None, "Model", "size: 512 MB", "extra notes"]
+
+
 def test_search_models_ignores_non_model_size_hints_in_readme_text() -> None:
     payload = [
         {

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -538,19 +538,20 @@ def _is_weight_or_config_file(filename: str) -> bool:
 
 
 def _size_hint_bytes(payload: dict[str, Any]) -> int:
-    card_data = payload.get("cardData") if isinstance(payload.get("cardData"), dict) else {}
+    raw_card_data = payload.get("cardData")
+    card_data = raw_card_data if isinstance(raw_card_data, dict) else {}
     direct_card_hint = _size_hint_from_text(_string(card_data.get("model_size")), allow_bare=True)
     if direct_card_hint > 0:
         return direct_card_hint
 
     text = "\n".join(
-        _string(value)
+        text
         for value in (
             payload.get("description"),
             payload.get("readme"),
             card_data.get("description"),
         )
-        if _string(value)
+        if (text := _string(value))
     )
     if not text:
         return 0


### PR DESCRIPTION
## Summary
- Normalize Hub catalog size-hint payload text fields once instead of calling `_string(...)` twice for every non-empty candidate field.
- Extend the registered Hub catalog size-hint probe workload so it exercises `_size_hint_bytes(...)` payload parsing in addition to direct text parsing while keeping the existing direct-text guard-rail metrics stable.
- Add focused regression coverage for the single-normalization behavior and document the slice plan.
- Follow-up update: removed the PR-scoped performance test-file diff so this Python slice no longer force-selects unrelated macOS Swift probes.

## Plan or Spec
- `docs/plans/2026-05-07-hub-catalog-size-hint-text-normalization.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py::test_size_hint_bytes_normalizes_each_payload_text_once services/mlx-worker-python/tests/test_hub_catalog.py::test_search_models_ignores_non_model_size_hints_in_readme_text services/mlx-worker-python/tests/test_hub_catalog.py::test_size_hint_parser_uses_precompiled_patterns services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 4 passed in 0.13s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 35 passed in 0.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py scripts/hub_catalog_size_hint_probe.py
# 35 passed; TOTAL 33 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# {"checksum": 404881408.0, "elapsed_ms_mean": 15115.887459437363, "matched_hint_count": 150000.0, "peak_bytes_mean": 4643.0, "sample_count": 5.0, "size_hint_calls_mean": 200000.0}

git diff --check
# passed

python3 /tmp/hub_size_hint_compare_probe.py <base/head> 240000 5 (three paired runs)
# paired mean: base elapsed_ms_mean=2810.2191289498783 ms, head elapsed_ms_mean=2799.813333332228 ms, delta=-10.405795617650256 ms, speedup=1.0037x; checksum and matched_hint_count unchanged.
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 0 0 100%` after rescoping changed executable lines for `hub_catalog.py`, `test_hub_catalog.py`, and `hub_catalog_size_hint_probe.py`.
- Registered local probe: `elapsed_ms_mean=15115.887459437363`, `matched_hint_count=150000.0`, `checksum=404881408.0`, `sample_count=5.0`, `size_hint_calls_mean=200000.0`.
- Base-vs-head local comparison for `_size_hint_bytes(...)` payload workload: paired three-run mean `old_mean=2810.2191289498783 ms`, `new_mean=2799.813333332228 ms`, `delta_ms=-10.405795617650256`, `speedup=1.0037x`, guard rails unchanged.
- CI PR-scoped performance workflow is required for the registered probe validation before merge; after rescoping, expected selected probes are the three Hub catalog Ubuntu probes only.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime behavior is touched.
- The local improvement is small; CI registered probe should confirm direction before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.

