### PR TITLE
perf: cache duplicate deterministic rerank document scores

### DIFF
--- a/docs/plans/2026-05-09-rerank-duplicate-document-score-cache.md
+++ b/docs/plans/2026-05-09-rerank-duplicate-document-score-cache.md
@@ -1,0 +1,33 @@
+# Rerank Duplicate Document Score Cache
+
+## Goal
+
+Reduce redundant deterministic rerank scoring work when a single request contains repeated document texts. The runtime should score each unique document once per request, then reuse the score while preserving output order and duplicate positions.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py`
+- `services/mlx-worker-python/tests/test_rerank_runtime.py`
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Linux-only Constraint
+
+This is a Python worker optimization and can be locally verified on Linux with focused pytest, changed-scope coverage, and the existing PR-scoped performance harness.
+
+## Probe Definition
+
+Update the existing `deterministic-rerank-query-context-reuse` probe to use a duplicate-heavy synthetic document set and report structural duplicate-score reuse metrics:
+
+- `tokenize_calls_mean`: should drop from one query plus every document to one query plus each unique document.
+- `score_calls_mean`: should equal the unique document count per iteration on the optimized path.
+- `unique_document_count`: confirms the synthetic workload shape.
+- `elapsed_ms_mean`: lower is better, but structural metrics are the primary gate.
+
+## Success Metrics
+
+- Focused rerank tests pass.
+- Changed executable coverage for touched Python files is at least 95%.
+- Local probe reports `score_calls_mean == unique_document_count` and `tokenize_calls_mean == unique_document_count + 1`.
+- `git diff --check` passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1648,9 +1648,21 @@
         "warn_pct": 0.0
       },
       {
+        "key": "score_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
         "key": "tokenize_calls_mean",
         "unit": "calls",
         "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "unique_document_count",
+        "unit": "documents",
+        "direction": "informational",
         "warn_pct": 0.0
       }
     ]

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2282,7 +2282,9 @@ def test_probe_smokes_return_metrics_against_current_repo() -> None:
     assert rerank_metrics["query_context_builds_mean"] == 1.0
     assert rerank_metrics["document_count"] == 2048.0
     assert rerank_metrics["iteration_count"] == 8.0
-    assert rerank_metrics["tokenize_calls_mean"] == 2049.0
+    assert rerank_metrics["tokenize_calls_mean"] == 65.0
+    assert rerank_metrics["score_calls_mean"] == 64.0
+    assert rerank_metrics["unique_document_count"] == 64.0
     assert evaluation_job_id_metrics["elapsed_ms_mean"] > 0
     assert evaluation_job_id_metrics["per_call_ms_mean"] > 0
     assert evaluation_job_id_metrics["allocation_count"] == 200.0
@@ -2379,7 +2381,9 @@ def test_dispatch_probe_impl_supports_deterministic_rerank_probe() -> None:
     assert metrics["query_context_builds_mean"] == 1.0
     assert metrics["document_count"] == 2048.0
     assert metrics["iteration_count"] == 8.0
-    assert metrics["tokenize_calls_mean"] == 2049.0
+    assert metrics["tokenize_calls_mean"] == 65.0
+    assert metrics["score_calls_mean"] == 64.0
+    assert metrics["unique_document_count"] == 64.0
 
 
 def test_dispatch_probe_impl_supports_benchmark_export_probe() -> None:

--- a/services/mlx-worker-python/tests/test_rerank_runtime.py
+++ b/services/mlx-worker-python/tests/test_rerank_runtime.py
@@ -396,6 +396,40 @@ def test_score_documents_tokenizes_the_query_once_for_multiple_documents() -> No
     ]
 
 
+def test_score_documents_reuses_scores_for_duplicate_documents() -> None:
+    class TrackingFamilyAdapter(JinaV3RerankFamilyAdapter):
+        def __init__(self) -> None:
+            self.scored_documents: list[str] = []
+
+        def score(self, backend: DeterministicRerankBackend, query: str, document: str, **kwargs: object) -> float:
+            self.scored_documents.append(document)
+            return super().score(backend, query, document, **kwargs)
+
+    runtime = DeterministicRerankRuntime()
+    family = TrackingFamilyAdapter()
+    documents = [
+        "swift runtime is available",
+        "python packaging release",
+        "swift runtime is available",
+        "python packaging release",
+        "control plane routes swift runtime",
+    ]
+
+    scores = runtime.score_documents(
+        {
+            "rerank_backend": DeterministicRerankBackend(),
+            "rerank_family_adapter": family,
+        },
+        "swift runtime",
+        documents,
+    )
+
+    assert len(scores) == len(documents)
+    assert scores[0] == scores[2]
+    assert scores[1] == scores[3]
+    assert family.scored_documents == list(dict.fromkeys(documents))
+
+
 def test_score_documents_builds_query_context_once_for_multiple_documents() -> None:
     class TrackingFamilyAdapter(JinaV3RerankFamilyAdapter):
         def __init__(self) -> None:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -994,10 +994,12 @@ def _probe_deterministic_rerank_query_context_reuse(repo_root: Path) -> dict[str
     iteration_count = 8
     sample_count = 5
     query = "swift control plane runtime"
-    documents = [
+    unique_document_count = 64
+    unique_documents = [
         f"swift runtime document {index} control plane" if index % 2 == 0 else f"python worker document {index} packaging"
-        for index in range(document_count)
+        for index in range(unique_document_count)
     ]
+    documents = [unique_documents[index % unique_document_count] for index in range(document_count)]
 
     class CountingBackend(DeterministicRerankBackend):
         def __init__(self) -> None:
@@ -1010,13 +1012,19 @@ def _probe_deterministic_rerank_query_context_reuse(repo_root: Path) -> dict[str
     class TrackingFamily(JinaV3RerankFamilyAdapter):
         def __init__(self) -> None:
             self.query_context_builds = 0
+            self.score_calls = 0
 
         def build_query_context(self, backend: DeterministicRerankBackend, query: str, **kwargs: object):
             self.query_context_builds += 1
             return super().build_query_context(backend, query, **kwargs)
 
+        def score(self, backend: DeterministicRerankBackend, query: str, document: str, **kwargs: object) -> float:
+            self.score_calls += 1
+            return super().score(backend, query, document, **kwargs)
+
     elapsed_samples: list[float] = []
     query_context_build_samples: list[float] = []
+    score_call_samples: list[float] = []
     tokenize_call_samples: list[float] = []
 
     runtime = DeterministicRerankRuntime()
@@ -1037,6 +1045,7 @@ def _probe_deterministic_rerank_query_context_reuse(repo_root: Path) -> dict[str
                 raise ValueError(f"expected {document_count} scores, got {len(scores)}")
         elapsed_samples.append((time.perf_counter() - started) * 1000.0)
         query_context_build_samples.append(float(family.query_context_builds) / float(iteration_count))
+        score_call_samples.append(float(family.score_calls) / float(iteration_count))
         tokenize_call_samples.append(float(backend.tokenize_calls) / float(iteration_count))
 
     return {
@@ -1048,7 +1057,9 @@ def _probe_deterministic_rerank_query_context_reuse(repo_root: Path) -> dict[str
             6,
         ),
         "sample_count": float(sample_count),
+        "score_calls_mean": round(sum(score_call_samples) / len(score_call_samples), 6),
         "tokenize_calls_mean": round(sum(tokenize_call_samples) / len(tokenize_call_samples), 6),
+        "unique_document_count": float(unique_document_count),
     }
 
 

--- a/services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py
@@ -38,14 +38,19 @@ class DeterministicRerankRuntime:
             query_tokens=query_tokens,
             query_token_set=query_token_set,
         )
-        return [
-            family.score(
-                backend,
-                query,
-                document,
-                query_context=query_context,
-                query_tokens=query_tokens,
-                query_token_set=query_token_set,
-            )
-            for document in documents
-        ]
+        document_score_cache: dict[str, float] = {}
+        scores: list[float] = []
+        for document in documents:
+            score = document_score_cache.get(document)
+            if score is None:
+                score = family.score(
+                    backend,
+                    query,
+                    document,
+                    query_context=query_context,
+                    query_tokens=query_tokens,
+                    query_token_set=query_token_set,
+                )
+                document_score_cache[document] = score
+            scores.append(score)
+        return scores


### PR DESCRIPTION
## Summary
- Cache deterministic rerank scores for duplicate document strings within a single `score_documents(...)` request.
- Preserve output order and duplicate positions while scoring each unique document once per request.
- Update the existing rerank PR-scoped performance probe to use a duplicate-heavy workload and report structural score/tokenization call metrics.

## Plan or Spec
- `docs/plans/2026-05-09-rerank-duplicate-document-score-cache.md`

## Commands Run
```text
# Focused pytest
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_rerank_runtime.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
Result: 42 passed in 14.64s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
  services/mlx-worker-python/tests/test_rerank_runtime.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe && \
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && \
python scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py \
  services/mlx-worker-python/worker/productization/pr_scoped_performance.py \
  services/mlx-worker-python/tests/test_rerank_runtime.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py
