### PR TITLE
perf: fast-path direct hub size hints

### DIFF
--- a/docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md
+++ b/docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md
@@ -1,0 +1,27 @@
+# Hub Catalog Card Model Size Fast Path
+
+## Goal
+
+Avoid running the generic size-hint regex for the common Hugging Face `cardData.model_size` shape where the value is already a bare numeric size such as `128 MB`. The generic parser remains the fallback for labeled or unusual text.
+
+## Scope
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+
+## Registered Probe
+
+The affected path is already covered by the PR-scoped `hub-catalog-size-hint-regex-precompile` command-json probe in `infra/perf/pr_scoped_probes.json`. It provides focused `test_command`, `coverage_command`, and `probe_command` entries for this file and probe script.
+
+## Verification Plan
+
+- Run the registered focused pytest command for the hub catalog probe.
+- Run the registered changed-scope coverage command and require at least 95% coverage for touched executable scope.
+- Run `scripts/hub_catalog_size_hint_probe.py` before and after the change on Linux and compare `elapsed_ms_mean` plus `size_hint_calls_mean`.
+
+## Success Metrics
+
+- Preserve all existing size-hint parsing behavior by falling back to `_size_hint_from_text(...)` when the direct parser cannot handle the value.
+- Reduce `_size_hint_from_text(...)` calls for direct `cardData.model_size` values in the registered probe.
+- Improve or hold steady `elapsed_ms_mean` in the local registered probe.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -578,6 +578,34 @@ def test_size_hint_bytes_skips_direct_hint_parser_when_card_model_size_missing(
     assert calls == [("Model size: 7 MB", False)]
 
 
+def test_size_hint_bytes_uses_direct_card_model_size_without_regex(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parser = Mock(return_value=0)
+    monkeypatch.setattr(hub_catalog_module, "_size_hint_from_text", parser)
+
+    assert hub_catalog_module._size_hint_bytes({"cardData": {"model_size": "128 MB"}}) == 128 * MB
+    assert hub_catalog_module._size_hint_bytes({"cardData": {"model_size": "1.5 GB"}}) == int(1.5 * GB)
+    parser.assert_not_called()
+
+
+def test_size_hint_bytes_falls_back_for_labeled_direct_card_model_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parser = Mock(return_value=7 * MB)
+    monkeypatch.setattr(hub_catalog_module, "_size_hint_from_text", parser)
+
+    assert hub_catalog_module._size_hint_bytes({"cardData": {"model_size": "Model size: 7 MB"}}) == 7 * MB
+    parser.assert_called_once_with("Model size: 7 MB", allow_bare=True)
+
+
+def test_direct_size_hint_parser_covers_units_and_invalid_values() -> None:
+    assert hub_catalog_module._direct_size_hint_from_text("512 kb") == 512 * KB
+    assert hub_catalog_module._direct_size_hint_from_text("512 tb") == 0
+    assert hub_catalog_module._direct_size_hint_from_text("not-a-number MB") == 0
+    assert hub_catalog_module._direct_size_hint_from_text("model size 512 MB") == 0
+
+
 @pytest.mark.parametrize(
     ("payload", "expected_text"),
     [

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1168,7 +1168,7 @@ def test_hub_catalog_size_hint_probe_script_emits_metrics(
     assert exc_info.value.code == 0
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["sample_count"] == 1.0
-    assert metrics["size_hint_calls_mean"] == 4.0
+    assert metrics["size_hint_calls_mean"] == 2.0
     assert metrics["matched_hint_count"] == 4.0
     assert metrics["elapsed_ms_mean"] >= 0
     assert metrics["peak_bytes_mean"] > 0

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -572,6 +572,9 @@ def _size_hint_bytes(payload: dict[str, Any]) -> int:
     card_data = raw_card_data if isinstance(raw_card_data, dict) else {}
     direct_card_text = _string(card_data.get("model_size"))
     if direct_card_text:
+        direct_card_hint = _direct_size_hint_from_text(direct_card_text)
+        if direct_card_hint > 0:
+            return direct_card_hint
         direct_card_hint = _size_hint_from_text(direct_card_text, allow_bare=True)
         if direct_card_hint > 0:
             return direct_card_hint
@@ -604,6 +607,27 @@ def _size_hint_bytes(payload: dict[str, Any]) -> int:
         if text
     )
     return _size_hint_from_text(text, allow_bare=False)
+
+
+def _direct_size_hint_from_text(text: str) -> int:
+    parts = text.split()
+    if len(parts) != 2:
+        return 0
+    value_text, unit_text = parts
+    unit = unit_text.lower()
+    if unit == "kb":
+        multiplier = 1024
+    elif unit == "mb":
+        multiplier = 1024 ** 2
+    elif unit == "gb":
+        multiplier = 1024 ** 3
+    else:
+        return 0
+    try:
+        value = float(value_text)
+    except ValueError:
+        return 0
+    return int(value * multiplier)
 
 
 def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:


### PR DESCRIPTION
## Summary
- Fast-path direct `cardData.model_size` values such as `128 MB` without calling the generic regex parser.
- Preserve fallback behavior for labeled or unusual model-size text.
- Update focused probe expectations because direct card values no longer call `_size_hint_from_text(...)`.

## Plan or Spec
- `docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md`
- Registered PR-scoped probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# before: exit 0; {"elapsed_ms_mean": 1448.2856864109635, "size_hint_calls_mean": 100000.0, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# exit 0; 48 passed in 0.29s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# exit 0; 48 passed in 0.34s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# exit 0; Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# exit 0; TOTAL 38 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# after: exit 0; {"elapsed_ms_mean": 1329.268830572255, "size_hint_calls_mean": 50000.0, ...}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 38 0 100%`.
- Local registered probe: old_mean=1448.285686 ms, new_mean=1329.268831 ms, delta_ms=-119.016856, speedup=1.089536x, improvement=8.218%.
- Structural metric: `size_hint_calls_mean` dropped from `100000.0` to `50000.0` on the local probe.
- CI must run the registered PR-scoped performance workflow and publish the hosted probe report before merge.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime surface is touched.
- Hosted registered probe validation is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
