### PR TITLE
perf: cache benchmark queue sort key

### DIFF
--- a/docs/plans/2026-05-08-benchmark-queue-sort-key-attrgetter.md
+++ b/docs/plans/2026-05-08-benchmark-queue-sort-key-attrgetter.md
@@ -1,0 +1,26 @@
+# Benchmark queue sort-key attrgetter slice
+
+## Context
+
+`BenchmarkQueueStore.list_records()` returns queue records in deterministic
+`created_at_unix_ms, queue_item_id` order. The path is covered by the registered
+PR-scoped performance probe `benchmark-queue-decoded-record-cache` in
+`infra/perf/pr_scoped_probes.json`, including focused tests, changed-scope
+coverage, and a probe command.
+
+## Slice
+
+Replace the per-call lambda sort key allocation in the queue listing hot path
+with a module-level `operator.attrgetter` sort key. This keeps ordering and
+public clone boundaries unchanged while reducing repeated warm-cache listing
+work.
+
+## Verification
+
+Use the registered probe and focused queue tests:
+
+- `services/mlx-worker-python/tests/test_benchmark_queue.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py` registered
+  probe checks for `benchmark-queue-decoded-record-cache`
+- registered changed-scope coverage command from `infra/perf/pr_scoped_probes.json`
+- registered benchmark queue probe on Linux and PR-scoped performance CI

--- a/services/mlx-worker-python/worker/productization/benchmark_queue.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_queue.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass
+from operator import attrgetter
 from pathlib import Path
 import stat
+
+
+_RECORD_SORT_KEY = attrgetter("created_at_unix_ms", "queue_item_id")
 
 
 @dataclass(frozen=True)
@@ -101,7 +105,7 @@ class BenchmarkQueueStore:
                     )
         except OSError:
             return []
-        records.sort(key=lambda record: (record.created_at_unix_ms, record.queue_item_id))
+        records.sort(key=_RECORD_SORT_KEY)
         return [self._clone_record(record) for record in records]
 
     def transition(


### PR DESCRIPTION
## Summary
- Replaces the benchmark queue listing sort lambda with a module-level `operator.attrgetter` sort key.
- Keeps deterministic `(created_at_unix_ms, queue_item_id)` ordering and public clone boundaries unchanged.

## Plan or Spec
- `docs/plans/2026-05-08-benchmark-queue-sort-key-attrgetter.md`
- Registered PR-scoped probe: `benchmark-queue-decoded-record-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
# 26 passed in 11.74s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_queue.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 26 passed in 36.80s; TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_benchmark_queue_probe.py
# {"cold_elapsed_ms": 5.404877, "cold_json_loads": 128.0, "record_count": 128.0, "warm_elapsed_ms_mean": 0.70399, "warm_json_loads_mean": 0.0, "warm_sample_count": 5.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 3 0 100%`).
- Registered local probe after change: `cold_elapsed_ms=5.404877`, `warm_elapsed_ms_mean=0.70399`, `warm_json_loads_mean=0.0`, `record_count=128.0`.
- Local baseline comparison on `origin/main` over 10 probe invocations: `cold_mean=5.8208169`, `warm_mean=0.7835331`.
- Local head comparison over 10 probe invocations: `cold_mean=5.2594593`, `warm_mean=0.6873708`.
- Estimated delta from repeated local probe: cold `-0.5613576 ms` (~9.64% faster), warm `-0.0961623 ms` (~12.27% faster). CI PR-scoped performance must validate the registered probe report before merge.

## Known Gaps
- Full repository `make py-test` was not run locally; this is a focused registered Python performance slice.
- GitHub Actions PR-scoped performance is required as the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
