### PR TITLE
perf: avoid rerank request document copy

### DIFF
--- a/docs/plans/2026-05-09-rerank-request-document-passthrough.md
+++ b/docs/plans/2026-05-09-rerank-request-document-passthrough.md
@@ -1,0 +1,32 @@
+# Rerank Request Document Passthrough Optimization
+
+## Goal
+
+Avoid materializing a duplicate Python `list` for `RerankRequest.documents` before dispatching to the deterministic rerank runtime.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/engine/rerank_core.py`
+- `services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py`
+- `services/mlx-worker-python/tests/test_rerank_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/rerank_top_k_probe.py`
+
+## Linux-only Constraint
+
+This is a Python worker slice and can be verified on Linux with focused pytest, changed-scope coverage, and the existing PR-scoped rerank performance probe.
+
+## Performance Probe
+
+Use the existing registered probe `rerank-core-top-k-heap-selection`, extending `scripts/rerank_top_k_probe.py` with request-document passthrough metrics:
+
+- `request_document_identity_hits`
+- `request_document_iterations`
+- `request_elapsed_ms`
+
+## Success Metrics
+
+- Rerank request behavior and top-k ordering remain unchanged.
+- Focused tests pass.
+- Changed executable line coverage is at least 95%.
+- The local probe reports `request_document_identity_hits == request_iteration_count`, proving the runtime sees the original request document iterable instead of a copied list.

--- a/scripts/rerank_top_k_probe.py
+++ b/scripts/rerank_top_k_probe.py
@@ -16,6 +16,53 @@ sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 from worker.engine.rerank_core import RerankCore  # noqa: E402
 
 
+class _ProbeLoadedModel:
+    runtime_kind = "rerank"
+    runtime_model = {"model_id": "rerank-copy-probe"}
+
+
+class _ProbeDocuments:
+    def __init__(self, count: int) -> None:
+        self._values = tuple(f"document-{index}" for index in range(count))
+        self.iterations = 0
+
+    def __iter__(self):
+        self.iterations += 1
+        return iter(self._values)
+
+
+class _ProbeRuntime:
+    def __init__(self, expected_documents: _ProbeDocuments) -> None:
+        self.expected_documents = expected_documents
+        self.document_identity_hits = 0
+
+    def score_documents(self, loaded_model, query: str, documents) -> list[float]:
+        if loaded_model != _ProbeLoadedModel.runtime_model:  # pragma: no cover - probe guard
+            raise RuntimeError("unexpected loaded model payload")
+        if query != "swift runtime":  # pragma: no cover - probe guard
+            raise RuntimeError("unexpected query payload")
+        self.document_identity_hits += int(documents is self.expected_documents)
+        return [float(index) for index, _document in enumerate(documents)]
+
+
+class _ProbeRegistry:
+    def __init__(self, rerank_runtime: _ProbeRuntime) -> None:
+        self.rerank_runtime = rerank_runtime
+
+    def get_loaded_model(self, model_handle: str) -> _ProbeLoadedModel | None:
+        if model_handle != "probe-model":  # pragma: no cover - probe guard
+            return None
+        return _ProbeLoadedModel()
+
+
+class _ProbeRequest:
+    def __init__(self, documents: _ProbeDocuments, *, top_k: int) -> None:
+        self.model_handle = "probe-model"
+        self.query = "swift runtime"
+        self.documents = documents
+        self.top_k = top_k
+
+
 def _legacy_rank_scores(scores: list[float], *, top_k: int | None) -> list[tuple[int, float]]:
     ranked = sorted(enumerate(scores), key=lambda item: (-item[1], item[0]))
     limit = top_k if top_k else len(ranked)
@@ -38,11 +85,42 @@ def _build_scores(document_count: int) -> list[float]:
     ]
 
 
+def _measure_request_document_passthrough(document_count: int, iteration_count: int) -> dict[str, float]:
+    documents = _ProbeDocuments(document_count)
+    runtime = _ProbeRuntime(documents)
+    core = RerankCore(_ProbeRegistry(runtime))
+    checksum = 0.0
+
+    started = time.perf_counter()
+    for _ in range(iteration_count):
+        response = core.rerank(_ProbeRequest(documents, top_k=1))
+        if response.error.code:  # pragma: no cover - probe guard
+            raise RuntimeError(response.error.message)
+        if len(response.items) != 1 or response.items[0].index != document_count - 1:  # pragma: no cover - probe guard
+            raise RuntimeError("rerank request probe changed ranking semantics")
+        checksum += response.items[0].score
+
+    return {
+        "request_elapsed_ms": round((time.perf_counter() - started) * 1000.0, 6),
+        "request_document_count": float(document_count),
+        "request_document_identity_hits": float(runtime.document_identity_hits),
+        "request_document_iterations": float(documents.iterations),
+        "request_iteration_count": float(iteration_count),
+        "request_score_checksum": round(checksum, 6),
+    }
+
+
 def main() -> int:
     document_count = int(os.environ.get("MELIX_RERANK_TOP_K_PROBE_DOCUMENTS", "50000"))
     top_k = int(os.environ.get("MELIX_RERANK_TOP_K_PROBE_TOP_K", "1"))
     iteration_count = int(os.environ.get("MELIX_RERANK_TOP_K_PROBE_ITERATIONS", "120"))
     sample_count = int(os.environ.get("MELIX_RERANK_TOP_K_PROBE_SAMPLES", "7"))
+    request_document_count = int(
+        os.environ.get("MELIX_RERANK_REQUEST_PROBE_DOCUMENTS", str(document_count))
+    )
+    request_iteration_count = int(
+        os.environ.get("MELIX_RERANK_REQUEST_PROBE_ITERATIONS", str(iteration_count))
+    )
     scores = _build_scores(document_count)
 
     expected = _legacy_rank_scores(scores, top_k=top_k)
@@ -76,6 +154,12 @@ def main() -> int:
         "sample_count": float(sample_count),
         "top_k": float(top_k),
     }
+    metrics.update(
+        _measure_request_document_passthrough(
+            request_document_count,
+            request_iteration_count,
+        )
+    )
     print(json.dumps(metrics, sort_keys=True))
     return 0
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -751,6 +751,8 @@ def test_rerank_top_k_probe_script_emits_top_k_one_metrics(
     monkeypatch.setenv("MELIX_RERANK_TOP_K_PROBE_DOCUMENTS", "64")
     monkeypatch.setenv("MELIX_RERANK_TOP_K_PROBE_ITERATIONS", "2")
     monkeypatch.setenv("MELIX_RERANK_TOP_K_PROBE_SAMPLES", "1")
+    monkeypatch.setenv("MELIX_RERANK_REQUEST_PROBE_DOCUMENTS", "16")
+    monkeypatch.setenv("MELIX_RERANK_REQUEST_PROBE_ITERATIONS", "3")
 
     with pytest.raises(SystemExit) as exc_info:
         runpy.run_path(
@@ -766,6 +768,11 @@ def test_rerank_top_k_probe_script_emits_top_k_one_metrics(
     assert metrics["top_k"] == 1.0
     assert metrics["result_count"] == 1.0
     assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["request_document_count"] == 16.0
+    assert metrics["request_iteration_count"] == 3.0
+    assert metrics["request_document_identity_hits"] == 3.0
+    assert metrics["request_document_iterations"] == 3.0
+    assert metrics["request_score_checksum"] == 45.0
 
 
 def test_scope_report_selects_deterministic_embedding_probe() -> None:

--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -136,6 +136,45 @@ def test_rerank_returns_sorted_scores_and_honors_top_k() -> None:
     assert first.items[1].score == second.items[1].score
 
 
+def test_rerank_core_passes_request_documents_without_copying() -> None:
+    class FakeDocuments:
+        def __init__(self, values: tuple[str, ...]) -> None:
+            self.values = values
+            self.iterations = 0
+
+        def __iter__(self):
+            self.iterations += 1
+            return iter(self.values)
+
+    class FakeRerankRuntime:
+        def __init__(self) -> None:
+            self.seen_documents = None
+
+        def score_documents(self, loaded_model, query: str, documents):
+            assert loaded_model == {"model_id": "rerank-probe"}
+            assert query == "swift runtime"
+            self.seen_documents = documents
+            return [float(index) for index, _document in enumerate(documents)]
+
+    documents = FakeDocuments(("first", "second", "third"))
+    rerank_runtime = FakeRerankRuntime()
+    registry = Mock()
+    registry.get_loaded_model.return_value = Mock(
+        runtime_kind="rerank",
+        runtime_model={"model_id": "rerank-probe"},
+    )
+    registry.rerank_runtime = rerank_runtime
+
+    response = RerankCore(registry).rerank(
+        Mock(model_handle="model-1", query="swift runtime", documents=documents, top_k=1)
+    )
+
+    assert response.error.code == ""
+    assert [item.index for item in response.items] == [2]
+    assert rerank_runtime.seen_documents is documents
+    assert documents.iterations == 1
+
+
 def test_load_model_exposes_jina_v3_rerank_metadata() -> None:
     runtime = DeterministicRerankRuntime()
 

--- a/services/mlx-worker-python/worker/engine/rerank_core.py
+++ b/services/mlx-worker-python/worker/engine/rerank_core.py
@@ -30,7 +30,7 @@ class RerankCore:
             scores = self._registry.rerank_runtime.score_documents(
                 loaded_model.runtime_model,
                 request.query,
-                list(request.documents),
+                request.documents,
             )
         except Exception as exc:  # pragma: no cover - defensive branch
             return inference_pb2.RerankResponse(

--- a/services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from worker.runtime.rerank_backends import (
     resolve_rerank_backend,
     resolve_rerank_family,
@@ -23,7 +25,7 @@ class DeterministicRerankRuntime:
         backend = resolve_rerank_backend(model_spec.ext.get("rerank_backend_id", "token-overlap-v1"))
         return int(backend.descriptor.estimated_resident_bytes)
 
-    def score_documents(self, loaded_model, query: str, documents: list[str]) -> list[float]:
+    def score_documents(self, loaded_model, query: str, documents: Iterable[str]) -> list[float]:
         backend = loaded_model.get("rerank_backend")
         if backend is None:
             backend = resolve_rerank_backend(loaded_model.get("rerank_backend_id", "token-overlap-v1"))


### PR DESCRIPTION
## Summary
- Avoid a redundant `list(request.documents)` materialization in `RerankCore` before dispatching to the deterministic rerank runtime.
- Broaden the deterministic rerank runtime input annotation to accept `Iterable[str]`, matching its actual iteration-only usage.
- Extend the existing `rerank-core-top-k-heap-selection` PR-scoped probe with request-document passthrough metrics and add focused regression coverage.

## Plan or Spec
- Plan: `docs/plans/2026-05-09-rerank-request-document-passthrough.md`
- Optimization slice: Python worker request path.
- Verification path: focused pytest, changed-scope coverage, local PR-scoped probe, and existing hosted PR-scoped performance probe `rerank-core-top-k-heap-selection`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_core_passes_request_documents_without_copying services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_preserves_sort_contract_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_uses_single_scan_for_top_k_one services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_uses_heap_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_keeps_full_sort_when_unbounded services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_returns_sorted_scores_and_honors_top_k services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_rerank_core_top_k_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_rerank_top_k_probe_script_emits_top_k_one_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...same focused test nodes...`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/rerank_core.py services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/rerank_top_k_probe.py`
- `MELIX_RERANK_TOP_K_PROBE_DOCUMENTS=20000 MELIX_RERANK_TOP_K_PROBE_ITERATIONS=30 MELIX_RERANK_TOP_K_PROBE_SAMPLES=3 MELIX_RERANK_REQUEST_PROBE_DOCUMENTS=20000 MELIX_RERANK_REQUEST_PROBE_ITERATIONS=30 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/rerank_top_k_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `9 passed in 0.33s`.
- Changed-scope coverage: `TOTAL 76 0 100%`.
- Local PR-scoped probe output:
  ```json
  {"checksum": 1084350.53185, "document_count": 20000.0, "elapsed_ms_mean": 233.101844, "iteration_count": 30.0, "peak_bytes_mean": 741.333333, "request_document_count": 20000.0, "request_document_identity_hits": 30.0, "request_document_iterations": 30.0, "request_elapsed_ms": 58.991655, "request_iteration_count": 30.0, "request_score_checksum": 599970.0, "result_count": 1.0, "sample_count": 3.0, "top_k": 1.0}
  ```
- Detached `origin/main` vs head synthetic request-path comparison:
  - Baseline: `identity_hits_mean=0.0`, `peak_bytes_mean=828680.0`, `elapsed_ms_mean=617.371806`.
  - Head: `identity_hits_mean=30.0`, `peak_bytes_mean=654427.6`, `elapsed_ms_mean=635.972048`.
- Interpretation: the structural signal is the primary gate: the request document object is now passed through without identity-breaking materialization. The synthetic comparison showed lower traced peak allocation for the request path; elapsed timing is disclosed as noisy/slightly slower in that detached comparison and is not the main success criterion.

## Known Gaps
- Linux verification only; no local macOS/Swift validation was run.
- Hosted `pr-scoped-performance` and broader branch CI must validate the PR before merge/auto-merge.

## Evidence Checklist
- [x] Focused tests added/updated.
- [x] Focused pytest passed locally.
- [x] Changed-scope coverage is at least 95% (`100%`).
- [x] Explicit local performance/probe measurement produced concrete metrics.
- [x] Existing PR-scoped performance probe updated/extended: `rerank-core-top-k-heap-selection`.
- [x] `git diff --check` passed.
- [x] No dependency or `uv.lock` changes included.
