### PR TITLE
perf: bind worker registry summary builder

### DIFF
--- a/docs/plans/2026-05-10-worker-registry-summary-list-elision.md
+++ b/docs/plans/2026-05-10-worker-registry-summary-list-elision.md
@@ -1,0 +1,33 @@
+# Worker registry loaded summary builder lookup elision
+
+## Goal
+
+Reduce repeated bound-method lookup overhead in the loaded-model listing hot path by binding the summary protobuf builder once per listing call.
+
+## Linux-only constraint
+
+This is a Python worker slice. It is locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered worker registry PR-scoped performance probe. No Swift runtime effect is claimed for this slice.
+
+## Registered probe
+
+Existing registered probe: `worker-registry-resident-bytes-accumulator` in `infra/perf/pr_scoped_probes.json`.
+
+The probe already covers this path through repeated `list_loaded_models()` and `list_loaded_model_summaries()` calls against a 2,000-model synthetic registry and reports:
+
+- `loaded_model_listing_elapsed_ms_mean` — lower is better.
+- `loaded_model_listing_sort_calls_mean` — lower is better / regression guard for sorted-handle cache reuse.
+
+The probe has focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Implementation approach
+
+- Keep sorted handle caching and the `LoadedModel` snapshot unchanged.
+- Bind `self._loaded_model_summary` to a local variable before constructing summary protobufs.
+- Do not change handle ordering, registry mutation semantics, protobuf fields, or resident-byte accounting.
+
+## Verification commands
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...focused worker registry tests...`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...focused tests... && coverage json ... && python3 scripts/changed_scope_coverage.py ...`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/worker_registry_resident_probe.py`
+- `git diff --check`

--- a/services/mlx-worker-python/worker/registry.py
+++ b/services/mlx-worker-python/worker/registry.py
@@ -361,7 +361,8 @@ class WorkerRegistry:
             loaded_models = [
                 self._loaded_models[handle] for handle in self._sorted_loaded_model_handles_locked()
             ]
-        return [self._loaded_model_summary(loaded) for loaded in loaded_models]
+        build_summary = self._loaded_model_summary
+        return [build_summary(loaded) for loaded in loaded_models]
 
     def start_request(self, request_id: str, runtime_kind: str = "text") -> RequestState:
         state = RequestState(request_id=request_id, runtime_kind=runtime_kind)


### PR DESCRIPTION
## Summary
- Bind `WorkerRegistry._loaded_model_summary` once per `list_loaded_model_summaries()` call to reduce repeated bound-method lookup overhead in the loaded-model listing hot path.
- Keep sorted-handle cache reuse, loaded-model snapshot semantics, protobuf summary fields, and resident-byte accounting unchanged.

## Plan or Spec
- `docs/plans/2026-05-10-worker-registry-summary-list-elision.md`

## Commands Run
```text
# Identity preflight before GitHub CLI actions
GH_CONFIG_DIR=/root/.hermes/profiles/coder/gh-config gh auth status
GH_CONFIG_DIR=/root/.hermes/profiles/coder/gh-config gh api user --jq .login
# login: Zigfreidish

# Focused behavior tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_runtime_edges.py::test_worker_registry_reuses_sorted_handles_across_listing_calls \
  services/mlx-worker-python/tests/test_runtime_service.py::test_load_model_returns_handle_and_lists_model \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_worker_registry_probe_script_emits_metrics
# 3 passed in 8.29s

# Registered probe head verification / changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...worker-registry registered probe selection...
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/registry.py \
  services/mlx-worker-python/tests/test_runtime_edges.py \
  services/mlx-worker-python/tests/test_runtime_service.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/worker_registry_resident_probe.py
# 12 passed; TOTAL 2 changed lines, 0 missed, 100% changed-line coverage

# Registered PR-scoped probe, base vs head
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py \
  --registry infra/perf/pr_scoped_probes.json \
  --probe-id worker-registry-resident-bytes-accumulator \
  --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-registry-summary-list-elision-20260510025253 \
  --head-repo "$PWD" \
  --output /tmp/worker-registry-summary-bind-report.json
# ok=true for head verification, base probe, and head probe

# Additional repeated local registered-probe samples for stability
# 4 base/head paired runs averaged with python3:
# loaded_model_listing_elapsed_ms_mean: base=8.882137 ms, head=8.502390 ms, delta=-0.379747 ms (-4.275%)
# elapsed_ms_mean: base=0.026387 ms, head=0.028240 ms, delta=+0.001853 ms (+7.021%; unrelated load/unload slice noise)
# request_stats_elapsed_ms_mean: base=0.013999 ms, head=0.014291 ms, delta=+0.000292 ms (+2.090%; unrelated runtime_stats slice noise)

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`services/mlx-worker-python/worker/registry.py` changed lines 364-365 covered).
- Registered probe: `worker-registry-resident-bytes-accumulator`.
- Primary affected metric over four paired local runs: `loaded_model_listing_elapsed_ms_mean` improved from `8.882137 ms` to `8.502390 ms` (`-0.379747 ms`, `-4.275%`).
- The registered probe remains somewhat noisy for unrelated metrics in the same probe; the affected loaded-model listing metric is the decision metric for this slice.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local verification ran on Linux only; this is a Python worker slice and does not claim Swift/macOS runtime effects.
- Waiting for GitHub Actions and the registered PR-scoped performance workflow to provide CI validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
