### PR TITLE
perf: bind engine generate sequence allocator

### DIFF
--- a/docs/plans/2026-05-09-engine-core-sequence-allocator-binding.md
+++ b/docs/plans/2026-05-09-engine-core-sequence-allocator-binding.md
@@ -1,0 +1,46 @@
+# Engine Core Sequence Allocator Binding
+
+## Scope
+
+This performance slice is limited to `EngineCore` event emission in
+`services/mlx-worker-python/worker/engine/engine_core.py`.
+
+The optimization preserves the existing event order and sequence numbers while
+binding the active request state's `allocate_seq` method once per generate
+request. This removes repeated attribute lookup work from the hot generate event
+emission path without changing request lifecycle, usage accounting, stop
+handling, or completed-event payloads.
+
+## Registered Probe
+
+The affected Python path is covered by the registered PR-scoped performance
+probe `engine-generate-usage-token-elision` in
+`infra/perf/pr_scoped_probes.json`.
+
+The probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for `engine_core.py`, `test_generate_stream.py`,
+`test_pr_scoped_performance.py`, and `scripts/engine_generate_usage_token_probe.py`.
+This slice does not add a new registry entry because the registered probe already
+watches the changed runtime path and exercises repeated no-usage `Generate`
+event emission on Linux.
+
+## Plan
+
+1. Keep behavior covered by the registered focused generate tests.
+2. Bind `state.allocate_seq` to a local callable after generate request state
+   creation.
+3. Use the local callable for generate event sequence allocation.
+4. Run the registered focused tests, changed-scope coverage, and registered
+   probe locally on Linux.
+5. Use GitHub Actions and the registered PR-scoped performance workflow as the
+   merge gate.
+
+## Verification
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_generate_stream.py::test_generate_without_usage_skips_prompt_token_count_fallback services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_reuses_sampling_when_stop_sequences_match services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_clones_when_stop_sequences_change services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_reuses_runtime_event_prompt_tokens_without_fallback_count services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_counts_prompt_tokens_only_for_missing_event_total services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_request_token_accumulation services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_usage_preserves_finish_reason services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion services/mlx-worker-python/tests/test_generate_stream.py::test_generate_stream_exports_stop_contract_metrics_and_stops_at_turn_boundary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_generate_stream.py::test_generate_without_usage_skips_prompt_token_count_fallback services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_reuses_sampling_when_stop_sequences_match services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_clones_when_stop_sequences_change services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_reuses_runtime_event_prompt_tokens_without_fallback_count services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_counts_prompt_tokens_only_for_missing_event_total services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_request_token_accumulation services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_usage_preserves_finish_reason services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion services/mlx-worker-python/tests/test_generate_stream.py::test_generate_stream_exports_stop_contract_metrics_and_stops_at_turn_boundary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/engine_core.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/engine_generate_usage_token_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
+```

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -25,6 +25,7 @@ class EngineCore:
 
         runtime = self._registry.runtime_for_loaded_model(loaded_model)
         state = self._registry.start_request(request_id, runtime_kind=loaded_model.runtime_kind)
+        allocate_seq = state.allocate_seq
         assembler = self._stream_assembler(request)
         stop_contract = resolve_text_stop_contract(
             loaded_model.runtime_model,
@@ -64,7 +65,7 @@ class EngineCore:
                     yield inference_pb2.ExecuteEvent(
                         request_id=request_id,
                         execution_kind="generate",
-                        seq=state.allocate_seq(),
+                        seq=allocate_seq(),
                         tool_call_delta=inference_pb2.ToolCallDelta(
                             call_id=runtime_event.call_id,
                             tool_name=runtime_event.tool_name,
@@ -87,7 +88,7 @@ class EngineCore:
                         yield inference_pb2.ExecuteEvent(
                             request_id=request_id,
                             execution_kind="generate",
-                            seq=state.allocate_seq(),
+                            seq=allocate_seq(),
                             reasoning_delta=inference_pb2.ReasoningDelta(
                                 text=delta.reasoning_text,
                                 raw_text=delta.raw_text,
@@ -98,7 +99,7 @@ class EngineCore:
                         yield inference_pb2.ExecuteEvent(
                             request_id=request_id,
                             execution_kind="generate",
-                            seq=state.allocate_seq(),
+                            seq=allocate_seq(),
                             tool_call_delta=inference_pb2.ToolCallDelta(
                                 call_id=delta.tool_call.call_id,
                                 tool_name=delta.tool_call.tool_name,
@@ -114,7 +115,7 @@ class EngineCore:
                         yield inference_pb2.ExecuteEvent(
                             request_id=request_id,
                             execution_kind="generate",
-                            seq=state.allocate_seq(),
+                            seq=allocate_seq(),
                             token_delta=inference_pb2.TokenDelta(
                                 text=delta.content_text,
                                 raw_text=delta.raw_text,
@@ -138,7 +139,7 @@ class EngineCore:
                 yield inference_pb2.ExecuteEvent(
                     request_id=request_id,
                     execution_kind="generate",
-                    seq=state.allocate_seq(),
+                    seq=allocate_seq(),
                     usage_delta=inference_pb2.UsageDelta(
                         prompt_tokens=prompt_tokens,
                         completion_tokens=completion_tokens,
@@ -159,7 +160,7 @@ class EngineCore:
             yield inference_pb2.ExecuteEvent(
                 request_id=request_id,
                 execution_kind="generate",
-                seq=state.allocate_seq(),
+                seq=allocate_seq(),
                 completed=inference_pb2.Completed(
                     finish_reason=finish_reason,
                     assistant_text=assembled.assistant_text,
@@ -172,7 +173,7 @@ class EngineCore:
                 ),
             )
         except Exception as exc:  # pragma: no cover - defensive branch
-            yield self._error_event(request_id, state.allocate_seq(), "runtime_error", str(exc))
+            yield self._error_event(request_id, allocate_seq(), "runtime_error", str(exc))
         finally:
             if loaded_model.runtime_kind in {"ocr", "vlm"} and hasattr(runtime, "last_probe_snapshot"):
                 self._registry.record_vision_probe(loaded_model.runtime_kind, runtime.last_probe_snapshot())


### PR DESCRIPTION
## Summary
- Bind `EngineCore.generate` request-state sequence allocation to a local callable.
- Preserve event ordering and payload behavior while removing repeated `state.allocate_seq` attribute lookups from generate event emission.

## Plan or Spec
- `docs/plans/2026-05-09-engine-core-sequence-allocator-binding.md`

## Commands Run
```text
# Baseline comparison from origin/main worktree, larger local probe shape:
MELIX_ENGINE_GENERATE_USAGE_PROBE_REQUESTS=1500 MELIX_ENGINE_GENERATE_USAGE_PROBE_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
baseline means: 101.15445584524423 ms, 96.05421482119709 ms, 98.70985283050686 ms

