### PR TITLE
perf: cache event semantic value groups

### DIFF
--- a/docs/plans/2026-05-07-event-extraction-semantic-value-group-cache.md
+++ b/docs/plans/2026-05-07-event-extraction-semantic-value-group-cache.md
@@ -1,0 +1,42 @@
+# Event Extraction Semantic Value-Group Cache
+
+## Goal
+
+Reduce repeated semantic action value-group combination construction in the event-extraction evaluator. The hot path scores action split/merge candidates and repeatedly requests the same index combinations for the same value counts within one semantic evaluation pass.
+
+## Linux Constraint
+
+This is a Python-only slice under `services/mlx-worker-python`, so it is locally verifiable on Linux with focused pytest, changed-scope coverage, and a synthetic performance probe.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/productization/event_extraction.py`
+- `services/mlx-worker-python/tests/test_event_extraction.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/event_extraction_semantic_value_group_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Implementation Plan
+
+1. Cache `_semantic_value_groups(value_count)` with a bounded LRU cache and return immutable tuples so callers can safely share cached groups.
+2. Preserve existing group ordering and split/merge action semantics.
+3. Add focused tests for cached identity, ordering, and the checked-in PR-scoped probe script.
+4. Register a dedicated PR-scoped performance probe for the semantic value-group cache.
+
+## Performance Probe
+
+Probe ID: `event-extraction-semantic-value-group-cache`
+
+The probe repeatedly requests semantic value groups for several action-value counts while wrapping the production `combinations` helper to count underlying combination construction. It reports:
+
+- `elapsed_ms_mean` / `elapsed_ms_min` (lower is better)
+- `peak_bytes_mean` (lower is better)
+- `combination_build_calls_mean` (lower is better structural metric)
+- checksum and workload-size metrics for output stability
+
+## Success Metrics
+
+- Focused pytest passes.
+- Changed-scope coverage is at least 95%.
+- Local base-vs-head probe shows materially fewer combination-build calls and improved elapsed time without changing output checksum.
+- `git diff --check` passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2064,6 +2064,47 @@
     ]
   },
   {
+    "id": "event-extraction-semantic-value-group-cache",
+    "name": "Event extraction semantic value-group cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/event_extraction.py",
+      "services/mlx-worker-python/tests/test_event_extraction.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/event_extraction_semantic_value_group_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_value_groups_are_cached_and_ordered services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_matches_bidirectional_action_split_merge services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_semantic_value_group_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_value_groups_are_cached_and_ordered services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_matches_bidirectional_action_split_merge services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_semantic_value_group_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_semantic_value_group_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/event_extraction_semantic_value_group_probe.py ]; then python scripts/event_extraction_semantic_value_group_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"IyEvdXNyL2Jpbi9lbnYgcHl0aG9uMwoiIiJNZWFzdXJlIGV2ZW50LWV4dHJhY3Rpb24gc2VtYW50aWMgYWN0aW9uIHZhbHVlLWdyb3VwIHJldXNlLiIiIgpmcm9tIF9fZnV0dXJlX18gaW1wb3J0IGFubm90YXRpb25zCgppbXBvcnQganNvbgppbXBvcnQgb3MKaW1wb3J0IHN0YXRpc3RpY3MKaW1wb3J0IHN5cwppbXBvcnQgdGltZQppbXBvcnQgdHJhY2VtYWxsb2MKZnJvbSBwYXRobGliIGltcG9ydCBQYXRoCmZyb20gdHlwaW5nIGltcG9ydCBJdGVyYWJsZQoKUkVQT19ST09UID0gUGF0aC5jd2QoKQpzeXMucGF0aC5pbnNlcnQoMCwgc3RyKFJFUE9fUk9PVCkpCnN5cy5wYXRoLmluc2VydCgwLCBzdHIoUkVQT19ST09UIC8gInNlcnZpY2VzL21seC13b3JrZXItcHl0aG9uIikpCgpmcm9tIHdvcmtlci5wcm9kdWN0aXphdGlvbiBpbXBvcnQgZXZlbnRfZXh0cmFjdGlvbiBhcyBldmVudF9leHRyYWN0aW9uX21vZHVsZSAgIyBub3FhOiBFNDAyCgoKZGVmIF9lbnZfaW50KG5hbWU6IHN0ciwgZGVmYXVsdDogaW50KSAtPiBpbnQ6CiAgICB2YWx1ZSA9IG9zLmdldGVudihuYW1lKQogICAgaWYgdmFsdWUgaXMgTm9uZToKICAgICAgICByZXR1cm4gZGVmYXVsdAogICAgcmV0dXJuIG1heCgxLCBpbnQodmFsdWUpKQoKCmRlZiBfcnVuX3Byb2JlKCosIGNvdW50czogSXRlcmFibGVbaW50XSwgaXRlcmF0aW9uczogaW50LCBzYW1wbGVzOiBpbnQpIC0+IGRpY3Rbc3RyLCBmbG9hdF06CiAgICBvcmlnaW5hbF9jb21iaW5hdGlvbnMgPSBldmVudF9leHRyYWN0aW9uX21vZHVsZS5jb21iaW5hdGlvbnMKICAgIGVsYXBzZWRfbXM6IGxpc3RbZmxvYXRdID0gW10KICAgIHBlYWtfYnl0ZXM6IGxpc3RbZmxvYXRdID0gW10KICAgIGNvbWJpbmF0aW9uX2NhbGxzOiBsaXN0W2Zsb2F0XSA9IFtdCiAgICBncm91cF9jb3VudCA9IDAKICAgIGNoZWNrc3VtID0gMAoKICAgIGRlZiBjb3VudGVkX2NvbWJpbmF0aW9ucygqYXJnczogb2JqZWN0LCAqKmt3YXJnczogb2JqZWN0KSAtPiBvYmplY3Q6CiAgICAgICAgbm9ubG9jYWwgY3VycmVudF9jb21iaW5hdGlvbl9jYWxscwogICAgICAgIGN1cnJlbnRfY29tYmluYXRpb25fY2FsbHMgKz0gMQogICAgICAgIHJldHVybiBvcmlnaW5hbF9jb21iaW5hdGlvbnMoKmFyZ3MsICoqa3dhcmdzKQoKICAgIGV2ZW50X2V4dHJhY3Rpb25fbW9kdWxlLmNvbWJpbmF0aW9ucyA9IGNvdW50ZWRfY29tYmluYXRpb25zCiAgICB0cnk6CiAgICAgICAgZm9yIF9zYW1wbGVfaW5kZXggaW4gcmFuZ2Uoc2FtcGxlcyk6CiAgICAgICAgICAgIGN1cnJlbnRfY29tYmluYXRpb25fY2FsbHMgPSAwCiAgICAgICAgICAgIGNhY2hlX2NsZWFyID0gZ2V0YXR0cihldmVudF9leHRyYWN0aW9uX21vZHVsZS5fc2VtYW50aWNfdmFsdWVfZ3JvdXBzLCAiY2FjaGVfY2xlYXIiLCBOb25lKQogICAgICAgICAgICBpZiBjYWNoZV9jbGVhciBpcyBub3QgTm9uZToKICAgICAgICAgICAgICAgIGNhY2hlX2NsZWFyKCkKICAgICAgICAgICAgdHJhY2VtYWxsb2Muc3RhcnQoKQogICAgICAgICAgICBzdGFydGVkID0gdGltZS5wZXJmX2NvdW50ZXIoKQogICAgICAgICAgICBzYW1wbGVfZ3JvdXBfY291bnQgPSAwCiAgICAgICAgICAgIHNhbXBsZV9jaGVja3N1bSA9IDAKICAgICAgICAgICAgZm9yIF8gaW4gcmFuZ2UoaXRlcmF0aW9ucyk6CiAgICAgICAgICAgICAgICBmb3IgdmFsdWVfY291bnQgaW4gY291bnRzOgogICAgICAgICAgICAgICAgICAgIGdyb3VwcyA9IGV2ZW50X2V4dHJhY3Rpb25fbW9kdWxlLl9zZW1hbnRpY192YWx1ZV9ncm91cHModmFsdWVfY291bnQpCiAgICAgICAgICAgICAgICAgICAgc2FtcGxlX2dyb3VwX2NvdW50ICs9IGxlbihncm91cHMpCiAgICAgICAgICAgICAgICAgICAgc2FtcGxlX2NoZWNrc3VtICs9IHN1bShzdW0oZ3JvdXApICsgbGVuKGdyb3VwKSAqIDE3IGZvciBncm91cCBpbiBncm91cHMpCiAgICAgICAgICAgIGVsYXBzZWRfbXMuYXBwZW5kKCh0aW1lLnBlcmZfY291bnRlcigpIC0gc3RhcnRlZCkgKiAxMDAwLjApCiAgICAgICAgICAgIF9jdXJyZW50LCBwZWFrID0gdHJhY2VtYWxsb2MuZ2V0X3RyYWNlZF9tZW1vcnkoKQogICAgICAgICAgICB0cmFjZW1hbGxvYy5zdG9wKCkKICAgICAgICAgICAgcGVha19ieXRlcy5hcHBlbmQoZmxvYXQocGVhaykpCiAgICAgICAgICAgIGNvbWJpbmF0aW9uX2NhbGxzLmFwcGVuZChmbG9hdChjdXJyZW50X2NvbWJpbmF0aW9uX2NhbGxzKSkKICAgICAgICAgICAgZ3JvdXBfY291bnQgPSBzYW1wbGVfZ3JvdXBfY291bnQKICAgICAgICAgICAgY2hlY2tzdW0gKz0gc2FtcGxlX2NoZWNrc3VtCiAgICBmaW5hbGx5OgogICAgICAgIGV2ZW50X2V4dHJhY3Rpb25fbW9kdWxlLmNvbWJpbmF0aW9ucyA9IG9yaWdpbmFsX2NvbWJpbmF0aW9ucwoKICAgIHJldHVybiB7CiAgICAgICAgImVsYXBzZWRfbXNfbWVhbiI6IHN0YXRpc3RpY3MuZm1lYW4oZWxhcHNlZF9tcyksCiAgICAgICAgImVsYXBzZWRfbXNfbWluIjogbWluKGVsYXBzZWRfbXMpLAogICAgICAgICJwZWFrX2J5dGVzX21lYW4iOiBzdGF0aXN0aWNzLmZtZWFuKHBlYWtfYnl0ZXMpLAogICAgICAgICJjb21iaW5hdGlvbl9idWlsZF9jYWxsc19tZWFuIjogc3RhdGlzdGljcy5mbWVhbihjb21iaW5hdGlvbl9jYWxscyksCiAgICAgICAgIml0ZXJhdGlvbnNfcGVyX3NhbXBsZSI6IGZsb2F0KGl0ZXJhdGlvbnMpLAogICAgICAgICJzYW1wbGVfY291bnQiOiBmbG9hdChzYW1wbGVzKSwKICAgICAgICAidmFsdWVfY291bnRfbWF4IjogZmxvYXQobWF4KGNvdW50cykpLAogICAgICAgICJncm91cF9jb3VudF9wZXJfc2FtcGxlIjogZmxvYXQoZ3JvdXBfY291bnQpLAogICAgICAgICJjaGVja3N1bSI6IGZsb2F0KGNoZWNrc3VtKSwKICAgIH0KCgpkZWYgbWFpbigpIC0+IGludDoKICAgIGNvdW50cyA9IHR1cGxlKAogICAgICAgIGludChwYXJ0KQogICAgICAgIGZvciBwYXJ0IGluIG9zLmdldGVudigiTUVMSVhfRVZFTlRfU0VNQU5USUNfR1JPVVBfUFJPQkVfQ09VTlRTIiwgIjQsOCwxMiwxNiIpLnNwbGl0KCIsIikKICAgICAgICBpZiBwYXJ0LnN0cmlwKCkKICAgICkKICAgIG1ldHJpY3MgPSBfcnVuX3Byb2JlKAogICAgICAgIGNvdW50cz1jb3VudHMsCiAgICAgICAgaXRlcmF0aW9ucz1fZW52X2ludCgiTUVMSVhfRVZFTlRfU0VNQU5USUNfR1JPVVBfUFJPQkVfSVRFUkFUSU9OUyIsIDIwMDAwKSwKICAgICAgICBzYW1wbGVzPV9lbnZfaW50KCJNRUxJWF9FVkVOVF9TRU1BTlRJQ19HUk9VUF9QUk9CRV9TQU1QTEVTIiwgNSksCiAgICApCiAgICBwcmludChqc29uLmR1bXBzKG1ldHJpY3MsIHNvcnRfa2V5cz1UcnVlKSkKICAgIHJldHVybiAwCgoKaWYgX19uYW1lX18gPT0gIl9fbWFpbl9fIjoKICAgIHJhaXNlIFN5c3RlbUV4aXQobWFpbigpKQo=\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      },
+      {
+        "key": "combination_build_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better"
+      },
+      {
+        "key": "group_count_per_sample",
+        "unit": "groups",
+        "direction": "informational"
+      }
+    ],
+    "notes": "Compares cached semantic action value-group combination reuse against rebuilding identical index groups during event-extraction semantic split/merge scoring."
+  },
+  {
     "id": "mlx-audio-wav-streaming-pcm",
     "name": "MLX audio WAV PCM streaming",
     "runner": "ubuntu-latest",

--- a/scripts/event_extraction_semantic_value_group_probe.py
+++ b/scripts/event_extraction_semantic_value_group_probe.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Measure event-extraction semantic action value-group reuse."""
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.productization import event_extraction as event_extraction_module  # noqa: E402
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return max(1, int(value))
+
+
+def _run_probe(*, counts: Iterable[int], iterations: int, samples: int) -> dict[str, float]:
+    original_combinations = event_extraction_module.combinations
+    elapsed_ms: list[float] = []
+    peak_bytes: list[float] = []
+    combination_calls: list[float] = []
+    group_count = 0
+    checksum = 0
+
+    def counted_combinations(*args: object, **kwargs: object) -> object:
+        nonlocal current_combination_calls
+        current_combination_calls += 1
+        return original_combinations(*args, **kwargs)
+
+    event_extraction_module.combinations = counted_combinations
+    try:
+        for _sample_index in range(samples):
+            current_combination_calls = 0
+            cache_clear = getattr(event_extraction_module._semantic_value_groups, "cache_clear", None)
+            if cache_clear is not None:
+                cache_clear()
+            tracemalloc.start()
+            started = time.perf_counter()
+            sample_group_count = 0
+            sample_checksum = 0
+            for _ in range(iterations):
+                for value_count in counts:
+                    groups = event_extraction_module._semantic_value_groups(value_count)
+                    sample_group_count += len(groups)
+                    sample_checksum += sum(sum(group) + len(group) * 17 for group in groups)
+            elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+            _current, peak = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            peak_bytes.append(float(peak))
+            combination_calls.append(float(current_combination_calls))
+            group_count = sample_group_count
+            checksum += sample_checksum
+    finally:
+        event_extraction_module.combinations = original_combinations
+
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_ms),
+        "elapsed_ms_min": min(elapsed_ms),
+        "peak_bytes_mean": statistics.fmean(peak_bytes),
+        "combination_build_calls_mean": statistics.fmean(combination_calls),
+        "iterations_per_sample": float(iterations),
+        "sample_count": float(samples),
+        "value_count_max": float(max(counts)),
+        "group_count_per_sample": float(group_count),
+        "checksum": float(checksum),
+    }
+
+
+def main() -> int:
+    counts = tuple(
+        int(part)
+        for part in os.getenv("MELIX_EVENT_SEMANTIC_GROUP_PROBE_COUNTS", "4,8,12,16").split(",")
+        if part.strip()
+    )
+    metrics = _run_probe(
+        counts=counts,
+        iterations=_env_int("MELIX_EVENT_SEMANTIC_GROUP_PROBE_ITERATIONS", 20000),
+        samples=_env_int("MELIX_EVENT_SEMANTIC_GROUP_PROBE_SAMPLES", 5),
+    )
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_event_extraction.py
+++ b/services/mlx-worker-python/tests/test_event_extraction.py
@@ -991,6 +991,28 @@ def test_evaluate_event_extraction_semantic_matches_bidirectional_action_split_m
         assert action["semantic_matches"][0]["score"] == 0.96
 
 
+def test_semantic_value_groups_are_cached_and_ordered() -> None:
+    event_extraction_module._semantic_value_groups.cache_clear()
+
+    first = event_extraction_module._semantic_value_groups(4)
+    second = event_extraction_module._semantic_value_groups(4)
+
+    assert first is second
+    assert first == (
+        (0, 1),
+        (0, 2),
+        (0, 3),
+        (1, 2),
+        (1, 3),
+        (2, 3),
+        (0, 1, 2),
+        (0, 1, 3),
+        (0, 2, 3),
+        (1, 2, 3),
+    )
+    assert event_extraction_module._semantic_value_groups(1) == ()
+
+
 def test_evaluate_event_extraction_semantic_matches_specific_check_action(tmp_path: Path) -> None:
     gold = tmp_path / "gold.jsonl"
     pred = tmp_path / "pred.jsonl"

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -108,8 +108,11 @@ def test_scope_report_selects_event_extraction_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/productization/event_extraction.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "event-extraction-alignment-accepted-edge-cache"
+    assert scope["selected_count"] == 2
+    assert {probe["id"] for probe in scope["selected_probes"]} == {
+        "event-extraction-alignment-accepted-edge-cache",
+        "event-extraction-semantic-value-group-cache",
+    }
 
 
 def test_scope_report_selects_hub_catalog_probe() -> None:
@@ -946,6 +949,27 @@ def test_event_extraction_alignment_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0
 
 
+def test_event_extraction_semantic_value_group_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_EVENT_SEMANTIC_GROUP_PROBE_COUNTS", "4,5")
+    monkeypatch.setenv("MELIX_EVENT_SEMANTIC_GROUP_PROBE_ITERATIONS", "3")
+    monkeypatch.setenv("MELIX_EVENT_SEMANTIC_GROUP_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(REPO_ROOT / "scripts/event_extraction_semantic_value_group_probe.py"), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["value_count_max"] == 5.0
+    assert metrics["iterations_per_sample"] == 3.0
+    assert metrics["sample_count"] == 1.0
+    assert metrics["group_count_per_sample"] > 0
+    assert metrics["combination_build_calls_mean"] > 0
+    assert metrics["elapsed_ms_mean"] >= 0
+
+
 def test_hub_catalog_tag_normalization_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -1374,6 +1398,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "dataset-registry-limited-read-streaming",
         "dataset-registry-snapshot-inference-single-pass",
         "event-extraction-alignment-accepted-edge-cache",
+        "event-extraction-semantic-value-group-cache",
         "hub-catalog-tag-normalization-single-pass",
         "hub-catalog-next-cursor-fast-parse",
         "hub-catalog-size-hint-regex-precompile",

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -4,6 +4,7 @@ import json
 import time
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
+from functools import lru_cache
 from hashlib import sha256
 from itertools import combinations
 from pathlib import Path
@@ -1614,12 +1615,13 @@ def _semantic_action_group_score(
     return _semantic_decision_score(decision), str(decision.get("reason_code") or "")
 
 
-def _semantic_value_groups(value_count: int) -> list[tuple[int, ...]]:
+@lru_cache(maxsize=32)
+def _semantic_value_groups(value_count: int) -> tuple[tuple[int, ...], ...]:
     groups: list[tuple[int, ...]] = []
     max_size = min(SEMANTIC_ACTION_GROUP_MAX_SIZE, value_count)
     for group_size in range(2, max_size + 1):
         groups.extend(tuple(group) for group in combinations(range(value_count), group_size))
-    return groups
+    return tuple(groups)
 
 
 def _maximum_weight_semantic_value_group_matching(


### PR DESCRIPTION
## Summary
- Cache event-extraction semantic action value-group combinations by `value_count` with a bounded `lru_cache`, returning immutable tuple groups so repeated split/merge scoring reuses the same ordered index combinations.
- Add a focused regression test for cached group ordering and preserve the existing bidirectional action split/merge semantic behavior test.
- Register `event-extraction-semantic-value-group-cache` in PR-scoped performance CI with a base-compatible command-json probe.

## Plan or Spec
- `docs/plans/2026-05-07-event-extraction-semantic-value-group-cache.md`

## Commands Run
```text
# Focused pytest
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_value_groups_are_cached_and_ordered services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_matches_bidirectional_action_split_merge services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_semantic_value_group_probe_script_emits_metrics
=> 5 passed in 0.52s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_value_groups_are_cached_and_ordered services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_matches_bidirectional_action_split_merge services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_semantic_value_group_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_semantic_value_group_probe.py
=> 5 passed; TOTAL 27 0 100%

# Local explicit probe script on head
MELIX_EVENT_SEMANTIC_GROUP_PROBE_ITERATIONS=20000 MELIX_EVENT_SEMANTIC_GROUP_PROBE_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/event_extraction_semantic_value_group_probe.py
=> elapsed_ms_mean=9405.766900582239; combination_build_calls_mean=8.0; checksum=6989600000.0

# Registered PR-scoped base-vs-head probe with reduced local workload
MELIX_EVENT_SEMANTIC_GROUP_PROBE_ITERATIONS=8000 MELIX_EVENT_SEMANTIC_GROUP_PROBE_SAMPLES=3 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id event-extraction-semantic-value-group-cache --base-repo /tmp/melix-cron-opt-20260507032936-base-1 --head-repo "$PWD" --output /tmp/event_semantic_probe_compare.json
=> head verification passed; base_probe.ok=true; head_probe.ok=true

# Diff hygiene
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.validate.json
=> passed

git diff --check
=> passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 27 0 100%`.
- Registered scoped CI probe: `event-extraction-semantic-value-group-cache`.
- Local base-vs-head probe, same synthetic workload (`iterations_per_sample=8000`, `sample_count=3`, `value_count_max=16`):
  - `elapsed_ms_mean`: base `5460.503674694337` ms → head `3808.394108976548` ms (~30.26% lower).
  - `combination_build_calls_mean`: base `64000.0` → head `8.0` (8000x fewer calls).
  - `checksum`: unchanged at `1677504000.0`.
  - `group_count_per_sample`: unchanged at `8480000.0`.
  - `peak_bytes_mean`: base `27352.0` bytes → head `36296.0` bytes; tracked as informational because the cache intentionally retains one immutable tuple set per sampled value count while eliminating repeated construction.

## Known Gaps
- Full repository `make py-test`, Swift, macOS, and integration gates were not run locally on this Linux host.
- Hosted `pr-scoped-performance` remains the merge gate for the registered probe and any broader workflow fan-out.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
