### PR TITLE
perf: load code eval payload JSON from bytes

### DIFF
--- a/docs/plans/2026-05-07-code-eval-payload-json-bytes.md
+++ b/docs/plans/2026-05-07-code-eval-payload-json-bytes.md
@@ -1,0 +1,71 @@
+# Code Eval Payload JSON Byte Loading Optimization
+
+## Goal
+
+Reduce redundant text decoding in the code-evaluation payload hot path by loading sandbox payload JSON directly from bytes before `json.loads(...)`.
+
+## Linux-only constraint
+
+This slice is Python-only and verifiable on Linux with focused pytest, changed-scope coverage, and a local PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/code_eval_payload_json_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Performance probe definition
+
+Register `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`.
+
+The probe repeatedly loads a representative UTF-8 JSON payload through `_load_payload_file(...)`, measures elapsed time and traced peak allocation, and emits:
+
+- `elapsed_ms_mean` (informational)
+- `peak_bytes_mean` (lower is better, 5% warning threshold)
+- `payload_bytes` (structural)
+- `sample_count` (structural)
+- `iteration_count` (structural)
+
+## Success metrics
+
+- Preserve valid payload, invalid JSON, non-mapping, and missing-file behavior.
+- Changed-scope coverage for touched executable Python lines is at least 95%.
+- The local base-vs-head PR-scoped probe should show no regression and should demonstrate reduced or flat peak allocation compared with `origin/main`.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/engine/code_eval_runner.py \
+  services/mlx-worker-python/tests/test_code_eval_runner.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/code_eval_payload_json_probe.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
+BASE=/tmp/melix-code-eval-payload-base
+[ -d "$BASE/.git" ] || git worktree add --detach "$BASE" origin/main
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py \
+  --registry infra/perf/pr_scoped_probes.json \
+  --probe-id code-eval-payload-json-bytes \
+  --base-repo "$BASE" \
+  --head-repo "$PWD" \
+  --output /tmp/code-eval-payload-json-probe.json
+
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1849,6 +1849,36 @@
     ]
   },
   {
+    "id": "code-eval-payload-json-bytes",
+    "name": "Code evaluation payload JSON byte loading",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/engine/code_eval_runner.py",
+      "services/mlx-worker-python/tests/test_code_eval_runner.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/code_eval_payload_json_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/code_eval_payload_json_probe.py ]; then python3 scripts/code_eval_payload_json_probe.py; else python3 - <<\"PYPROBE\"\nimport json, statistics, sys, tempfile, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.engine import code_eval_runner\ndef build_payload():\n    return {\"runtime_status\": \"ok\", \"timeout_status\": \"ok\", \"test_status\": \"passed\", \"tests_passed\": 128, \"tests_total\": 128, \"failure_detail\": \"\", \"stdout_tail\": \"x\" * 8192, \"stderr_tail\": \"\", \"metadata\": {f\"case_{index}\": {\"status\": \"passed\", \"duration_ms\": index % 17, \"message\": f\"synthetic payload row {index}\"} for index in range(512)}}\nsample_count = 7\niteration_count = 1200\nelapsed_ms = []\npeak_bytes = []\nwith tempfile.TemporaryDirectory(prefix=\"melix-code-eval-payload-probe-\") as temp_dir:\n    payload_path = Path(temp_dir) / \"payload.json\"\n    payload_path.write_text(json.dumps(build_payload(), sort_keys=True), encoding=\"utf-8\")\n    payload_bytes = float(payload_path.stat().st_size)\n    for _ in range(sample_count):\n        tracemalloc.start()\n        started = time.perf_counter()\n        for _iteration in range(iteration_count):\n            payload = code_eval_runner._load_payload_file(payload_path)\n            if not payload or payload.get(\"runtime_status\") != \"ok\":\n                raise SystemExit(\"unexpected payload\")\n        elapsed_ms.append((time.perf_counter() - started) * 1000.0)\n        _, peak = tracemalloc.get_traced_memory()\n        tracemalloc.stop()\n        peak_bytes.append(float(peak))\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed_ms), \"peak_bytes_mean\": statistics.fmean(peak_bytes), \"payload_bytes\": payload_bytes, \"sample_count\": float(sample_count), \"iteration_count\": float(iteration_count)}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "code-eval-stdio-tail-single-stat",
     "name": "Code evaluation stdio tail single stat",
     "runner": "ubuntu-latest",

--- a/scripts/code_eval_payload_json_probe.py
+++ b/scripts/code_eval_payload_json_probe.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.engine import code_eval_runner
+
+
+def _build_payload() -> dict[str, object]:
+    return {
+        "runtime_status": "ok",
+        "timeout_status": "ok",
+        "test_status": "passed",
+        "tests_passed": 128,
+        "tests_total": 128,
+        "failure_detail": "",
+        "stdout_tail": "x" * 8192,
+        "stderr_tail": "",
+        "metadata": {
+            f"case_{index}": {
+                "status": "passed",
+                "duration_ms": index % 17,
+                "message": f"synthetic payload row {index}",
+            }
+            for index in range(512)
+        },
+    }
+
+
+def main() -> None:
+    sample_count = 7
+    iteration_count = 1200
+    elapsed_ms: list[float] = []
+    peak_bytes: list[float] = []
+
+    with tempfile.TemporaryDirectory(prefix="melix-code-eval-payload-probe-") as temp_dir:
+        payload_path = Path(temp_dir) / "payload.json"
+        payload_path.write_text(json.dumps(_build_payload(), sort_keys=True), encoding="utf-8")
+        payload_bytes = float(payload_path.stat().st_size)
+
+        for _ in range(sample_count):
+            tracemalloc.start()
+            started = time.perf_counter()
+            for _iteration in range(iteration_count):
+                payload = code_eval_runner._load_payload_file(payload_path)
+                if not payload or payload.get("runtime_status") != "ok":
+                    raise RuntimeError("unexpected payload")
+            elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+            _, peak = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            peak_bytes.append(float(peak))
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed_ms),
+                "peak_bytes_mean": statistics.fmean(peak_bytes),
+                "payload_bytes": payload_bytes,
+                "sample_count": float(sample_count),
+                "iteration_count": float(iteration_count),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -6,6 +6,8 @@ import subprocess
 import tempfile
 import textwrap
 
