### PR TITLE
perf: prefilter hub mlx-only searches

### DIFF
--- a/docs/plans/2026-05-07-hub-catalog-mlx-only-prefilter.md
+++ b/docs/plans/2026-05-07-hub-catalog-mlx-only-prefilter.md
@@ -1,0 +1,38 @@
+# Hub Catalog MLX-only Prefilter Optimization
+
+## Goal
+
+Avoid redundant hub summary/local-fit work for search results that are discarded by `HubCatalog.search_models(..., mlx_only=True)`.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+
+## Linux-only constraint
+
+This is a Python worker slice and can be verified on Linux with focused pytest, changed-scope coverage, and a synthetic local probe.
+
+## Performance probe definition
+
+Synthetic workload:
+
+- construct a large in-memory Hub payload page with a small fraction of MLX-compatible records
+- call `HubCatalog.search_models(..., mlx_only=True)` through a fake opener
+- count `_local_fit_evidence(...)` calls and measure elapsed time / traced peak bytes
+
+Success metrics:
+
+- returned MLX records are identical
+- local-fit calls drop from all payloads to only MLX-compatible payloads
+- elapsed time improves materially on the synthetic mostly-non-MLX page
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py
+python3 /tmp/hub_catalog_mlx_prefilter_probe.py
+```

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -95,6 +95,79 @@ def test_search_models_with_mlx_only_keeps_repo_ids_with_mlx_suffix() -> None:
     assert [item.repo_id for item in page.items] == ["unsloth/gemma-4-E4B-it-MLX-8bit"]
 
 
+def test_search_models_with_mlx_only_prefilters_payloads_before_local_fit(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = [
+        {
+            "id": "plain/standard-model",
+            "author": "plain",
+            "pipeline_tag": "text-generation",
+            "tags": ["transformers"],
+            "siblings": [{"rfilename": "model.safetensors"}],
+            "cardData": {},
+        },
+        {
+            "id": "tagged/model",
+            "author": "tagged",
+            "pipeline_tag": "text-generation",
+            "tags": ["MLX", "text-generation"],
+            "siblings": [{"rfilename": "model.safetensors"}],
+            "cardData": {},
+        },
+        {
+            "id": "library/model",
+            "author": "library",
+            "pipeline_tag": "text-generation",
+            "tags": ["transformers"],
+            "library_name": "mlx",
+            "siblings": [{"rfilename": "model.safetensors"}],
+            "cardData": {},
+        },
+        {
+            "id": "card/model",
+            "author": "card",
+            "pipeline_tag": "text-generation",
+            "tags": ["transformers"],
+            "siblings": [{"rfilename": "model.safetensors"}],
+            "cardData": {"tags": ["mlx"]},
+        },
+        {
+            "id": "owner/repo-mlx-suffix",
+            "author": "owner",
+            "pipeline_tag": "text-generation",
+            "tags": ["transformers"],
+            "siblings": [{"rfilename": "model.safetensors"}],
+            "cardData": {},
+        },
+    ]
+    local_fit_repo_ids: list[str] = []
+    original_local_fit = hub_catalog_module._local_fit_evidence
+
+    def counting_local_fit(**kwargs):
+        local_fit_repo_ids.append(kwargs["repo_id"])
+        return original_local_fit(**kwargs)
+
+    def opener(_request: Request):
+        return FakeHTTPResponse(payload)
+
+    monkeypatch.setattr(hub_catalog_module, "_local_fit_evidence", counting_local_fit)
+
+    catalog = HubCatalog(opener=opener)
+    page = catalog.search_models(query="model", page_size=10, cursor="", mlx_only=True)
+
+    assert [item.repo_id for item in page.items] == [
+        "tagged/model",
+        "library/model",
+        "card/model",
+        "owner/repo-mlx-suffix",
+    ]
+    assert local_fit_repo_ids == [
+        "tagged/model",
+        "library/model",
+        "card/model",
+        "owner/repo-mlx-suffix",
+    ]
+
+
 def test_get_model_card_raises_invalid_argument_for_blank_repo_id() -> None:
     catalog = HubCatalog()
 

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -112,9 +112,9 @@ class HubCatalog:
             page_size=page_size,
             cursor=cursor,
         )
-        items = [self._summary_record(payload) for payload in payloads]
         if mlx_only:
-            items = [item for item in items if item.mlx_compatible]
+            payloads = [payload for payload in payloads if _payload_is_mlx_compatible(payload)]
+        items = [self._summary_record(payload) for payload in payloads]
         return HubSearchPage(items=items, next_cursor=next_cursor)
 
     def get_model_card(self, *, repo_id: str) -> HubModelCardRecord:
@@ -366,6 +366,23 @@ def _base_models(value: Any) -> list[str]:
     if isinstance(value, list):
         return [item for item in value if isinstance(item, str) and item]
     return []
+
+
+def _payload_is_mlx_compatible(payload: dict[str, Any]) -> bool:
+    card_data = payload.get("cardData") if isinstance(payload.get("cardData"), dict) else {}
+    tags = _string_list(payload.get("tags"))
+    if any(tag.lower() == "mlx" for tag in tags):
+        return True
+    library_name = _string(payload.get("library_name") or card_data.get("library_name"))
+    if library_name.lower() == "mlx":
+        return True
+    repo_id = _string(payload.get("id") or payload.get("modelId"))
+    if "mlx" in repo_id.lower():
+        return True
+    card_tags = card_data.get("tags")
+    if not card_tags:
+        return False
+    return any(tag.lower() == "mlx" for tag in _string_list(card_tags))
 
 
 def _is_mlx_compatible(


### PR DESCRIPTION
## Summary
- Prefilters `HubCatalog.search_models(..., mlx_only=True)` payloads before building full summary records.
- Avoids redundant local-fit estimation for non-MLX Hub search results that would be discarded anyway.
- Adds a focused regression test covering tag, library, card-data, and repo-id MLX compatibility signals.

## Plan or Spec
- `docs/plans/2026-05-07-hub-catalog-mlx-only-prefilter.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py
# 32 passed in 0.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py
# 32 passed in 0.25s
# TOTAL 31 0 100%

