### PR TITLE
perf: reduce code eval fence rescans

### DIFF
--- a/docs/plans/2026-05-08-code-eval-fence-count-fast-path.md
+++ b/docs/plans/2026-05-08-code-eval-fence-count-fast-path.md
@@ -1,0 +1,38 @@
+# Code Eval Fence Count Fast Path
+
+## Goal
+
+Reduce redundant code-fence scanning in `extract_candidate_code(...)` while preserving the existing candidate extraction contract.
+
+## Scope
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py` (existing focused coverage)
+
+## Linux Constraint
+
+This is a Python-only string parsing slice. It can be verified on Linux with focused pytest, changed-scope coverage, and the existing code-eval code-block extraction performance probe.
+
+## Performance Probe
+
+Registered scoped CI probe: `code-eval-code-block-last-match-streaming`.
+
+Local probe command:
+
+```bash
+python scripts/code_eval_code_block_extract_probe.py
+```
+
+## Success Metrics
+
+- Preserve output for empty responses, plain code, Python fenced blocks, non-Python fenced blocks, multiple complete blocks, and trailing unterminated blocks.
+- Keep changed executable coverage at or above 95%.
+- Improve or maintain `elapsed_ms_mean` and `peak_bytes_mean` for the synthetic many-block extraction probe.
+
+## Implementation Plan
+
+1. Count code fences once with `str.count(...)`.
+2. Use the count parity to decide whether the final fence is a closing fence or an unmatched trailing opening fence.
+3. Locate only the selected closing fence and matching opening fence with bounded `rfind(...)` calls.
+4. Return the extracted last complete block through the existing `_code_block_content_start(...)` helper.
+5. Reuse existing focused tests and the registered probe for verification.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -41,15 +41,15 @@ def extract_candidate_code(raw_response: str) -> tuple[str, str]:
     if not normalized:
         return "", "empty_prediction"
 
-    closing = normalized.rfind("```")
-    while closing >= 0:
+    fence_count = normalized.count("```")
+    if fence_count >= 2:
+        closing = normalized.rfind("```")
+        if fence_count % 2:
+            closing = normalized.rfind("```", 0, closing)
         opening = normalized.rfind("```", 0, closing)
-        if opening < 0:
-            break
-        if normalized.count("```", 0, opening) % 2 == 0:
+        if opening >= 0:
             content_start = _code_block_content_start(normalized, opening + 3)
             return normalized[content_start:closing].strip(), "parsed_code_block"
-        closing = opening
 
     return normalized, "parsed_code"
 


### PR DESCRIPTION
## Summary
- Reduce redundant code-fence scanning in `extract_candidate_code(...)` by counting fences once and using parity to choose the final complete fenced block.
- Preserve existing extraction behavior for empty/plain responses, Python and non-Python fenced blocks, multiple blocks, and trailing unterminated blocks.

## Plan or Spec
- `docs/plans/2026-05-08-code-eval-fence-count-fast-path.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks
# 1 passed in 0.07s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o /tmp/code_eval_coverage.json
python scripts/python_changed_line_coverage.py --coverage-json /tmp/code_eval_coverage.json --diff-from origin/main services/mlx-worker-python/worker/engine/code_eval_runner.py
# services/mlx-worker-python/worker/engine/code_eval_runner.py 100.00% 6/6
# TOTAL 100.00% 6/6

python scripts/code_eval_code_block_extract_probe.py
# {"block_count": 2500.0, "elapsed_ms_mean": 0.16884171470467532, "extracted_chars_mean": 37.0, "peak_bytes_mean": 289.0, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-code-block-last-match-streaming --base-repo /tmp/melix-code-eval-base-20260508-070718 --head-repo "$PWD" --output /tmp/code-eval-code-block-probe.json
# head verification: 4 passed; TOTAL 6 0 100%
# base_probe elapsed_ms_mean=0.06904258459274258 peak_bytes_mean=245.0
# head_probe elapsed_ms_mean=0.05930254701524973 peak_bytes_mean=273.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed executable coverage: `100.00%` (`6/6`) for `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
- Registered scoped CI probe: `code-eval-code-block-last-match-streaming`.
- Local registered base-vs-head probe:
  - base `elapsed_ms_mean=0.06904258459274258`, `peak_bytes_mean=245.0`
  - head `elapsed_ms_mean=0.05930254701524973`, `peak_bytes_mean=273.0`
  - interpretation: latency improved by ~14.1%; peak traced bytes increased by 28 bytes in this tiny parser probe and remains effectively flat.

## Known Gaps
- Linux-only local verification. Full macOS/Swift checks were not run on this host.
- Hosted GitHub Actions must validate the registered `pr-scoped-performance` probe before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
