### PR TITLE
perf: cache QAT fake-quant byte error table

### DIFF
--- a/docs/plans/2026-05-08-qat-fake-quant-error-table.md
+++ b/docs/plans/2026-05-08-qat-fake-quant-error-table.md
@@ -1,0 +1,63 @@
+# QAT fake-quant byte error table
+
+## Goal
+
+Reduce repeated per-byte floating-point reconstruction work in QAT fake-quant source statistics while preserving the manifest payload exactly.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/model_ops/quantization_pipeline.py`
+- `services/mlx-worker-python/tests/test_quantization_pipeline.py`
+- `scripts/quantization_qat_source_scan_probe.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux-only constraint
+
+This is a Python worker slice and is fully locally verifiable on Linux with focused pytest, changed-scope coverage, and a command-json PR-scoped performance probe.
+
+## Performance probe
+
+Update the existing `quantization-qat-source-scan-scandir` probe to also measure `_qat_fake_quant_source_stats(...)` over a deterministic synthetic byte workload.
+
+Metrics:
+
+- `source_stats_elapsed_ms_mean`: lower is better
+- `source_stats_peak_bytes_mean`: informational
+- `source_stats_byte_count`: structural workload size
+
+## Success metrics
+
+- Focused pytest passes for QAT source scanning/stats and PR-scoped probe smoke tests.
+- Changed-scope coverage is at least 95% for touched executable Python files.
+- Local base-vs-head PR-scoped probe shows lower `source_stats_elapsed_ms_mean` with matching structural workload metrics.
+- `git diff --check` passes.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_uses_scandir_stack_without_path_rglob \
+  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_skips_bad_scandir_entries_and_empty_roots \
+  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence \
+  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_fake_quant_error_table_matches_reference_and_caches \
+  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_fake_quant_source_stats_reuses_byte_error_table \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_qat_source_scan_probe_script_emits_metrics
+```
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && \
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && \
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/model_ops/quantization_pipeline.py \
+  services/mlx-worker-python/tests/test_quantization_pipeline.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/quantization_qat_source_scan_probe.py
+```
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_QAT_SOURCE_SCAN_REPO_ROOT="$PWD" \
+  uv run --project services/mlx-worker-python python3 scripts/quantization_qat_source_scan_probe.py
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2902,9 +2902,9 @@
       "scripts/quantization_qat_source_scan_probe.py",
       "scripts/changed_scope_coverage.py"
     ],
