### PR TITLE
perf: short-circuit hub catalog card tag checks

### DIFF
--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -294,6 +294,22 @@ def test_is_mlx_compatible_preserves_card_data_tag_signal_after_fast_paths() -> 
     ) is True
 
 
+def test_is_mlx_compatible_short_circuits_card_tag_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    def card_tags():
+        yield "MLX"
+        raise AssertionError("card tag fallback should stop after the first MLX tag")  # pragma: no cover
+
+    monkeypatch.setattr(hub_catalog_module, "_string_list", lambda _value: card_tags())
+
+    assert _is_mlx_compatible(
+        repo_id="plain/card-tagged-model",
+        tags=["transformers"],
+        library_name="transformers",
+        card_data={"tags": ["MLX", "transformers"]},
+        lowered_tags={"transformers"},
+    ) is True
+
+
 def test_is_mlx_compatible_skips_empty_card_tag_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     string_list = Mock(side_effect=AssertionError("empty cardData.tags should not be normalized"))
     monkeypatch.setattr(hub_catalog_module, "_string_list", string_list)

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -417,7 +417,7 @@ def _is_mlx_compatible(
     card_tags = card_data.get("tags")
     if not card_tags:
         return False
-    return "mlx" in {tag.lower() for tag in _string_list(card_tags)}
+    return any(tag.lower() == "mlx" for tag in _string_list(card_tags))
 
 
 def _local_fit_evidence(


### PR DESCRIPTION
## Summary
- Optimizes Hub catalog card-data MLX tag fallback checks by short-circuiting once the first `MLX` tag is found.
- Adds a regression test that fails if the fallback consumes later card tags after an early match.

## Plan or Spec
- Python-only Linux-safe optimization slice in `worker/model_ops/hub_catalog.py`.
- Keep existing `_is_mlx_compatible(...)` semantics while avoiding a full lowercase set materialization for `cardData.tags` fallback.
- Verification path uses the existing registered PR-scoped performance probe `hub-catalog-tag-normalization-single-pass`, which already watches the touched Hub catalog source/tests and runs changed-scope coverage.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py`
- `python3 /tmp/hub_card_tag_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/hub_catalog_tag_normalization_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `45 passed in 0.26s`.
- Changed-scope coverage: `TOTAL 6 0 100%`.
- Local synthetic card-tag fallback probe (`257` tags, early `MLX`, `200000` iterations, `7` samples):
  - old set-materializing fallback mean: `22145.865 ms`
  - new short-circuit fallback mean: `603.709 ms`
  - elapsed improvement: `97.27%` lower
  - old peak traced bytes mean: `22998`
  - new peak traced bytes mean: `752`
  - peak traced allocation improvement: `96.73%` lower
- Existing registered scoped probe local run (`hub-catalog-tag-normalization-single-pass`): `elapsed_ms_mean=256.337`, `peak_bytes_mean=8748506.4`, `record_count=5000`, `tag_normalization_calls_mean=5000`.

## Known Gaps
- Linux host: no macOS/Swift checks were run locally.
- The registered scoped probe is the existing Hub catalog probe; the direct card-tag short-circuit measurement is a local synthetic probe because no registry edit was needed for source/test watch coverage.

## Evidence Checklist
- [x] Focused tests pass locally.
- [x] Changed executable scope coverage is at least 95% (`100%`).
- [x] Explicit local performance measurement includes concrete before/after numbers.
- [x] `git diff --check` passes.
- [x] PR-scoped performance probe identified: `hub-catalog-tag-normalization-single-pass`.
