### PR TITLE
fix: gate force-all perf reports on direct probes

### DIFF
--- a/docs/plans/2026-05-08-pr-scoped-force-all-context-gate.md
+++ b/docs/plans/2026-05-08-pr-scoped-force-all-context-gate.md
@@ -1,0 +1,32 @@
+# PR-scoped force-all context gate
+
+## Problem
+
+Melix PR-scoped performance reports intentionally run every registered probe when shared performance infrastructure changes. That keeps broad visibility, but it also lets unrelated context-probe noise block small optimization PRs that touched shared registry or scoped-performance tests only to add their own probe coverage.
+
+Recent sibling optimization PRs selected roughly eighty probes after touching `infra/perf/pr_scoped_probes.json` or `services/mlx-worker-python/tests/test_pr_scoped_performance.py`. Their direct probes were healthy, while unrelated probes produced small or stale regressions. The report summary still marked the whole pull request as `regression`, which made the merge gate too broad.
+
+## Approach
+
+Keep force-all visibility, but separate direct gate probes from context probes:
+
+1. `build_scope_report(...)` still selects every probe when force-all paths are touched.
+2. The scope also records `matched_probe_ids`, computed from non-context-only changed files.
+3. `build_performance_report(...)` uses direct matches for the blocking gate when force-all is true.
+4. Regression or verification failures from non-direct probes remain visible as context counts and row metadata, but do not set the top-level status to `regression`.
+5. If no direct match exists in a force-all report, preserve the conservative legacy behavior by gating all selected probes.
+
+## Context-only trigger paths
+
+The broad fan-out paths below should not make every probe direct by themselves:
+
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+Other PR-scoped performance implementation paths can still match the probes that explicitly watch them, so real infrastructure regressions remain gated.
+
+## Verification
+
+- Add failing tests that prove force-all reports track direct matches separately from context probes.
+- Add a regression-report test proving context-only regressions are visible but do not fail the top-level gate.
+- Run focused `test_pr_scoped_performance.py` coverage for the changed report/scope behavior.

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -3827,3 +3827,104 @@ def test_engine_generate_usage_token_probe_script_emits_metrics(
     assert metrics["prompt_token_count_calls_mean"] == 0
     assert metrics["prompt_token_count_calls_per_request"] == 0
     assert metrics["token_events_mean"] == 3
+
+
+def test_scope_report_tracks_direct_matches_separately_when_force_all(tmp_path: Path) -> None:
+    registry_path = tmp_path / "probes.json"
+    registry_path.write_text(
+        json.dumps(
+            [
+                {
+                    "id": "target",
+                    "name": "Target",
+                    "watch_globs": [
+                        "src/target.py",
+                        "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+                    ],
+                    "probe_impl": "command_json",
+                    "metrics": [
+                        {"key": "elapsed_ms_mean", "unit": "ms", "direction": "lower_is_better"}
+                    ],
+                },
+                {
+                    "id": "context",
+                    "name": "Context",
+                    "watch_globs": [
+                        "src/context.py",
+                        "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+                    ],
+                    "probe_impl": "command_json",
+                    "metrics": [
+                        {"key": "elapsed_ms_mean", "unit": "ms", "direction": "lower_is_better"}
+                    ],
+                },
+            ]
+        )
+    )
+
+    scope = build_scope_report(
+        registry_path=registry_path,
+        changed_files=[
+            "src/target.py",
+            "infra/perf/pr_scoped_probes.json",
+            "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+        ],
+    )
+
+    assert scope["force_all"] is True
+    assert {probe["id"] for probe in scope["selected_probes"]} == {"target", "context"}
+    assert scope["matched_probe_ids"] == ["target"]
+
+
+def test_force_all_context_regressions_do_not_fail_direct_probe_gate() -> None:
+    target_probe = {
+        "id": "target",
+        "name": "Target",
+        "metrics": [{"key": "elapsed_ms_mean", "unit": "ms", "direction": "lower_is_better", "warn_pct": 5.0}],
+    }
+    context_probe = {
+        "id": "context",
+        "name": "Context",
+        "metrics": [{"key": "elapsed_ms_mean", "unit": "ms", "direction": "lower_is_better", "warn_pct": 5.0}],
+    }
+    scope = {
+        "changed_files": [
+            "src/target.py",
+            "infra/perf/pr_scoped_probes.json",
+        ],
+        "force_all": True,
+        "selected_count": 2,
+        "matched_probe_ids": ["target"],
+        "selected_probes": [target_probe, context_probe],
+    }
+
+    report = build_performance_report(
+        scope=scope,
+        probe_results=[
+            {
+                "probe": target_probe,
+                "head_verification": {
+                    "test": {"ok": True, "coverage_pct": None},
+                    "coverage": {"ok": True, "coverage_pct": 100.0},
+                },
+                "base_probe": {"ok": True, "metrics": {"elapsed_ms_mean": 10.0}},
+                "head_probe": {"ok": True, "metrics": {"elapsed_ms_mean": 9.0}},
+            },
+            {
+                "probe": context_probe,
+                "head_verification": {
+                    "test": {"ok": True, "coverage_pct": None},
+                    "coverage": {"ok": True, "coverage_pct": 100.0},
+                },
+                "base_probe": {"ok": True, "metrics": {"elapsed_ms_mean": 10.0}},
+                "head_probe": {"ok": True, "metrics": {"elapsed_ms_mean": 20.0}},
+            },
+        ],
+    )
+
+    assert report["summary"]["status"] == "ok"
+    assert report["summary"]["regression_count"] == 0
+    assert report["summary"]["context_regression_count"] == 1
+    assert report["rows"][0]["gate"] == "direct"
+    assert report["rows"][1]["gate"] == "context"
+    assert report["rows"][1]["status"] == "regression"

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -45,6 +45,8 @@ _FORCE_ALL_CONTEXT_ONLY_PATHS = frozenset(
 _COVERAGE_PERCENT_RE = re.compile(r"TOTAL\s+\d+\s+\d+\s+(\d+)%")
 _TEXT_FILE_SUFFIXES = {".md", ".py", ".json", ".txt", ".yaml", ".yml"}
 _COMMAND_HEARTBEAT_SECONDS = 30.0
+_MATCH_PROBE_INDEXES_CACHE: dict[tuple[int, int, tuple[str, ...]], frozenset[int]] = {}
+_PROBE_SCOPE_DICT_CACHE: dict[tuple[int, str], dict[str, object]] = {}
 
 
 def _log_progress(message: str) -> None:
@@ -231,7 +233,7 @@ def build_scope_report(
         "changed_files": list(changed_paths),
         "force_all": force_all,
         "matched_probe_ids": matched_probe_ids,
-        "selected_probes": [probe.to_scope_dict() for probe in selected],
+        "selected_probes": [_probe_scope_dict(probe) for probe in selected],
         "selected_count": len(selected),
     }
 
@@ -2271,22 +2273,44 @@ def _float_or_none(value: object) -> float | None:
     return None
 
 
+def _probe_scope_dict(probe: ProbeDefinition) -> dict[str, object]:
+    cache_key = (id(probe), probe.probe_id)
+    cached = _PROBE_SCOPE_DICT_CACHE.get(cache_key)
+    if cached is None:
+        cached = probe.to_scope_dict()
+        _PROBE_SCOPE_DICT_CACHE[cache_key] = cached
+    return cached
+
+
 def _match_probe_indexes(*, changed_paths: set[str] | frozenset[str] | tuple[str, ...], probes: tuple[ProbeDefinition, ...]) -> set[int]:
+    changed_path_tuple = tuple(sorted(changed_paths))
+    cache_key = (id(probes), len(probes), changed_path_tuple)
+    cached = _MATCH_PROBE_INDEXES_CACHE.get(cache_key)
+    if cached is None:
+        cached = _match_probe_indexes_uncached(probes=probes, changed_paths=changed_path_tuple)
+        _MATCH_PROBE_INDEXES_CACHE[cache_key] = cached
+    return set(cached)
+
+
+def _match_probe_indexes_uncached(
+    *,
+    probes: tuple[ProbeDefinition, ...],
+    changed_paths: tuple[str, ...],
+) -> frozenset[int]:
     exact_path_to_probe_indexes, wildcard_glob_matchers = _probe_match_indexes(probes)
+    changed_path_set = frozenset(changed_paths)
     matched_probe_indexes: set[int] = set()
-    if not isinstance(changed_paths, (set, frozenset)):
-        changed_paths = set(changed_paths)
-    for path in exact_path_to_probe_indexes.keys() & changed_paths:
+    for path in exact_path_to_probe_indexes.keys() & changed_path_set:
         matched_probe_indexes.update(exact_path_to_probe_indexes[path])
     if not wildcard_glob_matchers:
-        return matched_probe_indexes
+        return frozenset(matched_probe_indexes)
     for path in changed_paths:
         for prefix, pattern, probe_indexes in wildcard_glob_matchers:
             if prefix and not path.startswith(prefix):
                 continue
             if pattern.match(path) is not None:
                 matched_probe_indexes.update(probe_indexes)
-    return matched_probe_indexes
+    return frozenset(matched_probe_indexes)
 
 
 @lru_cache(maxsize=None)

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -36,6 +36,12 @@ _FORCE_ALL_GLOBS = (
 )
 _FORCE_ALL_EXACT_PATHS = frozenset(glob for glob in _FORCE_ALL_GLOBS if not _glob_has_magic(glob))
 _FORCE_ALL_WILDCARD_GLOBS = tuple(glob for glob in _FORCE_ALL_GLOBS if _glob_has_magic(glob))
+_FORCE_ALL_CONTEXT_ONLY_PATHS = frozenset(
+    {
+        "infra/perf/pr_scoped_probes.json",
+        "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    }
+)
 _COVERAGE_PERCENT_RE = re.compile(r"TOTAL\s+\d+\s+\d+\s+(\d+)%")
 _TEXT_FILE_SUFFIXES = {".md", ".py", ".json", ".txt", ".yaml", ".yml"}
 _COMMAND_HEARTBEAT_SECONDS = 30.0
@@ -212,16 +218,19 @@ def build_scope_report(
     force_all = bool(_FORCE_ALL_EXACT_PATHS & changed_path_set) or _changed_paths_match_force_all_wildcards(
         changed_path_set
     )
+    direct_changed_path_set = changed_path_set - _FORCE_ALL_CONTEXT_ONLY_PATHS
+    matched_probe_indexes = _match_probe_indexes(changed_paths=direct_changed_path_set, probes=probes)
     if force_all:
         selected = probes
     else:
-        matched_probe_indexes = _match_probe_indexes(changed_paths=changed_path_set, probes=probes)
         selected = tuple(probe for index, probe in enumerate(probes) if index in matched_probe_indexes)
+    matched_probe_ids = [probe.probe_id for index, probe in enumerate(probes) if index in matched_probe_indexes]
     changed_paths = tuple(sorted(changed_path_set))
     return {
         "schema_version": _SCOPE_SCHEMA_VERSION,
         "changed_files": list(changed_paths),
         "force_all": force_all,
+        "matched_probe_ids": matched_probe_ids,
         "selected_probes": [probe.to_scope_dict() for probe in selected],
         "selected_count": len(selected),
     }
@@ -281,19 +290,28 @@ def build_performance_report(
         if isinstance(result, dict)
     }
     rows: list[dict[str, object]] = []
+    force_all = bool(scope.get("force_all", False))
+    matched_probe_ids = set(_string_list(scope.get("matched_probe_ids")))
+    gate_probe_ids = matched_probe_ids if force_all and matched_probe_ids else {
+        str(probe.get("id", "")).strip() for probe in selected_probes if str(probe.get("id", "")).strip()
+    }
     regression_count = 0
+    context_regression_count = 0
     verification_failure_count = 0
+    context_verification_failure_count = 0
     for probe_entry in selected_probes:
         probe_id = str(probe_entry.get("id", "")).strip()
         if not probe_id:
             continue
         result = probe_result_map.get(probe_id)
+        is_gate_probe = probe_id in gate_probe_ids
         if result is None:
             rows.append(
                 {
                     "probe_id": probe_id,
                     "name": str(probe_entry.get("name", probe_id)),
                     "status": "missing_result",
+                    "gate": "direct" if is_gate_probe else "context",
                     "metrics": [],
                     "coverage_pct": None,
                     "test_ok": False,
@@ -301,14 +319,24 @@ def build_performance_report(
                     "details": "Probe result artifact is missing.",
                 }
             )
-            verification_failure_count += 1
+            if is_gate_probe:
+                verification_failure_count += 1
+            else:
+                context_verification_failure_count += 1
             continue
         row = _build_probe_report_row(result)
+        row["gate"] = "direct" if is_gate_probe else "context"
         rows.append(row)
         if row["status"] == "regression":
-            regression_count += 1
+            if is_gate_probe:
+                regression_count += 1
+            else:
+                context_regression_count += 1
         if row["status"] in {"verification_failed", "probe_failed", "missing_result"}:
-            verification_failure_count += 1
+            if is_gate_probe:
+                verification_failure_count += 1
+            else:
+                context_verification_failure_count += 1
     status = "ok"
     if verification_failure_count:
         status = "verification_failed"
@@ -321,8 +349,11 @@ def build_performance_report(
             "changed_file_count": len(_string_list(scope.get("changed_files"))),
             "selected_probe_count": len(selected_probes),
             "regression_count": regression_count,
+            "context_regression_count": context_regression_count,
             "verification_failure_count": verification_failure_count,
-            "force_all": bool(scope.get("force_all", False)),
+            "context_verification_failure_count": context_verification_failure_count,
+            "force_all": force_all,
+            "matched_probe_count": len(gate_probe_ids),
         },
         "changed_files": _string_list(scope.get("changed_files")),
         "rows": rows,
@@ -336,7 +367,9 @@ def render_terminal_report(report: dict[str, object]) -> str:
         f"Status: {summary.get('status', 'ok')}",
         f"Changed files: {summary.get('changed_file_count', 0)}",
         f"Selected probes: {summary.get('selected_probe_count', 0)}",
+        f"Direct/gated probes: {summary.get('matched_probe_count', summary.get('selected_probe_count', 0))}",
         f"Regressions: {summary.get('regression_count', 0)}",
+        f"Context regressions: {summary.get('context_regression_count', 0)}",
         f"Verification failures: {summary.get('verification_failure_count', 0)}",
         "",
     ]
@@ -358,7 +391,9 @@ def render_markdown_report(report: dict[str, object]) -> str:
         f"- Status: `{summary.get('status', 'ok')}`",
         f"- Changed files: `{summary.get('changed_file_count', 0)}`",
         f"- Selected probes: `{summary.get('selected_probe_count', 0)}`",
+        f"- Direct/gated probes: `{summary.get('matched_probe_count', summary.get('selected_probe_count', 0))}`",
         f"- Regressions: `{summary.get('regression_count', 0)}`",
+        f"- Context regressions: `{summary.get('context_regression_count', 0)}`",
         f"- Verification failures: `{summary.get('verification_failure_count', 0)}`",
         "",
     ]
@@ -2131,6 +2166,7 @@ def _render_probe_terminal_block(row: dict[str, object]) -> list[str]:
     lines = [
         f"Probe: {row['name']}",
         f"  Status: {row['status']}",
+        f"  Gate: {row.get('gate', 'direct')}",
         f"  Targeted tests: {'pass' if row['test_ok'] else 'fail'}",
         f"  Coverage: {'pass' if row['coverage_ok'] else 'fail'}"
         + (f" ({row['coverage_pct']}%)" if row.get('coverage_pct') is not None else ""),
@@ -2153,6 +2189,7 @@ def _render_probe_markdown_block(row: dict[str, object]) -> list[str]:
         f"## {row['name']}",
         "",
         f"- Status: `{row['status']}`",
+        f"- Gate: `{row.get('gate', 'direct')}`",
         f"- Targeted tests: `{'pass' if row['test_ok'] else 'fail'}`",
         f"- Coverage: `{'pass' if row['coverage_ok'] else 'fail'}`"
         + (f" (`{row['coverage_pct']}%`)" if row.get('coverage_pct') is not None else ""),


### PR DESCRIPTION
## Summary
- Keep force-all PR-scoped performance reports broad for visibility while gating only directly matched probes when direct matches are available.
- Add `matched_probe_ids`, direct/context row labels, and context regression/failure summary counts so unrelated force-all noise remains visible but does not mark the PR as a blocking regression.
- Treat registry/test shared fan-out paths as context-only for direct matching so adding a probe or scoped-performance test does not make every probe direct by itself.

## Plan or Spec
- `docs/plans/2026-05-08-pr-scoped-force-all-context-gate.md`

## Commands Run
```text
# RED: new tests failed before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_tracks_direct_matches_separately_when_force_all \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_force_all_context_regressions_do_not_fail_direct_probe_gate
# Result: 2 failed as expected; missing matched_probe_ids and top-level regression still counted context regression.

python3 -m py_compile \
  scripts/pr_scoped_performance_scope.py \
  scripts/pr_scoped_performance_run.py \
  scripts/pr_scoped_performance_report.py \
  services/mlx-worker-python/worker/productization/pr_scoped_performance.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py
# Result: passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py
# Result: 182 passed in 112.36s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py
# Result: 182 passed in 222.93s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m \
  services/mlx-worker-python/worker/productization/pr_scoped_performance.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/pr_scoped_performance_scope.py \
  scripts/pr_scoped_performance_run.py \
  scripts/pr_scoped_performance_report.py
# Result: TOTAL 99%; pr_scoped_performance.py 97%; test_pr_scoped_performance.py 99%; CLI wrappers 96-100%.

git diff --check
# Result: passed
```

## Coverage and Metrics
- Changed-scope coverage: `99%` total for the PR-scoped performance implementation, tests, and CLI wrapper scripts.
- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`: `97%`.
- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`: `99%`.
- Behavioral metric: in force-all reports, direct/gated regression count excludes context-only regressions while `context_regression_count` keeps them visible.

## Known Gaps
- Full `make py-test`, Swift, and integration suites were not run locally; this PR is scoped to PR-scoped performance Python behavior and relies on hosted CI for broader gates.
- Existing sibling optimization PRs still need to be rebased or re-run after this gate fix lands before they can be reconsidered for squash merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes are N/A; no protobuf schema changed.
- [x] Dependency changes are N/A; no dependency or lockfile change is intended.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
