### PR TITLE
perf: branch hub size unit multipliers

### DIFF
--- a/docs/plans/2026-05-07-hub-catalog-size-hint-text-normalization.md
+++ b/docs/plans/2026-05-07-hub-catalog-size-hint-text-normalization.md
@@ -32,5 +32,13 @@ The registered probe remains unchanged for apples-to-apples CI comparison and ve
 
 - Focused pytest passes.
 - Changed-scope coverage is at least 95% for touched executable lines.
-- Local base-vs-head payload microprobe shows lower `elapsed_ms_mean` with unchanged guard-rail metrics (`checksum`, `matched_hint_count`, `sample_count`).
-- `git diff --check` passes.
+## 2026-05-07 follow-up: unit multiplier branch
+
+A follow-up micro-slice keeps the same registered probe and narrows `_size_hint_from_text(...)` by replacing the per-match unit multiplier dictionary literal with direct `kb`/`mb`/`gb` branches. This preserves the precompiled regex behavior and accepted units while avoiding repeated short-lived dictionary allocation on every successful size-hint match.
+
+Success criteria for this follow-up:
+
+- Focused Hub catalog and PR-scoped performance tests pass.
+- Changed-scope coverage remains at least 95%.
+- The local registered probe reports lower `elapsed_ms_mean` versus the pre-change branch baseline with unchanged `checksum`, `matched_hint_count`, `sample_count`, and `size_hint_calls_mean` guard rails.
+- Hosted PR-scoped performance CI runs `hub-catalog-size-hint-regex-precompile` before merge.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -800,3 +800,9 @@ def test_size_hint_parser_uses_precompiled_patterns(monkeypatch: pytest.MonkeyPa
     assert hub_catalog_module._size_hint_from_text("Model size: 768 MB", allow_bare=False) == 768 * MB
     assert hub_catalog_module._size_hint_from_text("Readme says 768 MB", allow_bare=False) == 0
     assert hub_catalog_module._size_hint_from_text("MODEL SIZE | 512 kb", allow_bare=False) == 512 * KB
+
+
+def test_size_hint_parser_preserves_all_unit_multipliers() -> None:
+    assert hub_catalog_module._size_hint_from_text("Model size: 1 KB", allow_bare=False) == KB
+    assert hub_catalog_module._size_hint_from_text("Model size: 1.5 MB", allow_bare=False) == int(1.5 * MB)
+    assert hub_catalog_module._size_hint_from_text("Model size: 2 GB", allow_bare=False) == 2 * GB

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -588,7 +588,12 @@ def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:
         return 0
     value = float(match.group(1))
     unit = match.group(2).lower()
-    multiplier = {"kb": 1024, "mb": 1024 ** 2, "gb": 1024 ** 3}[unit]
+    if unit == "kb":
+        multiplier = 1024
+    elif unit == "mb":
+        multiplier = 1024 ** 2
+    else:
+        multiplier = 1024 ** 3
     return int(value * multiplier)
 
 


### PR DESCRIPTION
## Summary
- Replace the per-match Hub catalog size-hint unit multiplier dictionary with direct `kb`/`mb`/`gb` branches.
- Add regression coverage for all accepted unit multiplier branches.

## Plan or Spec
- `docs/plans/2026-05-07-hub-catalog-size-hint-text-normalization.md` follow-up: unit multiplier branch.

## Commands Run
```text
# Registered probe pre-change branch baseline (same worktree before edit)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
exit 0; elapsed_ms_mean=3426.0451159983254; size_hint_calls_mean=150000.0; checksum=0.0; matched_hint_count=100000.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
exit 0; 40 passed in 0.74s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
exit 0; 40 passed; TOTAL 9 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
exit 0; elapsed_ms_mean=2945.3277429953837; size_hint_calls_mean=150000.0; checksum=0.0; matched_hint_count=100000.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /tmp/melix-hub-size-base-476058 --head-repo "$PWD" --output /tmp/hub-size-hint-pr-perf.json
exit 0; base elapsed_ms_mean=3538.9411826618016; head elapsed_ms_mean=3371.4626136934385; coverage=100%

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 9 0 100%`.
- Registered probe: `hub-catalog-size-hint-regex-precompile` is registered with focused `test_command`, `coverage_command`, and `probe_command` entries.
- Local PR-scoped runner metrics (`MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=3`): `old_mean=3538.9411826618016 ms`, `new_mean=3371.4626136934385 ms`, `delta_ms=-167.4785689683631`, `speedup=4.732448501514646%`.
- Guard rails unchanged: `checksum=0.0`, `matched_hint_count=100000.0`, `size_hint_calls_mean=150000.0`, `sample_count=3.0`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime effect is claimed.
- The local probe also had a standalone same-worktree pre/post run (`3426.0451159983254 ms` -> `2945.3277429953837 ms`), but the merge decision should use the registered CI PR-scoped probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
