### PR TITLE
perf: elide text family config copies

### DIFF
--- a/docs/plans/2026-05-08-text-family-config-copy-elision.md
+++ b/docs/plans/2026-05-08-text-family-config-copy-elision.md
@@ -1,0 +1,48 @@
+# Text Family Config Copy Elision
+
+## Goal
+
+Reduce redundant work in text-family config resolution by avoiding repeated full `dict(...)` copies of large Hugging Face-style config payload mappings.
+
+## Linux-only constraint
+
+This slice is Python-only under `services/mlx-worker-python` and can be verified locally on Linux with focused pytest, changed-scope coverage, and a command-json performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/text_family_adapters.py`
+- `services/mlx-worker-python/tests/test_text_family_adapters.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/text_family_config_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Probe definition
+
+Register `text-family-config-copy-elision` in the PR-scoped performance registry.
+
+The probe repeatedly resolves a Qwen3-MoE text family config using a large read-only mapping that records `keys()` calls. The old implementation calls `dict(config_payload)` repeatedly, forcing whole-mapping copies; the optimized implementation reads from the mapping directly.
+
+Metrics:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- `config_copy_calls_mean`
+- `iterations`
+
+## Success metrics
+
+- Preserve existing text-family resolution behavior.
+- Drive `config_copy_calls_mean` to `0.0` on the optimized branch.
+- Improve local base-vs-head probe latency and/or peak traced memory on the registered synthetic workload.
+- Maintain at least 95% changed-scope coverage for touched executable Python files.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/text_family_adapters.py services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/text_family_config_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/text_family_config_probe.py
+python scripts/pr_scoped_performance_run.py --probe-id text-family-config-copy-elision --output /tmp/text-family-config-probe.json
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -309,6 +309,43 @@
     ]
   },
   {
+    "id": "text-family-config-copy-elision",
+    "name": "Text family config copy elision",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/text_family_adapters.py",
+      "services/mlx-worker-python/tests/test_text_family_adapters.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/text_family_config_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/text_family_adapters.py services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/text_family_config_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/text_family_config_probe.py ]; then python scripts/text_family_config_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"ZnJvbSBfX2Z1dHVyZV9fIGltcG9ydCBhbm5vdGF0aW9ucwppbXBvcnQganNvbiwgc3RhdGlzdGljcywgc3lzLCB0aW1lLCB0cmFjZW1hbGxvYwpmcm9tIGNvbGxlY3Rpb25zLmFiYyBpbXBvcnQgSXRlcmF0b3IsIE1hcHBpbmcKZnJvbSBwYXRobGliIGltcG9ydCBQYXRoCmZyb20gdHlwaW5nIGltcG9ydCBBbnkKcmVwb19yb290ID0gUGF0aC5jd2QoKQpzeXMucGF0aC5pbnNlcnQoMCwgc3RyKHJlcG9fcm9vdCkpCnN5cy5wYXRoLmluc2VydCgwLCBzdHIocmVwb19yb290IC8gInNlcnZpY2VzL21seC13b3JrZXItcHl0aG9uIikpCmZyb20gd29ya2VyLnJ1bnRpbWUudGV4dF9mYW1pbHlfYWRhcHRlcnMgaW1wb3J0IHJlc29sdmVfdGV4dF9mYW1pbHlfY29uZmlnCmNsYXNzIENvcHlDb3VudGluZ0NvbmZpZyhNYXBwaW5nW3N0ciwgQW55XSk6CiAgICBkZWYgX19pbml0X18oc2VsZiwgcGF5bG9hZDogTWFwcGluZ1tzdHIsIEFueV0pIC0+IE5vbmU6CiAgICAgICAgc2VsZi5fcGF5bG9hZCA9IGRpY3QocGF5bG9hZCkKICAgICAgICBzZWxmLmNvcHlfYXR0ZW1wdHMgPSAwCiAgICBkZWYgX19nZXRpdGVtX18oc2VsZiwga2V5OiBzdHIpIC0+IEFueToKICAgICAgICByZXR1cm4gc2VsZi5fcGF5bG9hZFtrZXldCiAgICBkZWYgX19pdGVyX18oc2VsZikgLT4gSXRlcmF0b3Jbc3RyXToKICAgICAgICByZXR1cm4gaXRlcihzZWxmLl9wYXlsb2FkKQogICAgZGVmIF9fbGVuX18oc2VsZikgLT4gaW50OgogICAgICAgIHJldHVybiBsZW4oc2VsZi5fcGF5bG9hZCkKICAgIGRlZiBrZXlzKHNlbGYpOgogICAgICAgIHNlbGYuY29weV9hdHRlbXB0cyArPSAxCiAgICAgICAgcmV0dXJuIHNlbGYuX3BheWxvYWQua2V5cygpCmRlZiBfcGF5bG9hZCgpIC0+IGRpY3Rbc3RyLCBBbnldOgogICAgcGF5bG9hZDogZGljdFtzdHIsIEFueV0gPSB7ZiJ1bnVzZWRfe2luZGV4fSI6IGluZGV4IGZvciBpbmRleCBpbiByYW5nZSgyMDQ4KX0KICAgIHBheWxvYWQudXBkYXRlKHsibW9kZWxfdHlwZSI6ICJxd2VuM19tb2UiLCAiYXJjaGl0ZWN0dXJlcyI6IFsiUXdlbjNNb2VGb3JDYXVzYWxMTSJdLCAicm9wZV9zY2FsaW5nIjogeyJ0eXBlIjogInlhcm4iLCAiaW50ZXJsZWF2ZWQiOiBUcnVlfSwgInJvcGVfaW50ZXJsZWF2ZWQiOiBUcnVlLCAibnVtX2xvY2FsX2V4cGVydHMiOiAxMjgsICJtb2VfZ2F0ZV9kZXF1YW50IjogVHJ1ZX0pCiAgICByZXR1cm4gcGF5bG9hZApkZWYgX3J1bl9zYW1wbGUoKiwgaXRlcmF0aW9uczogaW50KSAtPiB0dXBsZVtmbG9hdCwgaW50LCBpbnRdOgogICAgY29uZmlnID0gQ29weUNvdW50aW5nQ29uZmlnKF9wYXlsb2FkKCkpCiAgICBtZXRhZGF0YSA9IHsidGV4dF9mYW1pbHlfaWQiOiAicXdlbjNtb2UifQogICAgY2hlY2tzdW0gPSAwCiAgICB0cmFjZW1hbGxvYy5zdGFydCgpOyBzdGFydGVkID0gdGltZS5wZXJmX2NvdW50ZXIoKQogICAgZm9yIF8gaW4gcmFuZ2UoaXRlcmF0aW9ucyk6CiAgICAgICAgcmVzb2x2ZWQgPSByZXNvbHZlX3RleHRfZmFtaWx5X2NvbmZpZyhtZXRhZGF0YSwgbW9kZWxfcGF0aD0ibW9kZWxzL3F3ZW4zLW1vZS0xMjhlIiwgY29uZmlnX3BheWxvYWQ9Y29uZmlnLCBkZWZhdWx0X3JvdXRlX2tpbmQ9InN3aWZ0X3RleHQiKQogICAgICAgIGNoZWNrc3VtICs9IHJlc29sdmVkLmV4cGVydF9jb3VudAogICAgICAgIGlmIHJlc29sdmVkLnJvcGVfcHJvZmlsZSA9PSAieWFybl9pbnRlcmxlYXZlZCI6IGNoZWNrc3VtICs9IDEKICAgICAgICBpZiByZXNvbHZlZC5tb2VfZ2F0ZV9kZXF1YW50OiBjaGVja3N1bSArPSAxCiAgICBlbGFwc2VkX21zID0gKHRpbWUucGVyZl9jb3VudGVyKCkgLSBzdGFydGVkKSAqIDEwMDAuMAogICAgXywgcGVha19ieXRlcyA9IHRyYWNlbWFsbG9jLmdldF90cmFjZWRfbWVtb3J5KCk7IHRyYWNlbWFsbG9jLnN0b3AoKQogICAgaWYgY2hlY2tzdW0gIT0gaXRlcmF0aW9ucyAqIDEzMDogcmFpc2UgQXNzZXJ0aW9uRXJyb3IoZiJ1bmV4cGVjdGVkIGNoZWNrc3VtOiB7Y2hlY2tzdW19IikKICAgIHJldHVybiBlbGFwc2VkX21zLCBwZWFrX2J5dGVzLCBjb25maWcuY29weV9hdHRlbXB0cwplbGFwc2VkPVtdOyBwZWFrPVtdOyBjb3B5X2NhbGxzPVtdOyBpdGVyYXRpb25zPTEwMDAwCmZvciBfIGluIHJhbmdlKDUpOgogICAgZWxhcHNlZF9tcywgcGVha19ieXRlcywgY29waWVzID0gX3J1bl9zYW1wbGUoaXRlcmF0aW9ucz1pdGVyYXRpb25zKQogICAgZWxhcHNlZC5hcHBlbmQoZWxhcHNlZF9tcyk7IHBlYWsuYXBwZW5kKHBlYWtfYnl0ZXMpOyBjb3B5X2NhbGxzLmFwcGVuZChjb3BpZXMpCnByaW50KGpzb24uZHVtcHMoeyJlbGFwc2VkX21zX21lYW4iOiBzdGF0aXN0aWNzLmZtZWFuKGVsYXBzZWQpLCAicGVha19ieXRlc19tZWFuIjogc3RhdGlzdGljcy5mbWVhbihwZWFrKSwgImNvbmZpZ19jb3B5X2NhbGxzX21lYW4iOiBzdGF0aXN0aWNzLmZtZWFuKGNvcHlfY2FsbHMpLCAiaXRlcmF0aW9ucyI6IGl0ZXJhdGlvbnN9LCBzb3J0X2tleXM9VHJ1ZSkpCg==\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "config_copy_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "mlx-audio-speech-signature-cache",
     "name": "MLX audio speech signature cache",
     "runner": "ubuntu-latest",

--- a/scripts/text_family_config_probe.py
+++ b/scripts/text_family_config_probe.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+import tracemalloc
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+repo_root = Path.cwd()
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
+
+from worker.runtime.text_family_adapters import resolve_text_family_config
+
+
+class CopyCountingConfig(Mapping[str, Any]):
+    def __init__(self, payload: Mapping[str, Any]) -> None:
+        self._payload = dict(payload)
+        self.copy_attempts = 0
+
+    def __getitem__(self, key: str) -> Any:
+        return self._payload[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._payload)
+
+    def __len__(self) -> int:
+        return len(self._payload)
+
+    def keys(self):  # type: ignore[override]
+        self.copy_attempts += 1
+        return self._payload.keys()
+
+
+def _payload() -> dict[str, Any]:
+    payload: dict[str, Any] = {f"unused_{index}": index for index in range(2048)}
+    payload.update(
+        {
+            "model_type": "qwen3_moe",
+            "architectures": ["Qwen3MoeForCausalLM"],
+            "rope_scaling": {"type": "yarn", "interleaved": True},
+            "rope_interleaved": True,
+            "num_local_experts": 128,
+            "moe_gate_dequant": True,
+        }
+    )
+    return payload
+
+
+def _run_sample(*, iterations: int) -> tuple[float, int, int]:
+    config = CopyCountingConfig(_payload())
+    metadata = {"text_family_id": "qwen3moe"}
+    checksum = 0
+    tracemalloc.start()
+    started = time.perf_counter()
+    for _ in range(iterations):
+        resolved = resolve_text_family_config(
+            metadata,
+            model_path="models/qwen3-moe-128e",
+            config_payload=config,
+            default_route_kind="swift_text",
+        )
+        checksum += resolved.expert_count
+        if resolved.rope_profile == "yarn_interleaved":
+            checksum += 1
+        if resolved.moe_gate_dequant:
+            checksum += 1
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    _, peak_bytes = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    if checksum != iterations * 130:
+        raise AssertionError(f"unexpected checksum: {checksum}")
+    return elapsed_ms, peak_bytes, config.copy_attempts
+
+
+def main() -> None:
+    iterations = 10_000
+    elapsed: list[float] = []
+    peak: list[int] = []
+    copy_calls: list[int] = []
+    for _ in range(5):
+        elapsed_ms, peak_bytes, copies = _run_sample(iterations=iterations)
+        elapsed.append(elapsed_ms)
+        peak.append(peak_bytes)
+        copy_calls.append(copies)
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed),
+                "peak_bytes_mean": statistics.fmean(peak),
+                "config_copy_calls_mean": statistics.fmean(copy_calls),
+                "iterations": iterations,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1810,6 +1810,31 @@ def test_release_gates_m9_failure_count_probe_script_emits_metrics(
     assert metrics["failures_per_section"] == 4.0
 
 
+def test_scope_report_selects_text_family_config_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/text_family_adapters.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "text-family-config-copy-elision"
+
+
+def test_text_family_config_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["text_family_config_probe.py"])
+
+    runpy.run_path(str(REPO_ROOT / "scripts/text_family_config_probe.py"), run_name="__main__")
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["config_copy_calls_mean"] == 0.0
+    assert metrics["iterations"] == 10_000
+
+
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
         "dataset-registry-limited-read-streaming",

