### PR TITLE
perf: reduce LoRA run-dir scan retention

### DIFF
--- a/docs/plans/lora-run-dir-name-scan.md
+++ b/docs/plans/lora-run-dir-name-scan.md
@@ -1,0 +1,36 @@
+# LoRA run-dir name scan optimization
+
+## Goal
+
+Reduce temporary object retention in the LoRA experiment index rebuild path by keeping only eligible run-directory names while scanning `train_lora/`, instead of retaining `os.DirEntry` objects until after sorting.
+
+## Linux-only constraint
+
+This is a Python worker slice. It is locally verifiable on Linux with focused pytest, changed-scope coverage, and a synthetic probe. No Swift/macOS local validation is required.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/productization/lora_experiment_store.py`
+- `services/mlx-worker-python/tests/test_lora_experiment_store.py`
+- `scripts/lora_experiment_run_dir_scan_probe.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Probe
+
+Register `lora-experiment-run-dir-name-scan` in the PR-scoped performance registry.
+
+The probe monkeypatches `os.scandir()` with many fake `DirEntry`-like objects and measures repeated `_iter_lora_run_dirs(...)` calls. It reports:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- `run_dir_count`
+- `path_attr_reads_mean`
+
+## Success metrics
+
+- Preserve sorted path output and unreadable-entry fallback behavior.
+- Drive `path_attr_reads_mean` to `0.0` on the optimized branch while `origin/main` reads `entry.path` once per eligible run directory.
+- Reduce `peak_bytes_mean` for the synthetic scan workload.
+- Keep `elapsed_ms_mean` in the probe output as informational because this slice prioritizes lower retention/metadata access over latency.
+- Keep changed-scope coverage at or above 95%.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1100,6 +1100,43 @@
     ]
   },
   {
+    "id": "lora-experiment-run-dir-name-scan",
+    "name": "LoRA experiment run-dir name scan",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/lora_experiment_store.py",
+      "services/mlx-worker-python/tests/test_lora_experiment_store.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/lora_experiment_run_dir_scan_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py::test_iter_lora_run_dirs_sorts_names_without_reading_entry_paths services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_prefers_run_record_over_manifest_when_both_exist services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_experiment_run_dir_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_experiment_run_dir_scan_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py::test_iter_lora_run_dirs_sorts_names_without_reading_entry_paths services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_prefers_run_record_over_manifest_when_both_exist services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_experiment_run_dir_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_experiment_run_dir_scan_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/lora_experiment_store.py services/mlx-worker-python/tests/test_lora_experiment_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_experiment_run_dir_scan_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python - <<'PY'\nimport json, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nsys.path[:0] = [str(Path.cwd()), str(Path.cwd() / \"services/mlx-worker-python\")]\nfrom worker.productization import lora_experiment_store as store_module\nRUN_COUNT=8000; NOISE_COUNT=1000; ITERATIONS=24; SAMPLES=5; TRAIN_ROOT=Path(\"/tmp/melix-lora-scan-probe/train_lora\")\npath_attr_reads=0\nclass FakeEntry:\n    __slots__=(\"name\",\"_path\",\"_is_dir\")\n    def __init__(self,name,is_dir=True): self.name=name; self._path=str(TRAIN_ROOT/name); self._is_dir=is_dir\n    @property\n    def path(self):\n        global path_attr_reads\n        path_attr_reads += 1\n        return self._path\n    def is_dir(self): return self._is_dir\nclass FakeScandir:\n    def __init__(self,path): self.path=path\n    def __enter__(self): return iter(fake_entries)\n    def __exit__(self, exc_type, exc, tb): return False\nfake_entries=tuple([FakeEntry(f\"model-ops-{idx:05d}\") for idx in range(RUN_COUNT,0,-1)] + [FakeEntry(f\"noise-{idx:05d}\") for idx in range(NOISE_COUNT)] + [FakeEntry(f\"model-ops-file-{idx:05d}\", False) for idx in range(NOISE_COUNT)])\ndef run_sample():\n    global path_attr_reads\n    path_attr_reads=0\n    original_scandir=store_module.os.scandir\n    store_module.os.scandir=FakeScandir\n    tracemalloc.start(); started=time.perf_counter()\n    try:\n        for _ in range(ITERATIONS):\n            result=store_module._iter_lora_run_dirs(TRAIN_ROOT)\n            if len(result) != RUN_COUNT: raise AssertionError(len(result))\n            if result[0].name != \"model-ops-00001\" or result[-1].name != f\"model-ops-{RUN_COUNT:05d}\": raise AssertionError(\"unsorted\")\n    finally:\n        elapsed=(time.perf_counter()-started)*1000.0\n        _, peak=tracemalloc.get_traced_memory(); tracemalloc.stop(); store_module.os.scandir=original_scandir\n    return elapsed, float(peak), float(path_attr_reads)\nsamples=[run_sample() for _ in range(SAMPLES)]\nprint(json.dumps({\"run_dir_count\":RUN_COUNT,\"iteration_count\":ITERATIONS,\"sample_count\":SAMPLES,\"elapsed_ms_mean\":statistics.fmean(s[0] for s in samples),\"peak_bytes_mean\":statistics.fmean(s[1] for s in samples),\"path_attr_reads_mean\":statistics.fmean(s[2] for s in samples)}, sort_keys=True))\nPY",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "path_attr_reads_mean",
+        "unit": "count",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "run_dir_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "training-dataset-token-percentiles-single-sort",
     "name": "Training dataset quality/token summary",
     "runner": "ubuntu-latest",

--- a/scripts/lora_experiment_run_dir_scan_probe.py
+++ b/scripts/lora_experiment_run_dir_scan_probe.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Iterator
+
+REPO_ROOT = Path.cwd()
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.productization import lora_experiment_store as store_module  # noqa: E402
+
+RUN_COUNT = 8_000
+NOISE_COUNT = 1_000
+ITERATIONS = 24
+SAMPLES = 5
+TRAIN_ROOT = Path("/tmp/melix-lora-scan-probe/train_lora")
+
+
+class FakeEntry:
+    __slots__ = ("name", "_path", "_is_dir")
+
+    def __init__(self, name: str, *, is_dir: bool = True) -> None:
+        self.name = name
+        self._path = str(TRAIN_ROOT / name)
+        self._is_dir = is_dir
+
+    @property
+    def path(self) -> str:
+        global path_attr_reads
+        path_attr_reads += 1
+        return self._path
+
+    def is_dir(self) -> bool:
+        return self._is_dir
+
+
+class FakeScandir:
+    def __init__(self, path: object) -> None:
+        self.path = path
+
+    def __enter__(self) -> Iterator[FakeEntry]:
+        return iter(fake_entries)
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+        return False
+
+
+fake_entries = tuple(
+    [FakeEntry(f"model-ops-{idx:05d}") for idx in range(RUN_COUNT, 0, -1)]
+    + [FakeEntry(f"noise-{idx:05d}") for idx in range(NOISE_COUNT)]
+    + [FakeEntry(f"model-ops-file-{idx:05d}", is_dir=False) for idx in range(NOISE_COUNT)]
+)
+path_attr_reads = 0
+
+
+def run_sample() -> dict[str, float]:
+    global path_attr_reads
+    path_attr_reads = 0
+    original_scandir = store_module.os.scandir
+    store_module.os.scandir = FakeScandir  # type: ignore[assignment]
+    tracemalloc.start()
+    started = time.perf_counter()
+    try:
+        result_count = 0
+        for _ in range(ITERATIONS):
+            result = store_module._iter_lora_run_dirs(TRAIN_ROOT)
+            result_count = len(result)
+            if result_count != RUN_COUNT:
+                raise AssertionError(f"unexpected run dir count: {result_count}")
+            if result[0].name != "model-ops-00001" or result[-1].name != f"model-ops-{RUN_COUNT:05d}":
+                raise AssertionError("run dirs are not sorted by name")
+    finally:
+        elapsed = time.perf_counter() - started
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        store_module.os.scandir = original_scandir
+    return {
+        "elapsed_ms": elapsed * 1000,
+        "peak_bytes": float(peak),
+        "path_attr_reads": float(path_attr_reads),
+    }
+
+
+def main() -> None:
+    samples = [run_sample() for _ in range(SAMPLES)]
+    payload = {
+        "run_dir_count": RUN_COUNT,
+        "iteration_count": ITERATIONS,
+        "sample_count": SAMPLES,
+        "elapsed_ms_mean": statistics.fmean(sample["elapsed_ms"] for sample in samples),
+        "peak_bytes_mean": statistics.fmean(sample["peak_bytes"] for sample in samples),
+        "path_attr_reads_mean": statistics.fmean(sample["path_attr_reads"] for sample in samples),
+    }
+    print(json.dumps(payload, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_lora_experiment_store.py
+++ b/services/mlx-worker-python/tests/test_lora_experiment_store.py
@@ -79,6 +79,51 @@ def _write_manifest(
     return manifest_path
 
 
+def test_iter_lora_run_dirs_sorts_names_without_reading_entry_paths(tmp_path: Path, monkeypatch) -> None:
+    train_root = tmp_path / "train_lora"
+    path_reads = 0
+
+    class FakeEntry:
+        def __init__(self, name: str, *, is_dir: bool = True, raises: bool = False) -> None:
+            self.name = name
+            self._is_dir = is_dir
+            self._raises = raises
+
+        @property
+        def path(self) -> str:  # pragma: no cover - executed only if the regression returns
+            nonlocal path_reads
+            path_reads += 1
+            raise AssertionError("_iter_lora_run_dirs should rebuild paths from entry names")
+
+        def is_dir(self) -> bool:
+            if self._raises:
+                raise OSError("unreadable")
+            return self._is_dir
+
+    class FakeScandir:
+        def __enter__(self):
+            return iter(
+                [
+                    FakeEntry("model-ops-0002"),
+                    FakeEntry("ignored-prefix"),
+                    FakeEntry("model-ops-file", is_dir=False),
+                    FakeEntry("model-ops-unreadable", raises=True),
+                    FakeEntry("model-ops-0001"),
+                ]
+            )
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    monkeypatch.setattr(lora_experiment_store_module.os, "scandir", lambda path: FakeScandir())
+
+    assert lora_experiment_store_module._iter_lora_run_dirs(train_root) == (
+        train_root / "model-ops-0001",
+        train_root / "model-ops-0002",
+    )
+    assert path_reads == 0
+
+
 def test_rebuild_index_prefers_runs_with_reported_loss_for_best_run(tmp_path: Path) -> None:
     jobs_root = tmp_path / "model-ops"
     _write_run_record(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -248,6 +248,31 @@ def test_training_config_target_modules_probe_script_smoke(
     assert metrics["case_count"] == 4.0
 
 
+def test_scope_report_selects_lora_experiment_run_dir_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/lora_experiment_store.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "lora-experiment-run-dir-name-scan"
+
+
+def test_lora_experiment_run_dir_scan_probe_script_smoke(capsys: pytest.CaptureFixture[str]) -> None:
+    runpy.run_path(
+        str(REPO_ROOT / "scripts/lora_experiment_run_dir_scan_probe.py"),
+        run_name="__main__",
+    )
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["run_dir_count"] == 8000
+    assert metrics["iteration_count"] == 24
+    assert metrics["sample_count"] == 5
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["path_attr_reads_mean"] == 0.0
+
+
 def test_scope_report_selects_mlx_audio_speech_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -1760,6 +1785,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "engine-generate-usage-token-elision",
         "job-registry-derived-model-single-pass",
         "job-registry-restore-sort-elision",
+        "lora-experiment-run-dir-name-scan",
         "lora-reward-summary-candidate-minmax",
         "mlx-lm-structured-result-tail-parse",
         "mlx-audio-local-uri-zero-copy-preprocess",

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -14,7 +14,7 @@ _INDEX_SCHEMA_VERSION = "melix.lora_experiment_index.v1"
 def _iter_lora_run_dirs(train_root: Path) -> tuple[Path, ...]:
     try:
         with os.scandir(train_root) as entries:
-            run_dir_entries = []
+            run_dir_names = []
             for entry in entries:
                 if not entry.name.startswith("model-ops-"):
                     continue
@@ -23,11 +23,11 @@ def _iter_lora_run_dirs(train_root: Path) -> tuple[Path, ...]:
                         continue
                 except OSError:
                     continue
-                run_dir_entries.append(entry)
+                run_dir_names.append(entry.name)
     except OSError:
         return ()
 
-    return tuple(Path(entry.path) for entry in sorted(run_dir_entries, key=lambda entry: entry.name))
+    return tuple(train_root / name for name in sorted(run_dir_names))
 
 
 class LoraExperimentStore:


### PR DESCRIPTION
## Summary
- Reduces temporary object retention in the LoRA experiment index rebuild scan by storing eligible run-directory names instead of retaining `os.DirEntry` objects through sorting.
- Adds a focused regression test proving `_iter_lora_run_dirs()` no longer reads `entry.path` while preserving sorted output and unreadable-entry handling.
- Registers the `lora-experiment-run-dir-name-scan` PR-scoped performance probe.

## Plan or Spec
- `docs/plans/lora-run-dir-name-scan.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.validated.json
# OK

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PROJECT_ENVIRONMENT=/tmp/melix-uv-env-cron-opt uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py::test_iter_lora_run_dirs_sorts_names_without_reading_entry_paths services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_prefers_run_record_over_manifest_when_both_exist services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_experiment_run_dir_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_experiment_run_dir_scan_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 5 passed in 7.62s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PROJECT_ENVIRONMENT=/tmp/melix-uv-env-cron-opt uv run --frozen --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py::test_iter_lora_run_dirs_sorts_names_without_reading_entry_paths services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_prefers_run_record_over_manifest_when_both_exist services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_experiment_run_dir_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_experiment_run_dir_scan_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && coverage json + scripts/changed_scope_coverage.py ...
# 5 passed; TOTAL 36 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PROJECT_ENVIRONMENT=/tmp/melix-uv-env-cron-opt uv run --frozen --project services/mlx-worker-python python scripts/lora_experiment_run_dir_scan_probe.py
# {"elapsed_ms_mean": 1101.2467412045226, "iteration_count": 24, "path_attr_reads_mean": 0.0, "peak_bytes_mean": 3091903.2, "run_dir_count": 8000, "sample_count": 5}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PROJECT_ENVIRONMENT=/tmp/melix-uv-env-cron-opt uv run --frozen --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id lora-experiment-run-dir-name-scan --base-repo /tmp/melix-cron-opt-20260508171637-base --head-repo "$PWD" --output /tmp/lora-pr-scoped-report.json
# head verification OK; base/head probes OK

git diff --check
# OK
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 36 0 100%`.
- Registered scoped probe: `lora-experiment-run-dir-name-scan`.
- Local base vs head probe (`scripts/pr_scoped_performance_run.py`):
  - `peak_bytes_mean`: base `3,347,656.0`, head `3,091,824.0` (~7.64% lower).
  - `path_attr_reads_mean`: base `192,000.0`, head `0.0`.
  - `run_dir_count`: base/head `8,000.0`.
  - Informational wall time: base `859.473 ms`, head `1061.615 ms`; this slice intentionally gates memory/structural metrics rather than latency.

## Known Gaps
- Full repository `make py-test`, Swift, and integration suites were not run on this Linux cron host.
- Hosted PR-scoped performance and broader CI still need to run on GitHub before merge/auto-merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
