### PR TITLE
perf: stream quantization gate manifest events

### DIFF
--- a/docs/plans/quantization-gate-manifest-event-streaming.md
+++ b/docs/plans/quantization-gate-manifest-event-streaming.md
@@ -1,0 +1,33 @@
+# Quantization Gate Manifest Event Streaming
+
+## Goal
+
+Reduce transient memory pressure in `collect_quantization_benchmark_evidence(...)` by avoiding full materialization of every `convert_model(...)` event when the gate only needs the first manifest payload for each quantization profile.
+
+## Linux-only constraint
+
+This slice is Python-only under `services/mlx-worker-python` and is locally verifiable on Linux with focused pytest, changed-scope coverage, and a command-json PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/productization/quantization_gates.py`
+- `services/mlx-worker-python/tests/test_release_gates.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+- `docs/plans/quantization-gate-manifest-event-streaming.md`
+
+## Performance probe definition
+
+Register `quantization-gate-manifest-event-streaming` in `infra/perf/pr_scoped_probes.json`.
+
+The probe monkeypatches `_build_maintenance_core(...)` with a fake core that emits many non-manifest events after the manifest event. It measures `collect_quantization_benchmark_evidence(...)` over a synthetic profile set and reports:
+
+- `elapsed_ms_mean` / `elapsed_ms_min` (lower is better)
+- `events_consumed_mean` (lower is better; expected to drop from consuming all post-manifest events to only the started + manifest events per profile)
+
+## Success metrics
+
+- Focused release-gate tests pass.
+- Changed executable coverage for touched Python scope is at least 95%.
+- Local base-vs-head probe shows fewer consumed events and lower or acceptable elapsed time.
+- `git diff --check` passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1893,6 +1893,44 @@
     ]
   },
   {
+    "id": "quantization-gate-manifest-event-streaming",
+    "name": "Quantization gate manifest event streaming",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/quantization_gates.py",
+      "services/mlx-worker-python/tests/test_release_gates.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/quantization_gate_manifest_event_streaming_probe.py",
+      "scripts/changed_scope_coverage.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_gates.py::test_collect_quantization_benchmark_evidence_returns_profile_metrics services/mlx-worker-python/tests/test_release_gates.py::test_collect_quantization_benchmark_evidence_stops_after_manifest_event services/mlx-worker-python/tests/test_release_gates.py::test_first_convert_manifest_raises_when_manifest_is_missing services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_quantization_gate_reports_regressions services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_gate_manifest_event_streaming_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_gate_manifest_event_streaming_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_release_gates.py::test_collect_quantization_benchmark_evidence_returns_profile_metrics services/mlx-worker-python/tests/test_release_gates.py::test_collect_quantization_benchmark_evidence_stops_after_manifest_event services/mlx-worker-python/tests/test_release_gates.py::test_first_convert_manifest_raises_when_manifest_is_missing services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_quantization_gate_reports_regressions services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_gate_manifest_event_streaming_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_gate_manifest_event_streaming_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/quantization_gates.py services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/quantization_gate_manifest_event_streaming_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 - <<'PY'\nimport json, statistics, tempfile, time\nfrom pathlib import Path\nfrom packages.protocol.python.worker.v1 import maintenance_pb2\nfrom worker.productization import quantization_gates as quantization_gates_module\nfrom worker.productization.quantization_gates import collect_quantization_benchmark_evidence\nprofile_count = 6\npost_manifest_event_count = 2000\nsample_count = 7\npayload = {\"artifact_bytes\": 128, \"manifest_bytes\": 96, \"calibration\": {\"sample_count\": 16}, \"compatibility\": {\"smoke_test_passed\": True}, \"manifest_path\": \"/tmp/melix-quantization-gate-probe/manifest.json\", \"artifact_path\": \"/tmp/melix-quantization-gate-probe/artifact.bin\"}\nclass CountingCore:\n    def __init__(self):\n        self.consumed_events = 0\n    def convert_model(self, request):\n        self.consumed_events += 1\n        yield maintenance_pb2.ConvertModelEvent(started=maintenance_pb2.ConvertStarted())\n        self.consumed_events += 1\n        yield maintenance_pb2.ConvertModelEvent(manifest=maintenance_pb2.ConvertManifest(manifest_json=json.dumps(payload)))\n        for _ in range(post_manifest_event_count):\n            self.consumed_events += 1\n            yield maintenance_pb2.ConvertModelEvent(started=maintenance_pb2.ConvertStarted())\nelapsed_samples = []\nconsumed_samples = []\nprofiles = tuple(f\"q{index}\" for index in range(profile_count))\noriginal_build_core = quantization_gates_module._build_maintenance_core\ntry:\n    with tempfile.TemporaryDirectory(prefix=\"melix-quant-gate-probe-\") as temp_dir:\n        jobs_root = Path(temp_dir) / \"jobs\"\n        for _ in range(sample_count):\n            core = CountingCore()\n            quantization_gates_module._build_maintenance_core = lambda jobs_root: core\n            started_at = time.perf_counter()\n            evidence = collect_quantization_benchmark_evidence(jobs_root, profiles=profiles)\n            elapsed_samples.append((time.perf_counter() - started_at) * 1000.0)\n            consumed_samples.append(float(core.consumed_events))\n            assert evidence[\"summary\"][\"profile_count\"] == profile_count\n            assert evidence[\"summary\"][\"smoke_pass_rate\"] == 100.0\nfinally:\n    quantization_gates_module._build_maintenance_core = original_build_core\nprint(json.dumps({\"elapsed_ms_mean\": round(statistics.fmean(elapsed_samples), 6), \"elapsed_ms_min\": round(min(elapsed_samples), 6), \"events_consumed_mean\": round(statistics.fmean(consumed_samples), 6), \"profile_count\": float(profile_count), \"post_manifest_event_count\": float(post_manifest_event_count), \"sample_count\": float(sample_count)}, sort_keys=True))\nPY",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "events_consumed_mean",
+        "unit": "events",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "model-ops-bundle-artifact-byte-accounting",
     "name": "Model ops bundle artifact byte accounting",
     "runner": "ubuntu-latest",

--- a/scripts/quantization_gate_manifest_event_streaming_probe.py
+++ b/scripts/quantization_gate_manifest_event_streaming_probe.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1] if "__file__" in globals() else Path.cwd()
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from packages.protocol.python.worker.v1 import maintenance_pb2
+from worker.productization import quantization_gates as quantization_gates_module
+from worker.productization.quantization_gates import collect_quantization_benchmark_evidence
+
+
+PROFILE_COUNT = 6
+POST_MANIFEST_EVENT_COUNT = 2000
+SAMPLE_COUNT = 7
+
+
+PAYLOAD = {
+    "artifact_bytes": 128,
+    "manifest_bytes": 96,
+    "calibration": {"sample_count": 16},
+    "compatibility": {"smoke_test_passed": True},
+    "manifest_path": "/tmp/melix-quantization-gate-probe/manifest.json",
+    "artifact_path": "/tmp/melix-quantization-gate-probe/artifact.bin",
+}
+
+
+class CountingCore:
+    def __init__(self) -> None:
+        self.consumed_events = 0
+
+    def convert_model(self, request: maintenance_pb2.ConvertModelRequest):
+        self.consumed_events += 1
+        yield maintenance_pb2.ConvertModelEvent(started=maintenance_pb2.ConvertStarted())
+        self.consumed_events += 1
+        yield maintenance_pb2.ConvertModelEvent(
+            manifest=maintenance_pb2.ConvertManifest(manifest_json=json.dumps(PAYLOAD))
+        )
+        for _ in range(POST_MANIFEST_EVENT_COUNT):
+            self.consumed_events += 1
+            yield maintenance_pb2.ConvertModelEvent(started=maintenance_pb2.ConvertStarted())
+
+
+def main() -> None:
+    profiles = tuple(f"q{index}" for index in range(PROFILE_COUNT))
+    elapsed_samples: list[float] = []
+    consumed_samples: list[float] = []
+    original_build_core = quantization_gates_module._build_maintenance_core
+    try:
+        with tempfile.TemporaryDirectory(prefix="melix-quant-gate-probe-") as temp_dir:
+            jobs_root = Path(temp_dir) / "jobs"
+            for _ in range(SAMPLE_COUNT):
+                core = CountingCore()
+                quantization_gates_module._build_maintenance_core = lambda jobs_root: core
+                started_at = time.perf_counter()
+                evidence = collect_quantization_benchmark_evidence(jobs_root, profiles=profiles)
+                elapsed_samples.append((time.perf_counter() - started_at) * 1000.0)
+                consumed_samples.append(float(core.consumed_events))
+                if evidence["summary"]["profile_count"] != PROFILE_COUNT:
+                    raise AssertionError("unexpected profile count")
+                if evidence["summary"]["smoke_pass_rate"] != 100.0:
+                    raise AssertionError("unexpected smoke pass rate")
+    finally:
+        quantization_gates_module._build_maintenance_core = original_build_core
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+                "elapsed_ms_min": round(min(elapsed_samples), 6),
+                "events_consumed_mean": round(statistics.fmean(consumed_samples), 6),
+                "profile_count": float(PROFILE_COUNT),
+                "post_manifest_event_count": float(POST_MANIFEST_EVENT_COUNT),
+                "sample_count": float(SAMPLE_COUNT),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -307,6 +307,30 @@ def test_scope_report_selects_quantization_qat_source_scan_probe() -> None:
     assert "quantization-qat-source-scan-scandir" in _selected_probe_ids(scope)
 
 
