### PR TITLE
perf: reuse parsed video uri for format inference

### DIFF
--- a/docs/plans/2026-05-08-video-preprocessing-uri-parse-elision.md
+++ b/docs/plans/2026-05-08-video-preprocessing-uri-parse-elision.md
@@ -1,0 +1,38 @@
+# Video preprocessing URI parse elision
+
+## Goal
+
+Reduce redundant parsing in `prepare_video_input(...)` for URI-backed video inputs when the media metadata does not provide an explicit filename.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/video_preprocessing.py`
+- `services/mlx-worker-python/tests/test_video_preprocessing.py`
+- `scripts/video_preprocessing_uri_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Linux-only constraint
+
+This is a Python worker slice and can be verified on Linux with focused pytest, changed-scope coverage, and the registered PR-scoped performance probe.
+
+## Performance probe
+
+Use the existing registered probe `video-preprocessing-uri-byte-length-reuse` and extend its script metrics with `parse_calls_per_call`.
+
+Success metrics:
+
+- Preserve existing `byte_length_getattrs_per_call == 1.0`.
+- Reduce URI parse calls for a remote URI without explicit filename from two per call to one per call.
+- Keep behavior identical for inferred format, filename, byte length, and identity hash.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/video_preprocessing_uri_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/video_preprocessing_uri_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --probe-id video-preprocessing-uri-byte-length-reuse --repo-root "$PWD" --base-ref origin/main --output /tmp/video-preprocessing-uri-probe.json
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2436,6 +2436,12 @@
         "unit": "calls",
         "direction": "lower_is_better",
         "warn_pct": 0.0
+      },
+      {
+        "key": "parse_calls_per_call",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
       }
     ]
   },

--- a/scripts/video_preprocessing_uri_probe.py
+++ b/scripts/video_preprocessing_uri_probe.py
@@ -10,7 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 
-from worker.runtime.video_preprocessing import prepare_video_input
+from worker.runtime import video_preprocessing
 
 
 class CountingMedia:
@@ -38,21 +38,36 @@ class CountingVideoPart:
 def run_probe(iterations: int = 50_000, sample_count: int = 5) -> dict[str, float]:
     elapsed_samples: list[float] = []
     byte_length_reads: list[float] = []
+    parse_calls_per_call: list[float] = []
     checksum = 0
+    original_parse = video_preprocessing._parse_video_reference
     for _ in range(sample_count):
         media = CountingMedia()
         part = CountingVideoPart(media)
+        parse_calls = 0
+
+        def counting_parse(reference: str):
+            nonlocal parse_calls
+            parse_calls += 1
+            return original_parse(reference)
+
+        video_preprocessing._parse_video_reference = counting_parse
         started = time.perf_counter()
-        for _index in range(iterations):
-            prepared = prepare_video_input(part)
-            checksum += prepared.byte_length + len(prepared.sha256_hex)
+        try:
+            for _index in range(iterations):
+                prepared = video_preprocessing.prepare_video_input(part)
+                checksum += prepared.byte_length + len(prepared.sha256_hex)
+        finally:
+            video_preprocessing._parse_video_reference = original_parse
         elapsed_samples.append((time.perf_counter() - started) * 1000.0)
         byte_length_reads.append(float(media.byte_length_reads) / float(iterations))
+        parse_calls_per_call.append(float(parse_calls) / float(iterations))
     if checksum <= 0:
         raise RuntimeError("unexpected empty video preprocessing probe checksum")
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
         "byte_length_getattrs_per_call": statistics.fmean(byte_length_reads),
