### PR TITLE
perf: bind release gate section threshold checks

### DIFF
--- a/docs/plans/2026-05-10-release-gates-section-threshold-bindings.md
+++ b/docs/plans/2026-05-10-release-gates-section-threshold-bindings.md
@@ -1,0 +1,33 @@
+# Release Gates Section Threshold Binding Performance Slice
+
+## Scope
+
+This Python-only performance slice is limited to
+`services/mlx-worker-python/worker/productization/release_gates.py` and the
+M9 release-gate section metric evaluator used by
+`evaluate_m9_release_evidence`.
+
+## Goal
+
+Keep release-gate failure messages and failure counters unchanged while reducing
+per-rule overhead in `_evaluate_section_metrics_with_counts` by:
+
+- binding repeated lookups (`values.get`, `failures.append`) once per section;
+- reusing the numeric type tuple instead of recreating it for each rule;
+- converting min/max thresholds once before both comparison and failure-message
+  formatting.
+
+## Probe
+
+The affected path is covered by the registered PR-scoped probe
+`release-gates-m9-failure-count-single-pass` in
+`infra/perf/pr_scoped_probes.json`. The probe includes focused
+`test_command`, `coverage_command`, and `probe_command` entries and measures
+`elapsed_ms_mean`, `endswith_checks_mean`, and `failure_count_mean` for a large
+M9 policy workload.
+
+## Verification Plan
+
+Run the registered focused test command, changed-scope coverage command, and
+registered probe locally on Linux before opening the PR. CI remains the source
+of truth for the PR-scoped registered probe report.

--- a/services/mlx-worker-python/worker/productization/release_gates.py
+++ b/services/mlx-worker-python/worker/productization/release_gates.py
@@ -1631,30 +1631,36 @@ def _evaluate_section_metrics_with_counts(
     failures: list[str] = []
     missing_count = 0
     failed_threshold_count = 0
+    values_get = values.get
+    failures_append = failures.append
+    numeric_types = (int, float)
     for name, rule in rules.items():
-        value = values.get(name)
-        display_name = f"{prefix}{name}"
+        value = values_get(name)
         if value is None:
-            failures.append(f"{display_name} is missing")
+            failures_append(f"{prefix}{name} is missing")
             missing_count += 1
             continue
-        if not isinstance(value, (int, float)):
-            failures.append(f"{display_name} must be numeric")
+        if not isinstance(value, numeric_types):
+            failures_append(f"{prefix}{name} must be numeric")
             failed_threshold_count += 1
             continue
         numeric = float(value)
         minimum = rule.get("min")
         maximum = rule.get("max")
-        if minimum is not None and numeric < float(minimum):
-            failures.append(
-                f"{display_name}={numeric:.2f} fell below minimum {float(minimum):.2f}"
-            )
-            failed_threshold_count += 1
-        if maximum is not None and numeric > float(maximum):
-            failures.append(
-                f"{display_name}={numeric:.2f} exceeded maximum {float(maximum):.2f}"
-            )
-            failed_threshold_count += 1
+        if minimum is not None:
+            minimum_float = float(minimum)
+            if numeric < minimum_float:
+                failures_append(
+                    f"{prefix}{name}={numeric:.2f} fell below minimum {minimum_float:.2f}"
+                )
+                failed_threshold_count += 1
+        if maximum is not None:
+            maximum_float = float(maximum)
+            if numeric > maximum_float:
+                failures_append(
+                    f"{prefix}{name}={numeric:.2f} exceeded maximum {maximum_float:.2f}"
+                )
+                failed_threshold_count += 1
     return failures, missing_count, failed_threshold_count
 
 


### PR DESCRIPTION
## Summary
- Bind repeated lookups inside `_evaluate_section_metrics_with_counts` to reduce per-rule overhead in M9 release-gate policy evaluation.
- Convert min/max thresholds once before comparison and failure formatting while preserving existing failure messages and counters.
- Add a scoped plan for the release-gates threshold-binding performance slice.

## Plan or Spec
- `docs/plans/2026-05-10-release-gates-section-threshold-bindings.md`

## Commands Run
```text
# Baseline before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_m9_release_evidence_reuses_section_failure_counts services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_section_metrics_counts_failure_types_without_suffix_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_release_gates_m9_failure_count_probe_script_emits_metrics
# exit 0; 3 passed in 1.19s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/release_gates_m9_failure_count_probe.py
# exit 0; {"elapsed_ms_mean": 8.455704641528428, "endswith_checks_mean": 0.0, "failure_count_mean": 12800.0, "failures_per_section": 80.0, "sample_count": 5.0, "section_count": 160.0}

# Registered focused test/coverage/probe after implementation
python3 - <<'PY' >/tmp/release_probe_cmds.sh
import json
from pathlib import Path
probes=json.loads(Path('infra/perf/pr_scoped_probes.json').read_text())
probe=next(p for p in probes if p['id']=='release-gates-m9-failure-count-single-pass')
print('set -e')
print(probe['test_command'])
print(probe['coverage_command'])
print(probe['probe_command'])
PY
bash /tmp/release_probe_cmds.sh
# exit 0; tests: 6 passed; changed-scope coverage: TOTAL 17 0 100%; probe JSON below
# {"elapsed_ms_mean": 6.385177979245782, "endswith_checks_mean": 0.0, "failure_count_mean": 12800.0, "failures_per_section": 80.0, "sample_count": 5.0, "section_count": 160.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 17 0 100%` from the registered coverage command for `release-gates-m9-failure-count-single-pass`.
- Local registered probe delta on Linux:
  - old `elapsed_ms_mean=8.455704641528428`
  - new `elapsed_ms_mean=6.385177979245782`
  - delta `-2.070526662282646 ms`
  - speedup `1.324x` (~24.49% lower elapsed mean)
  - `endswith_checks_mean=0.0` unchanged
  - `failure_count_mean=12800.0` unchanged
- CI PR-scoped performance workflow is still required as the registered probe validation source for the PR.

## Known Gaps
- Full repository `make` gates were not run locally; this is a Python-only registered-probe slice with focused local verification.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
