### PR TITLE
perf: bind code eval payload JSON decoder

### DIFF
--- a/docs/plans/2026-05-07-code-eval-payload-json-bytes.md
+++ b/docs/plans/2026-05-07-code-eval-payload-json-bytes.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Reduce redundant text decoding in the code-evaluation payload hot path by loading sandbox payload JSON directly from bytes before `json.loads(...)`.
+Reduce overhead in the code-evaluation payload hot path by loading sandbox payload JSON directly from bytes and binding the JSON decoder used by repeated payload loads.
 
 ## Linux-only constraint
 

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -15,6 +15,8 @@ import tempfile
 import textwrap
 
 _DEFAULT_STDIO_LIMIT_BYTES = 32_768
+_JSON_LOADS = json.loads
+_JSON_DECODE_ERROR = json.JSONDecodeError
 _NONBLANK_TEST_LINE_RE = re.compile(r"\S[^\r\n]*(?:\r\n?|\n|$)")
 
 
@@ -252,12 +254,17 @@ def _count_nonblank_test_lines(test_code: str) -> int:
     return sum(1 for _ in _NONBLANK_TEST_LINE_RE.finditer(test_code))
 
 
-def _load_payload_file(payload_path: Path) -> dict[str, object] | None:
+def _load_payload_file(
+    payload_path: Path,
+    *,
+    _loads=_JSON_LOADS,
+    _decode_error=_JSON_DECODE_ERROR,
+) -> dict[str, object] | None:
     try:
-        payload = json.loads(payload_path.read_bytes())
+        payload = _loads(payload_path.read_bytes())
     except OSError:
         return None
-    except json.JSONDecodeError:
+    except _decode_error:
         return None
     if not isinstance(payload, dict):
         return None


### PR DESCRIPTION
## Summary
- Bind the code-evaluation payload JSON decoder and decode-error type once at module import time.
- Keep `_load_payload_file(...)` on the existing byte-loading path while reducing repeated global attribute lookup overhead in the registered payload probe.

## Plan or Spec
- `docs/plans/2026-05-07-code-eval-payload-json-bytes.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
# exit 0; 5 passed in 26.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py
# exit 0; 5 passed in 27.78s; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
# exit 0; {"elapsed_ms_mean": 2554.48630560256, "iteration_count": 1200.0, "payload_bytes": 55474.0, "peak_bytes_mean": 440500.14285714284, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-payload-json-bytes --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-code-eval-payload-bind-20260509130902 --head-repo "$PWD" --output /tmp/code-eval-payload-json-probe-20260509130902.json
# exit 0; head verification ok; base/head probe ok

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 5 0 100%` from `scripts/changed_scope_coverage.py`.
- Registered local probe `code-eval-payload-json-bytes`:
  - base `elapsed_ms_mean=2567.543543858587`, head `elapsed_ms_mean=2541.378090573874`, delta `-26.165453284713 ms` (~1.02% faster; elapsed is informational in the registry).
  - base `peak_bytes_mean=440500.14285714284`, head `peak_bytes_mean=440500.14285714284`, delta `0` bytes.
- CI is required to re-run the registered PR-scoped performance workflow on GitHub Actions before merge.

## Known Gaps
- Local Linux probe validates the Python code-evaluation payload hot path only; no Swift runtime effect is involved.
- The registered metric with lower-is-better enforcement is peak memory, which remains flat; elapsed time improved locally but is informational.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
