### PR TITLE
[codex] Add component-scoped Gemma 4 LoRA support

### DIFF
--- a/docs/plans/2026-05-08-component-scoped-gemma4-lora.md
+++ b/docs/plans/2026-05-08-component-scoped-gemma4-lora.md
@@ -1,0 +1,110 @@
+# Component-Scoped Gemma 4 LoRA Support
+
+## Purpose
+
+Melix should not reject a downloaded Gemma 4 multimodal model when the downloaded
+model exposes a trainable Gemma text backbone. The long-term contract is
+component-scoped adapter training: model discovery records which local component
+is trainable, LoRA validation targets that component, and adapter lifecycle
+artifacts preserve the component scope for activation and later catalog
+registration.
+
+## Scope
+
+This slice productizes the Gemma 4 `text_backbone` LoRA surface for local VLM
+model specs whose `config.json` exposes `text_config.model_type == "gemma4_text"`.
+It applies to both text-backed Gemma 4 snapshots and full multimodal Gemma 4
+snapshots. The source model remains a VLM model for runtime routing, while LoRA
+training uses the text-backbone family contract.
+
+Out of scope:
+
+- vision encoder LoRA
+- multimodal projector LoRA
+- audio component LoRA
+- fused multimodal activation for component-scoped adapters
+
+Those surfaces require separate adapter contracts and runtime loading behavior
+before they can be marked training-ready.
+
+## Design
+
+Model discovery emits explicit component metadata for Gemma 4 VLM specs:
+
+- `melix.model.components`
+- `melix.component.text_backbone.model_type`
+- `melix.component.text_backbone.family_id`
+- `melix.component.text_backbone.lora_supported`
+- `melix.component.text_backbone.training_ready`
+- `melix.component.vision_encoder.lora_supported`
+- `melix.component.multimodal_projector.lora_supported`
+
+The LoRA-facing compatibility keys remain under the existing `melix.lora.*`
+namespace so existing family resolution can reuse the stable Gemma mapper:
+
+- `melix.lora.adapter_scope = text_backbone`
+- `melix.lora.training_surface = text_backbone`
+- `melix.lora.base_model_path = <local model directory>`
+- `melix.lora.component_model_type = gemma4_text`
+- `melix.lora.family_id = gemma`
+- `melix.lora.training_ready = true`
+
+`normalize_training_config` stops using `model_kind == "text"` as the only
+admission rule. Text models stay supported. Non-text models are admitted only
+when the registry has marked a known component training surface as
+training-ready. Gemma 4 VLMs without component metadata and all embedding/image
+models remain rejected with `unsupported_model_family`.
+
+Training manifests record the adapter scope, training surface, source model
+kind, component model type, component family, and component path. Activation
+validates those fields against the requested source model. Adapter-backed
+runtime activation is allowed for the `text_backbone` scope; fused activation is
+rejected for non-text source models until a fused multimodal component contract
+exists.
+
+Derived-model registration and registry snapshots propagate the adapter scope so
+operators and runtime consumers can tell that a derived VLM entry is backed by a
+text-backbone adapter rather than an opaque whole-model adapter.
+
+## Performance Probes And Metrics
+
+This change does not add a new optimizer loop. The relevant probes are:
+
+- training request dispatch path: verify the backend receives the component
+  model path selected from `melix.lora.base_model_path`
+- training manifest write path: verify adapter scope and component metadata are
+  emitted deterministically
+- activation validation path: verify mismatched scopes fail before runtime load
+- derived registration path: verify adapter scope survives catalog restoration
+
+Success metrics:
+
+- targeted Python tests covering registry, training config, training manifest,
+  activation validation, and derived registration pass
+- changed-line coverage for touched Python files is at least 95 percent, or the
+  PR reports why a touched documentation-only path is not measurable
+- `git diff --check` passes
+
+## Verification Plan
+
+Targeted checks:
+
+```bash
+PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --locked --project services/mlx-worker-python --extra mlx pytest \
+  services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_promotes_gemma4_text_manifest_to_vlm_text_backed \
+  services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_keeps_multimodal_gemma4_manifest_in_multimodal_mode \
+  services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_normalize_training_config_rejects_non_text_models \
+  services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_normalize_training_config_accepts_gemma4_vlm_text_backbone_scope \
+  services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_lora_training_pipeline_uses_component_scope_metadata_for_gemma4_vlm \
+  services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_adapter_activation_pipeline_validates_component_scope_for_vlm_adapters \
+  services/mlx-worker-python/tests/test_lora_model_ops.py::test_activate_adapter_supports_adapter_backed_runtime_and_uses_training_alias \
+  -q
+```
+
+Coverage:
+
+```bash
+PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" COVERAGE_FILE="$(pwd)/.coverage.component_lora" uv run --locked --project services/mlx-worker-python --extra mlx coverage run -m pytest <targeted tests> -q
+uv run --locked --project services/mlx-worker-python --extra mlx coverage json -o coverage.component_lora.json
+python3 scripts/python_changed_line_coverage.py --coverage-json coverage.component_lora.json <changed python files>
+```

--- a/docs/runbooks/phase-8-lora-adapter-workflow.md
+++ b/docs/runbooks/phase-8-lora-adapter-workflow.md
@@ -7,7 +7,8 @@ Prepare a local dataset package, train a Melix LoRA adapter, activate it into a 
 ## Preconditions
 
 - the local Melix stack is available
-- the source model is a text-capable Melix model summary
+- the source model is a text model or a model summary with an explicit
+  training-ready component LoRA surface
 - the dataset exists either as a local `melix.training_dataset_package.v1` or as a supported Hugging Face dataset configuration
 - the target model family is supported by the current LoRA config mapper
 - operators understand whether the chosen family is stable, experimental, or currently blocked for LoRA training
@@ -187,6 +188,10 @@ Expected training behavior:
 - this slice defines worker-owned mode and dataset contracts; DPO, ORPO, and CPT optimizer-loop breadth remains bounded by the active local runner implementation
 - if `hf_valid_split` is provided, the normalized dataset snapshot persists the explicit validation source
 - Melix expands compact target modules or preset groups into family-specific module paths
+- Gemma 4 VLM snapshots that expose `text_config.model_type == "gemma4_text"` are accepted through the
+  component-scoped `text_backbone` LoRA surface; the source model remains a VLM entry, and adapter
+  artifacts record `adapter_scope=text_backbone`, `training_surface=text_backbone`,
+  `component_model_type=gemma4_text`, and `component_family=gemma`
 - supported preset groups currently include `attention`, `mlp`, `attention_mlp`, and `full`; `qwen` plus `kimi` also accept `qkv`, `gemma` also accepts `gated_mlp`, experimental `mixtral` accepts `experts`, and experimental `qwen3moe` accepts `qkv`, `experts`, and `attention_experts` (`full` is an alias for `attention_experts`)
 - dense-family defaults stay on the family-owned `attention_mlp` baseline, while experimental MoE families default to `attention` unless the operator explicitly opts into expert modules
 - quantized LoRA and QLoRA reject embedding, LM head, and output-projection target modules; keep quantized runs on attention or expert projection targets
@@ -203,6 +208,12 @@ Stable LoRA training families:
 - `gemma`
 - `kimi`
 
+Stable component-scoped LoRA surfaces:
+
+- Gemma 4 VLM `text_backbone` when local model discovery records
+  `melix.lora.adapter_scope=text_backbone`, `melix.lora.training_surface=text_backbone`,
+  `melix.lora.component_model_type=gemma4_text`, and `melix.lora.training_ready=true`
+
 Experimental LoRA training families:
 
 - `mixtral` is exposed through separate MoE hooks and currently defaults to `attention` targets only; expert-module presets are available but should be treated as an operator-tuned path
@@ -214,6 +225,8 @@ Explicitly unsupported or not-yet-productized LoRA families:
 - `mistral4`
 - `nemotron-h`
 - embedding-family models and other non-text capability classes
+- Gemma 4 `vision_encoder`, `multimodal_projector`, and audio components; these require separate
+  adapter contracts and are intentionally not marked training-ready by the registry
 
 Operator guidance:
 
