### PR TITLE
perf: cache event actor alias normalization

### DIFF
--- a/docs/plans/2026-05-07-event-extraction-group-actor-alias-cache.md
+++ b/docs/plans/2026-05-07-event-extraction-group-actor-alias-cache.md
@@ -1,0 +1,28 @@
+# Event Extraction Group Actor Alias Cache
+
+## Goal
+
+Avoid rebuilding the normalized group-actor alias set for every semantic actor value during event-extraction scoring.
+
+## Linux-only constraint
+
+This slice is Python-only under `services/mlx-worker-python`, so it is verifiable on Linux with focused pytest, changed-scope coverage, and a local command-json performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/productization/event_extraction.py`
+- `services/mlx-worker-python/tests/test_event_extraction.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/event_extraction_actor_alias_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Performance probe
+
+Register `event-extraction-group-actor-alias-cache` in PR-scoped performance CI. The probe repeatedly expands semantic actor values containing group aliases and non-aliases, reports elapsed time and structural normalize-call counts, and compares `origin/main` to the PR branch.
+
+## Success metrics
+
+- Focused tests pass.
+- Changed-scope automated coverage is at least 95%.
+- Local probe emits concrete metrics and shows fewer repeated alias-normalization calls on the branch.
+- Hosted `pr-scoped-performance` validates the registered probe before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2265,6 +2265,47 @@
     "notes": "Compares cached semantic action value-group combination reuse against rebuilding identical index groups during event-extraction semantic split/merge scoring."
   },
   {
+    "id": "event-extraction-group-actor-alias-cache",
+    "name": "Event extraction group actor alias cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/event_extraction.py",
+      "services/mlx-worker-python/tests/test_event_extraction.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/event_extraction_actor_alias_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_reuses_cached_group_actor_aliases services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_expands_group_actor_aliases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_actor_alias_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_reuses_cached_group_actor_aliases services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_expands_group_actor_aliases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_actor_alias_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_actor_alias_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/event_extraction_actor_alias_probe.py ]; then python scripts/event_extraction_actor_alias_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"IyEvdXNyL2Jpbi9lbnYgcHl0aG9uMwoiIiJNZWFzdXJlIGNhY2hlZCBncm91cC1hY3RvciBhbGlhcyBleHBhbnNpb24gaW4gZXZlbnQtZXh0cmFjdGlvbiBzZW1hbnRpYyBzY29yaW5nLiIiIgpmcm9tIF9fZnV0dXJlX18gaW1wb3J0IGFubm90YXRpb25zCgppbXBvcnQganNvbgppbXBvcnQgb3MKaW1wb3J0IHN0YXRpc3RpY3MKaW1wb3J0IHN5cwppbXBvcnQgdGltZQppbXBvcnQgdHJhY2VtYWxsb2MKZnJvbSBwYXRobGliIGltcG9ydCBQYXRoCgpSRVBPX1JPT1QgPSBQYXRoLmN3ZCgpCnN5cy5wYXRoLmluc2VydCgwLCBzdHIoUkVQT19ST09UKSkKc3lzLnBhdGguaW5zZXJ0KDAsIHN0cihSRVBPX1JPT1QgLyAic2VydmljZXMvbWx4LXdvcmtlci1weXRob24iKSkKCmZyb20gd29ya2VyLnByb2R1Y3RpemF0aW9uIGltcG9ydCBldmVudF9leHRyYWN0aW9uIGFzIGV2ZW50X2V4dHJhY3Rpb25fbW9kdWxlICAjIG5vcWE6IEU0MDIKCgpkZWYgX2Vudl9pbnQobmFtZTogc3RyLCBkZWZhdWx0OiBpbnQpIC0+IGludDoKICAgIHZhbHVlID0gb3MuZ2V0ZW52KG5hbWUpCiAgICBpZiB2YWx1ZSBpcyBOb25lOgogICAgICAgIHJldHVybiBkZWZhdWx0CiAgICByZXR1cm4gbWF4KDEsIGludCh2YWx1ZSkpCgoKZGVmIF9hY3Rvcl92YWx1ZXModmFsdWVfY291bnQ6IGludCkgLT4gbGlzdFtzdHJdOgogICAgYWxpYXNlcyA9IFsi5oiR5LusIiwgIuWPjOaWuSIsICLlkrHku6wiLCAi5ZKx5L+pIiwgIuaIkeS/qSJdCiAgICB2YWx1ZXM6IGxpc3Rbc3RyXSA9IFtdCiAgICBmb3IgaW5kZXggaW4gcmFuZ2UodmFsdWVfY291bnQpOgogICAgICAgIGlmIGluZGV4ICUgMyA9PSAwOgogICAgICAgICAgICB2YWx1ZXMuYXBwZW5kKGFsaWFzZXNbaW5kZXggJSBsZW4oYWxpYXNlcyldKQogICAgICAgIGVsaWYgaW5kZXggJSAzID09IDE6CiAgICAgICAgICAgIHZhbHVlcy5hcHBlbmQoZiJzcGVha2VyX3sxICsgKGluZGV4ICUgMil9IikKICAgICAgICBlbHNlOgogICAgICAgICAgICB2YWx1ZXMuYXBwZW5kKGYiYWN0b3Ite2luZGV4fSIpCiAgICByZXR1cm4gdmFsdWVzCgoKZGVmIF9ydW5fcHJvYmUoKiwgdmFsdWVfY291bnQ6IGludCwgaXRlcmF0aW9uczogaW50LCBzYW1wbGVzOiBpbnQpIC0+IGRpY3Rbc3RyLCBmbG9hdF06CiAgICBvcmlnaW5hbF9ub3JtYWxpemUgPSBldmVudF9leHRyYWN0aW9uX21vZHVsZS5fbm9ybWFsaXplX3NpbWlsYXJpdHlfdGV4dAogICAgbm9ybWFsaXplX2NhbGxzID0gMAoKICAgIGRlZiBjb3VudGVkX25vcm1hbGl6ZSh2YWx1ZTogc3RyKSAtPiBzdHI6CiAgICAgICAgbm9ubG9jYWwgbm9ybWFsaXplX2NhbGxzCiAgICAgICAgbm9ybWFsaXplX2NhbGxzICs9IDEKICAgICAgICByZXR1cm4gb3JpZ2luYWxfbm9ybWFsaXplKHZhbHVlKQoKICAgIGV2ZW50X2V4dHJhY3Rpb25fbW9kdWxlLl9ub3JtYWxpemVfc2ltaWxhcml0eV90ZXh0ID0gY291bnRlZF9ub3JtYWxpemUKICAgIGV2ZW50ID0geyJhY3RvciI6IF9hY3Rvcl92YWx1ZXModmFsdWVfY291bnQpfQogICAgZWxhcHNlZF9tczogbGlzdFtmbG9hdF0gPSBbXQogICAgcGVha19ieXRlczogbGlzdFtmbG9hdF0gPSBbXQogICAgbm9ybWFsaXplX2NhbGxzX3Blcl9zYW1wbGU6IGxpc3RbZmxvYXRdID0gW10KICAgIG91dHB1dF9sZW5ndGhzOiBsaXN0W2ludF0gPSBbXQogICAgdHJ5OgogICAgICAgIGZvciBfIGluIHJhbmdlKHNhbXBsZXMpOgogICAgICAgICAgICBub3JtYWxpemVfY2FsbHMgPSAwCiAgICAgICAgICAgIHRyYWNlbWFsbG9jLnN0YXJ0KCkKICAgICAgICAgICAgc3RhcnRlZCA9IHRpbWUucGVyZl9jb3VudGVyKCkKICAgICAgICAgICAgb3V0cHV0X2xlbmd0aCA9IDAKICAgICAgICAgICAgZm9yIF9pdGVyYXRpb24gaW4gcmFuZ2UoaXRlcmF0aW9ucyk6CiAgICAgICAgICAgICAgICBvdXRwdXRfbGVuZ3RoICs9IGxlbihldmVudF9leHRyYWN0aW9uX21vZHVsZS5fc2VtYW50aWNfZmllbGRfdmFsdWVzKCJhY3RvciIsIGV2ZW50KSkKICAgICAgICAgICAgZWxhcHNlZF9tcy5hcHBlbmQoKHRpbWUucGVyZl9jb3VudGVyKCkgLSBzdGFydGVkKSAqIDEwMDAuMCkKICAgICAgICAgICAgX2N1cnJlbnQsIHBlYWsgPSB0cmFjZW1hbGxvYy5nZXRfdHJhY2VkX21lbW9yeSgpCiAgICAgICAgICAgIHRyYWNlbWFsbG9jLnN0b3AoKQogICAgICAgICAgICBwZWFrX2J5dGVzLmFwcGVuZChmbG9hdChwZWFrKSkKICAgICAgICAgICAgbm9ybWFsaXplX2NhbGxzX3Blcl9zYW1wbGUuYXBwZW5kKGZsb2F0KG5vcm1hbGl6ZV9jYWxscykpCiAgICAgICAgICAgIG91dHB1dF9sZW5ndGhzLmFwcGVuZChvdXRwdXRfbGVuZ3RoKQogICAgZmluYWxseToKICAgICAgICBldmVudF9leHRyYWN0aW9uX21vZHVsZS5fbm9ybWFsaXplX3NpbWlsYXJpdHlfdGV4dCA9IG9yaWdpbmFsX25vcm1hbGl6ZQogICAgICAgIGlmIHRyYWNlbWFsbG9jLmlzX3RyYWNpbmcoKToKICAgICAgICAgICAgdHJhY2VtYWxsb2Muc3RvcCgpCgogICAgZXhwZWN0ZWRfb3V0cHV0X2xlbmd0aCA9IG91dHB1dF9sZW5ndGhzWzBdCiAgICBpZiBhbnkobGVuZ3RoICE9IGV4cGVjdGVkX291dHB1dF9sZW5ndGggZm9yIGxlbmd0aCBpbiBvdXRwdXRfbGVuZ3Rocyk6CiAgICAgICAgcmFpc2UgQXNzZXJ0aW9uRXJyb3IoZiJ1bnN0YWJsZSBvdXRwdXQgbGVuZ3Roczoge291dHB1dF9sZW5ndGhzfSIpCgogICAgcmV0dXJuIHsKICAgICAgICAiZWxhcHNlZF9tc19tZWFuIjogc3RhdGlzdGljcy5mbWVhbihlbGFwc2VkX21zKSwKICAgICAgICAiZWxhcHNlZF9tc19taW4iOiBtaW4oZWxhcHNlZF9tcyksCiAgICAgICAgInBlYWtfYnl0ZXNfbWVhbiI6IHN0YXRpc3RpY3MuZm1lYW4ocGVha19ieXRlcyksCiAgICAgICAgIm5vcm1hbGl6ZV9jYWxsc19tZWFuIjogc3RhdGlzdGljcy5mbWVhbihub3JtYWxpemVfY2FsbHNfcGVyX3NhbXBsZSksCiAgICAgICAgInZhbHVlX2NvdW50IjogZmxvYXQodmFsdWVfY291bnQpLAogICAgICAgICJpdGVyYXRpb25zX3Blcl9zYW1wbGUiOiBmbG9hdChpdGVyYXRpb25zKSwKICAgICAgICAic2FtcGxlX2NvdW50IjogZmxvYXQoc2FtcGxlcyksCiAgICAgICAgIm91dHB1dF9sZW5ndGhfcGVyX3NhbXBsZSI6IGZsb2F0KGV4cGVjdGVkX291dHB1dF9sZW5ndGgpLAogICAgfQoKCmRlZiBtYWluKCkgLT4gaW50OgogICAgdmFsdWVfY291bnQgPSBfZW52X2ludCgiTUVMSVhfRVZFTlRfQUNUT1JfQUxJQVNfUFJPQkVfVkFMVUVfQ09VTlQiLCAyMDApCiAgICBpdGVyYXRpb25zID0gX2Vudl9pbnQoIk1FTElYX0VWRU5UX0FDVE9SX0FMSUFTX1BST0JFX0lURVJBVElPTlMiLCAyMDApCiAgICBzYW1wbGVzID0gX2Vudl9pbnQoIk1FTElYX0VWRU5UX0FDVE9SX0FMSUFTX1BST0JFX1NBTVBMRVMiLCA1KQogICAgcHJpbnQoCiAgICAgICAganNvbi5kdW1wcygKICAgICAgICAgICAgX3J1bl9wcm9iZSh2YWx1ZV9jb3VudD12YWx1ZV9jb3VudCwgaXRlcmF0aW9ucz1pdGVyYXRpb25zLCBzYW1wbGVzPXNhbXBsZXMpLAogICAgICAgICAgICBzb3J0X2tleXM9VHJ1ZSwKICAgICAgICApCiAgICApCiAgICByZXR1cm4gMAoKCmlmIF9fbmFtZV9fID09ICJfX21haW5fXyI6CiAgICByYWlzZSBTeXN0ZW1FeGl0KG1haW4oKSkK\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      },
+      {
+        "key": "normalize_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better"
+      },
+      {
+        "key": "value_count",
+        "unit": "values",
+        "direction": "informational"
+      }
+    ],
+    "notes": "Compares cached normalized group-actor aliases against rebuilding the alias normalization set while expanding semantic actor values."
+  },
+  {
     "id": "mlx-audio-wav-streaming-pcm",
     "name": "MLX audio WAV PCM streaming",
     "runner": "ubuntu-latest",

--- a/scripts/event_extraction_actor_alias_probe.py
+++ b/scripts/event_extraction_actor_alias_probe.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Measure cached group-actor alias expansion in event-extraction semantic scoring."""
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path.cwd()
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.productization import event_extraction as event_extraction_module  # noqa: E402
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return max(1, int(value))
+
+
+def _actor_values(value_count: int) -> list[str]:
+    aliases = ["我们", "双方", "咱们", "咱俩", "我俩"]
+    values: list[str] = []
+    for index in range(value_count):
+        if index % 3 == 0:
+            values.append(aliases[index % len(aliases)])
+        elif index % 3 == 1:
+            values.append(f"speaker_{1 + (index % 2)}")
+        else:
+            values.append(f"actor-{index}")
+    return values
+
+
+def _run_probe(*, value_count: int, iterations: int, samples: int) -> dict[str, float]:
+    original_normalize = event_extraction_module._normalize_similarity_text
+    normalize_calls = 0
+
+    def counted_normalize(value: str) -> str:
+        nonlocal normalize_calls
+        normalize_calls += 1
+        return original_normalize(value)
+
+    event_extraction_module._normalize_similarity_text = counted_normalize
+    event = {"actor": _actor_values(value_count)}
+    elapsed_ms: list[float] = []
+    peak_bytes: list[float] = []
+    normalize_calls_per_sample: list[float] = []
+    output_lengths: list[int] = []
+    try:
+        for _ in range(samples):
+            normalize_calls = 0
+            tracemalloc.start()
+            started = time.perf_counter()
+            output_length = 0
+            for _iteration in range(iterations):
+                output_length += len(event_extraction_module._semantic_field_values("actor", event))
+            elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+            _current, peak = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            peak_bytes.append(float(peak))
+            normalize_calls_per_sample.append(float(normalize_calls))
+            output_lengths.append(output_length)
+    finally:
+        event_extraction_module._normalize_similarity_text = original_normalize
+        if tracemalloc.is_tracing():
+            tracemalloc.stop()
+
+    expected_output_length = output_lengths[0]
+    if any(length != expected_output_length for length in output_lengths):
+        raise AssertionError(f"unstable output lengths: {output_lengths}")
+
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_ms),
+        "elapsed_ms_min": min(elapsed_ms),
+        "peak_bytes_mean": statistics.fmean(peak_bytes),
+        "normalize_calls_mean": statistics.fmean(normalize_calls_per_sample),
+        "value_count": float(value_count),
+        "iterations_per_sample": float(iterations),
+        "sample_count": float(samples),
+        "output_length_per_sample": float(expected_output_length),
+    }
+
+
+def main() -> int:
+    value_count = _env_int("MELIX_EVENT_ACTOR_ALIAS_PROBE_VALUE_COUNT", 200)
+    iterations = _env_int("MELIX_EVENT_ACTOR_ALIAS_PROBE_ITERATIONS", 200)
+    samples = _env_int("MELIX_EVENT_ACTOR_ALIAS_PROBE_SAMPLES", 5)
+    print(
+        json.dumps(
+            _run_probe(value_count=value_count, iterations=iterations, samples=samples),
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_event_extraction.py
+++ b/services/mlx-worker-python/tests/test_event_extraction.py
@@ -7,6 +7,8 @@ from io import BytesIO
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 
+import pytest
+
 from worker.engine.evaluation_core import EvaluationCore
 from worker.engine import evaluation_core
 from worker.productization import event_extraction as event_extraction_module
@@ -484,6 +486,25 @@ def test_evaluate_event_extraction_semantic_judge_matches_event_and_values(tmp_p
     assert [row["kind"] for row in judge_audit] == ["event", "field", "field"]
     assert all("api_key" not in json.dumps(row) for row in judge_audit)
     assert len(judge.requests) == 3
+
+
+def test_semantic_field_values_reuses_cached_group_actor_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    original_normalize = event_extraction_module._normalize_similarity_text
+
+    def counted_normalize(value: str) -> str:
+        calls.append(value)
+        return original_normalize(value)
+
+    monkeypatch.setattr(event_extraction_module, "_normalize_similarity_text", counted_normalize)
+
+    assert event_extraction_module._semantic_field_values(
+        "actor",
+        {"actor": [" 我们 ", "speaker_1", "咱们", "speaker_2", "双方"]},
+    ) == ["speaker_1", "speaker_2"]
+    assert calls == ["我们", "speaker_1", "咱们", "speaker_2", "双方"]
 
 
 def test_evaluate_event_extraction_semantic_expands_group_actor_aliases(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -108,10 +108,11 @@ def test_scope_report_selects_event_extraction_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/productization/event_extraction.py"],
     )
 
-    assert scope["selected_count"] == 2
+    assert scope["selected_count"] == 3
     assert {probe["id"] for probe in scope["selected_probes"]} == {
         "event-extraction-alignment-accepted-edge-cache",
         "event-extraction-semantic-value-group-cache",
+        "event-extraction-group-actor-alias-cache",
     }
 
 
@@ -1026,6 +1027,27 @@ def test_event_extraction_semantic_value_group_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0
 
 
+def test_event_extraction_actor_alias_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_EVENT_ACTOR_ALIAS_PROBE_VALUE_COUNT", "6")
+    monkeypatch.setenv("MELIX_EVENT_ACTOR_ALIAS_PROBE_ITERATIONS", "3")
+    monkeypatch.setenv("MELIX_EVENT_ACTOR_ALIAS_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(REPO_ROOT / "scripts/event_extraction_actor_alias_probe.py"), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["value_count"] == 6.0
+    assert metrics["iterations_per_sample"] == 3.0
+    assert metrics["sample_count"] == 1.0
+    assert metrics["normalize_calls_mean"] == 18.0
+    assert metrics["output_length_per_sample"] > 0
+    assert metrics["elapsed_ms_mean"] >= 0
+
+
 def test_hub_catalog_tag_normalization_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -1479,6 +1501,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "dataset-registry-snapshot-inference-single-pass",
         "event-extraction-alignment-accepted-edge-cache",
         "event-extraction-semantic-value-group-cache",
+        "event-extraction-group-actor-alias-cache",
         "hub-catalog-tag-normalization-single-pass",
         "hub-catalog-next-cursor-fast-parse",
         "hub-catalog-size-hint-regex-precompile",

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -1720,7 +1720,7 @@ def _semantic_field_values(field_name: str, event: dict[str, object]) -> list[st
         return values
     expanded: list[str] = []
     for value in values:
-        if _normalize_similarity_text(value) in {_normalize_similarity_text(alias) for alias in _GROUP_ACTOR_ALIASES}:
+        if _normalize_similarity_text(value) in _NORMALIZED_GROUP_ACTOR_ALIASES:
             expanded.extend(("speaker_1", "speaker_2"))
         else:
             expanded.append(value)
@@ -2105,6 +2105,11 @@ def _string_similarity(left: str, right: str) -> float:
 
 def _normalize_similarity_text(value: str) -> str:
     return "".join(char for char in value.strip().lower() if char not in _SIMILARITY_IGNORED_CHARS)
+
+
+_NORMALIZED_GROUP_ACTOR_ALIASES = frozenset(
+    _normalize_similarity_text(alias) for alias in _GROUP_ACTOR_ALIASES
+)
 
 
 def _bigram_dice(left: str, right: str) -> float:


### PR DESCRIPTION
## Summary
- Cache normalized group-actor aliases once for event-extraction semantic actor expansion instead of rebuilding the alias normalization set for every actor value.
- Add a focused regression test plus a command-json PR-scoped performance probe for the cached alias path.
- Add a small plan documenting the Linux-verifiable optimization slice.

## Plan or Spec
- `docs/plans/2026-05-07-event-extraction-group-actor-alias-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_reuses_cached_group_actor_aliases services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_expands_group_actor_aliases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_actor_alias_probe_script_emits_metrics
# 5 passed in 0.52s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_reuses_cached_group_actor_aliases services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_expands_group_actor_aliases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_actor_alias_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_actor_alias_probe.py
# 5 passed in 0.27s; TOTAL 27 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/event_extraction_actor_alias_probe.py
# {"elapsed_ms_mean": 56.86852619983256, "normalize_calls_mean": 14600.0, "value_count": 200.0, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id event-extraction-group-actor-alias-cache --base-repo /tmp/melix-cron-opt-20260507084837-base2 --head-repo /tmp/melix-cron-opt-20260507084837 --output /tmp/event_actor_alias_probe_result.json
# head verification ok; base/head probes ok

git diff --check
# pass

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes_check.json
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 27 0 100%`.
- Registered scoped probe: `event-extraction-group-actor-alias-cache`.
- Local direct head probe: `elapsed_ms_mean=56.8685 ms`, `normalize_calls_mean=14600.0`, `peak_bytes_mean=4720.0`, `value_count=200.0`, `iterations_per_sample=200.0`, `sample_count=5.0`.
- Local registered base-vs-head probe:
  - base: `elapsed_ms_mean=562.0938 ms`, `normalize_calls_mean=131400.0`, `peak_bytes_mean=4720.0`.
  - head: `elapsed_ms_mean=57.5645 ms`, `normalize_calls_mean=14600.0`, `peak_bytes_mean=4720.0`.
  - result: ~89.76% lower elapsed time and ~88.89% fewer normalization calls for the synthetic alias-expansion workload.

## Known Gaps
- Linux-only local verification was run; full macOS/Swift verification was not run on this Linux host.
- Hosted `pr-scoped-performance` and broader GitHub checks are required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
