### PR TITLE
[codex] Gate PR CI by changed scope

### DIFF
--- a/.github/workflows/ci-full-scheduled.yml
+++ b/.github/workflows/ci-full-scheduled.yml
@@ -1,0 +1,67 @@
+name: ci-full-scheduled
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */4 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-full-scheduled-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  full-regression:
+    runs-on: macos-15
+    timeout-minutes: 120
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Restore Python dependency cache
+        uses: actions/cache@v4
+        with:
+          path: .uv-cache
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock', 'pyproject.toml', 'services/mlx-worker-python/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Restore Swift dependency cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .swift-home
+            .build/ModuleCache.noindex
+            .build
+            packages/protocol/swift/.build
+            services/control-plane-swift/.build
+            services/mlx-text-worker-swift/.build
+            apps/macos-menubar/.build
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-swift-full-${{ hashFiles('Package.swift', 'Package.resolved', 'packages/protocol/swift/Package.swift', 'packages/protocol/swift/Package.resolved', 'services/control-plane-swift/Package.swift', 'services/control-plane-swift/Package.resolved', 'services/mlx-text-worker-swift/Package.swift', 'services/mlx-text-worker-swift/Package.resolved', 'apps/macos-menubar/Package.swift', 'apps/macos-menubar/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-full-
+            ${{ runner.os }}-swift-
+
+      - name: Bootstrap
+        run: bash scripts/ci_progress.sh "Bootstrap" make bootstrap
+
+      - name: Protocol drift check
+        run: bash scripts/ci_progress.sh "Protocol drift check" make proto-check
+
+      - name: Swift tests
+        run: bash scripts/ci_progress.sh "Swift tests" make swift-test
+
+      - name: Python tests
+        run: bash scripts/ci_progress.sh "Python tests" make py-test
+
+      - name: Integration tests
+        run: bash scripts/ci_progress.sh "Integration tests" make integration-test

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -25,10 +25,56 @@ jobs:
       - name: Shell syntax check
         run: bash -n scripts/ci_progress.sh
 
+      - name: Python syntax check
+        run: python3 -m py_compile scripts/ci_scope.py
+
       - name: Diff check
         run: git diff --check HEAD^1 HEAD
 
+  ci-scope:
+    runs-on: ubuntu-latest
+    outputs:
+      proto_should_run: ${{ steps.scope.outputs.proto_should_run }}
+      swift_should_run: ${{ steps.scope.outputs.swift_should_run }}
+      python_should_run: ${{ steps.scope.outputs.python_should_run }}
+      integration_should_run: ${{ steps.scope.outputs.integration_should_run }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine changed paths
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/ci-scope
+
+          if git rev-parse --verify HEAD^1 >/dev/null 2>&1; then
+            git diff --name-only HEAD^1 HEAD > artifacts/ci-scope/changed-files.txt
+          elif [ "${{ github.event_name }}" = "merge_group" ]; then
+            git diff --name-only \
+              "${{ github.event.merge_group.base_sha }}" \
+              "${{ github.event.merge_group.head_sha }}" \
+              > artifacts/ci-scope/changed-files.txt
+          else
+            git diff --name-only \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}" \
+              > artifacts/ci-scope/changed-files.txt
+          fi
+
+          echo "Changed files:"
+          cat artifacts/ci-scope/changed-files.txt
+          python3 scripts/ci_scope.py \
+            --changed-files-file artifacts/ci-scope/changed-files.txt \
+            --github-output "$GITHUB_OUTPUT"
+
   proto-drift:
+    if: needs.ci-scope.outputs.proto_should_run == 'true'
+    needs:
+      - ci-scope
     runs-on: macos-15
     timeout-minutes: 30
 
@@ -68,6 +114,9 @@ jobs:
         run: bash scripts/ci_progress.sh "Protocol drift check" make proto-check
 
   swift-tests:
+    if: needs.ci-scope.outputs.swift_should_run == 'true'
+    needs:
+      - ci-scope
     name: swift-tests (${{ matrix.shard }})
     runs-on: macos-15
     timeout-minutes: 45
@@ -141,12 +190,17 @@ jobs:
   swift-tests-report:
     if: always()
     needs:
+      - ci-scope
       - swift-tests
     runs-on: ubuntu-latest
 
     steps:
       - name: Check Swift test shards
         run: |
+          if [ "${{ needs.ci-scope.outputs.swift_should_run }}" != "true" ]; then
+            echo "Swift test shards skipped by CI scope."
+            exit 0
+          fi
           if [ "${{ needs.swift-tests.result }}" != "success" ]; then
             echo "Swift test shards completed with result: ${{ needs.swift-tests.result }}"
             exit 1
@@ -154,6 +208,9 @@ jobs:
           echo "Swift test shards completed successfully."
 
   python-tests:
+    if: needs.ci-scope.outputs.python_should_run == 'true'
+    needs:
+      - ci-scope
     runs-on: macos-15
     timeout-minutes: 30
 
@@ -180,40 +237,10 @@ jobs:
       - name: Python tests
         run: bash scripts/ci_progress.sh "Python tests" make py-test
 
-  integration-scope:
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.scope.outputs.should_run }}
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Determine whether integration tests are affected
-        id: scope
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "merge_group" ]; then
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          should_run=false
-          while IFS= read -r path; do
-            case "$path" in
-              .github/workflows/ci-pr.yml|Makefile|Package.swift|Package.resolved|pyproject.toml|uv.lock|buf.yaml|buf.gen.yaml|packages/protocol/*|scripts/*|services/control-plane-swift/*|services/mlx-text-worker-swift/*|services/mlx-worker-python/*|tests/integration/*)
-                should_run=true
-                break
-                ;;
-            esac
-          done < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
-          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
-
   integration-tests:
-    if: github.event_name == 'merge_group' || needs.integration-scope.outputs.should_run == 'true'
+    if: needs.ci-scope.outputs.integration_should_run == 'true'
     needs:
-      - integration-scope
+      - ci-scope
     runs-on: macos-15
     timeout-minutes: 60
 

--- a/docs/plans/2026-05-07-ci-scope-scheduled-full.md
+++ b/docs/plans/2026-05-07-ci-scope-scheduled-full.md
@@ -1,0 +1,41 @@
+# CI Scope Gates And Scheduled Full Regression
+
+## Goal
+
+Reduce pull-request CI queue pressure by running heavyweight macOS jobs only
+when the changed paths require them, while preserving a complete repository
+regression signal on a four-hour scheduled workflow.
+
+## Scope
+
+- Add a repository-owned path classifier for `ci-pr`.
+- Gate `proto-drift`, Swift shards, Python tests, and integration tests from
+  the classifier output.
+- Keep `swift-tests-report` as the stable Swift aggregate check and let it pass
+  explicitly when Swift tests are skipped by scope.
+- Add a scheduled full regression workflow that runs every four hours and can
+  also be triggered manually.
+
+Out of scope:
+
+- Changing the existing local `make swift-test` aggregate.
+- Changing branch protection rules.
+- Fixing unrelated Swift test failures such as missing runner metallib state.
+
+## Metrics And Success Targets
+
+- Docs-only pull requests do not enqueue macOS Swift, protocol, Python, or
+  integration jobs.
+- Python-only pull requests do not enqueue Swift shards.
+- Swift or protocol pull requests still enqueue the relevant macOS checks.
+- Full regression still runs `make proto-check`, `make swift-test`,
+  `make py-test`, and `make integration-test` every four hours.
+- Workflow-only, Makefile, dependency, or toolchain changes conservatively run
+  every `ci-pr` test family.
+
+## Verification
+
+- `uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_ci_scope.py -q`
+- `python3 -m py_compile scripts/ci_scope.py`
+- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci-pr.yml"); YAML.load_file(".github/workflows/ci-full-scheduled.yml")'`
+- `git diff --check`

--- a/scripts/ci_scope.py
+++ b/scripts/ci_scope.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Iterable
+
+
+OUTPUT_KEYS = (
+    "proto_should_run",
+    "swift_should_run",
+    "python_should_run",
+    "integration_should_run",
+)
+
+FORCE_ALL_PATTERNS = (
+    ".github/workflows/ci-pr.yml",
+    ".github/workflows/ci-full-scheduled.yml",
+    "Makefile",
+    "Package.swift",
+    "Package.resolved",
+    "pyproject.toml",
+    "uv.lock",
+    "buf.yaml",
+    "buf.gen.yaml",
+    "scripts/ci_progress.sh",
+    "scripts/ci_scope.py",
+)
+
+PROTO_PATTERNS = (
+    "buf.yaml",
+    "buf.gen.yaml",
+    "packages/protocol/schema/**",
+    "packages/protocol/descriptors/**",
+    "packages/protocol/python/**",
+    "packages/protocol/swift/**",
+)
+
+SWIFT_PATTERNS = (
+    "Package.swift",
+    "Package.resolved",
+    "packages/protocol/swift/**",
+    "services/control-plane-swift/**",
+    "services/mlx-text-worker-swift/**",
+    "apps/macos-menubar/**",
+)
+
+PYTHON_PATTERNS = (
+    "pyproject.toml",
+    "uv.lock",
+    "infra/perf/**",
+    "scripts/**",
+    "services/mlx-worker-python/**",
+)
+
+INTEGRATION_PATTERNS = (
+    "Package.swift",
+    "Package.resolved",
+    "pyproject.toml",
+    "uv.lock",
+    "buf.yaml",
+    "buf.gen.yaml",
+    "packages/protocol/**",
+    "scripts/dev_app_up.py",
+    "scripts/dev_up.py",
+    "scripts/dev_up.sh",
+    "scripts/dev_down.sh",
+    "services/control-plane-swift/**",
+    "services/mlx-text-worker-swift/**",
+    "services/mlx-worker-python/worker/control_plane_bridge.py",
+    "services/mlx-worker-python/worker/runtime/**",
+    "tests/integration/**",
+)
+
+
+def _normalize_path(path: str) -> str:
+    normalized = path.strip()
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def _matches(path: str, pattern: str) -> bool:
+    if pattern.endswith("/**"):
+        prefix = pattern[:-3]
+        return path == prefix or path.startswith(f"{prefix}/")
+    return path == pattern
+
+
+def _any_match(path: str, patterns: Iterable[str]) -> bool:
+    return any(_matches(path, pattern) for pattern in patterns)
+
+
+def classify_paths(paths: Iterable[str]) -> dict[str, bool]:
+    normalized_paths = [
+        normalized
+        for path in paths
+        if (normalized := _normalize_path(path))
+    ]
+
+    result = {key: False for key in OUTPUT_KEYS}
+    if any(_any_match(path, FORCE_ALL_PATTERNS) for path in normalized_paths):
+        return {key: True for key in OUTPUT_KEYS}
+
+    for path in normalized_paths:
+        if _any_match(path, PROTO_PATTERNS):
+            result["proto_should_run"] = True
+            result["swift_should_run"] = True
+            result["python_should_run"] = True
+            result["integration_should_run"] = True
+            continue
+        if _any_match(path, SWIFT_PATTERNS):
+            result["swift_should_run"] = True
+            result["integration_should_run"] = True
+        if _any_match(path, PYTHON_PATTERNS):
+            result["python_should_run"] = True
+        if _any_match(path, INTEGRATION_PATTERNS):
+            result["integration_should_run"] = True
+    return result
+
+
+def _read_changed_files(args: argparse.Namespace) -> list[str]:
+    paths: list[str] = []
+    if args.changed_files_file:
+        paths.extend(Path(args.changed_files_file).read_text(encoding="utf-8").splitlines())
+    paths.extend(args.paths)
+    return paths
+
+
+def _write_github_output(values: dict[str, bool], output_path: str) -> None:
+    with Path(output_path).open("a", encoding="utf-8") as output_file:
+        for key in OUTPUT_KEYS:
+            output_file.write(f"{key}={str(values[key]).lower()}\n")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Classify changed paths for Melix PR CI scope.")
+    parser.add_argument("paths", nargs="*", help="Changed paths to classify.")
+    parser.add_argument(
+        "--changed-files-file",
+        help="Newline-delimited file containing changed paths.",
+    )
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT"),
+        help="GitHub Actions output file to append key=value results to.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print JSON instead of GitHub output lines.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    values = classify_paths(_read_changed_files(args))
+    if args.json:
+        print(json.dumps(values, sort_keys=True))
+    else:
+        for key in OUTPUT_KEYS:
+            print(f"{key}={str(values[key]).lower()}")
+    if args.github_output:
+        _write_github_output(values, args.github_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_ci_scope.py
+++ b/services/mlx-worker-python/tests/test_ci_scope.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / "scripts" / "ci_scope.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("ci_scope", MODULE_PATH)
+assert MODULE_SPEC is not None
+assert MODULE_SPEC.loader is not None
+ci_scope = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(ci_scope)
+
+
+def test_docs_only_paths_skip_heavy_ci() -> None:
+    assert ci_scope.classify_paths(
+        [
+            "README.md",
+            "docs/marketing/copy-kit.md",
+            "docs/plans/2026-05-07-melix-lora-storytelling-and-marketing-docs.md",
+        ]
+    ) == {
+        "proto_should_run": False,
+        "swift_should_run": False,
+        "python_should_run": False,
+        "integration_should_run": False,
+    }
+
+
+def test_python_only_paths_run_python_without_swift() -> None:
+    assert ci_scope.classify_paths(
+        [
+            "infra/perf/pr_scoped_probes.json",
+            "services/mlx-worker-python/worker/model_ops/hub_catalog.py",
+            "services/mlx-worker-python/tests/test_hub_catalog.py",
+        ]
+    ) == {
+        "proto_should_run": False,
+        "swift_should_run": False,
+        "python_should_run": True,
+        "integration_should_run": False,
+    }
+
+
+def test_runtime_python_paths_run_python_and_integration_without_swift() -> None:
+    assert ci_scope.classify_paths(
+        [
+            "services/mlx-worker-python/worker/runtime/mlx_text_runtime.py",
+            "services/mlx-worker-python/tests/test_mlx_backend.py",
+        ]
+    ) == {
+        "proto_should_run": False,
+        "swift_should_run": False,
+        "python_should_run": True,
+        "integration_should_run": True,
+    }
+
+
+def test_swift_paths_run_swift_and_integration() -> None:
+    assert ci_scope.classify_paths(
+        ["services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift"]
+    ) == {
+        "proto_should_run": False,
+        "swift_should_run": True,
+        "python_should_run": False,
+        "integration_should_run": True,
+    }
+
+
+def test_protocol_paths_run_all_ci_families() -> None:
+    assert ci_scope.classify_paths(
+        ["packages/protocol/schema/worker/v1/runtime.proto"]
+    ) == {
+        "proto_should_run": True,
+        "swift_should_run": True,
+        "python_should_run": True,
+        "integration_should_run": True,
+    }
+
+
+def test_workflow_and_toolchain_paths_run_all_ci_families() -> None:
+    assert ci_scope.classify_paths([".github/workflows/ci-pr.yml"]) == {
+        "proto_should_run": True,
+        "swift_should_run": True,
+        "python_should_run": True,
+        "integration_should_run": True,
+    }
+    assert ci_scope.classify_paths(["uv.lock"]) == {
+        "proto_should_run": True,
+        "swift_should_run": True,
+        "python_should_run": True,
+        "integration_should_run": True,
+    }
+
+
+def test_cli_writes_github_outputs(tmp_path: Path, capsys) -> None:
+    changed_files = tmp_path / "changed-files.txt"
+    changed_files.write_text("services/mlx-worker-python/worker/runtime/mlx_backend.py\n")
+    github_output = tmp_path / "github-output.txt"
+
+    result = ci_scope.main(
+        [
+            "--changed-files-file",
+            str(changed_files),
+            "--github-output",
+            str(github_output),
+            "--json",
+        ]
+    )
+
+    assert result == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "proto_should_run": False,
+        "swift_should_run": False,
+        "python_should_run": True,
+        "integration_should_run": True,
+    }
+    assert "python_should_run=true\n" in github_output.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add a repository-owned `ci-pr` scope classifier so PR and merge queue runs only enqueue protocol, Swift, Python, and integration jobs when changed paths require them.
- Add a `ci-full-scheduled` workflow that runs the full regression chain every four hours and by manual dispatch.
- Keep `swift-tests-report` as a stable aggregate check that succeeds explicitly when Swift shards are skipped by scope.

## Plan or Spec
- `docs/plans/2026-05-07-ci-scope-scheduled-full.md`

## Commands Run
```text
python3 -m py_compile scripts/ci_scope.py -> pass
uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_ci_scope.py -q -> 7 passed
uv run --project services/mlx-worker-python --extra mlx coverage run --source=scripts -m pytest services/mlx-worker-python/tests/test_ci_scope.py -q -> 7 passed
uv run --project services/mlx-worker-python --extra mlx coverage report --include='scripts/ci_scope.py' -> scripts/ci_scope.py 95% coverage
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci-pr.yml"); YAML.load_file(".github/workflows/ci-full-scheduled.yml")' -> pass
/private/tmp/actionlint .github/workflows/ci-pr.yml .github/workflows/ci-full-scheduled.yml -> pass
git diff --check -> pass
make py-test -> 1976 passed, 5 skipped, 2 warnings
python3 scripts/validate_pr_evidence.py --body-file /private/tmp/melix-ci-scope-pr-body.md -> pass
```

## Coverage and Metrics
- `scripts/ci_scope.py`: 95% line coverage from the focused scope-classifier test.
- CI queue pressure metric is expected to improve by skipping macOS Swift/protocol/integration jobs for docs-only and Python-only PRs that do not touch runtime or cross-language paths; GitHub-side queue reduction must be measured after this workflow lands.

## Known Gaps
- Full scheduled workflow execution must be observed on GitHub after merge or manual dispatch.
- Local `make swift-test` and `make integration-test` were not run because this change is workflow/scope logic and those macOS-heavy gates are moved to the scheduled full workflow.
- Branch protection required checks were not changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or are N/A.
- [x] Dependency changes include updated lockfiles, or are N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