# Candidate comparison from this branch, same larger local probe shape:
MELIX_ENGINE_GENERATE_USAGE_PROBE_REQUESTS=1500 MELIX_ENGINE_GENERATE_USAGE_PROBE_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
candidate means: 98.47297361120582 ms, 98.28638238832355 ms, 94.11423918791115 ms

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_generate_stream.py::test_generate_without_usage_skips_prompt_token_count_fallback services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_reuses_sampling_when_stop_sequences_match services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_clones_when_stop_sequences_change services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_reuses_runtime_event_prompt_tokens_without_fallback_count services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_counts_prompt_tokens_only_for_missing_event_total services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_request_token_accumulation services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_usage_preserves_finish_reason services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion services/mlx-worker-python/tests/test_generate_stream.py::test_generate_stream_exports_stop_contract_metrics_and_stops_at_turn_boundary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics
12 passed in 0.34s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests>
12 passed in 0.59s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/engine_core.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/engine_generate_usage_token_probe.py
changed_line_coverage=100.00%; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
{"elapsed_ms_mean": 18.99950362276286, "elapsed_ms_min": 18.372667022049427, "prompt_token_count_calls_mean": 0.0, "prompt_token_count_calls_per_request": 0.0, "prompt_words": 4096, "request_count": 300, "request_state_append_calls_mean": 0.0, "request_state_append_calls_per_request": 0.0, "samples": 5, "token_events_mean": 300.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% for the changed measurable line in `engine_core.py`.
- Registered local probe: `engine-generate-usage-token-elision` passed locally on Linux.
- Larger local comparison: `old_mean=98.63950783231606 ms`, `new_mean=96.95786506248017 ms`, `speedup=1.0173x`, `delta_ms=-1.6816427698358892` for 1500 requests x 5 samples per run, averaged across 3 runs.
- Registered CI PR-scoped performance report is required before merge.

## Known Gaps
- Local verification is Linux/Python-only; GitHub Actions remains the merge gate for the registered PR-scoped performance workflow.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
