### PR TITLE
perf: bind deterministic embedding hot-loop callables

### DIFF
--- a/docs/plans/2026-05-05-deterministic-embedding-duplicate-input-cache.md
+++ b/docs/plans/2026-05-05-deterministic-embedding-duplicate-input-cache.md
@@ -33,6 +33,14 @@ The probe will run a synthetic request with many duplicate input strings, measur
 
 Success means the branch keeps identical output cardinality/checksum while reducing repeated embed calls to the unique input count and improving elapsed time on the duplicate-heavy workload.
 
+## 2026-05-09 Follow-up Slice
+
+This follow-up keeps the existing request-local duplicate-vector cache and only
+binds the hot-loop cache lookup, append, and embedding-family callables before
+iterating over inputs. The change preserves vector ordering, duplicate-copy
+semantics, and the existing registered probe while reducing repeated attribute
+lookups in duplicate-heavy deterministic embedding requests.
+
 ## Verification commands
 
 - Focused pytest for embedding runtime and PR-scoped probe selection/smoke tests

--- a/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
@@ -38,12 +38,15 @@ class DeterministicEmbeddingRuntime:
 
         vector_cache: dict[str, list[float]] = {}
         vectors: list[list[float]] = []
+        cache_get = vector_cache.get
+        append_vector = vectors.append
+        embed_text = family.embed_text
         for text in inputs:
-            vector = vector_cache.get(text)
+            vector = cache_get(text)
             if vector is None:
-                vector = family.embed_text(backend, text, dimensions)
+                vector = embed_text(backend, text, dimensions)
                 vector_cache[text] = vector
-                vectors.append(vector)
+                append_vector(vector)
             else:
-                vectors.append(vector.copy())
+                append_vector(vector.copy())
         return vectors


### PR DESCRIPTION
## Summary
- Bind deterministic embedding hot-loop callables (`vector_cache.get`, `vectors.append`, `family.embed_text`) before iterating request inputs.
- Preserve duplicate-input cache behavior, output order, and duplicate vector copy semantics.
- Update the deterministic embedding performance plan with the follow-up slice evidence.

## Plan or Spec
- `docs/plans/2026-05-05-deterministic-embedding-duplicate-input-cache.md`
- Registered probe: `deterministic-embedding-duplicate-input-cache`

## Commands Run
```text
# focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics
# exit 0; 16 passed in 1.01s

# changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_duplicate_probe.py
# exit 0; TOTAL 7 0 100%

# registered local probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-duplicate-input-cache --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-code-eval-language-slice-elision-202605091401 --head-repo "$PWD" --output /tmp/deterministic-embedding-local-bindings-probe.json
# exit 0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Local registered probe (`deterministic-embedding-duplicate-input-cache`):
  - base `elapsed_ms_mean=5.318931`, head `elapsed_ms_mean=5.305890`, delta `-0.013041 ms`, speedup `1.00246x`.
  - base/head `embed_text_calls_mean=512.0`; behavior context unchanged (`input_count=8192`, `unique_input_count=512`, checksum `2169.411765`).
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local Linux validation covers the Python deterministic embedding path only.
- Improvement is intentionally small and hot-loop scoped; the registered CI probe is the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
