### PR TITLE
perf: scan vision prompt tokens without split allocation

### DIFF
--- a/docs/plans/2026-05-07-vision-prompt-token-count-scan.md
+++ b/docs/plans/2026-05-07-vision-prompt-token-count-scan.md
@@ -1,0 +1,32 @@
+# Vision Prompt Token Count Scan Optimization
+
+## Goal
+
+Reduce memory pressure in vision-family prompt token accounting by replacing `prompt_text.split()` list materialization with a single-pass whitespace token counter.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/vision_family_adapters.py`
+- `services/mlx-worker-python/tests/test_vision_runtime.py`
+- `scripts/vision_family_prompt_token_count_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Linux-only constraint
+
+This slice is Python-only and can be verified locally on Linux with focused pytest, changed-scope coverage, and an explicit command-json performance probe.
+
+## Performance probe
+
+Register `vision-family-prompt-token-count-scan` in the PR-scoped performance registry. The probe compares repeated prompt-token estimates for a large whitespace-delimited prompt and reports:
+
+- `elapsed_ms_mean` (lower is better)
+- `split_calls_mean` (lower is better; optimized branch should be `0.0`)
+- `peak_bytes_mean` (lower is better)
+- `token_count` (structural parity metric)
+
+## Success metrics
+
+- Focused tests pass.
+- Changed executable scope coverage is at least 95%.
+- Local probe shows the optimized path avoids `split()` calls and materially reduces peak traced allocation while preserving token count.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2962,5 +2962,42 @@
         "direction": "informational"
       }
     ]
