### PR TITLE
perf: stream mlx metal metadata version reads

### DIFF
--- a/docs/plans/2026-05-07-dev-up-metadata-version-streaming.md
+++ b/docs/plans/2026-05-07-dev-up-metadata-version-streaming.md
@@ -1,0 +1,49 @@
+# Dev-up MLX Metal metadata version streaming
+
+## Goal
+
+Reduce transient memory pressure in `scripts/dev_up.py` when resolving the local `mlx_metal` wheel version for `mlx.metallib` discovery.
+
+## Touched files
+
+- `scripts/dev_up.py`
+- `services/mlx-worker-python/tests/test_dev_up_script.py`
+
+## Linux-only constraint
+
+This slice is Python-only and can be verified on Linux with focused pytest, changed-scope coverage, and a synthetic metadata-reading probe.
+
+## Optimization
+
+`read_mlx_metal_dist_info_version(...)` previously materialized the entire `METADATA` file with `Path.read_text(...).splitlines()` even though it only needs the first `Version:` line. The change streams the file line-by-line and returns as soon as the version header is found.
+
+## Performance probe
+
+Run a synthetic comparison against detached `origin/main` and the head worktree. The workload creates an `mlx_metal-*.dist-info/METADATA` file with a large trailing payload after the `Version:` header and repeatedly calls `read_mlx_metal_dist_info_version(...)`.
+
+Success metrics:
+
+- Preserve the resolved version.
+- Reduce traced peak allocation by avoiding full-file materialization.
+- Avoid a meaningful elapsed-time regression.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_uses_scandir_without_path_glob \
+  services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_falls_back_to_dist_info_directory_name \
+  services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_skips_scandir_errors
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same test nodes>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/dev_up.py services/mlx-worker-python/tests/test_dev_up_script.py
+
+python /tmp/dev_up_metadata_probe.py <repo-root>
+
+git diff --check
+```
+
+## PR-scoped performance CI
+
+Existing registered probe: `dev-up-mlx-metal-dist-info-scandir`. The touched script and focused tests are already in its `watch_globs`, `test_command`, and `coverage_command`, so no new registry entry is needed for this narrow metadata-reader optimization.

--- a/scripts/dev_up.py
+++ b/scripts/dev_up.py
@@ -317,6 +317,16 @@ def compatible_mlx_metal_versions_for_swift_mlx(repo_root: Path) -> tuple[str, .
     return tuple(compatible_versions)
 
 
+def _read_dist_info_metadata_version(metadata_path: Path) -> str | None:
+    with metadata_path.open("r", encoding="utf-8") as metadata_file:
+        for line in metadata_file:
+            if line.startswith("Version:"):
+                version = line.removeprefix("Version:").strip()
+                if version:
+                    return version
+    return None
+
+
 def read_mlx_metal_dist_info_version(metallib_path: Path) -> str | None:
     fallback_version: str | None = None
     for ancestor in metallib_path.resolve().parents:
@@ -335,14 +345,11 @@ def read_mlx_metal_dist_info_version(metallib_path: Path) -> str | None:
         for dist_info_name in dist_info_names:
             metadata_path = ancestor / dist_info_name / "METADATA"
             try:
-                metadata = metadata_path.read_text(encoding="utf-8")
+                version = _read_dist_info_metadata_version(metadata_path)
             except OSError:
                 continue
-            for line in metadata.splitlines():
-                if line.startswith("Version:"):
-                    version = line.removeprefix("Version:").strip()
-                    if version:
-                        return version
+            if version is not None:
+                return version
 
         for dist_info_name in dist_info_names:
             match = re.fullmatch(r"mlx_metal-(?P<version>.+)\.dist-info", dist_info_name)

--- a/services/mlx-worker-python/tests/test_dev_up_script.py
+++ b/services/mlx-worker-python/tests/test_dev_up_script.py
@@ -430,7 +430,14 @@ def test_read_mlx_metal_dist_info_version_uses_scandir_without_path_glob(
     def fail_glob(self: Path, pattern: str):  # pragma: no cover - exercised only on regression
         raise AssertionError("read_mlx_metal_dist_info_version() should not allocate Path.glob() results")
 
+    def fail_read_text(self: Path, *args: object, **kwargs: object) -> str:  # pragma: no cover
+        if self.name == "METADATA":
+            raise AssertionError("METADATA should be streamed line-by-line, not materialized")
+        return original_read_text(self, *args, **kwargs)
+
+    original_read_text = dev_up.Path.read_text
     monkeypatch.setattr(dev_up.Path, "glob", fail_glob)
+    monkeypatch.setattr(dev_up.Path, "read_text", fail_read_text)
 
     assert dev_up.read_mlx_metal_dist_info_version(metallib_path) == "0.29.1"
 
@@ -442,6 +449,7 @@ def test_read_mlx_metal_dist_info_version_falls_back_to_dist_info_directory_name
     metallib_path.write_text("mlx", encoding="utf-8")
     dist_info_path = tmp_path / "site-packages/mlx_metal-0.31.1.dist-info"
     dist_info_path.mkdir()
+    (dist_info_path / "METADATA").write_text("Name: mlx-metal\nSummary: missing version\n", encoding="utf-8")
 
     assert dev_up.read_mlx_metal_dist_info_version(metallib_path) == "0.31.1"
 


### PR DESCRIPTION
## Summary
- Stream `mlx_metal-*.dist-info/METADATA` line-by-line while resolving the local `mlx.metallib` companion wheel version in `scripts/dev_up.py`.
- Avoid materializing the full `METADATA` payload and split-lines list when the `Version:` header appears near the top.
- Extend the existing dev-up tests so the registered scoped probe covers the streaming behavior and the no-version fallback path.

## Plan or Spec
- Plan: `docs/plans/2026-05-07-dev-up-metadata-version-streaming.md`
- Slice type: Python/Linux-verifiable utility optimization.
- Verification path: existing registered PR-scoped probe `dev-up-mlx-metal-dist-info-scandir` plus focused local pytest/changed-scope coverage and an explicit synthetic large-METADATA memory probe.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_falls_back_to_dist_info_directory_name services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_skips_scandir_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dev_up_mlx_metal_dist_info_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/dev_up.py services/mlx-worker-python/tests/test_dev_up_script.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dev-up-mlx-metal-dist-info-scandir --base-repo /tmp/melix-base-dev-up-scoped-... --head-repo "$PWD" --output /tmp/dev-up-scoped-result.json`
- `python /tmp/dev_up_metadata_probe.py /tmp/melix-base-dev-up-metadata-...`
- `python /tmp/dev_up_metadata_probe.py "$PWD"`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `5 passed`.
- Pre-commit changed-scope coverage: `TOTAL 14 0 100%`.
- Registered scoped probe: `dev-up-mlx-metal-dist-info-scandir`.
  - Head verification: `test_ok=True`, `coverage_ok=True`.
  - Pre-rebase scoped metrics: base `elapsed_ms_mean=1.201562`, head `elapsed_ms_mean=1.192852`, `dist_info_count=2000.0`, `sample_count=7.0`.
  - Post-rebase scoped runner remained green; post-commit changed-scope output reports `TOTAL 0 0 100%` because the runner measures current uncommitted diff after commit, so the pre-commit `TOTAL 14 0 100%` is the changed-line gate evidence.
- Synthetic large-METADATA probe (`120000` trailing lines, `9` samples, version preserved as `0.31.1`):
  - Base: `elapsed_ms_mean=128.300256`, `peak_bytes_mean=13735394.0`.
  - Head before rebase: `elapsed_ms_mean=0.45999`, `peak_bytes_mean=22749.4`.
  - Head after rebase: `elapsed_ms_mean=0.361393`, `peak_bytes_mean=22749.4`.
- `git diff --check`: passed.

## Known Gaps
- Linux-only local verification. No macOS/Swift validation was run because this slice only touches Python/dev tooling.
- The existing registered scoped probe primarily measures many dist-info directory scans; the synthetic local probe separately captures the large-METADATA memory-pressure win.

## Evidence Checklist
- [x] Focused tests run and passing.
- [x] Changed-scope coverage is at least 95% for touched executable scope (`100%`, pre-commit).
- [x] Explicit local performance probe with concrete base/head numbers.
- [x] Registered PR-scoped performance probe identified and run locally: `dev-up-mlx-metal-dist-info-scandir`.
- [x] `git diff --check` passed.
- [x] Linux/macOS limitation documented.
