### PR TITLE
perf: reduce code eval fallback test count allocation

### DIFF
--- a/docs/plans/2026-05-08-code-eval-count-tests-line-scan.md
+++ b/docs/plans/2026-05-08-code-eval-count-tests-line-scan.md
@@ -1,0 +1,42 @@
+# Code-eval test count line scan
+
+## Goal
+
+Reduce allocation pressure in the code-evaluation fallback test counter by avoiding `str.splitlines()` list materialization when `_count_tests()` cannot derive an assert count from the AST.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `scripts/code_eval_count_tests_probe.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux-only constraint
+
+This is a Python worker slice and is locally verifiable on Linux with focused pytest, changed-scope coverage, and a command-json performance probe.
+
+## Performance probe definition
+
+Register `code-eval-count-tests-line-scan` in the PR-scoped performance registry. The probe exercises the syntax-error and no-assert fallback paths with large blank-heavy test strings and reports:
+
+- `elapsed_ms_mean` (lower is better)
+- `peak_bytes_mean` (lower is better)
+- structural row-count metrics to prove the same synthetic workload ran
+
+## Success metrics
+
+- Functional behavior matches the old nonblank-line counting semantics for LF, CRLF, CR, blank, and whitespace-only lines.
+- Changed-scope coverage is at least 95%.
+- Local base-vs-head probe shows lower peak allocation and no severe latency regression on the fallback line-count path.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <focused test nodes>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <focused test nodes>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python scripts/changed_scope_coverage.py --coverage-json coverage.json <changed files>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/code_eval_count_tests_probe.py
+python scripts/pr_scoped_performance_run.py --probe-id code-eval-count-tests-line-scan --base-ref origin/main --head-ref HEAD --output /tmp/code-eval-count-tests-probe.json
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2111,6 +2111,37 @@
     ]
   },
   {
+    "id": "code-eval-count-tests-line-scan",
+    "name": "Code evaluation fallback test count line scan",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/engine/code_eval_runner.py",
+      "services/mlx-worker-python/tests/test_code_eval_runner.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/code_eval_count_tests_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_fallback_avoids_splitlines_materialization services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_avoids_splitlines_materialization services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_count_tests_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_fallback_avoids_splitlines_materialization services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_avoids_splitlines_materialization services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_count_tests_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_count_tests_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/code_eval_count_tests_probe.py ]; then python3 scripts/code_eval_count_tests_probe.py; else python3 - <<\"PYPROBE\"\nimport json, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.engine import code_eval_runner\ndef syntax_tests(n):\n    return \"def broken(:\\n\" + \"\\n\".join((f\"assert value_{i} == {i}\" if i % 3 else \"   \") for i in range(n))\ndef no_assert_tests(n):\n    return \"def check(candidate):\\n\" + \"\\n\".join((f\"value_{i} = candidate({i})\" if i % 4 else \"\\t\") for i in range(n)) + \"\\ncheck(identity)\"\ndef expected(text):\n    return sum(1 for line in text.splitlines() if line.strip())\nline_count=8000; iterations=25; sample_count=7\nsyntax=syntax_tests(line_count); no_assert=no_assert_tests(line_count)\nexpected_syntax=expected(syntax); expected_no_assert=expected(no_assert)\nelapsed=[]; peaks=[]; syntax_count=0; no_assert_count=0\nfor _ in range(sample_count):\n    tracemalloc.start(); started=time.perf_counter()\n    for _i in range(iterations):\n        syntax_count=code_eval_runner._count_tests(syntax); no_assert_count=code_eval_runner._count_tests(no_assert)\n    elapsed.append((time.perf_counter()-started)*1000.0); _, peak=tracemalloc.get_traced_memory(); tracemalloc.stop(); peaks.append(float(peak))\n    if syntax_count != expected_syntax or no_assert_count != expected_no_assert:\n        raise SystemExit(\"unexpected fallback count\")\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed), \"peak_bytes_mean\": statistics.fmean(peaks), \"line_count\": float(line_count), \"iteration_count\": float(iterations), \"sample_count\": float(sample_count), \"syntax_count\": float(syntax_count), \"no_assert_count\": float(no_assert_count)}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "changed-scope-coverage-empty-path-short-circuit",
     "name": "Changed-scope coverage empty-path short circuit",
     "runner": "ubuntu-latest",

--- a/scripts/code_eval_count_tests_probe.py
+++ b/scripts/code_eval_count_tests_probe.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path.cwd()
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.engine import code_eval_runner  # noqa: E402
+
+
+def _build_syntax_error_tests(line_count: int) -> str:
+    body = "\n".join(
+        f"assert value_{index} == {index}" if index % 3 else "   "
+        for index in range(line_count)
+    )
+    return f"def broken(:\n{body}"
+
+
+def _build_no_assert_tests(line_count: int) -> str:
+    body = "\n".join(
+        f"value_{index} = candidate({index})" if index % 4 else "\t"
+        for index in range(line_count)
+    )
+    return "def check(candidate):\n" + body + "\ncheck(identity)"
+
+
+def _expected_nonblank_lines(test_code: str) -> int:
+    return sum(1 for line in test_code.splitlines() if line.strip())
+
+
+def _run_sample(syntax_tests: str, no_assert_tests: str, iterations: int) -> tuple[float, int, int]:
+    started = time.perf_counter()
+    syntax_count = 0
+    no_assert_count = 0
+    for _ in range(iterations):
+        syntax_count = code_eval_runner._count_tests(syntax_tests)
+        no_assert_count = code_eval_runner._count_tests(no_assert_tests)
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    return elapsed_ms, syntax_count, no_assert_count
+
+
+def main() -> int:
+    line_count = 8000
+    iterations = 25
+    sample_count = 7
+    syntax_tests = _build_syntax_error_tests(line_count)
+    no_assert_tests = _build_no_assert_tests(line_count)
+    expected_syntax_count = _expected_nonblank_lines(syntax_tests)
+    expected_no_assert_count = _expected_nonblank_lines(no_assert_tests)
+
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    syntax_count = 0
+    no_assert_count = 0
+    for _ in range(sample_count):
+        tracemalloc.start()
+        elapsed_ms, syntax_count, no_assert_count = _run_sample(
+            syntax_tests, no_assert_tests, iterations
+        )
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        if syntax_count != expected_syntax_count:
+            raise SystemExit(
+                f"unexpected syntax fallback count: {syntax_count} != {expected_syntax_count}"
+            )
+        if no_assert_count != expected_no_assert_count:
+            raise SystemExit(
+                f"unexpected no-assert fallback count: {no_assert_count} != {expected_no_assert_count}"
+            )
+        elapsed_samples.append(elapsed_ms)
+        peak_samples.append(float(peak))
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+                "peak_bytes_mean": statistics.fmean(peak_samples),
+                "line_count": float(line_count),
+                "iteration_count": float(iterations),
+                "sample_count": float(sample_count),
+                "syntax_count": float(syntax_count),
+                "no_assert_count": float(no_assert_count),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -345,6 +345,38 @@ def test_count_tests_falls_back_for_syntax_error_input() -> None:
     assert code_eval_runner._count_tests("assert True\n  assert False") == 2
 
 
+def test_count_nonblank_test_lines_matches_splitlines_semantics() -> None:
+    test_code = "\n assert one\r\n\t\rassert two\n   \nassert three"
+
+    assert code_eval_runner._count_nonblank_test_lines(test_code) == len(
+        [line for line in test_code.splitlines() if line.strip()]
+    )
+
+
+class _SplitlinesGuard(str):
+    def splitlines(self, *args, **kwargs):
+        raise AssertionError("fallback test counting should not materialize splitlines")
+
+
+def test_count_tests_fallback_avoids_splitlines_materialization() -> None:
+    assert code_eval_runner._count_tests(_SplitlinesGuard("def broken(:\nassert one\nassert two")) == 3
+
+
+def test_count_tests_no_assert_fallback_avoids_splitlines_materialization() -> None:
+    test_code = _SplitlinesGuard(
+        textwrap.dedent(
+            """
+            def check(candidate):
+                return candidate(1)
+
+            check(identity)
+            """
+        ).strip()
+    )
+
+    assert code_eval_runner._count_tests(test_code) == 3
+
+
 def test_read_limited_text_handles_missing_and_oversized_files(tmp_path: Path) -> None:
     missing_path = tmp_path / "missing.txt"
     assert code_eval_runner._read_limited_text(missing_path, 8) == ""

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -359,12 +359,13 @@ def test_scope_report_selects_code_eval_stdio_probe() -> None:
     )
 
     probe_ids = {probe["id"] for probe in scope["selected_probes"]}
-    assert scope["selected_count"] == 4
+    assert scope["selected_count"] == 5
     assert probe_ids == {
         "code-eval-code-block-last-match-streaming",
         "code-eval-payload-json-bytes",
         "code-eval-stdio-tail-single-stat",
         "code-eval-runner-script-cache",
+        "code-eval-count-tests-line-scan",
     }
 
 
@@ -1651,6 +1652,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "code-eval-payload-json-bytes",
         "code-eval-stdio-tail-single-stat",
         "code-eval-runner-script-cache",
+        "code-eval-count-tests-line-scan",
         "deterministic-embedding-duplicate-input-cache",
         "deterministic-embedding-project-digest-allocation",
         "deterministic-image-edit-digest-reuse",
@@ -2143,6 +2145,23 @@ def test_code_eval_runner_script_probe_script_emits_metrics(
     assert metrics["peak_bytes_mean"] > 0
     assert metrics["iteration_count"] == 20000.0
     assert metrics["sample_count"] == 7.0
+
+
+def test_code_eval_count_tests_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/code_eval_count_tests_probe.py"))
+
+    probe_script["main"]()
+    metrics = json.loads(capsys.readouterr().out)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["line_count"] == 8000.0
+    assert metrics["iteration_count"] == 25.0
+    assert metrics["sample_count"] == 7.0
+    assert metrics["syntax_count"] == 5334.0
+    assert metrics["no_assert_count"] == 6002.0
 
 
 def test_probe_smokes_return_metrics_against_current_repo() -> None:

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 import json
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import sys
@@ -14,6 +15,7 @@ import tempfile
 import textwrap
 
 _DEFAULT_STDIO_LIMIT_BYTES = 32_768
+_NONBLANK_TEST_LINE_RE = re.compile(r"\S[^\r\n]*(?:\r\n?|\n|$)")
 
 
 @dataclass(frozen=True)
@@ -229,9 +231,13 @@ def _count_tests(test_code: str) -> int:
     try:
         module = ast.parse(test_code, filename="<tests>", mode="exec")
     except SyntaxError:
-        return len([line for line in test_code.splitlines() if line.strip()])
+        return _count_nonblank_test_lines(test_code)
     assert_count = sum(1 for node in ast.walk(module) if isinstance(node, ast.Assert))
-    return assert_count or len([line for line in test_code.splitlines() if line.strip()])
+    return assert_count or _count_nonblank_test_lines(test_code)
+
+
+def _count_nonblank_test_lines(test_code: str) -> int:
+    return sum(1 for _ in _NONBLANK_TEST_LINE_RE.finditer(test_code))
 
 
 def _load_payload_file(payload_path: Path) -> dict[str, object] | None:


### PR DESCRIPTION
## Summary
- Replaces code-eval fallback test counting's `splitlines()` list materialization with a compiled regex iterator that counts nonblank test lines without building a full line list.
- Adds guard tests for syntax-error and no-assert fallback paths so future changes do not reintroduce `splitlines()` materialization.
- Registers the `code-eval-count-tests-line-scan` PR-scoped performance probe with a base-compatible fallback command.

## Plan or Spec
- `docs/plans/2026-05-08-code-eval-count-tests-line-scan.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_probes_validated.json
# PASS

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_fallback_avoids_splitlines_materialization services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_avoids_splitlines_materialization services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_count_tests_probe_script_emits_metrics
# PASS: 7 passed in 3.43s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_fallback_avoids_splitlines_materialization services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_avoids_splitlines_materialization services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_count_tests_probe_script_emits_metrics
# PASS: 7 passed in 4.57s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_count_tests_probe.py
# PASS: TOTAL 29 1 97%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_count_tests_probe.py
# PASS: {"elapsed_ms_mean": 336.9644371393536, "peak_bytes_mean": 204516.85714285713, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-count-tests-line-scan --base-repo /tmp/melix-cron-opt-base-20260508121251 --head-repo "$PWD" --output /tmp/code-eval-count-tests-line-scan.json
# PASS: head verification ok, base_probe ok, head_probe ok

 git diff --check
# PASS
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 29 1 97%`.
- Registered scoped probe: `code-eval-count-tests-line-scan`.
- Local base-vs-head probe (`origin/main` detached at `f366e37` vs branch head):
  - `elapsed_ms_mean`: `337.7995733005394` → `328.4191054158977` (~2.78% lower)
  - `peak_bytes_mean`: `583180.0` → `204563.85714285713` (~64.92% lower)
  - `syntax_count`: `5334.0` unchanged
  - `no_assert_count`: `6002.0` unchanged

## Known Gaps
- Linux-only local verification. macOS/Swift checks were not run locally.
- Broader CI is left to GitHub Actions.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
