### PR TITLE
perf: avoid full sort for validation split

### DIFF
--- a/docs/plans/2026-05-07-training-dataset-validation-split-nsmallest.md
+++ b/docs/plans/2026-05-07-training-dataset-validation-split-nsmallest.md
@@ -1,0 +1,38 @@
+# Training Dataset Validation Split Partial Selection
+
+## Goal
+
+Reduce redundant sorting work in automatic training-dataset validation splitting.
+
+## Scope
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset.py`
+- `services/mlx-worker-python/tests/test_training_dataset_builder.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Linux-only constraint
+
+This is a Python worker slice and can be verified on Linux with focused pytest, changed-scope coverage, and a PR-scoped performance probe.
+
+## Optimization
+
+`_deterministic_validation_split(...)` previously sorted every `(digest, index)` pair even though it only needs the lowest `validation_count` items. Replace the full sort with `heapq.nsmallest(validation_count, ...)` while preserving tuple tie-breaking and the existing original-order output contract for train and validation rows.
+
+## Probe
+
+Register `training-dataset-validation-split-nsmallest` in `infra/perf/pr_scoped_probes.json`.
+
+The probe builds a deterministic synthetic prompt/completion dataset, calls `_deterministic_validation_split(...)` repeatedly, verifies the selected validation count and checksum, and reports:
+
+- `elapsed_ms_mean` lower is better
+- `peak_bytes_mean` lower is better
+- `validation_count` stable structural metric
+- `checksum` stable structural metric
+
+## Success metrics
+
+- Focused pytest passes for the touched training dataset behavior and PR-scoped registry checks.
+- Changed-scope executable coverage is at least 95%.
+- Local base-vs-head probe shows lower elapsed time and/or memory while preserving structural metrics.
+- `git diff --check` passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1013,6 +1013,49 @@
     ]
   },
   {
+    "id": "training-dataset-validation-split-nsmallest",
+    "name": "Training dataset validation split partial selection",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/training_dataset.py",
+      "services/mlx-worker-python/tests/test_training_dataset_builder.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_build_training_dataset_artifact_loads_existing_package_and_helper_branches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_build_training_dataset_artifact_loads_existing_package_and_helper_branches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python - <<'PY'\nimport json\nimport statistics\nimport time\nimport tracemalloc\nfrom worker.model_ops.training_dataset import _deterministic_validation_split\n\nsamples = [\n    {\n        \"prompt\": (f\"prompt {index} \") * 3,\n        \"completion\": (f\"completion {index % 97} \") * 3,\n        \"meta\": {\"index\": index, \"group\": index % 11},\n    }\n    for index in range(30000)\n]\nmeasurements = []\nfor _ in range(5):\n    tracemalloc.start()\n    started = time.perf_counter()\n    train_samples, validation_samples = _deterministic_validation_split(samples, 0.05)\n    elapsed_ms = (time.perf_counter() - started) * 1000.0\n    _, peak_bytes = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    measurements.append((elapsed_ms, float(peak_bytes), validation_samples))\nvalidation_samples = measurements[-1][2]\nprint(json.dumps({\n    \"elapsed_ms_mean\": statistics.fmean(sample[0] for sample in measurements),\n    \"peak_bytes_mean\": statistics.fmean(sample[1] for sample in measurements),\n    \"sample_count\": float(len(samples)),\n    \"validation_count\": float(len(validation_samples)),\n    \"checksum\": float(sum(sample[\"meta\"][\"index\"] for sample in validation_samples)),\n}, sort_keys=True))\nPY",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "validation_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "checksum",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "training-dataset-validation-sample-limit",
     "name": "Training dataset validation sample-limit loading",
     "runner": "ubuntu-latest",

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -266,9 +266,10 @@ def test_scope_report_selects_training_dataset_probe() -> None:
     )
 
     probe_ids = {probe["id"] for probe in scope["selected_probes"]}
-    assert scope["selected_count"] == 2
+    assert scope["selected_count"] == 3
     assert probe_ids == {
         "training-dataset-token-percentiles-single-sort",
+        "training-dataset-validation-split-nsmallest",
         "training-dataset-validation-sample-limit",
     }
 
@@ -1533,6 +1534,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "quantization-qat-source-scan-scandir",
         "training-config-target-module-cache",
         "training-dataset-token-percentiles-single-sort",