Result: 42 passed in 41.89s; TOTAL 39 0 100%

# Registered scoped probe local run
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py \
  --registry infra/perf/pr_scoped_probes.json \
  --probe-id deterministic-rerank-query-context-reuse \
  --base-repo /tmp/melix-cron-opt-base-20260509035145 \
  --head-repo "$PWD" \
  --output /tmp/rerank-duplicate-probe.json
Result: head verification ok; base_probe ok=true; head_probe ok=true

# Direct detached origin/main vs head duplicate-document probe
BASE /tmp/rerank_duplicate_document_probe.py: score_calls_mean=2048.0, tokenize_calls_mean=2049.0, elapsed_ms_mean=87.640019
HEAD /tmp/rerank_duplicate_document_probe.py: score_calls_mean=64.0, tokenize_calls_mean=65.0, elapsed_ms_mean=3.689785
Checksum matched: 200.690784

# Diff hygiene
git diff --check
Result: passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 39 0 100%`.
- Registered scoped CI probe: `deterministic-rerank-query-context-reuse`.
- Local direct duplicate-document probe, 2,048 documents / 64 unique / 8 iterations / 7 samples:
  - `score_calls_mean`: `2048.0` on detached `origin/main` -> `64.0` on this branch.
  - `tokenize_calls_mean`: `2049.0` on detached `origin/main` -> `65.0` on this branch.
  - `elapsed_ms_mean`: `87.640019` -> `3.689785`.
  - `checksum`: unchanged at `200.690784`.
- Local registered probe run on head reported `score_calls_mean=64.0`, `tokenize_calls_mean=65.0`, `unique_document_count=64.0`, and `elapsed_ms_mean=3.678077`.

## Known Gaps
- Linux-only local verification; macOS/Swift surfaces were not exercised because this is a Python worker-only slice.
- The existing `deterministic-rerank-query-context-reuse` probe was updated rather than adding a second nearby rerank probe.
- Hosted GitHub Actions results are pending at PR creation time.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
