### PR TITLE
perf: avoid bootstrap constant-tail slicing

### DIFF
--- a/docs/plans/statistical-evidence-constant-bootstrap-short-circuit.md
+++ b/docs/plans/statistical-evidence-constant-bootstrap-short-circuit.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Avoid redundant paired-bootstrap sampling when every paired outcome has the same value. In that case every bootstrap replicate has the same mean, so the percentile interval can be returned exactly without allocating and sorting the replicate vector.
+Avoid redundant paired-bootstrap work when every paired outcome has the same value. In that case every bootstrap replicate has the same mean, so the percentile interval can be returned exactly without allocating and sorting the replicate vector. This follow-up slice keeps that short-circuit and removes the preflight tuple-tail slice used to detect constant outcomes.
 
 ## Linux-only constraint
 
@@ -12,12 +12,11 @@ This is a Python worker/productization slice and is verifiable on Linux with foc
 
 - `services/mlx-worker-python/worker/productization/statistical_evidence.py`
 - `services/mlx-worker-python/tests/test_statistical_evidence.py`
-- `infra/perf/pr_scoped_probes.json`
 - `docs/plans/statistical-evidence-constant-bootstrap-short-circuit.md`
 
 ## Performance probe definition
 
-Run `/tmp/statistical_evidence_constant_probe.py <origin-main-worktree> <head-worktree>` against a synthetic homogeneous `paired_outcomes=(1.0,) * 10000` workload with `bootstrap_iterations=1000` and five samples. Compare mean elapsed time and traced peak allocation while asserting the returned bootstrap bounds stay exactly `1.0`.
+Run `/tmp/statistical_evidence_constant_probe.py <origin-main-worktree> <head-worktree>` against a synthetic homogeneous `paired_outcomes=(1.0,) * 200000` workload with `bootstrap_iterations=1000` and five samples. Compare mean elapsed time and traced peak allocation while asserting the returned bootstrap bounds stay exactly `1.0`.
 
 The repository already has the `statistical-evidence-bootstrap-single-sort` PR-scoped performance probe watching this production file and test file. This slice relies on that registered probe to validate no regression in the mixed-outcome bootstrap path, and the local homogeneous probe validates the new short-circuit path.
 

--- a/services/mlx-worker-python/tests/test_statistical_evidence.py
+++ b/services/mlx-worker-python/tests/test_statistical_evidence.py
@@ -182,6 +182,39 @@ def test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling(
     assert evidence["analytical"]["upper_bound"] == 1.0
 
 
+def test_constant_outcome_detection_avoids_tail_slice_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class SliceGuardedTuple(tuple):
+        def __getitem__(self, key: object) -> object:
+            if isinstance(key, slice):
+                raise AssertionError("constant bootstrap detection must not slice outcomes")
+            return super().__getitem__(key)
+
+    forbidden_random = object()
+    monkeypatch.setattr(statistical_evidence_module.random, "Random", forbidden_random)
+    outcomes = SliceGuardedTuple((1.0,) * 512)
+    with pytest.raises(AssertionError, match="must not slice outcomes"):
+        _ = outcomes[1:]
+
+    evidence = statistical_evidence_module._paired_bootstrap_interval(
+        outcomes=outcomes,  # type: ignore[arg-type]
+        confidence_level=0.95,
+        bootstrap_iterations=1000,
+        bootstrap_seed=17,
+    )
+
+    assert evidence == {
+        "method": "paired_bootstrap_percentile",
+        "confidence_level": 0.95,
+        "lower_bound": 1.0,
+        "upper_bound": 1.0,
+        "crosses_zero": False,
+        "iterations": 1000,
+        "seed": 17,
+    }
+
+
 def test_classify_release_verdict_returns_inconclusive_when_any_interval_crosses_zero() -> None:
     verdict = classify_release_verdict(
         delta_accuracy=0.2,

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -153,8 +153,9 @@ def _paired_bootstrap_interval(
 
 
 def _all_values_equal(values: tuple[float, ...]) -> bool:
-    first_value = values[0]
-    return all(value == first_value for value in values[1:])
+    iterator = iter(values)
+    first_value = next(iterator)
+    return all(value == first_value for value in iterator)
 
 
 def _paired_analytical_interval(


### PR DESCRIPTION
## Summary
- Avoid allocating a tuple tail slice while detecting constant paired-bootstrap outcomes in `statistical_evidence`.
- Add a regression test with a slice-guarded tuple to keep the constant-outcome short-circuit allocation-free before sampling.
- Update the existing plan to describe this follow-up and its Linux verification path.

## Plan or Spec
- `docs/plans/statistical-evidence-constant-bootstrap-short-circuit.md`
- Registered scoped CI probe: `statistical-evidence-bootstrap-single-sort` (existing probe watches the touched production/test files and guards the mixed-outcome bootstrap path).

## Commands Run
```text
# Focused pytest
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics
# Result: 15 passed in 0.07s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_bootstrap_probe.py
# Result: TOTAL 16 0 100%

# Local constant-outcome base-vs-head probe
python3 /tmp/statistical_evidence_constant_probe.py <detached-origin-main-worktree> "$PWD"
# Result: base elapsed_ms_mean=50.5766, peak_bytes_mean=3,200,556; head elapsed_ms_mean=50.0028, peak_bytes_mean=1,814,384

# Registered scoped probe local run
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id statistical-evidence-bootstrap-single-sort --base-repo <detached-origin-main-worktree> --head-repo "$PWD" --output /tmp/statistical-evidence-pr-scoped.json
# Result: head verification ok, coverage 100%; base/head probe ok.

# Diff hygiene
git diff --check
# Result: passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 16 0 100%`.
- Constant homogeneous bootstrap probe (`sample_size=200000`, `bootstrap_iterations=1000`, `sample_count=5`):
  - `elapsed_ms_mean`: base `50.5766 ms`, head `50.0028 ms` (~1.13% lower).
  - `peak_bytes_mean`: base `3,200,556`, head `1,814,384` (~43.31% lower).
- Registered `statistical-evidence-bootstrap-single-sort` local scoped probe:
  - base `elapsed_ms_mean=135.6599`, `peak_bytes_mean=56801.6`, `sorted_calls_mean=1.0`.
  - head `elapsed_ms_mean=138.1685`, `peak_bytes_mean=56883.2`, `sorted_calls_mean=1.0`.
  - Both base and head probes completed successfully; mixed-outcome timing/peak movement is within the existing 5% warning threshold while the targeted constant-outcome path shows the allocation reduction.

## Known Gaps
- Linux-only local verification; macOS/Swift surfaces were not touched.
- Full repository `make swift-test`, `make py-test`, and `make integration-test` were not run in this cron slice.
- No new PR-scoped probe was added because the existing `statistical-evidence-bootstrap-single-sort` probe already watches the touched files and validates the broader bootstrap path; the constant-outcome allocation improvement is covered by focused tests and the explicit local base-vs-head probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
