### PR TITLE
perf: stream final-result extraction candidates

### DIFF
--- a/docs/plans/2026-05-07-evaluation-final-result-extraction-streaming.md
+++ b/docs/plans/2026-05-07-evaluation-final-result-extraction-streaming.md
@@ -1,0 +1,44 @@
+# Evaluation Final Result Extraction Streaming
+
+## Goal
+
+Reduce transient list materialization and repeated suffix JSON parse attempts in final-result heuristic extraction while preserving the existing extraction contract.
+
+## Scope
+
+Touched files:
+
+- `services/mlx-worker-python/worker/productization/evaluation_final_result.py`
+- `services/mlx-worker-python/tests/test_evaluation_final_result.py`
+- `docs/plans/2026-05-07-evaluation-final-result-extraction-streaming.md`
+
+## Linux-only constraint
+
+This slice is Python-only and can be verified locally on Linux with focused pytest, changed-scope coverage, and an explicit synthetic extraction probe.
+
+## Performance probe definition
+
+Run a synthetic probe that repeatedly extracts JSON from a long response containing many non-final JSON-looking fragments and one final balanced JSON payload. Compare current branch behavior against a detached `origin/main` worktree.
+
+Metrics:
+
+- `elapsed_ms_mean` for repeated extraction calls; lower is better.
+- `peak_bytes_mean` from `tracemalloc`; lower is better.
+- `parse_calls_mean` by monkeypatching `_parses_json`; lower is better while preserving identical extracted payloads.
+
+## Success metrics
+
+- Focused extraction tests pass.
+- Changed executable scope coverage is at least 95%.
+- Synthetic probe shows lower parse-call count and no behavioral drift. Lower elapsed time and/or peak memory is expected but can be noisy for small string helpers.
+
+## Verification commands
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py::<focused nodes>`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py::<focused nodes> && ... changed_scope_coverage.py ...`
+- Local base-vs-head extraction probe using `/tmp/evaluation_final_result_extraction_probe.py`.
+- `git diff --check`
+
+## PR-scoped CI
+
+The existing `evaluation-final-result-materialization-streaming` PR-scoped probe watches both the production file and focused test file for this Python path, so the PR-scoped performance workflow will select the evaluation-final-result scope without adding a new registry entry for this narrow extraction helper slice.

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -105,6 +105,105 @@ def test_extract_final_result_marks_ambiguous_text_answer_prefixes_as_failure() 
     assert outcome.failure_reason == "multiple_answer_prefix_candidates"
 
 
