### PR TITLE
[codex] Add macOS app screenshot capture

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift
+++ b/apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift
@@ -1,0 +1,455 @@
+import AppKit
+import Foundation
+import MelixControlPlaneCore
+import MelixControlPlaneProtocol
+import SwiftUI
+
+private let appScreenshotCaptureSchemaVersion = "melix.app_screenshots.v1"
+
+public enum AppScreenshotCaptureError: Error, LocalizedError {
+    case invalidOutputDirectory(String)
+    case renderFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidOutputDirectory(let path):
+            return "Invalid app screenshot output directory: \(path)"
+        case .renderFailed(let reason):
+            return "App screenshot capture failed: \(reason)"
+        }
+    }
+}
+
+public struct AppScreenshotCaptureConfig: Equatable, Sendable {
+    public let outputDirectoryPath: String
+    public let appPath: String
+    public let width: Int
+    public let height: Int
+
+    public init(
+        outputDirectoryPath: String,
+        appPath: String = "",
+        width: Int = 1440,
+        height: Int = 960
+    ) {
+        self.outputDirectoryPath = outputDirectoryPath
+        self.appPath = appPath
+        self.width = width
+        self.height = height
+    }
+
+    public init(environment: [String: String]) {
+        self.outputDirectoryPath = Self.normalized(environment["MELIX_APP_SCREENSHOT_OUTPUT_DIR"])
+            ?? Self.defaultOutputDirectoryPath()
+        self.appPath = Self.normalized(environment["MELIX_APP_SCREENSHOT_APP_PATH"]) ?? ""
+        self.width = Self.positiveInt(environment["MELIX_APP_SCREENSHOT_WIDTH"]) ?? 1440
+        self.height = Self.positiveInt(environment["MELIX_APP_SCREENSHOT_HEIGHT"]) ?? 960
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func positiveInt(_ value: String?) -> Int? {
+        guard let normalized = normalized(value), let parsed = Int(normalized), parsed > 0 else {
+            return nil
+        }
+        return parsed
+    }
+
+    private static func defaultOutputDirectoryPath() -> String {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-app-screenshots-\(UUID().uuidString)", isDirectory: true)
+            .path
+    }
+}
+
+public enum AppScreenshotCaptureCase: Equatable, Sendable {
+    case workspace(DesktopSurface)
+    case toolSection(DesktopToolSection)
+    case commandCenter
+
+    public static var defaultCases: [AppScreenshotCaptureCase] {
+        DesktopSurface.allCases.map(AppScreenshotCaptureCase.workspace)
+            + DesktopToolSection.allCases.map(AppScreenshotCaptureCase.toolSection)
+            + [.commandCenter]
+    }
+
+    public var id: String {
+        switch self {
+        case .workspace(let surface):
+            return "workspace-\(Self.slug(surface.rawValue))"
+        case .toolSection(let section):
+            return "workspace-tools-\(Self.slug(section.rawValue))"
+        case .commandCenter:
+            return "command-center"
+        }
+    }
+
+    var kind: String {
+        switch self {
+        case .workspace:
+            return "workspace"
+        case .toolSection:
+            return "tool_section"
+        case .commandCenter:
+            return "command_center"
+        }
+    }
+
+    var surface: DesktopSurface? {
+        switch self {
+        case .workspace(let surface):
+            return surface
+        case .toolSection:
+            return .tools
+        case .commandCenter:
+            return nil
+        }
+    }
+
+    var toolSection: DesktopToolSection? {
+        switch self {
+        case .toolSection(let section):
+            return section
+        case .workspace, .commandCenter:
+            return nil
+        }
+    }
+
+    private static func slug(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics
+        var result = ""
+        var previousWasSeparator = false
+        for scalar in value.lowercased().unicodeScalars {
+            if allowed.contains(scalar) {
+                result.unicodeScalars.append(scalar)
+                previousWasSeparator = false
+            } else if previousWasSeparator == false {
+                result.append("-")
+                previousWasSeparator = true
+            }
+        }
+        return result.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+}
+
+public struct AppScreenshotCaptureEntry: Codable, Equatable, Sendable {
+    public let id: String
+    public let kind: String
+    public let surface: String
+    public let toolSection: String
+    public let path: String
+    public let renderMs: Double
+}
+
+public struct AppScreenshotCaptureManifest: Codable, Equatable, Sendable {
+    public let schemaVersion: String
+    public let manifestPath: String
+    public let appPath: String
+    public let outputDirectoryPath: String
+    public let screenshotRoot: String
+    public let width: Int
+    public let height: Int
+    public let screenshots: [AppScreenshotCaptureEntry]
+}
+
+@MainActor
+public final class AppScreenshotCaptureRunner {
+    private let config: AppScreenshotCaptureConfig
+    private let viewModel: RuntimeViewModel
+    private let renderer: MelixSwiftUIScreenshotRenderer
+    private let fileManager: FileManager
+    private let cases: [AppScreenshotCaptureCase]
+
+    public init(
+        config: AppScreenshotCaptureConfig,
+        viewModel: RuntimeViewModel? = nil,
+        renderer: MelixSwiftUIScreenshotRenderer = MelixSwiftUIScreenshotRenderer(),
+        fileManager: FileManager = .default,
+        cases: [AppScreenshotCaptureCase] = AppScreenshotCaptureCase.defaultCases
+    ) {
+        self.config = config
+        self.viewModel = viewModel ?? RuntimeViewModel(client: AppScreenshotCaptureControlPlaneClient())
+        self.renderer = renderer
+        self.fileManager = fileManager
+        self.cases = cases
+    }
+
+    public func run() async throws -> AppScreenshotCaptureManifest {
+        let outputDirectoryPath = config.outputDirectoryPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard outputDirectoryPath.isEmpty == false else {
+            throw AppScreenshotCaptureError.invalidOutputDirectory(config.outputDirectoryPath)
+        }
+        let outputRoot = URL(fileURLWithPath: outputDirectoryPath, isDirectory: true)
+        let screenshotRoot = outputRoot.appendingPathComponent("screenshots", isDirectory: true)
+        let manifestURL = outputRoot.appendingPathComponent("screenshot_manifest.json")
+        let size = CGSize(width: config.width, height: config.height)
+
+        try fileManager.createDirectory(at: screenshotRoot, withIntermediateDirectories: true)
+        await viewModel.start()
+
+        var entries: [AppScreenshotCaptureEntry] = []
+        for captureCase in cases {
+            apply(captureCase)
+            let screenshotURL = screenshotRoot.appendingPathComponent("\(captureCase.id).png")
+            let startedAt = Date()
+            do {
+                switch captureCase {
+                case .commandCenter:
+                    try renderer.render(
+                        DesktopCommandCenterView(viewModel: viewModel),
+                        to: screenshotURL,
+                        size: size
+                    )
+                case .workspace, .toolSection:
+                    try renderer.render(
+                        DesktopFoundationRootView(viewModel: viewModel),
+                        to: screenshotURL,
+                        size: size
+                    )
+                }
+            } catch {
+                throw AppScreenshotCaptureError.renderFailed(String(describing: error))
+            }
+
+            entries.append(
+                AppScreenshotCaptureEntry(
+                    id: captureCase.id,
+                    kind: captureCase.kind,
+                    surface: captureCase.surface?.rawValue ?? "",
+                    toolSection: captureCase.toolSection?.rawValue ?? "",
+                    path: screenshotURL.path,
+                    renderMs: round(Date().timeIntervalSince(startedAt) * 1_000_000) / 1_000
+                )
+            )
+        }
+
+        let manifest = AppScreenshotCaptureManifest(
+            schemaVersion: appScreenshotCaptureSchemaVersion,
+            manifestPath: manifestURL.path,
+            appPath: config.appPath,
+            outputDirectoryPath: outputRoot.path,
+            screenshotRoot: screenshotRoot.path,
+            width: config.width,
+            height: config.height,
+            screenshots: entries
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        try encoder.encode(manifest).write(to: manifestURL)
+        return manifest
+    }
+
+    private func apply(_ captureCase: AppScreenshotCaptureCase) {
+        switch captureCase {
+        case .workspace(let surface):
+            viewModel.selectedSurface = surface
+            if surface == .tools {
+                viewModel.selectedToolSection = .modelsLibrary
+            }
+        case .toolSection(let section):
+            viewModel.selectedSurface = .tools
+            viewModel.selectedToolSection = section
+        case .commandCenter:
+            break
+        }
+    }
+}
+
+actor AppScreenshotCaptureControlPlaneClient: ControlPlaneXPCClient {
+    private let snapshot: Melix_Controlplane_V1_ServerSnapshot
+
+    init() {
+        self.snapshot = Self.makeSnapshot()
+    }
+
+    func handshake() async throws -> Melix_Controlplane_V1_HandshakeResponse {
+        var response = Melix_Controlplane_V1_HandshakeResponse()
+        response.protocolVersion = "melix.controlplane.v1"
+        response.serverVersion = "0.1.0"
+        response.daemonInstanceID = "screenshot-daemon"
+        response.features = ["xpc", "models", "metrics", "cache-metadata", "image-jobs"]
+        response.snapshot = snapshot
+        return response
+    }
+
+    func subscribe(lastSeenSeq: UInt64) async -> AsyncStream<Melix_Controlplane_V1_ControlPlaneEvent> {
+        _ = lastSeenSeq
+        return AsyncStream { continuation in
+            continuation.finish()
+        }
+    }
+
+    func startChat(_ request: ControlPlaneChatRequest) async throws -> ControlPlaneChatExecution {
+        _ = request
+        throw unimplemented("chat")
+    }
+
+    func serverSnapshot() async throws -> Melix_Controlplane_V1_ServerSnapshot {
+        snapshot
+    }
+
+    func loadModel(modelID: String) async throws -> Melix_Controlplane_V1_ModelSummary {
+        _ = modelID
+        return snapshot.models.first(where: { $0.modelID == modelID }) ?? Self.makeModelSummary(
+            modelID: "melix-dev-text",
+            kind: "text",
+            features: ["chat"],
+            state: .modelWarm
+        )
+    }
+
+    func unloadModel(modelID: String) async throws -> Melix_Controlplane_V1_ModelSummary {
+        try await loadModel(modelID: modelID)
+    }
+
+    func updateModelSettings(
+        modelID: String,
+        values: [String: String]
+    ) async throws -> Melix_Controlplane_V1_ModelSummary {
+        _ = values
+        return try await loadModel(modelID: modelID)
+    }
+
+    func modelInfo(modelID: String) async throws -> Melix_Controlplane_V1_ModelInfo {
+        _ = modelID
+        var info = Melix_Controlplane_V1_ModelInfo()
+        info.ok = true
+        info.modelKind = "text"
+        info.maxContext = 8192
+        info.supportedModalities = ["text"]
+        info.supportedParsers = ["text", "json"]
+        return info
+    }
+
+    func runModelOperation(
+        modelID: String,
+        operation: String,
+        outputDir: String,
+        quantProfileID: String,
+        weightQuant: String,
+        kvQuant: String,
+        ext: [String: String]
+    ) async throws -> Melix_Controlplane_V1_ModelOperationResult {
+        _ = modelID
+        _ = operation
+        _ = outputDir
+        _ = quantProfileID
+        _ = weightQuant
+        _ = kvQuant
+        _ = ext
+        throw unimplemented("model operation")
+    }
+
+    private func unimplemented(_ operation: String) -> Error {
+        ControlPlaneXPCClientError.requestFailed(
+            code: "screenshot_capture_fixture",
+            message: "App screenshot capture fixture does not execute \(operation)."
+        )
+    }
+
+    private static func makeSnapshot() -> Melix_Controlplane_V1_ServerSnapshot {
+        var snapshot = Melix_Controlplane_V1_ServerSnapshot()
+        snapshot.serverState = .serverReady
+        snapshot.models = [
+            makeModelSummary(
+                modelID: "melix-dev-text",
+                kind: "text",
+                features: ["chat", "responses", "evaluation"],
+                state: .modelWarm
+            ),
+            makeModelSummary(
+                modelID: "melix-dev-image",
+                kind: "image",
+                features: ["image-generation", "image-edit"],
+                state: .modelDiscovered
+            ),
+        ]
+        snapshot.queues = makeQueueSummary()
+        snapshot.cache = makeCacheSummary()
+        snapshot.metrics = makeMetricsSummary()
+        snapshot.runtimeSessions = [makeRuntimeSession()]
+        return snapshot
+    }
+
+    private static func makeModelSummary(
+        modelID: String,
+        kind: String,
+        features: [String],
+        state: Melix_Controlplane_V1_ModelState
+    ) -> Melix_Controlplane_V1_ModelSummary {
+        var settings = Melix_Controlplane_V1_ModelSettings()
+        settings.alias = modelID == "melix-dev-text" ? "Melix Text" : "Melix Image"
+        settings.memoryPolicy = .memoryResidencyEvictable
+        settings.defaultAccelerationMode = .baseline
+
+        var model = Melix_Controlplane_V1_ModelSummary()
+        model.modelID = modelID
+        model.kind = kind
+        model.features = features
+        model.maxContext = 8192
+        model.state = state
+        model.settings = settings
+        return model
+    }
+
+    private static func makeQueueSummary() -> Melix_Controlplane_V1_QueueSummary {
+        var queue = Melix_Controlplane_V1_QueueSummary()
+        queue.activeRequests = 1
+        queue.queuedRequests = 1
+        queue.backpressure = 0.12
+
+        var decode = Melix_Controlplane_V1_QueueLaneSummary()
+        decode.laneID = "text.decode.interactive"
+        decode.laneClass = "interactive-decode"
+        decode.activeRequests = 1
+        decode.priorityScore = 100
+
+        var prefill = Melix_Controlplane_V1_QueueLaneSummary()
+        prefill.laneID = "text.prefill.hot"
+        prefill.laneClass = "hot-prefill"
+        prefill.queuedRequests = 1
+        prefill.priorityScore = 120
+
+        queue.lanes = [decode, prefill]
+        return queue
+    }
+
+    private static func makeCacheSummary() -> Melix_Controlplane_V1_CacheSummary {
+        var cache = Melix_Controlplane_V1_CacheSummary()
+        cache.l1Bytes = 16 * 1024 * 1024
+        cache.l2Bytes = 64 * 1024 * 1024
+        cache.l1HitRate = 0.72
+        cache.l2HitRate = 0.35
+        cache.activeMode = .tiered
+        cache.cacheRoot = "/tmp/melix-cache"
+        cache.supportedModes = [.tiered, .rotating, .hybrid]
+        return cache
+    }
+
+    private static func makeMetricsSummary() -> Melix_Controlplane_V1_MetricsSummary {
+        var metrics = Melix_Controlplane_V1_MetricsSummary()
+        metrics.values = [
+            "http.translation_ms": 2.4,
+            "http.stream_first_event_ms": 18.8,
+            "requests.inflight": 1,
+        ]
+        return metrics
+    }
+
+    private static func makeRuntimeSession() -> Melix_Controlplane_V1_ServerSessionRuntimeState {
+        var runtimeSession = Melix_Controlplane_V1_ServerSessionRuntimeState()
+        runtimeSession.serverSessionID = "screenshot-local-server"
+        runtimeSession.lifecycleState = .ready
+        runtimeSession.powerState = .active
+        runtimeSession.wakeReason = .initialBoot
+        runtimeSession.updatedAtUnixMs = 1_717_171_717
+        return runtimeSession
+    }
+}

--- a/apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift
+++ b/apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift
@@ -129,7 +129,7 @@ public enum AppScreenshotCaptureCase: Equatable, Sendable {
             if allowed.contains(scalar) {
                 result.unicodeScalars.append(scalar)
                 previousWasSeparator = false
-            } else if previousWasSeparator == false {
+            } else if !previousWasSeparator {
                 result.append("-")
                 previousWasSeparator = true
             }
@@ -182,7 +182,7 @@ public final class AppScreenshotCaptureRunner {
 
     public func run() async throws -> AppScreenshotCaptureManifest {
         let outputDirectoryPath = config.outputDirectoryPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard outputDirectoryPath.isEmpty == false else {
+        guard !outputDirectoryPath.isEmpty else {
             throw AppScreenshotCaptureError.invalidOutputDirectory(config.outputDirectoryPath)
         }
         let outputRoot = URL(fileURLWithPath: outputDirectoryPath, isDirectory: true)
@@ -224,7 +224,7 @@ public final class AppScreenshotCaptureRunner {
                     surface: captureCase.surface?.rawValue ?? "",
                     toolSection: captureCase.toolSection?.rawValue ?? "",
                     path: screenshotURL.path,
-                    renderMs: round(Date().timeIntervalSince(startedAt) * 1_000_000) / 1_000
+                    renderMs: (Date().timeIntervalSince(startedAt) * 1_000_000).rounded() / 1_000
                 )
             )
         }
@@ -306,6 +306,7 @@ actor AppScreenshotCaptureControlPlaneClient: ControlPlaneXPCClient {
     }
 
     func unloadModel(modelID: String) async throws -> Melix_Controlplane_V1_ModelSummary {
+        // Fixture: treat unload as a no-op and return the model's current state.
         try await loadModel(modelID: modelID)
     }
 

--- a/apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift
+++ b/apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift
@@ -262,6 +262,9 @@ public final class AppScreenshotCaptureRunner {
     }
 }
 
+// Capture-only fixture client. The screenshot runner drives it from the main actor,
+// but the actor still owns ControlPlaneXPCClient serialization; revisit this boundary
+// before reusing the fixture outside deterministic off-screen capture.
 actor AppScreenshotCaptureControlPlaneClient: ControlPlaneXPCClient {
     private let snapshot: Melix_Controlplane_V1_ServerSnapshot
 

--- a/apps/macos-menubar/Sources/AppMain/Acceptance/MelixSwiftUIScreenshotRenderer.swift
+++ b/apps/macos-menubar/Sources/AppMain/Acceptance/MelixSwiftUIScreenshotRenderer.swift
@@ -24,6 +24,8 @@ public struct MelixSwiftUIScreenshotRenderer {
         to outputURL: URL,
         size: CGSize
     ) throws {
+        // Render off-window for deterministic CI captures; views that require a live
+        // window, safe-area insets, or dynamic geometry need a dedicated renderer path.
         let hostingView = NSHostingView(
             rootView: rootView
                 .frame(width: size.width, height: size.height)

--- a/apps/macos-menubar/Sources/AppMain/Acceptance/MelixSwiftUIScreenshotRenderer.swift
+++ b/apps/macos-menubar/Sources/AppMain/Acceptance/MelixSwiftUIScreenshotRenderer.swift
@@ -1,0 +1,49 @@
+import AppKit
+import SwiftUI
+
+public enum MelixSwiftUIScreenshotRenderError: Error, LocalizedError {
+    case bitmapAllocationFailed
+    case pngEncodingFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .bitmapAllocationFailed:
+            return "NSHostingView could not allocate a bitmap snapshot."
+        case .pngEncodingFailed:
+            return "Bitmap snapshot could not be encoded as PNG."
+        }
+    }
+}
+
+@MainActor
+public struct MelixSwiftUIScreenshotRenderer {
+    public init() {}
+
+    public func render<Content: View>(
+        _ rootView: Content,
+        to outputURL: URL,
+        size: CGSize
+    ) throws {
+        let hostingView = NSHostingView(
+            rootView: rootView
+                .frame(width: size.width, height: size.height)
+        )
+        hostingView.frame = CGRect(origin: .zero, size: size)
+        hostingView.layoutSubtreeIfNeeded()
+
+        guard let bitmap = hostingView.bitmapImageRepForCachingDisplay(in: hostingView.bounds) else {
+            throw MelixSwiftUIScreenshotRenderError.bitmapAllocationFailed
+        }
+        bitmap.size = size
+        hostingView.cacheDisplay(in: hostingView.bounds, to: bitmap)
+
+        guard let data = bitmap.representation(using: .png, properties: [:]) else {
+            throw MelixSwiftUIScreenshotRenderError.pngEncodingFailed
+        }
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: outputURL)
+    }
+}

--- a/apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift
+++ b/apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift
@@ -475,32 +475,16 @@ public protocol Phase8WindowUIRendering: Sendable {
 
 @MainActor
 public struct LivePhase8WindowUIRenderer: Phase8WindowUIRendering {
+    private let renderer = MelixSwiftUIScreenshotRenderer()
+
     public init() {}
 
     public func render(viewModel: RuntimeViewModel, to outputURL: URL, size: CGSize) throws {
-        let hostingView = NSHostingView(
-            rootView: DesktopFoundationRootView(viewModel: viewModel)
-                .frame(width: size.width, height: size.height)
-        )
-        hostingView.frame = CGRect(origin: .zero, size: size)
-        hostingView.layoutSubtreeIfNeeded()
-
-        guard let bitmap = hostingView.bitmapImageRepForCachingDisplay(in: hostingView.bounds) else {
-            throw Phase8WindowUIAcceptanceError.screenshotRenderFailed(
-                "NSHostingView could not allocate a bitmap snapshot."
-            )
+        do {
+            try renderer.render(DesktopFoundationRootView(viewModel: viewModel), to: outputURL, size: size)
+        } catch {
+            throw Phase8WindowUIAcceptanceError.screenshotRenderFailed(String(describing: error))
         }
-        bitmap.size = size
-        hostingView.cacheDisplay(in: hostingView.bounds, to: bitmap)
-
-        guard let data = bitmap.representation(using: .png, properties: [:]) else {
-            throw Phase8WindowUIAcceptanceError.screenshotRenderFailed("Bitmap snapshot could not be encoded as PNG.")
-        }
-        try FileManager.default.createDirectory(
-            at: outputURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-        try data.write(to: outputURL)
     }
 }
 

--- a/apps/macos-menubar/Sources/AppMain/AppMain.swift
+++ b/apps/macos-menubar/Sources/AppMain/AppMain.swift
@@ -896,7 +896,7 @@ enum MelixMenuBarApp {
             encoder.keyEncodingStrategy = .convertToSnakeCase
             let data = try encoder.encode(result)
             writeStandardOutput(data)
-            writeStandardOutput(Data([0x0A]))
+            writeStandardOutput(Data("\n".utf8))
             return 0
         } catch {
             let message = error.localizedDescription + "\n"
@@ -919,7 +919,7 @@ enum MelixMenuBarApp {
             encoder.keyEncodingStrategy = .convertToSnakeCase
             let data = try encoder.encode(result)
             writeStandardOutput(data)
-            writeStandardOutput(Data([0x0A]))
+            writeStandardOutput(Data("\n".utf8))
             return 0
         } catch {
             let message = error.localizedDescription + "\n"

--- a/apps/macos-menubar/Sources/AppMain/AppMain.swift
+++ b/apps/macos-menubar/Sources/AppMain/AppMain.swift
@@ -108,6 +108,13 @@ protocol Phase8WindowUIAcceptanceRunning {
 extension Phase8WindowUIAcceptanceRunner: Phase8WindowUIAcceptanceRunning {}
 
 @MainActor
+protocol AppScreenshotCaptureRunning {
+    func run() async throws -> AppScreenshotCaptureManifest
+}
+
+extension AppScreenshotCaptureRunner: AppScreenshotCaptureRunning {}
+
+@MainActor
 public final class MenuBarTerminationCoordinator: NSObject {
     private let mode: MenuBarTerminationMode
     private let repoRoot: String
@@ -799,8 +806,13 @@ enum MelixMenuBarApp {
     static func main(
         environment: [String: String],
         launchLiveHandler: @escaping @MainActor () -> Void = defaultMainLaunchLiveHandler,
-        phase8WindowUIAcceptanceHandler: @escaping @MainActor ([String: String]) -> Void = defaultMainPhase8WindowUIAcceptanceHandler
+        phase8WindowUIAcceptanceHandler: @escaping @MainActor ([String: String]) -> Void = defaultMainPhase8WindowUIAcceptanceHandler,
+        appScreenshotCaptureHandler: @escaping @MainActor ([String: String]) -> Void = defaultMainAppScreenshotCaptureHandler
     ) {
+        if environment["MELIX_APP_SCREENSHOT_CAPTURE"] == "1" {
+            appScreenshotCaptureHandler(environment)
+            return
+        }
         if environment["MELIX_PHASE8_WINDOW_UI_ACCEPTANCE"] == "1" {
             phase8WindowUIAcceptanceHandler(environment)
             return
@@ -839,6 +851,32 @@ enum MelixMenuBarApp {
         runLoopRunner()
     }
 
+    static func runAppScreenshotCapture(
+        environment: [String: String],
+        application: any MenuBarApplicationLifecycle = LiveMenuBarApplication(),
+        runnerFactory: @escaping @MainActor ([String: String]) throws -> any AppScreenshotCaptureRunning = makeAppScreenshotCaptureRunner,
+        writeStandardOutput: @escaping @MainActor (Data) -> Void = writeAppScreenshotCaptureStandardOutput,
+        writeStandardError: @escaping @MainActor (Data) -> Void = writeAppScreenshotCaptureStandardError,
+        flushHandler: @escaping @MainActor () -> Void = flushAppScreenshotCaptureIO,
+        exitHandler: @escaping @MainActor (Int32) -> Void = exitAppScreenshotCapture,
+        operationScheduler: @escaping @MainActor (@escaping @MainActor @Sendable () async -> Void) -> Void = scheduleAppScreenshotCaptureOperation,
+        runLoopRunner: @escaping @MainActor () -> Void = runAppScreenshotCaptureLoop
+    ) {
+        application.setActivationPolicy(.accessory)
+        operationScheduler {
+            let exitCode = await executeAppScreenshotCapture(
+                environment: environment,
+                runnerFactory: runnerFactory,
+                writeStandardOutput: writeStandardOutput,
+                writeStandardError: writeStandardError
+            )
+            flushHandler()
+            exitHandler(exitCode)
+        }
+
+        runLoopRunner()
+    }
+
     static func executePhase8WindowUIAcceptance(
         environment: [String: String],
         bootstrapFactory: @escaping @MainActor ([String: String]) -> MelixMenuBarBootstrap = makePhase8WindowUIAcceptanceBootstrap,
@@ -867,10 +905,37 @@ enum MelixMenuBarApp {
         }
     }
 
+    static func executeAppScreenshotCapture(
+        environment: [String: String],
+        runnerFactory: @escaping @MainActor ([String: String]) throws -> any AppScreenshotCaptureRunning = makeAppScreenshotCaptureRunner,
+        writeStandardOutput: @escaping @MainActor (Data) -> Void = writeAppScreenshotCaptureStandardOutput,
+        writeStandardError: @escaping @MainActor (Data) -> Void = writeAppScreenshotCaptureStandardError
+    ) async -> Int32 {
+        do {
+            let runner = try runnerFactory(environment)
+            let result = try await runner.run()
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            encoder.keyEncodingStrategy = .convertToSnakeCase
+            let data = try encoder.encode(result)
+            writeStandardOutput(data)
+            writeStandardOutput(Data([0x0A]))
+            return 0
+        } catch {
+            let message = error.localizedDescription + "\n"
+            writeStandardError(Data(message.utf8))
+            return 1
+        }
+    }
+
     private static func defaultMainLaunchLiveHandler() { launchLive() }
 
     private static func defaultMainPhase8WindowUIAcceptanceHandler(environment: [String: String]) {
         runPhase8WindowUIAcceptance(environment: environment)
+    }
+
+    private static func defaultMainAppScreenshotCaptureHandler(environment: [String: String]) {
+        runAppScreenshotCapture(environment: environment)
     }
 
     private static func makePhase8WindowUIAcceptanceBootstrap(
@@ -918,4 +983,34 @@ enum MelixMenuBarApp {
             config: .init(environment: environment)
         )
     }
+
+    private static func makeAppScreenshotCaptureRunner(
+        environment: [String: String]
+    ) throws -> any AppScreenshotCaptureRunning {
+        AppScreenshotCaptureRunner(config: .init(environment: environment))
+    }
+
+    private static func writeAppScreenshotCaptureStandardOutput(_ data: Data) {
+        FileHandle.standardOutput.write(data)
+    }
+
+    private static func writeAppScreenshotCaptureStandardError(_ data: Data) {
+        FileHandle.standardError.write(data)
+    }
+
+    private static func flushAppScreenshotCaptureIO() {
+        fflush(nil)
+    }
+
+    private static func exitAppScreenshotCapture(_ exitCode: Int32) { Darwin.exit(exitCode) }
+
+    private static func scheduleAppScreenshotCaptureOperation(
+        _ operation: @escaping @MainActor @Sendable () async -> Void
+    ) {
+        Task { @MainActor in
+            await operation()
+        }
+    }
+
+    private static func runAppScreenshotCaptureLoop() { RunLoop.main.run() }
 }

--- a/apps/macos-menubar/Tests/MenuBarTests/AppMainBootstrapTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/AppMainBootstrapTests.swift
@@ -378,7 +378,7 @@ struct AppMainBootstrapTests {
         )
 
         try await waitForBootstrapCondition("expected app screenshot capture entrypoint to exit") {
-            recorder.exitCodes.isEmpty == false
+            !recorder.exitCodes.isEmpty
         }
 
         let standardOutput = String(decoding: recorder.standardOutput, as: UTF8.self)
@@ -472,6 +472,7 @@ struct AppMainBootstrapTests {
     @MainActor
     func appScreenshotCaptureEntrySupportsDefaultOutputFlushAndScheduling() async throws {
         let application = RecordingApplicationLifecycle()
+        var standardOutput = Data()
         var exitCodes: [Int32] = []
         var runLoopInvocationCount = 0
 
@@ -494,6 +495,10 @@ struct AppMainBootstrapTests {
                     )
                 )
             },
+            writeStandardOutput: { data in
+                standardOutput.append(data)
+            },
+            writeStandardError: { _ in },
             exitHandler: { exitCode in
                 exitCodes.append(exitCode)
             },
@@ -503,10 +508,11 @@ struct AppMainBootstrapTests {
         )
 
         try await waitForBootstrapCondition("expected default app screenshot capture scheduling to exit") {
-            exitCodes.isEmpty == false
+            !exitCodes.isEmpty
         }
 
         #expect(application.recordedPolicies == [.accessory])
+        #expect(!standardOutput.isEmpty)
         #expect(runLoopInvocationCount == 1)
         #expect(exitCodes == [0])
     }

--- a/apps/macos-menubar/Tests/MenuBarTests/AppMainBootstrapTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/AppMainBootstrapTests.swift
@@ -290,6 +290,227 @@ struct AppMainBootstrapTests {
         #expect(capturedAcceptanceEnvironment?["MELIX_PHASE8_WINDOW_UI_ACCEPTANCE"] == "1")
     }
 
+    @Test("main routes the app screenshot capture flag through the screenshot entrypoint")
+    @MainActor
+    func mainRoutesAppScreenshotCaptureFlag() {
+        var launchLiveCallCount = 0
+        var phase8CallCount = 0
+        var capturedScreenshotEnvironment: [String: String]?
+
+        MelixMenuBarApp.main(
+            environment: [
+                "MELIX_HOME": "/tmp/melix-home",
+                "MELIX_APP_SCREENSHOT_CAPTURE": "1",
+                "MELIX_PHASE8_WINDOW_UI_ACCEPTANCE": "1",
+            ],
+            launchLiveHandler: {
+                launchLiveCallCount += 1
+            },
+            phase8WindowUIAcceptanceHandler: { _ in
+                phase8CallCount += 1
+            },
+            appScreenshotCaptureHandler: { environment in
+                capturedScreenshotEnvironment = environment
+            }
+        )
+
+        #expect(launchLiveCallCount == 0)
+        #expect(phase8CallCount == 0)
+        #expect(capturedScreenshotEnvironment?["MELIX_HOME"] == "/tmp/melix-home")
+        #expect(capturedScreenshotEnvironment?["MELIX_APP_SCREENSHOT_CAPTURE"] == "1")
+    }
+
+    @Test("app screenshot capture entry writes snake_case json and exits zero")
+    @MainActor
+    func appScreenshotCaptureEntryWritesSnakeCaseJSONAndExitsZero() async throws {
+        let application = RecordingApplicationLifecycle()
+        let recorder = AppScreenshotCaptureMainRecorder()
+
+        MelixMenuBarApp.runAppScreenshotCapture(
+            environment: [
+                "MELIX_APP_SCREENSHOT_OUTPUT_DIR": "/tmp/melix-screenshots",
+            ],
+            application: application,
+            runnerFactory: { environment in
+                #expect(environment["MELIX_APP_SCREENSHOT_OUTPUT_DIR"] == "/tmp/melix-screenshots")
+                return SucceedingAppScreenshotCaptureMainRunner(
+                    result: AppScreenshotCaptureManifest(
+                        schemaVersion: "melix.app_screenshots.v1",
+                        manifestPath: "/tmp/melix-screenshots/screenshot_manifest.json",
+                        appPath: "/tmp/Melix.app",
+                        outputDirectoryPath: "/tmp/melix-screenshots",
+                        screenshotRoot: "/tmp/melix-screenshots/screenshots",
+                        width: 1440,
+                        height: 960,
+                        screenshots: [
+                            AppScreenshotCaptureEntry(
+                                id: "command-center",
+                                kind: "command_center",
+                                surface: "",
+                                toolSection: "",
+                                path: "/tmp/melix-screenshots/screenshots/command-center.png",
+                                renderMs: 12.5
+                            ),
+                        ]
+                    )
+                )
+            },
+            writeStandardOutput: { data in
+                recorder.standardOutput.append(data)
+            },
+            writeStandardError: { data in
+                recorder.standardError.append(data)
+            },
+            flushHandler: {
+                recorder.flushCount += 1
+            },
+            exitHandler: { exitCode in
+                recorder.exitCodes.append(exitCode)
+            },
+            operationScheduler: { operation in
+                Task { @MainActor in
+                    await operation()
+                }
+            },
+            runLoopRunner: {
+                recorder.runLoopInvocationCount += 1
+            }
+        )
+
+        try await waitForBootstrapCondition("expected app screenshot capture entrypoint to exit") {
+            recorder.exitCodes.isEmpty == false
+        }
+
+        let standardOutput = String(decoding: recorder.standardOutput, as: UTF8.self)
+        let outputJSON = try #require(
+            JSONSerialization.jsonObject(with: recorder.standardOutput) as? [String: Any]
+        )
+        let screenshots = try #require(outputJSON["screenshots"] as? [[String: Any]])
+
+        #expect(application.recordedPolicies == [.accessory])
+        #expect(recorder.runLoopInvocationCount == 1)
+        #expect(recorder.flushCount == 1)
+        #expect(recorder.exitCodes == [0])
+        #expect(recorder.standardError.isEmpty)
+        #expect(standardOutput.hasSuffix("\n"))
+        #expect(outputJSON["schema_version"] as? String == "melix.app_screenshots.v1")
+        #expect(outputJSON["screenshot_root"] as? String == "/tmp/melix-screenshots/screenshots")
+        #expect(screenshots.first?["id"] as? String == "command-center")
+    }
+
+    @Test("app screenshot capture execution writes localized stderr on runner failures")
+    @MainActor
+    func appScreenshotCaptureExecutionWritesLocalizedStderrOnRunnerFailures() async {
+        var standardOutput = Data()
+        var standardError = Data()
+
+        let exitCode = await MelixMenuBarApp.executeAppScreenshotCapture(
+            environment: [
+                "MELIX_APP_SCREENSHOT_OUTPUT_DIR": "",
+            ],
+            runnerFactory: { _ in
+                FailingAppScreenshotCaptureMainRunner(
+                    error: AppScreenshotCaptureError.invalidOutputDirectory("")
+                )
+            },
+            writeStandardOutput: { data in
+                standardOutput.append(data)
+            },
+            writeStandardError: { data in
+                standardError.append(data)
+            }
+        )
+
+        #expect(exitCode == 1)
+        #expect(standardOutput.isEmpty)
+        #expect(String(decoding: standardError, as: UTF8.self) == "Invalid app screenshot output directory: \n")
+    }
+
+    @Test("app screenshot capture execution supports the default runner factory path")
+    @MainActor
+    func appScreenshotCaptureExecutionSupportsDefaultRunnerFactoryPath() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("app-screenshot-main-runner-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        var standardOutput = Data()
+        var standardError = Data()
+
+        let exitCode = await MelixMenuBarApp.executeAppScreenshotCapture(
+            environment: [
+                "MELIX_APP_SCREENSHOT_OUTPUT_DIR": tempRoot.path,
+                "MELIX_APP_SCREENSHOT_APP_PATH": "/tmp/Melix.app",
+                "MELIX_APP_SCREENSHOT_WIDTH": "360",
+                "MELIX_APP_SCREENSHOT_HEIGHT": "240",
+            ],
+            writeStandardOutput: { data in
+                standardOutput.append(data)
+            },
+            writeStandardError: { data in
+                standardError.append(data)
+            }
+        )
+
+        let outputJSON = try #require(
+            JSONSerialization.jsonObject(with: standardOutput) as? [String: Any]
+        )
+        let screenshots = try #require(outputJSON["screenshots"] as? [[String: Any]])
+
+        #expect(exitCode == 0)
+        #expect(standardError.isEmpty)
+        #expect(outputJSON["app_path"] as? String == "/tmp/Melix.app")
+        #expect(outputJSON["width"] as? Int == 360)
+        #expect(outputJSON["height"] as? Int == 240)
+        #expect(screenshots.count == 12)
+        #expect(fileManager.fileExists(atPath: tempRoot.appendingPathComponent("screenshot_manifest.json").path))
+        #expect(fileManager.fileExists(atPath: tempRoot.appendingPathComponent("screenshots/command-center.png").path))
+    }
+
+    @Test("app screenshot capture entry supports default output flushing and scheduling")
+    @MainActor
+    func appScreenshotCaptureEntrySupportsDefaultOutputFlushAndScheduling() async throws {
+        let application = RecordingApplicationLifecycle()
+        var exitCodes: [Int32] = []
+        var runLoopInvocationCount = 0
+
+        MelixMenuBarApp.runAppScreenshotCapture(
+            environment: [
+                "MELIX_APP_SCREENSHOT_OUTPUT_DIR": "/tmp/melix-screenshots",
+            ],
+            application: application,
+            runnerFactory: { _ in
+                SucceedingAppScreenshotCaptureMainRunner(
+                    result: AppScreenshotCaptureManifest(
+                        schemaVersion: "melix.app_screenshots.v1",
+                        manifestPath: "/tmp/melix-screenshots/screenshot_manifest.json",
+                        appPath: "/tmp/Melix.app",
+                        outputDirectoryPath: "/tmp/melix-screenshots",
+                        screenshotRoot: "/tmp/melix-screenshots/screenshots",
+                        width: 320,
+                        height: 200,
+                        screenshots: []
+                    )
+                )
+            },
+            exitHandler: { exitCode in
+                exitCodes.append(exitCode)
+            },
+            runLoopRunner: {
+                runLoopInvocationCount += 1
+            }
+        )
+
+        try await waitForBootstrapCondition("expected default app screenshot capture scheduling to exit") {
+            exitCodes.isEmpty == false
+        }
+
+        #expect(application.recordedPolicies == [.accessory])
+        #expect(runLoopInvocationCount == 1)
+        #expect(exitCodes == [0])
+    }
+
     @Test("main routes non-acceptance launches through the live path")
     @MainActor
     func mainRoutesDefaultLaunchPath() {
@@ -1207,6 +1428,33 @@ private struct SucceedingPhase8WindowUIAcceptanceMainRunner: Phase8WindowUIAccep
 
     func run() async throws -> Phase8WindowUIAcceptanceResult {
         result
+    }
+}
+
+@MainActor
+private final class AppScreenshotCaptureMainRecorder {
+    var standardOutput = Data()
+    var standardError = Data()
+    var flushCount = 0
+    var exitCodes: [Int32] = []
+    var runLoopInvocationCount = 0
+}
+
+@MainActor
+private struct SucceedingAppScreenshotCaptureMainRunner: AppScreenshotCaptureRunning {
+    let result: AppScreenshotCaptureManifest
+
+    func run() async throws -> AppScreenshotCaptureManifest {
+        result
+    }
+}
+
+@MainActor
+private struct FailingAppScreenshotCaptureMainRunner: AppScreenshotCaptureRunning {
+    let error: Error
+
+    func run() async throws -> AppScreenshotCaptureManifest {
+        throw error
     }
 }
 

--- a/apps/macos-menubar/Tests/MenuBarTests/AppScreenshotCaptureTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/AppScreenshotCaptureTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import MelixControlPlaneCore
+import Testing
+
+@testable import AppMain
+
+@Suite("App Screenshot Capture", .serialized)
+struct AppScreenshotCaptureTests {
+    @Test("default cases cover all workspace surfaces, tool sections, and command center")
+    func defaultCasesCoverAllAppSurfaces() {
+        let cases = AppScreenshotCaptureCase.defaultCases
+        let workspaceSurfaces = cases.compactMap { captureCase -> String? in
+            guard case .workspace(let surface) = captureCase else {
+                return nil
+            }
+            return surface.rawValue
+        }
+        let toolSections = cases.compactMap { captureCase -> String? in
+            guard case .toolSection(let section) = captureCase else {
+                return nil
+            }
+            return section.rawValue
+        }
+        let commandCenterCount = cases.filter {
+            if case .commandCenter = $0 {
+                return true
+            }
+            return false
+        }.count
+
+        #expect(workspaceSurfaces.sorted() == DesktopSurface.allCases.map(\.rawValue).sorted())
+        #expect(toolSections.sorted() == DesktopToolSection.allCases.map(\.rawValue).sorted())
+        #expect(commandCenterCount == 1)
+    }
+
+    @Test("config environment normalizes overrides and falls back to deterministic defaults")
+    func configEnvironmentNormalizesOverridesAndDefaults() {
+        let configured = AppScreenshotCaptureConfig(environment: [
+            "MELIX_APP_SCREENSHOT_OUTPUT_DIR": " /tmp/melix-screenshots \n",
+            "MELIX_APP_SCREENSHOT_APP_PATH": " /tmp/Melix.app ",
+            "MELIX_APP_SCREENSHOT_WIDTH": "1280",
+            "MELIX_APP_SCREENSHOT_HEIGHT": "720",
+        ])
+        let fallback = AppScreenshotCaptureConfig(environment: [
+            "MELIX_APP_SCREENSHOT_OUTPUT_DIR": " \n",
+            "MELIX_APP_SCREENSHOT_WIDTH": "0",
+            "MELIX_APP_SCREENSHOT_HEIGHT": "invalid",
+        ])
+
+        #expect(configured.outputDirectoryPath == "/tmp/melix-screenshots")
+        #expect(configured.appPath == "/tmp/Melix.app")
+        #expect(configured.width == 1280)
+        #expect(configured.height == 720)
+        #expect(fallback.outputDirectoryPath.contains("melix-app-screenshots-"))
+        #expect(fallback.appPath == "")
+        #expect(fallback.width == 1440)
+        #expect(fallback.height == 960)
+    }
+
+    @Test("capture and render errors expose localized descriptions")
+    func captureAndRenderErrorsExposeLocalizedDescriptions() throws {
+        let outputDirectoryError = AppScreenshotCaptureError.invalidOutputDirectory("")
+        let renderFailureError = AppScreenshotCaptureError.renderFailed("bitmap unavailable")
+        let bitmapError = MelixSwiftUIScreenshotRenderError.bitmapAllocationFailed
+        let pngError = MelixSwiftUIScreenshotRenderError.pngEncodingFailed
+
+        #expect(outputDirectoryError.localizedDescription == "Invalid app screenshot output directory: ")
+        #expect(renderFailureError.localizedDescription == "App screenshot capture failed: bitmap unavailable")
+        #expect(bitmapError.localizedDescription == "NSHostingView could not allocate a bitmap snapshot.")
+        #expect(pngError.localizedDescription == "Bitmap snapshot could not be encoded as PNG.")
+    }
+
+    @Test("runner writes manifest and png screenshots")
+    @MainActor
+    func runnerWritesManifestAndPNGScreenshots() async throws {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-app-screenshot-tests-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: outputURL)
+        }
+
+        let runner = AppScreenshotCaptureRunner(
+            config: AppScreenshotCaptureConfig(
+                outputDirectoryPath: outputURL.path,
+                appPath: "/tmp/Melix.app",
+                width: 640,
+                height: 420
+            ),
+            cases: [.workspace(.tools), .toolSection(.downloads), .commandCenter]
+        )
+
+        let manifest = try await runner.run()
+        let manifestURL = URL(fileURLWithPath: manifest.manifestPath)
+        let firstScreenshot = try #require(manifest.screenshots.first)
+        let screenshot = try #require(manifest.screenshots.last)
+        let screenshotURL = URL(fileURLWithPath: screenshot.path)
+        let screenshotData = try Data(contentsOf: screenshotURL)
+        let manifestJSON = try #require(
+            JSONSerialization.jsonObject(with: Data(contentsOf: manifestURL)) as? [String: Any]
+        )
+
+        #expect(manifest.schemaVersion == "melix.app_screenshots.v1")
+        #expect(manifest.appPath == "/tmp/Melix.app")
+        #expect(manifest.width == 640)
+        #expect(manifest.height == 420)
+        #expect(manifest.screenshots.map(\.id) == [
+            "workspace-tools",
+            "workspace-tools-downloads",
+            "command-center",
+        ])
+        #expect(firstScreenshot.surface == "Tools")
+        #expect(firstScreenshot.toolSection == "")
+        #expect(screenshot.id == "command-center")
+        #expect(screenshot.surface == "")
+        #expect(screenshotURL.path.hasSuffix("command-center.png"))
+        #expect(Array(screenshotData.prefix(8)) == [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+        #expect(manifestJSON["schema_version"] as? String == "melix.app_screenshots.v1")
+        #expect(manifestJSON["screenshot_root"] as? String == manifest.screenshotRoot)
+    }
+
+    @Test("runner rejects an empty output directory before writing artifacts")
+    @MainActor
+    func runnerRejectsEmptyOutputDirectory() async {
+        let runner = AppScreenshotCaptureRunner(
+            config: AppScreenshotCaptureConfig(outputDirectoryPath: ""),
+            cases: [.workspace(.chat)]
+        )
+
+        await #expect(throws: AppScreenshotCaptureError.self) {
+            try await runner.run()
+        }
+    }
+
+    @Test("screenshot fixture client provides deterministic app data")
+    @MainActor
+    func screenshotFixtureClientProvidesDeterministicAppData() async throws {
+        let client = AppScreenshotCaptureControlPlaneClient()
+        let handshake = try await client.handshake()
+        let stream = await client.subscribe(lastSeenSeq: 42)
+        var iterator = stream.makeAsyncIterator()
+        let firstEvent = await iterator.next()
+        let snapshot = try await client.serverSnapshot()
+        let fallbackModel = try await client.loadModel(modelID: "missing-model")
+        let unloadedModel = try await client.unloadModel(modelID: "melix-dev-text")
+        let updatedModel = try await client.updateModelSettings(modelID: "melix-dev-text", values: ["alias": "Text"])
+        let modelInfo = try await client.modelInfo(modelID: "melix-dev-text")
+
+        #expect(handshake.protocolVersion == "melix.controlplane.v1")
+        #expect(handshake.daemonInstanceID == "screenshot-daemon")
+        #expect(firstEvent == nil)
+        #expect(snapshot.models.map(\.modelID) == ["melix-dev-text", "melix-dev-image"])
+        #expect(fallbackModel.modelID == "melix-dev-text")
+        #expect(unloadedModel.modelID == "melix-dev-text")
+        #expect(updatedModel.modelID == "melix-dev-text")
+        #expect(modelInfo.ok)
+        #expect(modelInfo.supportedModalities == ["text"])
+
+        await #expect(throws: ControlPlaneXPCClientError.self) {
+            try await client.startChat(
+                ControlPlaneChatRequest(
+                    modelID: "melix-dev-text",
+                    messages: [.init(role: "user", content: "hello")]
+                )
+            )
+        }
+        await #expect(throws: ControlPlaneXPCClientError.self) {
+            try await client.runModelOperation(
+                modelID: "melix-dev-text",
+                operation: "quantize",
+                outputDir: "/tmp/model",
+                quantProfileID: "q4",
+                weightQuant: "q4",
+                kvQuant: "q4",
+                ext: [:]
+            )
+        }
+    }
+
+    @Test("live phase 8 renderer writes a png through the shared SwiftUI renderer")
+    @MainActor
+    func livePhase8RendererWritesPNGThroughSharedRenderer() async throws {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-phase8-renderer-\(UUID().uuidString)")
+            .appendingPathComponent("workspace.png")
+        defer {
+            try? FileManager.default.removeItem(at: outputURL.deletingLastPathComponent().deletingLastPathComponent())
+        }
+        let viewModel = RuntimeViewModel(client: AppScreenshotCaptureControlPlaneClient())
+        await viewModel.start()
+
+        try LivePhase8WindowUIRenderer().render(
+            viewModel: viewModel,
+            to: outputURL,
+            size: CGSize(width: 360, height: 240)
+        )
+
+        let data = try Data(contentsOf: outputURL)
+        #expect(Array(data.prefix(8)) == [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+    }
+}

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -6107,6 +6107,29 @@ struct Phase8WindowUIAcceptanceRunnerTests {
         #expect(failedCaseGate.cliCaseStatus == "failed")
     }
 
+    @Test("phase 8 fixture export response surfaces write failures")
+    func phase8FixtureExportResponseSurfacesWriteFailures() {
+        let command = MelixCLICommand.benchExportCSV(
+            .init(jobID: "bench-newer", outputPath: "/dev/null/bench.csv", json: true)
+        )
+
+        let result = makePhase8FixtureExportResponse(
+            command: command,
+            jobID: "bench-newer",
+            outputPath: "/dev/null/bench.csv",
+            rowCount: 1,
+            contents: "metric,value\nbench,1\n"
+        )
+
+        switch result {
+        case .success(let output):
+            Issue.record("expected fixture export write failure, got \(output)")
+        case .failure(let error):
+            #expect(error.failureKind == .processFailed)
+            #expect(error.errorDescription?.contains("Failed to write fixture export") == true)
+        }
+    }
+
     @Test("phase 8 window ui acceptance runner writes a screenshot and evidence bundle")
     @MainActor
     func phase8WindowUIAcceptanceRunnerWritesEvidenceBundle() async throws {
@@ -6217,58 +6240,52 @@ struct Phase8WindowUIAcceptanceRunnerTests {
             case .evalRun:
                 return .success(makeCLIEvaluationRunJSON(jobID: "eval-newer"))
             case .benchExportCSV(let options):
-                try? Data("metric,value\nbench,1\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "metric,value\nbench,1\n"
                 )
             case .benchMatrixExportSummaryCSV(let options):
-                try? Data("suite,ttft_ms\nsmoke,21.1\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "suite,ttft_ms\nsmoke,21.1\n"
                 )
             case .benchMatrixExportRequestsCSV(let options):
-                try? Data("request,latency_ms\n0,28.7\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "request,latency_ms\n0,28.7\n"
                 )
             case .evalExportSummaryCSV(let options):
-                try? Data("{\"ok\":true}\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "{\"ok\":true}\n"
                 )
             case .evalExportSamplesCSV(let options):
-                try? Data("{\"ok\":true}\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "{\"ok\":true}\n"
                 )
             case .evalExportSamplesJSONL(let options):
-                try? Data("{\"ok\":true}\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "{\"ok\":true}\n"
                 )
             default:
                 return .failure(.unsupportedCommand(commandID: command.workflowCommandID, surface: .subprocess))
@@ -6568,58 +6585,52 @@ struct Phase8WindowUIAcceptanceRunnerTests {
             case .evalRun:
                 return .success(makeCLIEvaluationRunJSON(jobID: "eval-newer"))
             case .benchExportCSV(let options):
-                try? Data("metric,value\nbench,1\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "metric,value\nbench,1\n"
                 )
             case .benchMatrixExportSummaryCSV(let options):
-                try? Data("suite,ttft_ms\nsmoke,21.1\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "suite,ttft_ms\nsmoke,21.1\n"
                 )
             case .benchMatrixExportRequestsCSV(let options):
-                try? Data("request,latency_ms\n0,28.7\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "request,latency_ms\n0,28.7\n"
                 )
             case .evalExportSummaryCSV(let options):
-                try? Data("{\"ok\":true}\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "{\"ok\":true}\n"
                 )
             case .evalExportSamplesCSV(let options):
-                try? Data("{\"ok\":true}\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "{\"ok\":true}\n"
                 )
             case .evalExportSamplesJSONL(let options):
-                try? Data("{\"ok\":true}\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "{\"ok\":true}\n"
                 )
             default:
                 return .failure(.unsupportedCommand(commandID: command.workflowCommandID, surface: .subprocess))
@@ -6901,58 +6912,52 @@ struct Phase8WindowUIAcceptanceRunnerTests {
             case .evalRun:
                 return .success(makeCLIEvaluationRunJSON(jobID: "eval-newer"))
             case .benchExportCSV(let options):
-                try? Data("ok\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "ok\n"
                 )
             case .benchMatrixExportSummaryCSV(let options):
-                try? Data("ok\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "ok\n"
                 )
             case .benchMatrixExportRequestsCSV(let options):
-                try? Data("ok\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "ok\n"
                 )
             case .evalExportSummaryCSV(let options):
-                try? Data("ok\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "ok\n"
                 )
             case .evalExportSamplesCSV(let options):
-                try? Data("ok\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "ok\n"
                 )
             case .evalExportSamplesJSONL(let options):
-                try? Data("ok\n".utf8).write(to: URL(fileURLWithPath: options.outputPath))
-                return .success(
-                    makeCLIExportResponseJSON(
-                        jobID: options.jobID,
-                        outputPath: options.outputPath,
-                        rowCount: 1
-                    )
+                return makePhase8FixtureExportResponse(
+                    command: command,
+                    jobID: options.jobID,
+                    outputPath: options.outputPath,
+                    rowCount: 1,
+                    contents: "ok\n"
                 )
             default:
                 return .failure(.unsupportedCommand(commandID: command.workflowCommandID, surface: .subprocess))
@@ -7005,6 +7010,39 @@ private final class RecordingPhase8WindowUIRenderer: Phase8WindowUIRendering {
             withIntermediateDirectories: true
         )
         try Data("png".utf8).write(to: outputURL)
+    }
+}
+
+private func makePhase8FixtureExportResponse(
+    command: MelixCLICommand,
+    jobID: String,
+    outputPath: String,
+    rowCount: Int,
+    contents: String
+) -> Result<String, MelixCLIWorkflowError> {
+    let outputURL = URL(fileURLWithPath: outputPath)
+    do {
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(contents.utf8).write(to: outputURL)
+        return .success(
+            makeCLIExportResponseJSON(
+                jobID: jobID,
+                outputPath: outputPath,
+                rowCount: rowCount
+            )
+        )
+    } catch {
+        return .failure(
+            .processFailed(
+                commandID: command.workflowCommandID,
+                surface: .subprocess,
+                exitCode: 1,
+                stderr: "Failed to write fixture export at \(outputPath): \(error)"
+            )
+        )
     }
 }
 

--- a/docs/plans/2026-05-08-macos-app-screenshot-capture.md
+++ b/docs/plans/2026-05-08-macos-app-screenshot-capture.md
@@ -1,0 +1,38 @@
+# macOS App Screenshot Capture
+
+**Goal:** Add a repeatable local script that builds Melix.app, captures every
+native app surface through deterministic SwiftUI rendering, and writes the PNGs
+plus a manifest to a temporary directory.
+
+**Architecture:** Keep app packaging delegated to the existing macOS packaging
+script. Add a screenshot-only menubar entrypoint that renders SwiftUI views
+off-screen from fixture runtime state, avoiding mouse automation, screen focus,
+or screen-recording permissions for the default capture path.
+
+## Scope
+
+- Add a Python orchestration script for build, package, capture, and manifest
+  validation.
+- Add a menubar screenshot capture entrypoint gated by
+  `MELIX_APP_SCREENSHOT_CAPTURE=1`.
+- Capture all `DesktopSurface` cases, all `DesktopToolSection` cases, and the
+  standalone Command Center.
+- Leave live menu bar popover capture out of v1 because it requires AppKit
+  window automation and system permissions.
+
+## Verification
+
+- `HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --filter 'AppMainBootstrapTests|AppScreenshotCaptureTests'`
+- `HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'AppMainBootstrapTests|AppScreenshotCaptureTests'`
+- `PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_capture_macos_app_screenshots_script.py -q`
+- `PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" COVERAGE_FILE=/tmp/melix_app_screenshots_python.coverage UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest services/mlx-worker-python/tests/test_capture_macos_app_screenshots_script.py -q`
+- `python3 scripts/capture_macos_app_screenshots.py --json`
+- `git diff --check`
+
+## Metrics
+
+- Screenshot coverage target: 100% of `DesktopSurface.allCases`,
+  `DesktopToolSection.allCases`, and Command Center in the generated manifest.
+- PNG validation target: every manifest entry points at an existing PNG file.
+- Changed-line coverage target: at least 95% for measurable Swift and Python
+  lines in the touched screenshot-capture scope.

--- a/scripts/capture_macos_app_screenshots.py
+++ b/scripts/capture_macos_app_screenshots.py
@@ -134,6 +134,7 @@ def capture_screenshots(
     width: int,
     height: int,
 ) -> dict[str, Any]:
+    # Capture runs the packaged app, so its environment is intentionally separate from build_environment().
     environment = os.environ.copy()
     environment.update(
         {

--- a/scripts/capture_macos_app_screenshots.py
+++ b/scripts/capture_macos_app_screenshots.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def run_command(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        capture_output=capture_output,
+        text=True,
+        check=True,
+    )
+
+
+def default_output_dir() -> Path:
+    tmp_root = Path("/private/tmp") if Path("/private/tmp").is_dir() else Path(tempfile.gettempdir())
+    return Path(tempfile.mkdtemp(prefix="melix-app-screenshots-", dir=tmp_root))
+
+
+def build_environment(repo_root: Path) -> dict[str, str]:
+    environment = os.environ.copy()
+    environment.setdefault("UV_CACHE_DIR", str(repo_root / ".uv-cache"))
+    environment["UV_PROJECT_ENVIRONMENT"] = str(repo_root / ".venv")
+    environment["HOME"] = str(repo_root / ".swift-home" / "app-screenshots")
+    environment["CLANG_MODULE_CACHE_PATH"] = str(
+        repo_root / ".build" / "ModuleCache.noindex" / "app-screenshots"
+    )
+    Path(environment["HOME"]).mkdir(parents=True, exist_ok=True)
+    Path(environment["CLANG_MODULE_CACHE_PATH"]).mkdir(parents=True, exist_ok=True)
+    return environment
+
+
+def build_required_artifacts(repo_root: Path) -> None:
+    environment = build_environment(repo_root)
+    commands = [
+        [
+            "uv",
+            "sync",
+            "--project",
+            "services/mlx-worker-python",
+            "--extra",
+            "mlx",
+            "--frozen",
+        ],
+        [
+            "xcrun",
+            "swift",
+            "build",
+            "--product",
+            "melix",
+            "--disable-automatic-resolution",
+        ],
+        [
+            "xcrun",
+            "swift",
+            "build",
+            "--package-path",
+            "services/mlx-text-worker-swift",
+            "--product",
+            "melix-text-worker-swift",
+            "--disable-automatic-resolution",
+        ],
+        [
+            "xcrun",
+            "swift",
+            "build",
+            "--package-path",
+            "apps/macos-menubar",
+            "--product",
+            "melix-menubar",
+            "--disable-automatic-resolution",
+        ],
+    ]
+    for command in commands:
+        run_command(command, cwd=repo_root, env=environment)
+
+
+def package_app(repo_root: Path, app_path: Path) -> dict[str, Any]:
+    completed = run_command(
+        [
+            str(package_python_executable(repo_root)),
+            "scripts/package_macos_menubar_app.py",
+            "--repo-root",
+            str(repo_root),
+            "--output-path",
+            str(app_path),
+            "--json",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def package_python_executable(repo_root: Path) -> Path:
+    repo_python = repo_root / ".venv" / "bin" / "python"
+    if repo_python.is_file():
+        return repo_python
+    return Path(sys.executable)
+
+
+def resolve_menubar_binary(app_path: Path) -> Path:
+    candidate = app_path / "Contents" / "Resources" / "melix-menubar"
+    if not candidate.is_file():
+        raise FileNotFoundError(f"Missing bundled menubar binary: {candidate}")
+    return candidate
+
+
+def capture_screenshots(
+    *,
+    repo_root: Path,
+    app_path: Path,
+    output_dir: Path,
+    width: int,
+    height: int,
+) -> dict[str, Any]:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "MELIX_APP_SCREENSHOT_CAPTURE": "1",
+            "MELIX_APP_SCREENSHOT_OUTPUT_DIR": str(output_dir),
+            "MELIX_APP_SCREENSHOT_APP_PATH": str(app_path),
+            "MELIX_APP_SCREENSHOT_WIDTH": str(width),
+            "MELIX_APP_SCREENSHOT_HEIGHT": str(height),
+            "MELIX_HOME": str(output_dir / "melix-home"),
+            "MELIX_REPO_ROOT": str(repo_root),
+        }
+    )
+    completed = run_command(
+        [str(resolve_menubar_binary(app_path))],
+        cwd=repo_root,
+        env=environment,
+        capture_output=True,
+    )
+    payload = json.loads(completed.stdout)
+    validate_capture_manifest(payload)
+    return payload
+
+
+def validate_capture_manifest(payload: dict[str, Any]) -> None:
+    if payload.get("schema_version") != "melix.app_screenshots.v1":
+        raise RuntimeError("Screenshot capture manifest has an unexpected schema_version.")
+    screenshots = payload.get("screenshots")
+    if not isinstance(screenshots, list) or not screenshots:
+        raise RuntimeError("Screenshot capture manifest does not contain screenshots.")
+    for screenshot in screenshots:
+        path_value = screenshot.get("path") if isinstance(screenshot, dict) else None
+        if not isinstance(path_value, str) or not path_value:
+            raise RuntimeError("Screenshot capture manifest contains an entry without a path.")
+        screenshot_path = Path(path_value)
+        if not screenshot_path.is_file():
+            raise RuntimeError(f"Screenshot file is missing: {screenshot_path}")
+        if screenshot_path.read_bytes()[: len(PNG_SIGNATURE)] != PNG_SIGNATURE:
+            raise RuntimeError(f"Screenshot file is not a PNG: {screenshot_path}")
+
+
+def run_capture(
+    *,
+    repo_root: Path,
+    output_dir: Path,
+    skip_build: bool,
+    width: int,
+    height: int,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    app_path = output_dir / "Melix.app"
+    if not skip_build:
+        build_required_artifacts(repo_root)
+    package_manifest = package_app(repo_root, app_path)
+    packaged_app_path = Path(str(package_manifest.get("app_path", app_path))).expanduser().resolve()
+    screenshot_manifest = capture_screenshots(
+        repo_root=repo_root,
+        app_path=packaged_app_path,
+        output_dir=output_dir,
+        width=width,
+        height=height,
+    )
+    return {
+        "ok": True,
+        "output_dir": str(output_dir),
+        "app_path": str(packaged_app_path),
+        "package_manifest": package_manifest,
+        "screenshot_manifest_path": screenshot_manifest["manifest_path"],
+        "screenshot_root": screenshot_manifest["screenshot_root"],
+        "screenshot_count": len(screenshot_manifest["screenshots"]),
+        "screenshots": screenshot_manifest["screenshots"],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build Melix.app and capture deterministic screenshots for every native app surface."
+    )
+    parser.add_argument("--repo-root", type=Path, default=ROOT)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--skip-build", action="store_true")
+    parser.add_argument("--width", type=int, default=1440)
+    parser.add_argument("--height", type=int, default=960)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable capture metadata.")
+    args = parser.parse_args(argv)
+
+    if args.width <= 0 or args.height <= 0:
+        raise SystemExit("--width and --height must be positive integers.")
+
+    repo_root = args.repo_root.expanduser().resolve()
+    output_dir = args.output_dir.expanduser().resolve() if args.output_dir else default_output_dir()
+    try:
+        payload = run_capture(
+            repo_root=repo_root,
+            output_dir=output_dir,
+            skip_build=args.skip_build,
+            width=args.width,
+            height=args.height,
+        )
+    except subprocess.CalledProcessError as error:
+        print(format_called_process_error(error), file=sys.stderr)
+        return 1
+    except (OSError, RuntimeError, json.JSONDecodeError) as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"Melix app screenshots: {payload['screenshot_root']}")
+        print(f"Manifest: {payload['screenshot_manifest_path']}")
+        print(f"Screenshots: {payload['screenshot_count']}")
+    return 0
+
+
+def format_called_process_error(error: subprocess.CalledProcessError) -> str:
+    lines = [str(error)]
+    if error.stdout:
+        lines.append("stdout:")
+        lines.append(error.stdout.rstrip())
+    if error.stderr:
+        lines.append("stderr:")
+        lines.append(error.stderr.rstrip())
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_capture_macos_app_screenshots_script.py
+++ b/services/mlx-worker-python/tests/test_capture_macos_app_screenshots_script.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "scripts" / "capture_macos_app_screenshots.py"
+PNG_BYTES = b"\x89PNG\r\n\x1a\nfixture"
+
+
+def load_capture_module():
+    assert MODULE_PATH.exists(), f"Expected screenshot capture entrypoint at {MODULE_PATH}"
+    spec = importlib.util.spec_from_file_location("melix_capture_macos_app_screenshots", MODULE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.pop(spec.name, None)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def install_fake_run_command(module: Any, tmp_path: Path, calls: list[dict[str, Any]]) -> None:
+    def fake_run_command(
+        command: list[str],
+        *,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+        capture_output: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(
+            {
+                "command": command,
+                "cwd": cwd,
+                "env": dict(env or {}),
+                "capture_output": capture_output,
+            }
+        )
+
+        if len(command) >= 2 and command[1] == "scripts/package_macos_menubar_app.py":
+            output_path = Path(command[command.index("--output-path") + 1])
+            menubar_binary = output_path / "Contents" / "Resources" / "melix-menubar"
+            menubar_binary.parent.mkdir(parents=True, exist_ok=True)
+            menubar_binary.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+            payload = {
+                "app_path": str(output_path),
+                "bundled_binary_path": str(menubar_binary),
+            }
+            return subprocess.CompletedProcess(command, 0, stdout=json.dumps(payload), stderr="")
+
+        if command and command[0].endswith("melix-menubar"):
+            assert env is not None
+            output_dir = Path(env["MELIX_APP_SCREENSHOT_OUTPUT_DIR"])
+            screenshot_root = output_dir / "screenshots"
+            screenshot_root.mkdir(parents=True, exist_ok=True)
+            screenshot_path = screenshot_root / "workspace-chat.png"
+            screenshot_path.write_bytes(PNG_BYTES)
+            manifest_path = output_dir / "screenshot_manifest.json"
+            payload = {
+                "schema_version": "melix.app_screenshots.v1",
+                "manifest_path": str(manifest_path),
+                "app_path": env["MELIX_APP_SCREENSHOT_APP_PATH"],
+                "output_directory_path": str(output_dir),
+                "screenshot_root": str(screenshot_root),
+                "width": int(env["MELIX_APP_SCREENSHOT_WIDTH"]),
+                "height": int(env["MELIX_APP_SCREENSHOT_HEIGHT"]),
+                "screenshots": [
+                    {
+                        "id": "workspace-chat",
+                        "kind": "workspace",
+                        "surface": "Chat",
+                        "tool_section": "",
+                        "path": str(screenshot_path),
+                        "render_ms": 1.25,
+                    }
+                ],
+            }
+            manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+            return subprocess.CompletedProcess(command, 0, stdout=json.dumps(payload), stderr="")
+
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    module.run_command = fake_run_command
+
+
+def test_run_command_executes_subprocess_with_captured_output(tmp_path: Path) -> None:
+    module = load_capture_module()
+
+    completed = module.run_command(
+        [sys.executable, "-c", "print('melix screenshots')"],
+        cwd=tmp_path,
+        capture_output=True,
+    )
+
+    assert completed.stdout == "melix screenshots\n"
+
+
+def test_default_output_dir_uses_temp_screenshot_prefix() -> None:
+    module = load_capture_module()
+
+    output_dir = module.default_output_dir()
+
+    try:
+        assert output_dir.name.startswith("melix-app-screenshots-")
+        assert output_dir.is_dir()
+    finally:
+        output_dir.rmdir()
+
+
+def test_package_python_executable_prefers_repo_virtualenv(tmp_path: Path) -> None:
+    module = load_capture_module()
+    repo_python = tmp_path / ".venv" / "bin" / "python"
+    repo_python.parent.mkdir(parents=True)
+    repo_python.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+
+    assert module.package_python_executable(tmp_path) == repo_python
+
+
+def test_resolve_menubar_binary_reports_missing_bundle_binary(tmp_path: Path) -> None:
+    module = load_capture_module()
+
+    with pytest.raises(FileNotFoundError, match="Missing bundled menubar binary"):
+        module.resolve_menubar_binary(tmp_path / "Melix.app")
+
+
+def test_run_capture_builds_packages_and_captures_app_screenshots(tmp_path: Path) -> None:
+    module = load_capture_module()
+    calls: list[dict[str, Any]] = []
+    install_fake_run_command(module, tmp_path, calls)
+
+    payload = module.run_capture(
+        repo_root=tmp_path,
+        output_dir=tmp_path / "capture",
+        skip_build=False,
+        width=800,
+        height=500,
+    )
+
+    commands = [call["command"] for call in calls]
+    assert commands[0][:4] == ["uv", "sync", "--project", "services/mlx-worker-python"]
+    assert commands[1][:4] == ["xcrun", "swift", "build", "--product"]
+    assert commands[2][:5] == ["xcrun", "swift", "build", "--package-path", "services/mlx-text-worker-swift"]
+    assert commands[3][:5] == ["xcrun", "swift", "build", "--package-path", "apps/macos-menubar"]
+    assert commands[4][1] == "scripts/package_macos_menubar_app.py"
+    assert commands[5][0].endswith("Melix.app/Contents/Resources/melix-menubar")
+    assert calls[0]["env"]["UV_PROJECT_ENVIRONMENT"] == str(tmp_path / ".venv")
+    assert calls[5]["env"]["MELIX_APP_SCREENSHOT_CAPTURE"] == "1"
+    assert calls[5]["env"]["MELIX_APP_SCREENSHOT_WIDTH"] == "800"
+    assert calls[5]["env"]["MELIX_APP_SCREENSHOT_HEIGHT"] == "500"
+    assert payload["ok"] is True
+    assert payload["screenshot_count"] == 1
+    assert payload["screenshots"][0]["id"] == "workspace-chat"
+
+
+def test_run_capture_skip_build_still_packages_and_captures(tmp_path: Path) -> None:
+    module = load_capture_module()
+    calls: list[dict[str, Any]] = []
+    install_fake_run_command(module, tmp_path, calls)
+
+    module.run_capture(
+        repo_root=tmp_path,
+        output_dir=tmp_path / "capture",
+        skip_build=True,
+        width=1440,
+        height=960,
+    )
+
+    commands = [call["command"] for call in calls]
+    assert all(command[:2] != ["uv", "sync"] for command in commands)
+    assert all(command[:3] != ["xcrun", "swift", "build"] for command in commands)
+    assert commands[0][1] == "scripts/package_macos_menubar_app.py"
+    assert commands[1][0].endswith("Melix.app/Contents/Resources/melix-menubar")
+
+
+def test_validate_capture_manifest_rejects_missing_png(tmp_path: Path) -> None:
+    module = load_capture_module()
+    payload = {
+        "schema_version": "melix.app_screenshots.v1",
+        "screenshots": [{"path": str(tmp_path / "missing.png")}],
+    }
+
+    with pytest.raises(RuntimeError, match="Screenshot file is missing"):
+        module.validate_capture_manifest(payload)
+
+
+def test_validate_capture_manifest_rejects_malformed_entries(tmp_path: Path) -> None:
+    module = load_capture_module()
+    non_png_path = tmp_path / "not-a-png.txt"
+    non_png_path.write_text("not png", encoding="utf-8")
+
+    malformed_payloads = [
+        ({}, "unexpected schema_version"),
+        ({"schema_version": "melix.app_screenshots.v1", "screenshots": []}, "does not contain screenshots"),
+        (
+            {"schema_version": "melix.app_screenshots.v1", "screenshots": [{}]},
+            "entry without a path",
+        ),
+        (
+            {
+                "schema_version": "melix.app_screenshots.v1",
+                "screenshots": [{"path": str(non_png_path)}],
+            },
+            "is not a PNG",
+        ),
+    ]
+
+    for payload, message in malformed_payloads:
+        with pytest.raises(RuntimeError, match=message):
+            module.validate_capture_manifest(payload)
+
+
+def test_main_json_emits_capture_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_capture_module()
+
+    def fake_run_capture(**kwargs):
+        return {
+            "ok": True,
+            "output_dir": str(kwargs["output_dir"]),
+            "app_path": str(kwargs["output_dir"] / "Melix.app"),
+            "screenshot_manifest_path": str(kwargs["output_dir"] / "screenshot_manifest.json"),
+            "screenshot_root": str(kwargs["output_dir"] / "screenshots"),
+            "screenshot_count": 12,
+            "screenshots": [],
+            "package_manifest": {},
+        }
+
+    monkeypatch.setattr(module, "run_capture", fake_run_capture)
+
+    result = module.main(
+        [
+            "--repo-root",
+            str(tmp_path / "repo"),
+            "--output-dir",
+            str(tmp_path / "capture"),
+            "--skip-build",
+            "--json",
+        ]
+    )
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["screenshot_count"] == 12
+
+
+def test_main_rejects_non_positive_dimensions() -> None:
+    module = load_capture_module()
+
+    with pytest.raises(SystemExit) as error:
+        module.main(["--width", "0"])
+
+    assert str(error.value) == "--width and --height must be positive integers."
+
+
+def test_main_text_output_uses_default_output_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_capture_module()
+    output_dir = tmp_path / "default-capture"
+
+    def fake_run_capture(**kwargs):
+        assert kwargs["output_dir"] == output_dir
+        return {
+            "ok": True,
+            "output_dir": str(output_dir),
+            "app_path": str(output_dir / "Melix.app"),
+            "screenshot_manifest_path": str(output_dir / "screenshot_manifest.json"),
+            "screenshot_root": str(output_dir / "screenshots"),
+            "screenshot_count": 3,
+            "screenshots": [],
+            "package_manifest": {},
+        }
+
+    monkeypatch.setattr(module, "default_output_dir", lambda: output_dir)
+    monkeypatch.setattr(module, "run_capture", fake_run_capture)
+
+    assert module.main(["--repo-root", str(tmp_path / "repo"), "--skip-build"]) == 0
+
+    output = capsys.readouterr().out
+    assert f"Melix app screenshots: {output_dir / 'screenshots'}" in output
+    assert f"Manifest: {output_dir / 'screenshot_manifest.json'}" in output
+    assert "Screenshots: 3" in output
+
+
+def test_main_reports_called_process_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_capture_module()
+
+    def fake_run_capture(**kwargs):
+        raise subprocess.CalledProcessError(
+            returncode=17,
+            cmd=["melix-menubar"],
+            output="partial stdout\n",
+            stderr="failure stderr\n",
+        )
+
+    monkeypatch.setattr(module, "run_capture", fake_run_capture)
+
+    result = module.main(["--repo-root", str(tmp_path), "--output-dir", str(tmp_path / "capture")])
+
+    assert result == 1
+    error_output = capsys.readouterr().err
+    assert "returned non-zero exit status 17" in error_output
+    assert "stdout:\npartial stdout" in error_output
+    assert "stderr:\nfailure stderr" in error_output
+
+
+def test_main_reports_runtime_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_capture_module()
+
+    def fake_run_capture(**kwargs):
+        raise RuntimeError("manifest failed")
+
+    monkeypatch.setattr(module, "run_capture", fake_run_capture)
+
+    result = module.main(["--repo-root", str(tmp_path), "--output-dir", str(tmp_path / "capture")])
+
+    assert result == 1
+    assert "manifest failed" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- Add a deterministic macOS app screenshot capture mode that renders every Desktop workspace surface, every Tools section, and Command Center.
- Add a Python orchestration script that builds required artifacts, packages `Melix.app`, runs the bundled `melix-menubar` capture mode, and validates the manifest plus PNG signatures.
- Reuse the shared SwiftUI screenshot renderer from Phase 8 acceptance and add focused Swift/Python coverage for success, config, and failure paths.
- Address review feedback on Swift style, timing readability, fixture no-op semantics, stdout test noise, capture environment readability, and capture-only rendering constraints.
- Stabilize the Phase 8 fixture export handlers after CI exposed a missing benchmark CSV artifact in the full menubar shard.

## Plan or Spec
- `docs/plans/2026-05-08-macos-app-screenshot-capture.md`

## Commands Run
```text
uv run --project services/mlx-worker-python --extra mlx coverage run --data-file /tmp/melix_app_screenshots_python.coverage -m pytest services/mlx-worker-python/tests/test_capture_macos_app_screenshots_script.py -q
PASS: 13 passed in 0.23s

uv run --project services/mlx-worker-python --extra mlx coverage json --data-file /tmp/melix_app_screenshots_python.coverage -o /tmp/melix_app_screenshots_python_coverage.json
PASS: wrote /tmp/melix_app_screenshots_python_coverage.json

python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/melix_app_screenshots_python_coverage.json scripts/capture_macos_app_screenshots.py services/mlx-worker-python/tests/test_capture_macos_app_screenshots_script.py
PASS: TOTAL 99.62% (265/266)

env HOME=/Users/ChenYu/Documents/Github/melix/.worktrees/macos-app-screenshot-capture/.swift-home CLANG_MODULE_CACHE_PATH=/Users/ChenYu/Documents/Github/melix/.worktrees/macos-app-screenshot-capture/.build/ModuleCache.noindex swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'AppMainBootstrapTests|AppScreenshotCaptureTests'
PASS: 58 tests in 2 suites passed

python3 scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift apps/macos-menubar/Sources/AppMain/Acceptance/MelixSwiftUIScreenshotRenderer.swift apps/macos-menubar/Sources/AppMain/AppMain.swift apps/macos-menubar/Tests/MenuBarTests/AppMainBootstrapTests.swift apps/macos-menubar/Tests/MenuBarTests/AppScreenshotCaptureTests.swift
PASS: TOTAL 96.41% (806/836)

python3 scripts/capture_macos_app_screenshots.py --json
PASS: output_dir=/private/tmp/melix-app-screenshots-9ecxglg8, screenshot_count=12
Note: an earlier run failed during packaging with ENOSPC while copying into /private/tmp; generated /private/tmp/melix-app-screenshots-* artifacts were removed and the same command passed.

git diff --check --cached
PASS

env HOME=/Users/ChenYu/Documents/Github/melix/.worktrees/pr-519-review/.swift-home CLANG_MODULE_CACHE_PATH=/Users/ChenYu/Documents/Github/melix/.worktrees/pr-519-review/.build/ModuleCache.noindex swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'AppMainBootstrapTests|AppScreenshotCaptureTests'
PASS: 58 tests in 2 suites passed

python3 scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift apps/macos-menubar/Sources/AppMain/Acceptance/MelixSwiftUIScreenshotRenderer.swift apps/macos-menubar/Sources/AppMain/AppMain.swift apps/macos-menubar/Tests/MenuBarTests/AppMainBootstrapTests.swift apps/macos-menubar/Tests/MenuBarTests/AppScreenshotCaptureTests.swift
PASS: review follow-up changed-line coverage TOTAL 100.00% (14/14)

git diff --check
PASS

env HOME=/Users/ChenYu/Documents/Github/melix/.worktrees/pr-519-review/.swift-home CLANG_MODULE_CACHE_PATH=/Users/ChenYu/Documents/Github/melix/.worktrees/pr-519-review/.build/ModuleCache.noindex swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'AppMainBootstrapTests|AppScreenshotCaptureTests'
PASS: 58 tests in 2 suites passed

python3 scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift apps/macos-menubar/Sources/AppMain/Acceptance/MelixSwiftUIScreenshotRenderer.swift apps/macos-menubar/Sources/AppMain/AppMain.swift apps/macos-menubar/Tests/MenuBarTests/AppMainBootstrapTests.swift apps/macos-menubar/Tests/MenuBarTests/AppScreenshotCaptureTests.swift
PASS: secondary review-note changed-line coverage TOTAL 100.00% (2/2); fixture comment lines skipped as non-executable

make swift-test-menubar
PASS: 588 tests in 15 suites passed

env HOME=/Users/ChenYu/Documents/Github/melix/.worktrees/pr-519-review/.swift-home CLANG_MODULE_CACHE_PATH=/Users/ChenYu/Documents/Github/melix/.worktrees/pr-519-review/.build/ModuleCache.noindex swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'Phase8WindowUIAcceptanceRunnerTests'
PASS: 8 tests in 1 suite passed

python3 scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
PASS: CI follow-up changed-line coverage TOTAL 99.35% (154/155)

git diff --check
PASS
```

## Coverage and Metrics
- Python changed-line coverage: 99.62% total (265/266); `scripts/capture_macos_app_screenshots.py` was 99.11% (111/112) and the focused Python test file was 100.00% (154/154).
- Swift changed-line coverage: 96.41% total (806/836) across the AppMain screenshot entrypoint, renderer, Phase 8 renderer reuse, and focused tests.
- Review follow-up changed-line coverage: 100.00% total (14/14) for the first review pass, plus 100.00% total (2/2) for the secondary review-note pass.
- CI follow-up changed-line coverage: 99.35% total (154/155) for the Phase 8 fixture export stabilization path.
- Screenshot capture coverage: 12/12 deterministic app screenshots generated: 5 Desktop workspace surfaces, 6 Tools sections, and Command Center.
- Packaging metrics from the passing run: total packaging time 4.231459s; site-packages copy 3.582343s; Python runtime copy 0.531884s.

## Known Gaps
- Full repository `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run; this PR used focused changed-scope coverage, `make swift-test-menubar`, and the end-to-end screenshot capture script.
- Live menu bar popover capture remains out of scope; this change intentionally uses deterministic off-screen SwiftUI rendering for reviewable app-surface screenshots.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
