### PR TITLE
perf: cache runtime package version lookups

### DIFF
--- a/docs/plans/2026-05-09-runtime-utils-package-version-cache.md
+++ b/docs/plans/2026-05-09-runtime-utils-package-version-cache.md
@@ -1,0 +1,36 @@
+# Runtime Utils Package Version Cache
+
+## Goal
+
+Reduce repeated runtime metadata lookup overhead by caching package-version discovery in `worker.runtime.runtime_utils.installed_package_version(...)`.
+
+## Linux-only constraint
+
+This slice is Python-only and verifiable on Linux through focused pytest, changed-scope coverage, and a local PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/runtime/runtime_utils.py`
+- `services/mlx-worker-python/tests/test_runtime_utils.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/runtime_utils_package_version_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Probe definition
+
+Register `runtime-utils-package-version-cache` in the PR-scoped performance registry.
+
+The probe repeatedly calls `installed_package_version(...)` for the same small package set while monkeypatching `importlib.metadata.version` to count metadata lookups. It reports:
+
+- `elapsed_ms_mean` — lower is better
+- `metadata_version_calls_mean` — lower is better; expected to drop to one call per unique package per sample
+- `iterations_per_sample`
+- `package_count`
+- `sample_count`
+
+## Success metrics
+
+- Focused runtime utils tests pass.
+- Changed-scope coverage is at least 95% for touched executable Python lines.
+- Local base-vs-head probe shows reduced metadata lookup calls and improved or non-regressive elapsed time.
+- `git diff --check` passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -234,6 +234,37 @@
     ]
   },
   {
+    "id": "runtime-utils-package-version-cache",
+    "name": "Runtime utils package version cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/runtime_utils.py",
+      "services/mlx-worker-python/tests/test_runtime_utils.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/runtime_utils_package_version_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_installed_package_version_returns_empty_for_missing_package services/mlx-worker-python/tests/test_runtime_utils.py::test_installed_package_version_caches_successful_lookups services/mlx-worker-python/tests/test_runtime_utils.py::test_installed_package_version_caches_missing_lookups services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_package_version_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_installed_package_version_returns_empty_for_missing_package services/mlx-worker-python/tests/test_runtime_utils.py::test_installed_package_version_caches_successful_lookups services/mlx-worker-python/tests/test_runtime_utils.py::test_installed_package_version_caches_missing_lookups services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_package_version_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_package_version_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/runtime_utils_package_version_probe.py ]; then python scripts/runtime_utils_package_version_probe.py; else python3 -c \"import base64; exec(base64.b64decode(\\\"ZnJvbSBfX2Z1dHVyZV9fIGltcG9ydCBhbm5vdGF0aW9ucwoKaW1wb3J0IGpzb24KaW1wb3J0IHN0YXRpc3RpY3MKaW1wb3J0IHN5cwppbXBvcnQgdGltZQpmcm9tIHBhdGhsaWIgaW1wb3J0IFBhdGgKCnJlcG9fcm9vdCA9IFBhdGguY3dkKCkKc3lzLnBhdGguaW5zZXJ0KDAsIHN0cihyZXBvX3Jvb3QpKQpzeXMucGF0aC5pbnNlcnQoMCwgc3RyKHJlcG9fcm9vdCAvICJzZXJ2aWNlcy9tbHgtd29ya2VyLXB5dGhvbiIpKQpmcm9tIHdvcmtlci5ydW50aW1lIGltcG9ydCBydW50aW1lX3V0aWxzCgppdGVyYXRpb25zID0gNjAwMDAKc2FtcGxlX2NvdW50ID0gNQpwYWNrYWdlX25hbWVzID0gKCJtbHgiLCAibWx4LWxtIiwgIm1seC12bG0iKQplbGFwc2VkX3NhbXBsZXM6IGxpc3RbZmxvYXRdID0gW10KdmVyc2lvbl9jYWxsX3NhbXBsZXM6IGxpc3RbaW50XSA9IFtdCm9yaWdpbmFsX3ZlcnNpb24gPSBydW50aW1lX3V0aWxzLmltcG9ydGxpYi5tZXRhZGF0YS52ZXJzaW9uCmZvciBfIGluIHJhbmdlKHNhbXBsZV9jb3VudCk6CiAgICBjbGVhcl9jYWNoZSA9IGdldGF0dHIocnVudGltZV91dGlscywgImNsZWFyX2luc3RhbGxlZF9wYWNrYWdlX3ZlcnNpb25fY2FjaGUiLCBOb25lKQogICAgaWYgY2xlYXJfY2FjaGUgaXMgbm90IE5vbmU6CiAgICAgICAgY2xlYXJfY2FjaGUoKQogICAgdmVyc2lvbl9jYWxscyA9IDAKICAgIGRlZiB0cmFja2VkX3ZlcnNpb24ocGFja2FnZV9uYW1lOiBzdHIpIC0+IHN0cjoKICAgICAgICBub25sb2NhbF92ZXJzaW9uX2NhbGxzWzBdICs9IDEKICAgICAgICByZXR1cm4gZiJ7cGFja2FnZV9uYW1lfS1wcm9iZS12ZXJzaW9uIgogICAgbm9ubG9jYWxfdmVyc2lvbl9jYWxscyA9IFswXQogICAgcnVudGltZV91dGlscy5pbXBvcnRsaWIubWV0YWRhdGEudmVyc2lvbiA9IHRyYWNrZWRfdmVyc2lvbgogICAgc3RhcnRlZCA9IHRpbWUucGVyZl9jb3VudGVyKCkKICAgIHRyeToKICAgICAgICBjaGVja3N1bSA9IDAKICAgICAgICBmb3IgaW5kZXggaW4gcmFuZ2UoaXRlcmF0aW9ucyk6CiAgICAgICAgICAgIHBhY2thZ2VfbmFtZSA9IHBhY2thZ2VfbmFtZXNbaW5kZXggJSBsZW4ocGFja2FnZV9uYW1lcyldCiAgICAgICAgICAgIGNoZWNrc3VtICs9IGxlbihydW50aW1lX3V0aWxzLmluc3RhbGxlZF9wYWNrYWdlX3ZlcnNpb24ocGFja2FnZV9uYW1lKSkKICAgICAgICBpZiBjaGVja3N1bSA8PSAwOgogICAgICAgICAgICByYWlzZSBTeXN0ZW1FeGl0KCJ1bmV4cGVjdGVkIGVtcHR5IHBhY2thZ2UtdmVyc2lvbiBjaGVja3N1bSIpCiAgICBmaW5hbGx5OgogICAgICAgIGVsYXBzZWRfc2FtcGxlcy5hcHBlbmQoKHRpbWUucGVyZl9jb3VudGVyKCkgLSBzdGFydGVkKSAqIDEwMDAuMCkKICAgICAgICB2ZXJzaW9uX2NhbGxfc2FtcGxlcy5hcHBlbmQobm9ubG9jYWxfdmVyc2lvbl9jYWxsc1swXSkKICAgICAgICBydW50aW1lX3V0aWxzLmltcG9ydGxpYi5tZXRhZGF0YS52ZXJzaW9uID0gb3JpZ2luYWxfdmVyc2lvbgogICAgICAgIGlmIGNsZWFyX2NhY2hlIGlzIG5vdCBOb25lOgogICAgICAgICAgICBjbGVhcl9jYWNoZSgpCnByaW50KGpzb24uZHVtcHMoewogICAgImVsYXBzZWRfbXNfbWVhbiI6IHN0YXRpc3RpY3MuZm1lYW4oZWxhcHNlZF9zYW1wbGVzKSwKICAgICJtZXRhZGF0YV92ZXJzaW9uX2NhbGxzX21lYW4iOiBzdGF0aXN0aWNzLmZtZWFuKHZlcnNpb25fY2FsbF9zYW1wbGVzKSwKICAgICJpdGVyYXRpb25zX3Blcl9zYW1wbGUiOiBmbG9hdChpdGVyYXRpb25zKSwKICAgICJwYWNrYWdlX2NvdW50IjogZmxvYXQobGVuKHBhY2thZ2VfbmFtZXMpKSwKICAgICJzYW1wbGVfY291bnQiOiBmbG9hdChzYW1wbGVfY291bnQpLAp9LCBzb3J0X2tleXM9VHJ1ZSkpCg==\\\"))\"; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "metadata_version_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "mlx-text-stop-kwarg-signature-cache",
     "name": "MLX text stop kwarg signature cache",
     "runner": "ubuntu-latest",

--- a/scripts/runtime_utils_package_version_probe.py
+++ b/scripts/runtime_utils_package_version_probe.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime import runtime_utils
+
+
+def main() -> int:
+    iterations = 60000
+    sample_count = 5
+    package_names = ("mlx", "mlx-lm", "mlx-vlm")
+    elapsed_samples: list[float] = []
+    version_call_samples: list[int] = []
+    original_version = runtime_utils.importlib.metadata.version
+
+    for _ in range(sample_count):
+        if hasattr(runtime_utils, "clear_installed_package_version_cache"):
+            runtime_utils.clear_installed_package_version_cache()
+        version_calls = 0
+
+        def tracked_version(package_name: str) -> str:
+            nonlocal version_calls
+            version_calls += 1
+            return f"{package_name}-probe-version"
+
+        runtime_utils.importlib.metadata.version = tracked_version
+        started = time.perf_counter()
+        try:
+            checksum = 0
+            for index in range(iterations):
+                package_name = package_names[index % len(package_names)]
+                checksum += len(runtime_utils.installed_package_version(package_name))
+            if checksum <= 0:
+                raise SystemExit("unexpected empty package-version checksum")
+        finally:
+            elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+            version_call_samples.append(version_calls)
+            runtime_utils.importlib.metadata.version = original_version
+            if hasattr(runtime_utils, "clear_installed_package_version_cache"):
+                runtime_utils.clear_installed_package_version_cache()
+
+    metrics = {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "metadata_version_calls_mean": statistics.fmean(version_call_samples),
+        "iterations_per_sample": float(iterations),
+        "package_count": float(len(package_names)),
+        "sample_count": float(sample_count),
+    }
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -152,8 +152,11 @@ def test_scope_report_selects_runtime_utils_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/runtime/runtime_utils.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "runtime-utils-kwarg-signature-cache"
+    assert scope["selected_count"] == 2
+    assert _selected_probe_ids(scope) == [
+        "runtime-utils-kwarg-signature-cache",
+        "runtime-utils-package-version-cache",
+    ]
 
 
 def test_scope_report_selects_engine_generate_usage_probe() -> None:
@@ -1455,6 +1458,24 @@ def test_runtime_utils_kwarg_cache_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0
 
 
+def test_runtime_utils_package_version_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/runtime_utils_package_version_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 5.0
+    assert metrics["iterations_per_sample"] == 60000.0
+    assert metrics["package_count"] == 3.0
+    assert metrics["metadata_version_calls_mean"] == 3.0
+    assert metrics["elapsed_ms_mean"] >= 0
+
+
 def test_mlx_text_stop_kwarg_signature_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -1739,6 +1760,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "deterministic-rerank-query-context-reuse",
         "rerank-core-top-k-heap-selection",
         "runtime-utils-kwarg-signature-cache",
+        "runtime-utils-package-version-cache",
         "mlx-text-stop-kwarg-signature-cache",
         "mlx-audio-wav-streaming-pcm",
         "mlx-audio-generate-signature-cache",

--- a/services/mlx-worker-python/tests/test_runtime_utils.py
+++ b/services/mlx-worker-python/tests/test_runtime_utils.py
@@ -174,6 +174,8 @@ def test_callable_accepts_kwarg_falls_back_for_unhashable_callable(monkeypatch: 
 
 
 def test_installed_package_version_returns_empty_for_missing_package(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime_utils.clear_installed_package_version_cache()
+
     def fake_version(package_name: str) -> str:
         _ = package_name
         raise importlib.metadata.PackageNotFoundError
@@ -181,3 +183,44 @@ def test_installed_package_version_returns_empty_for_missing_package(monkeypatch
     monkeypatch.setattr(runtime_utils.importlib.metadata, "version", fake_version)
 
     assert runtime_utils.installed_package_version("missing-package") == ""
+
+    runtime_utils.clear_installed_package_version_cache()
+
+
+def test_installed_package_version_caches_successful_lookups(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime_utils.clear_installed_package_version_cache()
+    version_calls: list[str] = []
+
+    def fake_version(package_name: str) -> str:
+        version_calls.append(package_name)
+        return f"{package_name}-1.0"
+
+    monkeypatch.setattr(runtime_utils.importlib.metadata, "version", fake_version)
+
+    assert runtime_utils.installed_package_version("mlx") == "mlx-1.0"
+    assert runtime_utils.installed_package_version("mlx") == "mlx-1.0"
+    assert runtime_utils.installed_package_version("mlx-lm") == "mlx-lm-1.0"
+    assert runtime_utils.installed_package_version("mlx") == "mlx-1.0"
+
+    assert version_calls == ["mlx", "mlx-lm"]
+
+    runtime_utils.clear_installed_package_version_cache()
+
+
+def test_installed_package_version_caches_missing_lookups(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime_utils.clear_installed_package_version_cache()
+    version_calls = 0
+
+    def fake_version(package_name: str) -> str:
+        nonlocal version_calls
+        version_calls += 1
+        _ = package_name
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(runtime_utils.importlib.metadata, "version", fake_version)
+
+    assert runtime_utils.installed_package_version("missing-package") == ""
+    assert runtime_utils.installed_package_version("missing-package") == ""
+    assert version_calls == 1
+
+    runtime_utils.clear_installed_package_version_cache()

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -104,8 +104,13 @@ def clear_callable_kwarg_signature_cache() -> None:
     _callable_kwarg_signature_cached.cache_clear()
 
 
+@lru_cache(maxsize=128)
 def installed_package_version(package_name: str) -> str:
     try:
         return importlib.metadata.version(package_name)
     except importlib.metadata.PackageNotFoundError:
         return ""
+
+
+def clear_installed_package_version_cache() -> None:
+    installed_package_version.cache_clear()


### PR DESCRIPTION
## Summary
- Cache `installed_package_version(...)` with a small LRU cache so repeated runtime model-load metadata snapshots do not repeatedly call `importlib.metadata.version(...)` for the same package names.
- Add focused regression coverage for successful and missing package-version cache hits.
- Register a dedicated PR-scoped performance probe for the package-version lookup hot path.

## Plan or Spec
- `docs/plans/2026-05-09-runtime-utils-package-version-cache.md`

## Commands Run
```text
# Scout (no edits): delegated one scouting subagent to inspect /tmp/melix-cron-opt-20260509004956 and propose 1-3 candidates.
# Result: chose the runtime_utils installed package version cache candidate.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_package_version_probe_script_emits_metrics
# 13 passed in 0.54s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_package_version_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_package_version_probe.py
# 13 passed; TOTAL 42 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-utils-package-version-cache --base-repo /tmp/melix-base-runtime-utils-package-version-20260509004956b --head-repo "$PWD" --output /tmp/runtime-utils-package-version-probe.json
# head verification: 6 passed; changed-scope coverage TOTAL 42 0 100%
# base probe ok; head probe ok

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/registry.json && python3 scripts/runtime_utils_package_version_probe.py
# JSON registry parsed; probe emitted metrics

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 42 0 100%`.
- Registered scoped CI probe: `runtime-utils-package-version-cache`.
- Local base-vs-head probe (`runtime-utils-package-version-cache`, 60,000 calls/sample, 5 samples, 3 package names):
  - `metadata_version_calls_mean`: `60000.0` -> `3.0`.
  - `elapsed_ms_mean`: `22.839745` -> `8.010355` (~64.9% lower, ~2.85x faster).
  - `package_count`: `3.0`; `sample_count`: `5.0`.

## Known Gaps
- Linux-only validation; no macOS/Swift checks were run because this is a Python-only worker utility slice.
- Hosted GitHub CI / PR-scoped performance status is tracked after PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