+  },
+  {
+    "id": "vision-family-prompt-token-count-scan",
+    "name": "Vision family prompt token count scan",
+    "description": "Avoid prompt_text.split() list materialization in vision-family prompt token accounting.",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/vision_family_adapters.py",
+      "services/mlx-worker-python/tests/test_vision_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/vision_family_prompt_token_count_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/vision_family_adapters.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/vision_family_prompt_token_count_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/vision_family_prompt_token_count_probe.py ]; then python scripts/vision_family_prompt_token_count_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"ZnJvbSBfX2Z1dHVyZV9fIGltcG9ydCBhbm5vdGF0aW9ucwoKaW1wb3J0IGpzb24KaW1wb3J0IHN0YXRpc3RpY3MKaW1wb3J0IHN5cwppbXBvcnQgdGltZQppbXBvcnQgdHJhY2VtYWxsb2MKZnJvbSBwYXRobGliIGltcG9ydCBQYXRoCgpSRVBPX1JPT1QgPSBQYXRoKGdsb2JhbHMoKS5nZXQoIl9fZmlsZV9fIiwgUGF0aC5jd2QoKSkpLnJlc29sdmUoKQppZiBSRVBPX1JPT1QuaXNfZmlsZSgpOgogICAgUkVQT19ST09UID0gUkVQT19ST09ULnBhcmVudHNbMV0Kc3lzLnBhdGguaW5zZXJ0KDAsIHN0cihSRVBPX1JPT1QpKQpzeXMucGF0aC5pbnNlcnQoMCwgc3RyKFJFUE9fUk9PVCAvICJzZXJ2aWNlcy9tbHgtd29ya2VyLXB5dGhvbiIpKQoKZnJvbSB3b3JrZXIucnVudGltZS5tdWx0aW1vZGFsX3ByZXByb2Nlc3NpbmcgaW1wb3J0IFByZXBhcmVkVmlzaW9uUmVxdWVzdCAgIyBub3FhOiBFNDAyCmZyb20gd29ya2VyLnJ1bnRpbWUudmlzaW9uX2ZhbWlseV9hZGFwdGVycyBpbXBvcnQgcmVzb2x2ZV92aXNpb25fZmFtaWx5X2NvbmZpZyAgIyBub3FhOiBFNDAyCgoKY2xhc3MgU3BsaXRUcmFja2luZ1Byb21wdChzdHIpOgogICAgc3BsaXRfY2FsbHMgPSAwCgogICAgZGVmIHNwbGl0KHNlbGYsICphcmdzOiBvYmplY3QsICoqa3dhcmdzOiBvYmplY3QpIC0+IGxpc3Rbc3RyXToKICAgICAgICB0eXBlKHNlbGYpLnNwbGl0X2NhbGxzICs9IDEKICAgICAgICByZXR1cm4gc3VwZXIoKS5zcGxpdCgqYXJncywgKiprd2FyZ3MpCgoKZGVmIF9idWlsZF9yZXF1ZXN0KHByb21wdF90ZXh0OiBzdHIpIC0+IFByZXBhcmVkVmlzaW9uUmVxdWVzdDoKICAgIHJldHVybiBQcmVwYXJlZFZpc2lvblJlcXVlc3QoCiAgICAgICAgcHJvbXB0X3RleHQ9cHJvbXB0X3RleHQsCiAgICAgICAgaW1hZ2VzPVtdLAogICAgICAgIHZpZGVvcz1bXSwKICAgICAgICB2aWRlb19mcmFtZV9wb2xpY2llcz1bXSwKICAgICAgICBwcmVwcm9jZXNzX2xhdGVuY3lfbXM9MC4wLAogICAgICAgIHByZXByb2Nlc3NfaW5wdXRfYnl0ZXM9MCwKICAgICAgICBwcmVwcm9jZXNzX3BlYWtfbWVtb3J5X2J5dGVzPTAsCiAgICApCgoKZGVmIG1haW4oKSAtPiBOb25lOgogICAgZmFtaWx5X2NvbmZpZyA9IHJlc29sdmVfdmlzaW9uX2ZhbWlseV9jb25maWcoeyJ2aXNpb25fZmFtaWx5X2lkIjogInBhbGlnZW1tYS12MSJ9KQogICAgcHJvbXB0ID0gU3BsaXRUcmFja2luZ1Byb21wdCgoImFscGhhIGJldGEgZ2FtbWEgZGVsdGFcbiIgKiA0MDk2KS5zdHJpcCgpKQogICAgcmVxdWVzdCA9IF9idWlsZF9yZXF1ZXN0KHByb21wdCkKICAgIGV4cGVjdGVkX2NvdW50ID0gbGVuKHN0cihwcm9tcHQpLnNwbGl0KCkpICsgZmFtaWx5X2NvbmZpZy5wcm9tcHRfdG9rZW5fYmlhcwogICAgc2FtcGxlcyA9IFtdCiAgICBzcGxpdF9jYWxsX3NhbXBsZXMgPSBbXQogICAgcGVha19zYW1wbGVzID0gW10KICAgIHRva2VuX2NvdW50ID0gMAoKICAgIGZvciBfIGluIHJhbmdlKDcpOgogICAgICAgIFNwbGl0VHJhY2tpbmdQcm9tcHQuc3BsaXRfY2FsbHMgPSAwCiAgICAgICAgdHJhY2VtYWxsb2Muc3RhcnQoKQogICAgICAgIHN0YXJ0ZWQgPSB0aW1lLnBlcmZfY291bnRlcigpCiAgICAgICAgZm9yIF9pbm5lciBpbiByYW5nZSg0MDApOgogICAgICAgICAgICB0b2tlbl9jb3VudCA9IGZhbWlseV9jb25maWcucHJvbXB0X3Rva2VuX2NvdW50KHJlcXVlc3QpCiAgICAgICAgZWxhcHNlZF9tcyA9ICh0aW1lLnBlcmZfY291bnRlcigpIC0gc3RhcnRlZCkgKiAxMDAwLjAKICAgICAgICBfLCBwZWFrX2J5dGVzID0gdHJhY2VtYWxsb2MuZ2V0X3RyYWNlZF9tZW1vcnkoKQogICAgICAgIHRyYWNlbWFsbG9jLnN0b3AoKQogICAgICAgIGlmIHRva2VuX2NvdW50ICE9IGV4cGVjdGVkX2NvdW50OgogICAgICAgICAgICByYWlzZSBTeXN0ZW1FeGl0KGYidW5leHBlY3RlZCB0b2tlbiBjb3VudDoge3Rva2VuX2NvdW50fSAhPSB7ZXhwZWN0ZWRfY291bnR9IikKICAgICAgICBzYW1wbGVzLmFwcGVuZChlbGFwc2VkX21zKQogICAgICAgIHNwbGl0X2NhbGxfc2FtcGxlcy5hcHBlbmQoZmxvYXQoU3BsaXRUcmFja2luZ1Byb21wdC5zcGxpdF9jYWxscykpCiAgICAgICAgcGVha19zYW1wbGVzLmFwcGVuZChmbG9hdChwZWFrX2J5dGVzKSkKCiAgICBwcmludCgKICAgICAgICBqc29uLmR1bXBzKAogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAiZWxhcHNlZF9tc19tZWFuIjogc3RhdGlzdGljcy5mbWVhbihzYW1wbGVzKSwKICAgICAgICAgICAgICAgICJzcGxpdF9jYWxsc19tZWFuIjogc3RhdGlzdGljcy5mbWVhbihzcGxpdF9jYWxsX3NhbXBsZXMpLAogICAgICAgICAgICAgICAgInBlYWtfYnl0ZXNfbWVhbiI6IHN0YXRpc3RpY3MuZm1lYW4ocGVha19zYW1wbGVzKSwKICAgICAgICAgICAgICAgICJ0b2tlbl9jb3VudCI6IGZsb2F0KHRva2VuX2NvdW50KSwKICAgICAgICAgICAgfSwKICAgICAgICAgICAgc29ydF9rZXlzPVRydWUsCiAgICAgICAgKQogICAgKQoKCmlmIF9fbmFtZV9fID09ICJfX21haW5fXyI6CiAgICBtYWluKCkK\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "split_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "token_count",
+        "unit": "tokens",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      }
+    ]
   }
 ]