--- a/services/mlx-worker-python/tests/test_text_family_adapters.py
+++ b/services/mlx-worker-python/tests/test_text_family_adapters.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
+from typing import Any
+
 import pytest
 
 from worker.runtime.text_family_adapters import (
@@ -7,6 +10,25 @@ from worker.runtime.text_family_adapters import (
     detect_text_family_identity,
     resolve_text_family_config,
 )
+
+
+class _CopyCountingConfig(Mapping[str, Any]):
+    def __init__(self, payload: Mapping[str, Any]) -> None:
+        self._payload = dict(payload)
+        self.copy_attempts = 0
+
+    def __getitem__(self, key: str) -> Any:
+        return self._payload[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._payload)
+
+    def __len__(self) -> int:
+        return len(self._payload)
+
+    def keys(self):  # type: ignore[override]
+        self.copy_attempts += 1
+        return self._payload.keys()
 
 
 def test_detect_text_family_identity_prefers_explicit_supported_override() -> None:
@@ -225,3 +247,32 @@ def test_resolve_text_family_config_prefers_live_config_over_stale_expert_metada
 def test_inferred_expert_count_preserves_config_before_family_default() -> None:
     assert _inferred_expert_count({"num_experts": 4}, default=128) == 4
     assert _inferred_expert_count({}, default=128) == 128
+
+
+def test_resolve_text_family_config_reads_config_mapping_without_copying() -> None:
+    config = _CopyCountingConfig(
+        {
+            **{f"unused_{index}": index for index in range(512)},
+            "model_type": "qwen3_moe",
+            "rope_scaling": {"type": "yarn", "interleaved": True},
+            "num_local_experts": 128,
+            "moe_gate_dequant": True,
+        }
+    )
+
+    resolved = resolve_text_family_config(
+        {"text_family_id": "qwen3moe"},
+        model_path="models/qwen3-moe-128e",
+        config_payload=config,
+        default_route_kind="swift_text",
+    )
+
+    assert resolved.family_id == "qwen3moe"
+    assert resolved.rope_profile == "yarn_interleaved"
+    assert resolved.expert_count == 128
+    assert resolved.moe_gate_dequant is True
+    assert config.copy_attempts == 0
+    assert list(config)[:1] == ["unused_0"]
+    assert len(config) == 516
+    assert dict(config)["model_type"] == "qwen3_moe"
+    assert config.copy_attempts == 1

--- a/services/mlx-worker-python/worker/runtime/text_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/text_family_adapters.py
@@ -89,6 +89,7 @@ class ResolvedTextFamilyConfig:
 
 
 _DEFAULT_TEXT_FAMILY_ID = "llama"
+_EMPTY_CONFIG_PAYLOAD: Mapping[str, Any] = {}
 _TEXT_FAMILY_ADAPTERS: dict[str, TextFamilyDescriptor] = {
     "llama": TextFamilyDescriptor(
         family_id="llama",
@@ -296,7 +297,7 @@ def resolve_text_family_config(
 
 
 def _detected_architecture(config_payload: Mapping[str, Any] | None) -> str:
-    config_payload = dict(config_payload or {})
+    config_payload = _config_mapping(config_payload)
     model_type = _model_type(config_payload)
     if model_type:
         return model_type
@@ -314,7 +315,7 @@ def _detected_architecture(config_payload: Mapping[str, Any] | None) -> str:
 
 
 def _model_type(config_payload: Mapping[str, Any] | None) -> str:
-    config_payload = dict(config_payload or {})
+    config_payload = _config_mapping(config_payload)
     model_type = _string(config_payload.get("model_type"))
     if model_type:
         return model_type.lower()
@@ -322,7 +323,7 @@ def _model_type(config_payload: Mapping[str, Any] | None) -> str:
 
 
 def _inferred_attention_profile(config_payload: Mapping[str, Any] | None, *, default: str) -> str:
-    config_payload = dict(config_payload or {})
+    config_payload = _config_mapping(config_payload)
     for key in ("attention_type", "attn_type", "attention_impl", "attn_impl"):
         value = _string(config_payload.get(key)).lower()
         if "mla" in value:
@@ -333,7 +334,7 @@ def _inferred_attention_profile(config_payload: Mapping[str, Any] | None, *, def
 
 
 def _inferred_rope_profile(config_payload: Mapping[str, Any] | None, *, default: str) -> str:
-    config_payload = dict(config_payload or {})
+    config_payload = _config_mapping(config_payload)
     rope_scaling = config_payload.get("rope_scaling")
     if isinstance(rope_scaling, Mapping):
         rope_type = _string(rope_scaling.get("rope_type") or rope_scaling.get("type")).lower()
@@ -379,7 +380,7 @@ def _resolved_expert_count(
 
 
 def _expert_count_from_config(config_payload: Mapping[str, Any] | None) -> int | None:
-    config_payload = dict(config_payload or {})
+    config_payload = _config_mapping(config_payload)
     for key in ("num_local_experts", "num_experts", "moe_num_experts", "n_routed_experts"):
         value = config_payload.get(key)
         if isinstance(value, bool):
@@ -397,12 +398,18 @@ def _expert_count_from_config(config_payload: Mapping[str, Any] | None) -> int |
 
 
 def _inferred_moe_gate_dequant(config_payload: Mapping[str, Any] | None, *, default: bool) -> bool:
-    config_payload = dict(config_payload or {})
+    config_payload = _config_mapping(config_payload)
     for key in ("moe_gate_dequant", "dequantize_router_logits", "moe_gate_requires_dequant"):
         value = config_payload.get(key)
         if value is not None:
             return _bool_from_any(value)
     return default
+
+
+def _config_mapping(config_payload: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    if config_payload is None:
+        return _EMPTY_CONFIG_PAYLOAD
+    return config_payload
 
 
 def _string_value(metadata: Mapping[str, str], key: str, default: str) -> str:


### PR DESCRIPTION
## Summary
- Avoid repeated full `dict(config_payload)` copies in text-family config helpers by reading config payload mappings directly.
- Add a focused copy-counting regression test and a registered `text-family-config-copy-elision` PR-scoped performance probe.
- Document the optimization plan and Linux verification path.

## Plan or Spec
- `docs/plans/2026-05-08-text-family-config-copy-elision.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics
Result: 15 passed in 2.70s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/text_family_adapters.py services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/text_family_config_probe.py
Result: 15 passed in 19.94s; TOTAL 50 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/text_family_config_probe.py
Result: {"config_copy_calls_mean": 0.0, "elapsed_ms_mean": 354.47624740190804, "iterations": 10000, "peak_bytes_mean": 3884.2}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id text-family-config-copy-elision --base-repo /tmp/melix-cron-opt-20260508192900-base-2 --head-repo /tmp/melix-cron-opt-20260508192900 --output /tmp/text-family-config-probe.json
Result: base/head comparison completed; base_probe.ok=true; head_probe.ok=true; head coverage 100%.

git diff --check
Result: passed with no output.
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 50 0 100%`.
- Registered scoped CI probe: `text-family-config-copy-elision`.
- Local base vs head probe (`10,000` iterations, 5 samples):
  - `config_copy_calls_mean`: `50000.0` -> `0.0`
  - `elapsed_ms_mean`: `12697.177457809448 ms` -> `354.61979042738676 ms`
  - `peak_bytes_mean`: `107031.4 bytes` -> `3884.2 bytes`

## Known Gaps
- Linux-only verification was run locally; full macOS/Swift checks were not run on this Linux host.
- Hosted GitHub Actions / PR-scoped performance results are expected to run on the PR branch after opening.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
