### PR TITLE
perf: streamline vision prompt image byte accounting

### DIFF
--- a/docs/plans/2026-05-10-vision-family-byte-length-fast-path.md
+++ b/docs/plans/2026-05-10-vision-family-byte-length-fast-path.md
@@ -1,0 +1,37 @@
+# Vision Family Byte-Length Fast Path
+
+## Scope
+
+This Python-only slice narrows `ResolvedVisionFamilyConfig.prompt_token_count(...)` in
+`services/mlx-worker-python/worker/runtime/vision_family_adapters.py`.
+
+The function already avoids `prompt_text.split()` list materialization for prompt
+tokens. This follow-up keeps the same semantics and removes the per-image
+`PreparedImageInput.byte_length` property call while summing image token costs by
+reading `len(image.bytes_data)` directly in the hot loop.
+
+## Registered probe
+
+The affected path is covered by PR-scoped probe
+`vision-family-prompt-token-count-scan` in `infra/perf/pr_scoped_probes.json`.
+The probe has focused `test_command`, `coverage_command`, and `probe_command`
+entries, and this slice pins the probe runner to `ubuntu-latest` so the
+registered CI report can validate the Python path.
+
+## Verification plan
+
+- Run the registered focused pytest command locally on Linux.
+- Run the registered changed-scope coverage command locally on Linux and require
+  at least 95% for the touched executable scope.
+- Run `scripts/vision_family_prompt_token_count_probe.py` before and after the
+  change and compare `elapsed_ms_mean`, `peak_bytes_mean`, `split_calls_mean`,
+  and `token_count`.
+- Use the PR-scoped performance workflow as the merge gate after push.
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage remains at or above 95%.
+- The local registered probe preserves `split_calls_mean == 0.0` and
+  `token_count == 1309.0`.
+- `elapsed_ms_mean` improves or remains within noise while preserving semantics.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3280,6 +3280,7 @@
     "id": "vision-family-prompt-token-count-scan",
     "name": "Vision family prompt token count scan",
     "description": "Avoid prompt_text.split() list materialization in vision-family prompt token accounting.",
+    "runner": "ubuntu-latest",
     "watch_globs": [
       "services/mlx-worker-python/worker/runtime/vision_family_adapters.py",
       "services/mlx-worker-python/tests/test_vision_runtime.py",

--- a/services/mlx-worker-python/worker/runtime/vision_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/vision_family_adapters.py
@@ -79,7 +79,7 @@ class ResolvedVisionFamilyConfig:
         image_token_divisor = max(1, self.image_token_divisor)
         image_tokens = 0
         for image in prepared_request.images:
-            token_count = image.byte_length // image_token_divisor
+            token_count = len(image.bytes_data) // image_token_divisor
             image_tokens += token_count if token_count > 1 else 1
 
         video_frame_token_cost = max(1, self.video_frame_token_cost)


### PR DESCRIPTION
## Summary
- Streamline vision prompt token image accounting by reading `len(image.bytes_data)` directly in the hot loop instead of routing through the `byte_length` property on every image.
- Pin the existing `vision-family-prompt-token-count-scan` registered probe to `ubuntu-latest` so the PR-scoped CI report validates this Python path.

## Plan or Spec
- `docs/plans/2026-05-10-vision-family-byte-length-fast-path.md`

## Commands Run
```text
# Baseline local probe on origin/main worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/vision_family_prompt_token_count_probe.py
exit 0; {"elapsed_ms_mean": 14.416753563896886, "peak_bytes_mean": 251.42857142857142, "split_calls_mean": 0.0, "token_count": 1309.0}

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_cached_prompt_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics
exit 0; 4 passed in 1.52s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_cached_prompt_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/vision_family_adapters.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/vision_family_prompt_token_count_probe.py
exit 0; TOTAL 1 0 100%

# Head local probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/vision_family_prompt_token_count_probe.py
exit 0; {"elapsed_ms_mean": 14.258168172091246, "peak_bytes_mean": 251.42857142857142, "split_calls_mean": 0.0, "token_count": 1309.0}

# Registered PR-scoped local base-vs-head probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id vision-family-prompt-token-count-scan --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-vision-byte-length-20260510115818 --head-repo "$PWD" --output /tmp/vision_pr_scoped_perf.json
exit 0; base elapsed_ms_mean=15.19272627774626, head elapsed_ms_mean=14.640492287331394, split_calls_mean=0.0, token_count=1309.0, coverage=100.0%

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_probes_valid.json
exit 0

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Manual same-worktree probe: old_mean=14.416754 ms, new_mean=14.258168 ms, delta=-0.158585 ms, speedup=1.0111x (+1.10%).
- Registered PR-scoped local probe: base `elapsed_ms_mean=15.19272627774626`, head `elapsed_ms_mean=14.640492287331394`, delta=-0.552234 ms, speedup=1.0377x (+3.63%).
- Structural guard rails preserved: `split_calls_mean=0.0`, `peak_bytes_mean=251.42857142857142`, `token_count=1309.0`.
- CI PR-scoped performance report is still the merge gate.

## Known Gaps
- Linux local validation covers the Python path only; no Swift runtime behavior is changed.
- CI must complete the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
