### PR TITLE
perf: streamline multimodal local image URI reads

### DIFF
--- a/docs/plans/2026-05-09-multimodal-image-uri-local-parse-fast-path.md
+++ b/docs/plans/2026-05-09-multimodal-image-uri-local-parse-fast-path.md
@@ -1,0 +1,33 @@
+# Multimodal Image URI Local Parse Fast Path
+
+## Scope
+
+This Python-only performance slice keeps behavior unchanged while reducing per-image overhead in `services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `multimodal-preprocessing-image-uri-single-parse` in `infra/perf/pr_scoped_probes.json`.
+
+Focused commands:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_accepts_remote_http_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_remote_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_missing_remote_and_unsupported_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_image_uri_parse_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_accepts_remote_http_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_remote_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_missing_remote_and_unsupported_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_image_uri_parse_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/multimodal_image_uri_parse_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/multimodal_image_uri_parse_probe.py
+```
+
+## Implementation Plan
+
+- Avoid scanning for `/` when an image reference has no `:` and is therefore a plain local path.
+- Reuse a module-level empty `ParseResult` for local image references rather than allocating an equivalent object for each local path.
+- Store parsed image-reference records in a slotted dataclass to avoid per-reference instance dictionaries.
+- Read local image references directly from the parsed `Path` in `_bytes_from_image_uri`, preserving the missing-file error while avoiding a separate `Path.exists()` stat on the valid hot path.
+- Keep remote `http`/`https` and `file://` parsing behavior unchanged.
+
+## Success Metrics
+
+- Focused tests pass.
+- Changed-scope coverage is at least 95%.
+- Local registered probe reports lower `elapsed_ms_mean` with unchanged `urlparse_calls_mean` for the synthetic mixed local-path/file-URI workload.

--- a/services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py
@@ -13,6 +13,9 @@ from urllib.request import urlopen
 from worker.runtime.video_preprocessing import PreparedVideoInput, prepare_video_input
 
 
+_LOCAL_IMAGE_PARSE = ParseResult("", "", "", "", "", "")
+
+
 class MultimodalPreprocessError(ValueError):
     pass
 
@@ -46,7 +49,7 @@ class PreparedVideoFramePolicy:
     clip_duration_ms: int
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ParsedImageReference:
     raw: str
     parsed: ParseResult
@@ -198,12 +201,22 @@ def _cached_image_uri_payload(
 
 def _parse_image_reference(uri: str) -> ParsedImageReference:
     colon_index = uri.find(":")
-    slash_index = uri.find("/")
-    if colon_index == -1 or (slash_index != -1 and slash_index < colon_index):
+    if colon_index == -1:
         path = Path(uri)
         return ParsedImageReference(
             raw=uri,
-            parsed=ParseResult("", "", uri, "", "", ""),
+            parsed=_LOCAL_IMAGE_PARSE,
+            decoded_path=uri,
+            path=path,
+            filename=path.name,
+            format=path.suffix.lstrip("."),
+        )
+    slash_index = uri.find("/")
+    if slash_index != -1 and slash_index < colon_index:
+        path = Path(uri)
+        return ParsedImageReference(
+            raw=uri,
+            parsed=_LOCAL_IMAGE_PARSE,
             decoded_path=uri,
             path=path,
             filename=path.name,
@@ -240,9 +253,13 @@ def _path_from_uri(uri: str | ParsedImageReference) -> Path:
 def _bytes_from_image_uri(uri: str) -> tuple[bytes, str, str, str, str]:
     reference = _parse_image_reference(uri)
     if reference.parsed.scheme in {"", "file"}:
-        path = _path_from_uri(reference)
+        path = reference.path
+        try:
+            bytes_data = path.read_bytes()
+        except FileNotFoundError as exc:
+            raise MultimodalPreprocessError(f"Missing local image input: {reference.raw}") from exc
         return (
-            path.read_bytes(),
+            bytes_data,
             reference.raw,
             "",
             reference.format,


### PR DESCRIPTION
## Summary
- Streamlines local image URI preprocessing by using a shared empty parse result and a slotted parsed-reference record.
- Avoids the extra `Path.exists()` stat before valid local image reads while preserving the missing-file `MultimodalPreprocessError` path.

## Plan or Spec
- `docs/plans/2026-05-09-multimodal-image-uri-local-parse-fast-path.md`
- Registered PR-scoped probe: `multimodal-preprocessing-image-uri-single-parse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline from detached origin/main (411e4f9d144143d6443b7a32652ab06e87213365)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/multimodal_image_uri_parse_probe.py
# 58.58154559973627 ms, urlparse_calls_mean=320.0
# 64.44303579628468 ms, urlparse_calls_mean=320.0
# 59.54678920097649 ms, urlparse_calls_mean=320.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_accepts_remote_http_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_remote_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_missing_remote_and_unsupported_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_image_uri_parse_probe_script_emits_metrics
# 7 passed in 0.76s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_accepts_remote_http_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_remote_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_missing_remote_and_unsupported_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_image_uri_parse_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/multimodal_image_uri_parse_probe.py
# 7 passed in 1.68s; TOTAL 11 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/multimodal_image_uri_parse_probe.py
# 58.113868022337556 ms, peak_bytes_mean=358192.4, urlparse_calls_mean=320.0
# 58.95468059461564 ms, peak_bytes_mean=358192.4, urlparse_calls_mean=320.0
# 53.07276521343738 ms, peak_bytes_mean=358192.4, urlparse_calls_mean=320.0
# 56.68928916566074 ms, peak_bytes_mean=358192.4, urlparse_calls_mean=320.0
# 55.60001018457115 ms, peak_bytes_mean=358192.4, urlparse_calls_mean=320.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 11 0 100%`).
- Local registered probe comparison:
  - `old_mean=60.857124 ms`
  - `new_mean=56.486123 ms`
  - `delta_ms=-4.371001 ms`
  - `speedup=7.18%`
  - `urlparse_calls_mean` remained `320.0`.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime behavior is touched.
- CI must run and pass the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
