### PR TITLE
perf: hoist hub quantization aliases

### DIFF
--- a/docs/plans/2026-05-08-hub-quantization-summary-alias-table.md
+++ b/docs/plans/2026-05-08-hub-quantization-summary-alias-table.md
@@ -1,0 +1,34 @@
+# Hub quantization summary alias table
+
+## Goal
+
+Reduce per-record allocation overhead in Hub catalog summary construction by
+hoisting quantization-summary alias definitions to a module-level immutable table
+instead of rebuilding the alias list and sets for every record.
+
+## Scope
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+
+## Registered Probe
+
+The affected path is covered by `hub-catalog-tag-normalization-single-pass` in
+`infra/perf/pr_scoped_probes.json`, including focused `test_command`,
+`coverage_command`, and `probe_command` entries.
+
+## Verification Plan
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py
+```
+
+## Decision Gate
+
+Accept only if the focused tests pass, changed-scope coverage remains above 95%,
+and the registered local probe shows a clear elapsed-time improvement versus the
+same-worktree baseline.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -13,6 +13,7 @@ from worker.model_ops.hub_catalog import (
     HubCatalogError,
     _is_mlx_compatible,
     _local_fit_evidence,
+    _quantization_summary,
     _size_hint_from_text,
 )
 
@@ -20,6 +21,25 @@ from worker.model_ops.hub_catalog import (
 KB = 1024
 MB = 1024 ** 2
 GB = 1024 ** 3
+
+
+def test_quantization_summary_preserves_alias_order_from_lowered_tags() -> None:
+    lowered_tags = {
+        "family-test",
+        "4bit",
+        "mixed_precision",
+        "optiq",
+        "float16",
+    }
+
+    assert (
+        _quantization_summary([], lowered_tags=lowered_tags)
+        == "4-bit, mixed-precision, optiq, fp16"
+    )
+    assert (
+        _quantization_summary(["2-bit", "3bit", "8-bit", "float32", "bf16"])
+        == "2-bit, 3-bit, 8-bit, fp32, bf16"
+    )
 
 
 class FakeHTTPResponse:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -17,6 +17,17 @@ RESIDENT_MEMORY_OVERHEAD_FACTOR = 1.35
 
 _BARE_SIZE_HINT_RE = re.compile(r"(?:model\s+size\s*[:|]?\s*)?(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
 _EXPLICIT_SIZE_HINT_RE = re.compile(r"\bmodel\s+size\s*[:|]?\s*(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
+_QUANTIZATION_ALIASES = (
+    ("2-bit", frozenset(("2bit", "2-bit"))),
+    ("3-bit", frozenset(("3bit", "3-bit"))),
+    ("4-bit", frozenset(("4bit", "4-bit"))),
+    ("8-bit", frozenset(("8bit", "8-bit"))),
+    ("mixed-precision", frozenset(("mixed-precision", "mixed_precision"))),
+    ("optiq", frozenset(("optiq",))),
+    ("fp32", frozenset(("fp32", "float32", "f32"))),
+    ("bf16", frozenset(("bf16",))),
+    ("fp16", frozenset(("fp16", "float16"))),
+)
 
 
 @dataclass(frozen=True)
@@ -662,18 +673,7 @@ def _bytes_per_parameter(tags: list[str], *, lowered_tags: set[str] | None = Non
 
 def _quantization_summary(tags: list[str], *, lowered_tags: set[str] | None = None) -> str:
     lowered = _normalized_lowered_tags(tags, lowered_tags)
-    ordered = [
-        ("2-bit", {"2bit", "2-bit"}),
-        ("3-bit", {"3bit", "3-bit"}),
-        ("4-bit", {"4bit", "4-bit"}),
-        ("8-bit", {"8bit", "8-bit"}),
-        ("mixed-precision", {"mixed-precision", "mixed_precision"}),
-        ("optiq", {"optiq"}),
-        ("fp32", {"fp32", "float32", "f32"}),
-        ("bf16", {"bf16"}),
-        ("fp16", {"fp16", "float16"}),
-    ]
-    values = [label for label, aliases in ordered if lowered.intersection(aliases)]
+    values = [label for label, aliases in _QUANTIZATION_ALIASES if lowered.intersection(aliases)]
     return ", ".join(values)
 
 


### PR DESCRIPTION
## Summary
- Hoists Hub catalog quantization alias definitions to a module-level immutable table so `_quantization_summary` no longer rebuilds the ordered alias list and sets for every record.
- Adds focused regression coverage for alias ordering and supplied `lowered_tags` reuse.

## Plan or Spec
- `docs/plans/2026-05-08-hub-quantization-summary-alias-table.md`
- Registered probe: `hub-catalog-tag-normalization-single-pass` in `infra/perf/pr_scoped_probes.json` covers `services/mlx-worker-python/worker/model_ops/hub_catalog.py` and includes focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
# Pre-slice baseline on origin/main worktree before edits
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py
=> {"elapsed_ms_mean": 299.11883419845253, "peak_bytes_mean": 8766348.0, "record_count": 5000.0, "sample_count": 5.0, "tag_normalization_calls_mean": 5000.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
=> 43 passed in 0.29s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
=> 43 passed in 0.37s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
=> Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py
=> TOTAL 6 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py
=> {"elapsed_ms_mean": 243.33579679951072, "peak_bytes_mean": 8748506.4, "record_count": 5000.0, "sample_count": 5.0, "tag_normalization_calls_mean": 5000.0}

git diff --check
=> passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 6 0 100%`).
- Registered local probe: `hub_catalog_tag_normalization_probe.py` (`record_count=5000`, `sample_count=5`).
- Baseline `elapsed_ms_mean=299.11883419845253`; optimized `elapsed_ms_mean=243.33579679951072`; delta `-55.78303739894181 ms`; speedup about `1.23x` (18.65% faster).
- Peak memory mean: `8766348.0` bytes -> `8748506.4` bytes.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local verification is Linux/Python-only; no Swift runtime effect is claimed for this Python slice.
- The registered CI probe report must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
