### PR TITLE
docs: add evidence telemetry roadmap

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ These are the authoritative interface and architecture definitions. Do not move 
 | [Control Plane Protocol](control-plane-protocol.md) | The typed protocol between the control plane and worker surfaces |
 | [Worker RPC Schema](worker-rpc-schema.md) | RPC message shapes and worker communication contracts |
 | [Benchmark & Evaluation Contract](benchmark-evaluation-contract.md) | Benchmark and evaluation data formats, output contracts, and artifact shapes |
+| [Evidence, Telemetry & Report Contract](evidence-telemetry-report-contract.md) | Run evidence, probe timeline, Apple Silicon telemetry, report, and release-gate source-of-truth rules |
 | [Repository Skeleton](repo-skeleton.md) | Directory layout and conventions for the Melix repository |
 
 ---
@@ -86,6 +87,7 @@ The plan archive is intentionally large and serves as an engineering record. Use
 |---|---|
 | [Full Capability Execution Index](plans/2026-03-30-full-capability-roadmap-execution-index.md) | Milestone-level closure detail for the full capability roadmap |
 | [Full Capability Roadmap](plans/2026-03-30-full-capability-roadmap.md) | The original full capability plan |
+| [Evidence, Telemetry & Report Roadmap](plans/2026-05-08-evidence-telemetry-roadmap.md) | Best-path plan for structured run evidence, probes, Apple Silicon telemetry, reports, PR/release gates, and desktop operator surfaces |
 | [README & Docs Realignment](plans/2026-04-12-readme-and-docs-realignment.md) | Documentation restructure and alignment plan |
 | [LoRA Capability Modules](plans/2026-04-16-lora-capability-modules-and-commit-plan.md) | LoRA expansion breakdown and commit plan |
 

--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -9,6 +9,15 @@ Define the canonical product contract for Melix operator benchmarking after the 
 
 This specification defines the required inputs, outputs, persistence shape, and presentation rules for both product lines. It does not define implementation sequencing; execution planning remains under `docs/plans/`.
 
+Structured run evidence, probe timelines, Apple Silicon telemetry, report JSON,
+and PR or release-gate verification are governed by
+`docs/evidence-telemetry-report-contract.md`. This document remains the domain
+contract for benchmark and evaluation semantics; the evidence contract defines
+how those results become auditable operator and release artifacts. For new
+evidence and report artifacts, the evidence contract is authoritative and does
+not inherit legacy export compatibility allowances documented later in this
+file.
+
 ## Scope
 
 This contract applies to:

