### PR TITLE
perf: reduce startup log tail delimiter scans

### DIFF
--- a/docs/plans/2026-05-09-startup-signals-tail-window.md
+++ b/docs/plans/2026-05-09-startup-signals-tail-window.md
@@ -1,0 +1,65 @@
+# Startup Signals Tail-Window Performance Slice
+
+## Goal
+
+Reduce avoidable small backward reads while classifying startup failures whose
+log files end with long whitespace tails. Keep the existing diagnostic contract:
+only the last non-empty line is decoded, missing logs are skipped by read
+fallback, and direct error-text classifications avoid log reads entirely.
+
+## Scope
+
+This slice is Python-only and limited to `worker.productization.startup_signals`
+and its focused tests. It does not change manifest fields, startup failure
+classification names, or operator-facing messages.
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped probe
+`startup-signals-lazy-worker-log-excerpts` in `infra/perf/pr_scoped_probes.json`.
+That probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries and reports:
+
+- `tail_scan_elapsed_ms_mean` (lower is better)
+- `tail_scan_peak_bytes_mean` (lower is better)
+- direct classification read/exists counts (lower is better)
+
+## Implementation Plan
+
+1. Keep focused regression coverage around CR-only, LF, invalid UTF-8, and
+   whitespace-only tail behavior.
+2. Change only `_seek_last_nonempty_line_bounds` so the hot path first searches
+   for the common LF delimiter and only falls back to CR when needed, avoiding a
+   second full-chunk reverse scan for normal newline-terminated logs.
+3. Preserve exact last-line bounds and UTF-8 replacement decoding behavior.
+4. Run focused pytest, changed-scope coverage, and the registered probe locally
+   on Linux before opening the PR.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_startup_signals.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_startup_signals.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/productization/startup_signals.py \
+  services/mlx-worker-python/tests/test_startup_signals.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/startup_signals_log_probe.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py \
+  --registry infra/perf/pr_scoped_probes.json \
+  --probe-id startup-signals-lazy-worker-log-excerpts \
+  --base-repo <baseline-worktree> \
+  --head-repo "$PWD" \
+  --output /tmp/startup-signals-tail-window-probe.json
+```

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -271,7 +271,9 @@ def _seek_last_nonempty_line_bounds(handle: Any, *, chunk_size: int) -> tuple[in
                 position = start
                 continue
             payload_end = start + search_end
-        newline_index = max(chunk.rfind(b"\n", 0, search_end), chunk.rfind(b"\r", 0, search_end))
+        newline_index = chunk.rfind(b"\n", 0, search_end)
+        if newline_index < 0:
+            newline_index = chunk.rfind(b"\r", 0, search_end)
         if newline_index >= 0:
             return start + newline_index + 1, payload_end
         position = start


### PR DESCRIPTION
## Summary
- Reduce startup log tail delimiter scans by checking for LF first and only falling back to CR when needed.
- Keep startup failure classification behavior and last non-empty log excerpt semantics unchanged.

## Plan or Spec
- `docs/plans/2026-05-09-startup-signals-tail-window.md`

## Commands Run
```text
python3 registry inspection for startup-signals-lazy-worker-log-excerpts: confirmed test_command, coverage_command, and probe_command are registered.
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
exit 0: 29 passed in 1.02s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py
exit 0: 29 passed; changed-line coverage TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id startup-signals-lazy-worker-log-excerpts --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-startup-tail-window-20260509111754 --head-repo "$PWD" --output /tmp/startup-signals-tail-window-probe.json
exit 0: head verification passed, base probe passed, head probe passed.

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-line coverage: 100% (`TOTAL 3 0 100%`).
- Registered probe: `startup-signals-lazy-worker-log-excerpts`.
- Local Linux probe results:
  - `tail_scan_elapsed_ms_mean`: base `155.679831`, head `148.475759`, delta `-7.204072 ms` (`-4.63%`).
  - `tail_scan_peak_bytes_mean`: base `21436.2`, head `21436.2`, delta `0.0`.
  - `control_crash_elapsed_ms_mean`: base `12.799827`, head `12.668496`, delta `-0.131331 ms`.
  - `worker_crash_elapsed_ms_mean`: base `13.30732`, head `12.807962`, delta `-0.499358 ms`.
  - Direct-error fast paths remained at `0.0` log reads; small elapsed variance stayed within probe thresholds.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local validation is Linux-only for this Python slice; GitHub Actions remains the merge gate for the registered probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
