### PR TITLE
perf: cache event actor alias checks

### DIFF
--- a/docs/plans/2026-05-07-event-extraction-group-actor-alias-cache.md
+++ b/docs/plans/2026-05-07-event-extraction-group-actor-alias-cache.md
@@ -18,7 +18,7 @@ This slice is Python-only under `services/mlx-worker-python`, so it is verifiabl
 
 ## Performance probe
 
-Register `event-extraction-group-actor-alias-cache` in PR-scoped performance CI. The probe repeatedly expands semantic actor values containing group aliases and non-aliases, reports elapsed time and structural normalize-call counts, and compares `origin/main` to the PR branch. The May 7 follow-up slice keeps the same registered probe and extends the cache boundary from the static alias set to repeated actor-value expansion for identical normalized actor tuples.
+Register `event-extraction-group-actor-alias-cache` in PR-scoped performance CI. The probe repeatedly expands semantic actor values containing group aliases and non-aliases, reports elapsed time and structural normalize-call counts, and compares `origin/main` to the PR branch. The May 7 follow-up slice keeps the same registered probe and extends the cache boundary from the static alias set to repeated actor-value expansion for identical normalized actor tuples. The May 8 follow-up keeps the same behavior and registered probe while adding a bounded cache to `_is_group_actor_alias(...)` so repeated group-alias checks across different actor tuples avoid rescanning the same strings.
 
 ## Success metrics
 

--- a/scripts/event_extraction_actor_alias_probe.py
+++ b/scripts/event_extraction_actor_alias_probe.py
@@ -44,6 +44,8 @@ def _actor_values(value_count: int) -> list[str]:
 
 
 def _run_probe(*, value_count: int, iterations: int, samples: int) -> dict[str, float]:
+    event_extraction_module._expanded_semantic_actor_values.cache_clear()
+    event_extraction_module._is_group_actor_alias.cache_clear()
     original_normalize = event_extraction_module._normalize_similarity_text
     normalize_calls = 0
 

--- a/services/mlx-worker-python/tests/test_event_extraction.py
+++ b/services/mlx-worker-python/tests/test_event_extraction.py
@@ -493,6 +493,7 @@ def test_semantic_field_values_reuses_cached_group_actor_aliases(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     event_extraction_module._expanded_semantic_actor_values.cache_clear()
+    event_extraction_module._is_group_actor_alias.cache_clear()
     calls: list[str] = []
     original_normalize = event_extraction_module._normalize_similarity_text
 
@@ -508,12 +509,14 @@ def test_semantic_field_values_reuses_cached_group_actor_aliases(
     ) == ["speaker_1", "speaker_2"]
     assert calls == ["我 们"]
     event_extraction_module._expanded_semantic_actor_values.cache_clear()
+    event_extraction_module._is_group_actor_alias.cache_clear()
 
 
 def test_semantic_field_values_caches_repeated_group_actor_expansion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     event_extraction_module._expanded_semantic_actor_values.cache_clear()
+    event_extraction_module._is_group_actor_alias.cache_clear()
     calls: list[str] = []
     original_normalize = event_extraction_module._normalize_similarity_text
 
@@ -528,6 +531,7 @@ def test_semantic_field_values_caches_repeated_group_actor_expansion(
     assert event_extraction_module._semantic_field_values("actor", event) == ["speaker_1", "speaker_2"]
     assert calls == ["我 们"]
     event_extraction_module._expanded_semantic_actor_values.cache_clear()
+    event_extraction_module._is_group_actor_alias.cache_clear()
 
 
 def test_semantic_field_values_normalizes_and_deduplicates_in_one_pass(monkeypatch) -> None:

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2142,6 +2142,7 @@ _NORMALIZED_GROUP_ACTOR_ALIASES = frozenset(
 )
 
 
+@lru_cache(maxsize=512)
 def _is_group_actor_alias(value: str) -> bool:
     if value in _GROUP_ACTOR_ALIASES:
         return True


### PR DESCRIPTION
## Summary
- Add a bounded `lru_cache` to the event-extraction group actor alias predicate so repeated alias checks across actor tuples can skip rescanning the same strings.
- Clear the new predicate cache in focused monkeypatch tests to keep normalization-call assertions deterministic.
- Update the governing performance plan with the May 8 follow-up boundary.

## Plan or Spec
- `docs/plans/2026-05-07-event-extraction-group-actor-alias-cache.md`

## Commands Run
```text
# focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_reuses_cached_group_actor_aliases services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_caches_repeated_group_actor_expansion services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_normalizes_and_deduplicates_in_one_pass services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_expands_group_actor_aliases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_actor_alias_probe_script_emits_metrics
# outcome: 7 passed in 0.94s

# changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_reuses_cached_group_actor_aliases services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_caches_repeated_group_actor_expansion services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_normalizes_and_deduplicates_in_one_pass services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_expands_group_actor_aliases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_actor_alias_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_actor_alias_probe.py
# outcome: 7 passed in 0.35s; TOTAL 5 0 100%

# registered probe, origin/main detached worktree
MELIX_EVENT_ACTOR_ALIAS_PROBE_SAMPLES=10 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_actor_alias_probe.py
# outcome: {"elapsed_ms_mean": 5.5235667852684855, "elapsed_ms_min": 5.035373964346945, "iterations_per_sample": 200.0, "normalize_calls_mean": 0.3, "output_length_per_sample": 13600.0, "peak_bytes_mean": 3557.6, "sample_count": 10.0, "value_count": 200.0}

# registered probe, PR branch
MELIX_EVENT_ACTOR_ALIAS_PROBE_SAMPLES=10 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_actor_alias_probe.py
# outcome: {"elapsed_ms_mean": 4.711339983623475, "elapsed_ms_min": 4.360017948783934, "iterations_per_sample": 200.0, "normalize_calls_mean": 0.3, "output_length_per_sample": 13600.0, "peak_bytes_mean": 4135.2, "sample_count": 10.0, "value_count": 200.0}

git diff --check
# outcome: passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Registered local probe (`event-extraction-group-actor-alias-cache`, 10 samples): `old_mean=5.5235667852684855ms`, `new_mean=4.711339983623475ms`, `speedup=1.1724x`, `delta_ms=-0.8122268016450104ms`.
- Probe structural parity: `normalize_calls_mean=0.3` both branches; `output_length_per_sample=13600.0` both branches.
- `peak_bytes_mean` increased from `3557.6` to `4135.2` bytes because the new bounded cache stores predicate entries; this metric is informational for this registered probe.
- CI PR-scoped performance is required before merge.

## Known Gaps
- Full repository test suite was not run locally; this is a focused Python performance slice.
- Hosted PR-scoped performance must validate the registered probe before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
