### PR TITLE
perf: skip hub size hints without model marker

### DIFF
--- a/docs/plans/2026-05-08-hub-catalog-size-hint-marker-guard.md
+++ b/docs/plans/2026-05-08-hub-catalog-size-hint-marker-guard.md
@@ -1,0 +1,65 @@
+# Hub Catalog Size Hint Marker Guard
+
+## Goal
+
+Reduce avoidable regex work in `worker.model_ops.hub_catalog._size_hint_from_text`
+for explicit size-hint scans that cannot match because the text does not contain a
+`model` marker.
+
+## Scope
+
+This is a Python-only performance slice. It keeps the existing direct
+`cardData.model_size` bare-size behavior unchanged, and it does not change Hub
+API fetching, local-fit scoring, sibling size accounting, or quantization tag
+normalization.
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped performance probe:
+
+- `hub-catalog-size-hint-regex-precompile`
+  - `test_command`: focused `test_hub_catalog.py` coverage plus probe registry tests
+  - `coverage_command`: focused coverage plus changed-scope coverage for the touched paths
+  - `probe_command`: `scripts/hub_catalog_size_hint_probe.py`
+
+## Change
+
+For single-source `description`, `readme`, and card description fields,
+`_size_hint_bytes` now skips `_size_hint_from_text` when the candidate text cannot
+contain a case-insensitive `model` marker because it lacks an `mo`/`MO` prefix.
+The explicit regex still owns final matching, including unusual mixed-case
+`model size` spellings, so the guard preserves behavior while reducing helper and
+regex calls for common description strings that mention a byte unit without being
+a model-size hint.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_hub_catalog.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_hub_catalog.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/model_ops/hub_catalog.py \
+  services/mlx-worker-python/tests/test_hub_catalog.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/hub_catalog_size_hint_probe.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" \
+  uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
+```
+
+## Success Criteria
+
+- Focused tests pass.
+- Changed-scope coverage is at least 95 percent.
+- The registered local probe reports lower `elapsed_ms_mean` while preserving
+  `size_hint_calls_mean` and output checksum.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -533,6 +533,17 @@ def test_size_hint_from_empty_text_skips_regex_search(monkeypatch: pytest.Monkey
     assert _size_hint_from_text("", allow_bare=False) == 0
 
 
+def test_size_hint_bytes_skips_explicit_parser_when_model_marker_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parser = Mock(return_value=0)
+    monkeypatch.setattr(hub_catalog_module, "_size_hint_from_text", parser)
+
+    assert hub_catalog_module._size_hint_bytes({"description": "description only 512 MB"}) == 0
+    assert hub_catalog_module._size_hint_bytes({"readme": "tokenizer size 12 MB"}) == 0
+    parser.assert_not_called()
+
+
 def test_size_hint_bytes_skips_direct_hint_parser_when_card_model_size_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -844,6 +855,7 @@ def test_size_hint_parser_uses_precompiled_patterns(monkeypatch: pytest.MonkeyPa
     assert hub_catalog_module._size_hint_from_text("Model size: 768 MB", allow_bare=False) == 768 * MB
     assert hub_catalog_module._size_hint_from_text("Readme says 768 MB", allow_bare=False) == 0
     assert hub_catalog_module._size_hint_from_text("MODEL SIZE | 512 kb", allow_bare=False) == 512 * KB
+    assert hub_catalog_module._size_hint_from_text("mOdEl SiZe: 256 MB", allow_bare=False) == 256 * MB
 
 
 def test_size_hint_parser_preserves_all_unit_multipliers() -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1167,7 +1167,7 @@ def test_hub_catalog_size_hint_probe_script_emits_metrics(
     assert exc_info.value.code == 0
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["sample_count"] == 1.0
-    assert metrics["size_hint_calls_mean"] == 6.0
+    assert metrics["size_hint_calls_mean"] == 4.0
     assert metrics["matched_hint_count"] == 4.0
     assert metrics["elapsed_ms_mean"] >= 0
     assert metrics["peak_bytes_mean"] > 0

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -582,19 +582,19 @@ def _size_hint_bytes(payload: dict[str, Any]) -> int:
     if not readme_text and not card_description_text:
         return (
             _size_hint_from_text(description_text, allow_bare=False)
-            if description_text
+            if description_text and _may_contain_model_marker(description_text)
             else 0
         )
     if not description_text and not card_description_text:
         return (
             _size_hint_from_text(readme_text, allow_bare=False)
-            if readme_text
+            if readme_text and _may_contain_model_marker(readme_text)
             else 0
         )
     if not description_text and not readme_text:
         return (
             _size_hint_from_text(card_description_text, allow_bare=False)
-            if card_description_text
+            if card_description_text and _may_contain_model_marker(card_description_text)
             else 0
         )
 
@@ -622,6 +622,10 @@ def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:
     else:
         multiplier = 1024 ** 3
     return int(value * multiplier)
+
+
+def _may_contain_model_marker(text: str) -> bool:
+    return "mo" in text or "mO" in text or "Mo" in text or "MO" in text
 
 
 def _parameter_count(value: Any) -> int:


### PR DESCRIPTION
## Summary
- Skip explicit Hub size-hint parsing for single-source description/readme/card-description text that cannot contain a `model` marker.
- Keep bare `cardData.model_size` parsing and mixed-case explicit `model size` parsing unchanged.
- Update the registered hub catalog probe expectation for the reduced helper-call count.

## Plan or Spec
- `docs/plans/2026-05-08-hub-catalog-size-hint-marker-guard.md`

## Commands Run
```text
# Baseline probe on origin/main (detached worktree f366e373)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=7 uv run --frozen --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
-> exit 0; {"elapsed_ms_mean": 1790.0455925846472, "size_hint_calls_mean": 150000.0, "checksum": 0.0, "matched_hint_count": 100000.0, "peak_bytes_mean": 1833.0, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
-> exit 0; 44 passed in 0.71s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
-> exit 0; TOTAL 10 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=7 uv run --frozen --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
-> exit 0; {"elapsed_ms_mean": 1674.2840475635603, "size_hint_calls_mean": 100000.0, "checksum": 0.0, "matched_hint_count": 100000.0, "peak_bytes_mean": 1833.0, "sample_count": 7.0}

git diff --check
-> exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Registered local probe: `hub-catalog-size-hint-regex-precompile`.
- Baseline vs head (`MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=7`):
  - `elapsed_ms_mean`: 1790.0456 ms -> 1674.2840 ms (delta -115.7615 ms, speedup 1.069x).
  - `size_hint_calls_mean`: 150000.0 -> 100000.0 (delta -50000.0 calls, 33.33% fewer calls).
  - `checksum`: 0.0 -> 0.0; `matched_hint_count`: 100000.0 -> 100000.0.
- CI PR-scoped performance must run the registered probe again before merge.

## Known Gaps
- None for this Python slice. Swift/macOS runtime effects are not touched.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
