### PR TITLE
perf: index changed-scope diff parser first char

### DIFF
--- a/docs/plans/2026-05-07-changed-scope-diff-parser-first-char-index.md
+++ b/docs/plans/2026-05-07-changed-scope-diff-parser-first-char-index.md
@@ -1,0 +1,37 @@
+# Changed-scope coverage diff parser first-character indexing
+
+## Goal
+
+Reduce per-line overhead in the hot changed-scope diff parser by avoiding a one-character string slice for every parsed diff line.
+
+## Scope
+
+This slice is limited to the Python changed-scope coverage parser and its registered PR-scoped diff-parser probe:
+
+- `scripts/changed_scope_coverage.py`
+- `tests/test_changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_parse_probe.py`
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `changed-scope-coverage-diff-parser`, which has focused `test_command`, `coverage_command`, and `probe_command` entries in `infra/perf/pr_scoped_probes.json`. The probe records:
+
+- `elapsed_ms_mean`
+- `elapsed_ms_min`
+- `line_count`
+- `file_count`
+- `changed_line_count`
+
+## Implementation plan
+
+1. Preserve the existing literal dispatch semantics for diff headers, hunk headers, additions, deletions, and blank context lines.
+2. Replace the hot `line[:1]` slice with direct first-character indexing guarded for empty lines.
+3. Reuse the existing parser regression tests for behavior parity, including blank-line handling.
+4. Compare the registered diff-parser probe against an `origin/main` baseline worktree before accepting the slice.
+
+## Verification
+
+- Focused changed-scope parser tests pass.
+- Changed-scope coverage for the touched parser/probe/test scope remains at least 95%.
+- The registered local probe reports lower `elapsed_ms_mean` versus the `origin/main` baseline.
+- `git diff --check` passes.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -45,7 +45,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     current_changed_lines: set[int] | None = None
     new_line: int | None = None
     for line in diff_text.splitlines():
-        first_char = line[:1]
+        first_char = line[0] if line else ""
         if first_char == "d" and line.startswith(_DIFF_HEADER_PREFIX):
             current_path = _parse_diff_header_new_path(line)
             current_changed_lines = (


### PR DESCRIPTION
## Summary
- Replace the hot changed-scope diff parser's one-character slice with guarded direct first-character indexing.
- Keep parser semantics unchanged for diff headers, hunk headers, additions, deletions, and blank context lines.
- Add the governing plan for this focused Python performance slice.

## Plan or Spec
- `docs/plans/2026-05-07-changed-scope-diff-parser-first-char-index.md`

## Commands Run
```text
# baseline/head repeated direct probe comparison against origin/main worktree
base elapsed_ms_mean samples: 3.5886, 3.4245, 3.4333, 3.7386, 3.5069
head elapsed_ms_mean samples: 3.1638, 3.1586, 3.2054, 3.3286, 3.1510

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 22 passed in 0.60s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 22 passed in 0.39s; TOTAL 1 0 100%

python3 scripts/changed_scope_coverage_parse_probe.py
# {"changed_line_count": 7680.0, "elapsed_ms_mean": 3.2241947386258594, "elapsed_ms_min": 3.012856002897024, "file_count": 240.0, "line_count": 16080.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-diff-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-diff-parser-char-index-20260507113908 --head-repo "$PWD" --output .runtime_changed_scope_diff_parser_probe.json
# base {'elapsed_ms_mean': 3.3463838238579533, 'elapsed_ms_min': 3.2170600024983287, 'line_count': 16080.0, 'file_count': 240.0, 'changed_line_count': 7680.0}
# head {'elapsed_ms_mean': 3.20475033367984, 'elapsed_ms_min': 3.1324520241469145, 'line_count': 16080.0, 'file_count': 240.0, 'changed_line_count': 7680.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%` for `scripts/changed_scope_coverage.py`, `tests/test_changed_scope_coverage.py`, `scripts/changed_scope_coverage_parse_probe.py`, and the PR-scoped performance test selection.
- Registered probe: `changed-scope-coverage-diff-parser`.
- Local registered probe delta: `elapsed_ms_mean` 3.3464 ms -> 3.2048 ms (about 4.2% faster; -0.1416 ms), `elapsed_ms_min` 3.2171 ms -> 3.1325 ms.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local validation covers the Linux Python changed-scope diff parser only; CI remains the source for final registered PR-scoped performance workflow validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
