### PR TITLE
perf: speed up event similarity normalization

### DIFF
--- a/docs/plans/2026-05-09-event-extraction-normalization-translate.md
+++ b/docs/plans/2026-05-09-event-extraction-normalization-translate.md
@@ -1,0 +1,28 @@
+# Event Extraction Similarity Normalization Translate Slice
+
+## Scope
+
+This Python-only performance slice keeps event-extraction string similarity semantics unchanged while replacing the per-character ignored-character filter in `_normalize_similarity_text` with a precomputed `str.translate` deletion table.
+
+Touched path:
+
+- `services/mlx-worker-python/worker/productization/event_extraction.py`
+- `services/mlx-worker-python/tests/test_event_extraction.py`
+
+## Probe Coverage
+
+The affected path is covered by the registered PR-scoped probe `event-extraction-alignment-accepted-edge-cache` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes:
+
+- `test_command` for focused event-extraction alignment and string-similarity tests.
+- `coverage_command` for changed-scope coverage.
+- `probe_command` reporting `elapsed_ms_mean` and `similarity_elapsed_ms_mean`.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage, and the local PR-scoped probe on Linux before pushing. The optimization is accepted only if behavior stays identical and the registered probe does not regress.
+
+## Expected Benefit
+
+Normalization currently lowercases and then filters ignored characters through a Python generator. A precomputed translation table lets CPython delete ignored characters in C after lowercasing, reducing overhead on uncached similarity inputs while preserving the same normalized strings.

--- a/services/mlx-worker-python/tests/test_event_extraction.py
+++ b/services/mlx-worker-python/tests/test_event_extraction.py
@@ -135,6 +135,7 @@ def test_string_similarity_reuses_normalized_text_and_bigram_counts() -> None:
     event_extraction_module._normalize_similarity_text.cache_clear()
     event_extraction_module._character_bigram_items.cache_clear()
 
+    assert event_extraction_module._normalize_similarity_text(" Delivered-SUPPLY, CRATE! ") == "deliveredsupplycrate"
     first = event_extraction_module._string_similarity("Delivered supply crate", "delivered supply crates")
     second = event_extraction_module._string_similarity("Delivered supply crate", "delivered supply crates")
     third = event_extraction_module._string_similarity("Delivered supply crate 2", "delivered supply crates 2")

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -41,6 +41,7 @@ _SIMILARITY_IGNORED_CHARS = set(
     "“”\"'`"
     "-_—"
 )
+_SIMILARITY_IGNORED_TRANSLATION = str.maketrans("", "", "".join(_SIMILARITY_IGNORED_CHARS))
 EVENT_EXTRACTION_PROMPT_ID = "builtin.event-extraction.baseline"
 EVENT_EXTRACTION_PROMPT_REVISION_ID = "baseline.v6"
 SEMANTIC_JUDGE_SYSTEM_PROMPT = """You are a semantic judge for event extraction evaluation.
@@ -2136,7 +2137,7 @@ def _string_similarity(left: str, right: str) -> float:
 
 @lru_cache(maxsize=4096)
 def _normalize_similarity_text(value: str) -> str:
-    return "".join(char for char in value.strip().lower() if char not in _SIMILARITY_IGNORED_CHARS)
+    return value.strip().lower().translate(_SIMILARITY_IGNORED_TRANSLATION)
 
 
 _NORMALIZED_GROUP_ACTOR_ALIASES = frozenset(


### PR DESCRIPTION
## Summary
- Replaces event-extraction similarity normalization's per-character Python filter with a precomputed `str.translate` deletion table.
- Keeps string similarity behavior unchanged and extends the focused regression test for punctuation/case normalization.
- Adds a small governing plan for this Python-only optimization slice.

## Plan or Spec
- `docs/plans/2026-05-09-event-extraction-normalization-translate.md`
- Registered PR-scoped probe: `event-extraction-alignment-accepted-edge-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_alignment_probe.py
exit 0; similarity_elapsed_ms_mean=1.3098272029310465; elapsed_ms_mean=2992.7640706067905

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_uses_global_optimum_not_greedy services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_precomputes_only_accepted_sparse_edges services/mlx-worker-python/tests/test_event_extraction.py::test_string_similarity_reuses_normalized_text_and_bigram_counts services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_reuses_alignment_payloads_for_matched_details services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_alignment_probe_script_emits_metrics
exit 0; 7 passed in 1.09s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_uses_global_optimum_not_greedy services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_precomputes_only_accepted_sparse_edges services/mlx-worker-python/tests/test_event_extraction.py::test_string_similarity_reuses_normalized_text_and_bigram_counts services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_reuses_alignment_payloads_for_matched_details services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_alignment_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_alignment_probe.py
exit 0; 7 passed; TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_alignment_probe.py
exit 0; similarity_elapsed_ms_mean=1.270864810794592; elapsed_ms_mean=2870.119162229821

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 3 0 100%`).
- Local registered probe (`event-extraction-alignment-accepted-edge-cache`) on Linux:
  - `similarity_elapsed_ms_mean`: `1.3098272029310465 ms` -> `1.270864810794592 ms` (`-0.03896239213645458 ms`, `-2.974620778165781%`, `1.0306581721403505x`).
  - Full probe `elapsed_ms_mean`: `2992.7640706067905 ms` -> `2870.119162229821 ms` (`-122.6449083769694 ms`, `-4.098048007910721%`, `1.0427316433376534x`).
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- None for the Python slice. CI remains the authoritative registered-probe validation before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
