### PR TITLE
perf: scan engine usage fallback tokens

### DIFF
--- a/docs/plans/2026-05-07-engine-generate-usage-token-elision.md
+++ b/docs/plans/2026-05-07-engine-generate-usage-token-elision.md
@@ -6,7 +6,7 @@ Avoid redundant prompt-token accounting work for `EngineCore.generate(...)` requ
 
 ## Current Slice
 
-The original prompt-token-count elision is already present on current `origin/main` (`prompt_token_count_calls_per_request=0.0`). This scheduled follow-up keeps that behavior and moves the lazy fallback calculation inline so `return_usage=false` requests do not allocate the unused fallback closure.
+The original prompt-token-count elision is already present on current `origin/main` (`prompt_token_count_calls_per_request=0.0`). This scheduled follow-up keeps that behavior and replaces the fallback `len(prompt.split())` usage-token calculation with a single-pass whitespace scanner for runtimes that do not expose `prompt_token_count(...)`. That preserves `str.split(None)` token semantics while avoiding temporary token-list materialization for large rendered prompts.
 
 ## Linux-only constraint
 
@@ -28,10 +28,12 @@ The probe runs many `return_usage=false` generate requests through a counting ru
 
 - `prompt_token_count_calls_per_request` — should remain zero for no-usage requests.
 - `elapsed_ms_mean` — lower is better for the same synthetic no-usage workload.
+- `fallback_elapsed_ms_mean` — lower is better for return-usage fallback requests on runtimes without a prompt-token helper.
+- `fallback_peak_bytes_mean` — lower is better and should drop when fallback token counting no longer materializes a split list.
 
 ## Success metrics
 
 - Focused generate tests pass.
 - Changed executable line coverage for touched Python scope is at least 95%.
-- Local probe reports `prompt_token_count_calls_per_request=0` on the optimized branch.
-- Detached `origin/main` vs head PR-scoped probe comparison shows lower `elapsed_ms_mean` with identical structural guard rails.
+- Local probe reports `prompt_token_count_calls_per_request=0` on the optimized branch and lower fallback peak bytes than the detached `origin/main` baseline.
+- Detached `origin/main` vs head PR-scoped probe comparison shows lower `fallback_peak_bytes_mean` with identical structural guard rails.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3259,8 +3259,21 @@
         "key": "elapsed_ms_mean",
         "unit": "ms",
         "direction": "informational"
+      },
+      {
+        "key": "fallback_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "fallback_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
       }
