### PR TITLE
perf: reuse shaped maintenance benchmark prompts

### DIFF
--- a/docs/plans/maintenance-text-bench-prompt-shape-reuse.md
+++ b/docs/plans/maintenance-text-bench-prompt-shape-reuse.md
@@ -1,0 +1,24 @@
+# Maintenance text benchmark prompt-shape reuse
+
+## Goal
+
+Avoid shaping the same text benchmark prompt twice for every measured sample. The matrix-level text benchmark path already expands each suite case to the requested context length once per `(case, context_length)` pair before iterating repeats; the sample measurement helper should be able to consume that shaped prompt directly.
+
+## Scope
+
+- `services/mlx-worker-python/worker/engine/maintenance_core.py`
+- `services/mlx-worker-python/tests/test_maintenance_service.py`
+
+## Linux verification plan
+
+- Focused pytest for the existing maintenance prompt-shape scoped test node.
+- Changed-scope coverage with `scripts/changed_scope_coverage.py` for the touched executable files.
+- Local performance/structure probe comparing `origin/main` and head by counting `_shape_benchmark_prompt(...)` invocations across repeated text benchmark samples.
+
+## Scoped CI probe
+
+The touched files are already watched by the registered `maintenance-prompt-shape-vector-repeat` PR-scoped performance probe. Its focused command includes `test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs`, which now covers the prompt-reuse path.
+
+## Success metric
+
+For one case, one context length, and three repeats, `_shape_benchmark_prompt(...)` should run once instead of once per repeat plus the initial shape pass, while preserving benchmark row output.

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -5303,7 +5303,10 @@ def test_benchmark_partial_prefix_cache_profile_uses_a_shorter_warmup_prompt(tmp
     assert partial_backend.prompts[0] != warm_backend.prompts[0]
 
 
-def test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs(tmp_path: Path) -> None:
+def test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     catalog = BenchmarkSuiteCatalog(hf_dataset_fetcher=FakeBenchmarkHFDatasetFetcher())
     suite = catalog.resolve_suite(
         "smoke",
@@ -5379,6 +5382,27 @@ def test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs(tmp_path: Pa
         "one two three one two three one two"
     )
     assert core._shape_benchmark_prompt("one two", context_length=6) == "one two one two one two"
+
+    shape_calls: list[tuple[str, int]] = []
+    original_shape_prompt = MaintenanceCore._shape_benchmark_prompt
+
+    def tracked_shape_prompt(prompt: str, *, context_length: int) -> str:
+        shape_calls.append((prompt, context_length))
+        return original_shape_prompt(prompt, context_length=context_length)
+
+    monkeypatch.setattr(MaintenanceCore, "_shape_benchmark_prompt", staticmethod(tracked_shape_prompt))
+    loaded = core._registry.load_model(WorkerModelCatalog.dev_text_model())
+    _, context_rows, _, _ = core._measure_text_bench_metrics(
+        loaded_model=loaded,
+        suite=suite,
+        parameters={"context_lengths": "8", "repeats": "3", "max_output_tokens": "1"},
+        job_id="shape-reuse",
+        source_repo="local",
+        task_kind="text-generation",
+    )
+    assert len(context_rows) == 3
+    assert shape_calls == [(suite.cases[0].prompt, 8)]
+
     with pytest.raises(ModelOperationError):
         core._measure_text_bench_sample(
             loaded_model=core._registry.load_model(WorkerModelCatalog.dev_text_model()),

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -2526,6 +2526,7 @@ class MaintenanceCore:
                         loaded_model=loaded_model,
                         suite=suite,
                         prompt=shaped_prompt,
+                        prompt_is_shaped=True,
                         parameters=parameters,
                         context_length=context_length,
                         repeat_index=repeat_index,
@@ -2671,9 +2672,10 @@ class MaintenanceCore:
         reasoning_mode: str,
         structured_output_mode: str,
         dataset_materialize_ms: float = 0.0,
+        prompt_is_shaped: bool = False,
     ) -> BenchSample:
         runtime = self._registry.runtime_for_loaded_model(loaded_model)
-        shaped_prompt = self._shape_benchmark_prompt(prompt, context_length=context_length)
+        shaped_prompt = prompt if prompt_is_shaped else self._shape_benchmark_prompt(prompt, context_length=context_length)
         execution_ext = self._benchmark_execution_ext(
             cache_profile=cache_profile,
             context_length=context_length,


### PR DESCRIPTION
## Summary
- Reuses already-shaped text benchmark prompts when measuring repeated maintenance benchmark samples.
- Adds a focused regression assertion that `_shape_benchmark_prompt(...)` runs once per `(case, context_length)` instead of once per repeat plus the initial shape.
- Adds a lightweight implementation plan documenting the Linux verification path and scoped probe.

## Plan or Spec
- `docs/plans/maintenance-text-bench-prompt-shape-reuse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_prompt_shape_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 3 passed in 1.80s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_prompt_shape_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_maintenance_service.py
# TOTAL 12 0 100%

python /tmp/maintenance_prompt_shape_reuse_probe.py on detached origin/main and this branch
# origin/main: {"elapsed_ms_mean": 6.351689, "row_count_mean": 3.0, "sample_count": 7.0, "shape_calls_mean": 4.0}
# branch:      {"elapsed_ms_mean": 4.618086, "row_count_mean": 3.0, "sample_count": 7.0, "shape_calls_mean": 1.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 <registered maintenance-prompt-shape-vector-repeat probe command>
# {"context_count": 3.0, "elapsed_ms_mean": 157.263922, "iteration_count": 120.0, "sample_count": 5.0, "token_count_mean": 5160960.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%` for `maintenance_core.py` and `test_maintenance_service.py`.
- Local structural/perf probe: shape calls reduced from `4.0` to `1.0` for one case/context with three repeats; mean elapsed time changed from `6.351689 ms` to `4.618086 ms` on the same synthetic workload.
- Registered scoped CI probe: `maintenance-prompt-shape-vector-repeat`.

## Known Gaps
- Full `make py-test`, Swift tests, and macOS-specific checks were not run on this Linux cron host.
- Hosted PR-scoped performance and broader CI are expected to provide additive validation after PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