@@ -221,6 +234,8 @@ Operator guidance:
 - use `attention` or `qkv` first when validating a new dense family rollout
 - treat MoE expert targeting as experimental and record compare evidence before promoting an adapter for wider use
 - if the registry marks `melix.lora.training_ready = false`, do not expect `train_lora` to accept that family yet
+- for component-scoped models, inspect `melix.lora.adapter_scope` and `melix.model.components` before
+  training; do not infer vision or projector support from the presence of a multimodal model card
 
 ## Activate Adapter
 
@@ -250,9 +265,13 @@ Expected activation behavior:
 - Melix validates adapter compatibility against the base model
 - `fused_derived_model` remains the default when `--activation-mode` is omitted
 - `adapter_backed_runtime` is a supported first-class activation mode for keeping adapter artifacts attached to the runtime instead of materializing a fused local model
+- component-scoped non-text adapters, including Gemma 4 `text_backbone` adapters, must use
+  `adapter_backed_runtime`; fused activation is rejected until Melix has a fused multimodal component
+  adapter contract
 - the completed artifact is `activate_adapter.derived_model.json` with schema `melix.derived_text_model.v1` under `<jobs_root>/activate_adapter/<job_id>/`
-- the result includes `derived_model_id`, `derived_model_path`, `activation_duration_ms`, and `adapter_set_hash`
-- the activated model is registered into the control-plane catalog as a text model
+- the result includes `derived_model_id`, `derived_model_path`, `activation_duration_ms`,
+  `adapter_set_hash`, and adapter scope metadata when present
+- the activated model is registered into the control-plane catalog with the source model kind preserved
 
 ## Verify Serving Behavior
 
@@ -261,8 +280,9 @@ Confirm the activation result before using the model for traffic:
 1. inspect the activation manifest and confirm `schema_version == "melix.derived_text_model.v1"`
 2. confirm `activation_mode` matches the requested mode, either `fused_derived_model` or `adapter_backed_runtime`
 3. confirm `melix.adapter_set_hash` is present and differs from incompatible adapters
-4. load the derived model through the existing text runtime path
-5. compare one controlled prompt against the base model and verify the derived model behavior changes in the expected direction
+4. for component-scoped adapters, confirm `adapter_scope` and `training_surface` match the source model metadata
+5. load the derived model through the expected runtime path
+6. compare one controlled prompt against the base model and verify the derived model behavior changes in the expected direction
 
 For operator state inspection, request a `registry_snapshot` and confirm:
 

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -3301,17 +3301,23 @@ def test_activate_adapter_supports_adapter_backed_runtime_and_uses_training_alia
     assert activation_payload["adapter_manifest_path"] == adapter_manifest_path
     assert activation_payload["adapter_weights_path"].endswith("adapters.safetensors")
     assert activation_payload["source_model_kind"] == "text"
+    assert activation_payload["adapter_scope"] == "model"
+    assert activation_payload["training_surface"] == "model"
     assert activation_payload["source_model_ext"]["text_family_id"] == "llama"
     assert activation_payload["derived_model_path"] == source_model.model_path
     assert activation_payload["remove_supported"] is True
     assert snapshot_payload["adapters"][0]["activation_mode"] == "adapter_backed_runtime"
     assert snapshot_payload["adapters"][0]["activation_backend"] == "internal"
     assert snapshot_payload["adapters"][0]["adapter_weights_path"] == activation_payload["adapter_weights_path"]
+    assert snapshot_payload["adapters"][0]["adapter_scope"] == "model"
+    assert snapshot_payload["adapters"][0]["training_surface"] == "model"
     # RuntimeMode enum flows through the snapshot alongside the legacy string.
     # RUNTIME_MODE_ADAPTER_BACKED = 2 per worker/v1/common.proto.
     assert snapshot_payload["adapters"][0]["runtime_mode"] == 2
     assert snapshot_payload["derived_models"][0]["activation_mode"] == "adapter_backed_runtime"
     assert snapshot_payload["derived_models"][0]["activation_backend"] == "internal"
+    assert snapshot_payload["derived_models"][0]["adapter_scope"] == "model"
+    assert snapshot_payload["derived_models"][0]["training_surface"] == "model"
     assert snapshot_payload["derived_models"][0]["runtime_mode"] == 2
     assert snapshot_payload["derived_models"][0]["model_id"] == activation_payload["derived_model_id"]
 
@@ -3320,6 +3326,8 @@ def test_activate_adapter_supports_adapter_backed_runtime_and_uses_training_alia
     assert registered_model.model_path == source_model.model_path
     assert registered_model.ext["melix.activation_mode"] == "adapter_backed_runtime"
     assert registered_model.ext["melix.adapter_manifest_path"] == adapter_manifest_path