-    ]
+    ],
+    "description": "Avoid prompt-token work when usage is disabled and scan fallback prompt tokens without split-list materialization."
   },
   {
     "id": "vision-family-prompt-token-count-scan",

--- a/scripts/engine_generate_usage_token_probe.py
+++ b/scripts/engine_generate_usage_token_probe.py
@@ -5,6 +5,7 @@ import os
 import statistics
 import sys
 import time
+import tracemalloc
 from pathlib import Path
 
 repo_root_env = os.environ.get("MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT")
@@ -13,10 +14,10 @@ sys.path.insert(0, str(repo_root))
 sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
 
 from packages.protocol.python.worker.v1 import common_pb2, inference_pb2, runtime_pb2
+from worker.engine.request_state import RequestState
 from worker.grpc_server import WorkerInferenceService, WorkerRuntimeService
 from worker.model_registry.catalog import WorkerModelCatalog
 from worker.registry import WorkerRegistry
-from worker.engine.request_state import RequestState
 from worker.runtime.mlx_text_runtime import RuntimeTokenEvent
 
 
@@ -55,7 +56,52 @@ class CountingRuntime:
         yield RuntimeTokenEvent(text="ok", prompt_tokens=0, completion_tokens=1, finish_reason="stop")
 
 
-def _build_request(model_handle: str, *, request_index: int) -> inference_pb2.GenerateRequest:
+class FallbackRuntime:
+    runtime_name = "probe-fallback-runtime"
+
+    def __init__(self, *, prompt_words: int) -> None:
+        self.prompt_words = prompt_words
+
+    def load_model(self, model_spec):
+        return {"model_id": model_spec.model_id}
+
+    def estimate_resident_bytes(self, model_spec):
+        _ = model_spec
+        return 0
+
+    def render_prompt(self, messages, loaded_model=None, template_kwargs=None, execution_ext=None):
+        _ = messages
+        _ = loaded_model
+        _ = template_kwargs
+        _ = execution_ext
+        # Include mixed whitespace so fallback behavior matches str.split(None).
+        words = ("probe" for _ in range(self.prompt_words))
+        return "\n\t ".join(words)
+
+    def generate_tokens(self, loaded_model, prompt, sampling, cancel_event, execution_ext=None):
+        _ = loaded_model
+        _ = prompt
+        _ = sampling
+        _ = cancel_event
+        _ = execution_ext
+        yield RuntimeTokenEvent(text="ok", prompt_tokens=0, completion_tokens=1, finish_reason="stop")
+
+
+def _load_services(runtime) -> tuple[WorkerInferenceService, str]:
+    registry = WorkerRegistry(
+        runtime=runtime,  # type: ignore[arg-type]
+        model_catalog=WorkerModelCatalog(environment={}),
+    )
+    runtime_service = WorkerRuntimeService(registry)
+    inference_service = WorkerInferenceService(registry)
+    load_response = runtime_service.LoadModel(
+        runtime_pb2.LoadModelRequest(model=WorkerModelCatalog.dev_text_model()),
+        context=None,
+    )
+    return inference_service, load_response.model_handle
+
+
+def _build_request(model_handle: str, *, request_index: int, return_usage: bool) -> inference_pb2.GenerateRequest:
     return inference_pb2.GenerateRequest(
         execution=inference_pb2.ExecutionMetadata(
             id=common_pb2.RequestIdentity(request_id=f"probe-generate-{request_index}"),
@@ -64,59 +110,97 @@ def _build_request(model_handle: str, *, request_index: int) -> inference_pb2.Ge
         messages=[
             common_pb2.ChatMessage(
                 role="user",
-                parts=[common_pb2.MessagePart(text="skip usage accounting")],
+                parts=[common_pb2.MessagePart(text="usage accounting probe")],
             )
         ],
         sampling=common_pb2.SamplingConfig(max_output_tokens=4),
         stream=True,
-        return_usage=False,
+        return_usage=return_usage,
     )
+
+
+def _run_no_usage_sample(*, request_count: int, prompt_words: int, sample: int) -> tuple[float, int, int, int]:
+    runtime = CountingRuntime(prompt_words=prompt_words)
+    inference_service, model_handle = _load_services(runtime)
+    token_count = 0
+    append_count = 0
+    original_append_token = RequestState.append_token
+
+    def counting_append_token(self: RequestState, token: str) -> None:
+        nonlocal append_count
+        append_count += 1  # pragma: no cover - exercised by base-version probe comparison
+        original_append_token(self, token)  # pragma: no cover - exercised by base-version probe comparison
+
+    RequestState.append_token = counting_append_token
+    start = time.perf_counter()
+    try:
+        for request_index in range(request_count):
+            request = _build_request(
+                model_handle,
+                request_index=sample * request_count + request_index,
+                return_usage=False,
+            )
+            events = list(inference_service.Generate(request, context=None))
+            token_count += sum(1 for event in events if event.HasField("token_delta"))
+    finally:
+        RequestState.append_token = original_append_token
+    return (time.perf_counter() - start) * 1000.0, runtime.prompt_token_count_calls, append_count, token_count
+
+
+def _run_fallback_sample(*, request_count: int, prompt_words: int, sample: int) -> tuple[float, float, int]:
+    runtime = FallbackRuntime(prompt_words=prompt_words)
+    inference_service, model_handle = _load_services(runtime)
+    prompt_tokens = 0
+    tracemalloc.start()
+    start = time.perf_counter()
+    try:
+        for request_index in range(request_count):
+            request = _build_request(
+                model_handle,
+                request_index=sample * request_count + request_index,
+                return_usage=True,
+            )
+            events = list(inference_service.Generate(request, context=None))
+            usage = next(event.usage_delta for event in events if event.HasField("usage_delta"))
+            prompt_tokens = int(usage.prompt_tokens)
+    finally:
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+    if prompt_tokens != prompt_words:
+        raise SystemExit(f"unexpected fallback prompt tokens: {prompt_tokens} != {prompt_words}")  # pragma: no cover
+    return (time.perf_counter() - start) * 1000.0, float(peak), prompt_tokens
 
 
 def run_probe() -> dict[str, float | int | str]:
     request_count = int(os.environ.get("MELIX_ENGINE_GENERATE_USAGE_PROBE_REQUESTS", "300"))
+    fallback_request_count = int(os.environ.get("MELIX_ENGINE_GENERATE_FALLBACK_PROBE_REQUESTS", "60"))
     samples = int(os.environ.get("MELIX_ENGINE_GENERATE_USAGE_PROBE_SAMPLES", "5"))
     prompt_words = int(os.environ.get("MELIX_ENGINE_GENERATE_USAGE_PROBE_PROMPT_WORDS", "4096"))
     elapsed_ms: list[float] = []
     call_counts: list[int] = []
     append_counts: list[int] = []
     token_events: list[int] = []
+    fallback_elapsed_ms: list[float] = []
+    fallback_peak_bytes: list[float] = []
 
     for sample in range(samples):
-        runtime = CountingRuntime(prompt_words=prompt_words)
-        registry = WorkerRegistry(
-            runtime=runtime,  # type: ignore[arg-type]
-            model_catalog=WorkerModelCatalog(environment={}),
+        elapsed, calls, appends, tokens = _run_no_usage_sample(
+            request_count=request_count,
+            prompt_words=prompt_words,
+            sample=sample,
         )
-        runtime_service = WorkerRuntimeService(registry)
-        inference_service = WorkerInferenceService(registry)
-        load_response = runtime_service.LoadModel(
-            runtime_pb2.LoadModelRequest(model=WorkerModelCatalog.dev_text_model()),
-            context=None,
+        elapsed_ms.append(elapsed)
+        call_counts.append(calls)
+        append_counts.append(appends)
+        token_events.append(tokens)
+
+        fallback_elapsed, fallback_peak, _ = _run_fallback_sample(
+            request_count=fallback_request_count,
+            prompt_words=prompt_words,
+            sample=sample,
         )
-
-        token_count = 0
-        append_count = 0
-        original_append_token = RequestState.append_token
-
-        def counting_append_token(self: RequestState, token: str) -> None:
-            nonlocal append_count
-            append_count += 1  # pragma: no cover - exercised by base-version probe comparison
-            original_append_token(self, token)  # pragma: no cover - exercised by base-version probe comparison
-
-        RequestState.append_token = counting_append_token
-        start = time.perf_counter()
-        try:
-            for request_index in range(request_count):
-                request = _build_request(load_response.model_handle, request_index=sample * request_count + request_index)
-                events = list(inference_service.Generate(request, context=None))
-                token_count += sum(1 for event in events if event.HasField("token_delta"))
-        finally:
-            RequestState.append_token = original_append_token
-        elapsed_ms.append((time.perf_counter() - start) * 1000.0)
-        call_counts.append(runtime.prompt_token_count_calls)
-        append_counts.append(append_count)
-        token_events.append(token_count)
+        fallback_elapsed_ms.append(fallback_elapsed)
+        fallback_peak_bytes.append(fallback_peak)
 
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_ms),
@@ -126,6 +210,9 @@ def run_probe() -> dict[str, float | int | str]:
         "request_state_append_calls_mean": statistics.fmean(append_counts),
         "request_state_append_calls_per_request": statistics.fmean(append_counts) / request_count,
         "token_events_mean": statistics.fmean(token_events),
+        "fallback_elapsed_ms_mean": statistics.fmean(fallback_elapsed_ms),
+        "fallback_peak_bytes_mean": statistics.fmean(fallback_peak_bytes),
+        "fallback_request_count": fallback_request_count,
         "request_count": request_count,
         "samples": samples,
         "prompt_words": prompt_words,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -4152,6 +4152,7 @@ def test_engine_generate_usage_token_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setenv("MELIX_ENGINE_GENERATE_USAGE_PROBE_REQUESTS", "3")
+    monkeypatch.setenv("MELIX_ENGINE_GENERATE_FALLBACK_PROBE_REQUESTS", "2")
     monkeypatch.setenv("MELIX_ENGINE_GENERATE_USAGE_PROBE_SAMPLES", "2")
     monkeypatch.setenv("MELIX_ENGINE_GENERATE_USAGE_PROBE_PROMPT_WORDS", "32")
 
@@ -4168,6 +4169,9 @@ def test_engine_generate_usage_token_probe_script_emits_metrics(
     assert metrics["request_state_append_calls_mean"] == 0
     assert metrics["request_state_append_calls_per_request"] == 0
     assert metrics["token_events_mean"] == 3
+    assert metrics["fallback_request_count"] == 2
+    assert metrics["fallback_elapsed_ms_mean"] > 0
+    assert metrics["fallback_peak_bytes_mean"] > 0
 
 
 def test_scope_report_tracks_direct_matches_separately_when_force_all(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -3,6 +3,18 @@ from __future__ import annotations
 from collections.abc import Iterator
 import json
 
+
+def _whitespace_token_count(text: str) -> int:
+    token_count = 0
+    in_token = False
+    for character in text:
+        if character.isspace():
+            in_token = False
+        elif not in_token:
+            token_count += 1
+            in_token = True
+    return token_count
+
 from packages.protocol.python.worker.v1 import common_pb2, inference_pb2
 
 from worker.registry import WorkerRegistry
@@ -132,7 +144,7 @@ class EngineCore:
                         prompt_tokens_default = (
                             runtime.prompt_token_count(prompt)
                             if hasattr(runtime, "prompt_token_count")
-                            else len(prompt.split())
+                            else _whitespace_token_count(prompt)
                         )
                     prompt_tokens = prompt_tokens_default
                 if last_token_event is not None:


### PR DESCRIPTION
## Summary
- Replace the EngineCore usage fallback `len(prompt.split())` path with a single-pass whitespace token scanner for runtimes without `prompt_token_count(...)`.
- Extend the registered `engine-generate-usage-token-elision` PR-scoped probe with fallback elapsed/peak-memory metrics while preserving the existing no-usage guard rails.

## Plan or Spec
- `docs/plans/2026-05-07-engine-generate-usage-token-elision.md`

## Commands Run
```text
bash /tmp/engine_test_cmd.sh
# 12 passed in 0.35s

bash /tmp/engine_cov_cmd.sh
# 12 passed in 0.63s
# changed-scope coverage: TOTAL 89 0 100%

bash /tmp/engine_probe_cmd.sh
# {"elapsed_ms_mean": 20.648074778728187, "fallback_elapsed_ms_mean": 248.78822499886155, "fallback_peak_bytes_mean": 73278.0, "prompt_token_count_calls_per_request": 0.0, ...}
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 89 0 100%`).
- Registered local probe (`engine-generate-usage-token-elision`, head):
  - `prompt_token_count_calls_per_request=0.0`
  - `request_state_append_calls_per_request=0.0`
  - `elapsed_ms_mean=20.648074778728187`
  - `fallback_elapsed_ms_mean=248.78822499886155`
  - `fallback_peak_bytes_mean=73278.0`
- Detached `origin/main` baseline using the same updated harness:
  - `fallback_elapsed_ms_mean=776.5043816063553`
  - `fallback_peak_bytes_mean=261754.6`
- Delta: fallback elapsed `-531.2341395998374 ms`; fallback peak bytes `-189783.2` (~3.64x lower peak memory).
- CI PR-scoped performance workflow is required for final registered probe validation before merge.

## Known Gaps
- Local verification is Linux/Python-only; no Swift runtime effect is involved in this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
