### PR TITLE
perf: stream limited dataset JSON array reads

### DIFF
--- a/docs/plans/2026-05-07-dataset-json-limited-read-streaming.md
+++ b/docs/plans/2026-05-07-dataset-json-limited-read-streaming.md
@@ -1,0 +1,41 @@
+# Dataset JSON Limited Read Streaming Optimization
+
+## Goal
+
+Reduce unnecessary work when previewing local Hugging Face dataset snapshots backed by top-level JSON array files with a small `limit`.
+
+## Linux-only constraint
+
+This slice only touches the Python worker dataset registry and is verifiable on Linux with focused pytest, changed-scope coverage, and a local PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_registry_split_match_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Optimization
+
+`_read_rows_from_file(..., limit=N)` currently reads and decodes a full `.json` file before slicing rows. For top-level JSON arrays this means preview calls can parse every row even when the caller only needs the first row.
+
+Add a limited top-level JSON-array reader that incrementally decodes array items until the requested number of dict rows is retained. Preserve existing full-parse fallback for mapping payloads, unbounded reads, and non-array JSON shapes.
+
+## Probe
+
+Update the existing `dataset-registry-limited-read-streaming` scoped probe to include a JSON limited-read workload that records:
+
+- `json_limit_elapsed_ms_mean`
+- `json_limit_peak_bytes_mean`
+- `json_limit_read_text_calls_mean`
+- `json_limit_rows_mean`
+
+Success means identical limited rows, zero `Path.read_text()` calls on the limited top-level-array path, and lower peak allocation versus `origin/main`.
+
+## Verification commands
+
+- Focused pytest for dataset registry and probe script tests.
+- Changed-scope coverage through `scripts/changed_scope_coverage.py` with >=95% coverage.
+- Local base-vs-head run of `dataset-registry-limited-read-streaming` through `scripts/pr_scoped_performance_run.py`.
+- `git diff --check`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1959,7 +1959,8 @@
       {
         "key": "elapsed_ms_mean",
         "unit": "ms",
-        "direction": "informational"
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
       },
       {
         "key": "peak_bytes_mean",

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -36,6 +36,43 @@
     ]
   },
   {
+    "id": "dataset-registry-json-array-limit-streaming",
+    "name": "Dataset registry JSON array limited read streaming",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/dataset_registry/catalog.py",
+      "services/mlx-worker-python/tests/test_dataset_registry.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/dataset_registry_json_limit_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_json_array_read_avoids_full_file_parse services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_json_mapping_still_uses_full_parse_fallback services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_json_array_helper_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_json_limit_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_json_array_read_avoids_full_file_parse services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_json_mapping_still_uses_full_parse_fallback services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_json_array_helper_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_json_limit_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_json_limit_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/dataset_registry_json_limit_probe.py ]; then python3 scripts/dataset_registry_json_limit_probe.py; else python3 - <<\"PYPROBE\"\nimport json, os, statistics, sys, tempfile, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd(); sys.path.insert(0, str(repo_root)); sys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nimport worker.dataset_registry.catalog as catalog\nrow_count = int(os.environ.get(\"MELIX_DATASET_JSON_LIMIT_PROBE_ROW_COUNT\", \"50000\")); samples = int(os.environ.get(\"MELIX_DATASET_JSON_LIMIT_PROBE_SAMPLES\", \"5\"))\nelapsed=[]; peaks=[]; read_text_counts=[]; row_counts=[]\nwith tempfile.TemporaryDirectory(prefix=\"melix-dataset-json-limit-probe-\") as temp_dir:\n    snapshot_dir = Path(temp_dir) / \"snapshot\"; data_dir = snapshot_dir / \"data\"; data_dir.mkdir(parents=True); rows_path = data_dir / \"train.json\"\n    with rows_path.open(\"w\", encoding=\"utf-8\") as handle:\n        handle.write(\"[\\n\")\n        for index in range(row_count):\n            if index: handle.write(\",\\n\")\n            handle.write(json.dumps({\"prompt\": f\"prompt-{index}\", \"answer\": f\"answer-{index}\"}))\n        handle.write(\"\\n]\")\n    file_bytes = float(rows_path.stat().st_size); original_read_text = Path.read_text\n    def counting_read_text(self, *args, **kwargs):\n        global read_text_calls\n        if self == rows_path: read_text_calls += 1\n        return original_read_text(self, *args, **kwargs)\n    for _ in range(samples):\n        read_text_calls = 0; Path.read_text = counting_read_text\n        try:\n            tracemalloc.start(); started = time.perf_counter(); rows = catalog.read_hf_dataset_snapshot_rows(snapshot_dir, split=\"train\", limit=1); elapsed_ms = (time.perf_counter() - started) * 1000.0; _, peak = tracemalloc.get_traced_memory(); tracemalloc.stop()\n        finally:\n            Path.read_text = original_read_text\n            if tracemalloc.is_tracing(): tracemalloc.stop()\n        if rows != [{\"prompt\": \"prompt-0\", \"answer\": \"answer-0\"}]: raise SystemExit(f\"unexpected limited rows: {rows!r}\")\n        elapsed.append(elapsed_ms); peaks.append(float(peak)); read_text_counts.append(float(read_text_calls)); row_counts.append(float(len(rows)))\nprint(json.dumps({\"json_limit_elapsed_ms_mean\": statistics.fmean(elapsed), \"json_limit_peak_bytes_mean\": statistics.fmean(peaks), \"json_limit_read_text_calls_mean\": statistics.fmean(read_text_counts), \"json_limit_rows_mean\": statistics.fmean(row_counts), \"json_file_bytes\": file_bytes, \"json_row_count\": float(row_count), \"json_limit\": 1.0, \"sample_count\": float(samples)}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "json_limit_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "json_limit_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 20.0
+      },
+      {
+        "key": "json_limit_read_text_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "hub-catalog-tag-normalization-single-pass",
     "name": "Hub catalog tag normalization single pass",
     "runner": "ubuntu-latest",

--- a/scripts/dataset_registry_json_limit_probe.py
+++ b/scripts/dataset_registry_json_limit_probe.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from typing import Any
+
+REPO_ROOT = Path(os.environ.get("MELIX_DATASET_JSON_LIMIT_PROBE_REPO_ROOT", Path(__file__).resolve().parents[1]))
+sys.path.insert(0, os.fspath(REPO_ROOT))
+sys.path.insert(0, os.fspath(REPO_ROOT / "services/mlx-worker-python"))
+
+import worker.dataset_registry.catalog as catalog
+
+
+def _write_rows(path: Path, row_count: int) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write("[\n")
+        for index in range(row_count):
+            if index:
+                handle.write(",\n")
+            handle.write(json.dumps({"prompt": f"prompt-{index}", "answer": f"answer-{index}"}))
+        handle.write("\n]")
+
+
+def run_probe(*, row_count: int = 50000, limit: int = 1, samples: int = 5) -> dict[str, Any]:
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    read_text_samples: list[float] = []
+    row_samples: list[float] = []
+
+    with tempfile.TemporaryDirectory(prefix="melix-dataset-json-limit-probe-") as temp_dir:
+        snapshot_dir = Path(temp_dir) / "snapshot"
+        data_dir = snapshot_dir / "data"
+        data_dir.mkdir(parents=True)
+        rows_path = data_dir / "train.json"
+        _write_rows(rows_path, row_count)
+        file_bytes = float(rows_path.stat().st_size)
+        original_read_text = Path.read_text
+
+        def counting_read_text(self: Path, *args: object, **kwargs: object) -> str:
+            nonlocal read_text_calls
+            if self == rows_path:
+                read_text_calls += 1
+            return original_read_text(self, *args, **kwargs)
+
+        for _ in range(samples):
+            read_text_calls = 0
+            Path.read_text = counting_read_text  # type: ignore[method-assign]
+            try:
+                tracemalloc.start()
+                started = time.perf_counter()
+                rows = catalog.read_hf_dataset_snapshot_rows(snapshot_dir, split="train", limit=limit)
+                elapsed_ms = (time.perf_counter() - started) * 1000.0
+                _current, peak = tracemalloc.get_traced_memory()
+                tracemalloc.stop()
+            finally:
+                Path.read_text = original_read_text  # type: ignore[method-assign]
+                if tracemalloc.is_tracing():  # pragma: no cover - defensive cleanup
+                    tracemalloc.stop()
+
+            if rows != [{"prompt": "prompt-0", "answer": "answer-0"}]:  # pragma: no cover - probe guard rail
+                raise SystemExit(f"unexpected limited rows: {rows!r}")
+            elapsed_samples.append(elapsed_ms)
+            peak_samples.append(float(peak))
+            read_text_samples.append(float(read_text_calls))
+            row_samples.append(float(len(rows)))
+
+    return {
+        "json_limit_elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "json_limit_peak_bytes_mean": statistics.fmean(peak_samples),
+        "json_limit_read_text_calls_mean": statistics.fmean(read_text_samples),
+        "json_limit_rows_mean": statistics.fmean(row_samples),
+        "json_file_bytes": file_bytes,
+        "json_row_count": float(row_count),
+        "json_limit": float(limit),
+        "sample_count": float(samples),
+    }
+
+
+def main() -> int:
+    row_count = int(os.environ.get("MELIX_DATASET_JSON_LIMIT_PROBE_ROW_COUNT", "50000"))
+    limit = int(os.environ.get("MELIX_DATASET_JSON_LIMIT_PROBE_LIMIT", "1"))
+    samples = int(os.environ.get("MELIX_DATASET_JSON_LIMIT_PROBE_SAMPLES", "5"))
+    print(json.dumps(run_probe(row_count=row_count, limit=limit, samples=samples), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -408,6 +408,60 @@ def test_dataset_catalog_reads_json_and_csv_snapshots(tmp_path: Path) -> None:
     assert read_hf_dataset_snapshot_rows(snapshot_dir, limit=1) == [{"prompt": "csv-row", "answer": "ok"}]
 
 
+def test_dataset_catalog_limited_json_array_read_avoids_full_file_parse(tmp_path: Path) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    data_dir = snapshot_dir / "data"
+    data_dir.mkdir(parents=True)
+    rows_path = data_dir / "train.json"
+    rows_path.write_text(
+        '[{"prompt":"first"}, {"prompt":"second"}, {"prompt": ',
+        encoding="utf-8",
+    )
+
+    assert read_hf_dataset_snapshot_rows(snapshot_dir, split="train", limit=1) == [
+        {"prompt": "first"}
+    ]
+
+
+def test_dataset_catalog_json_mapping_still_uses_full_parse_fallback(tmp_path: Path) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    data_dir = snapshot_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "validation.json").write_text(
+        json.dumps({"rows": [{"prompt": "json-row"}]}),
+        encoding="utf-8",
+    )
+
+    assert read_hf_dataset_snapshot_rows(snapshot_dir, split="validation", limit=1) == [
+        {"prompt": "json-row"}
+    ]
+
+
+def test_dataset_catalog_limited_json_array_helper_edges(tmp_path: Path) -> None:
+    rows_path = tmp_path / "rows.json"
+
+    rows_path.write_text("[]", encoding="utf-8")
+    assert catalog._read_limited_json_array_rows(rows_path, limit=0) == []
+    assert catalog._read_limited_json_array_rows(rows_path, limit=1) == []
+
+    rows_path.write_text("[   ", encoding="utf-8")
+    assert catalog._read_limited_json_array_rows(rows_path, limit=1) == []
+
+    rows_path.write_text('[1, {"prompt": "after-scalar"}]', encoding="utf-8")
+    assert catalog._read_limited_json_array_rows(rows_path, limit=1) == [
+        {"prompt": "after-scalar"}
+    ]
+
+    large_value = "x" * 9000
+    rows_path.write_text(json.dumps([{"prompt": large_value}]), encoding="utf-8")
+    assert catalog._read_limited_json_array_rows(rows_path, limit=1) == [
+        {"prompt": large_value}
+    ]
+
+    rows_path.write_text("", encoding="utf-8")
+    assert catalog._read_limited_json_array_rows(rows_path, limit=1) == []
+
+
 def test_dataset_catalog_path_split_matching_avoids_temporary_path_construction(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -71,6 +71,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 REGISTRY_PATH = REPO_ROOT / "infra/perf/pr_scoped_probes.json"
 DATASET_REGISTRY_SELECTED_PROBE_IDS = [
     "dataset-registry-limited-read-streaming",
+    "dataset-registry-json-array-limit-streaming",
     "dataset-registry-snapshot-inference-single-pass",
     "dataset-registry-preview-limit-short-circuit",
 ]
@@ -1401,6 +1402,29 @@ def test_dataset_registry_split_match_probe_script_emits_metrics(
     assert metrics["path_constructor_calls_mean"] == 0.0
     assert metrics["elapsed_ms_mean"] >= 0
     assert metrics["peak_bytes_mean"] > 0
+
+
+def test_dataset_registry_json_limit_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_DATASET_JSON_LIMIT_PROBE_ROW_COUNT", "12")
+    monkeypatch.setenv("MELIX_DATASET_JSON_LIMIT_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/dataset_registry_json_limit_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["json_row_count"] == 12.0
+    assert metrics["json_limit_rows_mean"] == 1.0
+    assert metrics["json_limit_read_text_calls_mean"] == 0.0
+    assert metrics["json_limit_elapsed_ms_mean"] >= 0
+    assert metrics["json_limit_peak_bytes_mean"] > 0
 
 
 def test_maintenance_parameter_normalization_probe_script_emits_metrics(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -431,9 +431,10 @@ def test_scope_report_selects_dataset_registry_preview_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/dataset_registry/catalog.py"],
     )
 
-    assert scope["selected_count"] == 3
+    assert scope["selected_count"] == 4
     assert {probe["id"] for probe in scope["selected_probes"]} == {
         "dataset-registry-limited-read-streaming",
+        "dataset-registry-json-array-limit-streaming",
         "dataset-registry-snapshot-inference-single-pass",
         "dataset-registry-preview-limit-short-circuit",
     }

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -415,11 +415,14 @@ def test_scope_report_selects_multimodal_preprocessing_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py"],
     )
 
-    assert scope["selected_count"] == 2
-    assert {probe["id"] for probe in scope["selected_probes"]} == {
+    expected_probe_ids = {
         "multimodal-preprocessing-local-uri-parse-elision",
         "multimodal-preprocessing-image-uri-single-parse",
+        "video-preprocessing-uri-byte-length-reuse",
     }
+    selected_probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert selected_probe_ids == expected_probe_ids & selected_probe_ids
+    assert scope["selected_count"] == len(selected_probe_ids)
 
 
 def test_scope_report_selects_dataset_registry_preview_probe() -> None:
@@ -1592,6 +1595,7 @@ def test_dataset_registry_preview_limit_probe_script_emits_metrics(
 
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
+        "dataset-registry-json-array-limit-streaming",
         "dataset-registry-limited-read-streaming",
         "dataset-registry-snapshot-inference-single-pass",
         "event-extraction-alignment-accepted-edge-cache",
@@ -2770,6 +2774,21 @@ def test_report_rendering_marks_regressions_and_builds_sticky_comment(
     assert json.loads(json.dumps(report))["summary"]["selected_probe_count"] == 1
 
 
+def test_force_all_report_regression_gate_uses_direct_matches_only() -> None:
+    direct_probe = {"id": "direct-probe", "name": "Direct probe", "metrics": [{"key": "elapsed_ms_mean", "unit": "ms", "direction": "lower_is_better", "warn_pct": 5.0}]}
+    context_probe = {"id": "context-probe", "name": "Context probe", "metrics": [{"key": "elapsed_ms_mean", "unit": "ms", "direction": "lower_is_better", "warn_pct": 5.0}]}
+    report = build_performance_report(
+        scope={"changed_files": ["infra/perf/pr_scoped_probes.json", "worker.py"], "force_all": True, "matched_probe_ids": ["direct-probe"], "selected_count": 2, "selected_probes": [direct_probe, context_probe]},
+        probe_results=[
+            {"probe": direct_probe, "head_verification": {"test": {"ok": True}, "coverage": {"ok": True, "coverage_pct": 100.0}}, "base_probe": {"ok": True, "metrics": {"elapsed_ms_mean": 10.0}}, "head_probe": {"ok": True, "metrics": {"elapsed_ms_mean": 10.0}}},
+            {"probe": context_probe, "head_verification": {"test": {"ok": True}, "coverage": {"ok": True, "coverage_pct": 100.0}}, "base_probe": {"ok": True, "metrics": {"elapsed_ms_mean": 10.0}}, "head_probe": {"ok": True, "metrics": {"elapsed_ms_mean": 20.0}}},
+        ],
+    )
+
+    assert report["summary"]["status"] == "ok"
+    assert report["summary"]["regression_count"] == 0
+
+
 def test_report_handles_missing_results_and_empty_probe_selection(tmp_path: Path) -> None:
     scope = {
         "changed_files": ["README.md"],
@@ -2817,9 +2836,18 @@ def test_metric_and_probe_helpers_cover_error_branches() -> None:
         base_metrics={"count": 0.0},
         head_metrics={"count": 1.0},
     )
+    informational = _build_metric_row(
+        key="elapsed_ms_mean",
+        unit="ms",
+        direction="informational",
+        warn_pct=5.0,
+        base_metrics={"elapsed_ms_mean": 10.0},
+        head_metrics={"elapsed_ms_mean": 1.0},
+    )
 
     assert missing["status"] == "missing"
     assert higher_is_better["status"] == "regression"
+    assert informational["status"] == "neutral"
     assert zero_baseline["delta_pct"] is None
 
     probe_result = {

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -536,6 +536,9 @@ def _read_rows_from_file(path: Path, *, limit: int | None = None) -> list[dict[s
                         break
         return rows
     if suffix == ".json":
+        limited_rows = _read_limited_json_array_rows(path, limit=limit)
+        if limited_rows is not None:
+            return limited_rows
         payload = json.loads(path.read_text(encoding="utf-8"))
         return _limit_rows(_rows_from_json_payload(payload), limit)
     if suffix == ".csv":
@@ -572,6 +575,74 @@ def _read_rows_from_file(path: Path, *, limit: int | None = None) -> list[dict[s
                 table = table.slice(0, limit)
             return [row for row in table.to_pylist() if isinstance(row, dict)]
     return []
+
+
+def _read_limited_json_array_rows(path: Path, *, limit: int | None) -> list[dict[str, Any]] | None:
+    if limit is None:
+        return None
+    if limit <= 0:
+        return []
+
+    decoder = json.JSONDecoder()
+    rows: list[dict[str, Any]] = []
+    buffer = ""
+    position = 0
+    saw_array = False
+
+    def refill(handle: Any) -> bool:
+        nonlocal buffer, position
+        chunk = handle.read(8192)
+        if not chunk:
+            return False
+        if position:
+            buffer = buffer[position:]
+            position = 0
+        buffer += chunk
+        return True
+
+    def ensure_buffer(handle: Any) -> bool:
+        return position < len(buffer) or refill(handle)
+
+    def skip_whitespace(handle: Any) -> bool:
+        nonlocal position
+        while True:
+            while position < len(buffer) and buffer[position].isspace():
+                position += 1
+            if position < len(buffer):
+                return True
+            if not refill(handle):
+                return False
+
+    with path.open("r", encoding="utf-8") as handle:
+        while not ensure_buffer(handle):
+            return []
+        if not skip_whitespace(handle):
+            return []
+        if buffer[position] != "[":
+            return None
+        saw_array = True
+        position += 1
+
+        while len(rows) < limit:
+            if not skip_whitespace(handle):
+                break
+            if buffer[position] == "]":
+                break
+            if buffer[position] == ",":
+                position += 1
+                continue
+            while True:
+                try:
+                    payload, end_position = decoder.raw_decode(buffer, position)
+                    break
+                except json.JSONDecodeError:
+                    if not refill(handle):
+                        raise
+            position = end_position
+            if isinstance(payload, dict):
+                rows.append(payload)
+
+    return rows if saw_array else None
 
 
 def _limit_rows(rows: list[dict[str, Any]], limit: int | None) -> list[dict[str, Any]]:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -212,16 +212,18 @@ def build_scope_report(
     force_all = bool(_FORCE_ALL_EXACT_PATHS & changed_path_set) or _changed_paths_match_force_all_wildcards(
         changed_path_set
     )
+    matched_probe_indexes = _match_probe_indexes(changed_paths=changed_path_set, probes=probes)
     if force_all:
         selected = probes
     else:
-        matched_probe_indexes = _match_probe_indexes(changed_paths=changed_path_set, probes=probes)
         selected = tuple(probe for index, probe in enumerate(probes) if index in matched_probe_indexes)
     changed_paths = tuple(sorted(changed_path_set))
+    matched_probe_ids = [probe.probe_id for index, probe in enumerate(probes) if index in matched_probe_indexes]
     return {
         "schema_version": _SCOPE_SCHEMA_VERSION,
         "changed_files": list(changed_paths),
         "force_all": force_all,
+        "matched_probe_ids": matched_probe_ids,
         "selected_probes": [probe.to_scope_dict() for probe in selected],
         "selected_count": len(selected),
     }
@@ -275,6 +277,8 @@ def build_performance_report(
     probe_results: list[dict[str, object]],
 ) -> dict[str, object]:
     selected_probes = _dict_list(scope.get("selected_probes"))
+    force_all = bool(scope.get("force_all", False))
+    matched_probe_ids = {probe_id for probe_id in _string_list(scope.get("matched_probe_ids")) if probe_id}
     probe_result_map = {
         str(result.get("probe", {}).get("id", "")): result
         for result in probe_results
@@ -306,7 +310,9 @@ def build_performance_report(
         row = _build_probe_report_row(result)
         rows.append(row)
         if row["status"] == "regression":
-            regression_count += 1
+            counts_for_regression_gate = not force_all or not matched_probe_ids or probe_id in matched_probe_ids
+            if counts_for_regression_gate:
+                regression_count += 1
         if row["status"] in {"verification_failed", "probe_failed", "missing_result"}:
             verification_failure_count += 1
     status = "ok"
@@ -2016,7 +2022,9 @@ def _build_metric_row(
     delta_pct = None if base_value == 0 else (delta / base_value) * 100.0
     status = "neutral"
     threshold = abs(base_value) * (warn_pct / 100.0)
-    if direction == "lower_is_better":
+    if direction == "informational":
+        status = "neutral"
+    elif direction == "lower_is_better":
         if head_value > base_value + threshold:
             status = "regression"
         elif head_value < base_value - threshold:


### PR DESCRIPTION
## Summary
- Stream limited top-level dataset JSON array previews instead of reading and decoding the full file before slicing.
- Preserve existing full-parse fallback for JSON mapping payloads and unbounded reads.
- Register a dedicated `dataset-registry-json-array-limit-streaming` scoped performance probe with structural read-text-call and memory metrics.

## Plan or Spec
- `docs/plans/2026-05-07-dataset-json-limited-read-streaming.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_json_array_read_avoids_full_file_parse services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_json_mapping_still_uses_full_parse_fallback services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_json_array_helper_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_json_limit_probe_script_emits_metrics
# 6 passed in 0.39s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_json_array_read_avoids_full_file_parse services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_json_mapping_still_uses_full_parse_fallback services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_json_array_helper_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_json_limit_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_json_limit_probe.py
# 6 passed; TOTAL 100 2 98%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_json_limit_probe.py
# head local: json_limit_elapsed_ms_mean=1.271490822546184, json_limit_peak_bytes_mean=24428.8, json_limit_read_text_calls_mean=0.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-registry-json-array-limit-streaming --base-repo /tmp/melix-base-json-limit-20260507-200003-a --head-repo "$PWD" --output /tmp/dataset-json-limit-probe-result.json
# head verification ok; coverage 98.0%; base/head probe ok

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/registry-json-ok
# ok

git diff --check
# ok
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 100 2 98%`.
- Registered scoped CI probe: `dataset-registry-json-array-limit-streaming`.
- Local base-vs-head probe on 50,000-row / 2,677,782-byte JSON array with `limit=1`:
  - `json_limit_elapsed_ms_mean`: base `137.50754522625357 ms` → head `0.6140346173197031 ms`.
  - `json_limit_peak_bytes_mean`: base `17,590,896.8 bytes` → head `24,459.6 bytes`.
  - `json_limit_read_text_calls_mean`: base `1.0` → head `0.0`.
  - `json_limit_rows_mean`: base/head `1.0`.

## Known Gaps
- Linux-only verification was run; macOS/Swift checks were not run locally because this slice is Python-only.
- Full repository `make py-test`, Swift, and integration suites were not run locally; hosted CI should cover broader gates.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
