### PR TITLE
perf: speed up startup log tail whitespace scan

### DIFF
--- a/docs/plans/2026-05-07-startup-signals-tail-whitespace-probe.md
+++ b/docs/plans/2026-05-07-startup-signals-tail-whitespace-probe.md
@@ -1,0 +1,35 @@
+# Startup Signals Tail Whitespace Probe Optimization
+
+## Goal
+
+Reduce Python-level work in startup log excerpt parsing when logs contain large trailing whitespace blocks, while preserving startup failure classification behavior.
+
+## Linux-only constraint
+
+This slice touches Python-only startup diagnostics and can be verified on Linux with focused pytest, changed-scope coverage, and the existing PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/productization/startup_signals.py`
+- `services/mlx-worker-python/tests/test_startup_signals.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/startup_signals_log_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Performance probe
+
+Use the existing registered probe ID `startup-signals-lazy-worker-log-excerpts`, extended with tail-scan metrics:
+
+- `tail_scan_elapsed_ms_mean`
+- `tail_scan_peak_bytes_mean`
+- `trailing_whitespace_bytes`
+
+The probe writes a synthetic log ending in `80,000` whitespace bytes, repeatedly calls `_read_last_nonempty_line(...)`, and verifies that the final non-empty line remains unchanged.
+
+## Success metrics
+
+- Focused startup signal tests pass.
+- Changed-scope coverage is at least 95%.
+- `git diff --check` is clean.
+- Local probe reports concrete tail-scan timing and allocation numbers.
+- PR-scoped performance CI selects and runs `startup-signals-lazy-worker-log-excerpts`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2024,6 +2024,23 @@
         "unit": "reads",
         "direction": "lower_is_better",
         "warn_pct": 0.0
+      },
+      {
+        "key": "tail_scan_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "tail_scan_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 10.0
+      },
+      {
+        "key": "trailing_whitespace_bytes",
+        "unit": "bytes",
+        "direction": "informational"
       }
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics",

--- a/scripts/startup_signals_log_probe.py
+++ b/scripts/startup_signals_log_probe.py
@@ -8,6 +8,7 @@ import statistics
 import sys
 import tempfile
 import time
+import tracemalloc
 from typing import Callable
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -17,7 +18,7 @@ sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 import worker.productization.startup_signals as startup_signals  # noqa: E402
 
 
-def _write_logs(root: Path) -> dict[str, str]:
+def _write_logs(root: Path) -> dict[str, str | int]:
     control_plane_stderr = root / "control-plane.stderr.log"
     worker_stderr = root / "python-worker.stderr.log"
     noise = "boot line with enough content to make reads realistic\n" * 2500
