### PR TITLE
perf: cache code eval runner script

### DIFF
--- a/docs/plans/2026-05-08-code-eval-runner-script-cache.md
+++ b/docs/plans/2026-05-08-code-eval-runner-script-cache.md
@@ -1,0 +1,35 @@
+# Code Eval Runner Script Cache Optimization
+
+## Goal
+
+Avoid rebuilding and dedenting the static Python code-evaluation runner script on every `run_python_code_evaluation(...)` request.
+
+## Scope
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `scripts/code_eval_runner_script_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Linux-only constraint
+
+This is a Python-only change and is locally verifiable on Linux with focused pytest, changed-scope coverage, and a command-json PR-scoped performance probe.
+
+## Performance probe
+
+Register `code-eval-runner-script-cache` in `infra/perf/pr_scoped_probes.json`.
+
+The probe repeatedly calls `_runner_script()` and reports:
+
+- `elapsed_ms_mean` lower is better
+- `dedent_calls_mean` lower is better, expected `1.0` per sample on the optimized branch
+- `peak_bytes_mean` lower is better
+- `identity_reuse_mean` higher is better, expected `1.0` on the optimized branch
+
+## Success metrics
+
+- Focused tests pass.
+- Changed-scope coverage is at least 95% for touched executable Python scope.
+- Local base-vs-head probe shows fewer repeated `textwrap.dedent(...)` calls and lower elapsed time/allocations.
+- `git diff --check` passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2006,6 +2006,49 @@
     ]
   },
   {
+    "id": "code-eval-runner-script-cache",
+    "name": "Code evaluation runner script cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/engine/code_eval_runner.py",
+      "services/mlx-worker-python/tests/test_code_eval_runner.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/code_eval_runner_script_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_runner_script_reuses_dedented_static_payload services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_runner_script_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_runner_script_reuses_dedented_static_payload services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_runner_script_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_runner_script_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/code_eval_runner_script_probe.py ]; then python3 scripts/code_eval_runner_script_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"IyEvdXNyL2Jpbi9lbnYgcHl0aG9uMwpmcm9tIF9fZnV0dXJlX18gaW1wb3J0IGFubm90YXRpb25zCgppbXBvcnQganNvbgppbXBvcnQgc3RhdGlzdGljcwppbXBvcnQgc3lzCmltcG9ydCB0aW1lCmltcG9ydCB0cmFjZW1hbGxvYwpmcm9tIHBhdGhsaWIgaW1wb3J0IFBhdGgKClJFUE9fUk9PVCA9IFBhdGguY3dkKCkKc3lzLnBhdGguaW5zZXJ0KDAsIHN0cihSRVBPX1JPT1QpKQpzeXMucGF0aC5pbnNlcnQoMCwgc3RyKFJFUE9fUk9PVCAvICJzZXJ2aWNlcy9tbHgtd29ya2VyLXB5dGhvbiIpKQoKZnJvbSB3b3JrZXIuZW5naW5lIGltcG9ydCBjb2RlX2V2YWxfcnVubmVyICAjIG5vcWE6IEU0MDIKCgpkZWYgX3J1bl9zYW1wbGUoaXRlcmF0aW9uczogaW50KSAtPiB0dXBsZVtmbG9hdCwgaW50LCBpbnQsIGludF06CiAgICBpZiBoYXNhdHRyKGNvZGVfZXZhbF9ydW5uZXIuX3J1bm5lcl9zY3JpcHQsICJjYWNoZV9jbGVhciIpOgogICAgICAgIGNvZGVfZXZhbF9ydW5uZXIuX3J1bm5lcl9zY3JpcHQuY2FjaGVfY2xlYXIoKQoKICAgIG9yaWdpbmFsX2RlZGVudCA9IGNvZGVfZXZhbF9ydW5uZXIudGV4dHdyYXAuZGVkZW50CiAgICBkZWRlbnRfY2FsbHMgPSAwCgogICAgZGVmIHRyYWNrZWRfZGVkZW50KHRleHQ6IHN0cikgLT4gc3RyOgogICAgICAgIG5vbmxvY2FsIGRlZGVudF9jYWxscwogICAgICAgIGRlZGVudF9jYWxscyArPSAxCiAgICAgICAgcmV0dXJuIG9yaWdpbmFsX2RlZGVudCh0ZXh0KQoKICAgIGNvZGVfZXZhbF9ydW5uZXIudGV4dHdyYXAuZGVkZW50ID0gdHJhY2tlZF9kZWRlbnQKICAgIHRyeToKICAgICAgICBzdGFydGVkID0gdGltZS5wZXJmX2NvdW50ZXIoKQogICAgICAgIGNoZWNrc3VtID0gMAogICAgICAgIHNjcmlwdF9pZCA9IE5vbmUKICAgICAgICByZXVzZWRfaWRlbnRpdHkgPSAxCiAgICAgICAgZm9yIF8gaW4gcmFuZ2UoaXRlcmF0aW9ucyk6CiAgICAgICAgICAgIHNjcmlwdCA9IGNvZGVfZXZhbF9ydW5uZXIuX3J1bm5lcl9zY3JpcHQoKQogICAgICAgICAgICBpZiAiZGVmIG1haW4oKSAtPiBpbnQ6IiBub3QgaW4gc2NyaXB0IG9yIG5vdCBzY3JpcHQuZW5kc3dpdGgoIlxuIik6CiAgICAgICAgICAgICAgICByYWlzZSBTeXN0ZW1FeGl0KCJ1bmV4cGVjdGVkIHJ1bm5lciBzY3JpcHQgcGF5bG9hZCIpCiAgICAgICAgICAgIGNoZWNrc3VtICs9IGxlbihzY3JpcHQpCiAgICAgICAgICAgIGN1cnJlbnRfaWQgPSBpZChzY3JpcHQpCiAgICAgICAgICAgIGlmIHNjcmlwdF9pZCBpcyBOb25lOgogICAgICAgICAgICAgICAgc2NyaXB0X2lkID0gY3VycmVudF9pZAogICAgICAgICAgICBlbGlmIGN1cnJlbnRfaWQgIT0gc2NyaXB0X2lkOgogICAgICAgICAgICAgICAgcmV1c2VkX2lkZW50aXR5ID0gMAogICAgICAgIGVsYXBzZWRfbXMgPSAodGltZS5wZXJmX2NvdW50ZXIoKSAtIHN0YXJ0ZWQpICogMTAwMC4wCiAgICBmaW5hbGx5OgogICAgICAgIGNvZGVfZXZhbF9ydW5uZXIudGV4dHdyYXAuZGVkZW50ID0gb3JpZ2luYWxfZGVkZW50CiAgICAgICAgaWYgaGFzYXR0cihjb2RlX2V2YWxfcnVubmVyLl9ydW5uZXJfc2NyaXB0LCAiY2FjaGVfY2xlYXIiKToKICAgICAgICAgICAgY29kZV9ldmFsX3J1bm5lci5fcnVubmVyX3NjcmlwdC5jYWNoZV9jbGVhcigpCgogICAgcmV0dXJuIGVsYXBzZWRfbXMsIGRlZGVudF9jYWxscywgY2hlY2tzdW0sIHJldXNlZF9pZGVudGl0eQoKCmRlZiBtYWluKCkgLT4gaW50OgogICAgaXRlcmF0aW9ucyA9IDIwMDAwCiAgICBzYW1wbGVfY291bnQgPSA3CiAgICBlbGFwc2VkX3NhbXBsZXM6IGxpc3RbZmxvYXRdID0gW10KICAgIGRlZGVudF9jYWxsczogbGlzdFtmbG9hdF0gPSBbXQogICAgcGVha19zYW1wbGVzOiBsaXN0W2Zsb2F0XSA9IFtdCiAgICBpZGVudGl0eV9yZXVzZTogbGlzdFtmbG9hdF0gPSBbXQogICAgY2hlY2tzdW0gPSAwCgogICAgZm9yIF8gaW4gcmFuZ2Uoc2FtcGxlX2NvdW50KToKICAgICAgICB0cmFjZW1hbGxvYy5zdGFydCgpCiAgICAgICAgZWxhcHNlZF9tcywgY2FsbHMsIGNoZWNrc3VtLCByZXVzZWRfaWRlbnRpdHkgPSBfcnVuX3NhbXBsZShpdGVyYXRpb25zKQogICAgICAgIF8sIHBlYWsgPSB0cmFjZW1hbGxvYy5nZXRfdHJhY2VkX21lbW9yeSgpCiAgICAgICAgdHJhY2VtYWxsb2Muc3RvcCgpCiAgICAgICAgZWxhcHNlZF9zYW1wbGVzLmFwcGVuZChlbGFwc2VkX21zKQogICAgICAgIGRlZGVudF9jYWxscy5hcHBlbmQoZmxvYXQoY2FsbHMpKQogICAgICAgIHBlYWtfc2FtcGxlcy5hcHBlbmQoZmxvYXQocGVhaykpCiAgICAgICAgaWRlbnRpdHlfcmV1c2UuYXBwZW5kKGZsb2F0KHJldXNlZF9pZGVudGl0eSkpCgogICAgcHJpbnQoCiAgICAgICAganNvbi5kdW1wcygKICAgICAgICAgICAgewogICAgICAgICAgICAgICAgImVsYXBzZWRfbXNfbWVhbiI6IHN0YXRpc3RpY3MuZm1lYW4oZWxhcHNlZF9zYW1wbGVzKSwKICAgICAgICAgICAgICAgICJkZWRlbnRfY2FsbHNfbWVhbiI6IHN0YXRpc3RpY3MuZm1lYW4oZGVkZW50X2NhbGxzKSwKICAgICAgICAgICAgICAgICJwZWFrX2J5dGVzX21lYW4iOiBzdGF0aXN0aWNzLmZtZWFuKHBlYWtfc2FtcGxlcyksCiAgICAgICAgICAgICAgICAiaWRlbnRpdHlfcmV1c2VfbWVhbiI6IHN0YXRpc3RpY3MuZm1lYW4oaWRlbnRpdHlfcmV1c2UpLAogICAgICAgICAgICAgICAgIml0ZXJhdGlvbl9jb3VudCI6IGZsb2F0KGl0ZXJhdGlvbnMpLAogICAgICAgICAgICAgICAgInNhbXBsZV9jb3VudCI6IGZsb2F0KHNhbXBsZV9jb3VudCksCiAgICAgICAgICAgICAgICAiY2hlY2tzdW0iOiBmbG9hdChjaGVja3N1bSksCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgIHNvcnRfa2V5cz1UcnVlLAogICAgICAgICkKICAgICkKICAgIHJldHVybiAwCgoKaWYgX19uYW1lX18gPT0gIl9fbWFpbl9fIjoKICAgIHJhaXNlIFN5c3RlbUV4aXQobWFpbigpKQo=\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "dedent_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 10.0
+      },
+      {
+        "key": "identity_reuse_mean",
+        "unit": "ratio",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "changed-scope-coverage-empty-path-short-circuit",
     "name": "Changed-scope coverage empty-path short circuit",
     "runner": "ubuntu-latest",

--- a/scripts/code_eval_runner_script_probe.py
+++ b/scripts/code_eval_runner_script_probe.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path.cwd()
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.engine import code_eval_runner  # noqa: E402
+
+
+def _run_sample(iterations: int) -> tuple[float, int, int, int]:
+    if hasattr(code_eval_runner._runner_script, "cache_clear"):
+        code_eval_runner._runner_script.cache_clear()
+
+    original_dedent = code_eval_runner.textwrap.dedent
+    dedent_calls = 0
+
+    def tracked_dedent(text: str) -> str:
+        nonlocal dedent_calls
+        dedent_calls += 1
+        return original_dedent(text)
+
+    code_eval_runner.textwrap.dedent = tracked_dedent
+    try:
+        started = time.perf_counter()
+        checksum = 0
+        script_id = None
+        reused_identity = 1
+        for _ in range(iterations):
+            script = code_eval_runner._runner_script()
+            if "def main() -> int:" not in script or not script.endswith("\n"):
+                raise SystemExit("unexpected runner script payload")
+            checksum += len(script)
+            current_id = id(script)
+            if script_id is None:
+                script_id = current_id
+            elif current_id != script_id:
+                reused_identity = 0
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+    finally:
+        code_eval_runner.textwrap.dedent = original_dedent
+        if hasattr(code_eval_runner._runner_script, "cache_clear"):
+            code_eval_runner._runner_script.cache_clear()
+
+    return elapsed_ms, dedent_calls, checksum, reused_identity
+
+
+def main() -> int:
+    iterations = 20000
+    sample_count = 7
+    elapsed_samples: list[float] = []
+    dedent_calls: list[float] = []
+    peak_samples: list[float] = []
+    identity_reuse: list[float] = []
+    checksum = 0
+
+    for _ in range(sample_count):
+        tracemalloc.start()
+        elapsed_ms, calls, checksum, reused_identity = _run_sample(iterations)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        elapsed_samples.append(elapsed_ms)
+        dedent_calls.append(float(calls))
+        peak_samples.append(float(peak))
+        identity_reuse.append(float(reused_identity))
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+                "dedent_calls_mean": statistics.fmean(dedent_calls),
+                "peak_bytes_mean": statistics.fmean(peak_samples),
+                "identity_reuse_mean": statistics.fmean(identity_reuse),
+                "iteration_count": float(iterations),
+                "sample_count": float(sample_count),
+                "checksum": float(checksum),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -526,6 +526,29 @@ def test_sandbox_profile_reuses_static_runtime_fragments(
     code_eval_runner._sandbox_static_profile_key_cache_clear()
 
 
+def test_runner_script_reuses_dedented_static_payload(monkeypatch) -> None:
+    code_eval_runner._runner_script.cache_clear()
+    calls = 0
+    original_dedent = code_eval_runner.textwrap.dedent
+
+    def tracked_dedent(text: str) -> str:
+        nonlocal calls
+        calls += 1
+        return original_dedent(text)
+
+    monkeypatch.setattr(code_eval_runner.textwrap, "dedent", tracked_dedent)
+
+    first_script = code_eval_runner._runner_script()
+    second_script = code_eval_runner._runner_script()
+
+    assert calls == 1
+    assert first_script is second_script
+    assert "def main() -> int:" in first_script
+    assert first_script.endswith("\n")
+
+    code_eval_runner._runner_script.cache_clear()
+
+
 def test_sandbox_profile_cache_key_tracks_python_environment(
     tmp_path: Path,
     monkeypatch,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -359,11 +359,12 @@ def test_scope_report_selects_code_eval_stdio_probe() -> None:
     )
 
     probe_ids = {probe["id"] for probe in scope["selected_probes"]}
-    assert scope["selected_count"] == 3
+    assert scope["selected_count"] == 4
     assert probe_ids == {
         "code-eval-code-block-last-match-streaming",
         "code-eval-payload-json-bytes",
         "code-eval-stdio-tail-single-stat",
+        "code-eval-runner-script-cache",
     }
 
 
@@ -1618,6 +1619,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "code-eval-code-block-last-match-streaming",
         "code-eval-payload-json-bytes",
         "code-eval-stdio-tail-single-stat",
+        "code-eval-runner-script-cache",
         "deterministic-embedding-duplicate-input-cache",
         "deterministic-embedding-project-digest-allocation",
         "deterministic-image-edit-digest-reuse",
@@ -2093,6 +2095,22 @@ def test_code_eval_payload_json_probe_script_emits_metrics(
     assert metrics["payload_bytes"] > 0
     assert metrics["sample_count"] == 7.0
     assert metrics["iteration_count"] == 1200.0
+
+
+def test_code_eval_runner_script_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/code_eval_runner_script_probe.py"))
+
+    probe_script["main"]()
+    metrics = json.loads(capsys.readouterr().out)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["dedent_calls_mean"] == 1.0
+    assert metrics["identity_reuse_mean"] == 1.0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["iteration_count"] == 20000.0
+    assert metrics["sample_count"] == 7.0
 
 
 def test_probe_smokes_return_metrics_against_current_repo() -> None:

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -481,6 +481,7 @@ def _sandbox_allow_path_variants(paths: tuple[Path, ...]) -> tuple[Path, ...]:
     return tuple(deduped)
 
 
+@lru_cache(maxsize=1)
 def _runner_script() -> str:
     script = """
         from __future__ import annotations


### PR DESCRIPTION
## Summary
- Cache the static code-evaluation runner script with `@lru_cache(maxsize=1)` so repeated `run_python_code_evaluation(...)` calls avoid rebuilding and dedenting the same payload.
- Add a focused regression test proving the static runner payload is dedented once and reused by identity.
- Register `code-eval-runner-script-cache` as a PR-scoped command-json performance probe with a base-compatible fallback.

## Plan or Spec
- `docs/plans/2026-05-08-code-eval-runner-script-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_runner_script_reuses_dedented_static_payload services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_runner_script_probe_script_emits_metrics
# 4 passed in 0.60s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_runner_script_reuses_dedented_static_payload services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_runner_script_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_runner_script_probe.py
# 4 passed; TOTAL 27 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m scripts/code_eval_runner_script_probe.py
# scripts/code_eval_runner_script_probe.py: 95%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_runner_script_probe.py
# {"dedent_calls_mean": 1.0, "elapsed_ms_mean": 61.87634670641273, "identity_reuse_mean": 1.0, "peak_bytes_mean": 31459.714285714286, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-runner-script-cache --base-repo /tmp/melix-base-code-eval-runner-script-rerun-506484 --head-repo "$PWD" --output /tmp/code-eval-runner-script-probe.json
# head verification passed; base and head probes ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 27 0 100%`.
- New probe-script focused coverage: `scripts/code_eval_runner_script_probe.py` 95%.
- Registered scoped CI probe: `code-eval-runner-script-cache`.
- Local base-vs-head probe (`20,000` calls/sample, `7` samples):
  - `dedent_calls_mean`: `20000.0` → `1.0`
  - `elapsed_ms_mean`: `7973.2466` → `59.3960`
  - `peak_bytes_mean`: `36640.43` → `31459.71`
  - `identity_reuse_mean`: `0.0` → `1.0`

## Known Gaps
- Linux-only verification was run locally. macOS/Swift tests were not run on this host.
- Hosted GitHub Actions must still validate the registered PR-scoped performance probe before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
