### PR TITLE
Add desktop evidence report surfaces

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -2,6 +2,7 @@ import AppKit
 import Charts
 import MelixCLICore
 import SwiftUI
+import UniformTypeIdentifiers
 
 @MainActor
 struct DesktopWorkspaceShellView: View {
@@ -3854,9 +3855,20 @@ struct DesktopDiagnosticsToolSectionView: View {
     static let emptyEvaluationTitle = "No Evaluation Results Yet"
     static let emptyEvaluationDetail = "Run Evaluation to inspect scores and sample previews."
 
+    private enum EvidenceRowLimit {
+        static let metrics = 6
+        static let runs = 8
+        static let probes = 10
+        static let telemetry = 8
+        static let processes = 8
+        static let artifacts = 12
+        static let gaps = 6
+    }
+
     let viewModel: RuntimeViewModel
     let foundation: DesktopFoundationState
     @State private var selectedStage: DesktopDiagnosticsStage
+    @State private var evidenceReportFilter = ""
 
     init(viewModel: RuntimeViewModel, foundation: DesktopFoundationState) {
         self.viewModel = viewModel
@@ -4239,6 +4251,449 @@ struct DesktopDiagnosticsToolSectionView: View {
         return "\(entry.taskTitle) • \(selectedSource) • \(entry.datasetID)"
     }
 
+    @ViewBuilder
+    private var evidenceReportSections: some View {
+        if let report = viewModel.evidenceReport {
+            DesktopEditorialSectionCard("Run Evidence Report") {
+                VStack(alignment: .leading, spacing: 12) {
+                    evidenceReportControlRow(report: report)
+                    evidenceReportStatusRows
+                    DesktopPassiveHeadlineButton(
+                        title: "\(report.reportKindText) • \(report.reportID)"
+                    )
+                    Text("\(report.generatedAtText) • \(report.identityText)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                    snapshotMetricGrid(
+                        items: report.summaryItems.map {
+                            DesktopEditorialMetricItem(
+                                title: $0.title,
+                                value: $0.value,
+                                detail: $0.detail
+                            )
+                        }
+                    )
+                    evidenceReportFilterField
+                    evidenceMetricRows(
+                        report.metricRows(matching: evidenceReportFilter)
+                            .prefix(EvidenceRowLimit.metrics)
+                    )
+                    evidenceGapRows(report)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            DesktopEditorialSectionCard("Run History") {
+                VStack(alignment: .leading, spacing: 10) {
+                    if report.runRows.isEmpty {
+                        DesktopInlineEmptyStateView(
+                            title: "No run evidence",
+                            detail: "Structured report has no run rows.",
+                            symbolName: "clock.badge.questionmark"
+                        )
+                    } else {
+                        ForEach(report.runRows.prefix(EvidenceRowLimit.runs)) { row in
+                            evidenceRunRow(row)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            DesktopEditorialSectionCard("Runtime Diagnostics") {
+                VStack(alignment: .leading, spacing: 10) {
+                    if report.probeRows.isEmpty {
+                        DesktopInlineEmptyStateView(
+                            title: "No probe timeline",
+                            detail: "Structured report did not include probe phase summaries.",
+                            symbolName: "waveform.path.ecg"
+                        )
+                    } else {
+                        ForEach(report.probeRows.prefix(EvidenceRowLimit.probes)) { row in
+                            evidenceProbeRow(row)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            DesktopEditorialSectionCard("Hardware Monitor") {
+                VStack(alignment: .leading, spacing: 12) {
+                    if report.telemetryRows.isEmpty {
+                        DesktopInlineEmptyStateView(
+                            title: "No Apple Silicon telemetry",
+                            detail: "Structured report did not include hardware telemetry rows.",
+                            symbolName: "cpu"
+                        )
+                    } else {
+                        ForEach(report.telemetryRows.prefix(EvidenceRowLimit.telemetry)) { row in
+                            evidenceTelemetryRow(row)
+                        }
+                    }
+
+                    if report.processRows.isEmpty == false {
+                        Divider()
+                        Text("Process Attribution")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        ForEach(report.processRows.prefix(EvidenceRowLimit.processes)) { row in
+                            evidenceProcessRow(row)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            DesktopEditorialSectionCard("Evidence Artifacts") {
+                VStack(alignment: .leading, spacing: 10) {
+                    if report.artifactRows.isEmpty {
+                        DesktopInlineEmptyStateView(
+                            title: "No artifact paths",
+                            detail: "Structured report did not include report, CSV, probe, or telemetry artifacts.",
+                            symbolName: "doc.badge.questionmark"
+                        )
+                    } else {
+                        ForEach(
+                            report.artifactRows(matching: evidenceReportFilter)
+                                .prefix(EvidenceRowLimit.artifacts)
+                        ) { row in
+                            evidenceArtifactRow(row)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        } else if viewModel.evidenceReportLoadError.isEmpty == false {
+            DesktopEditorialSectionCard("Run Evidence Report") {
+                VStack(alignment: .leading, spacing: 12) {
+                    evidenceReportControlRow(report: nil)
+                    evidenceReportStatusRows
+                    DesktopInlineEmptyStateView(
+                        title: "Evidence report failed to load",
+                        detail: viewModel.evidenceReportLoadError,
+                        symbolName: "exclamationmark.triangle"
+                    )
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        } else {
+            DesktopEditorialSectionCard("Run Evidence Report") {
+                VStack(alignment: .leading, spacing: 12) {
+                    evidenceReportControlRow(report: nil)
+                    evidenceReportStatusRows
+                    DesktopInlineEmptyStateView(
+                        title: "No structured report loaded",
+                        detail: "Load a report JSON artifact to inspect run evidence, probe phases, telemetry, and exports.",
+                        symbolName: "doc.text.magnifyingglass"
+                    )
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private var evidenceReportStatusRows: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if viewModel.evidenceReportSourcePath.isEmpty == false {
+                Text(viewModel.evidenceReportSourcePath)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+            if viewModel.evidenceReportLoadError.isEmpty == false {
+                Text(viewModel.evidenceReportLoadError)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+            if viewModel.evidenceReportOpenError.isEmpty == false {
+                Text(viewModel.evidenceReportOpenError)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private var evidenceReportFilterField: some View {
+        TextField("Filter report rows", text: $evidenceReportFilter)
+            .textFieldStyle(.roundedBorder)
+    }
+
+    private func evidenceReportControlRow(report: RuntimeEvidenceReportState?) -> some View {
+        HStack(spacing: 8) {
+            Button(action: loadEvidenceReportFromPicker) {
+                Label("Load Report JSON", systemImage: "doc.badge.plus")
+            }
+            Button(action: clearEvidenceReportSelection) {
+                Label("Clear", systemImage: "xmark.circle")
+            }
+            .disabled(report == nil && viewModel.evidenceReportLoadError.isEmpty && viewModel.evidenceReportOpenError.isEmpty)
+
+            if let markdownPath = report?.markdownReportPath {
+                Button(action: { openEvidenceArtifact(path: markdownPath, opener: NSWorkspace.shared.open) }) {
+                    Label("Open Markdown", systemImage: "doc.richtext")
+                }
+            }
+
+            if let report, report.csvArtifactRows.isEmpty == false {
+                Menu {
+                    ForEach(report.csvArtifactRows) { row in
+                        Button(row.kindText) {
+                            openEvidenceArtifact(path: row.path, opener: NSWorkspace.shared.open)
+                        }
+                    }
+                } label: {
+                    Label("Open CSV", systemImage: "tablecells")
+                }
+            }
+        }
+    }
+
+    private func loadEvidenceReportFromPicker() {
+        guard let url = Self.selectEvidenceReportURL() else {
+            return
+        }
+        Task {
+            await loadEvidenceReport(from: url)
+        }
+    }
+
+    @MainActor
+    private static func selectEvidenceReportURL() -> URL? {
+        let panel = NSOpenPanel()
+        panel.title = "Load Evidence Report JSON"
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.json]
+
+        return panel.runModal() == .OK ? panel.url : nil
+    }
+
+    @MainActor
+    private func loadEvidenceReport(from url: URL) async {
+        do {
+            try await viewModel.loadEvidenceReport(from: url)
+            evidenceReportFilter = ""
+        } catch {
+            viewModel.recordEvidenceReportLoadError(error)
+        }
+    }
+
+    private func clearEvidenceReportSelection() {
+        evidenceReportFilter = ""
+        viewModel.clearEvidenceReport()
+    }
+
+    func openEvidenceArtifact(path: String, opener: (URL) -> Bool) {
+        let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedPath.isEmpty == false else {
+            viewModel.recordEvidenceReportOpenError("Evidence artifact path is empty.")
+            return
+        }
+
+        let opened = opener(URL(fileURLWithPath: trimmedPath))
+        if opened {
+            viewModel.clearEvidenceReportOpenError()
+        } else {
+            viewModel.recordEvidenceReportOpenError("Could not open evidence artifact at \(trimmedPath).")
+        }
+    }
+
+    @ViewBuilder
+    private func evidenceMetricRows(_ rows: ArraySlice<RuntimeEvidenceReportMetricRow>) -> some View {
+        if rows.isEmpty == false {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Gate Metrics")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                ForEach(Array(rows)) { row in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text(row.metric)
+                                .font(.headline)
+                                .lineLimit(1)
+                            Spacer()
+                            Text(row.resultText)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                        }
+                        Text("\(row.statusText) • \(row.directionText) • \(row.deltaText)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+                    .background(
+                        Color.secondary.opacity(DesktopLoRAVisualPolish.sectionSurfaceOpacity),
+                        in: RoundedRectangle(cornerRadius: 12)
+                    )
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func evidenceGapRows(_ report: RuntimeEvidenceReportState) -> some View {
+        let gaps = Array((report.knownGapRows + report.instrumentationGapRows).prefix(EvidenceRowLimit.gaps))
+        if gaps.isEmpty == false {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Instrumentation Gaps")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                ForEach(Array(gaps.enumerated()), id: \.offset) { _, gap in
+                    Text(gap)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+    }
+
+    private func evidenceRunRow(_ row: RuntimeEvidenceReportRunRow) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack {
+                Text("\(row.side) • \(row.runID)")
+                    .font(.headline)
+                Spacer()
+                Text(row.statusText)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            Text("\(row.runKindText) • \(row.durationText) • \(row.targetText)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if row.issueText.isEmpty == false {
+                Text(row.issueText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if row.artifactRoot.isEmpty == false {
+                Text(row.artifactRoot)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(
+            Color.secondary.opacity(DesktopLoRAVisualPolish.sectionSurfaceOpacity),
+            in: RoundedRectangle(cornerRadius: 12)
+        )
+    }
+
+    private func evidenceProbeRow(_ row: RuntimeEvidenceReportProbeRow) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack {
+                Text("\(row.kind) • \(row.component) • \(row.phase)")
+                    .font(.headline)
+                Spacer()
+                Text(row.durationText)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            Text("\(row.side) • \(row.runID) • \(row.statusText)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if row.detailText.isEmpty == false {
+                Text(row.detailText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(
+            Color.secondary.opacity(DesktopLoRAVisualPolish.sectionSurfaceOpacity),
+            in: RoundedRectangle(cornerRadius: 12)
+        )
+    }
+
+    private func evidenceTelemetryRow(_ row: RuntimeEvidenceReportTelemetryRow) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack {
+                Text("\(row.side) • \(row.runID)")
+                    .font(.headline)
+                Spacer()
+                Text(row.collectorStatusText)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            Text(row.powerText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text([row.utilizationText, row.memoryText].filter { $0.isEmpty == false }.joined(separator: " • "))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if row.failureText.isEmpty == false {
+                Text(row.failureText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(
+            Color.secondary.opacity(DesktopLoRAVisualPolish.sectionSurfaceOpacity),
+            in: RoundedRectangle(cornerRadius: 12)
+        )
+    }
+
+    private func evidenceProcessRow(_ row: RuntimeEvidenceReportProcessRow) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("\(row.roleText) • \(row.nameText)")
+                    .font(.headline)
+                Spacer()
+                Text(row.side)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            Text("\(row.runID) • \(row.pidText)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if row.resourceText.isEmpty == false {
+                Text(row.resourceText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(
+            Color.secondary.opacity(DesktopLoRAVisualPolish.sectionSurfaceOpacity),
+            in: RoundedRectangle(cornerRadius: 12)
+        )
+    }
+
+    private func evidenceArtifactRow(_ row: RuntimeEvidenceReportArtifactRow) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(row.kindText)
+                    .font(.headline)
+                Spacer()
+                Text(row.detailText)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            Text(row.path)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(
+            Color.secondary.opacity(DesktopLoRAVisualPolish.sectionSurfaceOpacity),
+            in: RoundedRectangle(cornerRadius: 12)
+        )
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             DesktopEditorialSectionCard("Diagnostics Actions") {
@@ -4310,6 +4765,8 @@ struct DesktopDiagnosticsToolSectionView: View {
             DesktopEditorialSectionCard(diagnosticsSnapshotTitle) {
                 diagnosticsSnapshotContent
             }
+
+            evidenceReportSections
 
             if selectedStage != .evaluation {
                 DesktopEditorialSectionCard(selectedStage == .matrix ? "Matrix Configuration" : "Bench Configuration") {

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeEvidenceReportState.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeEvidenceReportState.swift
@@ -1,0 +1,1021 @@
+import Foundation
+import MelixControlPlaneCore
+
+public enum RuntimeEvidenceReportDecodeError: Error, LocalizedError, Equatable, Sendable {
+    case invalidJSON(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidJSON(let message):
+            return message
+        }
+    }
+}
+
+public struct RuntimeEvidenceReportSummaryItem: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let title: String
+    public let value: String
+    public let detail: String
+}
+
+public struct RuntimeEvidenceReportRunRow: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let side: String
+    public let runID: String
+    public let statusText: String
+    public let runKindText: String
+    public let durationText: String
+    public let targetText: String
+    public let artifactRoot: String
+    public let issueText: String
+}
+
+public struct RuntimeEvidenceReportMetricRow: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let metric: String
+    public let resultText: String
+    public let statusText: String
+    public let directionText: String
+    public let baselineText: String
+    public let candidateText: String
+    public let deltaText: String
+}
+
+public struct RuntimeEvidenceReportProbeRow: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let side: String
+    public let kind: String
+    public let runID: String
+    public let component: String
+    public let phase: String
+    public let durationText: String
+    public let statusText: String
+    public let detailText: String
+}
+
+public struct RuntimeEvidenceReportTelemetryRow: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let side: String
+    public let runID: String
+    public let collectorStatusText: String
+    public let powerText: String
+    public let utilizationText: String
+    public let memoryText: String
+    public let failureText: String
+}
+
+public struct RuntimeEvidenceReportProcessRow: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let side: String
+    public let runID: String
+    public let roleText: String
+    public let nameText: String
+    public let pidText: String
+    public let resourceText: String
+}
+
+public struct RuntimeEvidenceReportArtifactRow: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let kindText: String
+    public let path: String
+    public let detailText: String
+}
+
+public struct RuntimeEvidenceReportState: Equatable, Sendable {
+    public let schemaVersion: String
+    public let reportID: String
+    public let generatedAtText: String
+    public let reportKindText: String
+    public let identityText: String
+    public let summaryItems: [RuntimeEvidenceReportSummaryItem]
+    public let runRows: [RuntimeEvidenceReportRunRow]
+    public let metricRows: [RuntimeEvidenceReportMetricRow]
+    public let probeRows: [RuntimeEvidenceReportProbeRow]
+    public let telemetryRows: [RuntimeEvidenceReportTelemetryRow]
+    public let processRows: [RuntimeEvidenceReportProcessRow]
+    public let artifactRows: [RuntimeEvidenceReportArtifactRow]
+    public let csvArtifactRows: [RuntimeEvidenceReportArtifactRow]
+    public let knownGapRows: [String]
+    public let instrumentationGapRows: [String]
+
+    public var markdownReportPath: String? {
+        artifactRows.first { $0.kindText == "Markdown Report" }?.path
+    }
+
+    public func metricRows(matching query: String) -> [RuntimeEvidenceReportMetricRow] {
+        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard normalizedQuery.isEmpty == false else {
+            return metricRows
+        }
+        return metricRows.filter { row in
+            [
+                row.metric,
+                row.resultText,
+                row.statusText,
+                row.directionText,
+            ]
+            .contains { $0.lowercased().contains(normalizedQuery) }
+        }
+    }
+
+    public func artifactRows(matching query: String) -> [RuntimeEvidenceReportArtifactRow] {
+        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard normalizedQuery.isEmpty == false else {
+            return artifactRows
+        }
+        return artifactRows.filter { row in
+            [
+                row.kindText,
+                row.detailText,
+                row.path,
+            ]
+            .contains { $0.lowercased().contains(normalizedQuery) }
+        }
+    }
+
+    public static func decode(json: String) throws -> RuntimeEvidenceReportState {
+        try decode(data: Data(json.utf8))
+    }
+
+    public static func decode(data: Data) throws -> RuntimeEvidenceReportState {
+        do {
+            let payload = try JSONDecoder().decode(RuntimeEvidenceReportPayload.self, from: data)
+            return RuntimeEvidenceReportState(payload: payload)
+        } catch let error as RuntimeEvidenceReportDecodeError {
+            throw error
+        } catch {
+            throw RuntimeEvidenceReportDecodeError.invalidJSON(
+                "Evidence report JSON could not be decoded: \(error)"
+            )
+        }
+    }
+
+    private init(payload: RuntimeEvidenceReportPayload) {
+        schemaVersion = payload.schemaVersion
+        reportID = payload.reportID
+        generatedAtText = payload.generatedAt
+        reportKindText = Self.titleText(payload.reportKind)
+        identityText = [
+            Self.shortCommit(payload.melixCommit),
+            payload.gitBranch,
+            payload.dirtyWorktree ? "dirty" : "clean",
+        ]
+        .filter { $0.isEmpty == false }
+        .joined(separator: " | ")
+
+        let runs = payload.runs.map { Self.makeRunRow($0, targets: payload.targets) }
+            .sorted { lhs, rhs in
+                if lhs.side == rhs.side {
+                    return lhs.runID < rhs.runID
+                }
+                return Self.sideRank(lhs.side) < Self.sideRank(rhs.side)
+            }
+        runRows = runs
+
+        metricRows = payload.metrics
+            .map(Self.makeMetricRow)
+            .sorted { lhs, rhs in
+                if Self.resultRank(lhs.resultText) == Self.resultRank(rhs.resultText) {
+                    return lhs.metric < rhs.metric
+                }
+                return Self.resultRank(lhs.resultText) < Self.resultRank(rhs.resultText)
+            }
+
+        probeRows = Self.makeProbeRows(payload.probeSummary)
+        telemetryRows = Self.makeTelemetryRows(payload.telemetrySummary)
+        processRows = Self.makeProcessRows(payload.processAttribution)
+        artifactRows = Self.makeArtifactRows(payload.artifacts)
+        csvArtifactRows = artifactRows.filter { $0.detailText == "CSV export" }
+        knownGapRows = payload.knownGaps.sorted()
+        instrumentationGapRows = payload.instrumentationGaps.sorted()
+
+        let summary = payload.summary
+        let gate = payload.gateResult
+        summaryItems = [
+            RuntimeEvidenceReportSummaryItem(
+                id: "status",
+                title: "Report Status",
+                value: Self.titleText(summary.status),
+                detail: "\(summary.metricCount) metrics"
+            ),
+            RuntimeEvidenceReportSummaryItem(
+                id: "gate",
+                title: "Evidence Gate",
+                value: Self.titleText(gate.overallResult),
+                detail: "\(gate.blockingFailures.count) blocking | \(gate.informationalResults.count) informational"
+            ),
+            RuntimeEvidenceReportSummaryItem(
+                id: "runs",
+                title: "Runs",
+                value: "\(runs.count)",
+                detail: "\(payload.sourceEvidenceIDs.count) evidence IDs"
+            ),
+            RuntimeEvidenceReportSummaryItem(
+                id: "hardware",
+                title: "Hardware Telemetry",
+                value: telemetryRows.isEmpty ? "Missing" : "Available",
+                detail: "\(telemetryRows.filter { $0.failureText.isEmpty == false }.count) telemetry gaps"
+            ),
+        ]
+    }
+
+    private static func makeRunRow(
+        _ run: RuntimeEvidenceReportRunPayload,
+        targets: [RuntimeEvidenceReportTargetPayload]
+    ) -> RuntimeEvidenceReportRunRow {
+        let target = targets.first { $0.side == run.side && $0.runID == run.runID }
+        let issueText = [
+            run.failureSummary.compactSummary(prefix: "failure"),
+            run.fallbackSummary.compactSummary(prefix: "fallback"),
+        ]
+        .filter { $0.isEmpty == false }
+        .joined(separator: " | ")
+        return RuntimeEvidenceReportRunRow(
+            id: "\(run.side):\(run.runID)",
+            side: titleText(run.side),
+            runID: run.runID,
+            statusText: titleText(run.status),
+            runKindText: titleText(run.runKind),
+            durationText: durationText(milliseconds: Double(run.durationMS)),
+            targetText: [
+                target?.targetModelID ?? "",
+                target?.suiteID ?? "",
+                target?.taskKind ?? "",
+            ]
+            .filter { $0.isEmpty == false }
+            .joined(separator: " | "),
+            artifactRoot: run.artifactRoot,
+            issueText: issueText
+        )
+    }
+
+    private static func makeMetricRow(
+        _ row: RuntimeEvidenceReportMetricPayload
+    ) -> RuntimeEvidenceReportMetricRow {
+        RuntimeEvidenceReportMetricRow(
+            id: row.metric,
+            metric: row.metric,
+            resultText: titleText(row.result),
+            statusText: titleText(row.status),
+            directionText: titleText(row.direction),
+            baselineText: metricValueText(row.baseline),
+            candidateText: metricValueText(row.candidate),
+            deltaText: signedMetricValueText(row.delta, percent: row.deltaPercent)
+        )
+    }
+
+    private static func makeProbeRows(
+        _ summary: RuntimeEvidenceReportProbeSummaryPayload
+    ) -> [RuntimeEvidenceReportProbeRow] {
+        [
+            probeRows(for: "baseline", side: summary.baseline),
+            probeRows(for: "candidate", side: summary.candidate),
+        ]
+        .flatMap { $0 }
+        .sorted { lhs, rhs in
+            if probeKindRank(lhs.kind) == probeKindRank(rhs.kind) {
+                return lhs.durationText > rhs.durationText
+            }
+            return probeKindRank(lhs.kind) < probeKindRank(rhs.kind)
+        }
+    }
+
+    private static func probeRows(
+        for side: String,
+        side summary: RuntimeEvidenceReportProbeSidePayload
+    ) -> [RuntimeEvidenceReportProbeRow] {
+        let groups: [(String, [RuntimeEvidenceReportProbePhasePayload])] = [
+            ("Failed", summary.failedPhases),
+            ("Fallback", summary.fallbackPhases),
+            ("Skipped", summary.skippedPhases),
+            ("Slowest", summary.slowestPhases),
+        ]
+        return groups.flatMap { kind, phases in
+            phases.enumerated().map { index, phase in
+                RuntimeEvidenceReportProbeRow(
+                    id: "\(side):\(kind):\(phase.runID):\(phase.phase):\(index)",
+                    side: titleText(side),
+                    kind: kind,
+                    runID: phase.runID,
+                    component: titleText(phase.component),
+                    phase: titleText(phase.phase),
+                    durationText: durationText(milliseconds: phase.durationMS),
+                    statusText: titleText(phase.status),
+                    detailText: [
+                        phase.errorStage.isEmpty ? "" : "stage \(phase.errorStage)",
+                        phase.errorCode.isEmpty ? "" : "code \(phase.errorCode)",
+                    ]
+                    .filter { $0.isEmpty == false }
+                    .joined(separator: " | ")
+                )
+            }
+        }
+    }
+
+    private static func makeTelemetryRows(
+        _ summary: RuntimeEvidenceReportTelemetrySummaryPayload
+    ) -> [RuntimeEvidenceReportTelemetryRow] {
+        [
+            telemetryRows(for: "baseline", rows: summary.baseline),
+            telemetryRows(for: "candidate", rows: summary.candidate),
+        ]
+        .flatMap { $0 }
+        .sorted { lhs, rhs in
+            if lhs.side == rhs.side {
+                return lhs.runID < rhs.runID
+            }
+            return sideRank(lhs.side) < sideRank(rhs.side)
+        }
+    }
+
+    private static func telemetryRows(
+        for side: String,
+        rows: [RuntimeEvidenceReportTelemetryPayload]
+    ) -> [RuntimeEvidenceReportTelemetryRow] {
+        rows.map { row in
+            RuntimeEvidenceReportTelemetryRow(
+                id: "\(side):\(row.runID)",
+                side: titleText(side),
+                runID: row.runID,
+                collectorStatusText: titleText(row.collectorStatus),
+                powerText: powerText(row),
+                utilizationText: utilizationText(row),
+                memoryText: memoryText(row),
+                failureText: row.telemetryFailures.joined(separator: " | ")
+            )
+        }
+    }
+
+    private static func makeProcessRows(
+        _ attribution: RuntimeEvidenceReportProcessAttributionPayload
+    ) -> [RuntimeEvidenceReportProcessRow] {
+        [
+            processRows(for: "baseline", summaries: attribution.baseline),
+            processRows(for: "candidate", summaries: attribution.candidate),
+        ]
+        .flatMap { $0 }
+        .sorted { lhs, rhs in
+            if lhs.side == rhs.side {
+                return lhs.roleText < rhs.roleText
+            }
+            return sideRank(lhs.side) < sideRank(rhs.side)
+        }
+    }
+
+    private static func processRows(
+        for side: String,
+        summaries: [RuntimeEvidenceReportProcessSummaryPayload]
+    ) -> [RuntimeEvidenceReportProcessRow] {
+        summaries.flatMap { summary -> [RuntimeEvidenceReportProcessRow] in
+            let primary = summary.primaryRuntimeProcess.asRow(
+                side: side,
+                runID: summary.runID,
+                fallbackRole: "primary_runtime"
+            )
+            let control = summary.controlPlaneProcess.asRow(
+                side: side,
+                runID: summary.runID,
+                fallbackRole: "control_plane"
+            )
+            let workers = summary.workerProcesses.enumerated().compactMap { index, process in
+                process.asRow(side: side, runID: summary.runID, fallbackRole: "worker_\(index + 1)")
+            }
+            let external = summary.externalProviderProcesses.enumerated().compactMap { index, process in
+                process.asRow(side: side, runID: summary.runID, fallbackRole: "external_\(index + 1)")
+            }
+            return [primary, control].compactMap { $0 } + workers + external
+        }
+    }
+
+    private static func makeArtifactRows(
+        _ artifacts: RuntimeEvidenceReportArtifactsPayload
+    ) -> [RuntimeEvidenceReportArtifactRow] {
+        var rows: [RuntimeEvidenceReportArtifactRow] = []
+        appendArtifact(&rows, kind: "Report JSON", path: artifacts.reportJSONPath, detail: "Structured report")
+        appendArtifact(&rows, kind: "Markdown Report", path: artifacts.markdownReportPath, detail: "Markdown report")
+        appendArtifact(&rows, kind: "Evidence JSON", path: artifacts.evidenceJSONPath, detail: "Structured evidence")
+        for (name, path) in artifacts.csvExportPaths.sorted(by: { $0.key < $1.key }) {
+            appendArtifact(&rows, kind: titleText(name), path: path, detail: "CSV export")
+        }
+        appendArtifact(&rows, kind: "Probe Timeline", path: artifacts.probeTimelinePath, detail: "Probe data")
+        appendArtifact(&rows, kind: "Telemetry JSONL", path: artifacts.telemetryJSONLPath, detail: "Hardware samples")
+        for (index, path) in artifacts.rawOutputPaths.enumerated() {
+            appendArtifact(&rows, kind: "Raw Output \(index + 1)", path: path, detail: "Run artifact")
+        }
+        appendArtifact(&rows, kind: "Logs", path: artifacts.logsPath, detail: "Logs")
+        appendArtifact(&rows, kind: "Coverage", path: artifacts.coveragePath, detail: "Coverage")
+        return rows
+    }
+
+    private static func appendArtifact(
+        _ rows: inout [RuntimeEvidenceReportArtifactRow],
+        kind: String,
+        path: String,
+        detail: String
+    ) {
+        let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedPath.isEmpty == false else {
+            return
+        }
+        rows.append(
+            RuntimeEvidenceReportArtifactRow(
+                id: "\(kind):\(trimmedPath)",
+                kindText: kind,
+                path: trimmedPath,
+                detailText: detail
+            )
+        )
+    }
+
+    fileprivate static func titleText(_ raw: String) -> String {
+        let words = raw
+            .replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: "-", with: " ")
+            .split(separator: " ")
+        guard words.isEmpty == false else {
+            return "Unknown"
+        }
+        return words.map { word in
+            word.prefix(1).uppercased() + word.dropFirst()
+        }
+        .joined(separator: " ")
+    }
+
+    private static func shortCommit(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > 12 else {
+            return trimmed
+        }
+        return String(trimmed.prefix(12))
+    }
+
+    private static func sideRank(_ side: String) -> Int {
+        switch side.lowercased() {
+        case "baseline":
+            return 0
+        case "candidate":
+            return 1
+        default:
+            return 2
+        }
+    }
+
+    private static func resultRank(_ result: String) -> Int {
+        switch result.lowercased() {
+        case "fail":
+            return 0
+        case "informational":
+            return 1
+        case "pass":
+            return 2
+        default:
+            return 3
+        }
+    }
+
+    private static func probeKindRank(_ kind: String) -> Int {
+        switch kind.lowercased() {
+        case "failed":
+            return 0
+        case "fallback":
+            return 1
+        case "skipped":
+            return 2
+        default:
+            return 3
+        }
+    }
+
+    private static func metricValueText(_ value: Double?) -> String {
+        guard let value else {
+            return "-"
+        }
+        return String(format: "%.4f", value)
+    }
+
+    private static func signedMetricValueText(_ value: Double?, percent: Double?) -> String {
+        guard let value else {
+            return "-"
+        }
+        if let percent {
+            return String(format: "%+.4f (%+.2f%%)", value, percent)
+        }
+        return String(format: "%+.4f", value)
+    }
+
+    private static func durationText(milliseconds: Double) -> String {
+        if milliseconds >= 1_000 {
+            return String(format: "%.2f s", milliseconds / 1_000)
+        }
+        return String(format: "%.2f ms", milliseconds)
+    }
+
+    private static func powerText(_ row: RuntimeEvidenceReportTelemetryPayload) -> String {
+        let average = row.averageSystemPowerW.map { String(format: "%.2f W avg", $0) } ?? "system power missing"
+        let peak = row.peakSystemPowerW.map { String(format: "%.2f W peak", $0) } ?? ""
+        return [average, peak].filter { $0.isEmpty == false }.joined(separator: " | ")
+    }
+
+    private static func utilizationText(_ row: RuntimeEvidenceReportTelemetryPayload) -> String {
+        [
+            row.averageCPUUtilizationPercent.map { String(format: "CPU %.1f%%", $0) } ?? "",
+            row.averageGPUUtilizationPercent.map { String(format: "GPU %.1f%%", $0) } ?? "",
+            row.averageGPUFrequencyMHz.map { String(format: "GPU %.0f MHz", $0) } ?? "",
+        ]
+        .filter { $0.isEmpty == false }
+        .joined(separator: " | ")
+    }
+
+    private static func memoryText(_ row: RuntimeEvidenceReportTelemetryPayload) -> String {
+        [
+            row.memoryUsedBytes.map { "used \(byteText($0))" } ?? "",
+            row.memoryTotalBytes.map { "total \(byteText($0))" } ?? "",
+            row.peakProcessMemoryBytes.map { "process peak \(byteText($0))" } ?? "",
+        ]
+        .filter { $0.isEmpty == false }
+        .joined(separator: " | ")
+    }
+
+    fileprivate static func byteText(_ bytes: Int64) -> String {
+        let value = Double(bytes)
+        if value >= 1_073_741_824 {
+            return String(format: "%.2f GB", value / 1_073_741_824)
+        }
+        if value >= 1_048_576 {
+            return String(format: "%.2f MB", value / 1_048_576)
+        }
+        if value >= 1_024 {
+            return String(format: "%.2f KB", value / 1_024)
+        }
+        return "\(bytes) B"
+    }
+}
+
+private struct RuntimeEvidenceReportPayload: Decodable {
+    let schemaVersion: String
+    let reportID: String
+    let generatedAt: String
+    let melixCommit: String
+    let gitBranch: String
+    let dirtyWorktree: Bool
+    let sourceEvidenceIDs: [String]
+    let reportKind: String
+    let summary: RuntimeEvidenceReportSummaryPayload
+    let runs: [RuntimeEvidenceReportRunPayload]
+    let targets: [RuntimeEvidenceReportTargetPayload]
+    let metrics: [RuntimeEvidenceReportMetricPayload]
+    let probeSummary: RuntimeEvidenceReportProbeSummaryPayload
+    let telemetrySummary: RuntimeEvidenceReportTelemetrySummaryPayload
+    let processAttribution: RuntimeEvidenceReportProcessAttributionPayload
+    let gateResult: RuntimeEvidenceReportGateResultPayload
+    let artifacts: RuntimeEvidenceReportArtifactsPayload
+    let knownGaps: [String]
+    let instrumentationGaps: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case reportID = "report_id"
+        case generatedAt = "generated_at"
+        case melixCommit = "melix_commit"
+        case gitBranch = "git_branch"
+        case dirtyWorktree = "dirty_worktree"
+        case sourceEvidenceIDs = "source_evidence_ids"
+        case reportKind = "report_kind"
+        case summary
+        case runs
+        case targets
+        case metrics
+        case probeSummary = "probe_summary"
+        case telemetrySummary = "telemetry_summary"
+        case processAttribution = "process_attribution"
+        case gateResult = "gate_result"
+        case artifacts
+        case knownGaps = "known_gaps"
+        case instrumentationGaps = "instrumentation_gaps"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decodeIfPresent(String.self, forKey: .schemaVersion) ?? ""
+        reportID = try container.decodeIfPresent(String.self, forKey: .reportID) ?? ""
+        generatedAt = try container.decodeIfPresent(String.self, forKey: .generatedAt) ?? ""
+        melixCommit = try container.decodeIfPresent(String.self, forKey: .melixCommit) ?? ""
+        gitBranch = try container.decodeIfPresent(String.self, forKey: .gitBranch) ?? ""
+        dirtyWorktree = try container.decodeIfPresent(Bool.self, forKey: .dirtyWorktree) ?? false
+        sourceEvidenceIDs = try container.decodeIfPresent([String].self, forKey: .sourceEvidenceIDs) ?? []
+        reportKind = try container.decodeIfPresent(String.self, forKey: .reportKind) ?? ""
+        summary = try container.decodeIfPresent(RuntimeEvidenceReportSummaryPayload.self, forKey: .summary) ?? .empty
+        runs = try container.decodeIfPresent([RuntimeEvidenceReportRunPayload].self, forKey: .runs) ?? []
+        targets = try container.decodeIfPresent([RuntimeEvidenceReportTargetPayload].self, forKey: .targets) ?? []
+        metrics = try container.decodeIfPresent([RuntimeEvidenceReportMetricPayload].self, forKey: .metrics) ?? []
+        probeSummary = try container.decodeIfPresent(RuntimeEvidenceReportProbeSummaryPayload.self, forKey: .probeSummary) ?? .empty
+        telemetrySummary = try container.decodeIfPresent(RuntimeEvidenceReportTelemetrySummaryPayload.self, forKey: .telemetrySummary) ?? .empty
+        processAttribution = try container.decodeIfPresent(RuntimeEvidenceReportProcessAttributionPayload.self, forKey: .processAttribution) ?? .empty
+        gateResult = try container.decodeIfPresent(RuntimeEvidenceReportGateResultPayload.self, forKey: .gateResult) ?? .empty
+        artifacts = try container.decodeIfPresent(RuntimeEvidenceReportArtifactsPayload.self, forKey: .artifacts) ?? .empty
+        knownGaps = try container.decodeIfPresent([String].self, forKey: .knownGaps) ?? []
+        instrumentationGaps = try container.decodeIfPresent([String].self, forKey: .instrumentationGaps) ?? []
+    }
+}
+
+private struct RuntimeEvidenceReportSummaryPayload: Decodable {
+    let status: String
+    let metricCount: Int
+
+    static let empty = RuntimeEvidenceReportSummaryPayload(status: "", metricCount: 0)
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case metricCount = "metric_count"
+    }
+}
+
+private struct RuntimeEvidenceReportRunPayload: Decodable {
+    let side: String
+    let runID: String
+    let traceID: String
+    let runKind: String
+    let status: String
+    let durationMS: Int64
+    let artifactRoot: String
+    let failureSummary: [String: StructuredJSONValue]
+    let fallbackSummary: [String: StructuredJSONValue]
+
+    enum CodingKeys: String, CodingKey {
+        case side
+        case runID = "run_id"
+        case traceID = "trace_id"
+        case runKind = "run_kind"
+        case status
+        case durationMS = "duration_ms"
+        case artifactRoot = "artifact_root"
+        case failureSummary = "failure_summary"
+        case fallbackSummary = "fallback_summary"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        side = try container.decodeIfPresent(String.self, forKey: .side) ?? ""
+        runID = try container.decodeIfPresent(String.self, forKey: .runID) ?? ""
+        traceID = try container.decodeIfPresent(String.self, forKey: .traceID) ?? ""
+        runKind = try container.decodeIfPresent(String.self, forKey: .runKind) ?? ""
+        status = try container.decodeIfPresent(String.self, forKey: .status) ?? ""
+        durationMS = try container.decodeIfPresent(Int64.self, forKey: .durationMS) ?? 0
+        artifactRoot = try container.decodeIfPresent(String.self, forKey: .artifactRoot) ?? ""
+        failureSummary = try container.decodeIfPresent([String: StructuredJSONValue].self, forKey: .failureSummary) ?? [:]
+        fallbackSummary = try container.decodeIfPresent([String: StructuredJSONValue].self, forKey: .fallbackSummary) ?? [:]
+    }
+}
+
+private struct RuntimeEvidenceReportTargetPayload: Decodable {
+    let side: String
+    let runID: String
+    let targetModelID: String
+    let taskKind: String
+    let suiteID: String
+
+    enum CodingKeys: String, CodingKey {
+        case side
+        case runID = "run_id"
+        case targetModelID = "target_model_id"
+        case taskKind = "task_kind"
+        case suiteID = "suite_id"
+    }
+}
+
+private struct RuntimeEvidenceReportMetricPayload: Decodable {
+    let metric: String
+    let baseline: Double?
+    let candidate: Double?
+    let delta: Double?
+    let deltaPercent: Double?
+    let direction: String
+    let status: String
+    let result: String
+
+    enum CodingKeys: String, CodingKey {
+        case metric
+        case baseline
+        case candidate
+        case delta
+        case deltaPercent = "delta_percent"
+        case direction
+        case status
+        case result
+    }
+}
+
+private struct RuntimeEvidenceReportProbeSummaryPayload: Decodable {
+    let baseline: RuntimeEvidenceReportProbeSidePayload
+    let candidate: RuntimeEvidenceReportProbeSidePayload
+
+    static let empty = RuntimeEvidenceReportProbeSummaryPayload(
+        baseline: .empty,
+        candidate: .empty
+    )
+}
+
+private struct RuntimeEvidenceReportProbeSidePayload: Decodable {
+    let probeCount: Int
+    let slowestPhases: [RuntimeEvidenceReportProbePhasePayload]
+    let failedPhases: [RuntimeEvidenceReportProbePhasePayload]
+    let skippedPhases: [RuntimeEvidenceReportProbePhasePayload]
+    let fallbackPhases: [RuntimeEvidenceReportProbePhasePayload]
+
+    static let empty = RuntimeEvidenceReportProbeSidePayload(
+        probeCount: 0,
+        slowestPhases: [],
+        failedPhases: [],
+        skippedPhases: [],
+        fallbackPhases: []
+    )
+
+    enum CodingKeys: String, CodingKey {
+        case probeCount = "probe_count"
+        case slowestPhases = "slowest_phases"
+        case failedPhases = "failed_phases"
+        case skippedPhases = "skipped_phases"
+        case fallbackPhases = "fallback_phases"
+    }
+
+    init(
+        probeCount: Int,
+        slowestPhases: [RuntimeEvidenceReportProbePhasePayload],
+        failedPhases: [RuntimeEvidenceReportProbePhasePayload],
+        skippedPhases: [RuntimeEvidenceReportProbePhasePayload],
+        fallbackPhases: [RuntimeEvidenceReportProbePhasePayload]
+    ) {
+        self.probeCount = probeCount
+        self.slowestPhases = slowestPhases
+        self.failedPhases = failedPhases
+        self.skippedPhases = skippedPhases
+        self.fallbackPhases = fallbackPhases
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        probeCount = try container.decodeIfPresent(Int.self, forKey: .probeCount) ?? 0
+        slowestPhases = try container.decodeIfPresent([RuntimeEvidenceReportProbePhasePayload].self, forKey: .slowestPhases) ?? []
+        failedPhases = try container.decodeIfPresent([RuntimeEvidenceReportProbePhasePayload].self, forKey: .failedPhases) ?? []
+        skippedPhases = try container.decodeIfPresent([RuntimeEvidenceReportProbePhasePayload].self, forKey: .skippedPhases) ?? []
+        fallbackPhases = try container.decodeIfPresent([RuntimeEvidenceReportProbePhasePayload].self, forKey: .fallbackPhases) ?? []
+    }
+}
+
+private struct RuntimeEvidenceReportProbePhasePayload: Decodable {
+    let runID: String
+    let component: String
+    let phase: String
+    let durationMS: Double
+    let status: String
+    let errorStage: String
+    let errorCode: String
+
+    enum CodingKeys: String, CodingKey {
+        case runID = "run_id"
+        case component
+        case phase
+        case durationMS = "duration_ms"
+        case status
+        case errorStage = "error_stage"
+        case errorCode = "error_code"
+    }
+}
+
+private struct RuntimeEvidenceReportTelemetrySummaryPayload: Decodable {
+    let baseline: [RuntimeEvidenceReportTelemetryPayload]
+    let candidate: [RuntimeEvidenceReportTelemetryPayload]
+
+    static let empty = RuntimeEvidenceReportTelemetrySummaryPayload(baseline: [], candidate: [])
+}
+
+private struct RuntimeEvidenceReportTelemetryPayload: Decodable {
+    let runID: String
+    let collectorStatus: String
+    let telemetryFailures: [String]
+    let averageCPUUtilizationPercent: Double?
+    let averageGPUUtilizationPercent: Double?
+    let averageGPUFrequencyMHz: Double?
+    let averageSystemPowerW: Double?
+    let peakSystemPowerW: Double?
+    let memoryUsedBytes: Int64?
+    let memoryTotalBytes: Int64?
+    let peakProcessMemoryBytes: Int64?
+
+    enum CodingKeys: String, CodingKey {
+        case runID = "run_id"
+        case collectorStatus = "collector_status"
+        case telemetryFailures = "telemetry_failures"
+        case averageCPUUtilizationPercent = "average_cpu_utilization_percent"
+        case averageGPUUtilizationPercent = "average_gpu_utilization_percent"
+        case averageGPUFrequencyMHz = "average_gpu_frequency_mhz"
+        case averageSystemPowerW = "average_system_power_w"
+        case peakSystemPowerW = "peak_system_power_w"
+        case memoryUsedBytes = "memory_used_bytes"
+        case memoryTotalBytes = "memory_total_bytes"
+        case peakProcessMemoryBytes = "peak_process_memory_bytes"
+    }
+}
+
+private struct RuntimeEvidenceReportProcessAttributionPayload: Decodable {
+    let baseline: [RuntimeEvidenceReportProcessSummaryPayload]
+    let candidate: [RuntimeEvidenceReportProcessSummaryPayload]
+
+    static let empty = RuntimeEvidenceReportProcessAttributionPayload(baseline: [], candidate: [])
+}
+
+private struct RuntimeEvidenceReportProcessSummaryPayload: Decodable {
+    let runID: String
+    let primaryRuntimeProcess: RuntimeEvidenceReportProcessPayload
+    let controlPlaneProcess: RuntimeEvidenceReportProcessPayload
+    let workerProcesses: [RuntimeEvidenceReportProcessPayload]
+    let externalProviderProcesses: [RuntimeEvidenceReportProcessPayload]
+
+    enum CodingKeys: String, CodingKey {
+        case runID = "run_id"
+        case primaryRuntimeProcess = "primary_runtime_process"
+        case controlPlaneProcess = "control_plane_process"
+        case workerProcesses = "worker_processes"
+        case externalProviderProcesses = "external_provider_processes"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        runID = try container.decodeIfPresent(String.self, forKey: .runID) ?? ""
+        primaryRuntimeProcess = try container.decodeIfPresent(RuntimeEvidenceReportProcessPayload.self, forKey: .primaryRuntimeProcess) ?? .empty
+        controlPlaneProcess = try container.decodeIfPresent(RuntimeEvidenceReportProcessPayload.self, forKey: .controlPlaneProcess) ?? .empty
+        workerProcesses = try container.decodeIfPresent([RuntimeEvidenceReportProcessPayload].self, forKey: .workerProcesses) ?? []
+        externalProviderProcesses = try container.decodeIfPresent([RuntimeEvidenceReportProcessPayload].self, forKey: .externalProviderProcesses) ?? []
+    }
+}
+
+private struct RuntimeEvidenceReportProcessPayload: Decodable {
+    let pid: Int?
+    let name: String
+    let role: String
+    let port: Int?
+    let peakMemoryBytes: Int64?
+    let averageCPUPercent: Double?
+    let sampleCount: Int?
+
+    static let empty = RuntimeEvidenceReportProcessPayload(
+        pid: nil,
+        name: "",
+        role: "",
+        port: nil,
+        peakMemoryBytes: nil,
+        averageCPUPercent: nil,
+        sampleCount: nil
+    )
+
+    enum CodingKeys: String, CodingKey {
+        case pid
+        case name
+        case role
+        case port
+        case peakMemoryBytes = "peak_memory_bytes"
+        case averageCPUPercent = "avg_cpu_percent"
+        case sampleCount = "sample_count"
+    }
+
+    func asRow(
+        side: String,
+        runID: String,
+        fallbackRole: String
+    ) -> RuntimeEvidenceReportProcessRow? {
+        let effectiveName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let effectiveRole = role.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? fallbackRole : role
+        guard effectiveName.isEmpty == false || pid != nil else {
+            return nil
+        }
+        let pidText = pid.map { "pid \($0)" } ?? "pid unknown"
+        let portText = port.map { "port \($0)" } ?? ""
+        let memoryText = peakMemoryBytes.map { "peak \(RuntimeEvidenceReportState.byteText($0))" } ?? ""
+        let cpuText = averageCPUPercent.map { String(format: "CPU %.1f%%", $0) } ?? ""
+        let samplesText = sampleCount.map { "\($0) samples" } ?? ""
+        return RuntimeEvidenceReportProcessRow(
+            id: "\(side):\(runID):\(effectiveRole):\(pidText)",
+            side: RuntimeEvidenceReportState.titleText(side),
+            runID: runID,
+            roleText: RuntimeEvidenceReportState.titleText(effectiveRole),
+            nameText: effectiveName.isEmpty ? "Unknown process" : effectiveName,
+            pidText: [pidText, portText].filter { $0.isEmpty == false }.joined(separator: " | "),
+            resourceText: [memoryText, cpuText, samplesText].filter { $0.isEmpty == false }.joined(separator: " | ")
+        )
+    }
+}
+
+private struct RuntimeEvidenceReportGateResultPayload: Decodable {
+    let overallResult: String
+    let blockingFailures: [RuntimeEvidenceReportMetricPayload]
+    let informationalResults: [RuntimeEvidenceReportMetricPayload]
+
+    static let empty = RuntimeEvidenceReportGateResultPayload(
+        overallResult: "",
+        blockingFailures: [],
+        informationalResults: []
+    )
+
+    enum CodingKeys: String, CodingKey {
+        case overallResult = "overall_result"
+        case blockingFailures = "blocking_failures"
+        case informationalResults = "informational_results"
+    }
+}
+
+private struct RuntimeEvidenceReportArtifactsPayload: Decodable {
+    let evidenceJSONPath: String
+    let reportJSONPath: String
+    let markdownReportPath: String
+    let csvExportPaths: [String: String]
+    let probeTimelinePath: String
+    let telemetryJSONLPath: String
+    let rawOutputPaths: [String]
+    let logsPath: String
+    let coveragePath: String
+
+    static let empty = RuntimeEvidenceReportArtifactsPayload(
+        evidenceJSONPath: "",
+        reportJSONPath: "",
+        markdownReportPath: "",
+        csvExportPaths: [:],
+        probeTimelinePath: "",
+        telemetryJSONLPath: "",
+        rawOutputPaths: [],
+        logsPath: "",
+        coveragePath: ""
+    )
+
+    enum CodingKeys: String, CodingKey {
+        case evidenceJSONPath = "evidence_json_path"
+        case reportJSONPath = "report_json_path"
+        case markdownReportPath = "markdown_report_path"
+        case csvExportPaths = "csv_export_paths"
+        case probeTimelinePath = "probe_timeline_path"
+        case telemetryJSONLPath = "telemetry_jsonl_path"
+        case rawOutputPaths = "raw_output_paths"
+        case logsPath = "logs_path"
+        case coveragePath = "coverage_path"
+    }
+
+    init(
+        evidenceJSONPath: String,
+        reportJSONPath: String,
+        markdownReportPath: String,
+        csvExportPaths: [String: String],
+        probeTimelinePath: String,
+        telemetryJSONLPath: String,
+        rawOutputPaths: [String],
+        logsPath: String,
+        coveragePath: String
+    ) {
+        self.evidenceJSONPath = evidenceJSONPath
+        self.reportJSONPath = reportJSONPath
+        self.markdownReportPath = markdownReportPath
+        self.csvExportPaths = csvExportPaths
+        self.probeTimelinePath = probeTimelinePath
+        self.telemetryJSONLPath = telemetryJSONLPath
+        self.rawOutputPaths = rawOutputPaths
+        self.logsPath = logsPath
+        self.coveragePath = coveragePath
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        evidenceJSONPath = try container.decodeIfPresent(String.self, forKey: .evidenceJSONPath) ?? ""
+        reportJSONPath = try container.decodeIfPresent(String.self, forKey: .reportJSONPath) ?? ""
+        markdownReportPath = try container.decodeIfPresent(String.self, forKey: .markdownReportPath) ?? ""
+        csvExportPaths = try container.decodeIfPresent([String: String].self, forKey: .csvExportPaths) ?? [:]
+        probeTimelinePath = try container.decodeIfPresent(String.self, forKey: .probeTimelinePath) ?? ""
+        telemetryJSONLPath = try container.decodeIfPresent(String.self, forKey: .telemetryJSONLPath) ?? ""
+        rawOutputPaths = try container.decodeIfPresent([String].self, forKey: .rawOutputPaths) ?? []
+        logsPath = try container.decodeIfPresent(String.self, forKey: .logsPath) ?? ""
+        coveragePath = try container.decodeIfPresent(String.self, forKey: .coveragePath) ?? ""
+    }
+}
+
+private extension [String: StructuredJSONValue] {
+    func compactSummary(prefix: String) -> String {
+        let parts = sorted(by: { $0.key < $1.key }).compactMap { key, value -> String? in
+            switch value {
+            case .bool(false), .null:
+                return nil
+            case .string(let string):
+                return string.isEmpty ? nil : "\(key)=\(string)"
+            case .number(let number):
+                return number == 0 ? nil : "\(key)=\(String(format: "%.0f", number))"
+            case .bool(true):
+                return "\(key)=true"
+            case .array(let values):
+                return values.isEmpty ? nil : "\(key)=\(values.count)"
+            case .object(let object):
+                return object.isEmpty ? nil : "\(key)=\(object.count)"
+            }
+        }
+        guard parts.isEmpty == false else {
+            return ""
+        }
+        return "\(prefix): \(parts.joined(separator: ", "))"
+    }
+}

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -1867,6 +1867,10 @@ public final class RuntimeViewModel {
     public private(set) var evaluationMetricCards: [RuntimeEvaluationMetricCardState] = []
     public private(set) var evaluationSamplePreview: [RuntimeEvaluationSamplePreviewState] = []
     public private(set) var lastEvaluationExport: RuntimeEvaluationExportState?
+    public private(set) var evidenceReport: RuntimeEvidenceReportState?
+    public private(set) var evidenceReportLoadError = ""
+    public private(set) var evidenceReportOpenError = ""
+    public private(set) var evidenceReportSourcePath = ""
     public private(set) var adapterPackages: [RuntimeAdapterPackageState] = []
     public private(set) var trainingHistory: [RuntimeTrainingHistoryEntryState] = []
     public private(set) var loraExperimentGroups: [RuntimeLoraExperimentGroupState] = []
@@ -4716,6 +4720,49 @@ public final class RuntimeViewModel {
     public var selectedEvaluationHistoryEntry: RuntimeEvaluationHistoryEntryState? {
         evaluationHistory.first(where: { $0.jobID == selectedEvaluationHistoryJobID })
             ?? evaluationHistory.first
+    }
+
+    public func loadEvidenceReport(json: String) throws {
+        try loadEvidenceReport(json: json, sourcePath: "")
+    }
+
+    private func loadEvidenceReport(json: String, sourcePath: String) throws {
+        evidenceReport = try RuntimeEvidenceReportState.decode(json: json)
+        evidenceReportSourcePath = sourcePath
+        evidenceReportLoadError = ""
+        evidenceReportOpenError = ""
+        notifyStateChanged()
+    }
+
+    public func loadEvidenceReport(from url: URL) async throws {
+        let sourcePath = url.path
+        let json = try await Task.detached(priority: .userInitiated) {
+            try String(contentsOfFile: sourcePath, encoding: .utf8)
+        }.value
+        try loadEvidenceReport(json: json, sourcePath: sourcePath)
+    }
+
+    public func clearEvidenceReport() {
+        evidenceReport = nil
+        evidenceReportLoadError = ""
+        evidenceReportOpenError = ""
+        evidenceReportSourcePath = ""
+        notifyStateChanged()
+    }
+
+    public func recordEvidenceReportLoadError(_ error: Error) {
+        evidenceReportLoadError = error.localizedDescription
+        notifyStateChanged()
+    }
+
+    public func recordEvidenceReportOpenError(_ message: String) {
+        evidenceReportOpenError = message
+        notifyStateChanged()
+    }
+
+    public func clearEvidenceReportOpenError() {
+        evidenceReportOpenError = ""
+        notifyStateChanged()
     }
 
     private var selectedServerSessionID = ""

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeEvidenceReportStateTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeEvidenceReportStateTests.swift
@@ -1,0 +1,850 @@
+import Foundation
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import AppMain
+
+@Suite("Runtime Evidence Report State", .serialized)
+struct RuntimeEvidenceReportStateTests {
+    @Test("decodes report json into operator evidence rows")
+    func decodesReportJSONIntoOperatorEvidenceRows() throws {
+        let report = try RuntimeEvidenceReportState.decode(json: makeStructuredEvidenceReportJSON())
+
+        #expect(report.schemaVersion == "melix.benchmark_evaluation_report.v1")
+        #expect(report.reportID == "report-desktop-fixture")
+        #expect(report.summaryItems.map(\.id) == ["status", "gate", "runs", "hardware"])
+        #expect(report.runRows.map(\.statusText).contains("Completed"))
+        #expect(report.runRows.map(\.statusText).contains("Failed"))
+        #expect(report.runRows.map(\.statusText).contains("Fallback"))
+        #expect(report.metricRows.first?.resultText == "Fail")
+        #expect(report.probeRows.contains { $0.kind == "Failed" && $0.phase == "Decode" })
+        #expect(report.probeRows.contains { $0.kind == "Fallback" && $0.phase == "Fallback Enter" })
+        #expect(report.telemetryRows.contains { row in
+            row.collectorStatusText == "Partial"
+                && row.powerText.contains("17.50 W avg")
+                && row.failureText.contains("powermetrics_failed")
+        })
+        #expect(report.processRows.contains { row in
+            row.roleText == "Primary Runtime"
+                && row.nameText == "mlx-runner"
+                && row.resourceText.contains("CPU 12.5%")
+        })
+        #expect(report.metricRows(matching: "tokens").map(\.metric) == ["bench.smoke.tokens_per_second"])
+        #expect(report.artifactRows(matching: "telemetry").map(\.path).contains("/tmp/telemetry_summary.csv"))
+        #expect(report.markdownReportPath == "/tmp/report.md")
+        #expect(report.csvArtifactRows.map(\.kindText).contains("Telemetry Summary"))
+        #expect(report.artifactRows.contains { $0.kindText == "Markdown Report" })
+        #expect(report.instrumentationGapRows.contains("candidate:candidate-failed:powermetrics_failed:fixture"))
+    }
+
+    @Test("decodes sparse report defaults into explicit operator gaps")
+    func decodesSparseReportDefaultsIntoExplicitOperatorGaps() throws {
+        let report = try RuntimeEvidenceReportState.decode(json: makeSparseStructuredEvidenceReportJSON())
+
+        #expect(report.reportKindText == "Unknown")
+        #expect(report.summaryItems.first?.value == "Unknown")
+        #expect(report.metricRows.map(\.metric) == ["alpha.metric", "zeta.metric"])
+        #expect(report.metricRows.first?.baselineText == "-")
+        #expect(report.metricRows.first?.deltaText == "-")
+        #expect(report.telemetryRows.first?.memoryText.contains("512 B") == true)
+        #expect(report.processRows.contains { row in
+            row.roleText == "Worker 1"
+                && row.nameText == "Unknown process"
+                && row.resourceText.contains("512 B")
+        })
+        #expect(report.processRows.contains { $0.roleText == "External Provider" })
+        #expect(report.runRows.first?.issueText.contains("details=1") == true)
+
+        #expect(throws: RuntimeEvidenceReportDecodeError.self) {
+            try RuntimeEvidenceReportState.decode(data: Data("{".utf8))
+        }
+    }
+
+    @Test("diagnostics renders structured evidence report surfaces")
+    @MainActor
+    func diagnosticsRendersStructuredEvidenceReportSurfaces() async throws {
+        let viewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        viewModel.selectSurface(.tools)
+        viewModel.selectToolSection(.diagnostics)
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-render-report-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try makeStructuredEvidenceReportJSON().write(to: url, atomically: true, encoding: .utf8)
+        try await viewModel.loadEvidenceReport(from: url)
+        viewModel.recordEvidenceReportOpenError("fixture open warning")
+
+        let view = evidenceHostView(
+            DesktopDiagnosticsToolSectionView(
+                viewModel: viewModel,
+                foundation: viewModel.desktopFoundationState
+            ),
+            size: CGSize(width: 1280, height: 4200)
+        )
+        let renderedTexts = evidenceRenderedTextValues(in: view)
+
+        #expect(renderedTexts.contains("Run Evidence Report"))
+        #expect(renderedTexts.contains("Run History"))
+        #expect(renderedTexts.contains("Runtime Diagnostics"))
+        #expect(renderedTexts.contains("Hardware Monitor"))
+        #expect(renderedTexts.contains("Evidence Artifacts"))
+        #expect(renderedTexts.contains("Open CSV"))
+        #expect(viewModel.evidenceReport?.markdownReportPath == "/tmp/report.md")
+        #expect(viewModel.evidenceReport?.csvArtifactRows.isEmpty == false)
+        #expect(renderedTexts.contains { $0.contains(url.lastPathComponent) })
+        #expect(renderedTexts.contains("fixture open warning"))
+        #expect(renderedTexts.contains { $0.contains("report-desktop-fixture") })
+        #expect(renderedTexts.contains { $0.contains("powermetrics_failed:fixture") })
+        #expect(renderedTexts.contains { $0.contains("telemetry_summary.csv") })
+    }
+
+    @Test("view model loads clears and records evidence report errors")
+    @MainActor
+    func viewModelLoadsClearsAndRecordsEvidenceReportErrors() async throws {
+        let viewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-evidence-report-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try makeStructuredEvidenceReportJSON().write(to: url, atomically: true, encoding: .utf8)
+        try await viewModel.loadEvidenceReport(from: url)
+
+        #expect(viewModel.evidenceReport?.reportID == "report-desktop-fixture")
+        #expect(viewModel.evidenceReportSourcePath == url.path)
+
+        viewModel.recordEvidenceReportOpenError("fixture open failure")
+        #expect(viewModel.evidenceReportOpenError == "fixture open failure")
+
+        viewModel.clearEvidenceReportOpenError()
+        #expect(viewModel.evidenceReportOpenError.isEmpty)
+
+        viewModel.clearEvidenceReport()
+        #expect(viewModel.evidenceReport == nil)
+        #expect(viewModel.evidenceReportSourcePath.isEmpty)
+
+        viewModel.recordEvidenceReportLoadError(RuntimeEvidenceReportDecodeError.invalidJSON("fixture decode failure"))
+        #expect(viewModel.evidenceReportLoadError.contains("fixture decode failure"))
+    }
+
+    @Test("diagnostics artifact helper opens paths and reports failures")
+    @MainActor
+    func diagnosticsArtifactHelperOpensPathsAndReportsFailures() async throws {
+        let viewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        let validURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-helper-report-\(UUID().uuidString).json")
+        let invalidURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-helper-report-invalid-\(UUID().uuidString).json")
+        defer {
+            try? FileManager.default.removeItem(at: validURL)
+            try? FileManager.default.removeItem(at: invalidURL)
+        }
+
+        try makeStructuredEvidenceReportJSON().write(to: validURL, atomically: true, encoding: .utf8)
+        try "{".write(to: invalidURL, atomically: true, encoding: .utf8)
+
+        let diagnosticsView = DesktopDiagnosticsToolSectionView(
+            viewModel: viewModel,
+            foundation: viewModel.desktopFoundationState
+        )
+        try await viewModel.loadEvidenceReport(from: validURL)
+        #expect(viewModel.evidenceReport?.reportID == "report-desktop-fixture")
+        #expect(viewModel.evidenceReportSourcePath == validURL.path)
+
+        var openedURL: URL?
+        diagnosticsView.openEvidenceArtifact(path: " /tmp/report.md ") { url in
+            openedURL = url
+            return true
+        }
+        #expect(openedURL?.path == "/tmp/report.md")
+        #expect(viewModel.evidenceReportOpenError.isEmpty)
+
+        diagnosticsView.openEvidenceArtifact(path: " ") { _ in true }
+        #expect(viewModel.evidenceReportOpenError.contains("empty"))
+
+        diagnosticsView.openEvidenceArtifact(path: "/tmp/missing-report.md") { _ in false }
+        #expect(viewModel.evidenceReportOpenError.contains("Could not open"))
+
+        do {
+            try await viewModel.loadEvidenceReport(from: invalidURL)
+        } catch {
+            viewModel.recordEvidenceReportLoadError(error)
+        }
+        #expect(viewModel.evidenceReportLoadError.contains("could not be decoded"))
+
+        viewModel.clearEvidenceReport()
+        #expect(viewModel.evidenceReport == nil)
+        #expect(viewModel.evidenceReportLoadError.isEmpty)
+        #expect(viewModel.evidenceReportOpenError.isEmpty)
+    }
+
+    @Test("diagnostics renders empty and failed evidence report states")
+    @MainActor
+    func diagnosticsRendersEmptyAndFailedEvidenceReportStates() throws {
+        let emptyViewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        emptyViewModel.selectSurface(.tools)
+        emptyViewModel.selectToolSection(.diagnostics)
+        try emptyViewModel.loadEvidenceReport(json: makeEmptyStructuredEvidenceReportJSON())
+
+        let emptyView = evidenceHostView(
+            DesktopDiagnosticsToolSectionView(
+                viewModel: emptyViewModel,
+                foundation: emptyViewModel.desktopFoundationState
+            ),
+            size: CGSize(width: 1280, height: 2600)
+        )
+        let emptyTexts = evidenceRenderedTextValues(in: emptyView)
+
+        #expect(emptyTexts.contains("Run History"))
+        #expect(emptyTexts.contains("Runtime Diagnostics"))
+        #expect(emptyTexts.contains("Hardware Monitor"))
+        #expect(emptyTexts.contains("Evidence Artifacts"))
+        #expect(emptyTexts.contains("run_evidence_missing"))
+
+        let failedViewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        failedViewModel.recordEvidenceReportLoadError(
+            RuntimeEvidenceReportDecodeError.invalidJSON("fixture decode failure")
+        )
+        let failedView = evidenceHostView(
+            DesktopDiagnosticsToolSectionView(
+                viewModel: failedViewModel,
+                foundation: failedViewModel.desktopFoundationState
+            ),
+            size: CGSize(width: 1280, height: 1000)
+        )
+        let failedTexts = evidenceRenderedTextValues(in: failedView)
+
+        #expect(failedTexts.contains("Run Evidence Report"))
+
+        failedViewModel.clearEvidenceReport()
+        let noReportView = evidenceHostView(
+            DesktopDiagnosticsToolSectionView(
+                viewModel: failedViewModel,
+                foundation: failedViewModel.desktopFoundationState
+            ),
+            size: CGSize(width: 1280, height: 1000)
+        )
+        let noReportTexts = evidenceRenderedTextValues(in: noReportView)
+
+        #expect(noReportTexts.contains("Run Evidence Report"))
+    }
+}
+
+@MainActor
+private func evidenceHostView<Content: View>(_ rootView: Content, size: CGSize) -> NSView {
+    let controller = NSHostingController(rootView: rootView)
+    let view = controller.view
+    view.frame = NSRect(origin: .zero, size: size)
+    view.layoutSubtreeIfNeeded()
+    return view
+}
+
+@MainActor
+private func evidenceRenderedTextValues(in rootView: NSView) -> [String] {
+    var values: [String] = []
+
+    func appendValue(_ value: String) {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty == false {
+            values.append(trimmed)
+        }
+    }
+
+    func visit(_ view: NSView) {
+        if let textField = view as? NSTextField {
+            appendValue(textField.stringValue)
+        }
+        if let button = view as? NSButton {
+            appendValue(button.title)
+        }
+        if let popup = view as? NSPopUpButton {
+            appendValue(popup.title)
+        }
+        if let segmented = view as? NSSegmentedControl {
+            for index in 0..<segmented.segmentCount {
+                appendValue(segmented.label(forSegment: index) ?? "")
+            }
+        }
+        for subview in view.subviews {
+            visit(subview)
+        }
+    }
+
+    visit(rootView)
+    return values
+}
+
+private func makeSparseStructuredEvidenceReportJSON() -> String {
+    #"""
+    {
+      "schema_version": "melix.benchmark_evaluation_report.v1",
+      "report_id": "report-sparse-fixture",
+      "generated_at": "2026-05-08T13:00:00Z",
+      "melix_commit": "abc",
+      "git_branch": "",
+      "dirty_worktree": true,
+      "source_evidence_ids": [],
+      "runs": [
+        {
+          "side": "baseline",
+          "run_id": "sparse-run",
+          "trace_id": "sparse-run:trace",
+          "run_kind": "",
+          "status": "",
+          "duration_ms": 5,
+          "artifact_root": "",
+          "failure_summary": {"details": {"code": "missing"}},
+          "fallback_summary": {"fallback_count": 0}
+        }
+      ],
+      "metrics": [
+        {
+          "metric": "zeta.metric",
+          "direction": "",
+          "status": "",
+          "result": "unknown_result"
+        },
+        {
+          "metric": "alpha.metric",
+          "direction": "",
+          "status": "",
+          "result": "unknown_result"
+        }
+      ],
+      "telemetry_summary": {
+        "baseline": [
+          {
+            "run_id": "sparse-run",
+            "collector_status": "unsupported",
+            "telemetry_failures": ["missing_powermetrics"],
+            "memory_used_bytes": 512
+          }
+        ],
+        "candidate": []
+      },
+      "process_attribution": {
+        "baseline": [
+          {
+            "run_id": "sparse-run",
+            "worker_processes": [
+              {
+                "pid": 301,
+                "name": "",
+                "role": "",
+                "peak_memory_bytes": 512,
+                "avg_cpu_percent": 0.0,
+                "sample_count": 0
+              }
+            ],
+            "external_provider_processes": [
+              {
+                "pid": 302,
+                "name": "remote-provider",
+                "role": "external_provider"
+              }
+            ]
+          }
+        ],
+        "candidate": []
+      }
+    }
+    """#
+}
+
+private func makeStructuredEvidenceReportJSON() -> String {
+    #"""
+    {
+      "schema_version": "melix.benchmark_evaluation_report.v1",
+      "report_id": "report-desktop-fixture",
+      "generated_at": "2026-05-08T12:00:00Z",
+      "generator_name": "worker.productization.benchmark_evaluation_report",
+      "generator_version": "2026-05-08.plan4",
+      "melix_commit": "abcdef1234567890",
+      "git_branch": "codex/report-json-export",
+      "dirty_worktree": false,
+      "source_evidence_ids": ["baseline-completed", "candidate-failed", "candidate-fallback"],
+      "report_kind": "comparison",
+      "summary": {
+        "status": "warning",
+        "metric_count": 3,
+        "warning_count": 1,
+        "missing_count": 1,
+        "not_comparable_count": 0
+      },
+      "runs": [
+        {
+          "side": "baseline",
+          "run_id": "baseline-completed",
+          "trace_id": "baseline-completed:trace",
+          "run_kind": "benchmark",
+          "status": "completed",
+          "started_at": 1779000000000,
+          "ended_at": 1779000001200,
+          "duration_ms": 1200,
+          "command": "melix bench",
+          "operator": "desktop",
+          "artifact_root": "/tmp/baseline-completed",
+          "failure_summary": {"failed": false},
+          "fallback_summary": {"fallback_count": 0}
+        },
+        {
+          "side": "candidate",
+          "run_id": "candidate-failed",
+          "trace_id": "candidate-failed:trace",
+          "run_kind": "evaluation",
+          "status": "failed",
+          "started_at": 1779000000000,
+          "ended_at": 1779000002400,
+          "duration_ms": 2400,
+          "command": "melix eval",
+          "operator": "desktop",
+          "artifact_root": "/tmp/candidate-failed",
+          "failure_summary": {"failed": true, "stage": "decode"},
+          "fallback_summary": {"fallback_count": 0}
+        },
+        {
+          "side": "candidate",
+          "run_id": "candidate-fallback",
+          "trace_id": "candidate-fallback:trace",
+          "run_kind": "benchmark",
+          "status": "fallback",
+          "started_at": 1779000000000,
+          "ended_at": 1779000001800,
+          "duration_ms": 1800,
+          "command": "melix bench",
+          "operator": "desktop",
+          "artifact_root": "/tmp/candidate-fallback",
+          "failure_summary": {"failed": false},
+          "fallback_summary": {"fallback_count": 1, "fallbacks": ["provider_retry"]}
+        }
+      ],
+      "targets": [
+        {
+          "side": "baseline",
+          "run_id": "baseline-completed",
+          "target_model_id": "mlx-community/test-model",
+          "hf_repo_id": "mlx-community/test-model",
+          "task_kind": "text-generation",
+          "model_snapshot": "model-sha",
+          "adapter_id": "",
+          "adapter_snapshot": "",
+          "runtime_kind": "mlx",
+          "runtime_config": {},
+          "dataset_ref": "fixture.dataset",
+          "dataset_revision": "dataset-sha",
+          "suite_id": "smoke",
+          "sample_count": 1,
+          "input_digest": "input-sha",
+          "prompt_template_digest": "prompt-sha",
+          "generation_config": {}
+        },
+        {
+          "side": "candidate",
+          "run_id": "candidate-failed",
+          "target_model_id": "mlx-community/test-model",
+          "hf_repo_id": "mlx-community/test-model",
+          "task_kind": "event-extraction",
+          "model_snapshot": "model-sha",
+          "adapter_id": "adapter-a",
+          "adapter_snapshot": "adapter-sha",
+          "runtime_kind": "mlx",
+          "runtime_config": {},
+          "dataset_ref": "fixture.dataset",
+          "dataset_revision": "dataset-sha",
+          "suite_id": "event_extraction",
+          "sample_count": 1,
+          "input_digest": "input-sha",
+          "prompt_template_digest": "prompt-sha",
+          "generation_config": {}
+        },
+        {
+          "side": "candidate",
+          "run_id": "candidate-fallback",
+          "target_model_id": "mlx-community/test-model",
+          "hf_repo_id": "mlx-community/test-model",
+          "task_kind": "text-generation",
+          "model_snapshot": "model-sha",
+          "adapter_id": "",
+          "adapter_snapshot": "",
+          "runtime_kind": "mlx",
+          "runtime_config": {},
+          "dataset_ref": "fixture.dataset",
+          "dataset_revision": "dataset-sha",
+          "suite_id": "smoke",
+          "sample_count": 1,
+          "input_digest": "input-sha",
+          "prompt_template_digest": "prompt-sha",
+          "generation_config": {}
+        }
+      ],
+      "metrics": [
+        {
+          "metric": "bench.smoke.decode_ms",
+          "baseline": 10.0,
+          "current": 12.0,
+          "candidate": 12.0,
+          "delta": 2.0,
+          "delta_percent": 20.0,
+          "delta_pct": 20.0,
+          "direction": "lower_is_better",
+          "status": "warning",
+          "gate_policy": {"direction": "lower_is_better", "warning_threshold_pct": 5.0, "required": true},
+          "result": "fail"
+        },
+        {
+          "metric": "eval.event_extraction.failure_count",
+          "baseline": 0.0,
+          "current": 1.0,
+          "candidate": 1.0,
+          "delta": 1.0,
+          "delta_percent": 100.0,
+          "delta_pct": 100.0,
+          "direction": "lower_is_better",
+          "status": "missing",
+          "gate_policy": {"direction": "lower_is_better", "warning_threshold_pct": 5.0, "required": true},
+          "result": "informational"
+        },
+        {
+          "metric": "bench.smoke.tokens_per_second",
+          "baseline": 50.0,
+          "current": 55.0,
+          "candidate": 55.0,
+          "delta": 5.0,
+          "delta_percent": 10.0,
+          "delta_pct": 10.0,
+          "direction": "higher_is_better",
+          "status": "ok",
+          "gate_policy": {"direction": "higher_is_better", "warning_threshold_pct": 5.0, "required": true},
+          "result": "pass"
+        }
+      ],
+      "probe_summary": {
+        "baseline": {
+          "schema_version": "melix.probe_summary.v1",
+          "probe_count": 2,
+          "component_duration_ms": {"runtime": 9.0},
+          "slowest_phases": [
+            {
+              "run_id": "baseline-completed",
+              "trace_id": "baseline-completed:trace",
+              "span_id": "baseline-completed:decode",
+              "parent_span_id": "baseline-completed:prefill",
+              "component": "runtime",
+              "phase": "decode",
+              "duration_ms": 9.0,
+              "status": "completed",
+              "error_stage": "",
+              "error_code": ""
+            }
+          ],
+          "failed_phases": [],
+          "skipped_phases": [],
+          "fallback_phases": []
+        },
+        "candidate": {
+          "schema_version": "melix.probe_summary.v1",
+          "probe_count": 3,
+          "component_duration_ms": {"runtime": 17.5},
+          "slowest_phases": [
+            {
+              "run_id": "candidate-failed",
+              "trace_id": "candidate-failed:trace",
+              "span_id": "candidate-failed:decode",
+              "parent_span_id": "candidate-failed:prefill",
+              "component": "runtime",
+              "phase": "decode",
+              "duration_ms": 17.5,
+              "status": "failed",
+              "error_stage": "decode",
+              "error_code": "runtime_error"
+            }
+          ],
+          "failed_phases": [
+            {
+              "run_id": "candidate-failed",
+              "trace_id": "candidate-failed:trace",
+              "span_id": "candidate-failed:decode",
+              "parent_span_id": "candidate-failed:prefill",
+              "component": "runtime",
+              "phase": "decode",
+              "duration_ms": 17.5,
+              "status": "failed",
+              "error_stage": "decode",
+              "error_code": "runtime_error"
+            }
+          ],
+          "skipped_phases": [
+            {
+              "run_id": "candidate-failed",
+              "trace_id": "candidate-failed:trace",
+              "span_id": "candidate-failed:score",
+              "parent_span_id": "candidate-failed:decode",
+              "component": "worker",
+              "phase": "score_compute",
+              "duration_ms": 0.0,
+              "status": "skipped",
+              "error_stage": "",
+              "error_code": ""
+            }
+          ],
+          "fallback_phases": [
+            {
+              "run_id": "candidate-fallback",
+              "trace_id": "candidate-fallback:trace",
+              "span_id": "candidate-fallback:fallback_enter",
+              "parent_span_id": "candidate-fallback:dispatch",
+              "component": "runtime",
+              "phase": "fallback_enter",
+              "duration_ms": 0.001,
+              "status": "completed",
+              "error_stage": "",
+              "error_code": ""
+            }
+          ]
+        }
+      },
+      "telemetry_summary": {
+        "hardware_banner": "Apple Silicon / macOS telemetry",
+        "baseline": [
+          {
+            "side": "baseline",
+            "run_id": "baseline-completed",
+            "run_kind": "benchmark",
+            "collector_status": "collected",
+            "time_series_path": "/tmp/baseline/telemetry-samples.jsonl",
+            "telemetry_failures": [],
+            "average_cpu_utilization_percent": 42.0,
+            "average_gpu_utilization_percent": 55.0,
+            "average_gpu_frequency_mhz": 900.0,
+            "average_system_power_w": 14.5,
+            "peak_system_power_w": 16.0,
+            "memory_used_bytes": 1073741824,
+            "memory_total_bytes": 34359738368,
+            "peak_process_memory_bytes": 536870912
+          }
+        ],
+        "candidate": [
+          {
+            "side": "candidate",
+            "run_id": "candidate-failed",
+            "run_kind": "evaluation",
+            "collector_status": "partial",
+            "time_series_path": "/tmp/candidate/telemetry-samples.jsonl",
+            "telemetry_failures": ["powermetrics_failed:fixture"],
+            "average_cpu_utilization_percent": 48.0,
+            "average_gpu_utilization_percent": 61.0,
+            "average_gpu_frequency_mhz": 980.0,
+            "average_system_power_w": 17.5,
+            "peak_system_power_w": 19.0,
+            "memory_used_bytes": 2147483648,
+            "memory_total_bytes": 34359738368,
+            "peak_process_memory_bytes": 805306368
+          }
+        ]
+      },
+      "process_attribution": {
+        "baseline": [],
+        "candidate": [
+          {
+            "side": "candidate",
+            "run_id": "candidate-failed",
+            "run_kind": "evaluation",
+            "primary_runtime_process": {
+              "pid": 101,
+              "name": "mlx-runner",
+              "role": "primary_runtime",
+              "port": 12434,
+              "peak_memory_bytes": 805306368,
+              "avg_cpu_percent": 12.5,
+              "sample_count": 4
+            },
+            "control_plane_process": {
+              "pid": 102,
+              "name": "melix-control",
+              "role": "control_plane",
+              "port": 11434,
+              "peak_memory_bytes": 134217728,
+              "avg_cpu_percent": 2.5,
+              "sample_count": 4
+            },
+            "worker_processes": [
+              {
+                "pid": 103,
+                "name": "melix-worker",
+                "role": "worker",
+                "port": 0,
+                "peak_memory_bytes": 268435456,
+                "avg_cpu_percent": 4.5,
+                "sample_count": 4
+              }
+            ],
+            "external_provider_processes": [],
+            "process_tree_summary": {"roles": ["primary_runtime", "control_plane", "worker"]}
+          }
+        ]
+      },
+      "comparison": {
+        "baseline_report_id": "baseline-completed",
+        "current_report_id": "candidate-failed",
+        "comparison_dimensions": [],
+        "metric_deltas": [],
+        "probe_deltas": [],
+        "telemetry_deltas": [],
+        "regressions": [],
+        "improvements": [],
+        "unchanged": [],
+        "comparison_validity": "valid"
+      },
+      "gate_result": {
+        "overall_result": "fail",
+        "gate_results": [],
+        "informational_results": [
+          {
+            "metric": "eval.event_extraction.failure_count",
+            "baseline": 0.0,
+            "current": 1.0,
+            "delta": 1.0,
+            "delta_percent": 100.0,
+            "direction": "lower_is_better",
+            "status": "missing",
+            "gate_policy": {"direction": "lower_is_better", "warning_threshold_pct": 5.0, "required": true},
+            "result": "informational"
+          }
+        ],
+        "known_gaps": [],
+        "blocking_failures": [
+          {
+            "metric": "bench.smoke.decode_ms",
+            "baseline": 10.0,
+            "current": 12.0,
+            "delta": 2.0,
+            "delta_percent": 20.0,
+            "direction": "lower_is_better",
+            "status": "warning",
+            "gate_policy": {"direction": "lower_is_better", "warning_threshold_pct": 5.0, "required": true},
+            "result": "fail"
+          }
+        ],
+        "required_evidence_present": true,
+        "required_probe_phases_present": true,
+        "required_telemetry_present": true
+      },
+      "artifacts": {
+        "evidence_json_path": "/tmp/evidence.json",
+        "report_json_path": "/tmp/report.json",
+        "markdown_report_path": "/tmp/report.md",
+        "csv_export_paths": {
+          "runs": "/tmp/runs.csv",
+          "metrics": "/tmp/metrics.csv",
+          "telemetry_summary": "/tmp/telemetry_summary.csv",
+          "processes": "/tmp/processes.csv"
+        },
+        "probe_timeline_path": "/tmp/probes.jsonl",
+        "telemetry_jsonl_path": "/tmp/telemetry-samples.jsonl",
+        "raw_output_paths": ["/tmp/baseline-completed", "/tmp/candidate-failed"],
+        "logs_path": "/tmp/logs",
+        "screenshots_path": "",
+        "coverage_path": "/tmp/coverage"
+      },
+      "known_gaps": [],
+      "instrumentation_gaps": ["candidate:candidate-failed:powermetrics_failed:fixture"],
+      "operator_notes": [],
+      "non_blocking_warnings": ["candidate:candidate-failed:powermetrics_failed:fixture"],
+      "rows": []
+    }
+    """#
+}
+
+private func makeEmptyStructuredEvidenceReportJSON() -> String {
+    #"""
+    {
+      "schema_version": "melix.benchmark_evaluation_report.v1",
+      "report_id": "report-empty-fixture",
+      "generated_at": "2026-05-08T12:30:00Z",
+      "generator_name": "worker.productization.benchmark_evaluation_report",
+      "generator_version": "2026-05-08.plan4",
+      "melix_commit": "abcdef1234567890",
+      "git_branch": "codex/report-json-export",
+      "dirty_worktree": false,
+      "source_evidence_ids": [],
+      "report_kind": "comparison",
+      "summary": {
+        "status": "missing",
+        "metric_count": 0,
+        "warning_count": 0,
+        "missing_count": 0,
+        "not_comparable_count": 0
+      },
+      "runs": [],
+      "targets": [],
+      "metrics": [],
+      "probe_summary": {
+        "baseline": {
+          "schema_version": "melix.probe_summary.v1",
+          "probe_count": 0,
+          "component_duration_ms": {},
+          "slowest_phases": [],
+          "failed_phases": [],
+          "skipped_phases": [],
+          "fallback_phases": []
+        },
+        "candidate": {
+          "schema_version": "melix.probe_summary.v1",
+          "probe_count": 0,
+          "component_duration_ms": {},
+          "slowest_phases": [],
+          "failed_phases": [],
+          "skipped_phases": [],
+          "fallback_phases": []
+        }
+      },
+      "telemetry_summary": {
+        "hardware_banner": "Apple Silicon / macOS telemetry",
+        "baseline": [],
+        "candidate": []
+      },
+      "process_attribution": {
+        "baseline": [],
+        "candidate": []
+      },
+      "comparison": {
+        "baseline_report_id": "",
+        "current_report_id": "",
+        "comparison_dimensions": [],
+        "metric_deltas": [],
+        "probe_deltas": [],
+        "telemetry_deltas": [],
+        "regressions": [],
+        "improvements": [],
+        "unchanged": [],
+        "comparison_validity": "partial"
+      },
+      "gate_result": {
+        "overall_result": "informational",
+        "gate_results": [],
+        "informational_results": [],
+        "known_gaps": ["run_evidence_missing"],
+        "blocking_failures": [],
+        "required_evidence_present": false,
+        "required_probe_phases_present": false,
+        "required_telemetry_present": false
+      },
+      "artifacts": {
+        "evidence_json_path": "",
+        "report_json_path": "",
+        "markdown_report_path": "",
+        "csv_export_paths": {},
+        "probe_timeline_path": "",
+        "telemetry_jsonl_path": "",
+        "raw_output_paths": [],
+        "logs_path": "",
+        "screenshots_path": "",
+        "coverage_path": ""
+      },
+      "known_gaps": ["run_evidence_missing"],
+      "instrumentation_gaps": [],
+      "operator_notes": [],
+      "non_blocking_warnings": [],
+      "rows": []
+    }
+    """#
+}

--- a/docs/plans/2026-05-08-evidence-plan-6-desktop-operator-surfaces.md
+++ b/docs/plans/2026-05-08-evidence-plan-6-desktop-operator-surfaces.md
@@ -36,3 +36,18 @@ runtime diagnostics in the macOS operator app.
 - Operators can diagnose a run from the app without opening raw logs.
 - UI displays probe and telemetry gaps or failures explicitly.
 - All views are derived from structured artifacts.
+
+## Implementation Status
+
+- Added a read-only `RuntimeEvidenceReportState` decoder for
+  `melix.benchmark_evaluation_report.v1` JSON artifacts.
+- Added derived operator rows for report summary, run history, gate metrics,
+  probe phases, Apple Silicon telemetry, process attribution, artifacts, CSV
+  exports, and instrumentation gaps.
+- Added Diagnostics surfaces for Run Evidence Report, Run History, Runtime
+  Diagnostics, Hardware Monitor, and Evidence Artifacts.
+- Added JSON report loading, report-row filtering, Markdown artifact opening,
+  CSV artifact opening, and explicit load/open error state to the diagnostics
+  surface.
+- Added focused Swift tests for completed, failed, fallback, telemetry-failure,
+  probe, process, Markdown artifact, and CSV export report rows.


### PR DESCRIPTION
## Summary
- Add a read-only macOS Diagnostics surface for structured run evidence reports, including run history, runtime diagnostics, hardware monitor, evidence artifact, Markdown, and CSV rows.
- Add report loading, clearing, filtering, source-path, and artifact-open error state to the desktop runtime view model.
- Address review feedback by moving evidence report file reads off the main actor, keeping picker work main-actor-bound, tightening Diagnostics helpers to private scope, and replacing fragile row identities / magic caps.
- Cover report decoding and Diagnostics rendering for completed, failed, fallback, telemetry-failure, sparse/default, Markdown, and CSV artifact cases.

## Plan or Spec
- `docs/plans/2026-05-08-evidence-plan-6-desktop-operator-surfaces.md`

## Commands Run
```text
git rebase codex/pr-release-evidence-gate
Result: Passed. Skipped already-upstream parent commits and refreshed the Plan 6 stack on the updated Plan 5 branch.

swift build --package-path apps/macos-menubar
Result: Passed. Build complete.

swift test --package-path apps/macos-menubar --filter RuntimeEvidenceReportStateTests
Result: Passed. 6 tests in 1 suite passed.

swift test --package-path apps/macos-menubar --enable-code-coverage --filter RuntimeEvidenceReportStateTests
Result: Passed. 6 tests in 1 suite passed.

python3 scripts/swift_changed_line_coverage.py --diff-from codex/pr-release-evidence-gate --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift apps/macos-menubar/Sources/AppMain/Models/RuntimeEvidenceReportState.swift apps/macos-menubar/Tests/MenuBarTests/RuntimeEvidenceReportStateTests.swift
Result: Passed. TOTAL 97.79% (1768/1808) changed-line coverage.

git diff --check
Result: Passed. No whitespace errors.
```

## Coverage and Metrics
- Changed-line coverage: 97.79% (1768/1808) for the desktop evidence report scope.
- Metrics report: UI surfaces are derived from structured report artifacts and expose report/gate metrics, probe phase summaries, Apple Silicon telemetry, process attribution, CSV exports, and instrumentation gaps. No live runtime benchmark was run for this read-only operator-surface change.

## Known Gaps
- Repository-wide baseline gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run for this stacked desktop UI slice; focused macOS menubar build, test, and changed-line coverage gates passed.
- Live `NSOpenPanel` / `NSWorkspace` manual smoke was not run; artifact-open behavior is covered through an injected opener and SwiftUI Diagnostics rendering tests.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or are not applicable.
- [x] Dependency changes include updated lockfiles, or are not applicable.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