+def test_scope_report_selects_quantization_gate_manifest_event_streaming_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/quantization_gates.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "quantization-gate-manifest-event-streaming"
+
+
+def test_quantization_gate_manifest_event_streaming_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runpy.run_path(
+        str(REPO_ROOT / "scripts/quantization_gate_manifest_event_streaming_probe.py"),
+        run_name="__main__",
+    )
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["events_consumed_mean"] == 12.0
+    assert metrics["profile_count"] == 6.0
+
+
 def test_scope_report_selects_startup_signals_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -1774,6 +1798,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "package-macos-resolve-fallback-scandir",
         "pr-scoped-performance-scope-json-read-bytes",
         "pr-scoped-performance-scope-matcher",
+        "quantization-gate-manifest-event-streaming",
         "quantization-qat-source-scan-scandir",
         "release-gates-m9-failure-count-single-pass",
         "training-config-target-module-cache",

--- a/services/mlx-worker-python/tests/test_release_gates.py
+++ b/services/mlx-worker-python/tests/test_release_gates.py
@@ -31,6 +31,7 @@ from worker.productization.quantization_gates import (
     evaluate_quantization_gate,
     load_quantization_gate_policy,
 )
+from worker.productization import quantization_gates as quantization_gates_module
 from worker.productization import release_gates as release_gates_module
 
 
