### PR TITLE
perf: unpack deterministic embedding digest words

### DIFF
--- a/docs/plans/2026-05-08-deterministic-embedding-digest-struct-unpack.md
+++ b/docs/plans/2026-05-08-deterministic-embedding-digest-struct-unpack.md
@@ -1,0 +1,39 @@
+# Deterministic Embedding Digest Struct Unpack
+
+## Goal
+
+Reduce per-vector integer decoding overhead in deterministic embedding digest projection while preserving exact deterministic vector values.
+
+## Linux-only constraint
+
+This is a Python worker-runtime slice. It can be validated on Linux with focused pytest, changed-scope coverage, and a local registered PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/embedding_backends.py`
+- `docs/plans/2026-05-08-deterministic-embedding-digest-struct-unpack.md`
+
+## Optimization hypothesis
+
+`DeterministicEmbeddingBackend._project_digest(...)` derives eight little-endian `uint32` values from a SHA-256 digest. The previous loop sliced four bytes at a time and called `int.from_bytes(...)` for each chunk. Because SHA-256 always returns exactly 32 bytes, a single `struct.unpack("<8I", digest)` can decode the eight integers without per-chunk slice allocations and repeated conversion dispatch.
+
+The rest of the projection remains unchanged: base values, squared-sum normalization, rounding, repeat expansion, and zero-norm fallback all preserve the existing deterministic embedding contract.
+
+## Performance probe
+
+Use the existing registered PR-scoped probe `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json`. It already has focused `test_command`, `coverage_command`, and `probe_command` entries for `embedding_backends.py`.
+
+The probe reports:
+
+- `elapsed_ms_mean` — lower is better
+- `peak_bytes_mean` — lower is better
+- `vector_count` / `dimensions` — workload context
+
+Success means exact projection parity tests remain green, changed-scope coverage stays at or above 95%, and the registered probe shows a lower elapsed mean without checksum drift.
+
+## Verification commands
+
+- Focused pytest from the registered probe command.
+- Changed-scope coverage from the registered probe command.
+- Local registered probe via `scripts/pr_scoped_performance_run.py --probe-id deterministic-embedding-project-digest-allocation`.
+- `git diff --check`.

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import hashlib
 import math
+import struct
 import unicodedata
 
 
@@ -44,11 +45,8 @@ class DeterministicEmbeddingBackend:
         digest = hashlib.sha256(seed_text.encode("utf-8")).digest()
         base_values: list[float] = []
         base_squared_sum = 0.0
-        for start in range(0, len(digest), 4):
-            value = (
-                (int.from_bytes(digest[start : start + 4], "little") / 0xFFFFFFFF) * 2.0
-                - 1.0
-            )
+        for raw in struct.unpack("<8I", digest):
+            value = (raw / 0xFFFFFFFF) * 2.0 - 1.0
             base_values.append(value)
             base_squared_sum += value * value
         base_count = len(base_values)


### PR DESCRIPTION
## Summary
- Decode the eight SHA-256 digest words for deterministic embedding projection with one `struct.unpack("<8I", digest)` call instead of slicing four bytes and calling `int.from_bytes(...)` per word.
- Keeps projection normalization, rounding, output dimensions, and deterministic checksums unchanged.

## Plan or Spec
- `docs/plans/2026-05-08-deterministic-embedding-digest-struct-unpack.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo
# exit 0; 16 passed in 11.62s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
# exit 0; 16 passed in 37.56s; TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
# exit 0; {"checksum": 0.348915, "dimensions": 4096.0, "elapsed_ms_mean": 24.304983, "peak_bytes_mean": 66938.333333, "sample_count": 3.0, "vector_count": 500.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-project-digest-allocation --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-deterministic-embedding-local-bindings-20260508160510 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-scheduled-slice-20260508160510 --output /tmp/deterministic-embedding-digest-struct-pr-probe.json
# exit 0; head verification 17 passed; changed-scope coverage TOTAL 3 0 100%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for `embedding_backends.py` changed lines plus registered probe/test paths.
- Registered probe: `deterministic-embedding-project-digest-allocation`.
- Local PR-scoped probe comparison:
  - base `elapsed_ms_mean=25.952592`, `peak_bytes_mean=66667.666667`, `checksum=0.348915`
  - head `elapsed_ms_mean=18.700693`, `peak_bytes_mean=66938.333333`, `checksum=0.348915`
  - elapsed delta: `-7.251899 ms` (~27.94% faster); checksum unchanged. Peak bytes were effectively flat/slightly higher by 270.666666 bytes (~0.41%).
- CI PR-scoped performance workflow is required as the registered probe validation source before merge.

## Known Gaps
- Local validation is Linux-only and synthetic; real MLX embedding runtime effects are outside this Python deterministic probe slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
