### PR TITLE
[codex] Add report evidence gate

### DIFF
--- a/docs/plans/2026-05-08-evidence-plan-5-pr-release-evidence-gate.md
+++ b/docs/plans/2026-05-08-evidence-plan-5-pr-release-evidence-gate.md
@@ -40,3 +40,19 @@ required evidence, probes, telemetry, or gate metrics are missing.
 - Release evidence explains both result regressions and likely responsible
   runtime phases.
 - No public submission path is introduced.
+
+## Implementation Status
+
+- Added a repository-local report evidence gate that reads one or more
+  structured `report.json` files, reuses the report verifier, and emits a
+  machine-readable gate summary.
+- Added release evidence matrix coverage for serving benchmarks,
+  dialogue/event evaluation, adapter checks, and runtime checks.
+- Classified report rows into blocking failures, informational results, known
+  gaps, telemetry failures, and slowest probe phases for operator triage.
+- Added a CLI smoke path, `scripts/report_evidence_gate.py`, that can write a
+  PR-ready evidence bundle with `report-evidence-gate.json` and
+  `pr-evidence.md`.
+- Extended `scripts/validate_pr_evidence.py` so PR evidence validation can
+  also verify supplied structured report JSON paths and can require at least
+  one report JSON when a stricter workflow opts in.

