### PR TITLE
perf: fold embedding digest square sum

### DIFF
--- a/docs/plans/2026-05-08-deterministic-embedding-square-sum-single-pass.md
+++ b/docs/plans/2026-05-08-deterministic-embedding-square-sum-single-pass.md
@@ -1,0 +1,37 @@
+# Deterministic Embedding Projection Square-Sum Single Pass
+
+## Goal
+
+Reduce per-vector temporary allocation in deterministic embedding digest projection while preserving the exact deterministic vector values and normalization behavior.
+
+## Linux-only constraint
+
+This is a Python worker-runtime slice. It is locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/embedding_backends.py`
+- `docs/plans/2026-05-08-deterministic-embedding-square-sum-single-pass.md`
+
+## Optimization hypothesis
+
+`DeterministicEmbeddingBackend._project_digest()` already expands the normalized digest base vector with list multiplication, but it still builds a second `squared_values` list solely to compute the L2 normalization denominator. The digest base has only eight float values, yet this path is called once per embedding row and the temporary list allocation repeats for every vector.
+
+Accumulate the base squared sum while building `base_values`, then reuse that scalar for the full-repeat contribution and only rescan the short remainder. This removes one temporary list allocation per projected vector and preserves the legacy output ordering, rounding, and zero-dimension behavior.
+
+## Registered performance probe
+
+The affected path is covered by `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+Metrics:
+
+- `elapsed_ms_mean` — lower is better
+- `peak_bytes_mean` — lower is better
+- `dimensions`, `vector_count`, and checksum provide behavior context
+
+## Verification commands
+
+- Focused pytest for embedding runtime and PR-scoped probe selection/smoke tests
+- Changed-scope coverage for touched Python/tests with at least 95% automated coverage
+- Local registered probe run before and after the implementation
+- `git diff --check`

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -42,16 +42,20 @@ class DeterministicEmbeddingBackend:
 
     def _project_digest(self, seed_text: str, dimensions: int) -> list[float]:
         digest = hashlib.sha256(seed_text.encode("utf-8")).digest()
-        base_values = [
-            (int.from_bytes(digest[start : start + 4], "little") / 0xFFFFFFFF) * 2.0
-            - 1.0
-            for start in range(0, len(digest), 4)
-        ]
+        base_values: list[float] = []
+        base_squared_sum = 0.0
+        for start in range(0, len(digest), 4):
+            value = (
+                (int.from_bytes(digest[start : start + 4], "little") / 0xFFFFFFFF) * 2.0
+                - 1.0
+            )
+            base_values.append(value)
+            base_squared_sum += value * value
         base_count = len(base_values)
         full_repeats, remainder = divmod(dimensions, base_count)
-        squared_values = [value * value for value in base_values]
-        squared_sum = sum(squared_values) * full_repeats
-        squared_sum += sum(squared_values[:remainder])
+        squared_sum = base_squared_sum * full_repeats
+        for value in base_values[:remainder]:
+            squared_sum += value * value
 
         l2_norm = math.sqrt(squared_sum)
         if l2_norm == 0.0:


### PR DESCRIPTION
## Summary
- Fold deterministic embedding digest square-sum accumulation into the existing base-value construction loop.
- Remove the per-vector `squared_values` temporary list while preserving the exact legacy projection values.
- Add a focused plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-05-08-deterministic-embedding-square-sum-single-pass.md`
- Registered PR-scoped performance probe: `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline local probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
exit 0; elapsed_ms_mean=28.685320; peak_bytes_mean=66955.666667; checksum=0.348915

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
exit 0; 17 passed in 12.41s

# Changed-scope coverage (reruns focused tests)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
exit 0; 17 passed in 37.34s; TOTAL 9 0 100%

# Registered base-vs-head probe runner
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-project-digest-allocation --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-embedding-square-sum-20260508070646 --head-repo "$PWD" --output /tmp/deterministic_embedding_square_sum_probe.json
exit 0; base elapsed_ms_mean=24.365822; head elapsed_ms_mean=23.136870

# Final standalone head probe after formatting
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
exit 0; elapsed_ms_mean=26.589528; peak_bytes_mean=66667.666667; checksum=0.348915

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 9 0 100%` for `services/mlx-worker-python/worker/runtime/embedding_backends.py`.
- Registered local base-vs-head probe (`deterministic-embedding-project-digest-allocation`):
  - `elapsed_ms_mean`: base `24.365822 ms`, head `23.136870 ms`, delta `-1.228952 ms`, improvement `5.04%`, speedup `5.31%`.
  - `peak_bytes_mean`: base `66955.666667`, head `66667.666667`, delta `-288 bytes`.
  - `checksum`: base/head `0.348915`.
- CI PR-scoped performance remains the merge gate for the registered probe report.

## Known Gaps
- Local verification is Linux-only and covers the deterministic Python worker path; no Swift runtime effect is claimed.
- The final standalone head probe is noisier than the base-vs-head runner but preserves checksum and lower peak bytes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
