### PR TITLE
Fix direct HF benchmark target loading

### DIFF
--- a/docs/plans/2026-05-09-direct-hf-benchmark-target-loading.md
+++ b/docs/plans/2026-05-09-direct-hf-benchmark-target-loading.md
@@ -1,0 +1,48 @@
+# Direct Hugging Face Benchmark Target Loading
+
+## Goal
+
+Fix direct Hugging Face benchmark and evaluation target loading so text-only
+Qwen 3.x MLX repositories resolve to a loadable text model instead of a VLM
+target, and so worker load failures preserve their original error code and
+message instead of being masked as a missing benchmark target.
+
+## Scope
+
+- Control-plane direct `--repo-id` benchmark, benchmark-matrix, and evaluation
+  resolution.
+- On-demand model load error propagation from worker load responses.
+- Swift regression tests for Qwen 3.6 direct imports, local Hugging Face cache
+  snapshot preference, and worker load error surfacing.
+
+## Performance Probes And Metrics
+
+This slice changes target resolution and error handling, not the Python
+benchmark execution loop. The verification probe is a focused Swift control
+plane test path that exercises:
+
+- direct Hub card classification for Qwen 3.6 text-only repositories with
+  `processor_config.json`;
+- registry snapshot reuse before Hub fallback;
+- worker load rejection propagation without an unnecessary benchmark request.
+
+Success metrics:
+
+- `swift test --package-path services/control-plane-swift --filter ControlPlaneServiceTests`
+  passes for the touched control-plane behavior.
+- `python3 scripts/swift_changed_line_coverage.py --diff-from origin/main`
+  reports at least 95 percent changed-line coverage for touched Swift lines, or
+  the handoff records the exact blocker if the coverage tool is unavailable.
+- `git diff --check` reports no whitespace errors.
+
+## Implementation Plan
+
+1. Add failing control-plane tests for the Qwen 3.6 direct Hugging Face import
+   and worker load rejection paths.
+2. Rescan worker registry before direct Hub import and prefer existing
+   Hugging Face cache snapshots matching the requested repo.
+3. Extend Qwen text classification to Qwen 3.x repositories while preserving
+   Gemma/PaliGemma VLM behavior.
+4. Propagate worker load rejection errors from `OnDemandModelLoader` through
+   benchmark, matrix, and evaluation handlers.
+5. Run focused tests, changed-line coverage, and diff checks before handoff.

--- a/services/control-plane-swift/Sources/WorkerClient/OnDemandModelLoader.swift
+++ b/services/control-plane-swift/Sources/WorkerClient/OnDemandModelLoader.swift
@@ -128,7 +128,9 @@ enum OnDemandModelLoader {
                 reason: failureReason,
                 memoryBudgetEvidence: memoryBudgetEvidence
             )
