### PR TITLE
perf: fast-path sparse worker model specs

### DIFF
--- a/docs/plans/2026-05-10-worker-registry-sparse-model-spec-fast-path.md
+++ b/docs/plans/2026-05-10-worker-registry-sparse-model-spec-fast-path.md
@@ -1,0 +1,40 @@
+# Worker Registry Sparse Model Spec Fast Path
+
+## Context
+
+`WorkerRegistry.load_model` resolves every requested `ModelSpec` through
+`_is_sparse_model_request` before deciding whether to replace a sparse request
+with the catalog entry. The PR-scoped worker registry probe exercises this path
+inside a preloaded model churn loop, so the sparse check should avoid generic
+protobuf field enumeration when possible.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped probe
+`worker-registry-resident-bytes-accumulator` in
+`infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes:
+
+- `watch_globs` covering `services/mlx-worker-python/worker/registry.py`, the
+  focused runtime-edge tests, the PR-scoped performance tests, and
+  `scripts/worker_registry_resident_probe.py`.
+- `test_command` for worker registry sparse request, resident-byte, sorted
+  listing, request-counter, runtime-service, and probe-selection tests.
+- `coverage_command` for the changed worker registry scope.
+- `probe_command` via `scripts/worker_registry_resident_probe.py` reporting
+  model load/unload latency, listing latency, sort calls, request stats latency,
+  and resident bytes.
+
+## Slice
+
+Replace the sparse `ModelSpec` check's `ListFields()` allocation with direct
+field-default checks for the known `ModelSpec` fields. Preserve the existing
+semantics: an empty spec or `model_id`-only spec is sparse; any other populated
+field makes the request non-sparse.
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and
+registered probe locally on Linux. Compare the probe against an `origin/main`
+baseline worktree before accepting the slice.

--- a/services/mlx-worker-python/tests/test_runtime_edges.py
+++ b/services/mlx-worker-python/tests/test_runtime_edges.py
@@ -192,6 +192,35 @@ def test_worker_registry_sparse_model_request_fast_path_preserves_semantics() ->
     assert WorkerRegistry._is_sparse_model_request(full) is False
     assert WorkerRegistry._is_sparse_model_request(with_path) is False
 
+    non_sparse_variants = [
+        common_pb2.ModelSpec(model_id="melix-dev-text", model_kind="text"),
+        common_pb2.ModelSpec(model_id="melix-dev-text", revision="main"),
+        common_pb2.ModelSpec(model_id="melix-dev-text", tokenizer_hash="tok"),
+        common_pb2.ModelSpec(model_id="melix-dev-text", quant_profile_id="q4"),
+        common_pb2.ModelSpec(model_id="melix-dev-text", parser_mode="json"),
+        common_pb2.ModelSpec(model_id="melix-dev-text", reasoning_mode="off"),
+        common_pb2.ModelSpec(model_id="melix-dev-text", max_context=4096),
+        common_pb2.ModelSpec(model_id="melix-dev-text", ext={"k": "v"}),
+        common_pb2.ModelSpec(
+            model_id="melix-dev-text",
+            capability_class=common_pb2.MODEL_CAPABILITY_TEXT,
+        ),
+        common_pb2.ModelSpec(
+            model_id="melix-dev-text",
+            route_class=common_pb2.WORKER_ROUTE_SWIFT_TEXT,
+        ),
+        common_pb2.ModelSpec(
+            model_id="melix-dev-text",
+            settings=common_pb2.ModelSettings(pin_on_load=True),
+        ),
+        common_pb2.ModelSpec(model_id="melix-dev-text", features=["chat"]),
+        common_pb2.ModelSpec(
+            model_id="melix-dev-text",
+            runtime_mode=common_pb2.RUNTIME_MODE_FUSED_DERIVED_MODEL,
+        ),
+    ]
+    assert all(not WorkerRegistry._is_sparse_model_request(variant) for variant in non_sparse_variants)
+
     registry = build_registry()
     loaded = registry.load_model(sparse)
 

--- a/services/mlx-worker-python/worker/registry.py
+++ b/services/mlx-worker-python/worker/registry.py
@@ -276,10 +276,22 @@ class WorkerRegistry:
 
     @staticmethod
     def _is_sparse_model_request(model_spec: common_pb2.ModelSpec) -> bool:
-        populated_fields = model_spec.ListFields()
-        if not populated_fields:
-            return True
-        return len(populated_fields) == 1 and populated_fields[0][0].name == "model_id"
+        return not (
+            model_spec.model_path
+            or model_spec.model_kind
+            or model_spec.revision
+            or model_spec.tokenizer_hash
+            or model_spec.quant_profile_id
+            or model_spec.parser_mode
+            or model_spec.reasoning_mode
+            or model_spec.max_context
+            or model_spec.ext
+            or model_spec.capability_class != common_pb2.MODEL_CAPABILITY_CLASS_UNSPECIFIED
+            or model_spec.route_class != common_pb2.WORKER_ROUTE_CLASS_UNSPECIFIED
+            or model_spec.HasField("settings")
+            or model_spec.features
+            or model_spec.runtime_mode != common_pb2.RUNTIME_MODE_UNSPECIFIED
+        )
 
     def unload_model(self, handle: str) -> bool:
         with self._lock:


### PR DESCRIPTION
## Summary
- Fast-path `WorkerRegistry._is_sparse_model_request` by checking the known `ModelSpec` defaults directly instead of allocating `ListFields()` on every model load.
- Expand sparse-model regression coverage so every non-`model_id` field remains non-sparse.
- Add a focused plan for the worker registry sparse spec slice.

## Plan or Spec
- `docs/plans/2026-05-10-worker-registry-sparse-model-spec-fast-path.md`
- Registered probe: `worker-registry-resident-bytes-accumulator` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# focused sparse regression
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_edges.py::test_worker_registry_sparse_model_request_fast_path_preserves_semantics
# exit 0: 1 passed in 0.82s

# registered focused test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_edges.py::test_worker_registry_multimodal_request_kind_uses_expected_membership services/mlx-worker-python/tests/test_runtime_edges.py::test_worker_registry_sparse_model_request_fast_path_preserves_semantics services/mlx-worker-python/tests/test_runtime_edges.py::test_registry_capabilities_and_request_lifecycle services/mlx-worker-python/tests/test_runtime_edges.py::test_runtime_stats_request_counters_stay_consistent_without_request_scan services/mlx-worker-python/tests/test_runtime_edges.py::test_worker_registry_avoids_rescanning_loaded_models_for_resident_bytes services/mlx-worker-python/tests/test_runtime_edges.py::test_worker_registry_reuses_sorted_handles_across_listing_calls services/mlx-worker-python/tests/test_runtime_service.py::test_load_model_returns_handle_and_lists_model services/mlx-worker-python/tests/test_runtime_edges.py::test_runtime_service_handles_failures_and_state_transitions services/mlx-worker-python/tests/test_runtime_edges.py::test_runtime_service_rejects_model_loads_that_exceed_process_budget_and_reports_headroom services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_worker_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_worker_registry_probe_script_emits_metrics
# exit 0: 12 passed in 8.52s

# registered changed-scope coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <registered worker-registry test selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/registry.py services/mlx-worker-python/tests/test_runtime_edges.py services/mlx-worker-python/tests/test_runtime_service.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/worker_registry_resident_probe.py
# exit 0: 12 passed in 10.88s; TOTAL 3 0 100%

# registered PR-scoped probe runner
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id worker-registry-resident-bytes-accumulator --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-registry-sparse-spec-fastpath-20260510032558 --head-repo "$PWD" --output /tmp/worker_registry_sparse_pr_probe.json
# exit 0: head verification ok, base probe ok, head probe ok

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for the registered worker registry scope.
- Registered probe runner metrics (`worker-registry-resident-bytes-accumulator`, Linux local):
  - `elapsed_ms_mean`: base `0.026445`, head `0.024655`, delta `-0.001790 ms`, speedup `1.0726x`.
  - `request_stats_elapsed_ms_mean`: base `0.016450`, head `0.014031`, delta `-0.002419 ms`, speedup `1.1724x`.
  - `loaded_model_listing_elapsed_ms_mean`: base `8.436645`, head `8.711473`, delta `+0.274828 ms` (unrelated listing path, within the 5% warn threshold).
  - `loaded_model_listing_sort_calls_mean`: base `1.0`, head `1.0`.
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- Local validation is Linux-only. This is a Python worker slice, so runtime effect is locally measurable on Linux; GitHub Actions remains the authoritative PR gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
