### PR TITLE
perf: stream code eval fallback test counting

### DIFF
--- a/docs/plans/2026-05-08-code-eval-test-count-nonblank-streaming.md
+++ b/docs/plans/2026-05-08-code-eval-test-count-nonblank-streaming.md
@@ -1,0 +1,63 @@
+# Code Eval Test Count Nonblank Streaming Optimization
+
+## Goal
+
+Reduce temporary allocation pressure in the code-evaluation test-count fallback path by replacing list-materialized nonblank-line counting with a streaming generator count.
+
+## Linux-only constraint
+
+This slice is Python-only under `services/mlx-worker-python`, so it can be verified locally on Linux with focused pytest, changed-scope coverage, and a synthetic performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `scripts/code_eval_test_count_probe.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Probe definition
+
+Register `code-eval-test-count-nonblank-streaming` in the PR-scoped performance registry. The probe builds a large synthetic test-code payload and measures `_count_nonblank_lines(...)` directly, reporting:
+
+- `elapsed_ms_mean` (informational; lower is better but allocation is the main win)
+- `peak_bytes_mean` (lower is better)
+- `line_count`
+- `nonblank_line_count_mean`
+
+## Success metrics
+
+- Focused tests for syntax-error and no-assert fallback paths pass.
+- Changed-scope coverage for touched executable Python scope is at least 95%.
+- The local base-vs-head scoped probe shows materially lower `peak_bytes_mean` with identical nonblank line counts.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_syntax_error_fallback_uses_nonblank_line_counter \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same nodes>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/engine/code_eval_runner.py \
+  services/mlx-worker-python/tests/test_code_eval_runner.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/code_eval_test_count_probe.py
+
+python3 scripts/pr_scoped_performance_run.py \
+  --registry infra/perf/pr_scoped_probes.json \
+  --probe-id code-eval-test-count-nonblank-streaming \
+  --base-repo /tmp/melix-origin-main-code-eval-count \
+  --head-repo "$PWD" \
+  --output /tmp/code-eval-test-count-probe.json
+
+git diff --check
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2249,6 +2249,41 @@
     ]
   },
   {
+    "id": "code-eval-test-count-nonblank-streaming",
+    "name": "Code evaluation nonblank test count streaming",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/engine/code_eval_runner.py",
+      "services/mlx-worker-python/tests/test_code_eval_runner.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/code_eval_test_count_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_syntax_error_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_syntax_error_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_test_count_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/code_eval_test_count_probe.py ]; then python3 scripts/code_eval_test_count_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"ZnJvbSBfX2Z1dHVyZV9fIGltcG9ydCBhbm5vdGF0aW9ucwppbXBvcnQganNvbiwgc3RhdGlzdGljcywgc3lzLCB0aW1lLCB0cmFjZW1hbGxvYwpmcm9tIHBhdGhsaWIgaW1wb3J0IFBhdGgKcmVwb19yb290ID0gUGF0aC5jd2QoKQpzeXMucGF0aC5pbnNlcnQoMCwgc3RyKHJlcG9fcm9vdCkpCnN5cy5wYXRoLmluc2VydCgwLCBzdHIocmVwb19yb290IC8gInNlcnZpY2VzL21seC13b3JrZXItcHl0aG9uIikpCmZyb20gd29ya2VyLmVuZ2luZSBpbXBvcnQgY29kZV9ldmFsX3J1bm5lcgoKZGVmIGJ1aWxkX3Rlc3RfY29kZShsaW5lX2NvdW50OiBpbnQpIC0+IHN0cjoKICAgIGxpbmVzID0gW10KICAgIGZvciBpbmRleCBpbiByYW5nZShsaW5lX2NvdW50KToKICAgICAgICBpZiBpbmRleCAlIDUgPT0gMDoKICAgICAgICAgICAgbGluZXMuYXBwZW5kKCIgICAiKQogICAgICAgIGVsaWYgaW5kZXggJSA3ID09IDA6CiAgICAgICAgICAgIGxpbmVzLmFwcGVuZChmIiMgY29tbWVudCB7aW5kZXh9IikKICAgICAgICBlbHNlOgogICAgICAgICAgICBsaW5lcy5hcHBlbmQoZiJ2YWx1ZV97aW5kZXh9ID0gY2FuZGlkYXRlKHtpbmRleH0pIikKICAgIHJldHVybiAiXG4iLmpvaW4obGluZXMpCgpsaW5lX2NvdW50ID0gNjAwMDAKc2FtcGxlX2NvdW50ID0gNwp0ZXN0X2NvZGUgPSBidWlsZF90ZXN0X2NvZGUobGluZV9jb3VudCkKZXhwZWN0ZWRfbm9uYmxhbmsgPSBzdW0oMSBmb3IgbGluZSBpbiB0ZXN0X2NvZGUuc3BsaXRsaW5lcygpIGlmIGxpbmUuc3RyaXAoKSkKY291bnRfbm9uYmxhbmsgPSBnZXRhdHRyKAogICAgY29kZV9ldmFsX3J1bm5lciwKICAgICJfY291bnRfbm9uYmxhbmtfbGluZXMiLAogICAgbGFtYmRhIHNvdXJjZTogbGVuKFtsaW5lIGZvciBsaW5lIGluIHNvdXJjZS5zcGxpdGxpbmVzKCkgaWYgbGluZS5zdHJpcCgpXSksCikKZWxhcHNlZF9tcyA9IFtdCnBlYWtfYnl0ZXMgPSBbXQpjb3VudGVkX2xpbmVzID0gW10KZm9yIF8gaW4gcmFuZ2Uoc2FtcGxlX2NvdW50KToKICAgIHRyYWNlbWFsbG9jLnN0YXJ0KCkKICAgIHN0YXJ0ZWQgPSB0aW1lLnBlcmZfY291bnRlcigpCiAgICBjb3VudGVkID0gY291bnRfbm9uYmxhbmsodGVzdF9jb2RlKQogICAgZWxhcHNlZF9tcy5hcHBlbmQoKHRpbWUucGVyZl9jb3VudGVyKCkgLSBzdGFydGVkKSAqIDEwMDAuMCkKICAgIF8sIHBlYWsgPSB0cmFjZW1hbGxvYy5nZXRfdHJhY2VkX21lbW9yeSgpCiAgICB0cmFjZW1hbGxvYy5zdG9wKCkKICAgIHBlYWtfYnl0ZXMuYXBwZW5kKGZsb2F0KHBlYWspKQogICAgaWYgY291bnRlZCAhPSBleHBlY3RlZF9ub25ibGFuazoKICAgICAgICByYWlzZSBTeXN0ZW1FeGl0KGYidW5leHBlY3RlZCBub25ibGFuayBjb3VudDoge2NvdW50ZWR9ICE9IHtleHBlY3RlZF9ub25ibGFua30iKQogICAgY291bnRlZF9saW5lcy5hcHBlbmQoZmxvYXQoY291bnRlZCkpCnByaW50KGpzb24uZHVtcHMoewogICAgImVsYXBzZWRfbXNfbWVhbiI6IHN0YXRpc3RpY3MuZm1lYW4oZWxhcHNlZF9tcyksCiAgICAicGVha19ieXRlc19tZWFuIjogc3RhdGlzdGljcy5mbWVhbihwZWFrX2J5dGVzKSwKICAgICJsaW5lX2NvdW50IjogZmxvYXQobGluZV9jb3VudCksCiAgICAibm9uYmxhbmtfbGluZV9jb3VudF9tZWFuIjogc3RhdGlzdGljcy5mbWVhbihjb3VudGVkX2xpbmVzKSwKICAgICJzYW1wbGVfY291bnQiOiBmbG9hdChzYW1wbGVfY291bnQpLAp9LCBzb3J0X2tleXM9VHJ1ZSkpCg==\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "nonblank_line_count_mean",
+        "unit": "lines",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "changed-scope-coverage-empty-path-short-circuit",
     "name": "Changed-scope coverage empty-path short circuit",
     "runner": "ubuntu-latest",

--- a/scripts/code_eval_test_count_probe.py
+++ b/scripts/code_eval_test_count_probe.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path.cwd()
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.engine import code_eval_runner  # noqa: E402
+
+
+def _build_test_code(line_count: int) -> str:
+    lines = []
+    for index in range(line_count):
+        if index % 5 == 0:
+            lines.append("   ")
+        elif index % 7 == 0:
+            lines.append(f"# comment {index}")
+        else:
+            lines.append(f"value_{index} = candidate({index})")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    line_count = 60_000
+    sample_count = 7
+    test_code = _build_test_code(line_count)
+    expected_nonblank = sum(1 for line in test_code.splitlines() if line.strip())
+    elapsed_ms: list[float] = []
+    peak_bytes: list[float] = []
+    counted_lines: list[float] = []
+
+    for _ in range(sample_count):
+        tracemalloc.start()
+        started = time.perf_counter()
+        counted = code_eval_runner._count_nonblank_test_lines(test_code)
+        elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_bytes.append(float(peak))
+        if counted != expected_nonblank:
+            raise SystemExit(f"unexpected nonblank count: {counted} != {expected_nonblank}")
+        counted_lines.append(float(counted))
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed_ms),
+                "peak_bytes_mean": statistics.fmean(peak_bytes),
+                "line_count": float(line_count),
+                "nonblank_line_count_mean": statistics.fmean(counted_lines),
+                "sample_count": float(sample_count),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -405,6 +405,28 @@ def test_count_tests_no_assert_fast_path_skips_ast_parse(monkeypatch: pytest.Mon
     assert code_eval_runner._count_tests("setup()\nrun_case(identity)\n") == 2
 
 
+def test_count_tests_syntax_error_fallback_uses_nonblank_line_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def tracked_count(test_code: str) -> int:
+        calls.append(test_code)
+        return 5
+
+    monkeypatch.setattr(code_eval_runner, "_count_nonblank_test_lines", tracked_count)
+    code_eval_runner._count_tests.cache_clear()
+
+    assert code_eval_runner._count_tests("def check(candidate):\n    return candidate(1)") == 5
+    assert calls == ["def check(candidate):\n    return candidate(1)"]
+
+
+def test_count_nonblank_lines_streams_without_filtered_list() -> None:
+    test_code = "\n".join("assert value" if index % 3 else "   " for index in range(10_000))
+
+    assert code_eval_runner._count_nonblank_test_lines(test_code) == 6_666
+
+
 def test_read_limited_text_handles_missing_and_oversized_files(tmp_path: Path) -> None:
     missing_path = tmp_path / "missing.txt"
     assert code_eval_runner._read_limited_text(missing_path, 8) == ""
@@ -690,6 +712,22 @@ def test_count_tests_falls_back_when_no_asserts_are_present() -> None:
     ).strip()
 
     assert code_eval_runner._count_tests(test_code) == 3
+
+
+def test_count_tests_no_assert_fallback_uses_nonblank_line_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def tracked_count(test_code: str) -> int:
+        calls.append(test_code)
+        return 5
+
+    monkeypatch.setattr(code_eval_runner, "_count_nonblank_test_lines", tracked_count)
+    code_eval_runner._count_tests.cache_clear()
+
+    assert code_eval_runner._count_tests("def check(candidate):\n    return candidate(1)") == 5
+    assert calls == ["def check(candidate):\n    return candidate(1)"]
 
 
 def test_load_payload_file_rejects_invalid_and_non_mapping_json(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -401,13 +401,14 @@ def test_scope_report_selects_code_eval_stdio_probe() -> None:
     )
 
     probe_ids = {probe["id"] for probe in scope["selected_probes"]}
-    assert scope["selected_count"] == 5
+    assert scope["selected_count"] == 6
     assert probe_ids == {
         "code-eval-code-block-last-match-streaming",
         "code-eval-payload-json-bytes",
         "code-eval-stdio-tail-single-stat",
         "code-eval-runner-script-cache",
         "code-eval-count-tests-line-scan",
+        "code-eval-test-count-nonblank-streaming",
     }
 
 
@@ -1778,6 +1779,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "code-eval-stdio-tail-single-stat",
         "code-eval-runner-script-cache",
         "code-eval-count-tests-line-scan",
+        "code-eval-test-count-nonblank-streaming",
         "deterministic-embedding-duplicate-input-cache",
         "deterministic-embedding-project-digest-allocation",
         "deterministic-image-edit-digest-reuse",
@@ -2291,6 +2293,21 @@ def test_code_eval_count_tests_probe_script_emits_metrics(
     assert metrics["sample_count"] == 7.0
     assert metrics["syntax_count"] == 5334.0
     assert metrics["no_assert_count"] == 6002.0
+
+
+def test_code_eval_test_count_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/code_eval_test_count_probe.py"))
+
+    probe_script["main"]()
+    metrics = json.loads(capsys.readouterr().out)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["line_count"] == 60000.0
+    assert metrics["nonblank_line_count_mean"] == 48000.0
+    assert metrics["sample_count"] == 7.0
 
 
 def test_probe_smokes_return_metrics_against_current_repo() -> None:


### PR DESCRIPTION
## Summary
- Stream the code-evaluation fallback nonblank-line test counter instead of materializing a filtered list.
- Add focused regression coverage for syntax-error and no-assert fallback paths.
- Register `code-eval-test-count-nonblank-streaming` in PR-scoped performance CI with a base-compatible probe command.

## Plan or Spec
- Plan: `docs/plans/2026-05-08-code-eval-test-count-nonblank-streaming.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_syntax_error_fallback_uses_nonblank_line_counter \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics
# 8 passed in 0.39s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused nodes>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/engine/code_eval_runner.py \
  services/mlx-worker-python/tests/test_code_eval_runner.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/code_eval_test_count_probe.py
