### PR TITLE
perf: bind engine stream assembler accept

### DIFF
--- a/docs/plans/2026-05-09-engine-core-assembler-accept-binding.md
+++ b/docs/plans/2026-05-09-engine-core-assembler-accept-binding.md
@@ -1,0 +1,45 @@
+# Engine Core Stream Assembler Accept Binding
+
+## Scope
+
+This performance slice is limited to `EngineCore.generate` event emission in
+`services/mlx-worker-python/worker/engine/engine_core.py`.
+
+The optimization preserves the existing stream parsing behavior, event order,
+sequence allocation, usage accounting, and completion payloads while binding the
+active request's `RequestStreamAssembler.accept` method once per generate
+request. This removes repeated bound-method lookup work from the per-runtime-token
+hot path.
+
+## Registered Probe
+
+The affected Python path is covered by the registered PR-scoped performance
+probe `engine-generate-usage-token-elision` in
+`infra/perf/pr_scoped_probes.json`.
+
+The probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for `engine_core.py`, `test_generate_stream.py`,
+`test_pr_scoped_performance.py`, and `scripts/engine_generate_usage_token_probe.py`.
+This slice does not add a new registry entry because the registered probe already
+watches the changed runtime path and exercises repeated no-usage generate stream
+event emission on Linux.
+
+## Plan
+
+1. Keep behavior covered by the registered focused generate tests.
+2. Bind `assembler.accept` to a local callable after stream assembler creation.
+3. Use the local callable for per-token fragment acceptance.
+4. Run the registered focused tests, changed-scope coverage, and registered
+   probe locally on Linux.
+5. Use GitHub Actions and the registered PR-scoped performance workflow as the
+   merge gate.
+
+## Verification
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_generate_stream.py::test_generate_without_usage_skips_prompt_token_count_fallback services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_reuses_sampling_when_stop_sequences_match services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_clones_when_stop_sequences_change services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_reuses_runtime_event_prompt_tokens_without_fallback_count services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_counts_prompt_tokens_only_for_missing_event_total services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_request_token_accumulation services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_usage_preserves_finish_reason services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion services/mlx-worker-python/tests/test_generate_stream.py::test_generate_stream_exports_stop_contract_metrics_and_stops_at_turn_boundary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_generate_stream.py::test_generate_without_usage_skips_prompt_token_count_fallback services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_reuses_sampling_when_stop_sequences_match services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_clones_when_stop_sequences_change services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_reuses_runtime_event_prompt_tokens_without_fallback_count services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_counts_prompt_tokens_only_for_missing_event_total services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_request_token_accumulation services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_usage_preserves_finish_reason services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion services/mlx-worker-python/tests/test_generate_stream.py::test_generate_stream_exports_stop_contract_metrics_and_stops_at_turn_boundary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/engine_core.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/engine_generate_usage_token_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
+```

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -39,6 +39,7 @@ class EngineCore:
         last_token_event: RuntimeTokenEvent | None = None
         last_finish_reason = ""
         turn_boundary_stop_reason = ""
+        accept_stream_fragment = assembler.accept
 
         try:
             template_kwargs = self._chat_template_kwargs(request)
@@ -81,7 +82,7 @@ class EngineCore:
                         turn_boundary_stop_reason = "stop_sequence"
                 if track_usage:
                     last_token_event = runtime_event
-                for delta in assembler.accept(
+                for delta in accept_stream_fragment(
                     StreamFragment(text=runtime_event.text, raw_text=runtime_event.raw_text)
                 ):
                     if delta.reasoning_text:


### PR DESCRIPTION
## Summary
- Bind `RequestStreamAssembler.accept` once per generate request in `EngineCore.generate`.
- Avoid repeated bound-method lookup work in the per-runtime-token event emission path.
- Preserve event order, sequence allocation, usage accounting, and completion payloads.

## Plan or Spec
- `docs/plans/2026-05-09-engine-core-assembler-accept-binding.md`
- Registered PR-scoped probe: `engine-generate-usage-token-elision`.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_generate_stream.py::test_generate_without_usage_skips_prompt_token_count_fallback services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_reuses_sampling_when_stop_sequences_match services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_clones_when_stop_sequences_change services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_reuses_runtime_event_prompt_tokens_without_fallback_count services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_counts_prompt_tokens_only_for_missing_event_total services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_request_token_accumulation services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_usage_preserves_finish_reason services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion services/mlx-worker-python/tests/test_generate_stream.py::test_generate_stream_exports_stop_contract_metrics_and_stops_at_turn_boundary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics
12 passed in 1.33s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused test list> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/engine_core.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/engine_generate_usage_token_probe.py
12 passed in 0.60s
TOTAL 2 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
{"elapsed_ms_mean": 20.389195811003447, "elapsed_ms_min": 19.06564098317176, "prompt_token_count_calls_mean": 0.0, "prompt_token_count_calls_per_request": 0.0, "prompt_words": 4096, "request_count": 300, "request_state_append_calls_mean": 0.0, "request_state_append_calls_per_request": 0.0, "samples": 5, "token_events_mean": 300.0}

$ # local origin/main vs branch registered-probe comparison
{"delta_ms": -0.7442786358296871, "new_mean": 18.75539675820619, "new_min": 18.399951979517937, "old_mean": 19.499675394035876, "old_min": 18.938121967948973, "prompt_token_count_calls_per_request": 0.0, "speedup": 1.0396834386083589}

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%` for the touched engine-core lines.
- Registered local probe (`engine-generate-usage-token-elision`): `elapsed_ms_mean=20.389195811003447`, `elapsed_ms_min=19.06564098317176`, `prompt_token_count_calls_per_request=0.0`, `request_state_append_calls_per_request=0.0`.
- Local origin/main comparison over the same registered probe workload: `old_mean=19.499675394035876ms`, `new_mean=18.75539675820619ms`, `delta_ms=-0.7442786358296871`, `speedup=1.0396834386083589x`.
- CI PR-scoped performance report is required as the final registered probe validation before merge.

## Known Gaps
- None. This is a Python-only engine slice and was locally validated on Linux; CI remains the merge gate for the registered PR-scoped probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