--- a/docs/evidence-telemetry-report-contract.md
+++ b/docs/evidence-telemetry-report-contract.md
@@ -1,0 +1,465 @@
+# Melix Evidence, Telemetry, And Report Contract
+
+## Purpose
+
+This specification defines the canonical source of truth for Melix run evidence,
+stage probes, Apple Silicon telemetry, reports, and release evidence gates.
+
+The design is best-path only:
+
+- Melix targets macOS on Apple Silicon.
+- Hardware telemetry implementation is Apple Silicon/macOS only.
+- Telemetry uses a single implementation path with no alternate collectors.
+- Melix does not implement a public leaderboard or community submission API.
+- New evidence and report consumers read the current schema only.
+- New evidence and report artifacts do not carry legacy export aliases.
+- Logs, Markdown, CSV, and UI state are not sources of truth.
+
+## Source Of Truth
+
+`report.json` is the machine-readable source of truth for report verification,
+release gates, and desktop report views.
+
+Each report is derived from one or more run evidence artifacts. Each run
+evidence artifact contains:
+
+- run identity
+- target, runtime, adapter, and dataset identity
+- domain result payloads
+- probe timeline
+- Apple Silicon telemetry summary
+- linked raw artifacts
+- failure and fallback state
+
+Markdown and CSV exports are derived views. They must never become the only
+place where a metric, gate result, probe, or telemetry value exists.
+
+## Run Evidence Envelope
+
+Every benchmark, evaluation, event-extraction, and adapter/runtime check writes
+an evidence envelope.
+
+Required identity fields:
+
+- `run_id`
+- `schema_version`
+- `melix_commit`
+- `git_branch`
+- `dirty_worktree`
+- `run_kind`
+- `started_at`
+- `ended_at`
+- `duration_ms`
+- `status`
+- `command`
+- `artifact_root`
+
+Required target and input fields:
+
+- `target_model_id`
+- `hf_repo_id`
+- `task_kind`
+- `model_snapshot`
+- `adapter_id`
+- `adapter_snapshot`
+- `runtime_kind`
+- `runtime_config`
+- `dataset_ref`
+- `dataset_revision`
+- `suite_id`
+- `sample_count`
+- `input_digest`
+- `prompt_template_digest`
+- `generation_config`
+
+Required diagnostic fields:
+
+- `metrics`
+- `probe_timeline`
+- `telemetry_summary`
+- `artifacts`
+- `failure_summary`
+- `fallback_summary`
+
+## Probe Timeline
+
+Every material stage records a structured probe. A missing probe is a verifier
+failure for new evidence. Implementations must not infer zero duration from a
+missing probe.
+
+Required probe fields:
+
+- `run_id`
+- `trace_id`
+- `span_id`
+- `parent_span_id`
+- `component`
+- `phase`
+- `started_at_monotonic_ms`
+- `duration_ms`
+- `status`
+- `error_stage`
+- `error_code`
+- `attributes`
+
+Allowed `component` values:
+
+- `cli`
+- `control_plane`
+- `worker`
+- `runtime`
+- `adapter`
+- `cache`
+- `telemetry`
+- `report`
+
+Initial canonical phases:
+
+- `cli_parse`
+- `request_normalize`
+- `target_resolve`
+- `dataset_materialize`
+- `sample_select`
+- `prompt_render`
+- `queue_wait`
+- `worker_dispatch`
+- `runtime_prepare`
+- `model_load`
+- `adapter_resolve`
+- `adapter_load`
+- `cache_lookup`
+- `cache_restore`
+- `prefill`
+- `decode`
+- `stream_assemble`
+- `row_execute`
+- `score_compute`
+- `aggregate_result`
+- `hardware_sample`
+- `process_sample`
+- `power_sample`
+- `artifact_write`
+- `report_generate`
+- `export_write`
+- `fallback_enter`
+- `fallback_exit`
+
+Probe attributes must be small structured JSON values. They must not contain
+full prompts, responses, dataset rows, private credentials, or operator secrets.
+
+## Apple Silicon Telemetry
+
+Melix hardware telemetry is scoped to macOS on Apple Silicon.
+
+The collector records:
+
+- CPU utilization
+- P-core and E-core utilization
+- GPU utilization
+- GPU frequency
+- GPU power
+- CPU power
+- ANE power
+- DRAM power
+- system power
+- memory used and total
+- thermal state
+- process CPU and memory attribution
+
+Each run records:
+
+- telemetry time-series artifact path
+- average and peak CPU utilization
+- average and peak GPU utilization
+- average and peak GPU frequency
+- average and peak CPU power
+- average and peak GPU power
+- average and peak ANE power
+- average and peak DRAM power
+- average and peak system power
+- watts per output token
+- peak process memory
+- average process CPU percent
+- thermal events
+- telemetry failures
+
+Telemetry sampling runs off the hot path. Benchmark and evaluation execution
+read only cached telemetry samples.
+
+If IOReport or IORegistry sampling fails during a Melix run, the run records a
+telemetry failure probe and report entry. Implementations must not synthesize
+zero-watt or zero-duration values for missing telemetry.
+
+## Process Attribution
+
+Reports include process attribution for Melix and model runtimes.
+
+Required process fields:
+
+- `pid`
+- `name`
+- `role`
+- `port`
+- `bundle_prefix`
+- `peak_memory_bytes`
+- `avg_cpu_percent`
+- `sample_count`
+
+Required process groups:
+
+- `primary_runtime_process`
+- `control_plane_process`
+- `worker_processes`
+- `external_provider_processes`
+- `process_tree_summary`
+
+Attribution uses port, pid, process tree, and bundle prefix data so operators
+can separate Melix control-plane cost, worker cost, runtime cost, and external
+provider cost.
+
+## Report Contents
+
+Every report has these sections.
+
+### Report Identity
+
+- `report_id`
+- `schema_version`
+- `generated_at`
+- `generator_name`
+- `generator_version`
+- `melix_commit`
+- `git_branch`
+- `dirty_worktree`
+- `source_evidence_ids`
+- `report_kind`
+
+### Run Summary
+
+- `run_id`
+- `trace_id`
+- `run_kind`
+- `status`
+- `started_at`
+- `ended_at`
+- `duration_ms`
+- `command`
+- `operator`
+- `artifact_root`
+- `failure_summary`
+- `fallback_summary`
+
+### Target And Input
+
+- `target_model_id`
+- `hf_repo_id`
+- `task_kind`
+- `model_snapshot`
+- `adapter_id`
+- `adapter_snapshot`
+- `runtime_kind`
+- `runtime_config`
+- `dataset_ref`
+- `dataset_revision`
+- `suite_id`
+- `sample_count`
+- `input_digest`
+- `prompt_template_digest`
+- `generation_config`
+
+### Result Metrics
+
+Serving benchmark reports include:
+
+- `prefill_tokens_per_second`
+- `decode_tokens_per_second`
+- `output_tokens_per_second`
+- `ttft_ms`
+- `request_p50_ms`
+- `request_p95_ms`
+- `tokens_in`
+- `tokens_out`
+- `peak_memory_bytes`
+- `cache_hit_rate`
+- `speculative_acceptance_rate`
+- `dflash_rollback_count`
+
+Evaluation reports include:
+
+- `score`
+- `pass_count`
+- `fail_count`
+- `error_count`
+- `accuracy`
+- `precision`
+- `recall`
+- `f1`
+- `category_breakdown`
+- `sample_failures`
+
+Event-extraction reports include:
+
+- `dialogue_count`
+- `event_count`
+- `valid_json_rate`
+- `schema_valid_rate`
+- `field_accuracy`
+- `missing_event_count`
+- `extra_event_count`
+- `parse_error_count`
+
+Adapter/runtime reports include:
+
+- `adapter_load_ms`
+- `adapter_activate_ms`
+- `adapter_memory_bytes`
+- `runtime_prepare_ms`
+- `model_load_ms`
+- `fallback_count`
+
+### Probe Timeline Summary
+
+- `probe_count`
+- `slowest_phases`
+- `phase_breakdown`
+- `component_breakdown`
+- `failed_phases`
+- `skipped_phases`
+- `fallback_phases`
+
+Each phase summary includes:
+
+- `phase`
+- `component`
+- `count`
+- `total_duration_ms`
+- `mean_duration_ms`
+- `p95_duration_ms`
+- `max_duration_ms`
+- `status_counts`
+
+### Apple Silicon Hardware Telemetry
+
+- hardware identity banner
+- average and peak utilization
+- average and peak power
+- average and peak GPU frequency
+- watts per output token
+- peak process memory
+- process CPU summary
+- thermal events
+- telemetry failures
+- telemetry time-series artifact links
+
+### Process Attribution
+
+- process list
+- primary runtime process
+- control-plane process
+- worker processes
+- external provider processes
+- process tree summary
+
+### Comparison Results
+
+Comparison and release-gate reports include:
+
+- `baseline_report_id`
+- `current_report_id`
+- `comparison_dimensions`
+- `metric_deltas`
+- `probe_deltas`
+- `telemetry_deltas`
+- `regressions`
+- `improvements`
+- `unchanged`
+- `comparison_validity`
+
+Each delta includes:
+
+- `metric`
+- `baseline`
+- `current`
+- `delta`
+- `delta_percent`
+- `direction`
+- `gate_policy`
+- `result`
+
+### Gate Result
+
+Release-gate and PR-evidence reports include:
+
+- `overall_result`
+- `gate_results`
+- `informational_results`
+- `known_gaps`
+- `blocking_failures`
+- `required_evidence_present`
+- `required_probe_phases_present`
+- `required_telemetry_present`
+
+### Artifacts
+
+- `evidence_json_path`
+- `report_json_path`
+- `markdown_report_path`
+- `csv_export_paths`
+- `probe_timeline_path`
+- `telemetry_jsonl_path`
+- `raw_output_paths`
+- `logs_path`
+- `screenshots_path`
+- `coverage_path`
+
+### Known Gaps And Notes
+
+- `known_gaps`
+- `instrumentation_gaps`
+- `operator_notes`
+- `non_blocking_warnings`
+
+## Markdown And CSV Views
+
+Markdown reports include:
+
+- title and report identity
+- hardware banner
+- run summary table
+- result metrics table
+- gate summary
+- probe summary
+- telemetry summary
+- comparison table
+- known gaps
+- artifact links
+
+CSV exports are split by table:
+
+- `runs.csv`
+- `metrics.csv`
+- `probe_phases.csv`
+- `telemetry_summary.csv`
+- `processes.csv`
+- `gate_results.csv`
+- `comparison_deltas.csv`
+
+CSV exports do not preserve nested report structure.
+
+## Verifier Requirements
+
+The report verifier checks:
+
+- report identity is complete
+- source evidence exists
+- run identity is complete
+- target and input identity are complete
+- required metrics exist
+- required probe phases exist
+- Apple Silicon telemetry summary exists
+- telemetry failures are explicit
+- gate policy is complete
+- artifact links are resolvable
+- missing telemetry or probes are not encoded as zero values
+
+Reports that fail these checks cannot satisfy PR or release evidence.

