### PR TITLE
perf: short-circuit direct startup crash classification

### DIFF
--- a/docs/plans/2026-05-09-startup-signals-direct-crash-fast-path.md
+++ b/docs/plans/2026-05-09-startup-signals-direct-crash-fast-path.md
@@ -1,0 +1,26 @@
+# Startup Signals Direct Crash Fast Path
+
+## Scope
+
+This Python-only performance slice keeps startup failure classification behavior equivalent while avoiding startup log reads when the direct `error_text` already identifies a control-plane crash.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `startup-signals-lazy-worker-log-excerpts` in `infra/perf/pr_scoped_probes.json`.
+
+This slice extends the probe with direct-control-plane-crash metrics:
+
+- `direct_control_crash_elapsed_ms_mean`
+- `direct_control_crash_log_reads_mean`
+
+The existing focused `test_command`, `coverage_command`, and `probe_command` remain attached to the probe.
+
+## Expected Behavior
+
+- Direct host-port-conflict error text still short-circuits all log reads.
+- Direct crash-pattern error text now classifies as `control_plane_crash` without reading stale control-plane or worker logs.
+- Log-backed control-plane and worker crash classification remain unchanged when direct error text is generic.
+
+## Verification Plan
+
+Run the registered focused startup-signals tests, changed-scope coverage, and the registered probe locally on Linux before pushing. GitHub Actions PR-scoped performance remains the merge gate.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2476,6 +2476,18 @@
         "warn_pct": 0.0
       },
       {
+        "key": "direct_control_crash_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 15.0
+      },
+      {
+        "key": "direct_control_crash_log_reads_mean",
+        "unit": "reads",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
         "key": "worker_crash_elapsed_ms_mean",
         "unit": "ms",
         "direction": "lower_is_better",

--- a/scripts/startup_signals_log_probe.py
+++ b/scripts/startup_signals_log_probe.py
@@ -97,6 +97,9 @@ def main() -> int:
     control_elapsed: list[float] = []
     control_reads: list[float] = []
     control_exists: list[float] = []
+    direct_control_elapsed: list[float] = []
+    direct_control_reads: list[float] = []
+    direct_control_exists: list[float] = []
     worker_elapsed: list[float] = []
     worker_reads: list[float] = []
     worker_exists: list[float] = []
@@ -127,6 +130,16 @@ def main() -> int:
             control_reads.append(reads / iterations)
             control_exists.append(exists / iterations)
 
+            elapsed, reads, exists = _measure_case(
+                manifest,
+                error_text="fatal error: control plane crashed",
+                expected_classification="control_plane_crash",
+                iterations=iterations,
+            )
+            direct_control_elapsed.append(elapsed)
+            direct_control_reads.append(reads / iterations)
+            direct_control_exists.append(exists / iterations)
+
             worker_manifest = dict(manifest)
             worker_manifest.pop("control_plane_stderr_path")
             elapsed, reads, exists = _measure_case(
@@ -150,6 +163,18 @@ def main() -> int:
                 "control_crash_elapsed_ms_mean": round(statistics.fmean(control_elapsed), 6),
                 "control_crash_log_path_exists_checks_mean": round(statistics.fmean(control_exists), 6),
                 "control_crash_log_reads_mean": round(statistics.fmean(control_reads), 6),
+                "direct_control_crash_elapsed_ms_mean": round(
+                    statistics.fmean(direct_control_elapsed),
+                    6,
+                ),
+                "direct_control_crash_log_path_exists_checks_mean": round(
+                    statistics.fmean(direct_control_exists),
+                    6,
+                ),
+                "direct_control_crash_log_reads_mean": round(
+                    statistics.fmean(direct_control_reads),
+                    6,
+                ),
                 "iterations": float(iterations),
                 "sample_count": float(samples),
                 "tail_scan_elapsed_ms_mean": round(tail_elapsed_mean, 6),

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2578,6 +2578,9 @@ def test_startup_signals_probe_script_emits_metrics(capsys: pytest.CaptureFixtur
     assert payload["control_crash_elapsed_ms_mean"] > 0
     assert payload["control_crash_log_path_exists_checks_mean"] == 0.0
     assert payload["control_crash_log_reads_mean"] == 1.0
+    assert payload["direct_control_crash_elapsed_ms_mean"] > 0
+    assert payload["direct_control_crash_log_path_exists_checks_mean"] == 0.0
+    assert payload["direct_control_crash_log_reads_mean"] == 0.0
     assert payload["worker_crash_elapsed_ms_mean"] > 0
     assert payload["worker_crash_log_path_exists_checks_mean"] == 0.0
     assert payload["worker_crash_log_reads_mean"] == 1.0

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -191,6 +191,36 @@ def test_classify_startup_failure_skips_log_reads_when_error_text_reports_port_c
     assert read_paths == []
 
 
+def test_classify_startup_failure_skips_logs_when_error_text_reports_control_plane_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    control_plane_stderr = tmp_path / "control-plane.stderr.log"
+    worker_stderr = tmp_path / "python-worker.stderr.log"
+    control_plane_stderr.write_text("fatal error: stale control crash\n", encoding="utf-8")
+    worker_stderr.write_text("Traceback: stale worker crash\n", encoding="utf-8")
+
+    def fail_read(path: Path, *, chunk_size: int = 8192) -> str:
+        raise AssertionError(  # pragma: no cover
+            f"logs should not be read when error text already identifies a crash: {path}"
+        )
+
+    monkeypatch.setattr(startup_signals_module, "_read_last_nonempty_line", fail_read)
+
+    report = classify_startup_failure(
+        {
+            "http_port": 11434,
+            "ready_probe_url": "http://127.0.0.1:11434/v1/models",
+            "control_plane_stderr_path": str(control_plane_stderr),
+            "python_worker_stderr_path": str(worker_stderr),
+        },
+        error_text="fatal error: control plane crashed",
+    )
+
+    assert report.classification == "control_plane_crash"
+    assert report.log_excerpt == "fatal error: control plane crashed"
+
+
 def test_classify_startup_failure_reports_worker_crash(tmp_path: Path) -> None:
     python_worker_stderr = tmp_path / "python-worker.stderr.log"
     python_worker_stderr.write_text("Traceback: worker bootstrap failed\n", encoding="utf-8")

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -170,6 +170,11 @@ def classify_startup_failure(
         )
         excerpt = error_text
         classification = "host_port_conflict"
+    elif any(pattern in error_lower for pattern in CRASH_PATTERNS):
+        summary = "Control plane crashed before startup completed."
+        detail = f"Melix never reached {ready_probe_url}. Inspect the control-plane logs for the crash cause."
+        excerpt = error_text
+        classification = "control_plane_crash"
     else:
         control_plane_excerpt = _log_excerpt(
             manifest.get("control_plane_stderr_path"),


### PR DESCRIPTION
## Summary
- Short-circuit startup failure classification when direct `error_text` already contains a crash pattern.
- Extend the registered startup-signals PR-scoped probe with direct-control-plane-crash metrics.
- Add regression coverage proving stale startup logs are not read for direct crash evidence.

## Plan or Spec
- `docs/plans/2026-05-09-startup-signals-direct-crash-fast-path.md`

## Commands Run
```text
# Baseline from origin/main, one-off direct crash probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
...
PY
# exit 0; baseline_direct_control_crash_elapsed_ms_mean=10.200927, baseline_direct_control_crash_log_reads_mean=1.0

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/probes.json
# exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# exit 0; 29 passed in 1.48s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py
# exit 0; TOTAL 25 0 100%

bash /tmp/startup_probe_command.sh
# exit 0; direct_control_crash_elapsed_ms_mean=1.05063, direct_control_crash_log_reads_mean=0.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 25 0 100%`.
- Registered probe: `startup-signals-lazy-worker-log-excerpts`.
- Baseline direct crash one-off metric from `origin/main`: `baseline_direct_control_crash_elapsed_ms_mean=10.200927`, `baseline_direct_control_crash_log_reads_mean=1.0`.
- New registered probe metric: `direct_control_crash_elapsed_ms_mean=1.05063`, `direct_control_crash_log_reads_mean=0.0`.
- Direct crash delta: `-9.150297 ms` over 400 iterations, about `9.71x` faster for the direct-error case; log reads drop from `1.0` to `0.0` per classification.
- Existing log-backed cases remain measured: `control_crash_log_reads_mean=1.0`, `worker_crash_log_reads_mean=1.0`.

## Known Gaps
- Linux local validation only; GitHub Actions PR-scoped performance is still required as the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