python3 /tmp/hub_catalog_mlx_prefilter_probe.py /tmp/melix-cron-opt-20260507061514-base-2
# {"elapsed_ms_mean": 692.9005885962397, "local_fit_calls_mean": 5000.0, "mlx_result_count": 250.0, "peak_bytes_mean": 18573708.6, "record_count": 5000.0, "sample_count": 5.0}

python3 /tmp/hub_catalog_mlx_prefilter_probe.py /tmp/melix-cron-opt-20260507061514
# {"elapsed_ms_mean": 320.21376739721745, "local_fit_calls_mean": 250.0, "mlx_result_count": 250.0, "peak_bytes_mean": 18116555.0, "record_count": 5000.0, "sample_count": 5.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-tag-normalization-single-pass --base-repo /tmp/melix-cron-opt-20260507061514-base-2 --head-repo /tmp/melix-cron-opt-20260507061514 --output /tmp/hub-tag-probe-result.json
# head verification: 35 passed; changed-scope coverage TOTAL 31 0 100%; base/head probe ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 31 0 100%` for `hub_catalog.py` and `test_hub_catalog.py`.
- Synthetic mostly-non-MLX search probe (`5000` payloads, `250` MLX-compatible results, `5` samples):
  - `local_fit_calls_mean`: `5000.0` on `origin/main` -> `250.0` on this branch (95% fewer local-fit calls).
  - `elapsed_ms_mean`: `692.901 ms` -> `320.214 ms` (~53.79% lower).
  - `peak_bytes_mean`: `18,573,708.6` -> `18,116,555.0` (~2.46% lower).
- Registered scoped CI probe selected for this path: `hub-catalog-tag-normalization-single-pass`.

## Known Gaps
- Linux-only verification was run; macOS/Swift checks were not run locally because this is a Python worker slice on a Linux host.
- The existing registered hub catalog probe covers this file's scoped CI verification; the explicit MLX-only local-fit call reduction is captured by the local synthetic probe above.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
