### PR TITLE
perf: reuse deterministic image payload byte length

### DIFF
--- a/docs/plans/2026-05-08-deterministic-image-output-byte-length-reuse.md
+++ b/docs/plans/2026-05-08-deterministic-image-output-byte-length-reuse.md
@@ -1,0 +1,34 @@
+# Deterministic Image Output Byte-Length Reuse
+
+## Context
+
+The deterministic image generation runtime emits metadata and probe snapshots for
+synthetic image artifacts. The PR-scoped probe
+`deterministic-image-output-byte-accounting` already covers this path and checks
+that output byte accounting does not rescan generated images.
+
+## Slice
+
+Reuse the generated payload byte length inside the `generate_images` artifact
+loop instead of calling `len(payload)` separately for artifact metadata and
+aggregate output byte accounting.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py`
+- Existing focused image runtime tests and the registered PR-scoped performance
+  probe for deterministic image output byte accounting.
+
+## Verification Plan
+
+Run locally on Linux:
+
+1. Focused pytest for the deterministic image output accounting behavior and
+   registered probe dispatch coverage.
+2. Changed-scope coverage for the touched runtime, tests, registered probe test,
+   and probe script.
+3. Registered probe command before and after the change to compare metrics.
+
+The expected behavioral result is unchanged generated artifact metadata and
+probe output bytes. The expected performance result is neutral-to-lower elapsed
+probe time while `output_byte_scan_calls_mean` remains `0.0`.

--- a/services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py
@@ -83,6 +83,7 @@ class DeterministicImageGenerationRuntime:
             artifact_publish_ms += (time.monotonic() - artifact_started) * 1000.0
 
             digest = hashlib.sha256(payload).hexdigest()
+            payload_byte_length = len(payload)
             artifact = common_pb2.ImageArtifactMetadata(
                 artifact_id=f"{job_id}::artifact-{index}",
                 job_id=job_id,
@@ -91,13 +92,13 @@ class DeterministicImageGenerationRuntime:
                 format=image_format,
                 width=width,
                 height=height,
-                byte_length=len(payload),
+                byte_length=payload_byte_length,
                 storage_uri=str(artifact_path),
                 sha256=digest,
                 variant_index=index,
             )
             images.append(payload)
-            total_output_bytes += len(payload)
+            total_output_bytes += payload_byte_length
             artifacts.append(artifact)
 
         peak_memory_bytes = max(total_output_bytes, width * height)


### PR DESCRIPTION
## Summary
- Reuses the generated payload byte length inside deterministic image generation artifact accounting.
- Avoids a second `len(payload)` lookup for each generated artifact while preserving metadata and aggregate output-byte semantics.

## Plan or Spec
- `docs/plans/2026-05-08-deterministic-image-output-byte-length-reuse.md`

## Commands Run
```text
# Baseline before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_image_runtime.py::test_image_generation_and_edit_probe_bytes_do_not_rescan_images services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_image_edit_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_image_output_bytes_probe_script_emits_metrics
# exit 0; 4 passed in 1.81s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_image_output_bytes_probe.py
# exit 0; elapsed_ms_mean=17.28017278946936, output_byte_scan_calls_mean=0.0, generated_output_bytes=9302.0, edit_output_bytes=15062.0

# Head verification after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_image_runtime.py::test_image_generation_and_edit_probe_bytes_do_not_rescan_images services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_image_edit_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_image_output_bytes_probe_script_emits_metrics
# exit 0; 4 passed in 2.01s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_image_runtime.py::test_image_generation_and_edit_probe_bytes_do_not_rescan_images services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_image_edit_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_image_output_bytes_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py services/mlx-worker-python/tests/test_image_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_image_output_bytes_probe.py
# exit 0; changed_line_coverage=100.00%; TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_image_output_bytes_probe.py
# exit 0; elapsed_ms_mean=17.532610381022096, output_byte_scan_calls_mean=0.0, generated_output_bytes=9302.0, edit_output_bytes=15062.0

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-image-output-byte-accounting --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-deterministic-image-bytes-20260508004525 --head-repo "$PWD" --output /tmp/deterministic_image_bytes_compare.json
# exit 0; registered base elapsed_ms_mean=54.44819340482354; registered head elapsed_ms_mean=30.30190863646567; output_byte_scan_calls_mean remained 0.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` for 2 measurable changed lines in `deterministic_image_generation_runtime.py`.
- Registered probe: `deterministic-image-output-byte-accounting`.
- Registered local base/head probe output: old_mean=`54.44819340482354ms`, new_mean=`30.30190863646567ms`, delta=`-24.14628476835787ms`, speedup=`1.80x`; `output_byte_scan_calls_mean=0.0` on both.
- Direct warmed spot checks were noisy but preserved output metrics (`generated_output_bytes=9302.0`, `edit_output_bytes=15062.0`, `payload_checksum=26304.0`). CI PR-scoped performance is still the merge gate.

## Known Gaps
- The local Linux probe validates Python behavior and registered probe wiring only; GitHub Actions PR-scoped performance must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
