### PR TITLE
perf: sort bootstrap replicates in place

### DIFF
--- a/docs/plans/2026-05-08-statistical-evidence-bootstrap-in-place-sort.md
+++ b/docs/plans/2026-05-08-statistical-evidence-bootstrap-in-place-sort.md
@@ -1,0 +1,32 @@
+# Statistical Evidence Bootstrap In-Place Sort
+
+## Goal
+
+Reduce temporary allocation in the paired bootstrap confidence interval path by sorting the already-owned replicate vector in place instead of allocating a second sorted list.
+
+## Scope
+
+- `services/mlx-worker-python/worker/productization/statistical_evidence.py`
+- `services/mlx-worker-python/tests/test_statistical_evidence.py`
+
+## Linux-only verification path
+
+This is a Python-only optimization and can be verified on Linux with focused pytest, changed-scope coverage, and the existing registered PR-scoped performance probe.
+
+## Performance probe
+
+Registered probe: `statistical-evidence-bootstrap-single-sort`
+
+The probe runs `scripts/statistical_evidence_bootstrap_probe.py` and reports:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- `sorted_calls_mean`
+- interval bound sanity metrics
+
+## Success metrics
+
+- Bootstrap interval payloads remain identical for the deterministic focused fixture.
+- Focused tests pass.
+- Changed executable line coverage is at least 95%.
+- Local registered probe reduces `sorted_calls_mean` from `1.0` to `0.0` while preserving lower/upper bound ordering.

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1291,7 +1291,7 @@ def test_statistical_evidence_bootstrap_probe_script_emits_metrics(
     assert metrics["sample_count"] == 1.0
     assert metrics["sample_size"] == 16.0
     assert metrics["bootstrap_iterations"] == 8.0
-    assert metrics["sorted_calls_mean"] == 1.0
+    assert metrics["sorted_calls_mean"] == 0.0
     assert metrics["elapsed_ms_mean"] >= 0
     assert metrics["peak_bytes_mean"] > 0
     assert metrics["lower_bound_mean"] <= metrics["upper_bound_mean"]

--- a/services/mlx-worker-python/tests/test_statistical_evidence.py
+++ b/services/mlx-worker-python/tests/test_statistical_evidence.py
@@ -93,7 +93,7 @@ def test_build_paired_statistical_evidence_keeps_full_confidence_intervals_finit
     assert evidence["analytical"]["lower_bound"] <= evidence["analytical"]["upper_bound"]
 
 
-def test_bootstrap_interval_reuses_one_sorted_replicate_vector(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_bootstrap_interval_sorts_replicates_in_place(monkeypatch: pytest.MonkeyPatch) -> None:
     sorted_call_lengths: list[int] = []
     original_sorted = builtins.sorted
 
@@ -111,7 +111,7 @@ def test_bootstrap_interval_reuses_one_sorted_replicate_vector(monkeypatch: pyte
         bootstrap_seed=13,
     )
 
-    assert sorted_call_lengths == [64]
+    assert sorted_call_lengths == []
     assert evidence["bootstrap"] == {
         "method": "paired_bootstrap_percentile",
         "confidence_level": 0.9,

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -141,12 +141,12 @@ def _paired_bootstrap_interval(
         append_replicate(sum(choices(outcomes, k=sample_size)) * inverse_sample_size)
 
     alpha = (1.0 - confidence_level) / 2.0
-    ordered_replicates = sorted(replicates)
+    replicates.sort()
     return _interval_payload(
         method="paired_bootstrap_percentile",
         confidence_level=confidence_level,
-        lower_bound=_ordered_percentile(ordered_replicates, alpha),
-        upper_bound=_ordered_percentile(ordered_replicates, 1.0 - alpha),
+        lower_bound=_ordered_percentile(replicates, alpha),
+        upper_bound=_ordered_percentile(replicates, 1.0 - alpha),
         iterations=int(bootstrap_iterations),
         seed=int(bootstrap_seed),
     )


### PR DESCRIPTION
## Summary
- Sort paired bootstrap replicate samples in place instead of allocating a second sorted replicate list.
- Update focused statistical-evidence and PR-scoped probe tests to expect zero `sorted(...)` calls on the bootstrap hot path.

## Plan or Spec
- `docs/plans/2026-05-08-statistical-evidence-bootstrap-in-place-sort.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics
# 13 passed in 0.52s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o /tmp/melix-stat-evidence-coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json /tmp/melix-stat-evidence-coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 13 passed; TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id statistical-evidence-bootstrap-single-sort --base-repo /tmp/melix-base-stat-evidence-fixed --head-repo "$PWD" --output /tmp/melix-stat-evidence-probe.json
# head verification passed; base/head probe both ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Registered scoped probe: `statistical-evidence-bootstrap-single-sort`.
- Local base (`origin/main` c77acba) vs head metrics:
  - `sorted_calls_mean`: `1.0` -> `0.0`
  - `peak_bytes_mean`: `56,801.6` -> `47,211.2` (~16.9% lower)
  - `elapsed_ms_mean`: `136.632292` -> `134.358791` (~1.7% lower)
  - `lower_bound_mean`: `0.31374` -> `0.31374`
  - `upper_bound_mean`: `0.44190` -> `0.44190`

## Known Gaps
- Linux-focused Python verification only; no local macOS/Swift checks were run because this slice does not touch Swift/macOS surfaces.
- Hosted CI must still validate the registered `pr-scoped-performance` probe before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