# TOTAL 33 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_test_count_probe.py
# {"elapsed_ms_mean": 29.65417253186128, "line_count": 60000.0, "nonblank_line_count_mean": 48000.0, "peak_bytes_mean": 4316951.0, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py \
  --registry infra/perf/pr_scoped_probes.json \
  --probe-id code-eval-test-count-nonblank-streaming \
  --base-repo /tmp/melix-origin-main-code-eval-count-20260508021412 \
  --head-repo "$PWD" \
  --output /tmp/code-eval-test-count-probe.json
# head verification ok; base/head probes ok

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 33 0 100%`.
- Registered scoped CI probe: `code-eval-test-count-nonblank-streaming`.
- Local base-vs-head probe (`60,000` synthetic test lines, `48,000` nonblank lines, 7 samples):
  - `peak_bytes_mean`: base `4,711,503.0` → head `4,316,951.0` (~8.37% lower)
  - `elapsed_ms_mean`: base `25.677357567474246` → head `26.738289860077202` (informational; slightly slower in this local run)
  - `nonblank_line_count_mean`: base/head `48,000.0` (unchanged)

## Known Gaps
- Linux-only local verification; Swift/macOS tests were not run because this PR only changes Python worker/probe/test paths.
- The elapsed timing is informational and slightly slower locally; this slice is primarily an allocation-pressure reduction for the fallback counting path. Hosted `pr-scoped-performance` remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
