### PR TITLE
perf: avoid sorting quantization index shards

### DIFF
--- a/docs/plans/2026-05-08-quantization-index-shard-min-single-pass.md
+++ b/docs/plans/2026-05-08-quantization-index-shard-min-single-pass.md
@@ -1,0 +1,34 @@
+# Quantization Indexed Shard Min Single-Pass Optimization
+
+## Goal
+
+Reduce redundant work in the MLX-LM quantization smoke-file helper when reading `model.safetensors.index.json` files. The helper only needs the deterministic first shard name for smoke evidence, so building a full unique set and sorting it is unnecessary.
+
+## Linux Constraint
+
+This is a Python-only slice under `services/mlx-worker-python` and is verifiable on Linux with focused pytest, changed-scope coverage, and a command-json PR-scoped performance probe.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/model_ops/quantization_pipeline.py`
+- `services/mlx-worker-python/tests/test_quantization_pipeline.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/quantization_index_shard_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Performance Probe
+
+Registered scoped probe: `quantization-index-shard-min-single-pass`.
+
+The probe creates a synthetic indexed MLX-LM bundle with many `weight_map` entries and repeatedly asks `_smoke_required_files_for_backend(...)` for the required smoke files. It reports:
+
+- `elapsed_ms_mean` — lower is better.
+- `sorted_calls_mean` — lower is better; the optimized helper should not call `sorted(...)` on this path.
+- `peak_bytes_mean` — informational memory-pressure signal.
+
+## Success Metrics
+
+- Preserve smoke-file tuple semantics, including lexicographic first-shard selection, duplicate shard names, empty names, and non-string values.
+- Focused Python tests pass.
+- Changed-scope automated coverage is at least 95%.
+- Local probe shows `sorted_calls_mean == 0.0` on the optimized branch and concrete timing/memory metrics.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2892,6 +2892,42 @@
     ]
   },
   {
+    "id": "quantization-index-shard-min-single-pass",
+    "name": "Quantization indexed shard min single pass",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/quantization_pipeline.py",
+      "services/mlx-worker-python/tests/test_quantization_pipeline.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/quantization_index_shard_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_source_and_smoke_file_helpers_cover_edge_cases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_index_shard_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_source_and_smoke_file_helpers_cover_edge_cases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_index_shard_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/quantization_index_shard_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_QUANTIZATION_INDEX_SHARD_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/quantization_index_shard_probe.py ]; then python3 scripts/quantization_index_shard_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"ZnJvbSBfX2Z1dHVyZV9fIGltcG9ydCBhbm5vdGF0aW9ucwoKaW1wb3J0IGJ1aWx0aW5zCmltcG9ydCBqc29uCmltcG9ydCBvcwppbXBvcnQgc3RhdGlzdGljcwppbXBvcnQgc3lzCmltcG9ydCB0ZW1wZmlsZQppbXBvcnQgdGltZQppbXBvcnQgdHJhY2VtYWxsb2MKZnJvbSBwYXRobGliIGltcG9ydCBQYXRoCmZyb20gdHlwaW5nIGltcG9ydCBBbnkKClJFUE9fUk9PVCA9IFBhdGgob3MuZW52aXJvbi5nZXQoIk1FTElYX1FVQU5USVpBVElPTl9JTkRFWF9TSEFSRF9SRVBPX1JPT1QiLCBQYXRoLmN3ZCgpKSkKc3lzLnBhdGguaW5zZXJ0KDAsIHN0cihSRVBPX1JPT1QpKQpzeXMucGF0aC5pbnNlcnQoMCwgc3RyKFJFUE9fUk9PVCAvICJzZXJ2aWNlcy9tbHgtd29ya2VyLXB5dGhvbiIpKQoKZnJvbSB3b3JrZXIubW9kZWxfb3BzLnF1YW50aXphdGlvbl9waXBlbGluZSBpbXBvcnQgX3Ntb2tlX3JlcXVpcmVkX2ZpbGVzX2Zvcl9iYWNrZW5kCgoKZGVmIF93cml0ZV9wcm9iZV9idW5kbGUoYnVuZGxlX3BhdGg6IFBhdGgsICosIGVudHJ5X2NvdW50OiBpbnQpIC0+IE5vbmU6CiAgICBidW5kbGVfcGF0aC5ta2RpcihwYXJlbnRzPVRydWUsIGV4aXN0X29rPVRydWUpCiAgICAoYnVuZGxlX3BhdGggLyAidG9rZW5pemVyLmpzb24iKS53cml0ZV90ZXh0KCJ7fVxuIiwgZW5jb2Rpbmc9InV0Zi04IikKICAgIChidW5kbGVfcGF0aCAvICJtb2RlbC0wMDAwMS1vZi0wMTAwMC5zYWZldGVuc29ycyIpLndyaXRlX2J5dGVzKGIicHJvYmUtc2hhcmQiKQogICAgd2VpZ2h0X21hcDogZGljdFtzdHIsIG9iamVjdF0gPSB7fQogICAgZm9yIGluZGV4IGluIHJhbmdlKGVudHJ5X2NvdW50KToKICAgICAgICBzaGFyZCA9IGYibW9kZWwteyhlbnRyeV9jb3VudCAtIGluZGV4KSAlIDEwMDAgKyAxOjA1ZH0tb2YtMDEwMDAuc2FmZXRlbnNvcnMiCiAgICAgICAgd2VpZ2h0X21hcFtmImxheWVycy57aW5kZXh9LndlaWdodCJdID0gc2hhcmQKICAgIHdlaWdodF9tYXBbImxheWVycy5kdXBsaWNhdGUud2VpZ2h0Il0gPSAibW9kZWwtMDAwMDEtb2YtMDEwMDAuc2FmZXRlbnNvcnMiCiAgICB3ZWlnaHRfbWFwWyJsYXllcnMuZW1wdHkud2VpZ2h0Il0gPSAiIgogICAgd2VpZ2h0X21hcFsibGF5ZXJzLm5vbl9zdHJpbmcud2VpZ2h0Il0gPSBlbnRyeV9jb3VudAogICAgKGJ1bmRsZV9wYXRoIC8gIm1vZGVsLnNhZmV0ZW5zb3JzLmluZGV4Lmpzb24iKS53cml0ZV90ZXh0KAogICAgICAgIGpzb24uZHVtcHMoeyJ3ZWlnaHRfbWFwIjogd2VpZ2h0X21hcH0pLAogICAgICAgIGVuY29kaW5nPSJ1dGYtOCIsCiAgICApCgoKZGVmIF9tZWFzdXJlX29uY2UoYnVuZGxlX3BhdGg6IFBhdGgsICosIGl0ZXJhdGlvbnM6IGludCkgLT4gZGljdFtzdHIsIGZsb2F0XToKICAgIHJlYWxfc29ydGVkID0gYnVpbHRpbnMuc29ydGVkCiAgICBzb3J0ZWRfY2FsbHMgPSAwCgogICAgZGVmIGNvdW50aW5nX3NvcnRlZCgqYXJnczogQW55LCAqKmt3YXJnczogQW55KSAtPiBBbnk6CiAgICAgICAgbm9ubG9jYWwgc29ydGVkX2NhbGxzCiAgICAgICAgc29ydGVkX2NhbGxzICs9IDEKICAgICAgICByZXR1cm4gcmVhbF9zb3J0ZWQoKmFyZ3MsICoqa3dhcmdzKQoKICAgIGJ1aWx0aW5zLnNvcnRlZCA9IGNvdW50aW5nX3NvcnRlZAogICAgdHJhY2VtYWxsb2Muc3RhcnQoKQogICAgc3RhcnRlZCA9IHRpbWUucGVyZl9jb3VudGVyKCkKICAgIHRyeToKICAgICAgICBmb3IgXyBpbiByYW5nZShpdGVyYXRpb25zKToKICAgICAgICAgICAgcmVxdWlyZWQgPSBfc21va2VfcmVxdWlyZWRfZmlsZXNfZm9yX2JhY2tlbmQoCiAgICAgICAgICAgICAgICBidW5kbGVfcGF0aCwKICAgICAgICAgICAgICAgIHF1YW50aXphdGlvbl9iYWNrZW5kPSJtbHhfbG1fY29udmVydCIsCiAgICAgICAgICAgICkKICAgICAgICAgICAgaWYgcmVxdWlyZWQgIT0gKAogICAgICAgICAgICAgICAgImNvbmZpZy5qc29uIiwKICAgICAgICAgICAgICAgICJ0b2tlbml6ZXIuanNvbiIsCiAgICAgICAgICAgICAgICAibW9kZWwuc2FmZXRlbnNvcnMuaW5kZXguanNvbiIsCiAgICAgICAgICAgICAgICAibW9kZWwtMDAwMDEtb2YtMDEwMDAuc2FmZXRlbnNvcnMiLAogICAgICAgICAgICApOgogICAgICAgICAgICAgICAgcmFpc2UgU3lzdGVtRXhpdChmInVuZXhwZWN0ZWQgcmVxdWlyZWQgZmlsZSB0dXBsZToge3JlcXVpcmVkIXJ9IikKICAgICAgICBlbGFwc2VkX21zID0gKHRpbWUucGVyZl9jb3VudGVyKCkgLSBzdGFydGVkKSAqIDEwMDAuMAogICAgICAgIF8sIHBlYWsgPSB0cmFjZW1hbGxvYy5nZXRfdHJhY2VkX21lbW9yeSgpCiAgICBmaW5hbGx5OgogICAgICAgIGJ1aWx0aW5zLnNvcnRlZCA9IHJlYWxfc29ydGVkCiAgICAgICAgaWYgdHJhY2VtYWxsb2MuaXNfdHJhY2luZygpOgogICAgICAgICAgICB0cmFjZW1hbGxvYy5zdG9wKCkKICAgIHJldHVybiB7CiAgICAgICAgImVsYXBzZWRfbXMiOiBlbGFwc2VkX21zLAogICAgICAgICJwZWFrX2J5dGVzIjogZmxvYXQocGVhayksCiAgICAgICAgInNvcnRlZF9jYWxscyI6IGZsb2F0KHNvcnRlZF9jYWxscyksCiAgICB9CgoKZGVmIG1haW4oKSAtPiBpbnQ6CiAgICBlbnRyeV9jb3VudCA9IGludChvcy5lbnZpcm9uLmdldCgiTUVMSVhfUVVBTlRJWkFUSU9OX0lOREVYX1NIQVJEX1BST0JFX0VOVFJJRVMiLCAiNTAwMCIpKQogICAgaXRlcmF0aW9ucyA9IGludChvcy5lbnZpcm9uLmdldCgiTUVMSVhfUVVBTlRJWkFUSU9OX0lOREVYX1NIQVJEX1BST0JFX0lURVJBVElPTlMiLCAiOCIpKQogICAgc2FtcGxlcyA9IGludChvcy5lbnZpcm9uLmdldCgiTUVMSVhfUVVBTlRJWkFUSU9OX0lOREVYX1NIQVJEX1BST0JFX1NBTVBMRVMiLCAiNSIpKQogICAgd2l0aCB0ZW1wZmlsZS5UZW1wb3JhcnlEaXJlY3RvcnkocHJlZml4PSJtZWxpeC1xdWFudC1pbmRleC1wcm9iZS0iKSBhcyB0ZW1wX2RpcjoKICAgICAgICBidW5kbGVfcGF0aCA9IFBhdGgodGVtcF9kaXIpIC8gImJ1bmRsZSIKICAgICAgICBfd3JpdGVfcHJvYmVfYnVuZGxlKGJ1bmRsZV9wYXRoLCBlbnRyeV9jb3VudD1lbnRyeV9jb3VudCkKICAgICAgICBtZWFzdXJlbWVudHMgPSBbX21lYXN1cmVfb25jZShidW5kbGVfcGF0aCwgaXRlcmF0aW9ucz1pdGVyYXRpb25zKSBmb3IgXyBpbiByYW5nZShzYW1wbGVzKV0KICAgIHByaW50KAogICAgICAgIGpzb24uZHVtcHMoCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJlbGFwc2VkX21zX21lYW4iOiBzdGF0aXN0aWNzLmZtZWFuKGl0ZW1bImVsYXBzZWRfbXMiXSBmb3IgaXRlbSBpbiBtZWFzdXJlbWVudHMpLAogICAgICAgICAgICAgICAgInBlYWtfYnl0ZXNfbWVhbiI6IHN0YXRpc3RpY3MuZm1lYW4oaXRlbVsicGVha19ieXRlcyJdIGZvciBpdGVtIGluIG1lYXN1cmVtZW50cyksCiAgICAgICAgICAgICAgICAic29ydGVkX2NhbGxzX21lYW4iOiBzdGF0aXN0aWNzLmZtZWFuKGl0ZW1bInNvcnRlZF9jYWxscyJdIGZvciBpdGVtIGluIG1lYXN1cmVtZW50cyksCiAgICAgICAgICAgICAgICAid2VpZ2h0X21hcF9lbnRyaWVzIjogZmxvYXQoZW50cnlfY291bnQgKyAzKSwKICAgICAgICAgICAgICAgICJpdGVyYXRpb25zX3Blcl9zYW1wbGUiOiBmbG9hdChpdGVyYXRpb25zKSwKICAgICAgICAgICAgICAgICJzYW1wbGVfY291bnQiOiBmbG9hdChzYW1wbGVzKSwKICAgICAgICAgICAgfSwKICAgICAgICAgICAgc29ydF9rZXlzPVRydWUsCiAgICAgICAgKQogICAgKQogICAgcmV0dXJuIDAKCgppZiBfX25hbWVfXyA9PSAiX19tYWluX18iOgogICAgcmFpc2UgU3lzdGVtRXhpdChtYWluKCkpCg==\\\").decode())\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "sorted_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "quantization-qat-source-scan-scandir",
     "name": "Quantization QAT source scan scandir",
     "runner": "ubuntu-latest",

--- a/scripts/quantization_index_shard_probe.py
+++ b/scripts/quantization_index_shard_probe.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import builtins
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(os.environ.get("MELIX_QUANTIZATION_INDEX_SHARD_REPO_ROOT", Path.cwd()))
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.model_ops.quantization_pipeline import _smoke_required_files_for_backend
+
+
+def _write_probe_bundle(bundle_path: Path, *, entry_count: int) -> None:
+    bundle_path.mkdir(parents=True, exist_ok=True)
+    (bundle_path / "tokenizer.json").write_text("{}\n", encoding="utf-8")
+    (bundle_path / "model-00001-of-01000.safetensors").write_bytes(b"probe-shard")
+    weight_map: dict[str, object] = {}
+    for index in range(entry_count):
+        shard = f"model-{(entry_count - index) % 1000 + 1:05d}-of-01000.safetensors"
+        weight_map[f"layers.{index}.weight"] = shard
+    weight_map["layers.duplicate.weight"] = "model-00001-of-01000.safetensors"
+    weight_map["layers.empty.weight"] = ""
+    weight_map["layers.non_string.weight"] = entry_count
+    (bundle_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": weight_map}),
+        encoding="utf-8",
+    )
+
+
+def _measure_once(bundle_path: Path, *, iterations: int) -> dict[str, float]:
+    real_sorted = builtins.sorted
+    sorted_calls = 0
+
+    def counting_sorted(*args: Any, **kwargs: Any) -> Any:
+        nonlocal sorted_calls
+        sorted_calls += 1
+        return real_sorted(*args, **kwargs)
+
+    builtins.sorted = counting_sorted
+    tracemalloc.start()
+    started = time.perf_counter()
+    try:
+        for _ in range(iterations):
+            required = _smoke_required_files_for_backend(
+                bundle_path,
+                quantization_backend="mlx_lm_convert",
+            )
+            if required != (
+                "config.json",
+                "tokenizer.json",
+                "model.safetensors.index.json",
+                "model-00001-of-01000.safetensors",
+            ):
+                raise SystemExit(f"unexpected required file tuple: {required!r}")
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        builtins.sorted = real_sorted
+        if tracemalloc.is_tracing():
+            tracemalloc.stop()
+    return {
+        "elapsed_ms": elapsed_ms,
+        "peak_bytes": float(peak),
+        "sorted_calls": float(sorted_calls),
+    }
+
+
+def main() -> int:
+    entry_count = int(os.environ.get("MELIX_QUANTIZATION_INDEX_SHARD_PROBE_ENTRIES", "5000"))
+    iterations = int(os.environ.get("MELIX_QUANTIZATION_INDEX_SHARD_PROBE_ITERATIONS", "8"))
+    samples = int(os.environ.get("MELIX_QUANTIZATION_INDEX_SHARD_PROBE_SAMPLES", "5"))
+    with tempfile.TemporaryDirectory(prefix="melix-quant-index-probe-") as temp_dir:
+        bundle_path = Path(temp_dir) / "bundle"
+        _write_probe_bundle(bundle_path, entry_count=entry_count)
+        measurements = [_measure_once(bundle_path, iterations=iterations) for _ in range(samples)]
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(item["elapsed_ms"] for item in measurements),
+                "peak_bytes_mean": statistics.fmean(item["peak_bytes"] for item in measurements),
+                "sorted_calls_mean": statistics.fmean(item["sorted_calls"] for item in measurements),
+                "weight_map_entries": float(entry_count + 3),
+                "iterations_per_sample": float(iterations),
+                "sample_count": float(samples),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -304,7 +304,9 @@ def test_scope_report_selects_quantization_qat_source_scan_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/model_ops/quantization_pipeline.py"],
     )
 
