### PR TITLE
perf: skip unnecessary answer normalization extractors

### DIFF
--- a/docs/plans/2026-05-09-evaluation-answer-normalization-fast-path.md
+++ b/docs/plans/2026-05-09-evaluation-answer-normalization-fast-path.md
@@ -1,0 +1,33 @@
+# Evaluation Answer Normalization Fast Path
+
+## Goal
+
+Reduce redundant answer-normalization work in `EvaluationCore._normalized_answer` for free-text answers by avoiding numeric and option extractor scans unless the stripped answer shape can actually be accepted as numeric or single-option output.
+
+## Scope
+
+- `services/mlx-worker-python/worker/engine/evaluation_core.py`
+- `services/mlx-worker-python/tests/test_evaluation_core.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux-only verification path
+
+This is a Python-only slice and can be verified on Linux with focused pytest, changed-scope coverage, and a base-vs-head PR-scoped performance probe.
+
+## Probe definition
+
+Add `evaluation-answer-normalization-fast-path` to the PR-scoped performance registry. The probe repeatedly normalizes a mix of free-text, numeric, and option answers, while structurally counting extractor calls for free-text answers.
+
+Success metrics:
+
+- Preserve normalized output checksum and numeric/option behavior.
+- Reduce `numeric_extract_calls_mean` and `option_extract_calls_mean` for the synthetic mostly-free-text workload.
+- Keep changed executable coverage at or above 95%.
+
+## Verification commands
+
+- Focused pytest for evaluation helper behavior and PR-scoped registry selection/smoke tests.
+- Changed-scope coverage using `scripts/changed_scope_coverage.py`.
+- Local `scripts/pr_scoped_performance_run.py` run for `evaluation-answer-normalization-fast-path` against `origin/main` and head.
+- `git diff --check`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -728,6 +728,43 @@
     ]
   },
   {
+    "id": "evaluation-answer-normalization-fast-path",
+    "name": "Evaluation answer normalization fast path",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/engine/evaluation_core.py",
+      "services/mlx-worker-python/tests/test_evaluation_core.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_helpers_cover_numeric_option_and_normalization_paths services/mlx-worker-python/tests/test_evaluation_core.py::test_normalized_answer_skips_extractors_for_free_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_answer_normalization_probe_command_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_helpers_cover_numeric_option_and_normalization_paths services/mlx-worker-python/tests/test_evaluation_core.py::test_normalized_answer_skips_extractors_for_free_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_answer_normalization_probe_command_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 - <<'PYPROBE'\nimport json\nimport sys\nimport time\nfrom pathlib import Path\n\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / 'services/mlx-worker-python'))\nfrom worker.engine.evaluation_core import EvaluationCore\n\nfree_text_answers = tuple(\n    f\"Final Answer: city {index % 97} with extra spacing\"\n    for index in range(2400)\n)\nnumeric_answers = tuple(str((index % 31) + 0.0) for index in range(300))\noption_answers = tuple(chr(ord('A') + (index % 4)) for index in range(300))\nanswers = free_text_answers + numeric_answers + option_answers\nsample_count = 5\niteration_count = 80\n\noriginal_numeric = EvaluationCore._extract_numeric_value\noriginal_option = EvaluationCore._extract_option_value\nelapsed_samples = []\nnumeric_call_samples = []\noption_call_samples = []\nchecksum = 0\nfor _ in range(sample_count):\n    numeric_calls = [0]\n    option_calls = [0]\n\n    def counting_numeric(value: str) -> str | None:\n        numeric_calls[0] += 1\n        return original_numeric(value)\n\n    def counting_option(value: str) -> str | None:\n        option_calls[0] += 1\n        return original_option(value)\n\n    EvaluationCore._extract_numeric_value = staticmethod(counting_numeric)\n    EvaluationCore._extract_option_value = staticmethod(counting_option)\n    try:\n        started = time.perf_counter()\n        local_checksum = 0\n        for _ in range(iteration_count):\n            for answer in answers:\n                local_checksum += len(EvaluationCore._normalized_answer(answer))\n        elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n        numeric_call_samples.append(numeric_calls[0] / iteration_count)\n        option_call_samples.append(option_calls[0] / iteration_count)\n        checksum = local_checksum\n    finally:\n        EvaluationCore._extract_numeric_value = original_numeric\n        EvaluationCore._extract_option_value = original_option\n\nassert EvaluationCore._normalized_answer('9.0') == '9'\nassert EvaluationCore._normalized_answer('b') == 'B'\nassert EvaluationCore._normalized_answer('Final Answer: Paris') == 'final answer: paris'\nprint(json.dumps({\n    'elapsed_ms_mean': round(sum(elapsed_samples) / len(elapsed_samples), 6),\n    'numeric_extract_calls_mean': round(sum(numeric_call_samples) / len(numeric_call_samples), 6),\n    'option_extract_calls_mean': round(sum(option_call_samples) / len(option_call_samples), 6),\n    'answer_count': float(len(answers)),\n    'free_text_answer_count': float(len(free_text_answers)),\n    'iteration_count': float(iteration_count),\n    'normalization_checksum': float(checksum),\n}, sort_keys=True))\nPYPROBE",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "numeric_extract_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "option_extract_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "evaluation-latency-percentile-vector-reuse",
     "name": "Evaluation latency percentile vector reuse",
     "runner": "ubuntu-latest",

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -2266,6 +2266,35 @@ def test_evaluation_helpers_cover_numeric_option_and_normalization_paths() -> No
     assert EvaluationCore._answers_match(expected="b", predicted="B") is True
 
 
+def test_normalized_answer_skips_extractors_for_free_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    numeric_calls = 0
+    option_calls = 0
+    original_numeric = EvaluationCore._extract_numeric_value
+    original_option = EvaluationCore._extract_option_value
+
+    def counting_numeric(value: str) -> str | None:
+        nonlocal numeric_calls
+        numeric_calls += 1
+        return original_numeric(value)
+
+    def counting_option(value: str) -> str | None:
+        nonlocal option_calls
+        option_calls += 1
+        return original_option(value)
+
+    monkeypatch.setattr(EvaluationCore, "_extract_numeric_value", staticmethod(counting_numeric))
+    monkeypatch.setattr(EvaluationCore, "_extract_option_value", staticmethod(counting_option))
+
+    assert EvaluationCore._normalized_answer("  Final Answer: Paris. ") == "final answer: paris"
+    assert EvaluationCore._normalized_answer("`New   York`") == "new york"
+    assert EvaluationCore._normalized_answer("9.0") == "9"
+    assert EvaluationCore._normalized_answer("b") == "B"
+    assert EvaluationCore._normalized_answer("Option C is correct") == "option c is correct"
+
+    assert numeric_calls == 1
+    assert option_calls == 1
+
+
 def test_evaluation_helpers_cover_timeout_fallback_and_digit_choice_resolution() -> None:
     assert (
         EvaluationCore._sample_code_timeout_seconds({}, {"code_timeout_seconds": "invalid"}) == 5.0

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -84,6 +84,7 @@ SCOPE_MATCHER_SELECTED_PROBE_IDS = [
     "benchmark-export-run-scan-single-pass",
     "evaluation-job-id-high-water-mark",
     "evaluation-sample-probe-aggregation",
+    "evaluation-answer-normalization-fast-path",
     "evaluation-latency-percentile-vector-reuse",
     "evaluation-dialogue-diagnostics-top-k",
     "download-pipeline-directory-size-single-stat",
@@ -343,13 +344,31 @@ def test_scope_report_selects_evaluation_probes() -> None:
     )
 
     probe_ids = {probe["id"] for probe in scope["selected_probes"]}
-    assert scope["selected_count"] == 4
+    assert scope["selected_count"] == 5
     assert probe_ids == {
+        "evaluation-answer-normalization-fast-path",
         "evaluation-dialogue-diagnostics-top-k",
         "evaluation-job-id-high-water-mark",
         "evaluation-latency-percentile-vector-reuse",
         "evaluation-sample-probe-aggregation",
     }
+
+
+def test_evaluation_answer_normalization_probe_command_emits_metrics() -> None:
+    probe = next(
+        probe
+        for probe in load_probe_registry(REGISTRY_PATH)
+        if probe.probe_id == "evaluation-answer-normalization-fast-path"
+    )
+
+    metrics = _probe_command_json(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["numeric_extract_calls_mean"] == 300.0
+    assert metrics["option_extract_calls_mean"] == 300.0
+    assert metrics["answer_count"] == 3000.0
+    assert metrics["free_text_answer_count"] == 2400.0
+    assert metrics["normalization_checksum"] > 0
 
 
 def test_scope_report_selects_code_eval_stdio_probe() -> None:
@@ -1679,6 +1698,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "mlx-audio-speech-signature-cache",
         "video-preprocessing-uri-byte-length-reuse",
         "dev-up-mlx-metal-dist-info-scandir",
+        "evaluation-answer-normalization-fast-path",
         "evaluation-dialogue-diagnostics-top-k",
         "evaluation-job-id-high-water-mark",
         "evaluation-dialogue-diagnostics-top-k",

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -2846,12 +2846,14 @@ class EvaluationCore:
     @staticmethod
     def _normalized_answer(value: str) -> str:
         stripped = EvaluationCore._strip_wrapping(value)
-        numeric = EvaluationCore._extract_numeric_value(stripped)
-        if numeric is not None and EvaluationCore._looks_like_numeric(stripped):
-            return numeric
-        option = EvaluationCore._extract_option_value(stripped)
-        if option is not None and EvaluationCore._looks_like_option(stripped):
-            return option
+        if EvaluationCore._looks_like_numeric(stripped):
+            numeric = EvaluationCore._extract_numeric_value(stripped)
+            if numeric is not None:
+                return numeric
+        if EvaluationCore._looks_like_option(stripped):
+            option = EvaluationCore._extract_option_value(stripped)
+            if option is not None:
+                return option
         return re.sub(r"\s+", " ", stripped).casefold()
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Skips numeric and option extractor scans in `EvaluationCore._normalized_answer` unless the stripped answer shape can actually be accepted as numeric or single-option output.
- Adds a focused regression test proving free-text answers do not invoke the heavier extractors while numeric/option answers still normalize correctly.
- Registers `evaluation-answer-normalization-fast-path` in PR-scoped performance CI to compare extractor-call counts and latency against `origin/main`.

## Plan or Spec
- Plan: `docs/plans/2026-05-09-evaluation-answer-normalization-fast-path.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.pretty.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_helpers_cover_numeric_option_and_normalization_paths services/mlx-worker-python/tests/test_evaluation_core.py::test_normalized_answer_skips_extractors_for_free_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_answer_normalization_probe_command_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 5 passed in 5.59s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_helpers_cover_numeric_option_and_normalization_paths services/mlx-worker-python/tests/test_evaluation_core.py::test_normalized_answer_skips_extractors_for_free_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_answer_normalization_probe_command_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 5 passed in 4.66s; TOTAL 38 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-answer-normalization-fast-path --base-repo /tmp/melix-base-eval-answer-20260509-021109-2 --head-repo "$PWD" --output /tmp/evaluation-answer-normalization-probe.json
# base/head probes ok; head verification coverage 100%

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 38 0 100%`
  - `evaluation_core.py`: 8/8 changed executable lines covered.
  - `test_evaluation_core.py`: 20/20 changed executable lines covered.
  - `test_pr_scoped_performance.py`: 10/10 changed executable lines covered.
- Local PR-scoped probe: `evaluation-answer-normalization-fast-path`
  - `elapsed_ms_mean`: base `1170.283546` ms → head `612.767482` ms (~47.6% lower).
  - `numeric_extract_calls_mean`: base `3000.0` → head `300.0`.
  - `option_extract_calls_mean`: base `2700.0` → head `300.0`.
  - `normalization_checksum`: unchanged at `7724000.0`.

## Known Gaps
- Linux-only local verification; macOS/Swift surfaces were not run because this is a Python-only worker optimization.
- Full hosted CI is required before merge. The new PR-scoped probe is registered, but hosted CI state must be checked after PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