-    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_uses_scandir_stack_without_path_rglob services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_skips_bad_scandir_entries_and_empty_roots services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_qat_source_scan_probe_script_emits_metrics",
-    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_uses_scandir_stack_without_path_rglob services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_skips_bad_scandir_entries_and_empty_roots services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_qat_source_scan_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/quantization_qat_source_scan_probe.py",
-    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_QAT_SOURCE_SCAN_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python python3 \"${PWD}/scripts/quantization_qat_source_scan_probe.py\" || PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_QAT_SOURCE_SCAN_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python python3 \"${PWD}/../head/scripts/quantization_qat_source_scan_probe.py\"",
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_uses_scandir_stack_without_path_rglob services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_skips_bad_scandir_entries_and_empty_roots services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_fake_quant_error_table_matches_reference_and_caches services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_fake_quant_source_stats_reuses_byte_error_table services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_qat_source_scan_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_uses_scandir_stack_without_path_rglob services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_skips_bad_scandir_entries_and_empty_roots services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_fake_quant_error_table_matches_reference_and_caches services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_fake_quant_source_stats_reuses_byte_error_table services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_qat_source_scan_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/quantization_qat_source_scan_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_QAT_SOURCE_SCAN_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"${PWD}/scripts/quantization_qat_source_scan_probe.py\"; for CANDIDATE in \"${PWD}/../head/scripts/quantization_qat_source_scan_probe.py\" /tmp/melix-cron-opt-*/scripts/quantization_qat_source_scan_probe.py; do if [ -f \"$CANDIDATE\" ] && grep -q source_stats_elapsed_ms_mean \"$CANDIDATE\"; then SCRIPT=\"$CANDIDATE\"; break; fi; done; python3 \"$SCRIPT\"'",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
     "metrics": [
@@ -2922,6 +2922,22 @@
       },
       {
         "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      },
+      {
+        "key": "source_stats_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "source_stats_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      },
+      {
+        "key": "source_stats_byte_count",
         "unit": "bytes",
         "direction": "informational"
       }

--- a/scripts/quantization_qat_source_scan_probe.py
+++ b/scripts/quantization_qat_source_scan_probe.py
@@ -14,7 +14,7 @@ sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 
 from worker.model_ops import quantization_pipeline
-from worker.model_ops.quantization_pipeline import _source_artifact_files_for_qat
+from worker.model_ops.quantization_pipeline import _qat_fake_quant_source_stats, _source_artifact_files_for_qat
 
 
 def _int_env(name: str, default: int) -> int:
@@ -35,17 +35,36 @@ def _write_source_tree(root: Path, *, file_count: int) -> list[Path]:
     return sorted(expected)
 
 
+def _write_stats_sources(root: Path, *, bytes_per_file: int, file_count: int = 4) -> list[Path]:
+    root.mkdir(parents=True, exist_ok=True)
+    pattern = bytes(range(256))
+    paths: list[Path] = []
+    for index in range(file_count):
+        path = root / f"stats-source-{index:02d}.bin"
+        repeats, remainder = divmod(bytes_per_file, len(pattern))
+        path.write_bytes(pattern * repeats + pattern[:remainder])
+        paths.append(path)
+    return paths
+
+
 def main() -> int:
     file_count = _int_env("MELIX_QAT_SOURCE_SCAN_PROBE_FILES", 4000)
+    stats_bytes_per_file = _int_env("MELIX_QAT_SOURCE_STATS_PROBE_BYTES_PER_FILE", 1_000_000)
     sample_count = _int_env("MELIX_QAT_SOURCE_SCAN_PROBE_SAMPLES", 5)
     elapsed_samples: list[float] = []
     peak_samples: list[float] = []
     scandir_samples: list[float] = []
     rglob_samples: list[float] = []
+    stats_elapsed_samples: list[float] = []
+    stats_peak_samples: list[float] = []
 
     with tempfile.TemporaryDirectory(prefix="melix-qat-source-scan-probe-") as temp_dir:
         source_root = Path(temp_dir) / "merged-adapter"
         expected = _write_source_tree(source_root, file_count=file_count)
+        stats_sources = _write_stats_sources(
+            Path(temp_dir) / "stats-sources",
+            bytes_per_file=stats_bytes_per_file,
+        )
         original_scandir = quantization_pipeline.os.scandir
         original_rglob = Path.rglob
 
@@ -85,6 +104,17 @@ def main() -> int:
             scandir_samples.append(float(scandir_calls))
             rglob_samples.append(float(rglob_calls))
 
+            tracemalloc.start()
+            stats_started = time.perf_counter()
+            stats = _qat_fake_quant_source_stats(stats_sources, q_bits=4)
+            stats_elapsed_ms = (time.perf_counter() - stats_started) * 1000.0
+            _, stats_peak = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            if stats["source_byte_count"] != stats_bytes_per_file * len(stats_sources):
+                raise SystemExit("unexpected QAT source stats byte count")
+            stats_elapsed_samples.append(stats_elapsed_ms)
+            stats_peak_samples.append(float(stats_peak))
+
     print(
         json.dumps(
             {
@@ -93,6 +123,9 @@ def main() -> int:
                 "peak_bytes_mean": round(statistics.fmean(peak_samples), 3),
                 "scandir_calls_mean": round(statistics.fmean(scandir_samples), 3),
                 "rglob_calls_mean": round(statistics.fmean(rglob_samples), 3),
+                "source_stats_elapsed_ms_mean": round(statistics.fmean(stats_elapsed_samples), 6),
+                "source_stats_peak_bytes_mean": round(statistics.fmean(stats_peak_samples), 3),
+                "source_stats_byte_count": float(stats_bytes_per_file * 4),
                 "file_count": float(file_count),
                 "sample_count": float(sample_count),
             },

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1634,6 +1634,7 @@ def test_quantization_qat_source_scan_probe_script_emits_metrics(
 ) -> None:
     monkeypatch.setenv("MELIX_QAT_SOURCE_SCAN_PROBE_FILES", "4")
     monkeypatch.setenv("MELIX_QAT_SOURCE_SCAN_PROBE_SAMPLES", "1")
+    monkeypatch.setenv("MELIX_QAT_SOURCE_STATS_PROBE_BYTES_PER_FILE", "256")
 
     with pytest.raises(SystemExit) as exc_info:
         runpy.run_path(
@@ -1647,6 +1648,9 @@ def test_quantization_qat_source_scan_probe_script_emits_metrics(
     assert metrics["file_count"] == 4.0
     assert metrics["rglob_calls_mean"] == 0.0
     assert metrics["scandir_calls_mean"] >= 1.0
+    assert metrics["source_stats_byte_count"] == 1024.0
+    assert metrics["source_stats_elapsed_ms_mean"] >= 0
+    assert metrics["source_stats_peak_bytes_mean"] > 0
     assert metrics["elapsed_ms_mean"] >= 0
 
 

--- a/services/mlx-worker-python/tests/test_quantization_pipeline.py
+++ b/services/mlx-worker-python/tests/test_quantization_pipeline.py
@@ -16,6 +16,8 @@ from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.quantization_pipeline import (
     OQQuantizationPipeline,
     _local_source_path_for_mlx_lm_convert,
+    _qat_fake_quant_error_table,
+    _qat_fake_quant_source_stats,
     _smoke_required_files_for_backend,
     _source_artifact_files_for_qat,
     _sum_bundle_file_bytes,
@@ -1257,6 +1259,55 @@ def test_qat_source_artifact_files_skips_bad_scandir_entries_and_empty_roots(
     with pytest.raises(ModelOperationError) as root_error:
         _source_artifact_files_for_qat(source_path)
     assert root_error.value.code == "invalid_qat_source_artifact"
+
+
+def test_qat_fake_quant_error_table_matches_reference_and_caches() -> None:
+    _qat_fake_quant_error_table.cache_clear()
+
+    for q_bits in (2, 4, 8):
+        levels = (1 << q_bits) - 1
+        expected = tuple(
+            abs(value - round((round((value / 255.0) * levels) / levels) * 255.0)) / 255.0
+            for value in range(256)
+        )
+        first = _qat_fake_quant_error_table(q_bits)
+        second = _qat_fake_quant_error_table(q_bits)
+
+        assert first == expected
+        assert second is first
+
+    cache_info = _qat_fake_quant_error_table.cache_info()
+    assert cache_info.misses == 3
+    assert cache_info.hits == 3
+
+    with pytest.raises(ModelOperationError) as error:
+        _qat_fake_quant_error_table(0)
+    assert error.value.code == "invalid_quantization_backend_config"
+
+
+def test_qat_fake_quant_source_stats_reuses_byte_error_table(tmp_path: Path) -> None:
+    source_a = tmp_path / "a.safetensors"
+    source_b = tmp_path / "b.json"
+    source_a.write_bytes(bytes(range(256)) * 3)
+    source_b.write_bytes(b"melix-qat-source-stats\n")
+
+    q_bits = 4
+    levels = (1 << q_bits) - 1
+    payload = source_a.read_bytes() + source_b.read_bytes()
+    expected_errors = [
+        abs(value - round((round((value / 255.0) * levels) / levels) * 255.0)) / 255.0
+        for value in payload
+    ]
+
+    _qat_fake_quant_error_table.cache_clear()
+    stats = _qat_fake_quant_source_stats([source_a, source_b], q_bits=q_bits)
+
+    assert stats["source_sha256"] == quantization_pipeline_module.hashlib.sha256(payload).hexdigest()
+    assert stats["source_file_count"] == 2
+    assert stats["source_byte_count"] == len(payload)
+    assert stats["quant_error_proxy_mean"] == pytest.approx(sum(expected_errors) / len(payload))
+    assert stats["quant_error_proxy_max"] == max(expected_errors)
+    assert _qat_fake_quant_error_table.cache_info().misses == 1
 
 
 def test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+from functools import lru_cache
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Event
@@ -1230,13 +1231,7 @@ def _qat_fake_quant_source_stats(source_files: list[Path], *, q_bits: int) -> di
     source_byte_count = 0
     error_sum = 0.0
     error_max = 0.0
-    levels = (1 << q_bits) - 1
-    if levels <= 0:
-        raise ModelOperationError(
-            code="invalid_quantization_backend_config",
-            message="qat_q_bits must produce at least one fake-quant level.",
-            details={"field": "qat_q_bits", "value": str(q_bits)},
-        )
+    error_by_byte = _qat_fake_quant_error_table(q_bits)
     for source_file in source_files:
         source_file_count += 1
         with source_file.open("rb") as handle:
@@ -1247,9 +1242,7 @@ def _qat_fake_quant_source_stats(source_files: list[Path], *, q_bits: int) -> di
                 digest.update(chunk)
                 source_byte_count += len(chunk)
                 for value in chunk:
-                    quantized = round((value / 255.0) * levels) / levels
-                    reconstructed = round(quantized * 255.0)
-                    error = abs(value - reconstructed) / 255.0
+                    error = error_by_byte[value]
                     error_sum += error
                     if error > error_max:
                         error_max = error
@@ -1266,6 +1259,21 @@ def _qat_fake_quant_source_stats(source_files: list[Path], *, q_bits: int) -> di
         "quant_error_proxy_mean": error_sum / source_byte_count,
         "quant_error_proxy_max": error_max,
     }
+
+
+@lru_cache(maxsize=None)
+def _qat_fake_quant_error_table(q_bits: int) -> tuple[float, ...]:
+    levels = (1 << q_bits) - 1
+    if levels <= 0:
+        raise ModelOperationError(
+            code="invalid_quantization_backend_config",
+            message="qat_q_bits must produce at least one fake-quant level.",
+            details={"field": "qat_q_bits", "value": str(q_bits)},
+        )
+    return tuple(
+        abs(value - round((round((value / 255.0) * levels) / levels) * 255.0)) / 255.0
+        for value in range(256)
+    )
 
 
 def _write_json_artifact(path: Path, payload: dict[str, Any]) -> int:


### PR DESCRIPTION
## Summary
- Cache the 256-entry QAT fake-quant byte error table per `q_bits` so `_qat_fake_quant_source_stats(...)` stops redoing identical floating-point reconstruction math for every source byte.
- Extend focused QAT tests to lock exact source-stat semantics, cache reuse, and invalid `q_bits` handling.
- Update the registered `quantization-qat-source-scan-scandir` PR-scoped probe to measure the QAT source stats hot path in addition to the existing source tree scan.

## Plan or Spec
- Plan: `docs/plans/2026-05-08-qat-fake-quant-error-table.md`
- Slice type: Python worker optimization, Linux-verifiable.
- Registered scoped CI probe: `quantization-qat-source-scan-scandir`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_uses_scandir_stack_without_path_rglob services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_skips_bad_scandir_entries_and_empty_roots services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_fake_quant_error_table_matches_reference_and_caches services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_fake_quant_source_stats_reuses_byte_error_table services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_qat_source_scan_probe_script_emits_metrics` → `8 passed in 0.46s`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/quantization_qat_source_scan_probe.py` → `TOTAL 70 1 99%`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_QAT_SOURCE_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/quantization_qat_source_scan_probe.py` → branch probe emitted QAT stats metrics.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id quantization-qat-source-scan-scandir --base-repo /tmp/melix-cron-opt-base-20260508032711b --head-repo "$PWD" --output /tmp/qat-source-scan-probe.json` → head verification passed and base/head probe comparison completed.
- `python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.validated.json && git diff --check` → passed.

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 70 1 99%`.
- Production changed-line coverage: `services/mlx-worker-python/worker/model_ops/quantization_pipeline.py` → `100.00%`.
- Probe script changed-line coverage: `scripts/quantization_qat_source_scan_probe.py` → `96.00%`.
- Local registered probe comparison (`quantization-qat-source-scan-scandir`, 4,000,000-byte stats workload):
  - Base `source_stats_elapsed_ms_mean`: `14175.031413 ms`
  - Head `source_stats_elapsed_ms_mean`: `844.440374 ms`
  - Improvement: ~`94.04%` lower (`16.79x` faster)
  - Structural metric preserved: `source_stats_byte_count=4000000.0` on base and head
  - Existing scan structural metric preserved: `rglob_calls_mean=0.0`, `scandir_calls_mean=66.0` on base and head
- Direct branch probe sample: `source_stats_elapsed_ms_mean=829.881137 ms`, `source_stats_peak_bytes_mean=2055424.4`, `source_stats_byte_count=4000000.0`.

## Known Gaps
- Full macOS/Swift validation was not run locally because this cron host is Linux.
- Editing `infra/perf/pr_scoped_probes.json` may trigger broader hosted `pr-scoped-performance` fan-out; this PR should wait for the relevant hosted scoped performance run/report before merge.

## Evidence Checklist
- [x] Focused tests added/updated for changed behavior.
- [x] Changed-scope coverage measured and above 95%.
- [x] Explicit local performance probe run with concrete base/head metrics.
- [x] Registered PR-scoped performance probe updated: `quantization-qat-source-scan-scandir`.
- [x] `git diff --check` passed.
- [ ] Hosted PR-scoped performance CI completed.
- [ ] Auto-merge enabled after required CI is green.
