### PR TITLE
perf: cache statistical evidence normal distribution

### DIFF
--- a/docs/plans/2026-05-10-statistical-evidence-normaldist-cache.md
+++ b/docs/plans/2026-05-10-statistical-evidence-normaldist-cache.md
@@ -1,0 +1,31 @@
+# Statistical Evidence NormalDist Cache
+
+## Scope
+
+This slice targets the paired statistical evidence interval helper in
+`services/mlx-worker-python/worker/productization/statistical_evidence.py`.
+It keeps behavior unchanged while avoiding repeated `NormalDist` construction for
+the analytical confidence interval z-value lookup used by
+`build_paired_statistical_evidence`.
+
+## Registered Probe
+
+Affected path coverage is already registered through
+`statistical-evidence-bootstrap-single-sort` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused tests,
+changed-scope coverage, and `scripts/statistical_evidence_bootstrap_probe.py` as
+the performance probe.
+
+## Verification
+
+Run the focused registered-probe flow locally on Linux:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id statistical-evidence-bootstrap-single-sort --base-repo <baseline-worktree> --head-repo "$PWD" --output /tmp/stat_normaldist_probe.json
+```
+
+Success criteria:
+
+- focused statistical evidence tests pass;
+- changed-scope coverage remains at least 95%;
+- registered probe reports no regression and preferably lower `elapsed_ms_mean`.

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -4,6 +4,8 @@ import math
 import random
 from statistics import NormalDist
 
+_NORMAL_DIST = NormalDist()
+
 
 def build_paired_statistical_evidence(
     *,
@@ -227,7 +229,7 @@ def _two_sided_normal_z_value(confidence_level: float) -> float:
     bounded_confidence = min(max(float(confidence_level), 0.0), 1.0)
     percentile = 0.5 + (bounded_confidence / 2.0)
     bounded_percentile = min(max(percentile, 1e-12), 1.0 - 1e-12)
-    return NormalDist().inv_cdf(bounded_percentile)
+    return _NORMAL_DIST.inv_cdf(bounded_percentile)
 
 
 def _mean(values: list[float] | tuple[float, ...]) -> float:


### PR DESCRIPTION
## Summary
- Cache the `NormalDist` helper used by statistical evidence analytical interval z-value lookups.
- Add a governing plan for the narrowly scoped NormalDist cache slice.

## Plan or Spec
- `docs/plans/2026-05-10-statistical-evidence-normaldist-cache.md`

## Commands Run
```text
# Local focused probe before change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_bootstrap_probe.py
exit 0; elapsed_ms_mean=134.51144620776176; peak_bytes_mean=47129.6

# Focused tests after change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics
exit 0; 13 passed in 0.56s

# Registered local probe with changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id statistical-evidence-bootstrap-single-sort --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-stat-normaldist-cache-20260510132640 --head-repo "$PWD" --output /tmp/stat_normaldist_probe.json
exit 0; focused coverage TOTAL 2 0 100%; focused tests 15 passed in 0.17s

git diff --check
exit 0
```

## Coverage and Metrics
- Registered probe: `statistical-evidence-bootstrap-single-sort`.
- Changed-scope coverage: 100.00% (`TOTAL 2 0 100%`).
- Local registered probe metrics:
  - base `elapsed_ms_mean=135.00794416759163`, head `elapsed_ms_mean=133.89341598376632`, delta `-1.11452818382531 ms` (~0.83% faster).
  - base `peak_bytes_mean=47129.6`, head `peak_bytes_mean=47211.2`, delta `+81.6 bytes` (~0.17%; below 5% warning threshold and treated as trace noise).
  - `sorted_calls_mean` stayed `0.0`.
- GitHub Actions PR-scoped performance workflow is required as the registered CI validation source before merge.

## Known Gaps
- Local probe improvement is intentionally small because the slice only removes repeated `NormalDist` construction from the analytical interval helper; CI registered-probe validation is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
