### PR TITLE
perf: trim statistical category aggregation overhead

### DIFF
--- a/docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md
+++ b/docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md
@@ -17,6 +17,10 @@ Keep the Phase 8 evaluation-compare category breakdown path behaviorally identic
 - Registered local Linux probe command:
   `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_category_breakdown_probe.py`
 
+## Implementation Note
+
+The accepted slice removes the per-row `row_get = row.get` bound-method allocation and lets CPython dispatch the three `dict.get(...)` calls directly. A trial that added extra category-label sentinel/type-dispatch bindings increased mean time and peak traced bytes, so it was rejected and reverted before this smaller implementation.
+
 ## Acceptance Metric
 
 Accept only if the registered category breakdown probe keeps the same checksum/sample counts and improves `elapsed_ms_mean` versus the origin/main baseline in repeated local samples.

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -76,12 +76,11 @@ def build_category_breakdown(
 ) -> dict[str, dict[str, object]]:
     category_totals: dict[str, list[int]] = {}
     for row in rows:
-        row_get = row.get
-        category_label = str(row_get("category_label", "")).strip()
+        category_label = str(row.get("category_label", "")).strip()
         if not category_label:
             continue
-        base_correct = 1 if row_get("base_correct", False) else 0
-        target_correct = 1 if row_get("target_correct", False) else 0
+        base_correct = 1 if row.get("base_correct", False) else 0
+        target_correct = 1 if row.get("target_correct", False) else 0
         totals = category_totals.get(category_label)
         if totals is None:
             category_totals[category_label] = [1, base_correct, target_correct]


### PR DESCRIPTION
## Summary
- Remove the per-row `row_get = row.get` bound-method allocation in statistical category aggregation.
- Update the category-breakdown optimization plan with the accepted slice and a rejected trial note.

## Plan or Spec
- `docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics
# 5 passed in 0.56s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_category_breakdown_probe.py
# 5 passed; changed-scope coverage TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_STAT_CATEGORY_PROBE_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_category_breakdown_probe.py
# {"elapsed_ms_mean": 13.131783293959286, "peak_bytes_mean": 15649.142857142857, "checksum": 350512.00800000003, ...}

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id statistical-evidence-category-breakdown-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-stat-category-bindings-20260507171817 --head-repo "$PWD" --output /tmp/stat-category-probe-final.json
# head verification ok; base elapsed_ms_mean=15.699673164635897, head elapsed_ms_mean=14.402561588212848

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`TOTAL 3 0 100%`).
- Registered probe: `statistical-evidence-category-breakdown-single-pass`.
- Local base-vs-head registered probe metrics:
  - `elapsed_ms_mean`: base `15.699673164635897` ms, head `14.402561588212848` ms, delta `-1.297111576423049` ms (~`8.26%` faster).
  - `peak_bytes_mean`: base `16528.0`, head `16456.0`, delta `-72` bytes.
  - Guard metrics unchanged: `row_count=50000.0`, `category_count=64.0`, `sample_count=5.0`, `checksum=250365.72`.
- CI PR-scoped performance workflow is required as the authoritative registered probe validation after push.

## Known Gaps
- Full `make py-test` was not run locally; this slice used the registered focused test, changed-scope coverage, and registered probe.
- Linux-only Python slice; no Swift runtime validation is applicable.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
