### PR TITLE
perf: trim benchmark parameter normalization conversions

### DIFF
--- a/docs/plans/2026-05-07-maintenance-benchmark-parameter-normalization.md
+++ b/docs/plans/2026-05-07-maintenance-benchmark-parameter-normalization.md
@@ -1,0 +1,34 @@
+# Maintenance benchmark parameter normalization single-convert plan
+
+## Goal
+
+Reduce redundant conversion work in benchmark matrix parameter normalization by converting each value at most once while preserving existing ordering, de-duplication, and fallback semantics.
+
+## Linux-only constraint
+
+This slice touches Python worker code and is verifiable on Linux with focused pytest, changed-scope coverage, and a PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/engine/maintenance_core.py`
+- `services/mlx-worker-python/tests/test_maintenance_service.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/maintenance_benchmark_parameter_normalization_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Performance probe
+
+Register `maintenance-benchmark-parameter-normalization-single-convert` in the PR-scoped performance registry.
+
+The probe repeatedly normalizes synthetic integer and string benchmark parameter values and reports:
+
+- `elapsed_ms_mean` — lower is better.
+- `calls_per_value_mean` — lower is better; the optimized path should be `1.0` conversion per input value.
+- `peak_bytes_mean` — informational.
+
+## Success metrics
+
+- Focused parser tests pass.
+- Changed executable coverage for touched Python scope is at least 95%.
+- Local probe shows `calls_per_value_mean=1.0` on the optimized branch and concrete elapsed/peak metrics.
+- `git diff --check` passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1186,6 +1186,41 @@
     ]
   },
   {
+    "id": "maintenance-benchmark-parameter-normalization-single-convert",
+    "name": "Maintenance benchmark parameter normalization single convert",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/engine/maintenance_core.py",
+      "services/mlx-worker-python/tests/test_maintenance_service.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/maintenance_benchmark_parameter_normalization_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_parameter_normalization_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_parameter_normalization_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_parameter_normalization_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_parameter_normalization_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/maintenance_benchmark_parameter_normalization_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/maintenance_benchmark_parameter_normalization_probe.py ]; then python3 scripts/maintenance_benchmark_parameter_normalization_probe.py; else python3 - <<\"PYPROBE\"\nimport json, os, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd(); sys.path.insert(0, str(repo_root)); sys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.engine.maintenance_core import MaintenanceCore\nclass CountedInt:\n    def __init__(self, value): self.value=value; self.calls=0\n    def __int__(self): self.calls += 1; return self.value\nclass CountedString:\n    def __init__(self, value): self.value=value; self.calls=0\n    def __str__(self): self.calls += 1; return self.value\ndef int_values(n): return [CountedInt((i % 97) - 12) for i in range(n)]\ndef string_values(n):\n    variants=(\" cold \", \"\", \" warm\", \"default \", \" structured \", \"cold\")\n    return [CountedString(variants[i % len(variants)]) for i in range(n)]\ndef run_sample(value_count, iterations):\n    int_calls=string_calls=int_total=string_total=checksum=0\n    started=time.perf_counter()\n    for _ in range(iterations):\n        ints=int_values(value_count); strings=string_values(value_count)\n        positive=MaintenanceCore._positive_sorted_values(ints, default=(32,)); normalized=MaintenanceCore._normalized_string_values(strings, default=(\"default\",))\n        if positive[0] <= 0 or normalized != (\"cold\", \"default\", \"structured\", \"warm\"): raise SystemExit(\"unexpected benchmark parameter normalization output\")\n        int_calls += sum(v.calls for v in ints); string_calls += sum(v.calls for v in strings); int_total += len(ints); string_total += len(strings); checksum += len(positive) + len(normalized)\n    return (time.perf_counter()-started)*1000.0, int_calls, string_calls, int_total, string_total, checksum\nvalue_count=int(os.environ.get(\"MELIX_MAINTENANCE_PARAMETER_PROBE_VALUE_COUNT\", \"3000\")); iterations=int(os.environ.get(\"MELIX_MAINTENANCE_PARAMETER_PROBE_ITERATIONS\", \"80\")); sample_count=int(os.environ.get(\"MELIX_MAINTENANCE_PARAMETER_PROBE_SAMPLES\", \"5\"))\nelapsed=[]; peaks=[]; int_samples=[]; string_samples=[]; calls_per=[]; checksum=0\nfor _ in range(sample_count):\n    tracemalloc.start(); elapsed_ms, int_calls, string_calls, int_total, string_total, checksum = run_sample(value_count, iterations); _, peak = tracemalloc.get_traced_memory(); tracemalloc.stop()\n    elapsed.append(elapsed_ms); peaks.append(float(peak)); int_samples.append(float(int_calls)); string_samples.append(float(string_calls)); calls_per.append((int_calls + string_calls)/(int_total + string_total))\nprint(json.dumps({\"calls_per_value_mean\": round(statistics.fmean(calls_per), 6), \"checksum\": float(checksum), \"elapsed_ms_mean\": round(statistics.fmean(elapsed), 6), \"int_conversion_calls_mean\": round(statistics.fmean(int_samples), 6), \"iteration_count\": float(iterations), \"peak_bytes_mean\": round(statistics.fmean(peaks), 6), \"sample_count\": float(sample_count), \"string_conversion_calls_mean\": round(statistics.fmean(string_samples), 6), \"value_count\": float(value_count)}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "calls_per_value_mean",
+        "unit": "calls/value",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "upload-receipt-published-files-scandir",
     "name": "Upload receipt published-files scandir",
     "runner": "ubuntu-latest",

--- a/scripts/maintenance_benchmark_parameter_normalization_probe.py
+++ b/scripts/maintenance_benchmark_parameter_normalization_probe.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Measure benchmark parameter normalization conversion reuse."""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.engine.maintenance_core import MaintenanceCore  # noqa: E402
+
+
+class CountedInt:
+    def __init__(self, value: int) -> None:
+        self.value = value
+        self.calls = 0
+
+    def __int__(self) -> int:
+        self.calls += 1
+        return self.value
+
+
+class CountedString:
+    def __init__(self, value: str) -> None:
+        self.value = value
+        self.calls = 0
+
+    def __str__(self) -> str:
+        self.calls += 1
+        return self.value
+
+
+def _int_values(value_count: int) -> list[CountedInt]:
+    return [CountedInt((index % 97) - 12) for index in range(value_count)]
+
+
+def _string_values(value_count: int) -> list[CountedString]:
+    variants = (" cold ", "", " warm", "default ", " structured ", "cold")
+    return [CountedString(variants[index % len(variants)]) for index in range(value_count)]
+
+
+def _run_sample(value_count: int, iterations: int) -> tuple[float, int, int, int, int, int]:
+    int_conversion_calls = 0
+    string_conversion_calls = 0
+    int_value_total = 0
+    string_value_total = 0
+    checksum = 0
+    started = time.perf_counter()
+    for _ in range(iterations):
+        ints = _int_values(value_count)
+        strings = _string_values(value_count)
+        positive_values = MaintenanceCore._positive_sorted_values(ints, default=(32,))
+        normalized_strings = MaintenanceCore._normalized_string_values(strings, default=("default",))
+        if positive_values[0] <= 0 or normalized_strings != ("cold", "default", "structured", "warm"):
+            raise SystemExit("unexpected benchmark parameter normalization output")
+        int_conversion_calls += sum(value.calls for value in ints)
+        string_conversion_calls += sum(value.calls for value in strings)
+        int_value_total += len(ints)
+        string_value_total += len(strings)
+        checksum += len(positive_values) + len(normalized_strings)
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    return (
+        elapsed_ms,
+        int_conversion_calls,
+        string_conversion_calls,
+        int_value_total,
+        string_value_total,
+        checksum,
+    )
+
+
+def main() -> int:
+    value_count = int(os.environ.get("MELIX_MAINTENANCE_PARAMETER_PROBE_VALUE_COUNT", "3000"))
+    iterations = int(os.environ.get("MELIX_MAINTENANCE_PARAMETER_PROBE_ITERATIONS", "80"))
+    sample_count = int(os.environ.get("MELIX_MAINTENANCE_PARAMETER_PROBE_SAMPLES", "5"))
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    int_call_samples: list[float] = []
+    string_call_samples: list[float] = []
+    calls_per_value_samples: list[float] = []
+    checksum = 0
+
+    for _ in range(sample_count):
+        tracemalloc.start()
+        (
+            elapsed_ms,
+            int_calls,
+            string_calls,
+            int_values,
+            string_values,
+            checksum,
+        ) = _run_sample(value_count, iterations)
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        elapsed_samples.append(elapsed_ms)
+        peak_samples.append(float(peak_bytes))
+        int_call_samples.append(float(int_calls))
+        string_call_samples.append(float(string_calls))
+        calls_per_value_samples.append((int_calls + string_calls) / (int_values + string_values))
+
+    print(
+        json.dumps(
+            {
+                "calls_per_value_mean": round(statistics.fmean(calls_per_value_samples), 6),
+                "checksum": float(checksum),
+                "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+                "int_conversion_calls_mean": round(statistics.fmean(int_call_samples), 6),
+                "iteration_count": float(iterations),
+                "peak_bytes_mean": round(statistics.fmean(peak_samples), 6),
+                "sample_count": float(sample_count),
+                "string_conversion_calls_mean": round(statistics.fmean(string_call_samples), 6),
+                "value_count": float(value_count),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -5226,6 +5226,36 @@ def test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs(tmp_path: Pa
     assert core._benchmark_batch_sizes({"batch_sizes": "2, 1, 2, 1"}) == (1, 2)
     assert core._benchmark_batch_sizes({"batch_sizes": "1, , 2"}) == (1, 2)
     assert core._benchmark_batch_sizes({"batch_size": "oops"}) == (1,)
+
+    class CountedInt:
+        def __init__(self, value: int) -> None:
+            self.value = value
+            self.calls = 0
+
+        def __int__(self) -> int:
+            self.calls += 1
+            return self.value
+
+    counted_ints = [CountedInt(8), CountedInt(0), CountedInt(4), CountedInt(8)]
+    assert MaintenanceCore._positive_sorted_values(counted_ints, default=(32,)) == (4, 8)
+    assert [value.calls for value in counted_ints] == [1, 1, 1, 1]
+
+    class CountedString:
+        def __init__(self, value: str) -> None:
+            self.value = value
+            self.calls = 0
+
+        def __str__(self) -> str:
+            self.calls += 1
+            return self.value
+
+    counted_strings = [CountedString(" warm "), CountedString(""), CountedString("cold")]
+    assert MaintenanceCore._normalized_string_values(
+        counted_strings,
+        default=("default",),
+    ) == ("cold", "warm")
+    assert [value.calls for value in counted_strings] == [1, 1, 1]
+
     assert core._shape_benchmark_prompt("", context_length=3) == "benchmark benchmark benchmark"
     assert core._shape_benchmark_prompt("one two three", context_length=2) == "one two"
     assert core._shape_benchmark_prompt("one two three", context_length=8) == (

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -767,6 +767,16 @@ def test_scope_report_selects_maintenance_prompt_shape_probe() -> None:
     assert "maintenance-prompt-shape-vector-repeat" in probe_ids
 
 
+def test_scope_report_selects_maintenance_parameter_normalization_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/engine/maintenance_core.py"],
+    )
+
+    probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert "maintenance-benchmark-parameter-normalization-single-convert" in probe_ids
+
+
 def test_scope_report_selects_upload_receipt_published_files_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -1393,6 +1403,32 @@ def test_dataset_registry_split_match_probe_script_emits_metrics(
     assert metrics["peak_bytes_mean"] > 0
 
 
+def test_maintenance_parameter_normalization_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_MAINTENANCE_PARAMETER_PROBE_VALUE_COUNT", "12")
+    monkeypatch.setenv("MELIX_MAINTENANCE_PARAMETER_PROBE_ITERATIONS", "2")
+    monkeypatch.setenv("MELIX_MAINTENANCE_PARAMETER_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/maintenance_benchmark_parameter_normalization_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["iteration_count"] == 2.0
+    assert metrics["value_count"] == 12.0
+    assert metrics["calls_per_value_mean"] == 1.0
+    assert metrics["int_conversion_calls_mean"] == 24.0
+    assert metrics["string_conversion_calls_mean"] == 24.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_mlx_audio_wav_streaming_probe_script_emits_metrics(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -1600,6 +1636,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "maintenance-bench-report-readback",
         "maintenance-percentile-vector-reuse",
         "maintenance-prompt-shape-vector-repeat",
+        "maintenance-benchmark-parameter-normalization-single-convert",
         "phase8-metrics-closure-audit-reuse",
         "pr-scoped-performance-registry-cache",
         "real-model-support-hf-cache-latest-snapshot",

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -2349,25 +2349,21 @@ class MaintenanceCore:
 
     @staticmethod
     def _positive_sorted_values(values, *, default: tuple[int, ...]) -> tuple[int, ...]:
-        normalized = sorted(
-            {
-                int(value)
-                for value in values
-                if int(value) > 0
-            }
-        )
-        return tuple(normalized) or default
+        normalized_values: set[int] = set()
+        for value in values:
+            parsed = int(value)
+            if parsed > 0:
+                normalized_values.add(parsed)
+        return tuple(sorted(normalized_values)) or default
 
     @staticmethod
     def _normalized_string_values(values, *, default: tuple[str, ...]) -> tuple[str, ...]:
-        normalized = sorted(
-            {
-                str(value).strip()
-                for value in values
-                if str(value).strip()
-            }
-        )
-        return tuple(normalized) or default
+        normalized_values: set[str] = set()
+        for value in values:
+            normalized = str(value).strip()
+            if normalized:
+                normalized_values.add(normalized)
+        return tuple(sorted(normalized_values)) or default
 
     @staticmethod
     def _benchmark_matrix_request_count(


### PR DESCRIPTION
## Summary
- Converts benchmark matrix integer and string parameter values exactly once per input before filtering/deduping.
- Adds a focused regression guard for conversion call counts.
- Registers a PR-scoped performance probe for benchmark parameter normalization.

## Plan or Spec
- Plan: `docs/plans/2026-05-07-maintenance-benchmark-parameter-normalization.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_parameter_normalization_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_parameter_normalization_probe_script_emits_metrics
# 4 passed in 1.78s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
  services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_parameter_normalization_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_parameter_normalization_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/engine/maintenance_core.py \
  services/mlx-worker-python/tests/test_maintenance_service.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/maintenance_benchmark_parameter_normalization_probe.py
# 4 passed in 0.61s; TOTAL 52 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/maintenance_benchmark_parameter_normalization_probe.py
# {"calls_per_value_mean": 1.0, "checksum": 7040.0, "elapsed_ms_mean": 811.876612, "int_conversion_calls_mean": 240000.0, "iteration_count": 80.0, "peak_bytes_mean": 814419.4, "sample_count": 5.0, "string_conversion_calls_mean": 240000.0, "value_count": 3000.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py \
  --registry infra/perf/pr_scoped_probes.json \
  --probe-id maintenance-benchmark-parameter-normalization-single-convert \
  --base-repo /tmp/melix-cron-opt-20260507180937-base-postrebase-182116 \
  --head-repo "$PWD" \
  --output /tmp/maintenance-parameter-probe-result-postrebase.json
# head verification ok; base_probe ok; head_probe ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed executable coverage before commit: `TOTAL 52 0 100%`.
- Registered probe: `maintenance-benchmark-parameter-normalization-single-convert`.
- Post-rebase base-vs-head scoped probe:
  - `calls_per_value_mean`: `1.8495` -> `1.0` (~45.93% lower)
  - `int_conversion_calls_mean`: `447760.0` -> `240000.0`
  - `string_conversion_calls_mean`: `440000.0` -> `240000.0`
  - `elapsed_ms_mean` informational: `941.529325` -> `846.898319` (~10.06% lower in the final local run)
  - `peak_bytes_mean` informational: `814430.6` -> `814419.4`

## Known Gaps
- Linux-only local verification; macOS/Swift checks were not run locally.
- The post-rebase registered-probe head-verification coverage command reported `TOTAL 0 0 100%` because `scripts/changed_scope_coverage.py` measures the current uncommitted diff after the commit/rebase. The pre-commit changed-scope run above is the gating local coverage evidence.
- Hosted `pr-scoped-performance` remains the final CI validation for this registered probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