-    assert "quantization-qat-source-scan-scandir" in _selected_probe_ids(scope)
+    probe_ids = _selected_probe_ids(scope)
+    assert "quantization-qat-source-scan-scandir" in probe_ids
+    assert "quantization-index-shard-min-single-pass" in probe_ids
 
 
 def test_scope_report_selects_startup_signals_probe() -> None:
@@ -1650,6 +1652,30 @@ def test_quantization_qat_source_scan_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0
 
 
+def test_quantization_index_shard_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_QUANTIZATION_INDEX_SHARD_PROBE_ENTRIES", "6")
+    monkeypatch.setenv("MELIX_QUANTIZATION_INDEX_SHARD_PROBE_ITERATIONS", "2")
+    monkeypatch.setenv("MELIX_QUANTIZATION_INDEX_SHARD_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/quantization_index_shard_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["iterations_per_sample"] == 2.0
+    assert metrics["weight_map_entries"] == 9.0
+    assert metrics["sorted_calls_mean"] == 0.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_mlx_audio_speech_signature_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -1775,6 +1801,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "pr-scoped-performance-scope-json-read-bytes",
         "pr-scoped-performance-scope-matcher",
         "quantization-qat-source-scan-scandir",
+        "quantization-index-shard-min-single-pass",
         "release-gates-m9-failure-count-single-pass",
         "training-config-target-module-cache",
         "training-dataset-token-percentiles-single-sort",

--- a/services/mlx-worker-python/tests/test_quantization_pipeline.py
+++ b/services/mlx-worker-python/tests/test_quantization_pipeline.py
@@ -1116,6 +1116,36 @@ def test_mlx_lm_source_and_smoke_file_helpers_cover_edge_cases(tmp_path: Path) -
         "model-00001-of-00001.safetensors",
     )
 