+    assert registered_model.ext["melix.adapter_scope"] == "model"
+    assert registered_model.ext["melix.training_surface"] == "model"
     # Typed RuntimeMode enum must propagate from activation manifest through
     # catalog registration — this is the authoritative signal the runtime
     # backend keys off to decide adapter-aware load behavior.

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -80,6 +80,69 @@ def _text_model(*, model_path: str = "models/plain-llama", quant_profile_id: str
     return model
 
 
+def _gemma4_vlm_model(*, model_path: str = "models/gemma-4-E4B-it-bf16") -> common_pb2.ModelSpec:
+    model = common_pb2.ModelSpec(
+        model_id="melix-gemma4-vlm",
+        model_path=model_path,
+        model_kind="vlm",
+        revision="main",
+        max_context=8192,
+    )
+    model.ext["melix.lora.family_id"] = "gemma"
+    model.ext["melix.lora.family_kind"] = "dense"
+    model.ext["melix.lora.support_tier"] = "stable"
+    model.ext["melix.lora.training_ready"] = "true"
+    model.ext["melix.lora.default_target_preset"] = "attention_mlp"
+    model.ext["melix.lora.adapter_scope"] = "text_backbone"
+    model.ext["melix.lora.training_surface"] = "text_backbone"
+    model.ext["melix.lora.base_model_path"] = model_path
+    model.ext["melix.lora.component_model_type"] = "gemma4_text"
+    model.ext["melix.component.text_backbone.model_type"] = "gemma4_text"
+    model.ext["melix.component.text_backbone.family_id"] = "gemma"
+    model.ext["melix.component.text_backbone.lora_supported"] = "true"
+    model.ext["melix.component.text_backbone.training_ready"] = "true"
+    return model
+
+
+def test_lora_training_pipeline_uses_component_scope_metadata_for_gemma4_vlm(tmp_path: Path) -> None:
+    class RecordingRunner(DeterministicLoRARunner):
+        def __init__(self) -> None:
+            super().__init__()
+            self.last_request = None
+
+        def train_native(self, request):  # noqa: ANN001
+            self.last_request = request
+            return super().train_native(request)
+
+    component_model_dir = tmp_path / "gemma4-vlm"
+    component_model_dir.mkdir()
+    dataset_dir = _write_dataset_package(tmp_path / "dataset")
+    runner = RecordingRunner()
+
+    result = LoRATrainingPipeline(runner=runner).run(
+        job_id="train-gemma4-vlm",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "gemma4-text-backbone",
+            "dataset_uri": str(dataset_dir),
+        },
+        source_model=_gemma4_vlm_model(model_path=str(component_model_dir)),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    assert runner.last_request is not None
+    assert runner.last_request.model_path == component_model_dir
+    assert runner.last_request.source_model_kind == "vlm"
+    assert runner.last_request.source_model_ext["melix.lora.adapter_scope"] == "text_backbone"
+    assert result.manifest["source_model_kind"] == "vlm"
+    assert result.manifest["adapter_scope"] == "text_backbone"
+    assert result.manifest["training_surface"] == "text_backbone"
+    assert result.manifest["component_model_type"] == "gemma4_text"
+    assert result.manifest["component_family"] == "gemma"
+    assert result.manifest["component_model_path"] == str(component_model_dir)
+
+
 def test_checkpoint_summary_uses_scandir_stack_without_os_walk(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -2205,6 +2268,194 @@ def test_adapter_activation_pipeline_emits_explicit_adapter_backed_runtime_load_
     assert result.manifest["source_model_ext"]["text_family_id"] == "qwen"
 
 
+def test_adapter_activation_pipeline_validates_component_scope_for_vlm_adapters(tmp_path: Path) -> None:
+    weights_dir = tmp_path / "adapter-weights"
+    weights_dir.mkdir(parents=True)
+    manifest_path = tmp_path / "train_lora.adapter.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.lora_adapter_package.v1",
+                "source_model": "melix-gemma4-vlm",
+                "source_model_kind": "vlm",
+                "weights_path": str(weights_dir / "adapters.safetensors"),
+                "adapter_name": "gemma4-component-adapter",
+                "adapter_set_hash": "gemma4-adapter-hash",
+                "job_id": "model-ops-0003",
+                "adapter_scope": "text_backbone",
+                "training_surface": "text_backbone",
+                "component_model_type": "gemma4_text",
+                "component_family": "gemma",
+                "component_model_path": str(tmp_path / "gemma4-vlm"),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    source_model = _gemma4_vlm_model(model_path=str(tmp_path / "gemma4-vlm"))
+
+    result = AdapterActivationPipeline(runner=_UnexpectedActivationRunner()).run(
+        job_id="model-ops-0004",
+        request_ext={
+            "artifact_path": str(manifest_path),
+            "activation_mode": "adapter_backed_runtime",
+        },
+        source_model=source_model,
+        output_dir=tmp_path / "activate",
+    )
+
+    assert result.manifest["source_model_kind"] == "vlm"
+    assert result.manifest["adapter_scope"] == "text_backbone"
+    assert result.manifest["training_surface"] == "text_backbone"
+    assert result.manifest["component_model_type"] == "gemma4_text"
+    assert result.manifest["component_family"] == "gemma"
+    assert result.manifest["component_model_path"] == str(tmp_path / "gemma4-vlm")
+    assert result.manifest["derived_model_path"] == source_model.model_path
+
+    mismatched = _gemma4_vlm_model(model_path=str(tmp_path / "gemma4-vlm"))
+    mismatched.ext["melix.lora.adapter_scope"] = "vision_encoder"
+    with pytest.raises(ModelOperationError) as scope_exc:
+        AdapterActivationPipeline(runner=_UnexpectedActivationRunner()).run(
+            job_id="model-ops-0005",
+            request_ext={
+                "artifact_path": str(manifest_path),
+                "activation_mode": "adapter_backed_runtime",
+            },
+            source_model=mismatched,
+            output_dir=tmp_path / "mismatch",
+        )
+    assert scope_exc.value.code == "activation_failure"
+    assert "scope" in scope_exc.value.message
+
+    with pytest.raises(ModelOperationError) as fused_exc:
+        AdapterActivationPipeline().run(
+            job_id="model-ops-0006",
+            request_ext={"artifact_path": str(manifest_path)},
+            source_model=source_model,
+            output_dir=tmp_path / "fused",
+        )
+    assert fused_exc.value.code == "activation_failure"
+    assert "adapter_backed_runtime" in fused_exc.value.message
+
+
+def test_adapter_activation_pipeline_rejects_component_scope_metadata_mismatches(tmp_path: Path) -> None:
+    weights_dir = tmp_path / "adapter-weights"
+    weights_dir.mkdir(parents=True)
+
+    def write_manifest(payload: dict[str, object]) -> Path:
+        manifest_path = tmp_path / f"{payload['job_id']}.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "melix.lora_adapter_package.v1",
+                    "weights_path": str(weights_dir / "adapters.safetensors"),
+                    "adapter_name": "scope-mismatch",
+                    "adapter_set_hash": str(payload["job_id"]),
+                    **payload,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return manifest_path
+
+    with pytest.raises(ModelOperationError) as kind_exc:
+        AdapterActivationPipeline(runner=_UnexpectedActivationRunner()).run(
+            job_id="activate-kind",
+            request_ext={
+                "artifact_path": str(
+                    write_manifest(
+                        {
+                            "job_id": "adapter-kind",
+                            "source_model": "melix-gemma4-vlm",
+                            "source_model_kind": "text",
+                            "adapter_scope": "text_backbone",
+                            "training_surface": "text_backbone",
+                        }
+                    )
+                ),
+                "activation_mode": "adapter_backed_runtime",
+            },
+            source_model=_gemma4_vlm_model(model_path=str(tmp_path / "gemma4-vlm")),
+            output_dir=tmp_path / "activate-kind",
+        )
+    assert kind_exc.value.code == "activation_failure"
+    assert "kind" in kind_exc.value.message
+
+    with pytest.raises(ModelOperationError) as text_scope_exc:
+        AdapterActivationPipeline(runner=_UnexpectedActivationRunner()).run(
+            job_id="activate-text-scope",
+            request_ext={
+                "artifact_path": str(
+                    write_manifest(
+                        {
+                            "job_id": "adapter-text-scope",
+                            "source_model": "melix-test-text",
+                            "source_model_kind": "text",
+                            "adapter_scope": "text_backbone",
+                            "training_surface": "text_backbone",
+                        }
+                    )
+                ),
+                "activation_mode": "adapter_backed_runtime",
+            },
+            source_model=_text_model(model_path=str(tmp_path / "text-model")),
+            output_dir=tmp_path / "activate-text-scope",
+        )
+    assert text_scope_exc.value.code == "activation_failure"
+    assert "scope" in text_scope_exc.value.message
+
+    with pytest.raises(ModelOperationError) as type_exc:
+        AdapterActivationPipeline(runner=_UnexpectedActivationRunner()).run(
+            job_id="activate-type",
+            request_ext={
+                "artifact_path": str(
+                    write_manifest(
+                        {
+                            "job_id": "adapter-type",
+                            "source_model": "melix-gemma4-vlm",
+                            "source_model_kind": "vlm",
+                            "adapter_scope": "text_backbone",
+                            "training_surface": "text_backbone",
+                            "component_model_type": "llama",
+                            "component_family": "gemma",
+                        }
+                    )
+                ),
+                "activation_mode": "adapter_backed_runtime",
+            },
+            source_model=_gemma4_vlm_model(model_path=str(tmp_path / "gemma4-vlm")),
+            output_dir=tmp_path / "activate-type",
+        )
+    assert type_exc.value.code == "activation_failure"
+    assert "component type" in type_exc.value.message
+
+    with pytest.raises(ModelOperationError) as family_exc:
+        AdapterActivationPipeline(runner=_UnexpectedActivationRunner()).run(
+            job_id="activate-family",
+            request_ext={
+                "artifact_path": str(
+                    write_manifest(
+                        {
+                            "job_id": "adapter-family",
+                            "source_model": "melix-gemma4-vlm",
+                            "source_model_kind": "vlm",
+                            "adapter_scope": "text_backbone",
+                            "training_surface": "text_backbone",
+                            "component_model_type": "gemma4_text",
+                            "component_family": "qwen",
+                        }
+                    )
+                ),
+                "activation_mode": "adapter_backed_runtime",
+            },
+            source_model=_gemma4_vlm_model(model_path=str(tmp_path / "gemma4-vlm")),
+            output_dir=tmp_path / "activate-family",
+        )
+    assert family_exc.value.code == "activation_failure"
+    assert "component family" in family_exc.value.message
+
+
 
 def test_normalize_training_config_rejects_non_text_models() -> None:
     model = common_pb2.ModelSpec(model_id="melix-embed", model_path="models/embed", model_kind="embedding")
@@ -2219,6 +2470,35 @@ def test_normalize_training_config_rejects_non_text_models() -> None:
         )
 
     assert exc.value.code == "unsupported_model_family"
+    assert exc.value.details["model_kind"] == "embedding"
+
+    vlm = common_pb2.ModelSpec(model_id="melix-vlm", model_path="models/plain-vlm", model_kind="vlm")
+    with pytest.raises(ModelOperationError) as vlm_exc:
+        training_config_module.normalize_training_config(
+            source_model=vlm,
+            ext={},
+            dataset_format="chat_messages",
+            response_only_supported=True,
+            sample_count=1,
+        )
+
+    assert vlm_exc.value.code == "unsupported_model_family"
+    assert vlm_exc.value.details["adapter_scope"] == ""
+
+
+def test_normalize_training_config_accepts_gemma4_vlm_text_backbone_scope() -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_gemma4_vlm_model(model_path="mlx-community/gemma-4-E4B-it-bf16"),
+        ext={},
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+    )
+
+    assert config.family_id == "gemma"
+    assert config.quantization_mode == "none"
+    assert any(module.endswith(".self_attn.q_proj") for module in config.expanded_target_modules)
+    assert any(module.endswith(".mlp.gate_proj") for module in config.expanded_target_modules)
 
 
 def test_normalize_training_config_rejects_unknown_modes_and_families() -> None:

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -26,6 +26,7 @@ from worker.model_ops.lora_training_pipeline import (
     _load_manifest_payload,
     _resolve_resume_context,
     _resolve_resume_path_from_manifest,
+    _resolve_adapter_scope_metadata,
     _validated_resume_path,
 )
 from worker.model_ops.mlx_lm_runner import MLXLMRunner
