### PR TITLE
perf: trim startup log tail scan work

### DIFF
--- a/docs/plans/2026-05-07-startup-signals-tail-whitespace-probe.md
+++ b/docs/plans/2026-05-07-startup-signals-tail-whitespace-probe.md
@@ -26,6 +26,13 @@ Use the existing registered probe ID `startup-signals-lazy-worker-log-excerpts`,
 
 The probe writes a synthetic log ending in `80,000` whitespace bytes, repeatedly calls `_read_last_nonempty_line(...)`, and verifies that the final non-empty line remains unchanged.
 
+## Implementation note
+
+This slice keeps the reverse chunk scan semantics but combines trailing-whitespace
+skipping and last-line-bound discovery into a single helper. `_read_last_nonempty_line(...)`
+now avoids a second reverse scan after finding the last non-whitespace byte and
+returns the already-trimmed payload without a second decoded-string `rstrip()`.
+
 ## Success metrics
 
 - Focused startup signal tests pass.

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -243,38 +243,31 @@ def _log_excerpt(*paths: object) -> str:
 def _read_last_nonempty_line(path: Path, *, chunk_size: int = 8192) -> str:
     with path.open("rb") as handle:
         handle.seek(0, 2)
-        payload_end = _seek_non_whitespace_end(handle, chunk_size=chunk_size)
+        line_start, payload_end = _seek_last_nonempty_line_bounds(handle, chunk_size=chunk_size)
         if payload_end == 0:
             return ""
-        line_start = _seek_last_line_start(handle, payload_end=payload_end, chunk_size=chunk_size)
         handle.seek(line_start)
         payload = handle.read(payload_end - line_start)
-    return payload.decode("utf-8", errors="replace").rstrip()
+    return payload.decode("utf-8", errors="replace")
 
 
-def _seek_non_whitespace_end(handle: Any, *, chunk_size: int) -> int:
+def _seek_last_nonempty_line_bounds(handle: Any, *, chunk_size: int) -> tuple[int, int]:
     position = handle.tell()
+    payload_end = 0
     while position > 0:
         read_size = min(chunk_size, position)
         start = position - read_size
         handle.seek(start)
         chunk = handle.read(read_size)
-        trimmed = chunk.rstrip(_BYTE_WHITESPACE)
-        if trimmed:
-            return start + len(trimmed)
-        position = start
-    return 0
-
-
-def _seek_last_line_start(handle: Any, *, payload_end: int, chunk_size: int) -> int:
-    position = payload_end
-    while position > 0:
-        read_size = min(chunk_size, position)
-        start = position - read_size
-        handle.seek(start)
-        chunk = handle.read(read_size)
-        newline_index = max(chunk.rfind(b"\n"), chunk.rfind(b"\r"))
+        search_end = len(chunk)
+        if payload_end == 0:
+            search_end = len(chunk.rstrip(_BYTE_WHITESPACE))
+            if search_end == 0:
+                position = start
+                continue
+            payload_end = start + search_end
+        newline_index = max(chunk.rfind(b"\n", 0, search_end), chunk.rfind(b"\r", 0, search_end))
         if newline_index >= 0:
-            return start + newline_index + 1
+            return start + newline_index + 1, payload_end
         position = start
-    return 0
+    return 0, payload_end


### PR DESCRIPTION
## Summary
- Avoid redundant reverse-scan work in startup log tail parsing.
- Combine trailing-whitespace trimming and last-line boundary discovery into one reverse chunk pass while preserving whitespace-only, trailing-blank, and invalid-UTF8 behavior.

## Plan or Spec
- `docs/plans/2026-05-07-startup-signals-tail-whitespace-probe.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# 28 passed in 1.02s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py
# TOTAL 13 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id startup-signals-lazy-worker-log-excerpts --base-repo /tmp/melix-startup-signals-base-1778189472 --head-repo "$PWD" --output /tmp/startup_signals_probe_report_1778189472.json
# head verification ok, coverage_pct=100.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Registered probe: `startup-signals-lazy-worker-log-excerpts`.
- Local base-vs-head probe metrics after the combined-boundary pass:
  - `tail_scan_elapsed_ms_mean`: base `160.045590` ms → head `157.153871` ms (`-2.891719` ms, `-1.81%`).
  - `tail_scan_peak_bytes_mean`: base `21436.2` bytes → head `21436.2` bytes (`0.00%`).
  - `control_crash_elapsed_ms_mean`: base `14.779768` ms → head `10.553085` ms (`-28.60%`).
  - `worker_crash_elapsed_ms_mean`: base `14.930102` ms → head `11.156110` ms (`-25.28%`).
  - `conflict_elapsed_ms_mean`: base `1.063594` ms → head `0.954293` ms (`-10.28%`).
- CI PR-scoped performance report is still required as the merge gate.

## Known Gaps
- Local probe timings are Linux-only and subject to run-to-run variance; registered CI performance validation remains required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
