### PR TITLE
perf: streamline startup version comparison

### DIFF
--- a/docs/plans/2026-05-10-startup-version-compare-performance.md
+++ b/docs/plans/2026-05-10-startup-version-compare-performance.md
@@ -1,0 +1,37 @@
+# Startup Version Compare Performance Slice
+
+## Goal
+
+Reduce avoidable work in startup update-channel semantic version comparisons while
+preserving the existing tolerant version parsing contract.
+
+## Scope
+
+This slice is intentionally limited to `worker.productization.startup_signals`
+version parsing/comparison and its PR-scoped performance probe coverage. It does
+not change update-channel schema, startup failure classification, or packaging
+metadata.
+
+## Change
+
+- Reuse a precompiled leading-integer regex for version components instead of
+  going through `re.match()` on every component.
+- Compare normalized version parts in one pass with implicit zero padding instead
+  of allocating padded left/right lists before each comparison.
+- Register `startup-signals-version-compare-single-pass` as a PR-scoped probe
+  with focused test, coverage, and probe commands.
+
+## Metrics
+
+Primary registered probe: `startup-signals-version-compare-single-pass`.
+
+- `elapsed_ms_mean`: lower is better.
+- `peak_bytes_mean`: informational, because peak allocation is dominated by the
+  synthetic pair workload and should not gate this single-pass comparison change.
+- `comparison_total`: informational checksum to keep the workload observable.
+
+## Verification
+
+Run the registered focused test command, coverage command, and probe command from
+`infra/perf/pr_scoped_probes.json` before opening the PR. The PR-scoped
+performance workflow must complete successfully before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2759,6 +2759,41 @@
     "notes": "Compares startup failure classification log-read work for control-plane-resolved failures versus worker-crash fallback."
   },
   {
+    "id": "startup-signals-version-compare-single-pass",
+    "name": "Startup version comparison single pass",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/startup_signals.py",
+      "services/mlx-worker-python/tests/test_startup_signals.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/startup_signals_version_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_version_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/startup_signals_version_probe.py ]; then python3 scripts/startup_signals_version_probe.py; else python3 - <<\"PYPROBE\"\nimport json\nimport statistics\nimport sys\nimport time\nimport tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.productization import startup_signals\ndef version_pairs(count):\n    versions = [f\"v{major}.{minor}.{patch}{suffix}+build.{index}\" for index in range(count) for major in range(1, 4) for minor in range(0, 4) for patch in range(0, 3) for suffix in (\"\", \"-alpha\", \"-beta\", \"-rc1\")]\n    return list(zip(versions, reversed(versions)))[:count]\npair_count = 12000\nsample_count = 7\npairs = version_pairs(pair_count)\nelapsed_samples = []\npeak_samples = []\ncomparison_total = 0\nfor _ in range(sample_count):\n    tracemalloc.start()\n    started = time.perf_counter()\n    comparison_total = 0\n    for left, right in pairs:\n        comparison_total += startup_signals.compare_versions(left, right)\n    elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n    _, peak = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    peak_samples.append(float(peak))\nprint(json.dumps({\"comparison_total\": float(comparison_total), \"elapsed_ms_mean\": statistics.fmean(elapsed_samples), \"pair_count\": float(len(pairs)), \"peak_bytes_mean\": statistics.fmean(peak_samples), \"sample_count\": float(sample_count)}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      },
+      {
+        "key": "comparison_total",
+        "unit": "count",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "release-gates-m9-failure-count-single-pass",
     "name": "Release gates M9 failure count single pass",
     "runner": "ubuntu-latest",

--- a/scripts/startup_signals_version_probe.py
+++ b/scripts/startup_signals_version_probe.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.productization import startup_signals  # noqa: E402
+
+
+def _version_pairs(count: int) -> list[tuple[str, str]]:
+    versions = [
+        f"v{major}.{minor}.{patch}{suffix}+build.{index}"
+        for index in range(count)
+        for major in range(1, 4)
+        for minor in range(0, 4)
+        for patch in range(0, 3)
+        for suffix in ("", "-alpha", "-beta", "-rc1")
+    ]
+    return list(zip(versions, reversed(versions)))[:count]
+
+
+def main() -> int:
+    pair_count = 12_000
+    sample_count = 7
+    pairs = _version_pairs(pair_count)
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    comparison_total = 0
+
+    for _ in range(sample_count):
+        tracemalloc.start()
+        started = time.perf_counter()
+        comparison_total = 0
+        for left, right in pairs:
+            comparison_total += startup_signals.compare_versions(left, right)
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_samples.append(float(peak))
+
+    print(
+        json.dumps(
+            {
+                "comparison_total": float(comparison_total),
+                "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+                "pair_count": float(len(pairs)),
+                "peak_bytes_mean": statistics.fmean(peak_samples),
+                "sample_count": float(sample_count),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -390,8 +390,26 @@ def test_scope_report_selects_startup_signals_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/productization/startup_signals.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "startup-signals-lazy-worker-log-excerpts"
+    probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert scope["selected_count"] == 2
+    assert probe_ids == {
+        "startup-signals-lazy-worker-log-excerpts",
+        "startup-signals-version-compare-single-pass",
+    }
+
+
+def test_startup_signals_version_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runpy.run_path(
+        str(REPO_ROOT / "scripts/startup_signals_version_probe.py"),
+        run_name="__main__",
+    )
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["pair_count"] == 12000.0
+    assert metrics["sample_count"] == 7.0
 
 
 def test_scope_report_selects_release_gates_probe() -> None:
@@ -1979,6 +1997,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "stream-assembler-structural-prefix-cache",
         "swift-cli-json-envelope-encoding",
         "startup-signals-lazy-worker-log-excerpts",
+        "startup-signals-version-compare-single-pass",
         "upload-receipt-published-files-scandir",
         "video-preprocessing-uri-byte-length-reuse",
         "download-pipeline-directory-size-single-stat",

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -97,6 +97,13 @@ def test_compare_versions_ignores_build_metadata_suffix() -> None:
     assert compare_versions("1.2.2", "1.2.3") == -1
 
 
+def test_compare_versions_handles_suffixes_without_padding_lists() -> None:
+    assert normalized_version_parts(" v2.10rc1.0-beta+build ") == [2, 10, 0]
+    assert normalized_version_parts("release") == [0]
+    assert compare_versions("2.10rc1", "2.9.99") == 1
+    assert compare_versions("2.10", "2.10.0.0") == 0
+
+
 def test_resolve_http_port_can_pick_an_available_port_when_requested_is_busy() -> None:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
         listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -23,6 +23,7 @@ CRASH_PATTERNS = [
     "abort trap",
 ]
 _BYTE_WHITESPACE = bytes(value for value in range(256) if chr(value).isspace())
+_LEADING_VERSION_PART_RE = re.compile(r"(\d+)")
 
 
 @dataclass(frozen=True)
@@ -128,13 +129,15 @@ def check_for_updates(installed_version: str, channel_path: str | Path) -> Updat
 def compare_versions(left: str, right: str) -> int:
     left_parts = normalized_version_parts(left)
     right_parts = normalized_version_parts(right)
-    width = max(len(left_parts), len(right_parts))
-    left_normalized = left_parts + [0] * (width - len(left_parts))
-    right_normalized = right_parts + [0] * (width - len(right_parts))
-    if left_normalized < right_normalized:
-        return -1
-    if left_normalized > right_normalized:
-        return 1
+    left_length = len(left_parts)
+    right_length = len(right_parts)
+    for index in range(max(left_length, right_length)):
+        left_value = left_parts[index] if index < left_length else 0
+        right_value = right_parts[index] if index < right_length else 0
+        if left_value < right_value:
+            return -1
+        if left_value > right_value:
+            return 1
     return 0
 
 
@@ -142,13 +145,21 @@ def normalized_version_parts(value: str) -> list[int]:
     cleaned = value.strip()
     if cleaned.startswith("v"):
         cleaned = cleaned[1:]
-    cleaned = cleaned.split("+", 1)[0]
-    cleaned = cleaned.split("-", 1)[0]
-    parts = [segment for segment in cleaned.split(".") if segment]
+    plus_index = cleaned.find("+")
+    dash_index = cleaned.find("-")
+    suffix_index = len(cleaned)
+    if plus_index >= 0 and plus_index < suffix_index:
+        suffix_index = plus_index
+    if dash_index >= 0 and dash_index < suffix_index:
+        suffix_index = dash_index
+    cleaned = cleaned[:suffix_index]
     normalized: list[int] = []
-    for part in parts:
-        digits = re.match(r"(\d+)", part)
-        normalized.append(int(digits.group(1)) if digits else 0)
+    append_part = normalized.append
+    for part in cleaned.split("."):
+        if not part:
+            continue
+        digits = _LEADING_VERSION_PART_RE.match(part)
+        append_part(int(digits.group(1)) if digits else 0)
     return normalized or [0]
 
 


### PR DESCRIPTION
## Summary
- Streamline startup update-channel version comparison by using a precompiled leading-integer regex and single-pass zero-padded comparison.
- Add the registered PR-scoped performance probe `startup-signals-version-compare-single-pass` with focused test, coverage, and probe commands.
- Add regression coverage for suffix/build-metadata version parsing behavior.

## Plan or Spec
- `docs/plans/2026-05-10-startup-version-compare-performance.md`

## Commands Run
```text
# focused test_command from infra/perf/pr_scoped_probes.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics
# exit 0; 5 passed in 4.44s

# focused coverage_command from infra/perf/pr_scoped_probes.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_version_probe.py
# exit 0; 5 passed in 8.97s; changed-scope coverage TOTAL 0 0 100%

# direct probe command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_version_probe.py
# exit 0; {"comparison_total": -48.0, "elapsed_ms_mean": 328.19951413798015, "pair_count": 12000.0, "peak_bytes_mean": 1748.0, "sample_count": 7.0}

# registered local base/head probe runner
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id startup-signals-version-compare-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-startup-version-20260510150600 --head-repo "$PWD" --output /tmp/startup_version_probe_compare.json
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% reported by `scripts/changed_scope_coverage.py` for the touched startup signals, tests, PR-scoped performance test, and probe script paths.
- Registered local probe `startup-signals-version-compare-single-pass`:
  - base `elapsed_ms_mean`: 381.9206055652882 ms
  - head `elapsed_ms_mean`: 326.80818531662226 ms
  - delta: -55.11242024866596 ms
  - speedup: 1.1686x (~14.43% faster)
  - guardrail `comparison_total`: -48.0 on both base and head
- GitHub Actions PR-scoped performance is required as the merge gate and will provide the registered CI report.

## Known Gaps
- Local validation was Linux/Python-only; no Swift runtime effect is claimed for this slice.
- The changed-scope coverage tool reported no measurable changed lines for this focused diff while still returning 100%; focused pytest coverage and the registered probe were run successfully.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