--- a/scripts/report_evidence_gate.py
+++ b/scripts/report_evidence_gate.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "services/mlx-worker-python"))
+
+from worker.productization.report_evidence_gate import (  # noqa: E402
+    build_report_evidence_gate,
+    write_report_evidence_gate_outputs,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--report-json", action="append", default=[])
+    parser.add_argument("--output-dir", default="")
+    parser.add_argument("--require-release-matrix", action="store_true")
+    parser.add_argument("--require-hardware-telemetry", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    if not args.report_json:
+        print("at least one --report-json is required", file=sys.stderr)
+        return 2
+
+    try:
+        gate_report = build_report_evidence_gate(
+            args.report_json,
+            require_release_matrix=args.require_release_matrix,
+            require_hardware_telemetry=args.require_hardware_telemetry,
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    if args.output_dir:
+        write_report_evidence_gate_outputs(gate_report, args.output_dir)
+    print(json.dumps(gate_report, indent=2, sort_keys=True))
+    return 0 if gate_report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_pr_evidence.py
+++ b/scripts/validate_pr_evidence.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "services/mlx-worker-python"))
+
+from worker.productization.benchmark_evaluation_report import validate_report_payload  # noqa: E402
 
 
 REQUIRED_SECTIONS = (
@@ -25,6 +33,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--event-path",
         help="Path to a GitHub event JSON file containing pull_request.body.",
+    )
+    parser.add_argument(
+        "--report-json",
+        action="append",
+        default=[],
+        help="Optional structured report JSON path to validate with the PR evidence body.",
+    )
+    parser.add_argument(
+        "--require-report-json",
+        action="store_true",
+        help="Require at least one --report-json path.",
     )
     return parser.parse_args()
 
@@ -108,10 +127,34 @@ def validate_body_text(body_text: str) -> list[str]:
     return errors
 
 
+def validate_report_json_paths(paths: list[str]) -> list[str]:
+    errors: list[str] = []
+    for path in paths:
+        report_path = Path(path)
+        if not report_path.is_file():
+            errors.append(f"Report JSON is missing: {report_path}")
+            continue
+        try:
+            payload = json.loads(report_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            errors.append(f"Report JSON could not be decoded: {report_path}: {exc.msg}")
+            continue
+        if not isinstance(payload, dict):
+            errors.append(f"Report JSON must be an object: {report_path}")
+            continue
+        for error in validate_report_payload(payload):
+            errors.append(f"{report_path}: {error}")
+    return errors
+
+
 def main() -> int:
     args = parse_args()
     body_text = load_body_text(args)
     errors = validate_body_text(body_text)
+    report_json_paths = list(args.report_json or [])
+    if args.require_report_json and not report_json_paths:
+        errors.append("At least one --report-json path is required.")
+    errors.extend(validate_report_json_paths(report_json_paths))
     if errors:
         for error in errors:
             print(error)

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import report_evidence_gate as report_evidence_gate_script
+import worker.productization.report_evidence_gate as report_evidence_gate_module
+from worker.productization.benchmark_evaluation_report import (
+    build_benchmark_evaluation_report,
+    write_report_outputs,
+)
+from worker.productization.report_evidence_gate import (
+    build_report_evidence_gate,
+    load_report_payload,
+    render_pr_evidence_markdown,
+)
+
+
+def _run_evidence(
+    *,
+    run_id: str,
+    run_kind: str,
+    decode_ms: float,
+    telemetry_failures: list[str] | None = None,
+    adapter_id: str = "adapter-a",
+) -> dict[str, object]:
+    failures = telemetry_failures or []
+    probes = [
+        {
+            "run_id": run_id,
+            "trace_id": f"{run_id}:trace",
+            "span_id": f"{run_id}:{phase}",
+            "parent_span_id": f"{run_id}:root",
+            "component": component,
+            "phase": phase,
+            "started_at_monotonic_ms": index * 10,
+            "duration_ms": duration_ms,
+            "status": "completed",
+            "error_stage": "",
+            "error_code": "",
+            "attributes": {},
+        }
+        for index, (component, phase, duration_ms) in enumerate(
+            (
+                ("runtime", "runtime_prepare", 1.0),
+                ("runtime", "model_load", 2.0),
+                ("runtime", "decode", decode_ms),
+            ),
+            start=1,
+        )
+    ]
+    telemetry_summary: dict[str, object] = {
+        "schema_version": "melix.telemetry_summary.v1",
+        "collector_status": "partial" if failures else "collected",
+        "time_series_path": "telemetry-samples.jsonl",
+        "telemetry_failures": failures,
+        "sample_count": 2,
+    }
+    if not failures:
+        telemetry_summary.update(
+            {
+                "average_system_power_w": 15.0,
+                "peak_system_power_w": 16.0,
+                "watts_per_output_token": 1.5,
+            }
+        )
+    return {
+        "schema_version": "melix.run_evidence.v1",
+        "run_id": run_id,
+        "melix_commit": "abc123",
+        "git_branch": "codex/pr-release-evidence-gate",
+        "dirty_worktree": False,
+        "run_kind": run_kind,
+        "started_at": 1_779_000_000_000,
+        "ended_at": 1_779_000_001_000,
+        "duration_ms": 1000,
+        "status": "completed",
+        "command": "melix report evidence fixture",
+        "artifact_root": f"/tmp/{run_id}",
+        "target_model_id": "mlx-community/test-model",
+        "hf_repo_id": "mlx-community/test-model",
+        "task_kind": "text-generation",
+        "model_snapshot": "model-sha",
+        "adapter_id": adapter_id,
+        "adapter_snapshot": "adapter-sha" if adapter_id else "",
+        "runtime_kind": "mlx",
+        "runtime_config": {"quantization": "4bit"},
+        "dataset_ref": "fixture.dataset",
+        "dataset_revision": "dataset-sha",
+        "suite_id": "smoke",
+        "sample_count": 1,
+        "input_digest": "input-sha",
+        "prompt_template_digest": "prompt-sha",
+        "generation_config": {"max_tokens": 16},
+        "metrics": [{"name": "decode_ms", "value": decode_ms, "unit": "ms"}],
+        "probe_timeline": probes,
+        "telemetry_summary": telemetry_summary,
+        "artifacts": [{"kind": "probe_timeline", "path": "probes.jsonl", "role": "diagnostic"}],
+        "failure_summary": {},
+        "fallback_summary": {},
+    }
+
+
+def _write_report(
+    tmp_path: Path,
+    name: str,
+    *,
+    run_kind: str,
+    baseline_decode_ms: float = 10.0,
+    candidate_decode_ms: float = 10.0,
+    telemetry_failures: list[str] | None = None,
+    adapter_id: str = "adapter-a",
+) -> Path:
+    report = build_benchmark_evaluation_report(
+        baseline={
+            "run_evidence": [
+                _run_evidence(
+                    run_id=f"{name}-base",
+                    run_kind=run_kind,
+                    decode_ms=baseline_decode_ms,
+                    adapter_id=adapter_id,
+                )
+            ]
+        },
+        candidate={
+            "run_evidence": [
+                _run_evidence(
+                    run_id=f"{name}-head",
+                    run_kind=run_kind,
+                    decode_ms=candidate_decode_ms,
+                    telemetry_failures=telemetry_failures,
+                    adapter_id=adapter_id,
+                )
+            ]
+        },
+        report_kind="release_gate",
+    )
+    outputs = write_report_outputs(report=report, output_dir=tmp_path / name)
+    return outputs["json"]
+
+
+def test_report_evidence_gate_passes_complete_release_matrix(tmp_path: Path) -> None:
+    serving_report = _write_report(tmp_path, "serving", run_kind="serving_benchmark")
+    evaluation_report = _write_report(tmp_path, "evaluation", run_kind="evaluation")
+
+    gate = build_report_evidence_gate(
+        [serving_report, evaluation_report],
+        require_release_matrix=True,
+    )
+
+    assert gate["passed"] is True
+    assert {row["role"]: row["present"] for row in gate["release_matrix"]} == {
+        "serving_benchmark": True,
+        "dialogue_event_evaluation": True,
+        "adapter_check": True,
+        "runtime_check": True,
+    }
+    markdown = render_pr_evidence_markdown(gate)
+    assert "Report JSON" in markdown
+    assert "serving-head" in markdown
+
+
+def test_report_evidence_gate_reports_blocking_metrics_and_probe_phase(tmp_path: Path) -> None:
+    report_path = _write_report(
+        tmp_path,
+        "regression",
+        run_kind="serving_benchmark",
+        baseline_decode_ms=10.0,
+        candidate_decode_ms=20.0,
+    )
+
+    gate = build_report_evidence_gate([report_path])
+
+    assert gate["passed"] is False
+    assert gate["blocking_failures"][0]["source"] == "gate_metric"
+    assert gate["blocking_failures"][0]["metric"] == (
+        "probe.serving_benchmark.runtime.decode.duration_ms_mean"
+    )
+    assert gate["reports"][0]["slowest_probe_phases"][0]["phase"] == "decode"
+
+
+def test_report_evidence_gate_fails_matrix_and_hardware_when_required(tmp_path: Path) -> None:
+    report_path = _write_report(
+        tmp_path,
+        "telemetry",
+        run_kind="serving_benchmark",
+        telemetry_failures=["powermetrics_failed:fixture"],
+        adapter_id="",
+    )
+
+    gate = build_report_evidence_gate(
+        [report_path],
+        require_release_matrix=True,
+        require_hardware_telemetry=True,
+    )
+
+    assert gate["passed"] is False
+    messages = [failure["message"] for failure in gate["blocking_failures"]]
+    assert "hardware telemetry failure: candidate:telemetry-head:powermetrics_failed:fixture" in messages
+    assert "release evidence matrix role is missing: dialogue_event_evaluation" in messages
+    assert "release evidence matrix role is missing: adapter_check" in messages
+
+
+def test_report_evidence_gate_script_writes_bundle_and_exit_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    report_path = _write_report(tmp_path, "serving", run_kind="serving_benchmark")
+    output_dir = tmp_path / "gate"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "report_evidence_gate.py",
+            "--report-json",
+            str(report_path),
+            "--output-dir",
+            str(output_dir),
+            "--json",
+        ],
+    )
+
+    assert report_evidence_gate_script.main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["passed"] is True
+    assert (output_dir / "report-evidence-gate.json").is_file()
+    assert (output_dir / "pr-evidence.md").is_file()
+
+
+def test_report_evidence_gate_covers_invalid_payload_and_edge_summaries(tmp_path: Path) -> None:
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("{", encoding="utf-8")
+    array_json = tmp_path / "array.json"
+    array_json.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="could not be decoded"):
+        load_report_payload(bad_json)
+    with pytest.raises(ValueError, match="must be an object"):
+        load_report_payload(array_json)
+
+    invalid_report = tmp_path / "invalid-report.json"
+    invalid_report.write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.benchmark_evaluation_report.v1",
+                "report_id": "invalid",
+                "source_evidence_ids": ["bad-run"],
+                "metrics": [{"metric": "adapter.load_ms", "result": "pass", "gate_policy": {}}],
+                "probe_summary": {"baseline": [], "candidate": {}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    gate = build_report_evidence_gate(
+        [invalid_report],
+        matrix={"adapter_metric": {"metric_prefixes": ("adapter.",)}},
+        require_hardware_telemetry=True,
+    )
+
+    assert gate["passed"] is False
+    assert gate["release_matrix"][0]["present"] is True
+    assert "telemetry_summary_missing" in gate["reports"][0]["telemetry_failures"]
+    assert gate["reports"][0]["slowest_probe_phases"] == []
+    assert report_evidence_gate_module._probe_phases({"probe_summary": []}) == set()
+    assert report_evidence_gate_module._dict_list({"not": "a list"}) == []
+
+    markdown = render_pr_evidence_markdown(
+        {
+            **gate,
+            "known_gaps": ["baseline_probe_timeline_missing"],
+        }
+    )
+    assert "## Blocking Failures" in markdown
+    assert "## Known Gaps" in markdown
+
+
+def test_report_evidence_gate_script_handles_errors_and_failed_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["report_evidence_gate.py"])
+    assert report_evidence_gate_script.main() == 2
+    assert "at least one --report-json is required" in capsys.readouterr().err
+
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("{", encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["report_evidence_gate.py", "--report-json", str(bad_json)],
+    )
+    assert report_evidence_gate_script.main() == 2
+    assert "could not be decoded" in capsys.readouterr().err
+
+    regression_report = _write_report(
+        tmp_path,
+        "regression-cli",
+        run_kind="serving_benchmark",
+        baseline_decode_ms=10.0,
+        candidate_decode_ms=20.0,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["report_evidence_gate.py", "--report-json", str(regression_report)],
+    )
+    assert report_evidence_gate_script.main() == 1
+    assert json.loads(capsys.readouterr().out)["passed"] is False

