### PR TITLE
perf: reuse code fence count during extraction

### DIFF
--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -50,13 +50,18 @@ def extract_candidate_code(raw_response: str) -> tuple[str, str]:
         opening = normalized.rfind("```", 0, closing)
         if opening >= 0:
             trailing = normalized[closing + 3 :]
-            if trailing.strip() and normalized.count("```") % 2:
-                closing = opening
-                opening = normalized.rfind("```", 0, closing)
+            fence_count: int | None = None
+            if trailing.strip():
+                fence_count = normalized.count("```")
+                if fence_count % 2:
+                    closing = opening
+                    opening = normalized.rfind("```", 0, closing)
             if opening >= 0:
                 content_start = _code_block_content_start(normalized, opening + 3)
                 candidate = normalized[content_start:closing].strip()
-                if candidate or normalized.count("```") % 2 == 0:
+                if candidate or (
+                    fence_count if fence_count is not None else normalized.count("```")
+                ) % 2 == 0:
                     return candidate, "parsed_code_block"
                 closing = opening
                 opening = normalized.rfind("```", 0, closing)


### PR DESCRIPTION
## Summary
- Reuses the computed Markdown fence count while extracting the last code block from code-evaluation responses with trailing prose.
- Keeps the existing last-block parsing behavior and avoids an extra full-string fence scan on the trailing-prose path.

## Plan or Spec
- Governing plan: `docs/plans/2026-05-06-code-eval-code-block-memory-plan.md`.
- Registered PR-scoped probe: `code-eval-code-block-last-match-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe on origin/main before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py
{"block_count": 2500.0, "elapsed_ms_mean": 0.01472060102969408, "extracted_chars_mean": 37.0, "peak_bytes_mean": 245.0, "sample_count": 7.0}

# Focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
4 passed in 0.08s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
4 passed in 0.17s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
Wrote JSON report to coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py
TOTAL 7 0 100%

# Candidate probe after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py
{"block_count": 2500.0, "elapsed_ms_mean": 0.011524418368935585, "extracted_chars_mean": 37.0, "peak_bytes_mean": 245.0, "sample_count": 7.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Registered local probe (`code-eval-code-block-last-match-streaming`): old_mean=`0.01472060102969408ms`, new_mean=`0.011524418368935585ms`, delta=`-0.003196182660758495ms`, speedup=`1.28x`; peak bytes unchanged at `245.0`.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local Linux evidence covers the Python registered probe only; no Swift runtime effect is claimed.
- The probe is intentionally tiny in absolute milliseconds, so CI variance may be proportionally large.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