--- a/docs/plans/2026-05-08-evidence-plan-1-run-evidence-schema.md
+++ b/docs/plans/2026-05-08-evidence-plan-1-run-evidence-schema.md
@@ -1,0 +1,38 @@
+# Plan 1: Unified Run Evidence Schema
+
+## Goal
+
+Create the single structured evidence envelope used by benchmark, evaluation,
+event extraction, adapter/runtime checks, reports, and release gates.
+
+## Scope
+
+- Define the evidence JSON schema.
+- Attach domain-specific benchmark and evaluation results to the envelope.
+- Require probe timeline and Apple Silicon telemetry summary fields.
+- Make the new schema the only supported evidence input for new reports.
+
+## Implementation Notes
+
+- Add repository-owned schema/types for the evidence envelope across protocol,
+  worker productization, and Swift decoding.
+- Include identity, target, runtime, adapter, dataset, status, metrics, probes,
+  telemetry, artifacts, failure, and fallback fields from
+  `docs/evidence-telemetry-report-contract.md`.
+- Keep benchmark and evaluation domain payloads separate inside the common
+  envelope so score semantics do not drift into performance metrics.
+- Ensure artifact paths are relative to the run artifact root or repository
+  root.
+
+## Verification
+
+- Schema roundtrip tests for completed, failed, cancelled, and fallback runs.
+- End-to-end fixture evidence for one serving benchmark and one evaluation run.
+- Verifier fixture that rejects evidence missing run identity, target identity,
+  probe timeline, or telemetry summary.
+
+## Acceptance
+
+- New benchmark and evaluation evidence artifacts use the unified envelope.
+- Reports and gates consume evidence JSON rather than parsing logs or Markdown.
+- Missing required evidence fields fail verification.

