### PR TITLE
perf: aggregate JSON final-result scores in one pass

### DIFF
--- a/docs/plans/2026-05-08-json-typed-score-running-aggregate.md
+++ b/docs/plans/2026-05-08-json-typed-score-running-aggregate.md
@@ -1,0 +1,45 @@
+# JSON Typed Score Running Aggregate Optimization
+
+## Goal
+
+Reduce transient list allocation in final-result JSON typed scoring by replacing recursive per-node `scores = [...]` materialization with running `total`/`count` aggregation.
+
+## Scope
+
+Touched files:
+
+- `services/mlx-worker-python/worker/productization/evaluation_final_result.py`
+- `services/mlx-worker-python/tests/test_evaluation_final_result.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/evaluation_json_typed_score_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux-only constraint
+
+This is a Python worker/productization slice and is fully verifiable on Linux with focused pytest, changed-scope coverage, and a local base-vs-head performance probe.
+
+## Performance probe
+
+Register a dedicated PR-scoped performance probe:
+
+- Probe ID: `evaluation-final-result-json-typed-score-aggregate`
+- Workload: repeatedly score a wide JSON payload through `score_final_result(...)` with ignored paths preserved.
+- Metrics:
+  - `elapsed_ms_mean` (lower is better)
+  - `peak_bytes_mean` (lower is better)
+  - `score_checksum` (structural equivalence)
+  - `key_count` and `iteration_count` (workload shape)
+
+## Success metrics
+
+- Preserve JSON scoring semantics and ignored-path behavior.
+- Focused pytest passes.
+- Changed-scope coverage is at least 95%.
+- Local probe shows lower peak allocation and/or lower elapsed time vs `origin/main` for the same workload.
+
+## Verification commands
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json ... && python3 scripts/changed_scope_coverage.py ...`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/evaluation_json_typed_score_probe.py`
+- `python scripts/pr_scoped_performance_run.py --probe-id evaluation-final-result-json-typed-score-aggregate --output /tmp/evaluation-json-typed-score-probe.json`

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -933,6 +933,56 @@
     ]
   },
   {
+    "id": "evaluation-final-result-json-typed-score-aggregate",
+    "name": "Evaluation final-result JSON typed-score running aggregate",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/evaluation_final_result.py",
+      "services/mlx-worker-python/tests/test_evaluation_final_result.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/evaluation_json_typed_score_probe.py",
+      "infra/perf/pr_scoped_probes.json",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_json_typed_score_probe.py",
+    "probe_command": "if [ -f scripts/evaluation_json_typed_score_probe.py ]; then\n  PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python scripts/evaluation_json_typed_score_probe.py\nelse\n  PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python - <<'PYFALLBACK'\nimport json, statistics, time, tracemalloc\nfrom worker.productization.evaluation_final_result import EvaluationProfileDefinition, score_final_result\nKEYS=2000; ITERATIONS=40; SAMPLES=5\ndef payload():\n    expected={}; actual={}; ignored=[]\n    for index in range(KEYS):\n        key=f\"field_{index}\"\n        expected[key]={\"label\":f\"value-{index}\",\"scores\":[index,index+1,index+2],\"metadata\":{\"confidence\":index/max(KEYS,1),\"evidence\":[f\"source-{index}\",f\"source-{index+1}\"]}}\n        actual[key]={\"label\":expected[key][\"label\"] if index % 4 else \"mismatch\",\"scores\":expected[key][\"scores\"],\"metadata\":{\"confidence\":0.0,\"evidence\":[\"different-source\"]}}\n        ignored.append(f\"{key}.metadata\")\n    return json.dumps(expected), json.dumps(actual), tuple(ignored)\ndef run_once():\n    target, extracted, ignored_paths = payload()\n    profile=EvaluationProfileDefinition(profile_type=\"final_result\",result_kind=\"json\",extraction_mode=\"strict_full_response\",scoring_mode=\"json_field_match\",threshold=1.0,ignored_paths=ignored_paths)\n    checksum=0.0; tracemalloc.start(); started=time.perf_counter()\n    for _ in range(ITERATIONS):\n        outcome=score_final_result(extracted_result=extracted,target=target,profile=profile)\n        if outcome.validation_status != \"validated\": raise AssertionError(outcome)\n        checksum += outcome.typed_score\n    elapsed=(time.perf_counter()-started)*1000.0; _, peak=tracemalloc.get_traced_memory(); tracemalloc.stop(); return elapsed,float(peak),checksum\nsamples=[run_once() for _ in range(SAMPLES)]\nprint(json.dumps({\"elapsed_ms_mean\":statistics.fmean(s[0] for s in samples),\"peak_bytes_mean\":statistics.fmean(s[1] for s in samples),\"score_checksum\":samples[-1][2],\"key_count\":float(KEYS),\"iteration_count\":float(ITERATIONS)}, sort_keys=True))\nPYFALLBACK\nfi",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "score_checksum",
+        "unit": "score",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "key_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "iteration_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "training-config-target-module-cache",
     "name": "Training config target-module cache",
     "runner": "ubuntu-latest",

--- a/scripts/evaluation_json_typed_score_probe.py
+++ b/scripts/evaluation_json_typed_score_probe.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+import tracemalloc
+from typing import Any
+
+from worker.productization.evaluation_final_result import (
+    EvaluationProfileDefinition,
+    score_final_result,
+)
+
+
+def _payload(key_count: int) -> tuple[str, str, tuple[str, ...]]:
+    expected: dict[str, Any] = {}
+    actual: dict[str, Any] = {}
+    ignored_paths: list[str] = []
+    for index in range(key_count):
+        key = f"field_{index}"
+        expected[key] = {
+            "label": f"value-{index}",
+            "scores": [index, index + 1, index + 2],
+            "metadata": {
+                "confidence": index / max(key_count, 1),
+                "evidence": [f"source-{index}", f"source-{index + 1}"],
+            },
+        }
+        actual[key] = {
+            "label": expected[key]["label"] if index % 4 else "mismatch",
+            "scores": expected[key]["scores"],
+            "metadata": {
+                "confidence": 0.0,
+                "evidence": ["different-source"],
+            },
+        }
+        ignored_paths.append(f"{key}.metadata")
+    return json.dumps(expected), json.dumps(actual), tuple(ignored_paths)
+
+
+def _run_once(*, key_count: int, iterations: int) -> tuple[float, float, float]:
+    target, extracted, ignored_paths = _payload(key_count)
+    profile = EvaluationProfileDefinition(
+        profile_type="final_result",
+        result_kind="json",
+        extraction_mode="strict_full_response",
+        scoring_mode="json_field_match",
+        threshold=1.0,
+        ignored_paths=ignored_paths,
+    )
+    checksum = 0.0
+    tracemalloc.start()
+    started = time.perf_counter()
+    for _ in range(iterations):
+        outcome = score_final_result(
+            extracted_result=extracted,
+            target=target,
+            profile=profile,
+        )
+        if outcome.validation_status != "validated":
+            raise AssertionError(outcome)
+        checksum += outcome.typed_score
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    _, peak_bytes = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return elapsed_ms, float(peak_bytes), checksum
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--keys", type=int, default=2000)
+    parser.add_argument("--iterations", type=int, default=40)
+    parser.add_argument("--samples", type=int, default=5)
+    args = parser.parse_args()
+
+    samples = [
+        _run_once(key_count=args.keys, iterations=args.iterations)
+        for _ in range(args.samples)
+    ]
+    checksum = samples[-1][2]
+    expected_checksum = args.iterations * 0.875
+    if abs(checksum - expected_checksum) > 1e-9:
+        raise AssertionError((checksum, expected_checksum))
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(sample[0] for sample in samples),
+                "peak_bytes_mean": statistics.fmean(sample[1] for sample in samples),
+                "score_checksum": checksum,
+                "key_count": float(args.keys),
+                "iteration_count": float(args.iterations),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -266,6 +266,59 @@ def test_score_final_result_rejects_invalid_json_shape_before_scoring() -> None:
     assert score.typed_score == 0.0
 
 
+def test_score_final_result_aggregates_wide_json_without_losing_ignored_paths() -> None:
+    expected = {
+        f"field_{index}": {
+            "label": f"value-{index}",
+            "metadata": {"confidence": index / 1000, "evidence": [f"source-{index}"]},
+        }
+        for index in range(200)
+    }
+    actual = {
+        key: {
+            "label": value["label"] if index % 4 else "mismatch",
+            "metadata": {"confidence": 0.0, "evidence": ["different-source"]},
+        }
+        for index, (key, value) in enumerate(expected.items())
+    }
+
+    score = score_final_result(
+        extracted_result=json.dumps(actual),
+        target=json.dumps(expected),
+        profile=EvaluationProfileDefinition(
+            profile_type="final_result",
+            result_kind="json",
+            extraction_mode="strict_full_response",
+            scoring_mode="json_field_match",
+            threshold=1.0,
+            ignored_paths=tuple(f"field_{index}.metadata" for index in range(200)),
+        ),
+    )
+
+    assert score.validation_status == "validated"
+    assert score.failure_reason == ""
+    assert score.typed_score == pytest.approx(0.75)
+
+
+def test_score_final_result_treats_fully_ignored_json_object_as_match() -> None:
+    score = score_final_result(
+        extracted_result=json.dumps({"metadata": {"confidence": 0.0}}),
+        target=json.dumps({"metadata": {"confidence": 1.0}}),
+        profile=EvaluationProfileDefinition(
+            profile_type="final_result",
+            result_kind="json",
+            extraction_mode="strict_full_response",
+            scoring_mode="json_field_match",
+            threshold=1.0,
+            ignored_paths=("metadata",),
+        ),
+    )
+
+    assert score.validation_status == "validated"
+    assert score.failure_reason == ""
+    assert score.typed_score == 1.0
+
+
 def test_materialize_local_evaluation_dataset_requires_explicit_mapping_for_jsonl(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -388,8 +388,39 @@ def test_scope_report_selects_evaluation_final_result_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/productization/evaluation_final_result.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "evaluation-final-result-materialization-streaming"
+    assert scope["selected_count"] == 2
+    assert {probe["id"] for probe in scope["selected_probes"]} == {
+        "evaluation-final-result-materialization-streaming",
+        "evaluation-final-result-json-typed-score-aggregate",
+    }
+
+
+def test_evaluation_json_typed_score_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "evaluation_json_typed_score_probe.py",
+            "--keys",
+            "40",
+            "--iterations",
+            "3",
+            "--samples",
+            "2",
+        ],
+    )
+
+    runpy.run_path(str(REPO_ROOT / "scripts/evaluation_json_typed_score_probe.py"), run_name="__main__")
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["score_checksum"] == pytest.approx(2.625)
+    assert metrics["key_count"] == 40.0
+    assert metrics["iteration_count"] == 3.0
 
 
 def test_dispatch_probe_impl_supports_evaluation_final_result_probe() -> None:
@@ -1637,6 +1668,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "evaluation-job-id-high-water-mark",
         "evaluation-dialogue-diagnostics-top-k",
         "evaluation-final-result-materialization-streaming",
+        "evaluation-final-result-json-typed-score-aggregate",
         "evaluation-latency-percentile-vector-reuse",
         "evaluation-sample-probe-aggregation",
         "evaluation-store-compare-summary-csv-streaming",

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -375,29 +375,37 @@ def _validate_json_schema(schema: dict[str, Any], payload: Any) -> str:
 
 def _json_typed_score(*, expected: Any, actual: Any, ignored_paths: set[str], path: str = "") -> float:
     if isinstance(expected, dict):
-        expected_keys = [key for key in expected if _joined_path(path, key) not in ignored_paths]
-        if not expected_keys:
-            return 1.0
-        scores = [
-            _json_typed_score(
-                expected=expected[key],
-                actual=actual.get(key) if isinstance(actual, dict) else None,
+        total = 0.0
+        count = 0
+        actual_dict = actual if isinstance(actual, dict) else None
+        for key, expected_value in expected.items():
+            child_path = _joined_path(path, key)
+            if child_path in ignored_paths:
+                continue
+            total += _json_typed_score(
+                expected=expected_value,
+                actual=actual_dict.get(key) if actual_dict is not None else None,
                 ignored_paths=ignored_paths,
-                path=_joined_path(path, key),
+                path=child_path,
             )
-            for key in expected_keys
-        ]
-        return sum(scores) / len(scores)
+            count += 1
+        if count == 0:
+            return 1.0
+        return total / count
     if isinstance(expected, list):
         if not isinstance(actual, list) or len(expected) != len(actual):
             return 0.0
         if not expected:
             return 1.0
-        scores = [
-            _json_typed_score(expected=item, actual=actual[index], ignored_paths=ignored_paths, path=f"{path}[{index}]")
-            for index, item in enumerate(expected)
-        ]
-        return sum(scores) / len(scores)
+        total = 0.0
+        for index, item in enumerate(expected):
+            total += _json_typed_score(
+                expected=item,
+                actual=actual[index],
+                ignored_paths=ignored_paths,
+                path=f"{path}[{index}]",
+            )
+        return total / len(expected)
     return 1.0 if expected == actual else 0.0
 
 


### PR DESCRIPTION
## Summary
- Replaces JSON final-result typed-score list materialization with running aggregation for dict/list nodes.
- Adds focused regression coverage for wide JSON scoring, fully ignored JSON objects, and the new probe script.
- Registers `evaluation-final-result-json-typed-score-aggregate` in PR-scoped performance CI with a base-compatible fallback command.

## Plan or Spec
- `docs/plans/2026-05-08-json-typed-score-running-aggregate.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 31 passed in 0.19s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_json_typed_score_probe.py
# TOTAL 39 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/evaluation_json_typed_score_probe.py
# {"elapsed_ms_mean": 3496.1209036177024, "iteration_count": 40.0, "key_count": 2000.0, "peak_bytes_mean": 3575116.2, "score_checksum": 35.0}

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-final-result-json-typed-score-aggregate --base-repo /tmp/melix-base-json-score-20260508113226-b --head-repo /tmp/melix-cron-opt-20260508113226 --output /tmp/evaluation-json-typed-score-probe.json
# head verification ok; base/head probes ok

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.valid.json
# ok

git diff --check
# ok
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 39 0 100%`.
- Registered scoped probe: `evaluation-final-result-json-typed-score-aggregate`.
- Local base-vs-head probe on 2,000-key JSON payload × 40 iterations × 5 samples:
  - `elapsed_ms_mean`: base `3715.0818 ms` → head `3428.6538 ms` (~7.71% lower).
  - `peak_bytes_mean`: base `3,577,666.6` → head `3,575,116.2` bytes (~0.07% lower).
  - `score_checksum`: base/head `35.0`.
  - `key_count`: `2000.0`; `iteration_count`: `40.0`.

## Known Gaps
- Linux-only local verification; full macOS/Swift gates are left to hosted CI.
- Updating `infra/perf/pr_scoped_probes.json` may fan out the full `pr-scoped-performance` matrix before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
