### PR TITLE
perf: avoid following hf cache snapshot symlinks

### DIFF
--- a/scripts/real_model_support.py
+++ b/scripts/real_model_support.py
@@ -293,7 +293,7 @@ def _huggingface_cache_model_path(
     latest_snapshot_name: str | None = None
     with os.scandir(snapshots_root) as entries:
         for entry in entries:
-            if not entry.is_dir():
+            if not entry.is_dir(follow_symlinks=False):
                 continue
             if latest_snapshot_name is None or entry.name > latest_snapshot_name:
                 latest_snapshot_name = entry.name

--- a/tests/test_real_model_support.py
+++ b/tests/test_real_model_support.py
@@ -4,6 +4,7 @@ import builtins
 import json
 from pathlib import Path
 
+import scripts.real_model_support as real_model_support_module
 from scripts.real_model_support import (
     PHASE2_DEFAULT_DRAFT_TEXT_MODEL_ID,
     REAL_SMALL_TEXT_MODEL_ID,
@@ -273,6 +274,55 @@ def test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting
     assert source.local_model_path == str((snapshots_root / "zzz").resolve())
     assert source.source_resolution_mode == "hf_cache_snapshot"
     assert "using lexicographically last snapshot directory" in source.warnings[0]
+
+
+def test_hf_cache_snapshot_fallback_does_not_follow_symlinked_directories(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home = tmp_path / "home"
+    snapshots_root = (
+        home
+        / ".cache"
+        / "huggingface"
+        / "hub"
+        / "models--mlx-community--Qwen3.5-0.8B-OptiQ-4bit"
+        / "snapshots"
+    )
+    snapshots_root.mkdir(parents=True)
+    real_snapshot = snapshots_root / "real-snapshot"
+    real_snapshot.mkdir()
+
+    class _FakeEntry:
+        name = "real-snapshot"
+
+        def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+            if follow_symlinks:
+                raise AssertionError("HF cache snapshot scan should not follow symlinks")
+            return True
+
+    class _FakeScandir:
+        def __enter__(self):
+            return iter((_FakeEntry(),))
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    def fake_scandir(path: Path):
+        assert path == snapshots_root
+        return _FakeScandir()
+
+    monkeypatch.setattr(real_model_support_module.os, "scandir", fake_scandir)
+
+    source = resolve_real_small_text_model_source(
+        environment={"HOME": str(home)},
+        allow_managed_root=False,
+        allow_hf_cache=True,
+    )
+
+    assert source.live is False
+    assert source.local_model_path == str(real_snapshot.resolve())
+    assert source.source_resolution_mode == "hf_cache_snapshot"
 
 
 def test_runtime_model_preflight_marks_real_local_weights(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Avoid following symlinked directories while scanning the Hugging Face cache snapshot fallback path.
- Add a regression test that fails if the snapshot fallback calls `DirEntry.is_dir()` without `follow_symlinks=False`.

## Plan or Spec
- Governing plan/spec: AGENTS.md performance-slice guidance and `infra/perf/pr_scoped_probes.json` registered probe `real-model-support-hf-cache-latest-snapshot`.
- Behavior is unchanged for normal Hugging Face snapshot directories; the scan now avoids symlink traversal during fallback directory selection.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting tests/test_real_model_support.py::test_hf_cache_snapshot_fallback_does_not_follow_symlinked_directories services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics
# exit 0; 6 passed in 1.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting tests/test_real_model_support.py::test_hf_cache_snapshot_fallback_does_not_follow_symlinked_directories services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/real_model_support.py tests/test_real_model_support.py scripts/real_model_support_hf_cache_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; TOTAL 27 1 96%

for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/real_model_support_hf_cache_probe.py; done
# exit 0; head elapsed_ms_mean samples: 17.437801, 18.112452, 17.919508

# Baseline from origin/main in isolated worktree:
for i in 1 2 3; do PYTHONPATH="$base:$base/services/mlx-worker-python" uv run --project "$base/services/mlx-worker-python" python3 "$base/scripts/real_model_support_hf_cache_probe.py"; done
# exit 0; base elapsed_ms_mean samples: 18.218032, 18.883479, 17.707788

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 96% (`TOTAL 27 1 96%`).
- Registered local probe: `real-model-support-hf-cache-latest-snapshot` via `scripts/real_model_support_hf_cache_probe.py`.
- Local probe comparison over 3 runs: base_mean=18.269766 ms, head_mean=17.823254 ms, delta=-0.446513 ms, speedup=1.025052x (2.444% faster). Peak memory stayed 4710.0 bytes.
- GitHub Actions PR-scoped performance is required as the registered CI validation source before merge.

## Known Gaps
- Local Linux validates the Python fallback scan path only; no Swift runtime path is touched.
- The local timing improvement is modest and below 5%, so CI probe evidence is the final acceptance gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. (N/A: no formal docs behavior change beyond safer directory scan semantics.)
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