--- a/docs/plans/2026-05-08-evidence-plan-2-runtime-attribution-probes.md
+++ b/docs/plans/2026-05-08-evidence-plan-2-runtime-attribution-probes.md
@@ -1,0 +1,40 @@
+# Plan 2: Runtime Attribution And Stage Probes
+
+## Goal
+
+Make every material Melix run explainable by component and phase.
+
+## Scope
+
+- Add structured probes across CLI, control plane, worker, runtime, adapter,
+  cache, telemetry, and report generation.
+- Record runtime attribution for each run.
+- Attach cache, fallback, speculative decode, and DFlash diagnostics to the
+  relevant probe phases.
+
+## Implementation Notes
+
+- Use the probe fields and phase names from
+  `docs/evidence-telemetry-report-contract.md`.
+- Record worker id, runtime kind, runtime process hint, model snapshot, adapter
+  id, cache profile, and fallback state in the evidence envelope.
+- Write probes directly to the evidence artifact; do not reconstruct them from
+  logs after the run.
+- Keep probe attributes small and scrubbed of full prompts, responses, dataset
+  rows, credentials, and secrets.
+
+## Verification
+
+- Unit tests for probe serialization and parent/child span relationships.
+- Integration fixture proving a slow run can be localized to queue, dataset,
+  prompt render, adapter load, cache restore, prefill, decode, or report export.
+- Fixture coverage for adapter on/off, cache hit/miss, provider fallback, and
+  failed phase probes.
+
+## Acceptance
+
+- Every new benchmark and evaluation evidence artifact contains a probe
+  timeline.
+- Report generation can summarize slowest phases, failed phases, skipped phases,
+  and fallback phases.
+- Release evidence can point to the responsible component for a regression.