+        "training-dataset-validation-split-nsmallest",
         "training-dataset-validation-sample-limit",
         "training-dataset-chunker-top-level-base-copy",
         "dataset-registry-preview-limit-short-circuit",

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -988,6 +988,7 @@ def test_hf_preference_pair_schema_inference_and_mapping() -> None:
 
 def test_build_training_dataset_artifact_loads_existing_package_and_helper_branches(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source_package = tmp_path / "existing-package"
     _write_jsonl(
@@ -1117,6 +1118,40 @@ def test_build_training_dataset_artifact_loads_existing_package_and_helper_branc
     with pytest.raises(ModelOperationError) as split_exc:
         training_dataset_module._deterministic_validation_split([{"text": "solo"}], 0.5)
     assert split_exc.value.code == "invalid_dataset_source"
+
+    split_samples = [
+        {"prompt": f"prompt-{index}", "completion": f"completion-{index % 7}"}
+        for index in range(40)
+    ]
+    full_sort_indices = {
+        index
+        for _, index in sorted(
+            (
+                training_dataset_module._canonical_sample_digest(sample),
+                index,
+            )
+            for index, sample in enumerate(split_samples)
+        )[:4]
+    }
+    nsmallest_calls = []
+    real_nsmallest = training_dataset_module.heapq.nsmallest
+
+    def counting_nsmallest(count, iterable):
+        nsmallest_calls.append(count)
+        return real_nsmallest(count, iterable)
+
+    monkeypatch.setattr(training_dataset_module.heapq, "nsmallest", counting_nsmallest)
+    train_split, validation_split = training_dataset_module._deterministic_validation_split(
+        split_samples,
+        0.1,
+    )
+    assert nsmallest_calls == [4]
+    assert train_split == [
+        sample for index, sample in enumerate(split_samples) if index not in full_sort_indices
+    ]
+    assert validation_split == [
+        sample for index, sample in enumerate(split_samples) if index in full_sort_indices
+    ]
 
     assert training_dataset_module._sample_token_counts({}, "chat_messages") == (0, 0)
     assert training_dataset_module._sample_token_counts(

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import heapq
 import json
 from itertools import chain
 from contextlib import ExitStack
@@ -1450,14 +1451,17 @@ def _deterministic_validation_split(
 
     validation_count = int(round(len(samples) * validation_ratio))
     validation_count = max(1, min(len(samples) - 1, validation_count))
-    ranked = sorted(
+    ranked = heapq.nsmallest(
+        validation_count,
         (
-            _canonical_sample_digest(sample),
-            index,
-        )
-        for index, sample in enumerate(samples)
+            (
+                _canonical_sample_digest(sample),
+                index,
+            )
+            for index, sample in enumerate(samples)
+        ),
     )
-    validation_indices = {index for _, index in ranked[:validation_count]}
+    validation_indices = {index for _, index in ranked}
     train_samples = [sample for index, sample in enumerate(samples) if index not in validation_indices]
     validation_samples = [sample for index, sample in enumerate(samples) if index in validation_indices]
     return train_samples, validation_samples


### PR DESCRIPTION
## Summary
- Replaced the automatic training-dataset validation split full sort with `heapq.nsmallest(...)` so small validation ratios do not sort every sample digest.
- Preserved deterministic `(digest, index)` tie-breaking and the existing original-order train/validation output contract.
- Added focused regression coverage and registered the `training-dataset-validation-split-nsmallest` PR-scoped performance probe.

## Plan or Spec
- `docs/plans/2026-05-07-training-dataset-validation-split-nsmallest.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_build_training_dataset_artifact_loads_existing_package_and_helper_branches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 3 passed in 0.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_build_training_dataset_artifact_loads_existing_package_and_helper_branches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 16 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id training-dataset-validation-split-nsmallest --base-repo /tmp/melix-base-validation-split-20260507094000 --head-repo "$PWD" --output /tmp/training-dataset-validation-split-probe.json
# head verification passed; base/head probes ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 16 0 100%`.
- Registered scoped probe: `training-dataset-validation-split-nsmallest`.
- Local base-vs-head probe on 30,000 synthetic samples with 5% validation split:
  - `elapsed_ms_mean`: `1015.936` ms → `927.594` ms (~8.7% lower)
  - `peak_bytes_mean`: `5,010,344.8` bytes → `620,956.8` bytes (~87.6% lower)
  - `validation_count`: `1500.0` → `1500.0`
  - `checksum`: `22440493.0` → `22440493.0`

## Known Gaps
- Linux-only local verification; full macOS/Swift checks were not run locally.
- Editing `infra/perf/pr_scoped_probes.json` can fan out the hosted PR-scoped performance matrix; merge should wait for hosted scoped performance validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
