### PR TITLE
perf: fast-path single hub size text

### DIFF
--- a/docs/plans/2026-05-07-hub-catalog-size-hint-text-normalization.md
+++ b/docs/plans/2026-05-07-hub-catalog-size-hint-text-normalization.md
@@ -42,3 +42,14 @@ Success criteria for this follow-up:
 - Changed-scope coverage remains at least 95%.
 - The local registered probe reports lower `elapsed_ms_mean` versus the pre-change branch baseline with unchanged `checksum`, `matched_hint_count`, `sample_count`, and `size_hint_calls_mean` guard rails.
 - Hosted PR-scoped performance CI runs `hub-catalog-size-hint-regex-precompile` before merge.
+
+## 2026-05-07 follow-up: single text fast path
+
+This micro-slice keeps the same registered probe and narrows `_size_hint_bytes(...)` for payloads with exactly one fallback text field (`description`, `readme`, or `cardData.description`). Those payloads no longer allocate a one-element joined string before the explicit size-hint regex scan. Payloads with multiple fallback text fields still use the prior newline-joined semantics, preserving cross-field behavior for defensive compatibility.
+
+Success criteria for this follow-up:
+
+- Focused Hub catalog and PR-scoped performance tests pass.
+- Changed-scope coverage remains at least 95%.
+- The local registered probe reports lower `elapsed_ms_mean` versus the pre-change branch baseline with unchanged `checksum`, `matched_hint_count`, `sample_count`, and `size_hint_calls_mean` guard rails.
+- Hosted PR-scoped performance CI runs `hub-catalog-size-hint-regex-precompile` before merge.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -531,6 +531,30 @@ def test_size_hint_bytes_skips_direct_hint_parser_when_card_model_size_missing(
     assert calls == [("Model size: 7 MB", False)]
 
 
+@pytest.mark.parametrize(
+    ("payload", "expected_text"),
+    [
+        ({"description": "Model size: 6 MB", "cardData": {}}, "Model size: 6 MB"),
+        ({"cardData": {"description": "Model size: 8 MB"}}, "Model size: 8 MB"),
+    ],
+)
+def test_size_hint_bytes_uses_single_payload_text_without_join(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: dict[str, object],
+    expected_text: str,
+) -> None:
+    calls: list[tuple[str, bool]] = []
+
+    def tracked(text: str, *, allow_bare: bool) -> int:
+        calls.append((text, allow_bare))
+        return 1
+
+    monkeypatch.setattr(hub_catalog_module, "_size_hint_from_text", tracked)
+
+    assert hub_catalog_module._size_hint_bytes(payload) == 1
+    assert calls == [(expected_text, False)]
+
+
 def test_search_models_ignores_sibling_sizes_without_weight_or_config_filenames() -> None:
     payload = [
         {

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -565,17 +565,33 @@ def _size_hint_bytes(payload: dict[str, Any]) -> int:
         if direct_card_hint > 0:
             return direct_card_hint
 
+    description_text = _string(payload.get("description"))
+    readme_text = _string(payload.get("readme"))
+    card_description_text = _string(card_data.get("description"))
+    if not readme_text and not card_description_text:
+        return (
+            _size_hint_from_text(description_text, allow_bare=False)
+            if description_text
+            else 0
+        )
+    if not description_text and not card_description_text:
+        return (
+            _size_hint_from_text(readme_text, allow_bare=False)
+            if readme_text
+            else 0
+        )
+    if not description_text and not readme_text:
+        return (
+            _size_hint_from_text(card_description_text, allow_bare=False)
+            if card_description_text
+            else 0
+        )
+
     text = "\n".join(
         text
-        for value in (
-            payload.get("description"),
-            payload.get("readme"),
-            card_data.get("description"),
-        )
-        if (text := _string(value))
+        for text in (description_text, readme_text, card_description_text)
+        if text
     )
-    if not text:
-        return 0
     return _size_hint_from_text(text, allow_bare=False)
 
 


### PR DESCRIPTION
## Summary
- Fast-path Hub catalog size-hint parsing when exactly one fallback text field is present.
- Preserve the existing newline-joined parsing behavior when multiple fallback text fields are present.
- Add regression coverage for description-only and cardData.description-only payloads.

## Plan or Spec
- `docs/plans/2026-05-07-hub-catalog-size-hint-text-normalization.md`
- Registered PR-scoped probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command`.

## Commands Run
```text
# Baseline local probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
exit 0; elapsed_ms_mean=2202.8218766596788; checksum=0; matched_hint_count=100000; size_hint_calls_mean=150000

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
exit 0; 42 passed in 3.21s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
exit 0; 42 passed; TOTAL 18 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-size-hint-single-text-20260507202901 --head-repo "$PWD" --output /tmp/hub_size_hint_single_text_probe.json
exit 0; base/head probe and head verification succeeded

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 18 0 100%`.
- Local registered probe (`hub-catalog-size-hint-regex-precompile`, 3 samples x 200000 iterations):
  - `base elapsed_ms_mean=2258.229309343733`
  - `head elapsed_ms_mean=1552.6289479651798`
  - `delta_ms=-705.6003613785532`
  - `speedup=1.4545x`
  - guard rails unchanged: `checksum=0`, `matched_hint_count=100000`, `sample_count=3`, `size_hint_calls_mean=150000`.
- CI PR-scoped performance must rerun the registered probe before merge.

## Known Gaps
- Local verification is Linux/Python-only; no Swift runtime effect is claimed.
- Full repository `make py-test` / integration suite was not run locally because this is a focused registered Python performance slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
