### PR TITLE
perf: parse changed-scope hunk starts in one pass

### DIFF
--- a/docs/plans/2026-05-09-changed-scope-hunk-parser.md
+++ b/docs/plans/2026-05-09-changed-scope-hunk-parser.md
@@ -1,0 +1,28 @@
+# Changed-Scope Coverage Hunk Parser Micro-Optimization
+
+## Linux-only constraint
+
+This slice is Python tooling only. It can be verified locally on Linux with the focused changed-scope coverage tests, changed-scope coverage reporting, and the registered PR-scoped performance probe.
+
+## Optimization
+
+`changed_scope_coverage._parse_hunk_new_start()` runs once for every hunk in the changed-scope coverage diff parser. The previous implementation scanned the new-range digits, sliced the digit substring, and then called `int()` on that substring.
+
+This slice keeps the parser behavior unchanged while accumulating the integer value during the digit scan. That removes one short-lived string allocation per parsed hunk and keeps the hot path single-pass.
+
+## Registered probe
+
+Existing registered probe: `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.
+
+The probe covers:
+
+- `scripts/changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_parse_probe.py`
+- `tests/test_changed_scope_coverage.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+The registry already defines focused `test_command`, `coverage_command`, and `probe_command` entries, so no probe registry change is needed for this narrow parser optimization.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage, and local registered probe before opening the PR. The PR-scoped performance workflow remains the merge gate for the registered probe result in CI.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -33,11 +33,16 @@ def _parse_hunk_new_start(line: str) -> int | None:
     digit_index = new_range_index + 2
     end_index = digit_index
     line_length = len(line)
-    while end_index < line_length and line[end_index].isdigit():
+    value = 0
+    while end_index < line_length:
+        digit = ord(line[end_index]) - 48
+        if digit < 0 or digit > 9:
+            break
+        value = value * 10 + digit
         end_index += 1
     if end_index == digit_index:
         return None
-    return int(line[digit_index:end_index])
+    return value
 
 
 def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:


### PR DESCRIPTION
## Summary
- Parse changed-scope coverage hunk start line numbers in one pass.
- Avoid the short-lived digit substring allocation and `int()` parse in the diff parser hot path.
- Keep changed-scope coverage behavior unchanged.

## Plan or Spec
- `docs/plans/2026-05-09-changed-scope-hunk-parser.md`
- Registered PR-scoped probe: `changed-scope-coverage-diff-parser`.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
23 passed in 0.65s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
23 passed in 0.43s
TOTAL 7 0 100%

$ python3 scripts/changed_scope_coverage_parse_probe.py
{"changed_line_count": 7680.0, "elapsed_ms_mean": 3.6209965570985028, "elapsed_ms_min": 3.1853109830990434, "file_count": 240.0, "line_count": 16080.0}

$ python3 - <<'PY'  # local origin/main vs branch parser comparison
{"delta_ms": -0.7622368071073047, "new": {"mean": 2.9833334439899772, "median": 2.9629779746755958, "min": 2.890867996029556}, "old": {"mean": 3.745570251097282, "median": 3.3666554954834282, "min": 3.0445969896391034}, "speedup": 1.2554983616205744}
PY

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%` for the touched parser lines.
- Registered local probe (`changed-scope-coverage-diff-parser`): `elapsed_ms_mean=3.6209965570985028`, `elapsed_ms_min=3.1853109830990434`, `changed_line_count=7680.0`, `line_count=16080.0`.
- Local origin/main comparison over the same synthetic parser workload: `old_mean=3.745570251097282ms`, `new_mean=2.9833334439899772ms`, `delta_ms=-0.7622368071073047`, `speedup=1.2554983616205744x`.
- CI PR-scoped performance report is required as the final registered probe validation before merge.

## Known Gaps
- None. This is a Python-only tooling slice and was locally validated on Linux; CI remains the merge gate for the registered PR-scoped probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
