### PR TITLE
[codex] Fix PR scoped performance report metrics

### DIFF
--- a/docs/plans/2026-05-08-pr513-performance-follow-up.md
+++ b/docs/plans/2026-05-08-pr513-performance-follow-up.md
@@ -1,0 +1,78 @@
+# PR 513 Performance Report Follow-Up Plan
+
+## Goal
+
+Correct the PR-scoped performance report semantics that misclassified
+informational metrics in PR 513, then reduce avoidable peak allocations in the
+shared WAV PCM chunking helper used by the speech runtime.
+
+## Scope
+
+This follow-up is intentionally narrow. It does not change the progressive
+speech streaming protocol, the HTTP streaming contract, or generated protocol
+artifacts from PR 513.
+
+## Work Items
+
+1. Teach the PR-scoped performance reporter that `direction: informational`
+   metrics are measured and rendered but never counted as regressions or
+   improvements.
+2. Add focused coverage proving informational metrics remain neutral when head
+   values are higher or lower than base values.
+3. Reduce `worker.runtime.wav_helpers.audio_to_pcm_chunks` peak live memory by
+   resetting the reusable PCM array before yielding the materialized bytes, and
+   inline the per-sample clamp/scale operation on the hot path.
+4. Keep the existing WAV byte output contract unchanged for nested iterables,
+   array-like `.flat` values, and big-endian byte swapping.
+
+## Metrics
+
+Primary probes:
+
+- `mlx-audio-wav-streaming-pcm`
+  - `peak_bytes_mean`: lower is better, with the existing 5 percent warning
+    threshold.
+  - `elapsed_ms_mean`: informational; a lower value should be rendered as data
+    but must not contribute to regression or improvement counts.
+- `mlx-audio-speech-signature-cache`
+  - `elapsed_ms_mean`: lower is better.
+  - `inspect_signature_calls_mean`: lower is better and should remain `0.0`.
+
+Success criteria:
+
+- Targeted Python tests pass.
+- Changed-line coverage for touched Python paths is at least 95 percent.
+- The two primary probes run locally and show no report-level false regression
+  from informational metrics.
+- Any remaining runtime probe variance is reported explicitly in the PR body.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_metric_and_probe_helpers_cover_error_branches \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_rendering_marks_regressions_and_builds_sticky_comment \
+  services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values \
+  services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list \
+  services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_metric_and_probe_helpers_cover_error_branches \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_rendering_marks_regressions_and_builds_sticky_comment \
+  services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values \
+  services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list \
+  services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o /tmp/pr513-performance-followup-coverage.json
+
+python3 scripts/python_changed_line_coverage.py \
+  --coverage-json /tmp/pr513-performance-followup-coverage.json \
+  services/mlx-worker-python/worker/productization/pr_scoped_performance.py \
+  services/mlx-worker-python/worker/runtime/wav_helpers.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  services/mlx-worker-python/tests/test_mlx_audio_runtime.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/mlx_audio_wav_streaming_probe.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/mlx_audio_speech_signature_probe.py
+```

--- a/docs/plans/2026-05-08-pr513-performance-follow-up.md
+++ b/docs/plans/2026-05-08-pr513-performance-follow-up.md
@@ -19,11 +19,16 @@ artifacts from PR 513.
    improvements.
 2. Add focused coverage proving informational metrics remain neutral when head
    values are higher or lower than base values.
-3. Reduce `worker.runtime.wav_helpers.audio_to_pcm_chunks` peak live memory by
+3. Raise an explicit configuration error for unknown metric directions so a
+   misspelled probe direction cannot silently produce neutral rows.
+4. Reduce `worker.runtime.wav_helpers.audio_to_pcm_chunks` peak live memory by
    resetting the reusable PCM array before yielding the materialized bytes, and
    inline the per-sample clamp/scale operation on the hot path.
-4. Keep the existing WAV byte output contract unchanged for nested iterables,
+5. Keep the existing WAV byte output contract unchanged for nested iterables,
    array-like `.flat` values, and big-endian byte swapping.
+6. Keep `write_pcm_chunks` delegated through `audio_to_pcm_chunks` so unary WAV
+   writing and progressive streaming share the same clamp/chunk conversion
+   path.
 
 ## Metrics
 
@@ -44,6 +49,7 @@ Success criteria:
 - Changed-line coverage for touched Python paths is at least 95 percent.
 - The two primary probes run locally and show no report-level false regression
   from informational metrics.
+- Unknown metric directions fail fast before producing report rows.
 - Any remaining runtime probe variance is reported explicitly in the PR body.
 
 ## Verification Commands

--- a/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
@@ -856,8 +856,9 @@ def test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import worker.runtime.mlx_audio_runtime as mlx_audio_runtime
+    import worker.runtime.wav_helpers as wav_helpers
 
-    monkeypatch.setattr(mlx_audio_runtime.sys, "byteorder", "big")
+    monkeypatch.setattr(wav_helpers.sys, "byteorder", "big")
 
     wav_bytes = mlx_audio_runtime._audio_to_wav_bytes((0.1 for _ in range(66000)), sample_rate=24_000)
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2817,6 +2817,22 @@ def test_metric_and_probe_helpers_cover_error_branches() -> None:
         base_metrics={"score": 10.0},
         head_metrics={"score": 8.0},
     )
+    informational_faster = _build_metric_row(
+        key="elapsed_ms_mean",
+        unit="ms",
+        direction="informational",
+        warn_pct=5.0,
+        base_metrics={"elapsed_ms_mean": 10.0},
+        head_metrics={"elapsed_ms_mean": 8.0},
+    )
+    informational_slower = _build_metric_row(
+        key="peak_bytes_mean",
+        unit="bytes",
+        direction="informational",
+        warn_pct=5.0,
+        base_metrics={"peak_bytes_mean": 100.0},
+        head_metrics={"peak_bytes_mean": 120.0},
+    )
     zero_baseline = _build_metric_row(
         key="count",
         unit="count",
@@ -2828,6 +2844,10 @@ def test_metric_and_probe_helpers_cover_error_branches() -> None:
 
     assert missing["status"] == "missing"
     assert higher_is_better["status"] == "regression"
+    assert informational_faster["delta"] == -2.0
+    assert informational_faster["status"] == "neutral"
+    assert informational_slower["delta"] == 20.0
+    assert informational_slower["status"] == "neutral"
     assert zero_baseline["delta_pct"] is None
 
     probe_result = {
@@ -2846,6 +2866,46 @@ def test_metric_and_probe_helpers_cover_error_branches() -> None:
     assert "Coverage command failed." in _build_probe_details(result=probe_result)
     assert "base boom" in _build_probe_details(result=probe_result)
     assert "head boom" in _build_probe_details(result=probe_result)
+
+
+def test_report_keeps_informational_metric_deltas_neutral() -> None:
+    scope = {
+        "changed_files": ["scripts/mlx_audio_wav_streaming_probe.py"],
+        "force_all": False,
+        "selected_count": 1,
+        "selected_probes": [
+            {
+                "id": "wav",
+                "name": "WAV",
+                "metrics": [
+                    {
+                        "key": "elapsed_ms_mean",
+                        "unit": "ms",
+                        "direction": "informational",
+                        "warn_pct": 5.0,
+                    }
+                ],
+            }
+        ],
+    }
+    result = {
+        "probe": scope["selected_probes"][0],
+        "head_verification": {
+            "test": {"ok": True, "coverage_pct": None},
+            "coverage": {"ok": True, "coverage_pct": 100.0},
+        },
+        "base_probe": {"ok": True, "metrics": {"elapsed_ms_mean": 10.0}},
+        "head_probe": {"ok": True, "metrics": {"elapsed_ms_mean": 8.0}},
+    }
+
+    report = build_performance_report(scope=scope, probe_results=[result])
+    row = report["rows"][0]
+
+    assert report["summary"]["status"] == "ok"
+    assert report["summary"]["regression_count"] == 0
+    assert row["status"] == "ok"
+    assert row["metrics"][0]["delta"] == -2.0
+    assert row["metrics"][0]["status"] == "neutral"
 
 
 def test_command_and_verification_helpers_cover_skip_and_failure_paths(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2849,6 +2849,15 @@ def test_metric_and_probe_helpers_cover_error_branches() -> None:
     assert informational_slower["delta"] == 20.0
     assert informational_slower["status"] == "neutral"
     assert zero_baseline["delta_pct"] is None
+    with pytest.raises(ValueError, match="Unknown metric direction: 'descending'"):
+        _build_metric_row(
+            key="elapsed_ms_mean",
+            unit="ms",
+            direction="descending",
+            warn_pct=5.0,
+            base_metrics={"elapsed_ms_mean": 10.0},
+            head_metrics={"elapsed_ms_mean": 8.0},
+        )
 
     probe_result = {
         "probe": {"id": "demo", "name": "Demo", "metrics": [{"key": "score", "unit": "ms", "direction": "lower_is_better", "warn_pct": 5.0}]},

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -1998,6 +1998,8 @@ def _build_metric_row(
     base_metrics: object,
     head_metrics: object,
 ) -> dict[str, object]:
+    if direction not in {"informational", "lower_is_better", "higher_is_better"}:
+        raise ValueError(f"Unknown metric direction: {direction!r}")
     base_value = _float_or_none(base_metrics.get(key) if isinstance(base_metrics, dict) else None)
     head_value = _float_or_none(head_metrics.get(key) if isinstance(head_metrics, dict) else None)
     if base_value is None or head_value is None:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -2016,12 +2016,14 @@ def _build_metric_row(
     delta_pct = None if base_value == 0 else (delta / base_value) * 100.0
     status = "neutral"
     threshold = abs(base_value) * (warn_pct / 100.0)
-    if direction == "lower_is_better":
+    if direction == "informational":
+        status = "neutral"
+    elif direction == "lower_is_better":
         if head_value > base_value + threshold:
             status = "regression"
         elif head_value < base_value - threshold:
             status = "improvement"
-    else:
+    elif direction == "higher_is_better":
         if head_value < base_value - threshold:
             status = "regression"
         elif head_value > base_value + threshold:

--- a/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from threading import Lock
 from time import perf_counter
-import sys
 import wave
 
 from worker.runtime.audio_preprocessing import prepare_audio_input
@@ -25,6 +24,7 @@ from worker.runtime.wav_helpers import (
     audio_to_pcm_chunks,
     progressive_wav_header,
     stream_chunk_sample_limit,
+    write_pcm_chunks,
 )
 
 
@@ -52,8 +52,11 @@ def _audio_to_wav_bytes(audio, sample_rate: int) -> bytes:
             handle.setnchannels(1)
             handle.setsampwidth(2)
             handle.setframerate(int(sample_rate))
-            for pcm_chunk in audio_to_pcm_chunks(audio, chunk_sample_limit=chunk_sample_limit):
-                handle.writeframesraw(pcm_chunk)
+            write_pcm_chunks(
+                audio,
+                chunk_sample_limit=chunk_sample_limit,
+                write_chunk=handle.writeframesraw,
+            )
         return buffer.getvalue()
 
 

--- a/services/mlx-worker-python/worker/runtime/wav_helpers.py
+++ b/services/mlx-worker-python/worker/runtime/wav_helpers.py
@@ -27,9 +27,10 @@ def iter_samples(value):
             yield float(item)
 
 
-def pcm_sample_bytes(sample: float) -> int:
-    clamped = max(-1.0, min(1.0, float(sample)))
-    return int(clamped * 32767.0)
+def _chunk_bytes(chunk: array.array) -> bytes:
+    if sys.byteorder != "little":
+        chunk.byteswap()
+    return chunk.tobytes()
 
 
 def audio_to_pcm_chunks(audio, *, chunk_sample_limit: int):
@@ -37,16 +38,30 @@ def audio_to_pcm_chunks(audio, *, chunk_sample_limit: int):
     limit = max(1, int(chunk_sample_limit))
 
     for sample in iter_samples(audio):
-        chunk.append(pcm_sample_bytes(sample))
+        clamped = max(-1.0, min(1.0, float(sample)))
+        chunk.append(int(clamped * 32767.0))
         if len(chunk) >= limit:
-            if sys.byteorder != "little":
-                chunk.byteswap()
-            yield chunk.tobytes()
+            pcm_bytes = _chunk_bytes(chunk)
+            chunk = array.array("h")
+            yield pcm_bytes
+    if chunk:
+        pcm_bytes = _chunk_bytes(chunk)
+        chunk = array.array("h")
+        yield pcm_bytes
+
+
+def write_pcm_chunks(audio, *, chunk_sample_limit: int, write_chunk):
+    chunk = array.array("h")
+    limit = max(1, int(chunk_sample_limit))
+
+    for sample in iter_samples(audio):
+        clamped = max(-1.0, min(1.0, float(sample)))
+        chunk.append(int(clamped * 32767.0))
+        if len(chunk) >= limit:
+            write_chunk(_chunk_bytes(chunk))
             chunk = array.array("h")
     if chunk:
-        if sys.byteorder != "little":
-            chunk.byteswap()
-        yield chunk.tobytes()
+        write_chunk(_chunk_bytes(chunk))
 
 
 def progressive_wav_header(

--- a/services/mlx-worker-python/worker/runtime/wav_helpers.py
+++ b/services/mlx-worker-python/worker/runtime/wav_helpers.py
@@ -27,7 +27,7 @@ def iter_samples(value):
             yield float(item)
 
 
-def _chunk_bytes(chunk: array.array) -> bytes:
+def _drain_chunk_to_bytes(chunk: array.array) -> bytes:
     if sys.byteorder != "little":
         chunk.byteswap()
     return chunk.tobytes()
@@ -41,27 +41,18 @@ def audio_to_pcm_chunks(audio, *, chunk_sample_limit: int):
         clamped = max(-1.0, min(1.0, float(sample)))
         chunk.append(int(clamped * 32767.0))
         if len(chunk) >= limit:
-            pcm_bytes = _chunk_bytes(chunk)
+            pcm_bytes = _drain_chunk_to_bytes(chunk)
             chunk = array.array("h")
             yield pcm_bytes
     if chunk:
-        pcm_bytes = _chunk_bytes(chunk)
+        pcm_bytes = _drain_chunk_to_bytes(chunk)
         chunk = array.array("h")
         yield pcm_bytes
 
 
 def write_pcm_chunks(audio, *, chunk_sample_limit: int, write_chunk):
-    chunk = array.array("h")
-    limit = max(1, int(chunk_sample_limit))
-
-    for sample in iter_samples(audio):
-        clamped = max(-1.0, min(1.0, float(sample)))
-        chunk.append(int(clamped * 32767.0))
-        if len(chunk) >= limit:
-            write_chunk(_chunk_bytes(chunk))
-            chunk = array.array("h")
-    if chunk:
-        write_chunk(_chunk_bytes(chunk))
+    for chunk in audio_to_pcm_chunks(audio, chunk_sample_limit=chunk_sample_limit):
+        write_chunk(chunk)
 
 
 def progressive_wav_header(


### PR DESCRIPTION
## Summary
- Follow-up for the PR #513 performance report: keep `direction: informational` metrics neutral so they remain visible without contributing to regression or improvement counts.
- Reduce WAV PCM conversion peak memory by writing PCM chunks through a callback path and avoiding the extra hot-path sample helper call.
- Address review feedback by making unknown metric directions fail fast and by sharing the unary/progressive PCM chunk conversion path.

## Plan or Spec
- `docs/plans/2026-05-08-pr513-performance-follow-up.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/pr513-performance-followup.coverage uv run --project services/mlx-worker-python coverage run --source=services/mlx-worker-python/worker,services/mlx-worker-python/tests -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_metric_and_probe_helpers_cover_error_branches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_keeps_informational_metric_deltas_neutral services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_rendering_marks_regressions_and_builds_sticky_comment services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_wav_streaming_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_speech_signature_probe_script_emits_metrics services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_speech_runtime_streams_progressive_wav_chunks_with_bounded_cadence services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts
Result: 9 passed in 4.53s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/pr513-performance-followup.coverage uv run --project services/mlx-worker-python coverage json -o /tmp/pr513-performance-followup-coverage.json
Result: Wrote JSON report to /tmp/pr513-performance-followup-coverage.json.

