### PR TITLE
perf: bind chunker segment join lookup

### DIFF
--- a/docs/plans/2026-05-09-training-dataset-chunker-segment-join-binding.md
+++ b/docs/plans/2026-05-09-training-dataset-chunker-segment-join-binding.md
@@ -1,0 +1,25 @@
+# Training Dataset Chunker Segment Join Binding
+
+## Scope
+
+This Python-only performance slice narrows the long-context dataset chunker hot path in `services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py`.
+
+## Probe Coverage
+
+The affected path is already covered by the PR-scoped `training-dataset-chunker-top-level-base-copy` command-json probe in `infra/perf/pr_scoped_probes.json`. The registered probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py`
+- `services/mlx-worker-python/tests/test_training_dataset_chunker.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/training_dataset_chunker_top_level_copy_probe.py`
+
+## Optimization
+
+Bind the whitespace join callable once per `_iter_word_segments` invocation before the candidate segment loop. The behavior and segment boundaries stay unchanged, but the loop avoids repeated method lookup while evaluating many candidate chunks for long samples.
+
+## Verification Plan
+
+- Run the focused chunker regression tests from the registered probe.
+- Run changed-scope coverage for the touched source, test, and probe files.
+- Run the registered local probe on Linux and compare against an `origin/main` base worktree.
+- Let GitHub Actions run the PR-scoped performance workflow before merge.

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -252,9 +252,10 @@ class ProbeRuntime:
         self._response = response
         self._probe = probe
 
-    def render_prompt(self, messages, loaded_model=None, execution_ext=None):
+    def render_prompt(self, messages, loaded_model=None, execution_ext=None, template_kwargs=None):
         _ = loaded_model
         _ = execution_ext
+        _ = template_kwargs
         return "\n".join(part.text for message in messages for part in message.parts)
 
     def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event, execution_ext=None):

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -408,8 +408,11 @@ def test_scope_report_selects_evaluation_compare_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/productization/evaluation_compare.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "evaluation-compare-target-lookup-short-circuit"
+    assert scope["selected_count"] == 2
+    assert {probe["id"] for probe in scope["selected_probes"]} == {
+        "evaluation-compare-target-lookup-early-stop",
+        "evaluation-compare-target-lookup-short-circuit",
+    }
 
 
 def test_evaluation_compare_target_lookup_probe_script_emits_metrics(

--- a/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
@@ -147,9 +147,10 @@ def _iter_word_segments(words: list[str], k: int) -> Iterable[str]:
     bucket_size = len(words) // k
     extras = len(words) % k
     start = 0
+    join_words = " ".join
     for bucket_idx in range(k):
         length = bucket_size + (1 if bucket_idx < extras else 0)
-        segment = " ".join(words[start : start + length])
+        segment = join_words(words[start : start + length])
         start += length
         if segment:
             yield segment


### PR DESCRIPTION
## Summary
- Bind the training dataset chunker segment join callable once per `_iter_word_segments` invocation.
- Avoid repeated method lookup in the long-context candidate segment loop while preserving exact segment boundaries and output shape.
- Include two narrow CI-compatibility test updates discovered during the PR check rerun: the local event-extraction probe runtime now accepts `template_kwargs`, and the evaluation-compare scope assertion reflects both registered probes currently watching that path.

## Plan or Spec
- `docs/plans/2026-05-09-training-dataset-chunker-segment-join-binding.md`
- Registered PR-scoped probe: `training-dataset-chunker-top-level-base-copy` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# focused tests, original slice plus CI failure regressions
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_filter_top_level_keys_once_per_source_sample services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_single_turn_chunking_streams_candidate_segments_without_list_helper services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_single_turn_search_stops_candidate_rendering_after_first_oversized_segment services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_split_words_into_k_matches_string_helper_output services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_split_user_content_into_k_handles_trivial_and_word_shortage_cases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_chunker_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_dataset_chunker_top_level_copy_probe_script_emits_metrics services/mlx-worker-python/tests/test_evaluation_core.py::test_event_extraction_weighted_f1_can_use_local_loaded_model services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_compare_probe
# result: 11 passed in 0.35s

# changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage erase
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py services/mlx-worker-python/tests/test_training_dataset_chunker.py services/mlx-worker-python/tests/test_pr_scoped_performance.py services/mlx-worker-python/tests/test_evaluation_core.py scripts/training_dataset_chunker_top_level_copy_probe.py
# result: TOTAL 4 0 100%

# local registered probe script, HEAD worktree, 3 runs before CI follow-up
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/training_dataset_chunker_top_level_copy_probe.py
# elapsed_ms_mean: 21.671483, 21.849740, 21.816393

# local registered probe script, origin/main base worktree, 3 runs before CI follow-up
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/training_dataset_chunker_top_level_copy_probe.py
# elapsed_ms_mean: 22.613389, 22.052249, 21.994679

# local registered probe smoke after CI follow-up
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/training_dataset_chunker_top_level_copy_probe.py
# result: {"chunk_count": 174.0, "elapsed_ms_mean": 27.735961, "peak_bytes_mean": 774473.714, "sample_count": 7.0, "top_level_key_count": 123.0}

git diff --check
# result: exit 0

make py-test
# result: exit 2 on this Linux host because the suite includes macOS/Apple Silicon-only expectations (`sandbox-exec`, MLX `libmlx.so`, memory detection). The prior GitHub macOS run reached only two branch-main compatibility failures; both are covered by the focused regression tests above and are fixed in this update.
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 4 0 100%`).
- Local Linux probe comparison for `training-dataset-chunker-top-level-base-copy`:
  - `old_mean=22.220106 ms`
  - `new_mean=21.779205 ms`
  - `delta_ms=-0.440900 ms`
  - `speedup=1.020244x`
  - `improvement_pct=1.984%`
- Registered PR-scoped performance CI completed successfully for the first pushed commit. It must run again and pass on the amended commit before merge.

## Known Gaps
- The local probe is Linux-only and synthetic; GitHub Actions PR-scoped performance is the merge gate for the registered probe report.
- No Swift runtime effect is claimed.
- Full local `make py-test` is not representative on this Linux host because the suite includes macOS/Apple Silicon-only checks and optional MLX imports that fail without `sandbox-exec`/`libmlx.so`; GitHub Actions macOS is the full-suite gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
