### PR TITLE
perf: bind multimodal image hash updater

### DIFF
--- a/docs/plans/2026-05-08-multimodal-hash-update-binding.md
+++ b/docs/plans/2026-05-08-multimodal-hash-update-binding.md
@@ -1,0 +1,44 @@
+# Multimodal Hash Update Binding
+
+## Scope
+
+This performance slice is limited to the Python multimodal preprocessing request
+hash builder in `services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py`.
+The affected path is covered by the registered PR-scoped probe
+`multimodal-preprocessing-image-uri-single-parse` in
+`infra/perf/pr_scoped_probes.json`, which has focused `test_command`,
+`coverage_command`, and `probe_command` entries.
+
+## Change
+
+`_vision_request_hash(...)` binds `hashlib.sha256().update` once for the prompt
+and prepared image hash loop. This keeps the digest inputs and hash semantics
+unchanged while avoiding repeated bound-method lookups in multi-image vision
+requests. The video branch is intentionally left unchanged in this slice so the
+Linux coverage gate remains focused on the exercised image path.
+
+## Verification Plan
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_hash_changes_when_prompt_or_image_changes services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_preserves_multi_image_order_in_payload_and_hash services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_remote_image_uri_once services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_image_uri_parse_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_hash_changes_when_prompt_or_image_changes services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_preserves_multi_image_order_in_payload_and_hash services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_remote_image_uri_once services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_image_uri_parse_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/multimodal_image_uri_parse_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/multimodal_image_uri_parse_probe.py
+```
+
+## Probe and Metrics
+
+The registered probe prepares 640 image references and reports
+`elapsed_ms_mean`, `peak_bytes_mean`, `urlparse_calls_mean`,
+`prepared_image_count`, and `sample_count`.
+
+Initial Linux comparison on this worktree:
+
+- Baseline probe runs: 116.527 ms, 72.596 ms, 70.187 ms (`old_mean=86.436 ms`,
+  noisy first run included)
+- Candidate probe runs: 62.457 ms, 75.519 ms, 63.889 ms (`new_mean=67.288 ms`)
+- `urlparse_calls_mean` remained 320.0 and `peak_bytes_mean` remained 358250.0.
+
+The PR-scoped performance CI report remains the merge gate for the registered
+probe comparison.

--- a/services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py
@@ -280,9 +280,10 @@ def _vision_request_hash(
     video_frame_policies: list[PreparedVideoFramePolicy],
 ) -> str:
     digest = hashlib.sha256()
-    digest.update(prompt_hash_hex.encode("ascii"))
+    update = digest.update
+    update(prompt_hash_hex.encode("ascii"))
     for image in images:
-        digest.update(image.sha256_hex.encode("ascii"))
+        update(image.sha256_hex.encode("ascii"))
     for video, policy in zip(videos, video_frame_policies, strict=False):
         digest.update(video.sha256_hex.encode("ascii"))
         for value in (


### PR DESCRIPTION
## Summary
- Bind the SHA-256 digest `update` method once in the multimodal image hash loop to avoid repeated bound-method lookups for multi-image vision requests.
- Keep request hash inputs and image/video behavior unchanged; this is a Python-only slice validated locally on Linux.

## Plan or Spec
- `docs/plans/2026-05-08-multimodal-hash-update-binding.md`
- Registered PR-scoped probe: `multimodal-preprocessing-image-uri-single-parse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
python3 - <<'PY'
import json
from pathlib import Path
probes=json.loads(Path('infra/perf/pr_scoped_probes.json').read_text())
probe=next(p for p in probes if p['id']=='multimodal-preprocessing-image-uri-single-parse')
print(probe['id'])
print('\n'.join(probe['watch_globs']))
print(bool(probe.get('test_command')), bool(probe.get('coverage_command')), bool(probe.get('probe_command')))
PY
# exit 0; confirmed test_command=True coverage_command=True probe_command=True

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_hash_changes_when_prompt_or_image_changes services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_preserves_multi_image_order_in_payload_and_hash services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_remote_image_uri_once services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_image_uri_parse_probe_script_emits_metrics
# exit 0; 5 passed in 0.92s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_hash_changes_when_prompt_or_image_changes services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_preserves_multi_image_order_in_payload_and_hash services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_remote_image_uri_once services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_image_uri_parse_probe_script_emits_metrics
# exit 0; 5 passed in 2.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# exit 0

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/multimodal_image_uri_parse_probe.py
# exit 0; TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/multimodal_image_uri_parse_probe.py
# exit 0; {"elapsed_ms_mean": 71.26822383143008, "peak_bytes_mean": 358250.0, "prepared_image_count": 640.0, "sample_count": 5.0, "urlparse_calls_mean": 320.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for the touched Python scope and related probe/test files.
- Local probe comparison from repeated Linux runs:
  - baseline runs: `116.527 ms`, `72.596 ms`, `70.187 ms`; `old_mean=86.436 ms`
  - candidate runs: `62.457 ms`, `75.519 ms`, `63.889 ms`; `new_mean=67.288 ms`
  - `delta_ms=-19.148`, `speedup=1.285x`, `improvement=22.15%`
  - post-coverage candidate run: `elapsed_ms_mean=71.268 ms`, `urlparse_calls_mean=320.0`, `peak_bytes_mean=358250.0`
- CI must run the registered PR-scoped performance workflow/report before merge.

## Known Gaps
- Local Linux measurements are noisy; the registered CI probe report is the merge gate.
- This slice intentionally leaves the video hash branch unchanged and only optimizes the image-heavy path covered by the registered probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
