### PR TITLE
perf: reduce category breakdown aggregation overhead

### DIFF
--- a/docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md
+++ b/docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md
@@ -1,0 +1,22 @@
+# Statistical Evidence Category Breakdown Local Bindings
+
+## Purpose
+
+Keep the Phase 8 evaluation-compare category breakdown path behaviorally identical while reducing per-row aggregation overhead in `worker.productization.statistical_evidence.build_category_breakdown`.
+
+## Scope
+
+- Only touch the Python statistical-evidence category aggregation helper and its direct verification path.
+- Preserve category label stripping, empty-label skipping, truthiness handling for correctness fields, sorted output keys, and rounded payload fields.
+- Use the registered PR-scoped probe `statistical-evidence-category-breakdown-single-pass` as the performance gate.
+
+## Verification Plan
+
+- Focused tests for `services/mlx-worker-python/tests/test_statistical_evidence.py` and the registered PR-scoped performance selectors.
+- Changed-scope coverage through the registered probe `coverage_command`.
+- Registered local Linux probe command:
+  `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_category_breakdown_probe.py`
+
+## Acceptance Metric
+
+Accept only if the registered category breakdown probe keeps the same checksum/sample counts and improves `elapsed_ms_mean` versus the origin/main baseline in repeated local samples.

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -76,26 +76,26 @@ def build_category_breakdown(
 ) -> dict[str, dict[str, object]]:
     category_totals: dict[str, list[int]] = {}
     for row in rows:
-        category_label = str(row.get("category_label", "")).strip()
+        row_get = row.get
+        category_label = str(row_get("category_label", "")).strip()
         if not category_label:
             continue
+        base_correct = 1 if row_get("base_correct", False) else 0
+        target_correct = 1 if row_get("target_correct", False) else 0
         totals = category_totals.get(category_label)
         if totals is None:
-            category_totals[category_label] = [
-                1,
-                int(bool(row.get("base_correct", False))),
-                int(bool(row.get("target_correct", False))),
-            ]
+            category_totals[category_label] = [1, base_correct, target_correct]
             continue
         totals[0] += 1
-        totals[1] += int(bool(row.get("base_correct", False)))
-        totals[2] += int(bool(row.get("target_correct", False)))
+        totals[1] += base_correct
+        totals[2] += target_correct
 
     breakdown: dict[str, dict[str, object]] = {}
-    for category_label in sorted(category_totals):
-        sample_size, base_correct, target_correct = category_totals[category_label]
-        base_accuracy = _rounded(base_correct / max(sample_size, 1))
-        target_accuracy = _rounded(target_correct / max(sample_size, 1))
+    for category_label, totals in sorted(category_totals.items()):
+        sample_size, base_correct, target_correct = totals
+        inverse_sample_size = 1.0 / sample_size
+        base_accuracy = _rounded(base_correct * inverse_sample_size)
+        target_accuracy = _rounded(target_correct * inverse_sample_size)
         breakdown[category_label] = {
             "sample_size": sample_size,
             "base_accuracy": base_accuracy,


### PR DESCRIPTION
## Summary
- Reduces per-row overhead in `build_category_breakdown` by reusing row lookups, computing correctness counters once per row, and iterating sorted category items directly.
- Adds a focused plan for the statistical-evidence category breakdown performance slice.
- Keeps category label stripping, empty-label skipping, truthiness semantics, sorted output, and rounded metric payloads unchanged.

## Plan or Spec
- `docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md`
- Registered PR-scoped probe: `statistical-evidence-category-breakdown-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe on origin/main before implementation (3 runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_category_breakdown_probe.py
exit 0; elapsed_ms_mean: 20.102237374521792, 20.63092878088355, 19.32900040410459; checksum=250365.72 each run

# Post-change repeated local probe (3 exploratory runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_category_breakdown_probe.py
exit 0; elapsed_ms_mean: 16.380114830099046, 16.114937397651374, 15.729879215359688; checksum=250365.72 each run

# Focused registered test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics
exit 0; 13 passed in 0.51s

# Registered changed-scope coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_category_breakdown_probe.py
exit 0; 13 passed; TOTAL 12 0 100%

# Final registered local Linux probe after focused coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_category_breakdown_probe.py
exit 0; elapsed_ms_mean=16.82467379141599; checksum=250365.72

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%`.
- Local Linux registered probe baseline mean: old_mean=20.02072218650331 ms, new_mean=16.07497714770337 ms, delta_ms=-3.9457450387999415, speedup=1.2454588272533669x (19.70830523516235% lower elapsed mean across the three repeated exploratory samples).
- Final local probe after coverage: `elapsed_ms_mean=16.82467379141599`, `peak_bytes_mean=16528.0`, `row_count=50000.0`, `category_count=64.0`, `checksum=250365.72`.
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and integration tests were not run locally for this narrow Python-only slice.
- Local validation is Linux-only; no Swift runtime effects are claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