+def test_extract_final_result_marks_multiple_generic_json_fences_as_ambiguous() -> None:
+    outcome = extract_final_result(
+        raw_response=(
+            "Draft:\n"
+            "```\n"
+            "{\"answer\": \"wrong\"}\n"
+            "```\n"
+            "Final:\n"
+            "```\n"
+            "{\"answer\": \"Paris\"}\n"
+            "```"
+        ),
+        result_kind="json",
+        extraction_mode="heuristic_final",
+    )
+
+    assert outcome.extraction_status == "ambiguous_extraction"
+    assert outcome.extracted_result == ""
+    assert outcome.failure_reason == "multiple_generic_json_candidates"
+
+
+def test_extract_final_result_accepts_one_generic_json_fence_after_invalid_fence() -> None:
+    outcome = extract_final_result(
+        raw_response=(
+            "Draft:\n"
+            "```\n"
+            "not json yet\n"
+            "```\n"
+            "Final:\n"
+            "```\n"
+            "{\"answer\": \"Paris\"}\n"
+            "```"
+        ),
+        result_kind="json",
+        extraction_mode="heuristic_final",
+    )
+
+    assert outcome.extraction_status == "extracted"
+    assert json.loads(outcome.extracted_result) == {"answer": "Paris"}
+
+
+def test_extract_final_result_uses_last_text_fence_without_materializing_all_fences() -> None:
+    outcome = extract_final_result(
+        raw_response=(
+            "Earlier note:\n"
+            "```\n"
+            "draft answer\n"
+            "```\n"
+            "Final note:\n"
+            "```\n"
+            "Paris\n"
+            "```"
+        ),
+        result_kind="text",
+        extraction_mode="heuristic_final",
+    )
+
+    assert outcome.extraction_status == "extracted"
+    assert outcome.extracted_result == "Paris"
+
+
+def test_extract_final_result_accepts_one_answer_prefix() -> None:
+    outcome = extract_final_result(
+        raw_response="Final answer: Paris",
+        result_kind="text",
+        extraction_mode="heuristic_final",
+    )
+
+    assert outcome.extraction_status == "extracted"
+    assert outcome.extracted_result == "Paris"
+
+
+def test_extract_final_result_scans_json_suffix_candidates_from_the_tail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parse_attempts: list[str] = []
+    original_parses_json = evaluation_final_result_module._parses_json
+
+    def tracking_parses_json(payload: str) -> bool:
+        parse_attempts.append(payload)
+        return original_parses_json(payload)
+
+    monkeypatch.setattr(evaluation_final_result_module, "_parses_json", tracking_parses_json)
+
+    outcome = extract_final_result(
+        raw_response=(
+            "Reasoning with many stale objects: "
+            + " ".join(f"{{not-json-{index}}}" for index in range(50))
+            + "\nFinal payload: {\"answer\": \"Paris\", \"score\": 1}"
+        ),
+        result_kind="json",
+        extraction_mode="heuristic_final",
+    )
+
+    assert outcome.extraction_status == "extracted"
+    assert json.loads(outcome.extracted_result) == {"answer": "Paris", "score": 1}
+    assert len(parse_attempts) == 1
+
+
 def test_score_final_result_validates_json_schema_and_ignores_default_paths() -> None:
     score = score_final_result(
         extracted_result=json.dumps(

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -249,19 +249,22 @@ def materialize_hf_evaluation_dataset(
 
 
 def _extract_json_heuristic(raw_response: str) -> ExtractionOutcome:
-    json_blocks = [candidate.strip() for candidate in _JSON_FENCE_PATTERN.findall(raw_response) if candidate.strip()]
-    if json_blocks:
-        candidate = json_blocks[-1]
-        if _parses_json(candidate):
-            return ExtractionOutcome(candidate, "extracted")
-
-    generic_blocks = [candidate.strip() for candidate in _GENERIC_FENCE_PATTERN.findall(raw_response) if candidate.strip()]
-    valid_generic = [candidate for candidate in generic_blocks if _parses_json(candidate)]
-    if valid_generic:
-        candidate = valid_generic[-1]
-        if len(valid_generic) > 1:
-            return ExtractionOutcome("", "ambiguous_extraction", "multiple_generic_json_candidates")
+    candidate = _last_stripped_pattern_match(_JSON_FENCE_PATTERN, raw_response)
+    if candidate and _parses_json(candidate):
         return ExtractionOutcome(candidate, "extracted")
+
+    valid_generic_count = 0
+    valid_generic_candidate = ""
+    for match in _GENERIC_FENCE_PATTERN.finditer(raw_response):
+        candidate = match.group(1).strip()
+        if not candidate or not _parses_json(candidate):
+            continue
+        valid_generic_count += 1
+        if valid_generic_count > 1:
+            return ExtractionOutcome("", "ambiguous_extraction", "multiple_generic_json_candidates")
+        valid_generic_candidate = candidate
+    if valid_generic_candidate:
+        return ExtractionOutcome(valid_generic_candidate, "extracted")
 
     suffix = _last_balanced_json_suffix(raw_response)
     if suffix:
@@ -270,15 +273,22 @@ def _extract_json_heuristic(raw_response: str) -> ExtractionOutcome:
 
 
 def _extract_text_heuristic(raw_response: str) -> ExtractionOutcome:
-    answer_prefix_matches = [match.group(1).strip() for match in _TEXT_ANSWER_PATTERN.finditer(raw_response) if match.group(1).strip()]
-    if answer_prefix_matches:
-        if len(answer_prefix_matches) > 1:
+    answer_prefix_count = 0
+    answer_prefix_candidate = ""
+    for match in _TEXT_ANSWER_PATTERN.finditer(raw_response):
+        candidate = match.group(1).strip()
+        if not candidate:
+            continue
+        answer_prefix_count += 1
+        if answer_prefix_count > 1:
             return ExtractionOutcome("", "ambiguous_extraction", "multiple_answer_prefix_candidates")
-        return ExtractionOutcome(answer_prefix_matches[0], "extracted")
+        answer_prefix_candidate = candidate
+    if answer_prefix_candidate:
+        return ExtractionOutcome(answer_prefix_candidate, "extracted")
 
-    fenced_blocks = [candidate.strip() for candidate in _GENERIC_FENCE_PATTERN.findall(raw_response) if candidate.strip()]
-    if fenced_blocks:
-        return ExtractionOutcome(fenced_blocks[-1], "extracted")
+    candidate = _last_stripped_pattern_match(_GENERIC_FENCE_PATTERN, raw_response)
+    if candidate:
+        return ExtractionOutcome(candidate, "extracted")
 
     paragraphs = [paragraph.strip() for paragraph in re.split(r"\n\s*\n", raw_response) if paragraph.strip()]
     if paragraphs:
@@ -831,9 +841,18 @@ def _parses_json(payload: str) -> bool:
     return True
 
 
+def _last_stripped_pattern_match(pattern: re.Pattern[str], raw_response: str) -> str:
+    candidate = ""
+    for match in pattern.finditer(raw_response):
+        stripped = match.group(1).strip()
+        if stripped:
+            candidate = stripped
+    return candidate
+
+
 def _last_balanced_json_suffix(raw_response: str) -> str:
-    for index, character in enumerate(raw_response):
-        if character not in "[{":
+    for index in range(len(raw_response) - 1, -1, -1):
+        if raw_response[index] not in "[{":
             continue
         candidate = raw_response[index:].strip()
         if _parses_json(candidate):


### PR DESCRIPTION
## Summary
- Streams final-result heuristic extraction candidates instead of materializing full regex `findall()` lists for JSON/text fences and answer prefixes.
- Scans balanced JSON suffix candidates from the tail so final JSON payloads after long rationale text avoid repeated failed parse attempts.
- Adds focused regression tests for generic JSON ambiguity, single generic JSON fallback, text-fence selection, answer-prefix extraction, and tail-suffix parse-call behavior.

## Plan or Spec
- `docs/plans/2026-05-07-evaluation-final-result-extraction-streaming.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_prefers_last_fenced_json_block \
  services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_marks_ambiguous_text_answer_prefixes_as_failure \
  services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_marks_multiple_generic_json_fences_as_ambiguous \
  services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_accepts_one_generic_json_fence_after_invalid_fence \
  services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_uses_last_text_fence_without_materializing_all_fences \
  services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_accepts_one_answer_prefix \
  services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_scans_json_suffix_candidates_from_the_tail
# 7 passed in 0.20s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py
# 26 passed in 0.11s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <7 focused extraction tests> && \
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && \
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/productization/evaluation_final_result.py \
  services/mlx-worker-python/tests/test_evaluation_final_result.py
# 7 passed; TOTAL 65 1 98%

python3 /tmp/evaluation_final_result_extraction_probe.py <detached-origin-main-worktree> "$PWD"
# base elapsed_ms_mean=1314.7558, peak_bytes_mean=7918.3, parse_calls_mean=251.0
# head elapsed_ms_mean=9.8034, peak_bytes_mean=3238.3, parse_calls_mean=1.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py \
  --registry infra/perf/pr_scoped_probes.json \
  --probe-id evaluation-final-result-materialization-streaming \
  --base-repo <detached-origin-main-worktree> \
  --head-repo "$PWD" \
  --output /tmp/evaluation-final-result-scoped-probe.json
# head verification: 29 passed in 1.94s; changed-scope TOTAL 65 1 98%
# base probe: elapsed_ms_mean=2.2174, peak_bytes_mean=2102670.0, read_rows_calls_mean=0.0, cache_hit_count=5.0
# head probe: elapsed_ms_mean=2.2406, peak_bytes_mean=2102670.0, read_rows_calls_mean=0.0, cache_hit_count=5.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 65 1 98%`.
  - `evaluation_final_result.py`: 97.30% changed-line coverage.
  - `test_evaluation_final_result.py`: 100.00% changed-line coverage.
- Extraction micro-probe against detached `origin/main`:
  - `parse_calls_mean`: 251.0 -> 1.0 per extraction.
  - `elapsed_ms_mean`: 1314.7558 ms -> 9.8034 ms for 300 iterations x 7 samples.
  - `peak_bytes_mean`: 7918.3 -> 3238.3 bytes.
- Registered scoped CI probe: `evaluation-final-result-materialization-streaming` already watches the touched final-result file and focused tests; local base-vs-head run passed head verification and probe execution.

## Known Gaps
- Linux-only local verification. macOS/Swift checks were not run because this is a Python-only worker slice.
- The registered scoped probe is the existing final-result materialization probe; the extraction-specific timing probe was run locally as a temporary comparison script rather than added as a new registry entry to avoid broad registry churn for this narrow helper optimization.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