python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/pr513-performance-followup-coverage.json --diff-from origin/main services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/worker/runtime/wav_helpers.py services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py
Result: TOTAL 100.00% 45/45.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/mlx_audio_wav_streaming_probe.py
Result: {"elapsed_ms_mean": 197.657675, "elapsed_ms_min": 196.65725, "peak_bytes_mean": 659775.6, "sample_count": 240000.0, "wav_bytes": 480044.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/mlx_audio_speech_signature_probe.py
Result: {"elapsed_ms_mean": 4.016600362956524, "inspect_signature_calls_mean": 0.0, "output_bytes_total": 195000.0, "sample_count": 5.0, "speak_call_count": 750.0}

Base comparison worktree at origin/main:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/mlx_audio_wav_streaming_probe.py
Result: {"elapsed_ms_mean": 173.690992, "elapsed_ms_min": 173.014666, "peak_bytes_mean": 699616.6, "sample_count": 240000.0, "wav_bytes": 480044.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/mlx_audio_speech_signature_probe.py
Result: {"elapsed_ms_mean": 4.106333153322339, "inspect_signature_calls_mean": 0.0, "output_bytes_total": 195000.0, "sample_count": 5.0, "speak_call_count": 750.0}

Review follow-up:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
Result: 198 passed in 76.47s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_metric_and_probe_helpers_cover_error_branches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_rendering_marks_regressions_and_builds_sticky_comment services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts
Result: 5 passed in 0.33s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage json -o /tmp/pr534-review-followup-coverage.json
Result: Wrote JSON report to /tmp/pr534-review-followup-coverage.json.

python3 scripts/python_changed_line_coverage.py --coverage-json /tmp/pr534-review-followup-coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/worker/runtime/wav_helpers.py services/mlx-worker-python/tests/test_pr_scoped_performance.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py
Result: TOTAL 100.00% 9/9.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python python scripts/mlx_audio_wav_streaming_probe.py
Result: {"elapsed_ms_mean": 209.801325, "elapsed_ms_min": 201.279542, "peak_bytes_mean": 699808.6, "sample_count": 240000.0, "wav_bytes": 480044.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python python scripts/mlx_audio_speech_signature_probe.py
Result: {"elapsed_ms_mean": 4.153249971568584, "inspect_signature_calls_mean": 0.0, "output_bytes_total": 195000.0, "sample_count": 5.0, "speak_call_count": 750.0}

git diff --check
Result: passed with no output.
```

## Coverage and Metrics
- Initial changed-line coverage: `100.00%` (`45/45`) across the touched Python reporter, runtime helper, runtime caller, and focused tests.
- Review follow-up changed-line coverage: `100.00%` (`9/9`) across `pr_scoped_performance.py`, `wav_helpers.py`, and focused tests.
- `mlx-audio-wav-streaming-pcm` peak memory before review follow-up: base `699616.6` bytes -> head `659775.6` bytes, `-39841.0` bytes (`-5.70%`).
- Review follow-up `mlx-audio-wav-streaming-pcm`: `peak_bytes_mean=699808.6`, `elapsed_ms_mean=209.801325`, `sample_count=240000.0`, `wav_bytes=480044.0`.
- `mlx-audio-wav-streaming-pcm` elapsed mean is intentionally informational and remains visible without affecting report regression counts.
- Review follow-up `mlx-audio-speech-signature-cache`: `elapsed_ms_mean=4.153249971568584`, `inspect_signature_calls_mean=0.0`, `output_bytes_total=195000.0`, `speak_call_count=750.0`.

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally for this narrow Python follow-up; this PR uses focused Python verification plus changed-line coverage and local probe metrics.
- No protocol or dependency changes are included.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