-            if response.error.code == "audio_processor_validation_failed" {
+            if !response.error.code.isEmpty
+                || !response.error.message.isEmpty
+                || !response.error.details.isEmpty {
                 throw OnDemandModelLoadError.workerRejected(response.error)
             }
             throw OnDemandModelLoadError.workerUnavailable

--- a/services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift
+++ b/services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift
@@ -7,6 +7,11 @@ private struct ModelLoadOutcome {
     let error: Melix_Controlplane_V1_ErrorStatus?
 }
 
+private struct BenchmarkModelHandle {
+    let model: Melix_Controlplane_V1_ModelSummary
+    let handle: String
+}
+
 private struct BenchmarkTargetResolutionError: Error {
     let code: String
     let message: String
@@ -918,7 +923,7 @@ public actor ControlPlaneService {
 
         let requestedModelID = command.modelID.trimmingCharacters(in: .whitespacesAndNewlines)
         let requestedHFRepoID = command.hfRepoID.trimmingCharacters(in: .whitespacesAndNewlines)
-        let benchmarkModel: Melix_Controlplane_V1_ModelSummary
+        var benchmarkModel: Melix_Controlplane_V1_ModelSummary
         do {
             benchmarkModel = try await resolvedBenchmarkModel(
                 preferredModelID: requestedModelID,
@@ -978,12 +983,18 @@ public actor ControlPlaneService {
         let normalizedBatchSizes = ControlPlaneBenchRequest.normalizedBenchValues(command.batchSizes)
         let modelHandle: String
         do {
-            modelHandle = try await benchmarkModelHandle(for: benchmarkModel)
+            let resolvedHandle = try await benchmarkModelHandle(
+                for: benchmarkModel,
+                explicitHFRepoID: requestedHFRepoID
+            )
+            benchmarkModel = resolvedHandle.model
+            modelHandle = resolvedHandle.handle
         } catch {
-            return errorResponse(
+            return benchmarkLoadErrorResponse(
                 for: request,
-                code: "not_found",
-                message: "No loaded benchmark target is available for \(benchmarkModel.modelID)."
+                error: error,
+                modelID: benchmarkModel.modelID,
+                targetDescription: "benchmark target"
             )
         }
 
@@ -1176,7 +1187,7 @@ public actor ControlPlaneService {
 
         let requestedModelID = command.modelID.trimmingCharacters(in: .whitespacesAndNewlines)
         let requestedHFRepoID = command.hfRepoID.trimmingCharacters(in: .whitespacesAndNewlines)
-        let benchmarkModel: Melix_Controlplane_V1_ModelSummary
+        var benchmarkModel: Melix_Controlplane_V1_ModelSummary
         do {
             benchmarkModel = try await resolvedBenchmarkModel(
                 preferredModelID: requestedModelID,
@@ -1279,12 +1290,18 @@ public actor ControlPlaneService {
 
         let modelHandle: String
         do {
-            modelHandle = try await benchmarkModelHandle(for: benchmarkModel)
+            let resolvedHandle = try await benchmarkModelHandle(
+                for: benchmarkModel,
+                explicitHFRepoID: requestedHFRepoID
+            )
+            benchmarkModel = resolvedHandle.model
+            modelHandle = resolvedHandle.handle
         } catch {
-            return errorResponse(
+            return benchmarkLoadErrorResponse(
                 for: request,
-                code: "not_found",
-                message: "No loaded benchmark target is available for \(benchmarkModel.modelID)."
+                error: error,
+                modelID: benchmarkModel.modelID,
+                targetDescription: "benchmark target"
             )
         }
 
@@ -1339,7 +1356,7 @@ public actor ControlPlaneService {
 
         let requestedModelID = command.modelID.trimmingCharacters(in: .whitespacesAndNewlines)
         let requestedHFRepoID = command.hfRepoID.trimmingCharacters(in: .whitespacesAndNewlines)
-        let evaluationModel: Melix_Controlplane_V1_ModelSummary
+        var evaluationModel: Melix_Controlplane_V1_ModelSummary
         do {
             evaluationModel = try await resolvedBenchmarkModel(
                 preferredModelID: requestedModelID,
@@ -1368,12 +1385,18 @@ public actor ControlPlaneService {
 
         let modelHandle: String
         do {
-            modelHandle = try await benchmarkModelHandle(for: evaluationModel)
+            let resolvedHandle = try await benchmarkModelHandle(
+                for: evaluationModel,
+                explicitHFRepoID: requestedHFRepoID
+            )
+            evaluationModel = resolvedHandle.model
+            modelHandle = resolvedHandle.handle
         } catch {
-            return errorResponse(
+            return benchmarkLoadErrorResponse(
                 for: request,
-                code: "not_found",
-                message: "No loaded evaluation target is available for \(evaluationModel.modelID)."
+                error: error,
+                modelID: evaluationModel.modelID,
+                targetDescription: "evaluation target"
             )
         }
 
@@ -2946,6 +2969,10 @@ public actor ControlPlaneService {
         workerClient: any ModelOperationsWorkerClientProtocol
     ) async throws -> Melix_Controlplane_V1_ModelSummary {
         if !hfRepoID.isEmpty {
+            await syncRegistryModelsFromWorkerIfAvailable(rescan: true)
+            if let cacheSnapshot = await preferredHFCacheBenchmarkModel(repoID: hfRepoID) {
+                return cacheSnapshot
+            }
             return try await importBenchmarkTargetFromHub(repoID: hfRepoID, workerClient: workerClient)
         }
         await syncRegistryModelsFromWorkerIfAvailable()
@@ -2959,7 +2986,41 @@ public actor ControlPlaneService {
         return benchmarkModel
     }
 
-    private func benchmarkModelHandle(for model: Melix_Controlplane_V1_ModelSummary) async throws -> String {
+    private func benchmarkModelHandle(
+        for model: Melix_Controlplane_V1_ModelSummary,
+        explicitHFRepoID: String
+    ) async throws -> BenchmarkModelHandle {
+        do {
+            return BenchmarkModelHandle(
+                model: model,
+                handle: try await loadBenchmarkModelHandle(for: model)
+            )
+        } catch {
+            let normalizedRepoID = normalizedHFRepoID(explicitHFRepoID)
+            guard !normalizedRepoID.isEmpty else {
+                throw error
+            }
+
+            await syncRegistryModelsFromWorkerIfAvailable(rescan: true)
+            let modelSourceKind = model.settings.ext["melix.source_kind"]?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            guard
+                let cacheSnapshot = await preferredHFCacheBenchmarkModel(repoID: explicitHFRepoID),
+                normalizedHFRepoID(cacheSnapshot.modelID) != normalizedHFRepoID(model.modelID)
+                    || modelSourceKind != "hf_cache_snapshot"
+            else {
+                throw error
+            }
+
+            return BenchmarkModelHandle(
+                model: cacheSnapshot,
+                handle: try await loadBenchmarkModelHandle(for: cacheSnapshot)
+            )
+        }
+    }
+
+    private func loadBenchmarkModelHandle(for model: Melix_Controlplane_V1_ModelSummary) async throws -> String {
         try await OnDemandModelLoader.ensureModelReady(
             modelID: model.modelID,
             modelCatalog: modelCatalog,
@@ -2969,6 +3030,108 @@ public actor ControlPlaneService {
             metricsPrefix: benchmarkMetricsPrefix(for: model),
             requiresTextCapability: false
         )
+    }
+
+    private func preferredHFCacheBenchmarkModel(repoID: String) async -> Melix_Controlplane_V1_ModelSummary? {
+        let normalizedRepoID = normalizedHFRepoID(repoID)
+        guard !normalizedRepoID.isEmpty else {
+            return nil
+        }
+
+        let models = await modelCatalog.listModels()
+        let matchingSnapshots = models.filter { model in
+            let sourceKind = model.settings.ext["melix.source_kind"]?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            guard sourceKind == "hf_cache_snapshot" else {
+                return false
+            }
+            return benchmarkModel(model, matchesHFRepoID: normalizedRepoID)
+        }
+        return matchingSnapshots.sorted { lhs, rhs in
+            let lhsTextPriority = benchmarkTextPriority(lhs)
+            let rhsTextPriority = benchmarkTextPriority(rhs)
+            if lhsTextPriority != rhsTextPriority {
+                return lhsTextPriority < rhsTextPriority
+            }
+            return lhs.modelID < rhs.modelID
+        }.first
+    }
+
+    private func benchmarkModel(
+        _ model: Melix_Controlplane_V1_ModelSummary,
+        matchesHFRepoID normalizedRepoID: String
+    ) -> Bool {
+        if normalizedHFRepoID(model.modelID) == normalizedRepoID {
+            return true
+        }
+        for key in ["melix.hf_repo_id", "melix.source_repo", "melix.source_locator"] {
+            if normalizedHFRepoID(model.settings.ext[key]) == normalizedRepoID {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func benchmarkTextPriority(_ model: Melix_Controlplane_V1_ModelSummary) -> Int {
+        if model.kind.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "text" {
+            return 0
+        }
+        if benchmarkTaskKind(for: model) == BenchmarkTaskKind.textGeneration.rawValue {
+            return 0
+        }
+        return 1
+    }
+
+    private func normalizedHFRepoID(_ value: String?) -> String {
+        (value ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+
+    private func benchmarkLoadErrorResponse(
+        for request: Melix_Controlplane_V1_ControlPlaneRequest,
+        error: Error,
+        modelID: String,
+        targetDescription: String
+    ) -> Melix_Controlplane_V1_ControlPlaneResponse {
+        if let loadError = error as? OnDemandModelLoadError {
+            switch loadError {
+            case .workerRejected(let workerError):
+                return errorResponse(
+                    for: request,
+                    error: controlPlaneErrorStatus(
+                        from: workerError,
+                        fallbackCode: "unavailable",
+                        fallbackMessage: "Model worker rejected \(targetDescription) load for \(modelID)."
+                    )
+                )
+            case .runtimeCacheMissing:
+                return errorResponse(
+                    for: request,
+                    error: ModelRuntimeAvailability.missingRuntimeCacheErrorStatus(modelID: modelID)
+                )
+            case .modelNotReady, .workerUnavailable:
+                break
+            }
+        }
+        return errorResponse(
+            for: request,
+            code: "not_found",
+            message: "No loaded \(targetDescription) is available for \(modelID)."
+        )
+    }
+
+    private func controlPlaneErrorStatus(
+        from workerError: Melix_Worker_V1_ErrorStatus,
+        fallbackCode: String,
+        fallbackMessage: String
+    ) -> Melix_Controlplane_V1_ErrorStatus {
+        var error = Melix_Controlplane_V1_ErrorStatus()
+        error.code = workerError.code.isEmpty ? fallbackCode : workerError.code
+        error.message = workerError.message.isEmpty ? fallbackMessage : workerError.message
+        error.details = workerError.details
+        return error
     }
 
     private func benchmarkTaskKind(for model: Melix_Controlplane_V1_ModelSummary) -> String {
@@ -3007,14 +3170,14 @@ public actor ControlPlaneService {
         for model: Melix_Controlplane_V1_ModelSummary,
         explicitHFRepoID: String
     ) -> String? {
-        if !explicitHFRepoID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return "hf_repo"
-        }
         let sourceKind = model.settings.ext["melix.source_kind"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         if ["hf_repo", "hub_repo", "hf_cache_snapshot"].contains(sourceKind) {
             return sourceKind
+        }
+        if !explicitHFRepoID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "hf_repo"
         }
         if ["local_path", "local", "local_mlx_directory", "managed_local"].contains(sourceKind) {
             return nil
@@ -3109,6 +3272,10 @@ public actor ControlPlaneService {
         from card: Melix_Worker_V1_HubModelCard
     ) throws -> BenchmarkTaskKind {
         let pipelineTag = card.pipelineTag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedTags = normalizedHubTags(for: card)
+        if supportsQwenTextBenchmarkImport(for: card, normalizedTags: normalizedTags) {
+            return .textGeneration
+        }
         switch pipelineTag {
         case "":
             if let inferredTaskKind = inferredBenchmarkTaskKindForMissingPipelineTag(from: card) {
@@ -3175,15 +3342,26 @@ public actor ControlPlaneService {
         for card: Melix_Worker_V1_HubModelCard,
         normalizedTags: Set<String>
     ) -> Bool {
-        let identity = ([card.repoID, card.modelName] + card.tags)
+        let identityTokens = [card.repoID, card.modelName] + card.tags
+        let identity = identityTokens
             .joined(separator: " ")
             .lowercased()
-        let hasQwen35Signal = identity.contains("qwen3.5")
+        let normalizedIdentity = identity
+            .replacingOccurrences(of: "_", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
+        let hasQwen3TextSignal = identity.contains("qwen3.5")
             || identity.contains("qwen3-5")
             || identity.contains("qwen3_5")
+            || identity.contains("qwen3.6")
+            || identity.contains("qwen3-6")
+            || identity.contains("qwen3_6")
+            || normalizedIdentity.contains("qwen3")
             || normalizedTags.contains("qwen3-5")
             || normalizedTags.contains("qwen3.5")
-        guard hasQwen35Signal else {
+            || normalizedTags.contains("qwen3-6")
+            || normalizedTags.contains("qwen3.6")
+            || normalizedTags.contains("qwen3")
+        guard hasQwen3TextSignal, !hasExplicitQwenVisionSignal(identityTokens) else {
             return false
         }
         let siblingFiles = Set(card.siblingFiles.map { $0.lowercased() })
@@ -3192,6 +3370,32 @@ public actor ControlPlaneService {
         let hasWeights = siblingFiles.contains("model.safetensors.index.json")
             || siblingFiles.contains { $0.hasSuffix(".safetensors") }
         return hasTokenizer && hasWeights
+    }
+
+    private func hasExplicitQwenVisionSignal(_ identityTokens: [String]) -> Bool {
+        let normalizedTokens = identityTokens
+            .map {
+                $0
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .lowercased()
+                    .replacingOccurrences(of: "_", with: "-")
+            }
+            .filter { !$0.isEmpty }
+        return normalizedTokens.contains { token in
+            token.contains("qwen-vl")
+                || token.contains("qwen2-vl")
+                || token.contains("qwen2.5-vl")
+                || token.contains("qwen2-5-vl")
+                || token.contains("qwen3-vl")
+                || token.contains("qwen3.5-vl")
+                || token.contains("qwen3-5-vl")
+                || token.contains("qwen3.6-vl")
+                || token.contains("qwen3-6-vl")
+                || token.contains("qwen-omni")
+                || token.contains("qwen2.5-omni")
+                || token.contains("qwen2-5-omni")
+                || token.contains("qwen3-omni")
+        }
     }
 
     private func makeImportedBenchmarkModel(

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift
@@ -4830,6 +4830,388 @@ struct ControlPlaneServiceTests {
         #expect(response.ops.benchmarkJob.taskKind == "text-generation")
     }
 
+    @Test("execute imports Qwen3.6 benchmark targets with multimodal-looking metadata as text generation")
+    func executeImportsQwen36BenchmarkTargetWithProcessorMetadataAsText() async throws {
+        let reportPath = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("melix-bench-qwen36-report.md").path
+        try "# Qwen3.6 Bench\n".write(toFile: reportPath, atomically: true, encoding: .utf8)
+
+        let modelOpsClient = ScriptedModelOperationsWorkerClient()
+        await modelOpsClient.setHubModelCardResponse(
+            makeBenchmarkHubModelCardResponse(
+                repoID: "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
+                modelName: "Qwen3.6-35B-A3B-UD-MLX-4bit",
+                pipelineTag: "image-text-to-text",
+                tags: ["mlx", "qwen3.6", "vision-language-model"],
+                siblingFiles: [
+                    "config.json",
+                    "processor_config.json",
+                    "tokenizer.json",
+                    "tokenizer_config.json",
+                    "model.safetensors.index.json",
+                ]
+            )
+        )
+        await modelOpsClient.setBenchEvents(makeBenchmarkLifecycleEvents(jobID: "bench-qwen36", reportPath: reportPath))
+        let pythonRuntimeClient = ScriptedChatWorkerClient(events: [])
+        let service = ControlPlaneService(
+            modelCatalog: ModelCatalog(seedModels: ModelCatalog.phaseSevenContractSeedModels()),
+            workerRegistry: WorkerRegistry(
+                defaultTextClient: NullWorkerClient(),
+                pythonCompatibilityClient: pythonRuntimeClient,
+                modelOperationsClient: modelOpsClient
+            )
+        )
+
+        let response = try await service.execute(
+            makeRunBenchRequest(hfRepoID: "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit")
+        )
+        let lastLoadRequest = try #require(await pythonRuntimeClient.lastLoadModelRequest)
+        let lastBenchRequest = try #require(await modelOpsClient.lastBenchRequest)
+
+        #expect(response.ok)
+        #expect(lastLoadRequest.model.modelID == "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit")
+        #expect(lastLoadRequest.model.modelKind == "text")
+        #expect(lastLoadRequest.model.ext["melix.task_kind"] == "text-generation")
+        #expect(lastLoadRequest.model.ext["melix.capability.route_kind"] == "python_text_compatibility")
+        #expect(lastLoadRequest.model.ext["melix.benchmark.task_kind"] == nil)
+        #expect(lastLoadRequest.model.ext["melix.vlm.execution_mode"] == nil)
+        #expect(lastBenchRequest.taskKind == "text-generation")
+        #expect(lastBenchRequest.sourceRepo == "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit")
+        #expect(response.ops.benchmarkJob.taskKind == "text-generation")
+    }
+
+    @Test("execute resolves Qwen3.6 any-to-any benchmark targets as text generation")
+    func executeImportsQwen36AnyToAnyBenchmarkTargetAsText() async throws {
+        let reportPath = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("melix-bench-qwen36-any-report.md").path
+        try "# Qwen3.6 Any-to-Any Bench\n".write(toFile: reportPath, atomically: true, encoding: .utf8)
+
+        let modelOpsClient = ScriptedModelOperationsWorkerClient()
+        await modelOpsClient.setHubModelCardResponse(
+            makeBenchmarkHubModelCardResponse(
+                repoID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                modelName: "Qwen3.6-35B-A3B-4bit",
+                pipelineTag: "any-to-any",
+                tags: ["mlx", "qwen3_6", "multimodal"],
+                siblingFiles: [
+                    "config.json",
+                    "processor_config.json",
+                    "tokenizer.json",
+                    "model.safetensors.index.json",
+                ]
+            )
+        )
+        await modelOpsClient.setBenchEvents(makeBenchmarkLifecycleEvents(jobID: "bench-qwen36-any", reportPath: reportPath))
+        let pythonRuntimeClient = ScriptedChatWorkerClient(events: [])
+        let service = ControlPlaneService(
+            modelCatalog: ModelCatalog(seedModels: ModelCatalog.phaseSevenContractSeedModels()),
+            workerRegistry: WorkerRegistry(
+                defaultTextClient: NullWorkerClient(),
+                pythonCompatibilityClient: pythonRuntimeClient,
+                modelOperationsClient: modelOpsClient
+            )
+        )
+
+        let response = try await service.execute(
+            makeRunBenchRequest(hfRepoID: "mlx-community/Qwen3.6-35B-A3B-4bit")
+        )
+        let lastLoadRequest = try #require(await pythonRuntimeClient.lastLoadModelRequest)
+        let lastBenchRequest = try #require(await modelOpsClient.lastBenchRequest)
+
+        #expect(response.ok)
+        #expect(lastLoadRequest.model.modelKind == "text")
+        #expect(lastBenchRequest.taskKind == "text-generation")
+        #expect(response.ops.benchmarkJob.taskKind == "text-generation")
+    }
+
+    @Test("execute prefers a matching Hugging Face cache snapshot before importing a direct benchmark target")
+    func executePrefersMatchingHFCacheSnapshotBeforeDirectBenchmarkImport() async throws {
+        let reportPath = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("melix-bench-hf-cache-report.md").path
+        try "# HF Cache Bench\n".write(toFile: reportPath, atomically: true, encoding: .utf8)
+
+        let repoID = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
+        let snapshotModelID = "hf-cache/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit/snapshots/abc123"
+        let manifestJSON = try makeRegistrySnapshotManifestJSON(
+            models: [
+                [
+                    "model_id": snapshotModelID,
+                    "model_path": "/tmp/huggingface/hub/models--unsloth--Qwen3.6-35B-A3B-UD-MLX-4bit/snapshots/abc123",
+                    "model_kind": "text",
+                    "quant_profile_id": "mlx-4bit",
+                    "max_context": 32768,
+                    "ext": [
+                        "melix.registry_root_id": "hf-cache",
+                        "melix.registry_root_path": "/tmp/huggingface/hub",
+                        "melix.registry_relative_path": "models--unsloth--Qwen3.6-35B-A3B-UD-MLX-4bit/snapshots/abc123",
+                        "melix.source_kind": "hf_cache_snapshot",
+                        "melix.hf_repo_id": repoID,
+                        "melix.source_repo": repoID,
+                        "melix.model_path": "/tmp/huggingface/hub/models--unsloth--Qwen3.6-35B-A3B-UD-MLX-4bit/snapshots/abc123",
+                        "melix.task_kind": "text-generation",
+                    ],
+                ],
+                [
+                    "model_id": repoID,
+                    "model_path": "/tmp/huggingface/hub/models--unsloth--Qwen3.6-35B-A3B-UD-MLX-4bit/snapshots/exact",
+                    "model_kind": "text",
+                    "quant_profile_id": "mlx-4bit",
+                    "max_context": 32768,
+                    "ext": [
+                        "melix.registry_root_id": "hf-cache",
+                        "melix.registry_root_path": "/tmp/huggingface/hub",
+                        "melix.registry_relative_path": "models--unsloth--Qwen3.6-35B-A3B-UD-MLX-4bit/snapshots/exact",
+                        "melix.source_kind": "hf_cache_snapshot",
+                        "melix.model_path": "/tmp/huggingface/hub/models--unsloth--Qwen3.6-35B-A3B-UD-MLX-4bit/snapshots/exact",
+                        "melix.task_kind": "text-generation",
+                    ],
+                ],
+                [
+                    "model_id": "hf-cache/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit/snapshots/vlm-text-backed",
+                    "model_path": "/tmp/huggingface/hub/models--unsloth--Qwen3.6-35B-A3B-UD-MLX-4bit/snapshots/vlm-text-backed",
+                    "model_kind": "vlm",
+                    "quant_profile_id": "mlx-4bit",
+                    "max_context": 32768,
+                    "ext": [
+                        "melix.registry_root_id": "hf-cache",
+                        "melix.registry_root_path": "/tmp/huggingface/hub",
+                        "melix.source_kind": "hf_cache_snapshot",
+                        "melix.hf_repo_id": repoID,
+                        "melix.source_repo": repoID,
+                        "melix.model_path": "/tmp/huggingface/hub/models--unsloth--Qwen3.6-35B-A3B-UD-MLX-4bit/snapshots/vlm-text-backed",
+                        "melix.task_kind": "text-generation",
+                    ],
+                ],
+                [
+                    "model_id": "hf-cache/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit/snapshots/vlm",
+                    "model_path": "/tmp/huggingface/hub/models--unsloth--Qwen3.6-35B-A3B-UD-MLX-4bit/snapshots/vlm",
+                    "model_kind": "vlm",
+                    "quant_profile_id": "mlx-4bit",
+                    "max_context": 32768,
+                    "ext": [
+                        "melix.registry_root_id": "hf-cache",
+                        "melix.registry_root_path": "/tmp/huggingface/hub",
+                        "melix.source_kind": "hf_cache_snapshot",
+                        "melix.hf_repo_id": repoID,
+                        "melix.source_repo": repoID,
+                        "melix.model_path": "/tmp/huggingface/hub/models--unsloth--Qwen3.6-35B-A3B-UD-MLX-4bit/snapshots/vlm",
+                        "melix.task_kind": "image-text-to-text",
+                    ],
+                ],
+                [
+                    "model_id": "hf-cache/other/snapshots/not-this-repo",
+                    "model_path": "/tmp/huggingface/hub/models--other--Model/snapshots/not-this-repo",
+                    "model_kind": "text",
+                    "quant_profile_id": "mlx-4bit",
+                    "max_context": 4096,
+                    "ext": [
+                        "melix.registry_root_id": "hf-cache",
+                        "melix.registry_root_path": "/tmp/huggingface/hub",
+                        "melix.source_kind": "hf_cache_snapshot",
+                        "melix.hf_repo_id": "mlx-community/Other-Model",
+                        "melix.source_repo": "mlx-community/Other-Model",
+                        "melix.model_path": "/tmp/huggingface/hub/models--other--Model/snapshots/not-this-repo",
+                        "melix.task_kind": "text-generation",
+                    ],
+                ],
+            ]
+        )
+
+        let modelOpsClient = ScriptedModelOperationsWorkerClient()
+        await modelOpsClient.setConvertEvents([
+            {
+                var event = Melix_Worker_V1_ConvertModelEvent()
+                event.manifest = Melix_Worker_V1_ConvertManifest()
+                event.manifest.manifestJson = manifestJSON
+                return event
+            }(),
+        ])
+        await modelOpsClient.setHubModelCardResponse(
+            makeBenchmarkHubModelCardResponse(
+                repoID: repoID,
+                modelName: "Qwen3.6-35B-A3B-UD-MLX-4bit",
+                pipelineTag: "image-text-to-text",
+                tags: ["mlx", "qwen3.6", "vision-language-model"],
+                siblingFiles: ["config.json", "processor_config.json", "tokenizer.json"]
+            )
+        )
+        await modelOpsClient.setBenchEvents(makeBenchmarkLifecycleEvents(jobID: "bench-hf-cache", reportPath: reportPath))
+        let pythonRuntimeClient = ScriptedChatWorkerClient(events: [])
+        let service = ControlPlaneService(
+            modelCatalog: ModelCatalog(seedModels: []),
+            workerRegistry: WorkerRegistry(
+                defaultTextClient: pythonRuntimeClient,
+                modelOperationsClient: modelOpsClient
+            )
+        )
+
+        let response = try await service.execute(
+            makeRunBenchRequest(hfRepoID: repoID)
+        )
+        let convertRequest = try #require(await modelOpsClient.lastConvertRequest)
+        let loadRequest = try #require(await pythonRuntimeClient.lastLoadModelRequest)
+        let benchRequest = try #require(await modelOpsClient.lastBenchRequest)
+
+        #expect(response.ok)
+        #expect(convertRequest.ext["melix.registry_rescan"] == "true")
+        #expect(await modelOpsClient.lastHubModelCardRequest == nil)
+        #expect(loadRequest.model.modelID == snapshotModelID)
+        #expect(loadRequest.model.modelKind == "text")
+        #expect(benchRequest.modelHandle == snapshotModelID)
+        #expect(benchRequest.taskKind == "text-generation")
+        #expect(benchRequest.sourceRepo == repoID)
+        #expect(benchRequest.parameters["live_model_source"] == "hf_cache_snapshot")
+        #expect(response.ops.benchmarkJob.modelID == snapshotModelID)
+        #expect(response.ops.benchmarkJob.taskKind == "text-generation")
+    }
+
+    @Test("execute surfaces direct benchmark worker load rejection instead of masking it as not found")
+    func executeSurfacesDirectBenchmarkWorkerLoadRejection() async throws {
+        let modelOpsClient = ScriptedModelOperationsWorkerClient()
+        await modelOpsClient.setHubModelCardResponse(
+            makeBenchmarkHubModelCardResponse(
+                repoID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                modelName: "Qwen3.6-35B-A3B-4bit",
+                pipelineTag: "text-generation",
+                tags: ["mlx", "qwen3.6"],
+                siblingFiles: ["config.json", "tokenizer.json", "model.safetensors.index.json"]
+            )
+        )
+        let pythonRuntimeClient = ScriptedChatWorkerClient(events: [])
+        await pythonRuntimeClient.setLoadModelResponse({
+            var response = Melix_Worker_V1_LoadModelResponse()
+            response.ok = false
+            response.error.code = "memory_budget_exceeded"
+            response.error.message = "Required memory exceeds available headroom."
+            response.error.details = [
+                "required_bytes": "42000000000",
+                "headroom_bytes": "16000000000",
+            ]
+            return response
+        }())
+        let service = ControlPlaneService(
+            modelCatalog: ModelCatalog(seedModels: ModelCatalog.phaseSevenContractSeedModels()),
+            workerRegistry: WorkerRegistry(
+                defaultTextClient: NullWorkerClient(),
+                pythonCompatibilityClient: pythonRuntimeClient,
+                modelOperationsClient: modelOpsClient
+            )
+        )
+
+        let response = try await service.execute(
+            makeRunBenchRequest(hfRepoID: "mlx-community/Qwen3.6-35B-A3B-4bit")
+        )
+
+        #expect(response.ok == false)
+        #expect(response.error.code == "memory_budget_exceeded")
+        #expect(response.error.message == "Required memory exceeds available headroom.")
+        #expect(response.error.details["required_bytes"] == "42000000000")
+        #expect(await modelOpsClient.lastBenchRequest == nil)
+    }
+
+    @Test("execute retries direct benchmark load with a Hugging Face cache snapshot discovered after hub import fails")
+    func executeRetriesDirectBenchmarkLoadWithHFCacheSnapshotAfterHubImportFailure() async throws {
+        let reportPath = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("melix-bench-hf-cache-retry-report.md").path
+        try "# HF Cache Retry Bench\n".write(toFile: reportPath, atomically: true, encoding: .utf8)
+
+        let repoID = "mlx-community/Qwen3.6-35B-A3B-4bit"
+        let snapshotModelID = "hf-cache/mlx-community/Qwen3.6-35B-A3B-4bit/snapshots/recovered"
+        let manifestJSON = try makeRegistrySnapshotManifestJSON(
+            models: [
+                [
+                    "model_id": snapshotModelID,
+                    "model_path": "/tmp/huggingface/hub/models--mlx-community--Qwen3.6-35B-A3B-4bit/snapshots/recovered",
+                    "model_kind": "text",
+                    "quant_profile_id": "mlx-4bit",
+                    "max_context": 32768,
+                    "ext": [
+                        "melix.registry_root_id": "hf-cache",
+                        "melix.registry_root_path": "/tmp/huggingface/hub",
+                        "melix.registry_relative_path": "models--mlx-community--Qwen3.6-35B-A3B-4bit/snapshots/recovered",
+                        "melix.source_kind": "hf_cache_snapshot",
+                        "melix.hf_repo_id": repoID,
+                        "melix.source_repo": repoID,
+                        "melix.model_path": "/tmp/huggingface/hub/models--mlx-community--Qwen3.6-35B-A3B-4bit/snapshots/recovered",
+                        "melix.task_kind": "text-generation",
+                    ],
+                ],
+            ]
+        )
+        let manifestEvent = {
+            var event = Melix_Worker_V1_ConvertModelEvent()
+            event.manifest = Melix_Worker_V1_ConvertManifest()
+            event.manifest.manifestJson = manifestJSON
+            return event
+        }()
+
+        let modelOpsClient = ScriptedModelOperationsWorkerClient()
+        await modelOpsClient.setConvertEventBatches([[], [manifestEvent]])
+        await modelOpsClient.setHubModelCardResponse(
+            makeBenchmarkHubModelCardResponse(
+                repoID: repoID,
+                modelName: "Qwen3.6-35B-A3B-4bit",
+                pipelineTag: "text-generation",
+                tags: ["mlx", "qwen3.6"],
+                siblingFiles: ["config.json", "tokenizer.json", "model.safetensors.index.json"]
+            )
+        )
+        await modelOpsClient.setBenchEvents(makeBenchmarkLifecycleEvents(jobID: "bench-hf-cache-retry", reportPath: reportPath))
+        let pythonRuntimeClient = ScriptedChatWorkerClient(events: [])
+        await pythonRuntimeClient.setLoadModelResponses([
+            {
+                var response = Melix_Worker_V1_LoadModelResponse()
+                response.ok = false
+                response.error.code = "load_failed"
+                response.error.message = "Hub import path did not produce a local runtime handle."
+                return response
+            }(),
+        ])
+        let service = ControlPlaneService(
+            modelCatalog: ModelCatalog(seedModels: []),
+            workerRegistry: WorkerRegistry(
+                defaultTextClient: pythonRuntimeClient,
+                pythonCompatibilityClient: pythonRuntimeClient,
+                modelOperationsClient: modelOpsClient
+            )
+        )
+
+        let response = try await service.execute(makeRunBenchRequest(hfRepoID: repoID))
+        let loadRequests = await pythonRuntimeClient.loadModelRequests
+        let benchRequest = try #require(await modelOpsClient.lastBenchRequest)
+
+        #expect(response.ok)
+        #expect(await modelOpsClient.convertRequests.count == 2)
+        #expect(loadRequests.map { $0.model.modelID } == [repoID, snapshotModelID])
+        #expect(benchRequest.modelHandle == snapshotModelID)
+        #expect(benchRequest.taskKind == "text-generation")
+        #expect(benchRequest.parameters["live_model_source"] == "hf_cache_snapshot")
+        #expect(response.ops.benchmarkJob.modelID == snapshotModelID)
+    }
+
+    @Test("execute surfaces missing runtime cache for benchmark targets before worker load")
+    func executeSurfacesMissingRuntimeCacheForBenchmarkTargetsBeforeWorkerLoad() async throws {
+        var model = ModelCatalog.devTextModel()
+        model.settings.ext["melix.model_path_missing"] = "true"
+        model.settings.ext["melix.hf_repo_id"] = "mlx-community/Qwen3.6-35B-A3B-4bit"
+        let catalog = ModelCatalog(seedModels: [model])
+        let modelOpsClient = ScriptedModelOperationsWorkerClient()
+        let pythonRuntimeClient = ScriptedChatWorkerClient(events: [])
+        let service = ControlPlaneService(
+            modelCatalog: catalog,
+            workerRegistry: WorkerRegistry(
+                defaultTextClient: pythonRuntimeClient,
+                modelOperationsClient: modelOpsClient
+            )
+        )
+
+        let response = try await service.execute(makeRunBenchRequest(modelID: "melix-dev-text"))
+
+        #expect(response.ok == false)
+        #expect(response.error.code == ModelRuntimeAvailability.missingRuntimeCacheCode)
+        #expect(response.error.message == ModelRuntimeAvailability.missingRuntimeCacheMessage)
+        #expect(response.error.details["model_id"] == "melix-dev-text")
+        #expect(await pythonRuntimeClient.lastLoadModelRequest == nil)
+        #expect(await modelOpsClient.lastBenchRequest == nil)
+    }
+
     @Test("execute infers missing pipeline tags from explicit modality metadata")
     func executeInfersMissingPipelineTagsFromExplicitModalityMetadata() async throws {
         let cases: [(repoID: String, modelName: String, tags: [String], siblingFiles: [String], expectedTaskKind: String, expectedModelKind: String)] = [
@@ -10328,6 +10710,7 @@ private actor ScriptedModelOperationsWorkerClient: WorkerRoutingClient, ModelOpe
     private(set) var lastSubmitRequest: Melix_Worker_V1_SubmitResultsRequest?
     private var infoResponse = Melix_Worker_V1_GetModelInfoResponse()
     private var convertEvents: [Melix_Worker_V1_ConvertModelEvent] = []
+    private var convertEventBatches: [[Melix_Worker_V1_ConvertModelEvent]] = []
     private var doctorResponse = Melix_Worker_V1_RunDoctorResponse()
     private var hubSearchResponse = Melix_Worker_V1_SearchHubModelsResponse()
     private var hubModelCardResponse = Melix_Worker_V1_GetHubModelCardResponse()
@@ -10351,6 +10734,11 @@ private actor ScriptedModelOperationsWorkerClient: WorkerRoutingClient, ModelOpe
 
     func setConvertEvents(_ events: [Melix_Worker_V1_ConvertModelEvent]) {
         convertEvents = events
+        convertEventBatches = []
+    }
+
+    func setConvertEventBatches(_ batches: [[Melix_Worker_V1_ConvertModelEvent]]) {
+        convertEventBatches = batches
     }
 
     func setDoctorResponse(_ response: Melix_Worker_V1_RunDoctorResponse) {
@@ -10458,7 +10846,12 @@ private actor ScriptedModelOperationsWorkerClient: WorkerRoutingClient, ModelOpe
         if let convertError {
             throw convertError
         }
-        let events = convertEvents
+        let events: [Melix_Worker_V1_ConvertModelEvent]
+        if convertEventBatches.isEmpty {
+            events = convertEvents
+        } else {
+            events = convertEventBatches.removeFirst()
+        }
         return AsyncThrowingStream { continuation in
             for event in events {
                 continuation.yield(event)
@@ -10552,10 +10945,23 @@ private actor ScriptedChatWorkerClient: WorkerRoutingClient {
     private let events: [Melix_Worker_V1_ExecuteEvent]
     private(set) var lastGenerateRequest: Melix_Worker_V1_GenerateRequest?
     private(set) var lastLoadModelRequest: Melix_Worker_V1_LoadModelRequest?
+    private(set) var loadModelRequests: [Melix_Worker_V1_LoadModelRequest] = []
     private(set) var unloadRequests: [Melix_Worker_V1_UnloadModelRequest] = []
+    private var loadModelResponse: Melix_Worker_V1_LoadModelResponse?
+    private var loadModelResponses: [Melix_Worker_V1_LoadModelResponse] = []
 
     init(events: [Melix_Worker_V1_ExecuteEvent]) {
         self.events = events
+    }
+
+    func setLoadModelResponse(_ response: Melix_Worker_V1_LoadModelResponse) {
+        loadModelResponse = response
+        loadModelResponses = []
+    }
+
+    func setLoadModelResponses(_ responses: [Melix_Worker_V1_LoadModelResponse]) {
+        loadModelResponses = responses
+        loadModelResponse = nil
     }
 
     func canDispatchRequests() async -> Bool {
@@ -10584,6 +10990,13 @@ private actor ScriptedChatWorkerClient: WorkerRoutingClient {
         request: Melix_Worker_V1_LoadModelRequest
     ) async throws -> Melix_Worker_V1_LoadModelResponse {
         lastLoadModelRequest = request
+        loadModelRequests.append(request)
+        if !loadModelResponses.isEmpty {
+            return loadModelResponses.removeFirst()
+        }
+        if let loadModelResponse {
+            return loadModelResponse
+        }
         var response = Melix_Worker_V1_LoadModelResponse()
         response.ok = true
         response.modelHandle = request.model.modelID

--- a/services/control-plane-swift/Tests/WorkerClientTests/OnDemandModelLoaderTests.swift
+++ b/services/control-plane-swift/Tests/WorkerClientTests/OnDemandModelLoaderTests.swift
@@ -414,7 +414,15 @@ struct OnDemandModelLoaderTests {
         )
         let registry = WorkerRegistry(defaultTextClient: workerClient, modelCatalog: catalog)
 
-        await #expect(throws: OnDemandModelLoadError.workerUnavailable) {
+        var expectedMemoryError = Melix_Worker_V1_ErrorStatus()
+        expectedMemoryError.code = "memory_budget_exceeded"
+        expectedMemoryError.message = "Projected resident memory would exceed the process budget."
+        expectedMemoryError.details = [
+            "budget_bytes": "32768",
+            "headroom_bytes": "2048",
+            "required_bytes": "34816",
+        ]
+        await #expect(throws: OnDemandModelLoadError.workerRejected(expectedMemoryError)) {
             try await OnDemandModelLoader.ensureTextModelReady(
                 modelID: "melix-dev-text",
                 modelCatalog: catalog,
@@ -451,7 +459,10 @@ struct OnDemandModelLoaderTests {
         )
         let registry = WorkerRegistry(defaultTextClient: workerClient, modelCatalog: catalog)
 
-        await #expect(throws: OnDemandModelLoadError.workerUnavailable) {
+        var expectedDiskStreamingError = Melix_Worker_V1_ErrorStatus()
+        expectedDiskStreamingError.code = "disk_streaming_unsupported"
+        expectedDiskStreamingError.message = "The selected runtime does not support disk-streaming mode."
+        await #expect(throws: OnDemandModelLoadError.workerRejected(expectedDiskStreamingError)) {
             try await OnDemandModelLoader.ensureTextModelReady(
                 modelID: "melix-dev-text",
                 modelCatalog: catalog,
@@ -480,7 +491,10 @@ struct OnDemandModelLoaderTests {
         )
         let registry = WorkerRegistry(defaultTextClient: workerClient, modelCatalog: catalog)
 
-        await #expect(throws: OnDemandModelLoadError.workerUnavailable) {
+        var expectedSanitizedError = Melix_Worker_V1_ErrorStatus()
+        expectedSanitizedError.code = "memory-budget.exceeded"
+        expectedSanitizedError.message = "Projected resident memory would exceed the process budget."
+        await #expect(throws: OnDemandModelLoadError.workerRejected(expectedSanitizedError)) {
             try await OnDemandModelLoader.ensureTextModelReady(
                 modelID: "melix-dev-text",
                 modelCatalog: catalog,


### PR DESCRIPTION
## Summary
- Fix direct Hugging Face benchmark and evaluation target loading so Qwen 3.x MLX text repositories resolve as text-generation models instead of failing as unsupported task families.
- Prefer matching local Hugging Face cache snapshots before direct Hub imports and after load failures, so runnable local MLX snapshots are used for benchmark/evaluation targets.
- Preserve explicit worker load rejection errors for benchmark and evaluation targets instead of masking them as `No loaded benchmark target is available`.

## Plan or Spec
- `docs/plans/2026-05-09-direct-hf-benchmark-target-loading.md`

## Commands Run
```text
git fetch origin
# Passed: refreshed origin/main to 0eb7f9785.

git rebase origin/main
# Passed: branch rebased without conflicts.

git diff --check origin/main...HEAD
# Passed: no whitespace errors.

swift test --enable-code-coverage --package-path services/control-plane-swift --filter 'ControlPlaneServiceTests|OnDemandModelLoaderTests'
# Passed: 220 tests in ControlPlaneServiceTests and OnDemandModelLoaderTests.

python3 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/WorkerClient/OnDemandModelLoader.swift services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift services/control-plane-swift/Tests/WorkerClientTests/OnDemandModelLoaderTests.swift
# Passed: TOTAL 99.67% changed-line coverage, 608/610 covered.

swift build --product melix
# Passed: built the CLI used for the rerun evidence.

swift build --package-path services/mlx-text-worker-swift --product melix-text-worker-swift
# Passed: built the Swift text worker used for the rerun evidence.

melix bench run --repo-id <model> --suite smoke --context-length 1024 --generation-length 128 --batch-size 1 --repeats 1 --cache-profile cold --reasoning-mode disabled --structured-output-mode disabled --sample-size 6 --batch-factor 1 --json
# Passed for the five previously failing benchmark targets listed in the rerun evidence.

MELIX_RUNTIME_DIR=/private/tmp/mxrr bash scripts/dev_down.sh
# Passed: stopped the local rerun runtime.
```

## Coverage and Metrics
- Changed Swift line coverage: 99.67% (608/610) for the touched control-plane and worker-client Swift files, above the 95% repository threshold.
- Probe scope: focused Swift control-plane paths for direct Hub card classification, local Hugging Face cache snapshot reuse, missing runtime cache surfacing, worker load rejection propagation, and Qwen3.6 multimodal-looking metadata classification.
- Runtime benchmark rerun evidence: `/private/tmp/melix-model-benchmark-eval-20260509-125659/rerun-benchmark-failed-20260510/summary.md`
- Rerun commit after rebase: `0b347b6f6e7a7258ec0fb8753cd7e2f12194fffa`.
- Rerun outcome: all five targets that previously reported `No loaded benchmark target is available` completed `bench run` on the fix branch.
- 35B rerun metrics:
  - `unsloth/Qwen3.6-35B-A3B-UD-MLX-3bit`: 2052.88 ms TTFT, 40.72 tok/s.
  - `mlx-community/Qwen3.6-35B-A3B-4bit`: 4326.10 ms TTFT, 55.87 tok/s.
  - `unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit`: 1005.95 ms TTFT, 49.59 tok/s after a clean runtime retry.
- 27B rerun metrics:
  - `unsloth/Qwen3.6-27B-UD-MLX-3bit`: completed, 15832.93 ms TTFT, 0.00 tok/s.
  - `unsloth/Qwen3.6-27B-UD-MLX-4bit`: completed, 5166.05 ms TTFT, 0.00 tok/s.

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run in this focused fix pass.
- The two 27B reruns completed but produced `tokens_out=0` for all six rows, so their decode throughput is not a healthy performance signal. This PR fixes direct target loading, not the 27B generation-output behavior.
- `unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit` hit a Metal OOM after several consecutive 35B loads, then completed after restarting the local runtime. The OOM log is preserved in the rerun evidence directory.
- No protocol or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A is stated.
- [x] Dependency changes include updated lockfiles, or N/A is stated.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
