### PR TITLE
perf: skip code eval payload exists preflight

### DIFF
--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -590,6 +590,9 @@ def test_count_tests_falls_back_when_no_asserts_are_present() -> None:
 
 
 def test_load_payload_file_rejects_invalid_and_non_mapping_json(tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing.json"
+    assert code_eval_runner._load_payload_file(missing_path) is None
+
     invalid_path = tmp_path / "invalid.json"
     invalid_path.write_text("{", encoding="utf-8")
     assert code_eval_runner._load_payload_file(invalid_path) is None
@@ -607,9 +610,6 @@ class _BytesOnlyPayloadPath:
     def __init__(self, payload: bytes) -> None:
         self.payload = payload
         self.read_bytes_calls = 0
-
-    def exists(self) -> bool:
-        return True
 
     def read_bytes(self) -> bytes:
         self.read_bytes_calls += 1

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -235,10 +235,10 @@ def _count_tests(test_code: str) -> int:
 
 
 def _load_payload_file(payload_path: Path) -> dict[str, object] | None:
-    if not payload_path.exists():
-        return None
     try:
         payload = json.loads(payload_path.read_bytes())
+    except OSError:
+        return None
     except json.JSONDecodeError:
         return None
     if not isinstance(payload, dict):


### PR DESCRIPTION
## Summary
- Skip the separate `Path.exists()` preflight in the code-evaluation payload loader and let `read_bytes()` be the single filesystem probe.
- Preserve missing-file behavior by returning `None` on `OSError` and add focused coverage for that path.

## Plan or Spec
- N/A: this is a narrow implementation-level performance slice for the already registered PR-scoped probe `code-eval-payload-json-bytes`; no user-facing behavior or workflow changes.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
# baseline before change: {"elapsed_ms_mean": 4013.330889998802, "iteration_count": 1200.0, "payload_bytes": 55474.0, "peak_bytes_mean": 440500.14285714284, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
# 5 passed in 27.28s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py
# TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
# post-run 1: {"elapsed_ms_mean": 2746.45938059049, "iteration_count": 1200.0, "payload_bytes": 55474.0, "peak_bytes_mean": 440500.14285714284, "sample_count": 7.0}
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
# post-run 2: {"elapsed_ms_mean": 2715.2337120080897, "iteration_count": 1200.0, "payload_bytes": 55474.0, "peak_bytes_mean": 440500.14285714284, "sample_count": 7.0}
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
# post-run 3: {"elapsed_ms_mean": 2671.860367741569, "iteration_count": 1200.0, "payload_bytes": 55474.0, "peak_bytes_mean": 440500.14285714284, "sample_count": 7.0}

git diff --check
# passed
```

## Coverage and Metrics
- Registered probe: `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command`.
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Local probe baseline: `elapsed_ms_mean=4013.331 ms`, `peak_bytes_mean=440500.143 bytes`.
- Local post-change probe mean across 3 runs: `elapsed_ms_mean=2711.184 ms`, `speedup=1.480x`, `delta=-1302.146 ms` (`32.45%` faster), `peak_bytes_mean=440500.143 bytes`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation is Linux/Python focused; no Swift runtime effect is involved.
- Full repository `make py-test` / `make integration-test` were not run for this narrow registered-probe slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
