### PR TITLE
Fix model benchmark diagnostics and task inference

### DIFF
--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -128,6 +128,13 @@ Melix benchmark and evaluation targets use the following task-aligned values:
 - `image-to-text`
 - `image-text-to-text`
 
+Direct Hugging Face target resolution must prefer the explicit Hub
+`pipeline_tag` when it is present. Some valid MLX repositories omit
+`pipeline_tag`; Melix may infer the task kind from stronger repository metadata
+such as MLX/Qwen text-generation signals, sibling tokenizer and weight files,
+or explicit modality tags. A missing `pipeline_tag` alone is not an unsupported
+task-family signal.
+
 ## Performance Benchmark Contract
 
 Melix exposes two distinct performance workflows:

--- a/docs/evidence-telemetry-report-contract.md
+++ b/docs/evidence-telemetry-report-contract.md
@@ -159,6 +159,11 @@ only for diagnosis.
 
 Melix hardware telemetry is scoped to macOS on Apple Silicon.
 
+The canonical power collector uses `powermetrics` with the
+`cpu_power,gpu_power,ane_power,thermal` samplers. It must not request the legacy
+`smc` sampler as a required path; if this Apple Silicon sampler set fails, the
+run records an instrumentation gap instead of inventing substitute telemetry.
+
 The collector records:
 
 - CPU utilization
@@ -194,9 +199,9 @@ Each run records:
 Telemetry sampling runs off the hot path. Benchmark and evaluation execution
 read only cached telemetry samples.
 
-If IOReport or IORegistry sampling fails during a Melix run, the run records a
-telemetry failure probe and report entry. Implementations must not synthesize
-zero-watt or zero-duration values for missing telemetry.
+If `powermetrics`, memory, or process sampling fails during a Melix run, the run
+records a telemetry failure probe and report entry. Implementations must not
+synthesize zero-watt or zero-duration values for missing telemetry.
 
 ## Process Attribution
 