+        "parse_calls_per_call": statistics.fmean(parse_calls_per_call),
         "iterations_per_sample": float(iterations),
         "sample_count": float(sample_count),
     }

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1625,6 +1625,7 @@ def test_video_preprocessing_uri_probe_script_emits_metrics(
     assert metrics["sample_count"] == 5.0
     assert metrics["iterations_per_sample"] == 50000.0
     assert metrics["byte_length_getattrs_per_call"] == 1.0
+    assert metrics["parse_calls_per_call"] == 1.0
     assert metrics["elapsed_ms_mean"] >= 0
 
 

--- a/services/mlx-worker-python/tests/test_video_preprocessing.py
+++ b/services/mlx-worker-python/tests/test_video_preprocessing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from packages.protocol.python.worker.v1 import common_pb2
+from worker.runtime import video_preprocessing
 from worker.runtime.video_preprocessing import (
     MAX_VIDEO_FRAME_BUDGET,
     PreparedVideoInput,
@@ -125,6 +126,33 @@ def test_prepare_video_input_reuses_uri_byte_length_for_metadata_and_identity_ha
     assert prepared.byte_length == 123
     assert media.byte_length_reads == 1
     assert len(prepared.sha256_hex) == 64
+
+
+def test_prepare_video_input_reuses_parsed_uri_when_filename_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parse_calls = 0
+    original_parse = video_preprocessing._parse_video_reference
+
+    def counting_parse(reference: str):
+        nonlocal parse_calls
+        parse_calls += 1
+        return original_parse(reference)
+
+    monkeypatch.setattr(video_preprocessing, "_parse_video_reference", counting_parse)
+    part = common_pb2.MessagePart(
+        video_uri="https://example.com/media/demo.mov",
+        media=common_pb2.MediaMetadata(
+            media_type=common_pb2.MEDIA_TYPE_VIDEO,
+            source_kind=common_pb2.MEDIA_SOURCE_URI,
+        ),
+    )
+
+    prepared = prepare_video_input(part)
+
+    assert prepared.format == "mov"
+    assert prepared.filename == "demo.mov"
+    assert parse_calls == 1
 
 
 def test_prepare_video_input_infers_format_from_plain_local_path() -> None:

--- a/services/mlx-worker-python/worker/runtime/video_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/video_preprocessing.py
@@ -80,7 +80,10 @@ def prepare_video_input(part) -> PreparedVideoInput:
         raise VideoPreprocessError("No video input provided.")
     parsed_reference = _parse_video_reference(uri)
     _validate_video_uri(parsed_reference)
-    resolved_format = _resolve_video_format(format_name, mime_type, filename, parsed_reference)
+    format_candidates: tuple[str | ParsedVideoReference, ...] = (
+        (filename, parsed_reference) if filename else (parsed_reference,)
+    )
+    resolved_format = _resolve_video_format(format_name, mime_type, *format_candidates)
     resolved_filename = (
         filename or _filename_from_reference(parsed_reference) or f"remote-video.{resolved_format}"
     )


### PR DESCRIPTION
## Summary
- Reuses the already-parsed URI reference when inferring video format for URI-backed video inputs with no explicit metadata filename.
- Extends the existing video preprocessing scoped probe to emit a structural `parse_calls_per_call` metric alongside the existing byte-length reuse metric.
- Adds focused regression coverage for the no-filename URI path and preserves filename/format/hash behavior.

## Plan or Spec
- Plan: `docs/plans/2026-05-08-video-preprocessing-uri-parse-elision.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics
# 18 passed in 5.87s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/video_preprocessing_uri_probe.py
# 18 passed in 14.16s
# TOTAL 30 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/video_preprocessing_uri_probe.py
# {"byte_length_getattrs_per_call": 1.0, "elapsed_ms_mean": 1041.7631265940145, "iterations_per_sample": 50000.0, "parse_calls_per_call": 1.0, "sample_count": 5.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id video-preprocessing-uri-byte-length-reuse --base-repo /tmp/melix-video-base-20260508081131-a --head-repo "$PWD" --output /tmp/video-preprocessing-uri-probe.json
# head verification: ok, coverage 100%
# base_probe.ok=true, head_probe.ok=true
# base elapsed_ms_mean=1379.7946827718988; head elapsed_ms_mean=1044.0922657959163
# head parse_calls_per_call=1.0; byte_length_getattrs_per_call=1.0

git diff --check
# passed

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr-scoped-probes-validated.json
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 30 0 100%`.
- Direct probe (`scripts/video_preprocessing_uri_probe.py`): `parse_calls_per_call=1.0`, `byte_length_getattrs_per_call=1.0`, `elapsed_ms_mean=1041.7631265940145` over 5 samples x 50,000 iterations.
- Registered scoped probe (`video-preprocessing-uri-byte-length-reuse`) local base-vs-head: base `elapsed_ms_mean=1379.7946827718988`, head `elapsed_ms_mean=1044.0922657959163` (~24.33% lower); head structural metrics `parse_calls_per_call=1.0`, `byte_length_getattrs_per_call=1.0`.

## Known Gaps
- Linux-only verification was run for this Python worker slice; macOS/Swift checks were not run locally.
- Hosted PR-scoped performance and broader branch CI still need to run on GitHub before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
