### PR TITLE
perf: bound hub catalog cursor parsing

### DIFF
--- a/docs/plans/2026-05-07-hub-catalog-cursor-param-find.md
+++ b/docs/plans/2026-05-07-hub-catalog-cursor-param-find.md
@@ -20,7 +20,7 @@ Use the existing registered probe `hub-catalog-next-cursor-fast-parse` in `infra
 
 ## Optimization hypothesis
 
-`_cursor_query_value(...)` currently advances parameter by parameter and checks every parameter start with `startswith("cursor=")`. The cursor parser can instead use a bounded `str.find("cursor=", ..., query_end)` loop and validate the match is at the query start or immediately after `&`. For typical Hub pagination links where `cursor` appears after a few known parameters, this avoids repeated delimiter searches and prefix checks on non-cursor parameters.
+`_next_cursor_from_link(...)` can avoid allocating a sliced URL string for the `rel="next"` segment by passing the segment bounds into `_cursor_query_value(...)`. The cursor helper keeps the same exact-parameter semantics but searches only within the bounded URL range and looks for the two legal cursor parameter prefixes: `cursor=` at the beginning of the query string or `&cursor=` later in the query. This preserves boundary behavior for parameters such as `notcursor` and `mycursor` while reducing transient cursor-parse work.
 
 ## Success metrics
 

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -318,6 +318,12 @@ def test_next_cursor_from_link_scans_segments_without_splitting_on_url_commas() 
     assert hub_catalog_module._next_cursor_from_link(link_header) == "page,2"
 
 
+def test_next_cursor_from_link_accepts_cursor_at_query_start() -> None:
+    link_header = '<https://huggingface.co/api/models?cursor=page%2Fstart&limit=10>; rel="next"'
+
+    assert hub_catalog_module._next_cursor_from_link(link_header) == "page/start"
+
+
 def test_next_cursor_from_link_returns_empty_for_missing_or_malformed_next_cursor() -> None:
     assert hub_catalog_module._next_cursor_from_link('<https://huggingface.co/api/models?cursor=prev>; rel="prev"') == ""
     assert hub_catalog_module._next_cursor_from_link('<https://huggingface.co/api/models>; rel="next"') == ""

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -270,29 +270,31 @@ def _next_cursor_from_link(link_header: str) -> str:
         relation_start = url_end + 1
         relation_end = next_url_start if next_url_start >= 0 else len(link_header)
         if link_header.find('rel="next"', relation_start, relation_end) >= 0:
-            return _cursor_query_value(link_header[url_start + 1 : url_end])
+            return _cursor_query_value(link_header, url_start + 1, url_end)
         search_start = relation_end
 
 
-def _cursor_query_value(url: str) -> str:
-    query_start = url.find("?")
+def _cursor_query_value(url: str, start: int, end: int) -> str:
+    query_start = url.find("?", start, end)
     if query_start < 0:
         return ""
-    query_end = url.find("#", query_start + 1)
+    query_end = url.find("#", query_start + 1, end)
     if query_end < 0:
-        query_end = len(url)
-    cursor_start = query_start + 1
-    while True:
-        cursor_start = url.find("cursor=", cursor_start, query_end)
+        query_end = end
+
+    value_start = query_start + 1
+    if url.startswith("cursor=", value_start, query_end):
+        value_start += len("cursor=")
+    else:
+        cursor_start = url.find("&cursor=", value_start, query_end)
         if cursor_start < 0:
             return ""
-        if cursor_start == query_start + 1 or url[cursor_start - 1] == "&":
-            value_start = cursor_start + len("cursor=")
-            value_end = url.find("&", value_start, query_end)
-            if value_end < 0:
-                value_end = query_end
-            return unquote_plus(url[value_start:value_end])
-        cursor_start += len("cursor=")
+        value_start = cursor_start + len("&cursor=")
+
+    value_end = url.find("&", value_start, query_end)
+    if value_end < 0:
+        value_end = query_end
+    return unquote_plus(url[value_start:value_end])
 
 
 def _string(value: Any) -> str:


### PR DESCRIPTION
## Summary
- Avoid allocating a sliced URL string while parsing the Hugging Face Hub `Link` header `rel="next"` cursor.
- Bound `_cursor_query_value` to the URL segment and keep exact `cursor` parameter boundary semantics.
- Add a regression case for `cursor=` at the start of the query string.

## Plan or Spec
- `docs/plans/2026-05-07-hub-catalog-cursor-param-find.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics
# 39 passed in 0.22s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_next_cursor_probe.py
# TOTAL 17 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-next-cursor-fast-parse --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-hub-catalog-cursor-bounds-20260507140340 --head-repo "$PWD" --output /tmp/hub_cursor_bounds_probe_2.json
# base elapsed_ms_mean=1583.7588150519878, peak_bytes_mean=12224.0
# head elapsed_ms_mean=1433.1791864009574, peak_bytes_mean=10959.0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 17 0 100%`).
- Registered local probe: `hub-catalog-next-cursor-fast-parse`.
- Local base-vs-head probe: `elapsed_ms_mean` 1583.759 ms -> 1433.179 ms (delta -150.580 ms, 9.51% faster); `peak_bytes_mean` 12224.0 -> 10959.0 (delta -1265 bytes, 10.35% lower); checksum unchanged at 6509477.0.
- GitHub Actions PR-scoped performance workflow is required as the merge gate.

## Known Gaps
- None. This is a Python-only slice locally verified on Linux; CI remains the registered PR-scoped probe validation source before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