--- a/docs/plans/2026-05-08-evidence-plan-3-apple-silicon-power-telemetry.md
+++ b/docs/plans/2026-05-08-evidence-plan-3-apple-silicon-power-telemetry.md
@@ -1,0 +1,44 @@
+# Plan 3: Apple Silicon Hardware Power Telemetry
+
+## Goal
+
+Add Apple Silicon hardware telemetry for Melix performance diagnosis, including
+power, frequency, thermal, utilization, memory, and process attribution.
+
+## Scope
+
+- Build a macOS Apple Silicon telemetry collector.
+- Sample hardware and process metrics off the benchmark/evaluation hot path.
+- Persist run-level telemetry time series and summaries.
+- Attribute process cost to Melix control plane, workers, model runtimes, and
+  external providers.
+
+## Implementation Notes
+
+- Collect CPU utilization, P-core and E-core utilization, GPU utilization, GPU
+  frequency, GPU power, CPU power, ANE power, DRAM power, system power, memory
+  used and total, thermal state, process CPU, and process memory.
+- Use IOReport and IORegistry where required for Apple Silicon power and GPU
+  state sampling.
+- Use port, pid, process tree, and bundle prefix data for process attribution.
+- Run sampling on a background path and expose cached samples to benchmark and
+  evaluation execution.
+- Record telemetry failures explicitly with probes and report fields. Do not
+  synthesize zero values for missing samples.
+
+## Verification
+
+- Collector smoke test on Apple Silicon macOS producing telemetry summary and
+  JSONL time-series artifacts.
+- Failure fixture for unavailable IOReport or IORegistry channels.
+- Hot-path test proving telemetry sampling does not block stream consumption or
+  evaluation row execution.
+- Process-attribution test that separates control plane, worker, runtime, and
+  external provider processes.
+
+## Acceptance
+
+- Completed runs include Apple Silicon telemetry summary and time-series paths.
+- Reports include average/peak power, frequency, utilization, memory, thermal
+  events, process attribution, and watts per output token.
+- Telemetry failures are visible in evidence, reports, and gates.

--- a/docs/plans/2026-05-08-evidence-plan-4-reports-comparison-export.md
+++ b/docs/plans/2026-05-08-evidence-plan-4-reports-comparison-export.md
@@ -1,0 +1,40 @@
+# Plan 4: Reports, Comparison, And Export
+
+## Goal
+
+Generate report JSON, Markdown, CSV, and comparison output from structured run
+evidence.
+
+## Scope
+
+- Define report JSON as the report source of truth.
+- Derive Markdown and CSV exports from report JSON.
+- Support single-run, comparison, PR evidence, and release-gate report kinds.
+- Include probe and Apple Silicon telemetry summaries in every relevant report.
+
+## Implementation Notes
+
+- Include all report sections from
+  `docs/evidence-telemetry-report-contract.md`.
+- Support baseline comparison across commit, model, adapter, runtime, and
+  dataset dimensions.
+- Mark each comparison result as `pass`, `fail`, or `informational` according to
+  gate policy.
+- Include slowest probe phases, failed probe phases, fallback phases, telemetry
+  summaries, telemetry failures, and artifact links in Markdown output.
+- Split CSV exports into runs, metrics, probe phases, telemetry summary,
+  processes, gate results, and comparison deltas.
+
+## Verification
+
+- Golden tests for report JSON, Markdown, and CSV outputs.
+- Comparison fixture for baseline versus current evidence.
+- Verifier fixture rejecting reports missing required identity, target, metrics,
+  probe timeline, telemetry summary, or gate policy.
+- Fixture proving telemetry failures are not rendered as zero values.
+
+## Acceptance
+
+- Operators can inspect single-run and comparison reports without reading logs.
+- PR and release workflows can verify report JSON.
+- Markdown and CSV remain derived views of report JSON.

