### PR TITLE
perf: reuse sorted evaluation latency vector for max

### DIFF
--- a/docs/plans/2026-05-07-evaluation-latency-max-from-sorted-vector.md
+++ b/docs/plans/2026-05-07-evaluation-latency-max-from-sorted-vector.md
@@ -1,0 +1,31 @@
+# Evaluation latency max from sorted vector
+
+## Goal
+
+Reduce a small repeated scan in `EvaluationCore._latency_stats()` by reusing the sorted latency vector for the max value after percentile calculation.
+
+## Scope
+
+- `services/mlx-worker-python/worker/engine/evaluation_core.py`
+- `services/mlx-worker-python/tests/test_evaluation_core.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Registered probe
+
+The affected path is already covered by the `evaluation-latency-percentile-vector-reuse` PR-scoped probe in `infra/perf/pr_scoped_probes.json`:
+
+- `watch_globs` includes `services/mlx-worker-python/worker/engine/evaluation_core.py`, `services/mlx-worker-python/tests/test_evaluation_core.py`, and the PR-scoped performance tests.
+- `test_command` runs the focused latency-stat behavior tests and probe selection/command checks.
+- `coverage_command` measures changed-scope coverage for `evaluation_core.py`, `test_evaluation_core.py`, and `test_pr_scoped_performance.py`.
+- `probe_command` exercises `_latency_stats()` across a 12,000-value vector for 160 iterations and records elapsed time plus sorted-call count.
+
+## Implementation plan
+
+1. Keep percentile behavior unchanged by continuing to sort once and pass the ordered vector to `_ordered_percentile()`.
+2. Reuse `sorted_values[-1]` for the maximum instead of scanning the original vector with `max(values)`.
+3. Reuse the sorted-vector length for mean division to avoid a second `len(values)` call.
+4. Verify with focused tests, changed-scope coverage, and the registered probe against `origin/main`.
+
+## Success metrics
+
+The registered `evaluation-latency-percentile-vector-reuse` probe should keep `sorted_calls_mean` at `1.0`, preserve p50/p95 results, and show a lower `elapsed_ms_mean` versus the `origin/main` baseline.

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -1279,11 +1279,12 @@ class EvaluationCore:
         if not values:
             return {"mean": 0.0, "p50": 0.0, "p95": 0.0, "max": 0.0}
         sorted_values = sorted(values)
+        value_count = len(sorted_values)
         return {
-            "mean": cls._round_ms(sum(values) / len(values)),
+            "mean": cls._round_ms(sum(sorted_values) / value_count),
             "p50": cls._round_ms(cls._ordered_percentile(sorted_values, 50.0)),
             "p95": cls._round_ms(cls._ordered_percentile(sorted_values, 95.0)),
-            "max": cls._round_ms(max(values)),
+            "max": cls._round_ms(sorted_values[-1]),
         }
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Reuses the already sorted latency vector in `EvaluationCore._latency_stats()` for the max value instead of scanning the original vector again.
- Keeps the existing single-sort percentile behavior and output values unchanged.

## Plan or Spec
- `docs/plans/2026-05-07-evaluation-latency-max-from-sorted-vector.md`
- Registered probe: `evaluation-latency-percentile-vector-reuse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_percentile_preserves_interpolated_results services/mlx-worker-python/tests/test_evaluation_core.py::test_latency_stats_reuse_single_sorted_vector services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_latency_percentile_probe_command_emits_metrics services/mlx-worker-python/tests/test_event_extraction.py::test_event_extraction_dialogue_diagnostics_uses_top_k_for_slowest_dialogues
# exit 0; 5 passed in 1.92s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_percentile_preserves_interpolated_results services/mlx-worker-python/tests/test_evaluation_core.py::test_latency_stats_reuse_single_sorted_vector services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_latency_percentile_probe_command_emits_metrics services/mlx-worker-python/tests/test_event_extraction.py::test_event_extraction_dialogue_diagnostics_uses_top_k_for_slowest_dialogues && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; 5 passed in 1.58s; changed-line coverage TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-latency-percentile-vector-reuse --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-evaluation-latency-max-20260507 --head-repo "$PWD" --output /tmp/evaluation_latency_probe_compare.json
# exit 0; head verification ok; base/head probes ok

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`evaluation_core.py` changed line 1282 covered; aggregate TOTAL 1 0 100%).
- Registered local probe `evaluation-latency-percentile-vector-reuse`:
  - `base elapsed_ms_mean=260.287413`, `head elapsed_ms_mean=242.049364`, delta `-18.238049 ms` (`~7.01%` lower).
  - Three manual samples before/after: `old_mean=258.377522`, `new_mean=242.674206`, delta `-15.703316 ms`, speedup `1.064709x` (`6.078%` improvement).
  - `sorted_calls_mean` stayed `1.0`; `p50=495.0611` and `p95=950.5231` were unchanged.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Full repository `make py-test` was not run locally; this PR used the registered focused test/coverage/probe for the touched path.
- CI remains the final registered probe validation source for merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