--- a/scripts/vision_family_prompt_token_count_probe.py
+++ b/scripts/vision_family_prompt_token_count_probe.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(globals().get("__file__", Path.cwd())).resolve()
+if REPO_ROOT.is_file():
+    REPO_ROOT = REPO_ROOT.parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime.multimodal_preprocessing import PreparedVisionRequest  # noqa: E402
+from worker.runtime.vision_family_adapters import resolve_vision_family_config  # noqa: E402
+
+
+class SplitTrackingPrompt(str):
+    split_calls = 0
+
+    def split(self, *args: object, **kwargs: object) -> list[str]:
+        type(self).split_calls += 1
+        return super().split(*args, **kwargs)
+
+
+def _build_request(prompt_text: str) -> PreparedVisionRequest:
+    return PreparedVisionRequest(
+        prompt_text=prompt_text,
+        images=[],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=0,
+        preprocess_peak_memory_bytes=0,
+    )
+
+
+def main() -> None:
+    family_config = resolve_vision_family_config({"vision_family_id": "paligemma-v1"})
+    prompt = SplitTrackingPrompt(("alpha beta gamma delta\n" * 4096).strip())
+    request = _build_request(prompt)
+    expected_count = len(str(prompt).split()) + family_config.prompt_token_bias
+    samples = []
+    split_call_samples = []
+    peak_samples = []
+    token_count = 0
+
+    for _ in range(7):
+        SplitTrackingPrompt.split_calls = 0
+        tracemalloc.start()
+        started = time.perf_counter()
+        for _inner in range(400):
+            token_count = family_config.prompt_token_count(request)
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        if token_count != expected_count:
+            raise SystemExit(f"unexpected token count: {token_count} != {expected_count}")
+        samples.append(elapsed_ms)
+        split_call_samples.append(float(SplitTrackingPrompt.split_calls))
+        peak_samples.append(float(peak_bytes))
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(samples),
+                "split_calls_mean": statistics.fmean(split_call_samples),
+                "peak_bytes_mean": statistics.fmean(peak_samples),
+                "token_count": float(token_count),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1744,6 +1744,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "mlx-audio-generate-signature-cache",
         "mlx-audio-speech-signature-cache",
         "video-preprocessing-uri-byte-length-reuse",
+        "vision-family-prompt-token-count-scan",
         "dev-up-mlx-metal-dist-info-scandir",
         "evaluation-answer-normalization-fast-path",
         "evaluation-dialogue-diagnostics-top-k",
@@ -4057,3 +4058,15 @@ def test_force_all_context_regressions_do_not_fail_direct_probe_gate() -> None:
     assert report["rows"][0]["gate"] == "direct"
     assert report["rows"][1]["gate"] == "context"
     assert report["rows"][1]["status"] == "regression"
+
+
+def test_vision_family_prompt_token_count_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runpy.run_path(str(REPO_ROOT / "scripts/vision_family_prompt_token_count_probe.py"), run_name="__main__")
+
+    metrics = json.loads(capsys.readouterr().out)
+
+    assert metrics["token_count"] > 0
+    assert metrics["split_calls_mean"] == 0.0
+    assert metrics["peak_bytes_mean"] > 0