--- a/docs/plans/2026-05-08-evidence-plan-5-pr-release-evidence-gate.md
+++ b/docs/plans/2026-05-08-evidence-plan-5-pr-release-evidence-gate.md
@@ -1,0 +1,42 @@
+# Plan 5: PR And Release Evidence Gate
+
+## Goal
+
+Make PR and release evidence consume structured reports and fail clearly when
+required evidence, probes, telemetry, or gate metrics are missing.
+
+## Scope
+
+- Add report JSON verification to PR evidence workflows.
+- Define the minimum release evidence matrix.
+- Classify gate, informational, and known-gap metrics.
+- Keep all evidence local, repository-owned, or CI-artifact backed.
+
+## Implementation Notes
+
+- Release evidence should include serving benchmark, dialogue/event evaluation,
+  adapter checks, and runtime checks.
+- PR evidence should link the generated Markdown report and the machine-readable
+  report JSON path.
+- Gate failures should report blocking metrics and the slowest relevant probe
+  phases.
+- Telemetry failures should be explicit and may fail release gates when the
+  selected gate requires hardware evidence.
+- Do not add public leaderboard submission, identity sharing, or community
+  upload endpoints.
+
+## Verification
+
+- Verifier tests for complete and incomplete reports.
+- Release-gate fixture that emits pass, fail, informational, and known-gap
+  results.
+- PR-body evidence validation using the repository PR template headings.
+- Smoke command that generates a PR-ready evidence bundle.
+
+## Acceptance
+
+- PR evidence cannot pass with missing run identity, target identity, probe
+  timeline, telemetry summary, or required gate policy.
+- Release evidence explains both result regressions and likely responsible
+  runtime phases.
+- No public submission path is introduced.

--- a/docs/plans/2026-05-08-evidence-plan-6-desktop-operator-surfaces.md
+++ b/docs/plans/2026-05-08-evidence-plan-6-desktop-operator-surfaces.md
@@ -1,0 +1,38 @@
+# Plan 6: Desktop Operator Evidence Surfaces
+
+## Goal
+
+Expose run evidence, reports, probe timelines, Apple Silicon telemetry, and
+runtime diagnostics in the macOS operator app.
+
+## Scope
+
+- Add read-only Run History, Report, Runtime Diagnostics, and Hardware Monitor
+  surfaces.
+- Keep structured evidence and report artifacts as the only data source.
+- Support operator inspection and export without log parsing.
+
+## Implementation Notes
+
+- Run History shows run status, target, runtime, adapter, key metrics, and
+  artifact links.
+- Report surfaces read report JSON and expose filtering, sorting, Markdown
+  opening, and CSV export.
+- Runtime Diagnostics shows probe timeline summaries, phase duration, component
+  attribution, error stage, skipped phases, and fallback phases.
+- Hardware Monitor shows CPU, GPU, memory, power, frequency, thermal, and
+  process attribution, with current-run association where available.
+- UI state must not create or mutate evidence truth.
+
+## Verification
+
+- Swift view-model tests for evidence, report, probe, telemetry, and process
+  decoding.
+- UI acceptance for completed, failed, fallback, and telemetry-failure runs.
+- Export/open smoke tests for Markdown and CSV derived artifacts.
+
+## Acceptance
+
+- Operators can diagnose a run from the app without opening raw logs.
+- UI displays probe and telemetry gaps or failures explicitly.
+- All views are derived from structured artifacts.

