### PR TITLE
perf: fast-path local audio URI parsing

### DIFF
--- a/docs/plans/2026-05-05-mlx-audio-local-uri-zero-copy-preprocess.md
+++ b/docs/plans/2026-05-05-mlx-audio-local-uri-zero-copy-preprocess.md
@@ -25,3 +25,4 @@ Reduce redundant memory work in MLX audio transcription for local `audio_uri` in
 - Avoid `Path.read_bytes()` on the MLX local URI transcription path.
 - Reduce `preprocess_peak_memory_bytes_mean` and `preprocess_elapsed_ms_mean` in the synthetic local-URI probe.
 - Keep deterministic/default audio preprocessing behavior unchanged for callers that still need decoded bytes.
+- Resolve ordinary local paths and `file:///...` URIs without invoking generic URL parsing on the hot local-audio path; retain URL parsing only for unusual file authorities and unsupported-scheme diagnostics.

--- a/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
@@ -136,6 +136,43 @@ def test_mlx_audio_transcription_runtime_uses_local_uri_path_without_reading_byt
     assert probe.preprocess_input_bytes == audio_path.stat().st_size
     assert probe.preprocess_peak_memory_bytes == audio_path.stat().st_size
 
+    fail_urlparse = lambda uri: (_ for _ in ()).throw(  # noqa: E731
+        AssertionError(f"local audio URI should use the fast path: {uri}")
+    )
+
+    monkeypatch.setattr(audio_preprocessing, "urlparse", fail_urlparse)
+    assert audio_preprocessing._path_from_uri(audio_path.as_uri()) == audio_path
+
+    monkeypatch.setattr(audio_preprocessing, "urlparse", fail_urlparse)
+    assert audio_preprocessing._path_from_uri(str(audio_path)) == audio_path
+
+    monkeypatch.setattr(audio_preprocessing, "urlparse", fail_urlparse)
+    assert audio_preprocessing._path_from_uri(f"file://localhost{audio_path}") == audio_path
+
+    monkeypatch.setattr(
+        audio_preprocessing,
+        "urlparse",
+        lambda uri: SimpleNamespace(scheme="file", path=str(audio_path)),
+    )
+    assert audio_preprocessing._path_from_uri(f"file://remote-host{audio_path}") == audio_path
+
+    monkeypatch.setattr(
+        audio_preprocessing,
+        "urlparse",
+        lambda uri: SimpleNamespace(scheme="file", path=str(audio_path)),
+    )
+    assert audio_preprocessing._path_from_uri("custom://audio.wav") == audio_path
+
+    monkeypatch.setattr(
+        audio_preprocessing,
+        "urlparse",
+        lambda uri: SimpleNamespace(scheme="https", path="/audio.wav"),
+    )
+    with pytest.raises(audio_preprocessing.AudioPreprocessError, match="Unsupported audio URI scheme"):
+        audio_preprocessing._path_from_uri("https://example.com/audio.wav")
+    with pytest.raises(audio_preprocessing.AudioPreprocessError, match="Missing local audio input"):
+        audio_preprocessing._path_from_uri(str(tmp_path / "missing.wav"))
+
     monkeypatch.setattr(Path, "read_bytes", original_read_bytes)
     prepared = audio_preprocessing.prepare_audio_input(
         inference_pb2.TranscribeRequest(audio_uri=audio_path.as_uri(), format="wav")

--- a/services/mlx-worker-python/worker/runtime/audio_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/audio_preprocessing.py
@@ -82,10 +82,21 @@ def prepare_audio_input(request, *, read_uri_bytes: bool = True) -> PreparedAudi
 
 
 def _path_from_uri(uri: str) -> Path:
-    parsed = urlparse(uri)
-    if parsed.scheme in {"", "file"}:
-        candidate = Path(unquote(parsed.path)) if parsed.scheme == "file" else Path(uri)
-        if not candidate.exists():
-            raise AudioPreprocessError(f"Missing local audio input: {uri}")
-        return candidate
-    raise AudioPreprocessError(f"Unsupported audio URI scheme: {parsed.scheme}")
+    if uri.startswith("file://"):
+        path_part = uri[7:]
+        if path_part.startswith("localhost/"):
+            path_part = path_part[len("localhost") :]
+        elif not path_part.startswith("/"):
+            parsed = urlparse(uri)
+            path_part = parsed.path
+        candidate = Path(unquote(path_part))
+    elif "://" not in uri:
+        candidate = Path(uri)
+    else:
+        parsed = urlparse(uri)
+        if parsed.scheme != "file":
+            raise AudioPreprocessError(f"Unsupported audio URI scheme: {parsed.scheme}")
+        candidate = Path(unquote(parsed.path))
+    if not candidate.exists():
+        raise AudioPreprocessError(f"Missing local audio input: {uri}")
+    return candidate


### PR DESCRIPTION
## Summary
- Fast-path ordinary local audio paths and `file:///...` audio URIs before falling back to generic URL parsing.
- Preserve the zero-copy local URI transcription path: MLX STT still receives the local path without reading the audio bytes.
- Extend focused coverage for the fast path, localhost file URIs, fallback parsing, unsupported schemes, and missing local files.

## Plan or Spec
- `docs/plans/2026-05-05-mlx-audio-local-uri-zero-copy-preprocess.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_transcription_runtime_uses_local_uri_path_without_reading_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_local_uri_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_main_covers_checked_in_file
# 5 passed in 1.68s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_transcription_runtime_uses_local_uri_path_without_reading_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_local_uri_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_main_covers_checked_in_file && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/audio_preprocessing.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_audio_local_uri_probe.py
# TOTAL 33 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_audio_local_uri_probe.py
# before: {"elapsed_ms_mean": 0.2800414338707924, "local_uri_read_bytes_calls_mean": 0.0, "peak_bytes_mean": 2598.0}
# after:  {"elapsed_ms_mean": 0.2031590323895216, "local_uri_read_bytes_calls_mean": 0.0, "peak_bytes_mean": 2502.8}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (33/33 measurable changed lines).
- Registered probe: `mlx-audio-local-uri-zero-copy-preprocess`.
- Local Linux probe delta: `elapsed_ms_mean` 0.2800414338707924 -> 0.2031590323895216 ms (delta -0.07688240148127079 ms, ~1.38x faster); `peak_bytes_mean` 2598.0 -> 2502.8 bytes; `local_uri_read_bytes_calls_mean` remained 0.0.
- CI PR-scoped performance workflow is required for the registered probe validation before merge.

## Known Gaps
- Full repository `make py-test` was not run locally; this slice used the focused registered probe tests and changed-scope coverage.
- Linux local validation covers Python behavior only; no Swift runtime path is changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