+import pytest
+
 from worker.engine import code_eval_runner
 from worker.engine.code_eval_runner import run_python_code_evaluation
 
@@ -599,6 +601,36 @@ def test_load_payload_file_rejects_invalid_and_non_mapping_json(tmp_path: Path) 
     payload_path = tmp_path / "payload.json"
     payload_path.write_text(json.dumps({"runtime_status": "ok"}), encoding="utf-8")
     assert code_eval_runner._load_payload_file(payload_path) == {"runtime_status": "ok"}
+
+
+class _BytesOnlyPayloadPath:
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+        self.read_bytes_calls = 0
+
+    def exists(self) -> bool:
+        return True
+
+    def read_bytes(self) -> bytes:
+        self.read_bytes_calls += 1
+        return self.payload
+
+    def read_text(self, *args: object, **kwargs: object) -> str:
+        raise AssertionError("payload loading should not decode through read_text")
+
+
+def test_load_payload_file_reads_payload_bytes_without_text_decode() -> None:
+    payload_path = _BytesOnlyPayloadPath(
+        json.dumps({"runtime_status": "ok", "tests_total": 3}).encode("utf-8")
+    )
+
+    assert code_eval_runner._load_payload_file(payload_path) == {
+        "runtime_status": "ok",
+        "tests_total": 3,
+    }
+    assert payload_path.read_bytes_calls == 1
+    with pytest.raises(AssertionError):
+        payload_path.read_text()
 
 
 def test_code_exec_policy_support_and_output_summary_helpers() -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -337,9 +337,10 @@ def test_scope_report_selects_code_eval_stdio_probe() -> None:
     )
 
     probe_ids = {probe["id"] for probe in scope["selected_probes"]}
-    assert scope["selected_count"] == 2
+    assert scope["selected_count"] == 3
     assert probe_ids == {
         "code-eval-code-block-last-match-streaming",
+        "code-eval-payload-json-bytes",
         "code-eval-stdio-tail-single-stat",
     }
 
@@ -1514,6 +1515,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "changed-scope-coverage-diff-parser",
         "closure-audit-probe-source-short-circuit",
         "code-eval-code-block-last-match-streaming",
+        "code-eval-payload-json-bytes",
         "code-eval-stdio-tail-single-stat",
         "deterministic-embedding-duplicate-input-cache",
         "deterministic-embedding-project-digest-allocation",
@@ -1971,6 +1973,21 @@ def test_code_eval_code_block_extract_probe_script_emits_metrics(
     assert metrics["block_count"] == 2500.0
     assert metrics["sample_count"] == 7.0
     assert metrics["extracted_chars_mean"] > 0
+
+
+def test_code_eval_payload_json_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/code_eval_payload_json_probe.py"))
+
+    probe_script["main"]()
+    metrics = json.loads(capsys.readouterr().out)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["payload_bytes"] > 0
+    assert metrics["sample_count"] == 7.0
+    assert metrics["iteration_count"] == 1200.0
 
 
 def test_probe_smokes_return_metrics_against_current_repo() -> None:

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -238,7 +238,7 @@ def _load_payload_file(payload_path: Path) -> dict[str, object] | None:
     if not payload_path.exists():
         return None
     try:
-        payload = json.loads(payload_path.read_text(encoding="utf-8"))
+        payload = json.loads(payload_path.read_bytes())
     except json.JSONDecodeError:
         return None
     if not isinstance(payload, dict):


### PR DESCRIPTION
## Summary
- Load code-evaluation payload JSON directly from bytes instead of decoding to text before `json.loads(...)`.
- Add a focused regression test that fails if the payload loader falls back to `read_text()`.
- Register the `code-eval-payload-json-bytes` PR-scoped performance probe with a base-compatible fallback command.

## Plan or Spec
- `docs/plans/2026-05-07-code-eval-payload-json-bytes.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
# 5 passed in 28.10s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py
# 5 passed in 29.66s
# TOTAL 29 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
# {"elapsed_ms_mean": 2658.525268414191, "iteration_count": 1200.0, "payload_bytes": 55474.0, "peak_bytes_mean": 440500.14285714284, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-payload-json-bytes --base-repo /tmp/melix-cron-opt-base-20260507135430 --head-repo "$PWD" --output /tmp/code-eval-payload-json-probe.json
# head verification: 5 passed, TOTAL 29 0 100%
# base probe ok=true; head probe ok=true

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 29 0 100%`.
- Registered scoped CI probe: `code-eval-payload-json-bytes`.
- Local base-vs-head probe (`1200` payload loads/sample, `7` samples, `payload_bytes=55474`):
  - `peak_bytes_mean`: `446133.714` on `origin/main` → `440500.143` on this branch (~1.26% lower).
  - `elapsed_ms_mean`: `2598.005` on `origin/main` → `2680.528` on this branch (~3.18% higher, informational metric).
- Direct head probe: `peak_bytes_mean=440500.143`, `elapsed_ms_mean=2658.525`, `iteration_count=1200`, `sample_count=7`.

## Known Gaps
- Linux-only local verification; macOS/Swift checks were not run locally.
- Because `infra/perf/pr_scoped_probes.json` changed, hosted `pr-scoped-performance` may fan out beyond the new task-specific probe before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