@@ -2405,6 +2406,35 @@ def test_adapter_activation_pipeline_rejects_component_scope_metadata_mismatches
     assert text_scope_exc.value.code == "activation_failure"
     assert "scope" in text_scope_exc.value.message
 
+    with pytest.raises(ModelOperationError) as missing_scope_exc:
+        AdapterActivationPipeline(runner=_UnexpectedActivationRunner()).run(
+            job_id="activate-missing-scope",
+            request_ext={
+                "artifact_path": str(
+                    write_manifest(
+                        {
+                            "job_id": "adapter-missing-scope",
+                            "source_model": "plain-vlm",
+                            "source_model_kind": "vlm",
+                            "adapter_scope": "text_backbone",
+                            "training_surface": "text_backbone",
+                            "component_model_type": "gemma4_text",
+                            "component_family": "gemma",
+                        }
+                    )
+                ),
+                "activation_mode": "adapter_backed_runtime",
+            },
+            source_model=common_pb2.ModelSpec(
+                model_id="plain-vlm",
+                model_path=str(tmp_path / "plain-vlm"),
+                model_kind="vlm",
+            ),
+            output_dir=tmp_path / "activate-missing-scope",
+        )
+    assert missing_scope_exc.value.code == "activation_failure"
+    assert "no component LoRA scope metadata" in missing_scope_exc.value.message
+
     with pytest.raises(ModelOperationError) as type_exc:
         AdapterActivationPipeline(runner=_UnexpectedActivationRunner()).run(
             job_id="activate-type",
@@ -2499,6 +2529,33 @@ def test_normalize_training_config_accepts_gemma4_vlm_text_backbone_scope() -> N
     assert config.quantization_mode == "none"
     assert any(module.endswith(".self_attn.q_proj") for module in config.expanded_target_modules)
     assert any(module.endswith(".mlp.gate_proj") for module in config.expanded_target_modules)
+
+
+def test_normalize_training_config_accepts_registry_owned_component_model_type() -> None:
+    source_model = _gemma4_vlm_model(model_path="models/custom-component-vlm")
+    source_model.ext["melix.lora.component_model_type"] = "custom_text_backbone"
+    source_model.ext["melix.component.text_backbone.model_type"] = "custom_text_backbone"
+
+    config = training_config_module.normalize_training_config(
+        source_model=source_model,
+        ext={},
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+    )
+
+    assert config.family_id == "gemma"
+    assert any(module.endswith(".self_attn.q_proj") for module in config.expanded_target_modules)
+    assert any(module.endswith(".mlp.gate_proj") for module in config.expanded_target_modules)
+
+
+def test_resolve_adapter_scope_metadata_requires_validated_non_text_scope() -> None:
+    source_model = common_pb2.ModelSpec(model_id="plain-vlm", model_path="models/plain-vlm", model_kind="vlm")
+
+    with pytest.raises(AssertionError) as exc:
+        _resolve_adapter_scope_metadata(source_model)
+
+    assert "no adapter_scope" in str(exc.value)
 
 
 def test_normalize_training_config_rejects_unknown_modes_and_families() -> None:

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -3345,6 +3345,57 @@ def test_job_registry_helper_paths_cover_restore_and_runtime_edges(tmp_path: Pat
     assert common_pb2.RuntimeMode.Name(_runtime_mode_from_activation(" adapter_backed_runtime ")) == "RUNTIME_MODE_ADAPTER_BACKED"
 
 
+def test_derived_model_registration_preserves_component_scoped_adapter_metadata(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+    source_model = common_pb2.ModelSpec(
+        model_id="melix-gemma4-vlm",
+        model_path=str(tmp_path / "gemma4-vlm"),
+        model_kind="vlm",
+        revision="main",
+        max_context=8192,
+    )
+    source_model.ext["melix.lora.adapter_scope"] = "text_backbone"
+    source_model.ext["melix.lora.training_surface"] = "text_backbone"
+    source_model.ext["melix.lora.family_id"] = "gemma"
+    source_model.ext["melix.lora.component_model_type"] = "gemma4_text"
+    source_model.ext["melix.lora.base_model_path"] = source_model.model_path
+    service._core._registry.model_catalog.register_model(source_model)
+
+    model_spec = service._core._derived_model_spec_from_manifest(
+        {
+            "derived_model_id": "melix-gemma4-vlm-lora-abcd",
+            "derived_model_path": source_model.model_path,
+            "source_model": source_model.model_id,
+            "source_model_revision": "main",
+            "source_model_kind": "vlm",
+            "source_model_ext": dict(source_model.ext),
+            "activation_mode": "adapter_backed_runtime",
+            "adapter_manifest_path": str(tmp_path / "train_lora.adapter.json"),
+            "adapter_weights_path": str(tmp_path / "adapters.safetensors"),
+            "adapter_set_hash": "abcd1234",
+            "adapter_scope": "text_backbone",
+            "training_surface": "text_backbone",
+            "component_model_type": "gemma4_text",
+            "component_family": "gemma",
+            "component_model_path": source_model.model_path,
+        }
+    )
+
+    assert model_spec is not None
+    assert model_spec.model_kind == "vlm"
+    assert model_spec.runtime_mode == common_pb2.RUNTIME_MODE_ADAPTER_BACKED
+    assert model_spec.ext["melix.adapter_scope"] == "text_backbone"
+    assert model_spec.ext["melix.training_surface"] == "text_backbone"
+    assert model_spec.ext["melix.component_model_type"] == "gemma4_text"
+    assert model_spec.ext["melix.component_family"] == "gemma"
+    assert model_spec.ext["melix.component_model_path"] == source_model.model_path
+    assert model_spec.ext["melix.lora.adapter_scope"] == "text_backbone"
+    assert model_spec.ext["melix.lora.training_surface"] == "text_backbone"
+    assert model_spec.ext["melix.lora.component_model_type"] == "gemma4_text"
+    assert model_spec.ext["melix.lora.family_id"] == "gemma"
+    assert model_spec.ext["melix.lora.base_model_path"] == source_model.model_path
+
+
 def test_job_registry_snapshot_exposes_download_rows_with_machine_readable_status(tmp_path: Path) -> None:
     service = build_service(tmp_path)
     source_path, source_bytes = _write_download_source_file(tmp_path, size=1024)

--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -2519,6 +2519,17 @@ def test_registry_snapshot_promotes_gemma4_text_manifest_to_vlm_text_backed(tmp_
     assert gemma4.ext["vision_family_id"] == "gemma4-v1"
     assert gemma4.ext["vision_prompt_profile_id"] == "gemma4-chatml-v1"
     assert gemma4.ext["melix.capability.route_kind"] == "python_vlm"
+    assert gemma4.ext["melix.model.components"] == "text_backbone"
+    assert gemma4.ext["melix.model.component_contract"] == "component_scoped_v1"
+    assert gemma4.ext["melix.component.text_backbone.model_type"] == "gemma4_text"
+    assert gemma4.ext["melix.component.text_backbone.family_id"] == "gemma"
+    assert gemma4.ext["melix.component.text_backbone.lora_supported"] == "true"
+    assert gemma4.ext["melix.component.text_backbone.training_ready"] == "true"
+    assert gemma4.ext["melix.lora.adapter_scope"] == "text_backbone"
+    assert gemma4.ext["melix.lora.training_surface"] == "text_backbone"
+    assert gemma4.ext["melix.lora.component_model_type"] == "gemma4_text"
+    assert gemma4.ext["melix.lora.family_id"] == "gemma"
+    assert gemma4.ext["melix.lora.training_ready"] == "true"
 
 
 def test_registry_snapshot_keeps_multimodal_gemma4_manifest_in_multimodal_mode(tmp_path: Path) -> None:
@@ -2550,6 +2561,49 @@ def test_registry_snapshot_keeps_multimodal_gemma4_manifest_in_multimodal_mode(t
     assert gemma4.ext["melix.vlm.backend_id"] == "mlx_vlm"
     assert gemma4.ext.get("melix.vlm.execution_mode", "") == ""
     assert gemma4.ext["vision_family_id"] == "gemma4-v1"
+    assert gemma4.ext["melix.model.components"] == "text_backbone,vision_encoder,multimodal_projector"
+    assert gemma4.ext["melix.component.text_backbone.model_type"] == "gemma4_text"
+    assert gemma4.ext["melix.component.text_backbone.family_id"] == "gemma"
+    assert gemma4.ext["melix.component.text_backbone.lora_supported"] == "true"
+    assert gemma4.ext["melix.component.vision_encoder.model_type"] == "gemma4_vision"
+    assert gemma4.ext["melix.component.vision_encoder.lora_supported"] == "false"
+    assert gemma4.ext["melix.component.vision_encoder.lora_support_contract"] == "separate_contract"
+    assert gemma4.ext["melix.component.multimodal_projector.lora_supported"] == "false"
+    assert gemma4.ext["melix.component.multimodal_projector.lora_support_contract"] == "separate_contract"
+    assert gemma4.ext["melix.lora.adapter_scope"] == "text_backbone"
+    assert gemma4.ext["melix.lora.training_surface"] == "text_backbone"
+    assert gemma4.ext["melix.lora.component_model_type"] == "gemma4_text"
+    assert gemma4.ext["melix.lora.family_id"] == "gemma"
+    assert gemma4.ext["melix.lora.training_ready"] == "true"
+
+
+def test_gemma4_component_lora_metadata_requires_text_backbone_and_detects_processor_components(
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "gemma4"
+    model_dir.mkdir()
+
+    assert catalog_module._gemma4_component_lora_metadata(
+        model_path=str(model_dir),
+        model_dir=model_dir,
+        config_payload={},
+    ) == {}
+    assert catalog_module._gemma4_component_lora_metadata(
+        model_path=str(model_dir),
+        model_dir=model_dir,
+        config_payload={"text_config": {"model_type": "llama"}},
+    ) == {}
+
+    (model_dir / "processor_config.json").write_text("{}\n", encoding="utf-8")
+    metadata = catalog_module._gemma4_component_lora_metadata(
+        model_path=str(model_dir),
+        model_dir=model_dir,
+        config_payload={"text_config": {"model_type": "gemma4_text"}, "vision_config": None},
+    )
+
+    assert metadata["melix.model.components"] == "text_backbone,vision_encoder,multimodal_projector"
+    assert metadata["melix.component.vision_encoder.lora_supported"] == "false"
+    assert metadata["melix.component.multimodal_projector.lora_support_contract"] == "separate_contract"
 
 
 def test_registry_snapshot_promotes_gemma4_from_architecture_hint(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -2137,6 +2137,21 @@ class MaintenanceCore:
             ("adapter_manifest_path", "melix.adapter_manifest_path"),
             ("adapter_weights_path", "melix.adapter_weights_path"),
             ("adapter_set_hash", "melix.adapter_set_hash"),
+            ("adapter_scope", "melix.adapter_scope"),
+            ("training_surface", "melix.training_surface"),
+            ("component_model_type", "melix.component_model_type"),
+            ("component_family", "melix.component_family"),
+            ("component_model_path", "melix.component_model_path"),
+        ):
+            value = str(manifest.get(manifest_key, "")).strip()
+            if value:
+                model_spec.ext[ext_key] = value
+        for manifest_key, ext_key in (
+            ("adapter_scope", "melix.lora.adapter_scope"),
+            ("training_surface", "melix.lora.training_surface"),
+            ("component_model_type", "melix.lora.component_model_type"),
+            ("component_family", "melix.lora.family_id"),
+            ("component_model_path", "melix.lora.base_model_path"),
         ):
             value = str(manifest.get(manifest_key, "")).strip()
             if value:

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -2150,6 +2150,8 @@ class MaintenanceCore:
             ("adapter_scope", "melix.lora.adapter_scope"),
             ("training_surface", "melix.lora.training_surface"),
             ("component_model_type", "melix.lora.component_model_type"),
+            # Component-scoped adapters use the trainable component family for downstream
+            # LoRA resolution, which may differ from the wrapper model family.
             ("component_family", "melix.lora.family_id"),
             ("component_model_path", "melix.lora.base_model_path"),
         ):

--- a/services/mlx-worker-python/worker/model_ops/adapter_activation_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/adapter_activation_pipeline.py
@@ -64,6 +64,11 @@ class AdapterActivationPipeline:
                 code="activation_failure",
                 message=f"Unsupported activation mode: {activation_mode}",
             )
+        adapter_scope = _validate_adapter_scope(
+            adapter_manifest=adapter_manifest,
+            source_model=source_model,
+            activation_mode=activation_mode,
+        )
 
         emit("read_adapter", 0.2)
         emit("validate_base", 0.4)
@@ -125,6 +130,11 @@ class AdapterActivationPipeline:
             "source_model_revision": source_model.revision,
             "source_model_path": source_model.model_path,
             "source_model_kind": source_model.model_kind,
+            "adapter_scope": adapter_scope["adapter_scope"],
+            "training_surface": adapter_scope["training_surface"],
+            "component_model_type": adapter_scope["component_model_type"],
+            "component_family": adapter_scope["component_family"],
+            "component_model_path": adapter_scope["component_model_path"],
             "source_model_tokenizer_hash": source_model.tokenizer_hash,
             "source_model_quant_profile_id": source_model.quant_profile_id,
             "source_model_parser_mode": source_model.parser_mode,
@@ -147,3 +157,109 @@ class AdapterActivationPipeline:
             manifest["derived_model_alias"] = derived_model_alias
         manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
         return AdapterActivationPipelineResult(manifest=manifest, manifest_path=manifest_path)
+
+
+def _validate_adapter_scope(
+    *,
+    adapter_manifest: dict[str, Any],
+    source_model: common_pb2.ModelSpec,
+    activation_mode: str,
+) -> dict[str, str]:
+    adapter_scope = _manifest_str(adapter_manifest, "adapter_scope")
+    if not adapter_scope and source_model.model_kind == "text":
+        adapter_scope = "model"
+    training_surface = _manifest_str(adapter_manifest, "training_surface") or adapter_scope
+    source_model_kind = _manifest_str(adapter_manifest, "source_model_kind")
+    if source_model_kind and source_model_kind != source_model.model_kind:
+        raise ModelOperationError(
+            code="activation_failure",
+            message="Adapter package source model kind does not match the requested activation model.",
+            details={
+                "adapter_source_model_kind": source_model_kind,
+                "source_model_kind": source_model.model_kind,
+            },
+        )
+
+    component_model_type = _manifest_str(adapter_manifest, "component_model_type")
+    component_family = _manifest_str(adapter_manifest, "component_family")
+    component_model_path = _manifest_str(adapter_manifest, "component_model_path") or source_model.model_path
+
+    if source_model.model_kind == "text":
+        if adapter_scope != "model":
+            raise ModelOperationError(
+                code="activation_failure",
+                message="Adapter package scope does not match the requested text activation model.",
+                details={"adapter_scope": adapter_scope, "source_model_kind": source_model.model_kind},
+            )
+        return {
+            "adapter_scope": adapter_scope,
+            "training_surface": training_surface,
+            "component_model_type": component_model_type,
+            "component_family": component_family,
+            "component_model_path": component_model_path,
+        }
+
+    ext = source_model.ext
+    expected_scope = ext.get("melix.lora.adapter_scope", "").strip()
+    expected_surface = ext.get("melix.lora.training_surface", "").strip()
+    if adapter_scope != expected_scope or training_surface != expected_surface:
+        raise ModelOperationError(
+            code="activation_failure",
+            message="Adapter package scope does not match the requested activation model.",
+            details={
+                "adapter_scope": adapter_scope,
+                "expected_scope": expected_scope,
+                "training_surface": training_surface,
+                "expected_training_surface": expected_surface,
+            },
+        )
+
+    expected_component_model_type = (
+        ext.get("melix.lora.component_model_type", "").strip()
+        or ext.get(f"melix.component.{expected_scope}.model_type", "").strip()
+    )
+    if component_model_type and expected_component_model_type and component_model_type != expected_component_model_type:
+        raise ModelOperationError(
+            code="activation_failure",
+            message="Adapter package component type does not match the requested activation model.",
+            details={
+                "component_model_type": component_model_type,
+                "expected_component_model_type": expected_component_model_type,
+            },
+        )
+
+    expected_component_family = (
+        ext.get("melix.lora.family_id", "").strip()
+        or ext.get(f"melix.component.{expected_scope}.family_id", "").strip()
+    )
+    if component_family and expected_component_family and component_family != expected_component_family:
+        raise ModelOperationError(
+            code="activation_failure",
+            message="Adapter package component family does not match the requested activation model.",
+            details={
+                "component_family": component_family,
+                "expected_component_family": expected_component_family,
+            },
+        )
+
+    if activation_mode == "fused_derived_model":
+        raise ModelOperationError(
+            code="activation_failure",
+            message=(
+                "Fused activation is not supported for component-scoped non-text adapters; "
+                "use activation_mode=adapter_backed_runtime."
+            ),
+            details={"adapter_scope": adapter_scope, "source_model_kind": source_model.model_kind},
+        )
+
+    return {
+        "adapter_scope": adapter_scope,
+        "training_surface": training_surface,
+        "component_model_type": component_model_type or expected_component_model_type,
+        "component_family": component_family or expected_component_family,
+        "component_model_path": component_model_path,
+    }
+
+
+def _manifest_str(manifest: dict[str, Any], key: str) -> str:
+    return str(manifest.get(key, "") or "").strip()

--- a/services/mlx-worker-python/worker/model_ops/adapter_activation_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/adapter_activation_pipeline.py
@@ -202,6 +202,17 @@ def _validate_adapter_scope(
     ext = source_model.ext
     expected_scope = ext.get("melix.lora.adapter_scope", "").strip()
     expected_surface = ext.get("melix.lora.training_surface", "").strip()
+    if not expected_scope or not expected_surface:
+        raise ModelOperationError(
+            code="activation_failure",
+            message="Source model has no component LoRA scope metadata; cannot activate a component-scoped adapter.",
+            details={
+                "source_model_kind": source_model.model_kind,
+                "source_model": source_model.model_id,
+                "adapter_scope": adapter_scope,
+                "training_surface": training_surface,
+            },
+        )
     if adapter_scope != expected_scope or training_surface != expected_surface:
         raise ModelOperationError(
             code="activation_failure",

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -651,6 +651,11 @@ class ModelOpsJobRegistry:
                 "activation_duration_ms": float(manifest.get("activation_duration_ms", 0.0)),
                 "adapter_manifest_path": str(manifest.get("adapter_manifest_path", "")),
                 "adapter_weights_path": str(manifest.get("adapter_weights_path", "")),
+                "adapter_scope": str(manifest.get("adapter_scope", "")),
+                "training_surface": str(manifest.get("training_surface", "")),
+                "component_model_type": str(manifest.get("component_model_type", "")),
+                "component_family": str(manifest.get("component_family", "")),
+                "component_model_path": str(manifest.get("component_model_path", "")),
                 "activation_manifest_path": str(job.get("output_path", "")),
                 "source_adapter_job_id": str(manifest.get("source_adapter_job_id", "")),
                 "status": "activated",
@@ -676,6 +681,11 @@ class ModelOpsJobRegistry:
             publish = publish_by_path.get(output_path) or publish_by_name.get(adapter_name)
             activation = activation_by_path.get(output_path) or activation_by_hash.get(adapter_set_hash)
             removal_applied = output_path in removed_adapter_manifest_paths
+            adapter_scope = str(manifest.get("adapter_scope", ""))
+            training_surface = str(manifest.get("training_surface", ""))
+            component_model_type = str(manifest.get("component_model_type", ""))
+            component_family = str(manifest.get("component_family", ""))
+            component_model_path = str(manifest.get("component_model_path", ""))
 
             if publish:
                 status = "published"
@@ -730,6 +740,29 @@ class ModelOpsJobRegistry:
                     "activation_backend": "" if removal_applied else activation["activation_backend"] if activation else "",
                     "adapter_manifest_path": activation["adapter_manifest_path"] if activation else output_path,
                     "adapter_weights_path": "" if removal_applied else activation["adapter_weights_path"] if activation else "",
+                    "adapter_scope": (
+                        "" if removal_applied else activation["adapter_scope"] if activation else adapter_scope
+                    ),
+                    "training_surface": (
+                        ""
+                        if removal_applied
+                        else activation["training_surface"] if activation else training_surface
+                    ),
+                    "component_model_type": (
+                        ""
+                        if removal_applied
+                        else activation["component_model_type"] if activation else component_model_type
+                    ),
+                    "component_family": (
+                        ""
+                        if removal_applied
+                        else activation["component_family"] if activation else component_family
+                    ),
+                    "component_model_path": (
+                        ""
+                        if removal_applied
+                        else activation["component_model_path"] if activation else component_model_path
+                    ),
                     "source_adapter_job_id": activation["source_adapter_job_id"] if activation else job["job_id"],
                     "activation_duration_ms": 0.0 if removal_applied else activation["activation_duration_ms"] if activation else 0.0,
                     "exportable_state": "ready",
@@ -843,6 +876,11 @@ class ModelOpsJobRegistry:
                     "adapter_manifest_path": str(manifest.get("adapter_manifest_path", "")),
                     "adapter_weights_path": str(manifest.get("adapter_weights_path", "")),
                     "adapter_name": str(manifest.get("adapter_name", "")),
+                    "adapter_scope": str(manifest.get("adapter_scope", "")),
+                    "training_surface": str(manifest.get("training_surface", "")),
+                    "component_model_type": str(manifest.get("component_model_type", "")),
+                    "component_family": str(manifest.get("component_family", "")),
+                    "component_model_path": str(manifest.get("component_model_path", "")),
                     "derived_model_alias": str(manifest.get("derived_model_alias", "")),
                     "source_adapter_job_id": str(manifest.get("source_adapter_job_id", "")),
                     "source_model": str(manifest.get("source_model", "")),

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -99,13 +99,15 @@ class LoRATrainingPipeline:
         emit("apply_lora", 0.65)
         adapter_output_dir = output_dir / "adapter"
         resume_context = _resolve_resume_context(request_ext)
+        adapter_scope = _resolve_adapter_scope_metadata(source_model)
+        training_model_path = Path(adapter_scope["component_model_path"]).expanduser()
 
         emit("train", 0.8)
         training_result = self._runner.train(
             TrainingRequest(
                 job_id=job_id,
                 base_model_id=source_model.model_id,
-                model_path=Path(source_model.model_path).expanduser(),
+                model_path=training_model_path,
                 model_revision=source_model.revision,
                 adapter_output_dir=adapter_output_dir,
                 normalized_dataset_dir=normalized_snapshot.dataset_dir,
@@ -150,8 +152,14 @@ class LoRATrainingPipeline:
             "preset_id": config.preset_id,
             "preset_title": config.preset_title,
             "source_model": source_model.model_id,
+            "source_model_kind": source_model.model_kind,
             "source_model_revision": source_model.revision,
             "source_model_path": source_model.model_path,
+            "adapter_scope": adapter_scope["adapter_scope"],
+            "training_surface": adapter_scope["training_surface"],
+            "component_model_type": adapter_scope["component_model_type"],
+            "component_family": adapter_scope["component_family"],
+            "component_model_path": adapter_scope["component_model_path"],
             "experiment_group_id": experiment_group_id,
             "experiment_group_title": experiment_group_title,
             "dataset_uri": dataset.dataset_uri,
@@ -297,6 +305,35 @@ class LoRATrainingPipeline:
             manifest_path=manifest_path,
         )
         return LoRATrainingPipelineResult(manifest=manifest, manifest_path=manifest_path)
+
+
+def _resolve_adapter_scope_metadata(source_model: common_pb2.ModelSpec) -> dict[str, str]:
+    ext = source_model.ext
+    adapter_scope = ext.get("melix.lora.adapter_scope", "").strip()
+    if not adapter_scope and source_model.model_kind == "text":
+        adapter_scope = "model"
+    training_surface = ext.get("melix.lora.training_surface", "").strip() or adapter_scope
+    component_model_type = (
+        ext.get("melix.lora.component_model_type", "").strip()
+        or ext.get(f"melix.component.{adapter_scope}.model_type", "").strip()
+    )
+    component_family = (
+        ext.get("melix.lora.family_id", "").strip()
+        or ext.get(f"melix.component.{adapter_scope}.family_id", "").strip()
+        or ext.get("text_family_id", "").strip()
+    )
+    component_model_path = (
+        ext.get("melix.lora.base_model_path", "").strip()
+        or ext.get(f"melix.component.{adapter_scope}.path", "").strip()
+        or source_model.model_path
+    )
+    return {
+        "adapter_scope": adapter_scope,
+        "training_surface": training_surface,
+        "component_model_type": component_model_type,
+        "component_family": component_family,
+        "component_model_path": component_model_path,
+    }
 
 
 def _int_ext(ext: dict[str, str], key: str) -> int:

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -312,6 +312,11 @@ def _resolve_adapter_scope_metadata(source_model: common_pb2.ModelSpec) -> dict[
     adapter_scope = ext.get("melix.lora.adapter_scope", "").strip()
     if not adapter_scope and source_model.model_kind == "text":
         adapter_scope = "model"
+    if source_model.model_kind != "text" and not adapter_scope:
+        raise AssertionError(
+            "_resolve_adapter_scope_metadata called on non-text model with no adapter_scope; "
+            "caller should have rejected this model via _validate_lora_training_surface."
+        )
     training_surface = ext.get("melix.lora.training_surface", "").strip() or adapter_scope
     component_model_type = (
         ext.get("melix.lora.component_model_type", "").strip()

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -348,12 +348,7 @@ def normalize_training_config(
     sample_count: int,
     validation_sample_count: int = 0,
 ) -> LoRATrainingConfig:
-    if source_model.model_kind != "text":
-        raise ModelOperationError(
-            code="unsupported_model_family",
-            message="LoRA training is only supported for text models in v1.",
-            details={"model_kind": source_model.model_kind},
-        )
+    _validate_lora_training_surface(source_model)
 
     training_mode = ext.get("training_mode", "lora").strip().lower() or "lora"
     if training_mode not in _SUPPORTED_TRAINING_MODES:
@@ -891,6 +886,46 @@ def _resolve_family_id(source_model: common_pb2.ModelSpec) -> str:
     if any(token in searchable for token in ("mistral", "llama", "text")):
         return "llama"
     return "llama"
+
+
+def _validate_lora_training_surface(source_model: common_pb2.ModelSpec) -> None:
+    if source_model.model_kind == "text":
+        return
+
+    ext = source_model.ext
+    adapter_scope = ext.get("melix.lora.adapter_scope", "").strip().lower()
+    training_surface = ext.get("melix.lora.training_surface", "").strip().lower()
+    training_ready = ext.get("melix.lora.training_ready", "").strip().lower()
+    component_model_type = (
+        ext.get("melix.lora.component_model_type", "").strip().lower()
+        or ext.get("melix.component.text_backbone.model_type", "").strip().lower()
+    )
+    component_family = (
+        ext.get("melix.lora.family_id", "").strip().lower()
+        or ext.get("melix.component.text_backbone.family_id", "").strip().lower()
+    )
+
+    if (
+        adapter_scope == "text_backbone"
+        and training_surface == "text_backbone"
+        and training_ready == "true"
+        and component_model_type == "gemma4_text"
+        and component_family == "gemma"
+    ):
+        return
+
+    raise ModelOperationError(
+        code="unsupported_model_family",
+        message="LoRA training is only supported for text models or training-ready text_backbone components.",
+        details={
+            "model_kind": source_model.model_kind,
+            "adapter_scope": adapter_scope,
+            "training_surface": training_surface,
+            "training_ready": training_ready,
+            "component_model_type": component_model_type,
+            "component_family": component_family,
+        },
+    )
 
 
 def _resolve_family_hooks(source_model: common_pb2.ModelSpec, *, family_id: str) -> dict[str, str]:

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -103,6 +103,7 @@ _SUPPORTED_TRAINING_MODES = (
     | _RL_TRAINING_MODES
     | _CPT_TRAINING_MODES
 )
+_SUPPORTED_COMPONENT_SCOPES: frozenset[str] = frozenset({"text_backbone"})
 
 _NORMALIZED_TARGET_MODULE_PRESETS_KEY = "_normalized_target_module_presets"
 _NORMALIZED_DEFAULT_TARGET_MODULES_KEY = "_normalized_default_target_modules"
@@ -894,23 +895,27 @@ def _validate_lora_training_surface(source_model: common_pb2.ModelSpec) -> None:
 
     ext = source_model.ext
     adapter_scope = ext.get("melix.lora.adapter_scope", "").strip().lower()
-    training_surface = ext.get("melix.lora.training_surface", "").strip().lower()
+    training_surface = ext.get("melix.lora.training_surface", "").strip().lower() or adapter_scope
     training_ready = ext.get("melix.lora.training_ready", "").strip().lower()
+    component_lora_supported = ext.get(f"melix.component.{adapter_scope}.lora_supported", "").strip().lower()
+    component_training_ready = ext.get(f"melix.component.{adapter_scope}.training_ready", "").strip().lower()
     component_model_type = (
         ext.get("melix.lora.component_model_type", "").strip().lower()
-        or ext.get("melix.component.text_backbone.model_type", "").strip().lower()
+        or ext.get(f"melix.component.{adapter_scope}.model_type", "").strip().lower()
     )
     component_family = (
         ext.get("melix.lora.family_id", "").strip().lower()
-        or ext.get("melix.component.text_backbone.family_id", "").strip().lower()
+        or ext.get(f"melix.component.{adapter_scope}.family_id", "").strip().lower()
     )
 
     if (
-        adapter_scope == "text_backbone"
-        and training_surface == "text_backbone"
+        adapter_scope in _SUPPORTED_COMPONENT_SCOPES
+        and training_surface in _SUPPORTED_COMPONENT_SCOPES
         and training_ready == "true"
-        and component_model_type == "gemma4_text"
-        and component_family == "gemma"
+        and component_lora_supported == "true"
+        and component_training_ready == "true"
+        and component_model_type
+        and component_family
     ):
         return
 
@@ -922,6 +927,8 @@ def _validate_lora_training_surface(source_model: common_pb2.ModelSpec) -> None:
             "adapter_scope": adapter_scope,
             "training_surface": training_surface,
             "training_ready": training_ready,
+            "component_lora_supported": component_lora_supported,
+            "component_training_ready": component_training_ready,
             "component_model_type": component_model_type,
             "component_family": component_family,
         },

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -808,7 +808,7 @@ def _gemma4_execution_mode(
 
 
 def _gemma4_text_backbone_config(config_payload: Mapping[str, object] | None) -> Mapping[str, object] | None:
-    config_payload = dict(config_payload or {})
+    config_payload = config_payload or {}
     text_config = config_payload.get("text_config")
     if not isinstance(text_config, Mapping):
         return None
@@ -824,7 +824,7 @@ def _gemma4_has_vision_component(
     *,
     json_cache: dict[Path, tuple[int, int, dict[str, object]]] | None = None,
 ) -> bool:
-    config_payload = dict(config_payload or {})
+    config_payload = config_payload or {}
     vision_config = config_payload.get("vision_config")
     if isinstance(vision_config, Mapping) and len(vision_config) > 0:
         return True
@@ -868,7 +868,8 @@ def _gemma4_component_lora_metadata(
         "melix.lora.component_model_type": "gemma4_text",
     }
     if has_vision_component:
-        vision_config = dict(config_payload or {}).get("vision_config")
+        config_payload = config_payload or {}
+        vision_config = config_payload.get("vision_config")
         vision_model_type = ""
         if isinstance(vision_config, Mapping):
             vision_model_type = _normalized(str(vision_config.get("model_type", "")))

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -807,6 +807,83 @@ def _gemma4_execution_mode(
     return "text_backed"
 
 
+def _gemma4_text_backbone_config(config_payload: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    config_payload = dict(config_payload or {})
+    text_config = config_payload.get("text_config")
+    if not isinstance(text_config, Mapping):
+        return None
+    nested_model_type = _normalized(str(text_config.get("model_type", ""))).lower()
+    if nested_model_type != "gemma4_text":
+        return None
+    return text_config
+
+
+def _gemma4_has_vision_component(
+    model_dir: Path,
+    config_payload: Mapping[str, object] | None,
+    *,
+    json_cache: dict[Path, tuple[int, int, dict[str, object]]] | None = None,
+) -> bool:
+    config_payload = dict(config_payload or {})
+    vision_config = config_payload.get("vision_config")
+    if isinstance(vision_config, Mapping) and len(vision_config) > 0:
+        return True
+    if (model_dir / "processor_config.json").is_file() or (model_dir / "preprocessor_config.json").is_file():
+        return True
+    return _gemma4_index_has_vision_weights(model_dir, json_cache=json_cache)
+
+
+def _gemma4_component_lora_metadata(
+    *,
+    model_path: str,
+    model_dir: Path,
+    config_payload: Mapping[str, object] | None,
+    json_cache: dict[Path, tuple[int, int, dict[str, object]]] | None = None,
+) -> dict[str, str]:
+    text_config = _gemma4_text_backbone_config(config_payload)
+    if text_config is None:
+        return {}
+
+    components = ["text_backbone"]
+    has_vision_component = _gemma4_has_vision_component(
+        model_dir,
+        config_payload,
+        json_cache=json_cache,
+    )
+    if has_vision_component:
+        components.extend(["vision_encoder", "multimodal_projector"])
+
+    ext = {
+        **_text_lora_support_metadata("gemma", moe_enabled=False),
+        "melix.model.components": ",".join(components),
+        "melix.model.component_contract": "component_scoped_v1",
+        "melix.component.text_backbone.model_type": "gemma4_text",
+        "melix.component.text_backbone.family_id": "gemma",
+        "melix.component.text_backbone.lora_supported": "true",
+        "melix.component.text_backbone.training_ready": "true",
+        "melix.component.text_backbone.path": model_path,
+        "melix.lora.adapter_scope": "text_backbone",
+        "melix.lora.training_surface": "text_backbone",
+        "melix.lora.base_model_path": model_path,
+        "melix.lora.component_model_type": "gemma4_text",
+    }
+    if has_vision_component:
+        vision_config = dict(config_payload or {}).get("vision_config")
+        vision_model_type = ""
+        if isinstance(vision_config, Mapping):
+            vision_model_type = _normalized(str(vision_config.get("model_type", "")))
+        ext.update(
+            {
+                "melix.component.vision_encoder.model_type": vision_model_type or "gemma4_vision",
+                "melix.component.vision_encoder.lora_supported": "false",
+                "melix.component.vision_encoder.lora_support_contract": "separate_contract",
+                "melix.component.multimodal_projector.lora_supported": "false",
+                "melix.component.multimodal_projector.lora_support_contract": "separate_contract",
+            }
+        )
+    return ext
+
+
 def _gemma4_index_has_vision_weights(
     model_dir: Path,
     *,
@@ -893,6 +970,14 @@ def _vlm_capability_metadata(
     )
     if execution_mode:
         ext["melix.vlm.execution_mode"] = execution_mode
+    ext.update(
+        _gemma4_component_lora_metadata(
+            model_path=model_path,
+            model_dir=model_dir,
+            config_payload=config_payload,
+            json_cache=json_cache,
+        )
+    )
     return ext
 
 


### PR DESCRIPTION
## Summary
- Add component-scoped LoRA metadata for local Gemma 4 VLM model discovery when the model exposes a `gemma4_text` text backbone.
- Allow LoRA training and adapter-backed activation for training-ready Gemma 4 `text_backbone` adapters while preserving the source model as a VLM entry.
- Propagate adapter scope and component metadata through training manifests, activation manifests, derived model registration, job registry snapshots, and the Phase 8 LoRA runbook.
- Address review feedback by keeping component-scope admission metadata-driven, using dynamic component fallback keys, and surfacing missing component-scope activation metadata explicitly.

## Plan or Spec
- `docs/plans/2026-05-08-component-scoped-gemma4-lora.md`
- `docs/runbooks/phase-8-lora-adapter-workflow.md`

## Commands Run
```text
PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest <12 focused component-scoped LoRA tests> -q
-> 12 passed in 0.43s

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" COVERAGE_FILE="$(pwd)/.coverage.component_lora" uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest <12 focused component-scoped LoRA tests> -q
-> 12 passed in 0.42s

COVERAGE_FILE="$(pwd)/.coverage.component_lora" uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.component_lora.json
-> Wrote JSON report to coverage.component_lora.json

python3 scripts/python_changed_line_coverage.py --coverage-json coverage.component_lora.json --diff-from origin/main <changed Python files>
-> TOTAL 97.30% 288/296

make py-test
-> 2036 passed, 5 skipped, 2 warnings in 115.18s

make proto
-> passed before review follow-up; uv.lock runtime drift restored because this change does not modify dependencies or protobuf schemas

make swift-test
-> passed before review follow-up; final visible stage: 576 tests in 14 suites passed

PYTEST_DEBUG_TEMPROOT="$(pwd)/.runtime/pytest-tmp" make integration-test
-> 100 passed, 1 skipped in 1085.51s

git diff --check
-> passed
```

## Coverage and Metrics
- Changed-line Python coverage: `97.30% (288/296)` across the full PR diff from `origin/main`.
- Review follow-up changed-line coverage: `100.00% (29/29)` across the incremental review-fix diff.
- Performance probes and metrics are defined in `docs/plans/2026-05-08-component-scoped-gemma4-lora.md`:
  - training dispatch uses `melix.lora.base_model_path` as the component training path
  - training and activation manifests emit deterministic component metadata
  - activation rejects mismatched component scope before runtime load
  - derived registration preserves adapter scope in catalog restoration

## Known Gaps
- Gemma 4 `vision_encoder`, `multimodal_projector`, and audio component LoRA remain intentionally unsupported pending separate adapter contracts.
- Fused activation for non-text component-scoped adapters remains rejected; operators should use `activation_mode=adapter_backed_runtime`.
- An initial unisolated `make integration-test` run hit local pytest temp-dir and transient Swift code-signing setup failures; after a successful root Swift build and worktree-local `PYTEST_DEBUG_TEMPROOT`, the full integration suite passed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
