### PR TITLE
perf: skip fence count for code eval tail blocks

### DIFF
--- a/docs/plans/2026-05-08-code-eval-fence-tail-fast-path.md
+++ b/docs/plans/2026-05-08-code-eval-fence-tail-fast-path.md
@@ -1,0 +1,42 @@
+# Code Evaluation Fence Tail Fast Path
+
+## Context
+
+The code-evaluation runner extracts the final fenced code block from model
+responses before compiling and sandboxing candidate Python. The PR-scoped
+performance probe `code-eval-code-block-last-match-streaming` exercises large
+responses with thousands of complete fenced blocks and records extraction
+latency plus peak allocation.
+
+## Slice
+
+Optimize only the complete-tail fenced-block path in
+`services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+Many benchmark responses end with a completed code fence. In that common case,
+the extractor can locate the final closing fence and the preceding opening fence
+with reverse searches and skip the full-response fence count. Responses that have
+non-whitespace content after the last fence still keep the existing odd-fence
+fallback so an unterminated trailing block does not replace the last complete
+block.
+
+## Probe
+
+Registered PR-scoped probe:
+
+- `code-eval-code-block-last-match-streaming`
+
+Focused commands are defined in `infra/perf/pr_scoped_probes.json` and include:
+
+- code-eval extraction regression tests
+- changed-scope coverage for the extractor and probe script
+- `scripts/code_eval_code_block_extract_probe.py`
+
+## Success Criteria
+
+- Regression tests preserve empty, plaintext, multi-block, non-Python tag, and
+  unterminated trailing fence behavior.
+- Changed-scope coverage remains at or above 95%.
+- The registered probe shows lower `elapsed_ms_mean` for the complete-tail
+  multi-block response path without increasing extracted code length or changing
+  parse status.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -29,6 +29,9 @@ def test_extract_candidate_code_handles_empty_plaintext_and_code_blocks() -> Non
     assert code_eval_runner.extract_candidate_code(
         "```python\nprint('complete')\n```\n```python\nprint('unterminated')"
     ) == ("print('complete')", "parsed_code_block")
+    assert code_eval_runner.extract_candidate_code(
+        "```python\nprint('complete')\n```\n```"
+    ) == ("print('complete')", "parsed_code_block")
     blocks = [
         f"draft {index}\n```python\ndef candidate():\n    return {index}\n```"
         for index in range(32)

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -43,15 +43,24 @@ def extract_candidate_code(raw_response: str) -> tuple[str, str]:
     if not normalized:
         return "", "empty_prediction"
 
-    fence_count = normalized.count("```")
-    if fence_count >= 2:
-        closing = normalized.rfind("```")
-        if fence_count % 2:
-            closing = normalized.rfind("```", 0, closing)
+    closing = normalized.rfind("```")
+    if closing >= 0:
         opening = normalized.rfind("```", 0, closing)
         if opening >= 0:
-            content_start = _code_block_content_start(normalized, opening + 3)
-            return normalized[content_start:closing].strip(), "parsed_code_block"
+            trailing = normalized[closing + 3 :]
+            if trailing.strip() and normalized.count("```") % 2:
+                closing = opening
+                opening = normalized.rfind("```", 0, closing)
+            if opening >= 0:
+                content_start = _code_block_content_start(normalized, opening + 3)
+                candidate = normalized[content_start:closing].strip()
+                if candidate or normalized.count("```") % 2 == 0:
+                    return candidate, "parsed_code_block"
+                closing = opening
+                opening = normalized.rfind("```", 0, closing)
+                if opening >= 0:
+                    content_start = _code_block_content_start(normalized, opening + 3)
+                    return normalized[content_start:closing].strip(), "parsed_code_block"
 
     return normalized, "parsed_code"
 


### PR DESCRIPTION
## Summary
- Optimize `extract_candidate_code(...)` for responses whose final fenced code block is complete by using reverse fence searches before doing a full fence-count scan.
- Preserve odd-fence fallback behavior, including a trailing empty unmatched fence, with an added regression assertion.

## Plan or Spec
- `docs/plans/2026-05-08-code-eval-fence-tail-fast-path.md`
- Registered PR-scoped probe: `code-eval-code-block-last-match-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# exit 0; 4 passed in 0.14s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py
# exit 0; 4 passed in 0.16s; TOTAL 17 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-code-block-last-match-streaming --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-code-eval-fence-tail-202605082049 --head-repo "$PWD" --output .runtime-code-eval-fence-tail-probe.json
# exit 0; base/head probe and head verification completed successfully

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 17 0 100%`.
- Local registered probe `code-eval-code-block-last-match-streaming`:
  - `elapsed_ms_mean`: base `0.0655856981341328` ms → head `0.01170898654631206` ms (`-0.053876711587820744` ms, ~`5.60x` faster, `82.15%` lower).
  - `peak_bytes_mean`: base `273.0` bytes → head `245.0` bytes (`-28.0` bytes, `10.26%` lower).
  - `extracted_chars_mean`: base/head both `37.0`.
- CI PR-scoped performance workflow is required as the merge validation source after push.

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime behavior is touched.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