@@ -474,6 +475,55 @@ def test_collect_quantization_benchmark_evidence_returns_profile_metrics(tmp_pat
     assert evidence["profiles"]["q2"]["artifact_bytes"] > 0
     assert evidence["profiles"]["q2"]["manifest_bytes"] > 0
     assert evidence["profiles"]["q2"]["job_ms"] >= 0.0
+
+
+def test_collect_quantization_benchmark_evidence_stops_after_manifest_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    consumed_events = 0
+    requested_profiles: list[str] = []
+
+    payload = {
+        "artifact_bytes": 128,
+        "manifest_bytes": 96,
+        "calibration": {"sample_count": 16},
+        "compatibility": {"smoke_test_passed": True},
+        "manifest_path": str(tmp_path / "manifest.json"),
+        "artifact_path": str(tmp_path / "artifact.bin"),
+    }
+
+    class FakeCore:
+        def convert_model(self, request: maintenance_pb2.ConvertModelRequest):
+            nonlocal consumed_events
+            requested_profiles.append(request.weight_quant)
+            consumed_events += 1
+            yield maintenance_pb2.ConvertModelEvent(started=maintenance_pb2.ConvertStarted())
+            consumed_events += 1
+            yield maintenance_pb2.ConvertModelEvent(
+                manifest=maintenance_pb2.ConvertManifest(manifest_json=json.dumps(payload))
+            )
+            raise AssertionError(  # pragma: no cover - would mean streaming regressed
+                "collect_quantization_benchmark_evidence consumed post-manifest events"
+            )
+
+    monkeypatch.setattr(
+        quantization_gates_module,
+        "_build_maintenance_core",
+        lambda jobs_root: FakeCore(),
+    )
+
+    evidence = collect_quantization_benchmark_evidence(tmp_path / "jobs", profiles=("q4",))
+
+    assert requested_profiles == ["q4"]
+    assert consumed_events == 2
+    assert evidence["summary"] == {"profile_count": 1, "smoke_pass_rate": 100.0}
+    assert evidence["profiles"]["q4"]["artifact_bytes"] == 128
+
+
+def test_first_convert_manifest_raises_when_manifest_is_missing() -> None:
+    with pytest.raises(StopIteration, match="did not emit a manifest"):
+        quantization_gates_module._first_convert_manifest(iter(()))
 
 
 def test_evaluate_quantization_gate_reports_regressions() -> None:

--- a/services/mlx-worker-python/worker/productization/quantization_gates.py
+++ b/services/mlx-worker-python/worker/productization/quantization_gates.py
@@ -43,10 +43,11 @@ def collect_quantization_benchmark_evidence(
     profiles: tuple[str, ...] = ("q2", "q3", "q4", "q5", "q6", "q7", "q8"),
 ) -> dict[str, Any]:
     core = _build_maintenance_core(jobs_root)
+    jobs_root_path = Path(jobs_root)
     profile_reports: dict[str, Any] = {}
 
     for profile_id in profiles:
-        output_dir = Path(jobs_root) / profile_id
+        output_dir = jobs_root_path / profile_id
         request = maintenance_pb2.ConvertModelRequest(
             source_model="melix-dev-text",
             output_dir=str(output_dir),
@@ -57,9 +58,8 @@ def collect_quantization_benchmark_evidence(
             ext={"operation": "quantize", "quant_profile_id": profile_id},
         )
         started_at = time.perf_counter()
-        events = list(core.convert_model(request))
+        manifest = _first_convert_manifest(core.convert_model(request))
         elapsed_ms = (time.perf_counter() - started_at) * 1000.0
-        manifest = next(event.manifest for event in events if event.HasField("manifest"))
         payload = json.loads(manifest.manifest_json)
         profile_reports[profile_id] = {
             "quant_profile_id": profile_id,
@@ -81,6 +81,15 @@ def collect_quantization_benchmark_evidence(
         },
         "profiles": profile_reports,
     }
+
+
+def _first_convert_manifest(
+    events: Any,
+) -> maintenance_pb2.ConvertManifest:
+    for event in events:
+        if event.HasField("manifest"):
+            return event.manifest
+    raise StopIteration("convert_model did not emit a manifest event")
 
 
 def evaluate_quantization_gate(report: dict[str, Any], policy: dict[str, Any]) -> list[str]:


### PR DESCRIPTION
## Summary
- Streams `convert_model(...)` events in `collect_quantization_benchmark_evidence(...)` until the manifest event is found instead of materializing the full event stream.
- Adds focused regression coverage proving post-manifest events are not consumed.
- Registers `quantization-gate-manifest-event-streaming` in PR-scoped performance CI with a base-compatible command-json probe.

## Plan or Spec
- Plan: `docs/plans/quantization-gate-manifest-event-streaming.md`
- Slice type: Python-only optimization under `services/mlx-worker-python`.
- Probe ID: `quantization-gate-manifest-event-streaming`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_gates.py::test_collect_quantization_benchmark_evidence_returns_profile_metrics services/mlx-worker-python/tests/test_release_gates.py::test_collect_quantization_benchmark_evidence_stops_after_manifest_event services/mlx-worker-python/tests/test_release_gates.py::test_first_convert_manifest_raises_when_manifest_is_missing services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_quantization_gate_reports_regressions services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_gate_manifest_event_streaming_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_gate_manifest_event_streaming_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o /tmp/quantization-gate-coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json /tmp/quantization-gate-coverage.json services/mlx-worker-python/worker/productization/quantization_gates.py services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/quantization_gate_manifest_event_streaming_probe.py`
- `python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id quantization-gate-manifest-event-streaming --base-repo /tmp/melix-base-quant-gate-20260508164741 --head-repo /tmp/melix-cron-opt-20260508164741 --output /tmp/quant-gate-pr-scoped-report.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `7 passed in 0.42s`.
- Changed-scope coverage: `TOTAL 39 0 100%`.
- Local registered base-vs-head probe (`quantization-gate-manifest-event-streaming`):
  - `events_consumed_mean`: `12012.0` -> `12.0` events.
  - `elapsed_ms_mean`: `15.541171` -> `0.20914` ms.
  - `elapsed_ms_min`: `14.052166` -> `0.167435` ms.
- Diff hygiene: `git diff --check` passed.

## Known Gaps
- Linux-only local verification; no macOS/Swift checks were run because this slice only touches Python/productization and CI probe configuration.
- Hosted GitHub Actions are expected to provide the additive PR-scoped performance validation after PR creation.

## Evidence Checklist
- [x] Focused tests pass.
- [x] Changed-scope coverage is >=95%.
- [x] Explicit local performance probe has concrete base/head metrics.
- [x] PR-scoped performance probe is registered.
- [x] `git diff --check` passes.
- [ ] Hosted PR-scoped performance CI has completed.