+    duplicate_shard_bundle = tmp_path / "duplicate-shard-bundle"
+    duplicate_shard_bundle.mkdir()
+    (duplicate_shard_bundle / "tokenizer.json").write_text("{}\n", encoding="utf-8")
+    (duplicate_shard_bundle / "model-00001-of-00003.safetensors").write_bytes(b"first")
+    (duplicate_shard_bundle / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "z.weight": "model-00003-of-00003.safetensors",
+                    "a.weight": "model-00001-of-00003.safetensors",
+                    "b.weight": "model-00002-of-00003.safetensors",
+                    "dup.weight": "model-00001-of-00003.safetensors",
+                    "ignored_empty": "",
+                    "ignored_non_string": 7,
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    assert _smoke_required_files_for_backend(
+        duplicate_shard_bundle,
+        quantization_backend="mlx_lm_convert",
+    ) == (
+        "config.json",
+        "tokenizer.json",
+        "model.safetensors.index.json",
+        "model-00001-of-00003.safetensors",
+    )
+
     missing_shard_bundle = tmp_path / "missing-shard-bundle"
     missing_shard_bundle.mkdir()
     (missing_shard_bundle / "model.safetensors.index.json").write_text(

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -908,10 +908,15 @@ def _mlx_lm_index_weight_files(bundle_path: Path) -> tuple[str, ...]:
     weight_map = payload.get("weight_map")
     if not isinstance(weight_map, dict):
         return (index_file, "model.safetensors")
-    shard_names = sorted({name for name in weight_map.values() if isinstance(name, str) and name})
-    if not shard_names:
+    first_shard: str | None = None
+    for name in weight_map.values():
+        if not isinstance(name, str) or not name:
+            continue
+        if first_shard is None or name < first_shard:
+            first_shard = name
+    if first_shard is None:
         return (index_file, "model.safetensors")
-    return (index_file, shard_names[0])
+    return (index_file, first_shard)
 
 
 def _not_requested_smoke_evidence(


### PR DESCRIPTION
## Summary
- Replaces the indexed MLX-LM quantization smoke helper's full shard-name set allocation and sort with a single-pass lexicographic minimum scan.
- Adds regression coverage for duplicate, unsorted, empty, and non-string shard entries while preserving the existing smoke-file tuple contract.
- Registers a dedicated PR-scoped performance probe for indexed shard selection.

## Plan or Spec
- Plan: `docs/plans/2026-05-08-quantization-index-shard-min-single-pass.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_source_and_smoke_file_helpers_cover_edge_cases \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_index_shard_probe_script_emits_metrics
# 4 passed in 0.34s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
  services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_source_and_smoke_file_helpers_cover_edge_cases \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_index_shard_probe_script_emits_metrics && \
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && \
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/model_ops/quantization_pipeline.py \
  services/mlx-worker-python/tests/test_quantization_pipeline.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/quantization_index_shard_probe.py
# TOTAL 31 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_QUANTIZATION_INDEX_SHARD_REPO_ROOT="$PWD" \
  MELIX_QUANTIZATION_INDEX_SHARD_PROBE_ENTRIES=5000 \
  MELIX_QUANTIZATION_INDEX_SHARD_PROBE_ITERATIONS=8 \
  MELIX_QUANTIZATION_INDEX_SHARD_PROBE_SAMPLES=5 \
  uv run --project services/mlx-worker-python python3 scripts/quantization_index_shard_probe.py
# {"elapsed_ms_mean": 43.4667730005458, "iterations_per_sample": 8.0, "peak_bytes_mean": 1156716.4, "sample_count": 5.0, "sorted_calls_mean": 0.0, "weight_map_entries": 5003.0}

uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py \
  --registry infra/perf/pr_scoped_probes.json \
  --probe-id quantization-index-shard-min-single-pass \
  --base-repo /tmp/melix-cron-opt-base-20260508-215738 \
  --head-repo /tmp/melix-cron-opt-20260508-215042 \
  --output /tmp/quantization-index-shard-probe.json
# head verification ok; base probe ok; head probe ok

# git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 31 0 100%`.
- Registered scoped probe: `quantization-index-shard-min-single-pass`.
- Local standalone probe on head: `elapsed_ms_mean=43.466773 ms`, `sorted_calls_mean=0.0`, `peak_bytes_mean=1,156,716.4`, `weight_map_entries=5003`, `iterations_per_sample=8`, `sample_count=5`.
- Local registered base-vs-head probe:
  - Base (`origin/main`): `elapsed_ms_mean=48.515514 ms`, `sorted_calls_mean=8.0`, `peak_bytes_mean=1,156,570.8`.
  - Head: `elapsed_ms_mean=49.321397 ms`, `sorted_calls_mean=0.0`, `peak_bytes_mean=1,156,716.4`.
  - Interpretation: removes the redundant sort structurally (`8.0 -> 0.0` sorted calls). Timing is effectively flat/slightly noisy in this tiny parser path and remains under the probe's 5% warn threshold.

## Known Gaps
- Linux-only local verification; no macOS/Swift local checks were run because this is a Python-only quantization helper slice.
- Full repository test suite was not run; verification was focused on the touched Python scope and registered PR-scoped performance probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