--- a/services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift
+++ b/services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift
@@ -3110,6 +3110,14 @@ public actor ControlPlaneService {
     ) throws -> BenchmarkTaskKind {
         let pipelineTag = card.pipelineTag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         switch pipelineTag {
+        case "":
+            if let inferredTaskKind = inferredBenchmarkTaskKindForMissingPipelineTag(from: card) {
+                return inferredTaskKind
+            }
+            throw BenchmarkTargetResolutionError(
+                code: "unsupported_task_family",
+                message: "Hub repo \(card.repoID) declares unsupported pipeline_tag=\(card.pipelineTag)."
+            )
         case BenchmarkTaskKind.textGeneration.rawValue:
             return .textGeneration
         case BenchmarkTaskKind.imageToText.rawValue:
@@ -3134,6 +3142,56 @@ public actor ControlPlaneService {
                 message: "Hub repo \(card.repoID) declares unsupported pipeline_tag=\(card.pipelineTag)."
             )
         }
+    }
+
+    private func inferredBenchmarkTaskKindForMissingPipelineTag(
+        from card: Melix_Worker_V1_HubModelCard
+    ) -> BenchmarkTaskKind? {
+        let normalizedTags = normalizedHubTags(for: card)
+        if normalizedTags.contains(BenchmarkTaskKind.textGeneration.rawValue)
+            || normalizedTags.contains("causal-lm")
+            || supportsQwenTextBenchmarkImport(for: card, normalizedTags: normalizedTags) {
+            return .textGeneration
+        }
+        if normalizedTags.contains(BenchmarkTaskKind.imageToText.rawValue) {
+            return .imageToText
+        }
+        if normalizedTags.contains(BenchmarkTaskKind.imageTextToText.rawValue)
+            || normalizedTags.contains("vision-language-model")
+            || normalizedTags.contains("vlm")
+            || normalizedTags.contains("multimodal") {
+            return .imageTextToText
+        }
+        if normalizedTags.contains(BenchmarkTaskKind.textToImage.rawValue) {
+            return .textToImage
+        }
+        if normalizedTags.contains(BenchmarkTaskKind.imageTextToImage.rawValue) {
+            return .imageTextToImage
+        }
+        return nil
+    }
+
+    private func supportsQwenTextBenchmarkImport(
+        for card: Melix_Worker_V1_HubModelCard,
+        normalizedTags: Set<String>
+    ) -> Bool {
+        let identity = ([card.repoID, card.modelName] + card.tags)
+            .joined(separator: " ")
+            .lowercased()
+        let hasQwen35Signal = identity.contains("qwen3.5")
+            || identity.contains("qwen3-5")
+            || identity.contains("qwen3_5")
+            || normalizedTags.contains("qwen3-5")
+            || normalizedTags.contains("qwen3.5")
+        guard hasQwen35Signal else {
+            return false
+        }
+        let siblingFiles = Set(card.siblingFiles.map { $0.lowercased() })
+        let hasTokenizer = siblingFiles.contains("tokenizer.json")
+            || siblingFiles.contains("tokenizer_config.json")
+        let hasWeights = siblingFiles.contains("model.safetensors.index.json")
+            || siblingFiles.contains { $0.hasSuffix(".safetensors") }
+        return hasTokenizer && hasWeights
     }
 
     private func makeImportedBenchmarkModel(
@@ -3216,14 +3274,7 @@ public actor ControlPlaneService {
     private func supportsVisionAnyToAnyBenchmarkImport(
         for card: Melix_Worker_V1_HubModelCard
     ) -> Bool {
-        let normalizedTags = Set(
-            card.tags.map {
-                $0
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                    .lowercased()
-                    .replacingOccurrences(of: "_", with: "-")
-            }
-        )
+        let normalizedTags = normalizedHubTags(for: card)
         guard benchmarkVisionFamilyID(for: card) == "gemma4-v1" else {
             return false
         }
@@ -3233,6 +3284,17 @@ public actor ControlPlaneService {
             || normalizedTags.contains("vlm")
             || normalizedTags.contains("multimodal")
             || normalizedTags.contains("image-text-to-text")
+    }
+
+    private func normalizedHubTags(for card: Melix_Worker_V1_HubModelCard) -> Set<String> {
+        Set(
+            card.tags.map {
+                $0
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .lowercased()
+                    .replacingOccurrences(of: "_", with: "-")
+            }
+        )
     }
 
     private func shouldDeferVisionExecutionModeInference(

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift
@@ -4782,6 +4782,131 @@ struct ControlPlaneServiceTests {
         #expect(response.ops.benchmarkJob.sourceRepo == "unsloth/gemma-4-E4B-it-MLX-8bit")
     }
 
+    @Test("execute imports Qwen3.5 benchmark targets with missing pipeline tag as text generation")
+    func executeImportsQwen35BenchmarkTargetWithMissingPipelineTag() async throws {
+        let reportPath = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("melix-bench-qwen35-report.md").path
+        try "# Qwen3.5 Bench\n".write(toFile: reportPath, atomically: true, encoding: .utf8)
+
+        let modelOpsClient = ScriptedModelOperationsWorkerClient()
+        await modelOpsClient.setHubModelCardResponse(
+            makeBenchmarkHubModelCardResponse(
+                repoID: "mlx-community/Qwen3.5-9B-MLX-8bit",
+                modelName: "Qwen3.5-9B-MLX-8bit",
+                pipelineTag: "",
+                tags: ["mlx", "qwen3_5", "vision-language-model"],
+                siblingFiles: [
+                    "config.json",
+                    "processor_config.json",
+                    "tokenizer.json",
+                    "tokenizer_config.json",
+                    "model.safetensors.index.json",
+                ]
+            )
+        )
+        await modelOpsClient.setBenchEvents(makeBenchmarkLifecycleEvents(jobID: "bench-qwen35", reportPath: reportPath))
+        let pythonRuntimeClient = ScriptedChatWorkerClient(events: [])
+        let service = ControlPlaneService(
+            modelCatalog: ModelCatalog(seedModels: ModelCatalog.phaseSevenContractSeedModels()),
+            workerRegistry: WorkerRegistry(
+                defaultTextClient: NullWorkerClient(),
+                pythonCompatibilityClient: pythonRuntimeClient,
+                modelOperationsClient: modelOpsClient
+            )
+        )
+
+        let response = try await service.execute(
+            makeRunBenchRequest(hfRepoID: "mlx-community/Qwen3.5-9B-MLX-8bit")
+        )
+        let lastLoadRequest = try #require(await pythonRuntimeClient.lastLoadModelRequest)
+        let lastBenchRequest = try #require(await modelOpsClient.lastBenchRequest)
+
+        #expect(response.ok)
+        #expect(lastLoadRequest.model.modelID == "mlx-community/Qwen3.5-9B-MLX-8bit")
+        #expect(lastLoadRequest.model.modelKind == "text")
+        #expect(lastLoadRequest.model.ext["melix.task_kind"] == "text-generation")
+        #expect(lastLoadRequest.model.ext["melix.capability.route_kind"] == "python_text_compatibility")
+        #expect(lastBenchRequest.taskKind == "text-generation")
+        #expect(lastBenchRequest.sourceRepo == "mlx-community/Qwen3.5-9B-MLX-8bit")
+        #expect(response.ops.benchmarkJob.taskKind == "text-generation")
+    }
+
+    @Test("execute infers missing pipeline tags from explicit modality metadata")
+    func executeInfersMissingPipelineTagsFromExplicitModalityMetadata() async throws {
+        let cases: [(repoID: String, modelName: String, tags: [String], siblingFiles: [String], expectedTaskKind: String, expectedModelKind: String)] = [
+            (
+                repoID: "google/paligemma2-3b-ft-docci-448",
+                modelName: "paligemma2-3b-ft-docci-448",
+                tags: ["mlx", "image_to_text", "paligemma"],
+                siblingFiles: ["config.json", "processor_config.json", "tokenizer.json"],
+                expectedTaskKind: "image-to-text",
+                expectedModelKind: "vlm"
+            ),
+            (
+                repoID: "unsloth/gemma-4-E4B-it-MLX-8bit",
+                modelName: "gemma-4-E4B-it-MLX-8bit",
+                tags: ["mlx", "vision-language-model", "gemma4"],
+                siblingFiles: ["config.json", "processor_config.json", "tokenizer.json", "model.safetensors.index.json"],
+                expectedTaskKind: "image-text-to-text",
+                expectedModelKind: "vlm"
+            ),
+            (
+                repoID: "mlx-community/FLUX.1-schnell-4bit",
+                modelName: "FLUX.1-schnell-4bit",
+                tags: ["mlx", "text-to-image"],
+                siblingFiles: ["config.json"],
+                expectedTaskKind: "text-to-image",
+                expectedModelKind: "image"
+            ),
+            (
+                repoID: "mlx-community/sdxl-edit",
+                modelName: "sdxl-edit",
+                tags: ["mlx", "image-text-to-image"],
+                siblingFiles: ["config.json"],
+                expectedTaskKind: "image-text-to-image",
+                expectedModelKind: "image"
+            ),
+        ]
+
+        for testCase in cases {
+            let reportPath = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("melix-bench-missing-pipeline-\(testCase.expectedTaskKind).md")
+                .path
+            try "# Missing Pipeline Bench\n".write(toFile: reportPath, atomically: true, encoding: .utf8)
+
+            let modelOpsClient = ScriptedModelOperationsWorkerClient()
+            await modelOpsClient.setHubModelCardResponse(
+                makeBenchmarkHubModelCardResponse(
+                    repoID: testCase.repoID,
+                    modelName: testCase.modelName,
+                    pipelineTag: " ",
+                    tags: testCase.tags,
+                    siblingFiles: testCase.siblingFiles
+                )
+            )
+            await modelOpsClient.setBenchEvents(makeBenchmarkLifecycleEvents(jobID: "bench-\(testCase.expectedTaskKind)", reportPath: reportPath))
+            let pythonRuntimeClient = ScriptedChatWorkerClient(events: [])
+            let service = ControlPlaneService(
+                modelCatalog: ModelCatalog(seedModels: ModelCatalog.phaseSevenContractSeedModels()),
+                workerRegistry: WorkerRegistry(
+                    defaultTextClient: NullWorkerClient(),
+                    pythonCompatibilityClient: pythonRuntimeClient,
+                    modelOperationsClient: modelOpsClient
+                )
+            )
+
+            let response = try await service.execute(
+                makeRunBenchRequest(hfRepoID: testCase.repoID)
+            )
+            let lastLoadRequest = try #require(await pythonRuntimeClient.lastLoadModelRequest)
+            let lastBenchRequest = try #require(await modelOpsClient.lastBenchRequest)
+
+            #expect(response.ok)
+            #expect(lastLoadRequest.model.modelKind == testCase.expectedModelKind)
+            #expect(lastBenchRequest.taskKind == testCase.expectedTaskKind)
+            #expect(response.ops.benchmarkJob.taskKind == testCase.expectedTaskKind)
+        }
+    }
+
     @Test("execute imports image-to-text benchmark targets as OCR-capable VLM models")
     func executeImportsDirectImageToTextBenchmarkTarget() async throws {
         let reportPath = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("melix-bench-ocr-report.md").path
@@ -5108,6 +5233,32 @@ struct ControlPlaneServiceTests {
         #expect(unsupportedResponse.ok == false)
         #expect(unsupportedResponse.error.code == "unsupported_task_family")
         #expect(unsupportedResponse.error.message.contains("pipeline_tag=image-classification"))
+
+        let missingPipelineClient = ScriptedModelOperationsWorkerClient()
+        await missingPipelineClient.setHubModelCardResponse(
+            makeBenchmarkHubModelCardResponse(
+                repoID: "mlx-community/metadata-light-model",
+                modelName: "metadata-light-model",
+                pipelineTag: "",
+                tags: ["mlx"],
+                siblingFiles: ["config.json"]
+            )
+        )
+        let missingPipelineService = ControlPlaneService(
+            modelCatalog: ModelCatalog(seedModels: ModelCatalog.phaseSevenContractSeedModels()),
+            workerRegistry: WorkerRegistry(
+                defaultTextClient: NullWorkerClient(),
+                modelOperationsClient: missingPipelineClient
+            )
+        )
+
+        let missingPipelineResponse = try await missingPipelineService.execute(
+            makeRunBenchRequest(hfRepoID: "mlx-community/metadata-light-model")
+        )
+
+        #expect(missingPipelineResponse.ok == false)
+        #expect(missingPipelineResponse.error.code == "unsupported_task_family")
+        #expect(missingPipelineResponse.error.message.contains("pipeline_tag=."))
 
         let failedClient = ScriptedModelOperationsWorkerClient()
         await failedClient.setHubModelCardError(WorkerClientError.unavailable)

--- a/services/mlx-worker-python/tests/test_apple_silicon_telemetry.py
+++ b/services/mlx-worker-python/tests/test_apple_silicon_telemetry.py
@@ -269,6 +269,7 @@ Pages occupied by compressor:               50.
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess:
         if command[0] == "/usr/bin/powermetrics":
+            assert command[command.index("--samplers") + 1] == "cpu_power,gpu_power,ane_power,thermal"
             return subprocess.CompletedProcess(command, 0, stdout=plistlib.dumps(powermetrics_payload), stderr=b"")
         if command[0] == "/usr/bin/vm_stat":
             return subprocess.CompletedProcess(command, 0, stdout=vm_stat_output, stderr="")
@@ -282,6 +283,7 @@ Pages occupied by compressor:               50.
 
     assert sample.cpu_power_w == 8.0
     assert sample.gpu_power_w == 4.0
+    assert sample.ane_power_w == 1.0
     assert sample.system_power_w == 15.0
     assert sample.memory_used_bytes == 614_400
     assert sample.memory_total_bytes == 32_000_000_000

--- a/services/mlx-worker-python/tests/test_event_extraction.py
+++ b/services/mlx-worker-python/tests/test_event_extraction.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import builtins
 import json
 import runpy
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
 from urllib.error import HTTPError, URLError
 
 import pytest
@@ -74,6 +76,111 @@ def test_default_event_extraction_prompt_spec_uses_baseline_v6_feedback_rules() 
     assert "周二晚上7点上飞机" in spec.system_prompt
     assert "同事/朋友/表姐" in spec.system_prompt
     assert spec.content_hash == event_extraction_module.event_prompt_content_hash(spec.system_prompt, [])
+
+
+def test_local_event_extraction_disables_thinking_template_kwargs() -> None:
+    captured: dict[str, object] = {}
+
+    class FakeRuntime:
+        def render_prompt(self, messages, *, loaded_model, template_kwargs=None, execution_ext=None):
+            captured["messages"] = messages
+            captured["loaded_model"] = loaded_model
+            captured["template_kwargs"] = template_kwargs
+            captured["execution_ext"] = execution_ext
+            return "rendered prompt"
+
+        def generate_tokens(self, loaded_model, prompt, sampling, cancel_event, execution_ext=None):
+            captured["prompt"] = prompt
+            yield SimpleNamespace(text='{"events":[{"actor":["speaker_1"],"time":["明天"],"location":null,"action":["开会"]}]}')
+
+    class FakeRegistry:
+        def __init__(self) -> None:
+            self.runtime = FakeRuntime()
+            self.finished_request_id = ""
+
+        def runtime_for_loaded_model(self, loaded_model):
+            return self.runtime
+
+        def start_request(self, request_id, *, runtime_kind):
+            return SimpleNamespace(cancel_event=threading.Event())
+
+        def finish_request(self, request_id) -> None:
+            self.finished_request_id = request_id
+
+    registry = FakeRegistry()
+    client = evaluation_core._LocalEventExtractionClient(
+        registry=registry,
+        loaded_model=SimpleNamespace(runtime_model={"model": "fixture"}, runtime_kind="text"),
+        prompt_spec=event_extraction_module.default_event_extraction_prompt_spec(),
+        max_output_tokens=128,
+        seed=0,
+    )
+
+    events, raw_text = client.extract_events(["speaker_1: 明天我开会"], dialogue_id="dlg-local")
+
+    assert captured["template_kwargs"] == {"enable_thinking": False}
+    assert captured["prompt"] == "rendered prompt"
+    assert registry.finished_request_id.startswith("event-extraction:local:dlg-local:")
+    assert events == [{"actor": ["speaker_1"], "time": ["明天"], "location": None, "action": ["开会"]}]
+    assert raw_text.startswith("{")
+
+
+def test_local_event_extraction_parse_errors_keep_raw_response_for_diagnostics(tmp_path: Path) -> None:
+    source = tmp_path / "top200_final.jsonl"
+    _write_jsonl(
+        source,
+        [
+            {
+                "dialogue_id": "dlg-raw",
+                "dialogue": ["speaker_1: 明天我开会"],
+                "events": [{"actor": ["speaker_1"], "time": ["明天"], "location": None, "action": ["开会"]}],
+            }
+        ],
+    )
+
+    class FakeRuntime:
+        def render_prompt(self, messages, *, loaded_model, template_kwargs=None, execution_ext=None):
+            return "rendered prompt"
+
+        def generate_tokens(self, loaded_model, prompt, sampling, cancel_event, execution_ext=None):
+            yield SimpleNamespace(text="Thinking Process:")
+
+    class FakeRegistry:
+        def runtime_for_loaded_model(self, loaded_model):
+            return FakeRuntime()
+
+        def start_request(self, request_id, *, runtime_kind):
+            return SimpleNamespace(cancel_event=threading.Event())
+
+        def finish_request(self, request_id) -> None:
+            return None
+
+    loaded_model = SimpleNamespace(
+        runtime_model={"model": "fixture"},
+        runtime_kind="text",
+    )
+    core = EvaluationCore(jobs_root=tmp_path / "evals", registry=FakeRegistry())
+    run = core._run_event_extraction_suite(
+        model_id="local-qwen",
+        suite_id="event_extraction",
+        dataset_id="top200",
+        sample_size=1,
+        scoring_mode="event_extraction_weighted_f1",
+        parameters={"event_source_jsonl": str(source), "dataset_id": "top200"},
+        remote_target=None,
+        loaded_model=loaded_model,
+    )
+
+    trace_path = Path(run.job.parameters["event_eval_dialogue_traces"])
+    failure_path = Path(run.job.parameters["failure_jsonl"])
+    trace = json.loads(trace_path.read_text(encoding="utf-8").splitlines()[0])
+    failure = json.loads(failure_path.read_text(encoding="utf-8").splitlines()[0])
+
+    assert trace["status"] == "failed"
+    assert trace["raw_response_chars"] == len("Thinking Process:")
+    assert trace["response_body_bytes"] == len("Thinking Process:".encode("utf-8"))
+    assert Path(trace["raw_response_path"]).read_text(encoding="utf-8") == "Thinking Process:"
+    assert failure["raw_response_path"] == trace["raw_response_path"]
 
 
 def test_semantic_judge_prompt_v4_documents_event_field_and_group_boundaries() -> None:

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -134,6 +134,21 @@ class EvaluationRun:
         return self.results[0]
 
 
+class _LocalEventExtractionResponseParseError(ValueError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        raw_response: str,
+        request_body_bytes: int,
+        response_body_bytes: int,
+    ) -> None:
+        super().__init__(message)
+        self.raw_response = raw_response
+        self.request_body_bytes = request_body_bytes
+        self.response_body_bytes = response_body_bytes
+
+
 class _LocalEventExtractionClient:
     def __init__(
         self,
@@ -177,6 +192,7 @@ class _LocalEventExtractionClient:
             rendered_prompt = runtime.render_prompt(
                 chat_messages,
                 loaded_model=self._loaded_model.runtime_model,
+                template_kwargs={"enable_thinking": False},
                 execution_ext={},
             )
             sampling = common_pb2.SamplingConfig(
@@ -202,11 +218,21 @@ class _LocalEventExtractionClient:
                 self._registry.record_vision_probe(runtime_kind, runtime.last_probe_snapshot())
             self._registry.finish_request(request_id)
         raw_response = "".join(chunks).strip()
+        response_body_bytes = len(raw_response.encode("utf-8"))
+        try:
+            events = extract_events_from_response_text(raw_response)
+        except Exception as exc:  # noqa: BLE001
+            raise _LocalEventExtractionResponseParseError(
+                str(exc),
+                raw_response=raw_response,
+                request_body_bytes=request_body_bytes,
+                response_body_bytes=response_body_bytes,
+            ) from exc
         return EventExtractionClientResult(
-            events=extract_events_from_response_text(raw_response),
+            events=events,
             raw_response=raw_response,
             request_body_bytes=request_body_bytes,
-            response_body_bytes=len(raw_response.encode("utf-8")),
+            response_body_bytes=response_body_bytes,
         )
 
 
@@ -758,12 +784,24 @@ class EvaluationCore:
                 )
             except Exception as exc:  # noqa: BLE001
                 request_duration_ms = self._round_ms((time.perf_counter() - request_started_at) * 1_000.0)
+                failure_raw_response = str(getattr(exc, "raw_response", "") or "")
+                failure_raw_response_path: Path | None = None
+                if failure_raw_response:
+                    failure_raw_response_path = (
+                        raw_response_dir / f"{line_number:04d}-{self._safe_path_component(dialogue_id)}.txt"
+                    )
+                    failure_raw_response_path.write_text(
+                        failure_raw_response,
+                        encoding="utf-8",
+                    )
                 failure_record = {
                     "dialogue_id": dialogue_id,
                     "line_number": line_number,
                     "event_index": None,
                     "reason": str(exc),
                 }
+                if failure_raw_response_path is not None:
+                    failure_record["raw_response_path"] = str(failure_raw_response_path)
                 provider_error_code = self._event_extraction_provider_error_code(exc)
                 if provider_error_code:
                     failure_record["code"] = provider_error_code
@@ -779,10 +817,10 @@ class EvaluationCore:
                         request_duration_ms=request_duration_ms,
                         normalization_duration_ms=0.0,
                         dialogue=dialogue,
-                        request_body_bytes=0,
-                        response_body_bytes=0,
-                        raw_response="",
-                        raw_response_path=None,
+                        request_body_bytes=self._client_result_int(exc, "request_body_bytes"),
+                        response_body_bytes=self._client_result_int(exc, "response_body_bytes"),
+                        raw_response=failure_raw_response,
+                        raw_response_path=failure_raw_response_path,
                         predicted_event_count=0,
                         normalized_event_count=0,
                         normalization_failure_count=0,

--- a/services/mlx-worker-python/worker/productization/apple_silicon_telemetry.py
+++ b/services/mlx-worker-python/worker/productization/apple_silicon_telemetry.py
@@ -279,7 +279,7 @@ class MacOSAppleSiliconSampler:
                 [
                     "/usr/bin/powermetrics",
                     "--samplers",
-                    "cpu_power,gpu_power,thermal",
+                    "cpu_power,gpu_power,ane_power,thermal",
                     "--show-process-energy",
                     "-n",
                     "1",


### PR DESCRIPTION
## Summary
- Disable thinking-mode prompt rendering for local event extraction so Qwen3.5 JSON evaluation does not emit reasoning text before the JSON payload.
- Preserve raw local event-extraction responses on parse failure so future reports show the real model output instead of `raw_response_chars=0`.
- Infer direct Hugging Face benchmark task kind when valid MLX repos omit `pipeline_tag`, including the observed Qwen3.5 8-bit import path and explicit modality tags.
- Request the Apple Silicon `ane_power` powermetrics sampler and document that `smc` is not the canonical power path.

## Plan or Spec
- `docs/benchmark-evaluation-contract.md`
- `docs/evidence-telemetry-report-contract.md`

## Commands Run
```text
PYTHONPATH=/private/tmp/melix-main-model-benchmarks:/private/tmp/melix-main-model-benchmarks/services/mlx-worker-python uv run --frozen pytest services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_apple_silicon_telemetry.py
# 78 passed in 11.72s

swift test
# services/control-plane-swift: 744 tests passed

PYTHONPATH=/private/tmp/melix-main-model-benchmarks:/private/tmp/melix-main-model-benchmarks/services/mlx-worker-python uv run --frozen coverage run --source=services/mlx-worker-python/worker -m pytest services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_apple_silicon_telemetry.py
# 78 passed in 11.89s

PYTHONPATH=/private/tmp/melix-main-model-benchmarks:/private/tmp/melix-main-model-benchmarks/services/mlx-worker-python uv run --frozen coverage json -o /private/tmp/melix-main-model-benchmarks/.runtime/python-coverage-model-benchmark-fixes.json
# Wrote JSON report

python3 scripts/python_changed_line_coverage.py --coverage-json /private/tmp/melix-main-model-benchmarks/.runtime/python-coverage-model-benchmark-fixes.json --diff-from origin/main services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/worker/productization/apple_silicon_telemetry.py
# TOTAL 100.00% 18/18

swift test --enable-code-coverage
# services/control-plane-swift: 745 tests passed

python3 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift
# TOTAL 100.00% 62/62

git diff --check
# passed

/usr/bin/powermetrics --samplers cpu_power,gpu_power,ane_power,thermal -n 1 -i 100 -f plist
# failed as expected without elevated privileges: powermetrics must be invoked as the superuser
```

## Coverage and Metrics
- Python changed-line coverage: 100.00% (18/18) for `evaluation_core.py` and `apple_silicon_telemetry.py`.
- Swift changed-line coverage: 100.00% (62/62) for `ControlPlaneService.swift`.
- Qwen3.5-9B-MLX-4bit prior report root cause: all 20 evaluation samples failed JSON parse at char 0, producing `overall_weighted_f1=0.0`; the local chat template emits `<think>` unless `enable_thinking=false`.
- Qwen3.5-9B-MLX-8bit prior failure: direct Hub import rejected an empty `pipeline_tag` as `unsupported_task_family`; the new path infers task kind from stronger metadata.
- Apple Silicon sampler check: this host supports `cpu_power,gpu_power,ane_power,thermal`; direct unprivileged collection still requires elevated powermetrics access and is recorded as an instrumentation gap.

## Known Gaps
- Did not rerun the full 20-sample Qwen3.5-9B-MLX-4bit evaluation after the fix because it took about 28 minutes in the prior run.
- Did not download or execute mlx-community/Qwen3.5-9B-MLX-8bit; coverage uses control-plane import fixtures for the missing `pipeline_tag` failure mode.
- 26B OOM/root-cause evidence is diagnostic only in the prior run because the worker died with `Socket closed` before peak memory telemetry was captured.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