--- a/services/mlx-worker-python/tests/test_vision_runtime.py
+++ b/services/mlx-worker-python/tests/test_vision_runtime.py
@@ -17,6 +17,7 @@ from worker.runtime import multimodal_preprocessing
 from worker.runtime.multimodal_fast_paths import fast_path_probe_signature
 from worker.runtime.multimodal_preprocessing import (
     MultimodalPreprocessError,
+    PreparedVisionRequest,
     _bytes_from_image_uri,
     _path_from_uri,
     _prepare_image_part,
@@ -596,6 +597,26 @@ def test_resolve_vision_family_config_handles_invalid_family_overrides() -> None
 
     assert family_config.max_images_per_prompt == 1
     assert family_config.supports_tool_calls is False
+
+
+def test_vision_family_prompt_token_count_matches_split_without_materializing_tokens() -> None:
+    class NoSplitPrompt(str):
+        def split(self, *args: object, **kwargs: object) -> list[str]:
+            raise AssertionError("prompt token counting should not materialize split tokens")
+
+    prompt_text = NoSplitPrompt("  alpha beta\tgamma\n\nΔelta  ")
+    family_config = resolve_vision_family_config({"vision_family_id": "paligemma-v1"})
+    request = PreparedVisionRequest(
+        prompt_text=prompt_text,
+        images=[],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=0,
+        preprocess_peak_memory_bytes=0,
+    )
+
+    assert family_config.prompt_token_count(request) == len(str(prompt_text).split()) + 2
 
 
 def test_resolve_vision_family_config_rejects_multi_video_requests_for_single_video_families() -> None:

--- a/services/mlx-worker-python/worker/runtime/vision_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/vision_family_adapters.py
@@ -73,7 +73,7 @@ class ResolvedVisionFamilyConfig:
         return _with_prompt_text(prepared_request, prompt_text)
 
     def prompt_token_count(self, prepared_request: PreparedVisionRequest) -> int:
-        prompt_tokens = len(prepared_request.prompt_text.split())
+        prompt_tokens = _whitespace_token_count(prepared_request.prompt_text)
         image_tokens = sum(
             max(1, image.byte_length // max(1, self.image_token_divisor))
             for image in prepared_request.images
@@ -191,6 +191,18 @@ def resolve_vision_family_config(metadata: dict[str, str] | None = None) -> Reso
     if adapter is None:
         raise ValueError(f"Unsupported vision family adapter: {family_id}")
     return adapter.resolve(metadata)
+
+
+def _whitespace_token_count(text: str) -> int:
+    token_count = 0
+    in_token = False
+    for character in text:
+        if character.isspace():
+            in_token = False
+        elif not in_token:
+            token_count += 1
+            in_token = True
+    return token_count
 
 
 def _with_prompt_text(


### PR DESCRIPTION
## Summary
- Replace vision-family prompt token accounting's `prompt_text.split()` list materialization with a single-pass whitespace token counter.
- Add a focused no-`split()` regression test and a PR-scoped performance probe for the prompt-token scan path.
- Add a lightweight implementation plan documenting the measurement path and success metrics.

## Plan or Spec
- `docs/plans/2026-05-07-vision-prompt-token-count-scan.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics
# 3 passed in 32.59s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/vision_family_adapters.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/vision_family_prompt_token_count_probe.py
# 3 passed; TOTAL 25 1 96%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/vision_family_prompt_token_count_probe.py
# {"elapsed_ms_mean": 3371.4768717098714, "peak_bytes_mean": 640.0, "split_calls_mean": 0.0, "token_count": 16386.0}

python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id vision-family-prompt-token-count-scan --base-repo /tmp/melix-cron-opt-20260507-204616-base-205942 --head-repo /tmp/melix-cron-opt-20260507-204616 --output /tmp/vision-probe-result.json
# head verification passed; base/head probes passed

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 25 1 96%`.
  - `vision_family_adapters.py`: `11/11` changed executable lines covered (`100%`).
  - `test_vision_runtime.py`: `7/8` changed executable lines covered (`87.50%`).
  - `test_pr_scoped_performance.py`: `6/6` changed executable lines covered (`100%`).
  - Aggregate gate: `24/25` changed executable lines covered (`96%`).
- Registered scoped probe: `vision-family-prompt-token-count-scan`.
- Local base-vs-head probe metrics from `scripts/pr_scoped_performance_run.py`:
  - `split_calls_mean`: `400.0` -> `0.0`.
  - `peak_bytes_mean`: `886648.0` -> `640.0` traced bytes.
  - `token_count`: `16386.0` -> `16386.0`.
  - Informational elapsed metric (not a registered gating metric): `2921.7577 ms` -> `3586.1524 ms`; this slice intentionally gates on avoiding split calls and allocation pressure while preserving token-count output.

## Known Gaps
- Linux-only local verification was run. Full macOS/Swift checks were not run locally on this Linux host.
- Hosted `pr-scoped-performance` remains the final CI validation for the registered probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