--- a/docs/plans/2026-05-08-evidence-telemetry-roadmap.md
+++ b/docs/plans/2026-05-08-evidence-telemetry-roadmap.md
@@ -1,0 +1,54 @@
+# Evidence, Telemetry, And Report Roadmap
+
+## Goal
+
+Turn Melix benchmark and evaluation output into a structured product evidence
+system with first-class probes, Apple Silicon power telemetry, comparison
+reports, release gates, and desktop operator surfaces.
+
+The canonical contract is `docs/evidence-telemetry-report-contract.md`.
+
+## Design Rules
+
+- Use the current evidence and report schema only.
+- Treat breaking schema changes as acceptable during this roadmap.
+- Target macOS on Apple Silicon.
+- Use one Apple Silicon/macOS telemetry implementation path with no alternate
+  collectors.
+- Do not build a public leaderboard or community submission API.
+- Use structured evidence JSON as the source of truth.
+- Derive Markdown, CSV, UI views, and PR summaries from structured artifacts.
+
+## Execution Plans
+
+1. `docs/plans/2026-05-08-evidence-plan-1-run-evidence-schema.md`
+   - Define the unified run evidence envelope.
+2. `docs/plans/2026-05-08-evidence-plan-2-runtime-attribution-probes.md`
+   - Add runtime attribution and full stage probes.
+3. `docs/plans/2026-05-08-evidence-plan-3-apple-silicon-power-telemetry.md`
+   - Add Apple Silicon hardware telemetry and process attribution.
+4. `docs/plans/2026-05-08-evidence-plan-4-reports-comparison-export.md`
+   - Generate report JSON, Markdown, CSV, and comparison outputs.
+5. `docs/plans/2026-05-08-evidence-plan-5-pr-release-evidence-gate.md`
+   - Wire structured reports into PR and release evidence gates.
+6. `docs/plans/2026-05-08-evidence-plan-6-desktop-operator-surfaces.md`
+   - Expose evidence, reports, probes, and telemetry in the macOS operator app.
+
+## Dependencies
+
+The evidence schema must land before probes, telemetry, reports, gates, or UI.
+Runtime probes should land before report comparison so reports can explain why a
+run changed. Telemetry should land before release gates so power regressions can
+be classified with the same evidence model as latency and quality regressions.
+
+## Acceptance
+
+- The roadmap points to a canonical contract.
+- Every child plan includes probe and telemetry handling where relevant.
+- The roadmap excludes public leaderboard work.
+- The roadmap keeps hardware telemetry scoped to macOS on Apple Silicon.
+
+## Verification
+
+- Documentation review.
+- Link check for all child plan paths.


### PR DESCRIPTION
## Summary
- Add a canonical Evidence, Telemetry, and Report contract for structured run evidence, probe timelines, Apple Silicon telemetry, report JSON, derived exports, and PR/release gates.
- Add a roadmap plus six execution plans covering schema, probes, Apple Silicon power telemetry, reports, gates, and macOS operator surfaces.
- Update the docs index and benchmark/evaluation contract so new evidence/report artifacts use the new best-path contract.

## Plan or Spec
- `docs/evidence-telemetry-report-contract.md`
- `docs/plans/2026-05-08-evidence-telemetry-roadmap.md`

## Commands Run
```text
ls docs/evidence-telemetry-report-contract.md docs/plans/2026-05-08-evidence-telemetry-roadmap.md docs/plans/2026-05-08-evidence-plan-1-run-evidence-schema.md docs/plans/2026-05-08-evidence-plan-2-runtime-attribution-probes.md docs/plans/2026-05-08-evidence-plan-3-apple-silicon-power-telemetry.md docs/plans/2026-05-08-evidence-plan-4-reports-comparison-export.md docs/plans/2026-05-08-evidence-plan-5-pr-release-evidence-gate.md docs/plans/2026-05-08-evidence-plan-6-desktop-operator-surfaces.md
# passed: all new linked docs exist

rg -n "Linux|Windows|Intel|unsupported|alternate hardware telemetry|fallback collector|legacy compatibility|target platform|other platform|cross-platform" docs/evidence-telemetry-report-contract.md docs/plans/2026-05-08-evidence-*.md
# passed: no matches in the new evidence contract or roadmap/plan docs

rg -n "public leaderboard|community submission|community-submission" docs/evidence-telemetry-report-contract.md docs/plans/2026-05-08-evidence-*.md docs/benchmark-evaluation-contract.md
# passed: matches are explicit exclusions only

git diff --cached --check
# passed before commit: no whitespace errors

python3 scripts/validate_pr_evidence.py --body-file .runtime/anubis-evidence-pr-body.md
# passed
```

## Coverage and Metrics
- N/A: documentation-only roadmap and contract update; no executable code changed and no runtime performance path was modified.

## Known Gaps
- Runtime implementation is intentionally deferred to the six execution plans introduced here; this PR establishes the contract and sequencing only.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run. N/A for executable tests; documentation checks and PR evidence validation were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
