### PR TITLE
perf: avoid copying real model source environment

### DIFF
--- a/scripts/real_model_support.py
+++ b/scripts/real_model_support.py
@@ -77,7 +77,7 @@ def resolve_real_small_text_model_source(
     allow_managed_root: bool = True,
     allow_hf_cache: bool = False,
 ) -> RealSmallTextModelSource:
-    env = dict(os.environ if environment is None else environment)
+    env = os.environ if environment is None else environment
     resolved_model_id = model_id.strip() or REAL_SMALL_TEXT_MODEL_ID
     warnings: list[str] = []
 


### PR DESCRIPTION
## Summary
- Avoid copying the environment mapping on every real-small-model source resolution.
- Keep lookup semantics unchanged while reducing per-call allocation in the registered Hugging Face cache fallback path.

## Plan or Spec
- N/A: this is a small registered performance-slice implementation for `scripts/real_model_support.py`; it does not change product behavior or workflow.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics
# exit 0; 5 passed in 1.32s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/real_model_support.py tests/test_real_model_support.py scripts/real_model_support_hf_cache_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; 5 passed in 1.61s; changed-scope coverage TOTAL 1 0 100%

for label in old new; do ... PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/real_model_support_hf_cache_probe.py ...; done
# exit 0; old/new probe sampled three times each, see metrics below

git diff --check
# exit 0
```

## Coverage and Metrics
- Registered probe: `real-model-support-hf-cache-latest-snapshot` covers `scripts/real_model_support.py` with focused test, coverage, and probe commands in `infra/perf/pr_scoped_probes.json`.
- Changed-scope coverage: 100% (`scripts/real_model_support.py` line 80 covered; aggregate TOTAL 1 0 100%).
- Local Linux registered probe samples:
  - old elapsed means: 18.207622 ms, 17.215212 ms, 17.347344 ms (`old_mean=17.590059 ms`)
  - new elapsed means: 19.488867 ms, 18.295487 ms, 17.245004 ms (`new_mean=18.343119 ms`, `delta=+0.753060 ms`, within the probe's 5% warning band but not a local latency win)
  - old peak mean: 4894.0 bytes; new peak mean: 4710.0 bytes (`delta=-184 bytes`, `-3.7597%`)
- CI PR-scoped performance must provide the merge-gating registered probe validation.

## Known Gaps
- Local Linux timing is noisy for this tiny allocation slice; the consistent local improvement is peak traced allocation, while elapsed mean was not faster in the three-sample comparison.
- Full repository test matrix is left to GitHub Actions.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated.
- [x] Protocol changes include regenerated generated artifacts, or N/A (no protocol changes).
- [x] Dependency changes include updated lockfiles, or N/A (no dependency changes).
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