@@ -70,6 +71,23 @@ def _measure_case(
     return elapsed_ms, float(read_count), float(exists_count)
 
 
+def _measure_tail_scan(log_path: Path, *, iterations: int) -> tuple[float, float]:
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    for _ in range(5):
+        tracemalloc.start()
+        started = time.perf_counter()
+        for _ in range(iterations):
+            line = startup_signals._read_last_nonempty_line(log_path, chunk_size=8192)
+            if line != "final startup line":
+                raise AssertionError(f"unexpected tail line: {line!r}")
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_samples.append(float(peak))
+    return statistics.fmean(elapsed_samples), statistics.fmean(peak_samples)
+
+
 def main() -> int:
     iterations = 400
     samples = 5
@@ -84,7 +102,10 @@ def main() -> int:
     worker_exists: list[float] = []
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-        manifest = _write_logs(Path(tmp_dir))
+        root = Path(tmp_dir)
+        manifest = _write_logs(root)
+        tail_log = root / "trailing-whitespace.log"
+        tail_log.write_bytes(b"startup booted\nfinal startup line" + (b" \t\r\n" * 20000))
         for _ in range(samples):
             elapsed, reads, exists = _measure_case(
                 manifest,
@@ -118,6 +139,8 @@ def main() -> int:
             worker_reads.append(reads / iterations)
             worker_exists.append(exists / iterations)
 
+        tail_elapsed_mean, tail_peak_mean = _measure_tail_scan(tail_log, iterations=iterations)
+
     print(
         json.dumps(
             {
@@ -129,6 +152,9 @@ def main() -> int:
                 "control_crash_log_reads_mean": round(statistics.fmean(control_reads), 6),
                 "iterations": float(iterations),
                 "sample_count": float(samples),
+                "tail_scan_elapsed_ms_mean": round(tail_elapsed_mean, 6),
+                "tail_scan_peak_bytes_mean": round(tail_peak_mean, 6),
+                "trailing_whitespace_bytes": float(80000),
                 "worker_crash_elapsed_ms_mean": round(statistics.fmean(worker_elapsed), 6),
                 "worker_crash_log_path_exists_checks_mean": round(statistics.fmean(worker_exists), 6),
                 "worker_crash_log_reads_mean": round(statistics.fmean(worker_reads), 6),

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2154,6 +2154,9 @@ def test_startup_signals_probe_script_emits_metrics(capsys: pytest.CaptureFixtur
     assert payload["worker_crash_elapsed_ms_mean"] > 0
     assert payload["worker_crash_log_path_exists_checks_mean"] == 0.0
     assert payload["worker_crash_log_reads_mean"] == 1.0
+    assert payload["tail_scan_elapsed_ms_mean"] > 0
+    assert payload["tail_scan_peak_bytes_mean"] > 0
+    assert payload["trailing_whitespace_bytes"] == 80000.0
     assert payload["sample_count"] == 5.0
 
 

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -385,6 +385,30 @@ def test_read_last_nonempty_line_decodes_invalid_utf8_with_replacement(tmp_path:
     assert _read_last_nonempty_line(log_path) == "last line �"
 
 
+def test_read_last_nonempty_line_trims_byte_whitespace_without_python_byte_loop(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "python-worker.stderr.log"
+    log_path.write_bytes(b"booting\nlast line\x85\xa0\n\t  \r\n")
+
+    assert _read_last_nonempty_line(log_path, chunk_size=4) == "last line"
+
+
+def test_log_excerpt_uses_read_fallback_without_exists_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log_path = tmp_path / "control-plane.stderr.log"
+    log_path.write_text("booting\nready\n", encoding="utf-8")
+
+    def fail_exists(self: Path) -> bool:
+        raise AssertionError(f"log excerpt should read directly instead of checking exists(): {self}")
+
+    monkeypatch.setattr(Path, "exists", fail_exists)
+
+    assert startup_signals_module._log_excerpt(tmp_path / "missing.log", log_path) == "ready"
+
+
 def test_classify_startup_failure_falls_back_to_hang_when_logs_are_empty() -> None:
     report = classify_startup_failure(
         {

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -22,6 +22,7 @@ CRASH_PATTERNS = [
     "terminated",
     "abort trap",
 ]
+_BYTE_WHITESPACE = bytes(value for value in range(256) if chr(value).isspace())
 
 
 @dataclass(frozen=True)
@@ -258,11 +259,9 @@ def _seek_non_whitespace_end(handle: Any, *, chunk_size: int) -> int:
         start = position - read_size
         handle.seek(start)
         chunk = handle.read(read_size)
-        index = read_size - 1
-        while index >= 0 and chr(chunk[index]).isspace():
-            index -= 1
-        if index >= 0:
-            return start + index + 1
+        trimmed = chunk.rstrip(_BYTE_WHITESPACE)
+        if trimmed:
+            return start + len(trimmed)
         position = start
     return 0
 


### PR DESCRIPTION
## Summary
- Speeds up startup log tail parsing by replacing per-byte Python whitespace checks with a precomputed byte-whitespace `bytes.rstrip(...)` path.
- Reads log excerpts directly and treats `OSError` as the missing/unreadable-log fallback, avoiding a separate existence preflight.
- Extends the existing `startup-signals-lazy-worker-log-excerpts` scoped probe with a trailing-whitespace tail-scan workload.

## Plan or Spec
- `docs/plans/2026-05-07-startup-signals-tail-whitespace-probe.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# before commit: 27 passed in 1.39s
# after rebase: 28 passed in 1.31s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py
# before commit: TOTAL 43 2 95%
# after rebase/clean diff rerun: TOTAL 0 0 100% (clean-diff artifact after commit)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py
# {"conflict_elapsed_ms_mean": 1.161659, "conflict_log_reads_mean": 0.0, "control_crash_elapsed_ms_mean": 11.339032, "control_crash_log_reads_mean": 1.0, "iterations": 400.0, "sample_count": 5.0, "tail_scan_elapsed_ms_mean": 149.209249, "tail_scan_peak_bytes_mean": 21417.0, "trailing_whitespace_bytes": 80000.0, "worker_crash_elapsed_ms_mean": 13.30343, "worker_crash_log_reads_mean": 1.0}

python3 /tmp/startup_tail_compare.py
# {"base_tail_scan_elapsed_ms_mean": 18337.833556, "base_tail_scan_peak_bytes_mean": 21433.0, "elapsed_improvement_pct": 99.179314, "head_tail_scan_elapsed_ms_mean": 150.495947, "head_tail_scan_peak_bytes_mean": 21433.0, "iterations": 400.0, "peak_delta_bytes": 0.0, "sample_count": 5.0, "trailing_whitespace_bytes": 80000.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id startup-signals-lazy-worker-log-excerpts --base-repo /tmp/melix-cron-opt-base-20260507081108 --head-repo "$PWD" --output /tmp/startup-signals-probe-rebased.json
# head verification ok; base_probe ok=true; head_probe ok=true
# head probe tail_scan_elapsed_ms_mean=154.129394, tail_scan_peak_bytes_mean=21436.2, trailing_whitespace_bytes=80000.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage before commit: `TOTAL 43 2 95%`.
- Rebased PR-scoped head verification: `TOTAL 0 0 100%` because `scripts/changed_scope_coverage.py` measures the current uncommitted diff and the worktree was clean after commit/rebase.
- Direct old-vs-new tail-scan comparison on an 80,000-byte trailing-whitespace synthetic log: `18337.833556 ms` mean on `origin/main` vs `150.495947 ms` mean on this branch (`99.179314%` lower), with unchanged peak traced allocation (`21433` bytes mean).
- Registered scoped probe: `startup-signals-lazy-worker-log-excerpts`.

## Known Gaps
- Linux/Python-only verification. macOS/Swift checks were not run because this slice touches only Python startup diagnostics.
- The existing probe's historical base script does not emit the newly added tail metrics, so the local PR-scoped run validates head verification and existing comparable startup metrics while the direct old-vs-new script captures the tail-scan delta.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
