### PR TITLE
perf: reuse image edit payload byte length

### DIFF
--- a/docs/plans/2026-05-08-deterministic-image-output-byte-length-reuse.md
+++ b/docs/plans/2026-05-08-deterministic-image-output-byte-length-reuse.md
@@ -9,9 +9,11 @@ that output byte accounting does not rescan generated images.
 
 ## Slice
 
-Reuse the generated payload byte length inside the `generate_images` artifact
-loop instead of calling `len(payload)` separately for artifact metadata and
-aggregate output byte accounting.
+Reuse the generated payload byte length inside the `generate_images` and `edit_image`
+artifact loops instead of calling `len(payload)` separately for artifact metadata
+and aggregate output byte accounting. The shared artifact metadata helper accepts
+an already-known payload byte length so edit-generated artifacts do not re-read
+the payload length after the loop has already accounted for output bytes.
 
 ## Scope
 

--- a/services/mlx-worker-python/tests/test_image_runtime.py
+++ b/services/mlx-worker-python/tests/test_image_runtime.py
@@ -196,6 +196,49 @@ def test_image_generation_and_edit_probe_bytes_do_not_rescan_images(
     assert runtime.last_probe_snapshot().output_bytes == expected_edited_bytes
 
 
+def test_image_artifact_metadata_reuses_supplied_payload_byte_length(tmp_path: Path) -> None:
+    class CountingBytes(bytes):
+        len_calls = 0
+
+        def __len__(self) -> int:
+            type(self).len_calls += 1
+            return super().__len__()
+
+    payload = CountingBytes(b"generated-image-payload")
+    fallback_artifact = DeterministicImageGenerationRuntime._artifact_metadata(
+        job_id="image-byte-length-reuse",
+        artifact_id="image-byte-length-reuse::fallback",
+        role=common_pb2.IMAGE_ARTIFACT_GENERATED,
+        mime_type="image/png",
+        image_format="png",
+        width=128,
+        height=128,
+        payload=payload,
+        storage_path=tmp_path / "fallback-output-0.png",
+        variant_index=0,
+    )
+    assert fallback_artifact.byte_length == 23
+    assert CountingBytes.len_calls == 1
+
+    CountingBytes.len_calls = 0
+    artifact = DeterministicImageGenerationRuntime._artifact_metadata(
+        job_id="image-byte-length-reuse",
+        artifact_id="image-byte-length-reuse::artifact-0",
+        role=common_pb2.IMAGE_ARTIFACT_GENERATED,
+        mime_type="image/png",
+        image_format="png",
+        width=128,
+        height=128,
+        payload=payload,
+        payload_byte_length=23,
+        storage_path=tmp_path / "output-0.png",
+        variant_index=0,
+    )
+
+    assert artifact.byte_length == 23
+    assert CountingBytes.len_calls == 0
+
+
 def test_image_edit_persists_lineage_and_generated_artifact(tmp_path: Path) -> None:
     runtime_service, inference_service, _ = build_services(tmp_path)
     model_handle = load_model(runtime_service, WorkerModelCatalog.dev_image_model())

--- a/services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py
@@ -226,8 +226,9 @@ class DeterministicImageGenerationRuntime:
             )
             artifact_path = output_dir / f"output-{index}.{image_format}"
             artifact_publish_ms += self._write_bytes(artifact_path, payload)
+            payload_byte_length = len(payload)
             images.append(payload)
-            total_output_bytes += len(payload)
+            total_output_bytes += payload_byte_length
             artifacts.append(
                 self._artifact_metadata(
                     job_id=job_id,
@@ -238,6 +239,7 @@ class DeterministicImageGenerationRuntime:
                     width=width,
                     height=height,
                     payload=payload,
+                    payload_byte_length=payload_byte_length,
                     storage_path=artifact_path,
                     variant_index=index,
                     parent_artifact_id=request.source_artifact_id,
@@ -329,6 +331,7 @@ class DeterministicImageGenerationRuntime:
         height: int,
         payload: bytes,
         payload_sha256: str | None = None,
+        payload_byte_length: int | None = None,
         storage_path: Path,
         variant_index: int,
         parent_artifact_id: str = "",
@@ -343,7 +346,7 @@ class DeterministicImageGenerationRuntime:
             format=image_format,
             width=width,
             height=height,
-            byte_length=len(payload),
+            byte_length=payload_byte_length if payload_byte_length is not None else len(payload),
             storage_uri=str(storage_path),
             sha256=digest,
             variant_index=variant_index,


### PR DESCRIPTION
## Summary
- Reuses the already-known generated payload byte length in `edit_image` when building generated artifact metadata.
- Keeps the fallback metadata behavior for callers that do not provide a byte length.
- Adds a focused regression test proving the supplied byte length avoids an extra payload `len(...)` call.

## Plan or Spec
- `docs/plans/2026-05-08-deterministic-image-output-byte-length-reuse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_image_runtime.py::test_image_generation_and_edit_probe_bytes_do_not_rescan_images services/mlx-worker-python/tests/test_image_runtime.py::test_image_artifact_metadata_reuses_supplied_payload_byte_length services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_image_edit_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_image_output_bytes_probe_script_emits_metrics
# 5 passed in 2.54s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_image_runtime.py::test_image_generation_and_edit_probe_bytes_do_not_rescan_images services/mlx-worker-python/tests/test_image_runtime.py::test_image_artifact_metadata_reuses_supplied_payload_byte_length services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_image_edit_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_image_output_bytes_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py services/mlx-worker-python/tests/test_image_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_image_output_bytes_probe.py
# TOTAL 16 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_image_output_bytes_probe.py
# base: {"elapsed_ms_mean": 16.854542400687933, "output_byte_scan_calls_mean": 0.0, "generated_image_count": 96.0, "edit_image_count": 96.0, "generated_output_bytes": 9302.0, "edit_output_bytes": 15062.0, "sample_count": 5.0}
# head: {"elapsed_ms_mean": 16.539475228637457, "output_byte_scan_calls_mean": 0.0, "generated_image_count": 96.0, "edit_image_count": 96.0, "generated_output_bytes": 9302.0, "edit_output_bytes": 15062.0, "sample_count": 5.0}
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 16 0 100%`).
- Registered local probe: `deterministic-image-output-byte-accounting`.
- Local probe delta: `elapsed_ms_mean` 16.854542 ms -> 16.539475 ms (delta -0.315067 ms, -1.87%); `output_byte_scan_calls_mean` remained 0.0; generated/edit output bytes and image counts stayed unchanged.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local verification is Linux/Python-only; CI remains the merge gate for the registered PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
