### PR TITLE
perf: elide redundant WAV PCM sample recast

### DIFF
--- a/docs/plans/cron-wav-pcm-recast-elision.md
+++ b/docs/plans/cron-wav-pcm-recast-elision.md
@@ -1,0 +1,33 @@
+# Cron WAV PCM Recast Elision
+
+## Goal
+
+Reduce redundant per-sample work in the MLX audio WAV PCM streaming path by avoiding an extra `float(...)` conversion after `iter_samples(...)` has already normalized values to floats.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/wav_helpers.py`
+- `services/mlx-worker-python/tests/test_mlx_audio_runtime.py`
+
+## Linux-only constraint
+
+This is a Python worker slice and can be verified locally on Linux with focused pytest, changed-scope coverage, and the existing MLX audio WAV PR-scoped performance probe.
+
+## Performance probe
+
+Registered probe: `mlx-audio-wav-streaming-pcm`
+
+Local probe command:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/mlx_audio_wav_streaming_probe.py
+```
+
+The probe builds a synthetic nested audio payload, converts it to WAV bytes repeatedly, and reports elapsed time, peak traced bytes, sample count, and output size.
+
+## Success metrics
+
+- Preserve WAV PCM output shape and clamping behavior.
+- Add a focused regression test proving `audio_to_pcm_chunks(...)` does not re-cast the already-normalized values yielded by `iter_samples(...)`.
+- Achieve at least 95% changed executable line coverage for the touched Python files.
+- Keep the registered `mlx-audio-wav-streaming-pcm` probe green locally and in PR-scoped performance CI.

--- a/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
@@ -888,6 +888,26 @@ def test_audio_to_wav_bytes_does_not_materialize_flat_sample_list(monkeypatch: p
         assert handle.getnframes() == 4
         assert handle.getframerate() == 12_000
 
+    import worker.runtime.wav_helpers as wav_helpers
+
+    class NormalizedFloat(float):
+        def __float__(self):  # pragma: no cover - covered only by regression failure
+            raise AssertionError("audio_to_pcm_chunks should not re-cast normalized samples")
+
+    monkeypatch.setattr(
+        wav_helpers,
+        "iter_samples",
+        lambda audio: iter((NormalizedFloat(0.5), NormalizedFloat(2.0), NormalizedFloat(-2.0))),
+    )
+
+    chunks = list(wav_helpers.audio_to_pcm_chunks(object(), chunk_sample_limit=2))
+    decoded = [
+        int.from_bytes(chunk[index : index + 2], byteorder="little", signed=True)
+        for chunk in chunks
+        for index in range(0, len(chunk), 2)
+    ]
+    assert decoded == [16383, 32767, -32767]
+
 
 def test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts(
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/runtime/wav_helpers.py
+++ b/services/mlx-worker-python/worker/runtime/wav_helpers.py
@@ -37,8 +37,7 @@ def audio_to_pcm_chunks(audio, *, chunk_sample_limit: int):
     chunk = array.array("h")
     limit = max(1, int(chunk_sample_limit))
 
-    for sample in iter_samples(audio):
-        value = float(sample)
+    for value in iter_samples(audio):
         if value > 1.0:
             value = 1.0
         elif value < -1.0:


### PR DESCRIPTION
## Summary
- Removes the redundant per-sample `float(...)` recast in `audio_to_pcm_chunks(...)` after `iter_samples(...)` has already normalized samples.
- Extends the existing streaming WAV regression test to fail if the PCM chunk path re-casts normalized sample values.

## Plan or Spec
- Plan: `docs/plans/cron-wav-pcm-recast-elision.md`
- Registered scoped CI probe: `mlx-audio-wav-streaming-pcm` (existing probe; no registry edit required because the touched runtime/test files are already watched and covered by the registered commands).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_wav_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_wav_streaming_probe_script_emits_metrics
# 6 passed in 2.55s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts ...
# 6 passed in 12.61s; coverage JSON written

python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/wav_helpers.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py scripts/mlx_audio_wav_streaming_probe.py
# TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/mlx_audio_wav_streaming_probe.py
# {"elapsed_ms_mean": 343.566479, "elapsed_ms_min": 335.064868, "peak_bytes_mean": 699680.6, "sample_count": 240000.0, "wav_bytes": 480044.0}

python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id mlx-audio-wav-streaming-pcm --base-repo <detached-origin-main-worktree> --head-repo "$PWD" --output /tmp/melix-wav-probe2.json
# head verification ok; base probe ok; head probe ok

# base-vs-head metrics from /tmp/melix-wav-probe2.json:
# base elapsed_ms_mean=333.601510, peak_bytes_mean=699688.6
# head elapsed_ms_mean=319.443582, peak_bytes_mean=699680.6

# git diff --check
# passed with no output
```

## Coverage and Metrics
- Changed executable line coverage: `TOTAL 7 0 100%`.
- Focused pytest: `6 passed`.
- Local standalone probe on head: `elapsed_ms_mean=343.566479`, `elapsed_ms_min=335.064868`, `peak_bytes_mean=699680.6`, `sample_count=240000.0`, `wav_bytes=480044.0`.
- Local registered base-vs-head probe (`mlx-audio-wav-streaming-pcm`):
  - Base (`origin/main`): `elapsed_ms_mean=333.601510`, `peak_bytes_mean=699688.6`.
  - Head: `elapsed_ms_mean=319.443582`, `peak_bytes_mean=699680.6`.
  - Interpretation: same output size/sample count, slightly lower mean elapsed time and effectively flat peak traced bytes.

## Known Gaps
- Linux-only local verification; macOS/Swift surfaces were not exercised because this is a Python worker WAV helper slice.
- Hosted CI must still validate the PR-scoped performance probe and broader required checks before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