--- a/services/mlx-worker-python/tests/test_validate_pr_evidence.py
+++ b/services/mlx-worker-python/tests/test_validate_pr_evidence.py
@@ -184,7 +184,12 @@ def test_main_returns_non_zero_when_body_is_invalid(monkeypatch, capsys) -> None
     monkeypatch.setattr(
         validate_pr_evidence,
         "parse_args",
-        lambda: argparse.Namespace(body_file=None, event_path="/tmp/event.json"),
+        lambda: argparse.Namespace(
+            body_file=None,
+            event_path="/tmp/event.json",
+            report_json=[],
+            require_report_json=False,
+        ),
     )
     monkeypatch.setattr(validate_pr_evidence, "load_body_text", lambda args: "## Summary\n- hi\n")
 
@@ -199,7 +204,12 @@ def test_main_returns_zero_when_body_is_valid(monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         validate_pr_evidence,
         "parse_args",
-        lambda: argparse.Namespace(body_file="/tmp/body.md", event_path=None),
+        lambda: argparse.Namespace(
+            body_file="/tmp/body.md",
+            event_path=None,
+            report_json=[],
+            require_report_json=False,
+        ),
     )
     monkeypatch.setattr(
         validate_pr_evidence,
@@ -225,6 +235,77 @@ make proto-check
 
     output = capsys.readouterr().out
     assert "PR evidence looks valid." in output
+
+
+def test_validate_report_json_paths_reports_missing_and_payload_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report_path = tmp_path / "report.json"
+    report_path.write_text(json.dumps({"schema_version": "melix.benchmark_evaluation_report.v1"}), encoding="utf-8")
+    monkeypatch.setattr(
+        validate_pr_evidence,
+        "validate_report_payload",
+        lambda payload: ["missing required report identity field: report_id"],
+    )
+
+    errors = validate_pr_evidence.validate_report_json_paths(
+        [str(tmp_path / "missing.json"), str(report_path)]
+    )
+
+    assert f"Report JSON is missing: {tmp_path / 'missing.json'}" in errors
+    assert (
+        f"{report_path}: missing required report identity field: report_id"
+        in errors
+    )
+
+
+def test_validate_report_json_paths_reports_decode_and_shape_errors(tmp_path: Path) -> None:
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("{", encoding="utf-8")
+    array_json = tmp_path / "array.json"
+    array_json.write_text("[]", encoding="utf-8")
+
+    errors = validate_pr_evidence.validate_report_json_paths([str(bad_json), str(array_json)])
+
+    assert f"Report JSON could not be decoded: {bad_json}: " in errors[0]
+    assert f"Report JSON must be an object: {array_json}" in errors
+
+
+def test_main_can_require_report_json(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(
+        validate_pr_evidence,
+        "parse_args",
+        lambda: argparse.Namespace(
+            body_file="/tmp/body.md",
+            event_path=None,
+            report_json=[],
+            require_report_json=True,
+        ),
+    )
+    monkeypatch.setattr(
+        validate_pr_evidence,
+        "load_body_text",
+        lambda args: """
+## Plan or Spec
+- docs/plans/2026-05-08-evidence-plan-5-pr-release-evidence-gate.md
+
+## Commands Run
+```text
+python3 scripts/report_evidence_gate.py --report-json report.json
+```
+
+## Coverage and Metrics
+- N/A: validator-only test.
+
+## Known Gaps
+- None.
+""",
+    )
+
+    assert validate_pr_evidence.main() == 1
+
+    assert "At least one --report-json path is required." in capsys.readouterr().out
 
 
 def test_script_entrypoint_exits_zero_for_valid_body_file(tmp_path: Path, monkeypatch, capsys) -> None:

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from worker.productization.benchmark_evaluation_report import validate_report_payload
+
+REPORT_EVIDENCE_GATE_SCHEMA_VERSION = "melix.report_evidence_gate.v1"
+
+DEFAULT_RELEASE_EVIDENCE_MATRIX: dict[str, dict[str, object]] = {
+    "serving_benchmark": {
+        "run_kinds": ("serving_benchmark",),
+        "description": "Serving benchmark report evidence is present.",
+    },
+    "dialogue_event_evaluation": {
+        "run_kinds": ("evaluation", "dialogue_evaluation", "event_extraction"),
+        "description": "Dialogue or event evaluation report evidence is present.",
+    },
+    "adapter_check": {
+        "metric_prefixes": ("adapter.",),
+        "target_fields": ("adapter_id", "adapter_snapshot"),
+        "description": "Adapter check evidence is present.",
+    },
+    "runtime_check": {
+        "probe_phases": ("runtime_prepare", "model_load", "decode"),
+        "description": "Runtime probe evidence is present.",
+    },
+}
+
+
+def load_report_payload(path: str | Path) -> dict[str, object]:
+    report_path = Path(path)
+    try:
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"report JSON could not be decoded: {report_path}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"report JSON must be an object: {report_path}")
+    return payload
+
+
+def build_report_evidence_gate(
+    report_paths: list[str | Path],
+    *,
+    require_release_matrix: bool = False,
+    require_hardware_telemetry: bool = False,
+    matrix: dict[str, dict[str, object]] | None = None,
+) -> dict[str, object]:
+    active_matrix = matrix or DEFAULT_RELEASE_EVIDENCE_MATRIX
+    reports = [
+        _analyze_report(
+            path=Path(path),
+            report=load_report_payload(path),
+            require_hardware_telemetry=require_hardware_telemetry,
+            matrix=active_matrix,
+        )
+        for path in report_paths
+    ]
+    matrix_rows = _release_matrix_rows(reports, active_matrix)
+    blocking_failures = [
+        failure
+        for report in reports
+        for failure in _dict_list(report.get("blocking_failures"))
+    ]
+    if require_release_matrix:
+        for row in matrix_rows:
+            if row.get("required") and not row.get("present"):
+                blocking_failures.append(
+                    {
+                        "source": "release_matrix",
+                        "role": row.get("role"),
+                        "message": f"release evidence matrix role is missing: {row.get('role')}",
+                    }
+                )
+    known_gaps = sorted(
+        {
+            str(gap)
+            for report in reports
+            for gap in report.get("known_gaps", [])
+            if str(gap).strip()
+        }
+    )
+    informational_results = [
+        result
+        for report in reports
+        for result in _dict_list(report.get("informational_results"))
+    ]
+    passed = not blocking_failures
+    return {
+        "schema_version": REPORT_EVIDENCE_GATE_SCHEMA_VERSION,
+        "passed": passed,
+        "overall_result": "pass" if passed else "fail",
+        "require_release_matrix": require_release_matrix,
+        "require_hardware_telemetry": require_hardware_telemetry,
+        "release_matrix": matrix_rows,
+        "reports": reports,
+        "blocking_failures": blocking_failures,
+        "informational_results": informational_results,
+        "known_gaps": known_gaps,
+        "pr_evidence": {
+            "report_json_paths": [str(report.get("path", "")) for report in reports],
+            "markdown_report_paths": [
+                str(report.get("markdown_report_path", ""))
+                for report in reports
+                if str(report.get("markdown_report_path", "")).strip()
+            ],
+        },
+    }
+
+
+def render_pr_evidence_markdown(gate_report: dict[str, object]) -> str:
+    lines = [
+        "# Melix Report Evidence Gate",
+        "",
+        f"- Overall Result: `{gate_report.get('overall_result', 'fail')}`",
+        f"- Blocking Failures: `{len(_dict_list(gate_report.get('blocking_failures')))}`",
+        f"- Informational Results: `{len(_dict_list(gate_report.get('informational_results')))}`",
+        "",
+        "## Report Artifacts",
+        "",
+    ]
+    pr_evidence = gate_report.get("pr_evidence")
+    if isinstance(pr_evidence, dict):
+        for path in pr_evidence.get("report_json_paths", []):
+            lines.append(f"- Report JSON: `{path}`")
+        for path in pr_evidence.get("markdown_report_paths", []):
+            lines.append(f"- Markdown Report: `{path}`")
+    lines.extend(["", "## Release Matrix", ""])
+    lines.append("| Role | Required | Present | Evidence IDs |")
+    lines.append("| --- | --- | --- | --- |")
+    for row in _dict_list(gate_report.get("release_matrix")):
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(row.get("role", "")),
+                    str(row.get("required", "")),
+                    str(row.get("present", "")),
+                    ", ".join(str(item) for item in row.get("evidence_ids", [])),
+                ]
+            )
+            + " |"
+        )
+    failures = _dict_list(gate_report.get("blocking_failures"))
+    if failures:
+        lines.extend(["", "## Blocking Failures", ""])
+        for failure in failures:
+            lines.append(f"- `{failure.get('message', failure)}`")
+    known_gaps = [str(gap) for gap in gate_report.get("known_gaps", []) if str(gap).strip()]
+    if known_gaps:
+        lines.extend(["", "## Known Gaps", ""])
+        for gap in known_gaps:
+            lines.append(f"- `{gap}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_report_evidence_gate_outputs(
+    gate_report: dict[str, object],
+    output_dir: str | Path,
+) -> dict[str, Path]:
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    json_path = root / "report-evidence-gate.json"
+    markdown_path = root / "pr-evidence.md"
+    json_path.write_text(json.dumps(gate_report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_pr_evidence_markdown(gate_report), encoding="utf-8")
+    return {"json": json_path, "markdown": markdown_path}
+
+
+def _analyze_report(
+    *,
+    path: Path,
+    report: dict[str, object],
+    require_hardware_telemetry: bool,
+    matrix: dict[str, dict[str, object]],
+) -> dict[str, object]:
+    validation_errors = validate_report_payload(report)
+    gate_result = report.get("gate_result") if isinstance(report.get("gate_result"), dict) else {}
+    artifacts = report.get("artifacts") if isinstance(report.get("artifacts"), dict) else {}
+    telemetry_failures = _telemetry_failures(report)
+    blocking_failures = [
+        {
+            "source": "report_validation",
+            "report_id": report.get("report_id", ""),
+            "path": str(path),
+            "message": error,
+        }
+        for error in validation_errors
+    ]
+    for row in _dict_list(gate_result.get("blocking_failures")):
+        blocking_failures.append(
+            {
+                "source": "gate_metric",
+                "report_id": report.get("report_id", ""),
+                "path": str(path),
+                "metric": row.get("metric"),
+                "message": f"gate metric failed: {row.get('metric')}",
+                "row": row,
+            }
+        )
+    if require_hardware_telemetry:
+        for failure in telemetry_failures:
+            blocking_failures.append(
+                {
+                    "source": "hardware_telemetry",
+                    "report_id": report.get("report_id", ""),
+                    "path": str(path),
+                    "message": f"hardware telemetry failure: {failure}",
+                }
+            )
+    return {
+        "path": str(path),
+        "report_id": report.get("report_id", ""),
+        "report_kind": report.get("report_kind", ""),
+        "source_evidence_ids": list(report.get("source_evidence_ids", []))
+        if isinstance(report.get("source_evidence_ids"), list)
+        else [],
+        "markdown_report_path": artifacts.get("markdown_report_path", ""),
+        "validation_errors": validation_errors,
+        "gate_result": gate_result.get("overall_result", "fail"),
+        "blocking_failures": blocking_failures,
+        "informational_results": _dict_list(gate_result.get("informational_results")),
+        "known_gaps": list(report.get("known_gaps", []))
+        if isinstance(report.get("known_gaps"), list)
+        else [],
+        "telemetry_failures": telemetry_failures,
+        "slowest_probe_phases": _slowest_probe_phases(report),
+        "release_matrix_roles": _report_matrix_roles(report, matrix),
+    }
+
+
+def _release_matrix_rows(
+    reports: list[dict[str, object]],
+    matrix: dict[str, dict[str, object]],
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for role, rule in matrix.items():
+        evidence_ids: list[str] = []
+        for report in reports:
+            roles = report.get("release_matrix_roles")
+            if isinstance(roles, list) and role in roles:
+                evidence_ids.extend(str(item) for item in report.get("source_evidence_ids", []))
+        rows.append(
+            {
+                "role": role,
+                "required": bool(rule.get("required", True)),
+                "present": bool(evidence_ids),
+                "evidence_ids": sorted(set(evidence_ids)),
+                "description": str(rule.get("description", "")),
+            }
+        )
+    return rows
+
+
+def _report_matrix_roles(
+    report: dict[str, object],
+    matrix: dict[str, dict[str, object]],
+) -> list[str]:
+    roles: list[str] = []
+    runs = _dict_list(report.get("runs"))
+    targets = _dict_list(report.get("targets"))
+    metrics = _dict_list(report.get("metrics"))
+    probe_phases = _probe_phases(report)
+    for role, rule in matrix.items():
+        if _rule_matches_report(
+            rule=rule,
+            runs=runs,
+            targets=targets,
+            metrics=metrics,
+            probe_phases=probe_phases,
+        ):
+            roles.append(role)
+    return roles
+
+
+def _rule_matches_report(
+    *,
+    rule: dict[str, object],
+    runs: list[dict[str, object]],
+    targets: list[dict[str, object]],
+    metrics: list[dict[str, object]],
+    probe_phases: set[str],
+) -> bool:
+    run_kinds = tuple(str(item) for item in rule.get("run_kinds", ()))
+    if run_kinds and any(str(run.get("run_kind", "")) in run_kinds for run in runs):
+        return True
+    metric_prefixes = tuple(str(item) for item in rule.get("metric_prefixes", ()))
+    if metric_prefixes and any(
+        str(metric.get("metric", "")).startswith(metric_prefixes) for metric in metrics
+    ):
+        return True
+    target_fields = tuple(str(item) for item in rule.get("target_fields", ()))
+    if target_fields and any(str(target.get(field, "")).strip() for target in targets for field in target_fields):
+        return True
+    required_probe_phases = set(str(item) for item in rule.get("probe_phases", ()))
+    return bool(required_probe_phases and required_probe_phases.issubset(probe_phases))
+
+
+def _telemetry_failures(report: dict[str, object]) -> list[str]:
+    telemetry_summary = report.get("telemetry_summary")
+    if not isinstance(telemetry_summary, dict):
+        return ["telemetry_summary_missing"]
+    failures: list[str] = []
+    for side in ("baseline", "candidate"):
+        side_rows = telemetry_summary.get(side)
+        if not isinstance(side_rows, list) or not side_rows:
+            failures.append(f"{side}:telemetry_summary_missing")
+            continue
+        for row in _dict_list(side_rows):
+            telemetry_failures = row.get("telemetry_failures")
+            if isinstance(telemetry_failures, list):
+                failures.extend(
+                    f"{side}:{row.get('run_id', '')}:{failure}"
+                    for failure in telemetry_failures
+                    if str(failure).strip()
+                )
+    return failures
+
+
+def _slowest_probe_phases(report: dict[str, object]) -> list[dict[str, object]]:
+    probe_summary = report.get("probe_summary")
+    if not isinstance(probe_summary, dict):
+        return []
+    rows: list[dict[str, object]] = []
+    for side in ("baseline", "candidate"):
+        side_summary = probe_summary.get(side)
+        if not isinstance(side_summary, dict):
+            continue
+        for row in _dict_list(side_summary.get("slowest_phases")):
+            rows.append({"side": side, **row})
+    return sorted(rows, key=lambda row: float(row.get("duration_ms") or 0.0), reverse=True)[:5]
+
+
+def _probe_phases(report: dict[str, object]) -> set[str]:
+    phases: set[str] = set()
+    probe_summary = report.get("probe_summary")
+    if not isinstance(probe_summary, dict):
+        return phases
+    for side in ("baseline", "candidate"):
+        side_summary = probe_summary.get(side)
+        if not isinstance(side_summary, dict):
+            continue
+        for bucket in ("slowest_phases", "failed_phases", "skipped_phases", "fallback_phases"):
+            for row in _dict_list(side_summary.get(bucket)):
+                phase = str(row.get("phase", "")).strip()
+                if phase:
+                    phases.add(phase)
+    return phases
+
+
+def _dict_list(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]


### PR DESCRIPTION
## Summary
- Add a structured report evidence gate that validates one or more `report.json` files, classifies blocking/informational/known-gap evidence, and summarizes slowest probe phases for release triage.
- Add `scripts/report_evidence_gate.py` to emit a PR-ready evidence bundle with `report-evidence-gate.json` and `pr-evidence.md`.
- Extend `scripts/validate_pr_evidence.py` so stricter PR workflows can validate supplied report JSON paths and require at least one structured report JSON.

## Plan or Spec
- `docs/evidence-telemetry-report-contract.md`
- `docs/plans/2026-05-08-evidence-plan-5-pr-release-evidence-gate.md`

## Commands Run
```text
git rebase codex/report-json-export
# Passed; skipped already-upstream parent commits and refreshed the Plan 5 stack on the updated Plan 4 branch.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python:$PWD/services/mlx-worker-python/tests" python3 -m py_compile scripts/report_evidence_gate.py scripts/validate_pr_evidence.py services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_validate_pr_evidence.py
# Passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python:$PWD/services/mlx-worker-python/tests" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_validate_pr_evidence.py -q
# Passed: 21 passed in 0.05s.

COVERAGE_FILE=/private/tmp/pr-release-evidence-gate.coverage PYTHONPATH="$PWD:$PWD/services/mlx-worker-python:$PWD/services/mlx-worker-python/tests" uv run --project services/mlx-worker-python --extra mlx coverage run --source=services/mlx-worker-python/worker,services/mlx-worker-python/tests,scripts -m pytest services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_validate_pr_evidence.py -q
# Passed: 21 passed in 0.09s.

COVERAGE_FILE=/private/tmp/pr-release-evidence-gate.coverage PYTHONPATH="$PWD:$PWD/services/mlx-worker-python:$PWD/services/mlx-worker-python/tests" uv run --project services/mlx-worker-python --extra mlx coverage json -o /private/tmp/pr-release-evidence-gate-coverage.json
# Passed: wrote /private/tmp/pr-release-evidence-gate-coverage.json.

python3 scripts/python_changed_line_coverage.py --coverage-json /private/tmp/pr-release-evidence-gate-coverage.json --diff-from codex/report-json-export services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py scripts/report_evidence_gate.py scripts/validate_pr_evidence.py services/mlx-worker-python/tests/test_validate_pr_evidence.py
# Passed:
# services/mlx-worker-python/worker/productization/report_evidence_gate.py 98.03% (149/152)
# services/mlx-worker-python/tests/test_report_evidence_gate.py 100.00% (91/91)
# scripts/report_evidence_gate.py 96.77% (30/31)
# scripts/validate_pr_evidence.py 100.00% (29/29)
# services/mlx-worker-python/tests/test_validate_pr_evidence.py 100.00% (20/20)
# TOTAL 98.76% (319/323)

git diff --check
# Passed.
```

## Coverage and Metrics
- Changed-line coverage: 98.76% total (319/323).
- Source changed-line coverage: 98.03% for `report_evidence_gate.py` (149/152).
- Evidence-gate behavior is covered for complete release matrix pass, blocking metric failure, telemetry-required failure, missing matrix roles, PR markdown rendering, CLI success/failure, malformed report JSON, and PR evidence report-json validation.

## Known Gaps
- Full repository `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run locally for this stacked Python evidence-gate slice.
- GitHub Actions are pending on the draft PR.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes; `uv.lock` restored after local `uv run`.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
