### PR TITLE
Add Apple Silicon memory fit receipts

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -284,6 +284,16 @@ public struct LoraResumeOptions: Equatable, Sendable {
     }
 }
 
+public struct EstimateImportOptions: Equatable, Sendable {
+    public let repoID: String
+    public let json: Bool
+
+    public init(repoID: String, json: Bool = false) {
+        self.repoID = repoID
+        self.json = json
+    }
+}
+
 public struct BenchRunOptions: Equatable, Sendable {
     public let modelID: String
     public let hfRepoID: String
@@ -296,6 +306,8 @@ public struct BenchRunOptions: Equatable, Sendable {
     public let reasoningMode: String
     public let structuredOutputMode: String
     public let parameters: [String: String]
+    public let preflightFitCheck: Bool
+    public let allowMemoryRisk: Bool
     public let json: Bool
 
     public init(
@@ -310,6 +322,8 @@ public struct BenchRunOptions: Equatable, Sendable {
         reasoningMode: String = "",
         structuredOutputMode: String = "",
         parameters: [String: String] = [:],
+        preflightFitCheck: Bool = false,
+        allowMemoryRisk: Bool = false,
         json: Bool = false
     ) {
         self.modelID = modelID
@@ -323,6 +337,8 @@ public struct BenchRunOptions: Equatable, Sendable {
         self.reasoningMode = reasoningMode
         self.structuredOutputMode = structuredOutputMode
         self.parameters = parameters
+        self.preflightFitCheck = preflightFitCheck
+        self.allowMemoryRisk = allowMemoryRisk
         self.json = json
     }
 }
@@ -1339,6 +1355,7 @@ public struct MelixCLIInvocation: Equatable, Sendable {
 
 public enum MelixCLICommand: Equatable, Sendable {
     case doctor(DoctorOptions)
+    case estimateImport(EstimateImportOptions)
     case convert(ConvertOptions)
     case quantize(QuantizeOptions)
     case upload(UploadOptions)
@@ -1473,6 +1490,8 @@ public enum MelixCLIParser {
         switch group {
         case "doctor":
             return try parseDoctor(tail)
+        case "estimate":
+            return try parseEstimate(tail)
         case "convert":
             return try parseConvert(tail)
         case "quantize":
@@ -1507,6 +1526,8 @@ public enum MelixCLIParser {
     public static let usageText = """
     Usage:
       melix doctor [--json]
+      melix estimate import HF_REPO [--json]
+      melix estimate import --repo-id HF_REPO [--json]
       melix convert --model-id MODEL_ID [--output-dir PATH] [--target-format FORMAT] [--json]
       melix quantize --model-id MODEL_ID [--output-dir PATH] [--quant-profile-id ID] [--weight-quant MODE] [--kv-quant MODE] [--quantization-mode (ptq|qat)] [--source-artifact-kind (base_model|merged_adapter|adapter_export)] [--source-artifact-path PATH] [--quantization-backend (manifest_only|mlx_lm_convert)] [--mlx-lm-q-bits N] [--mlx-lm-q-group-size N] [--mlx-lm-q-mode (affine|mxfp4|nvfp4|mxfp8)] [--calibration-dataset-uri PATH] [--quality-delta N] [--latency-delta N] [--local-inference-smoke-mode (structural|runtime_generate)] [--local-inference-smoke-prompt TEXT] [--json]
       melix upload --model-id MODEL_ID --target-repo REPO [--output-dir PATH] [--artifact-path PATH] [--artifact-kind KIND] [--artifact-manifest-path PATH] [--publish-backend BACKEND] [--local-publish-root PATH] [--json]
@@ -1559,7 +1580,7 @@ public enum MelixCLIParser {
       melix lora resume --group-id GROUP_ID [--model-id MODEL_ID] [--preset PRESET] [--adapter-name NAME] [--dataset-uri URI] [--json]
       melix lora publishes list [--model-id MODEL_ID] [--json]
       melix lora publishes show --job-id JOB_ID [--model-id MODEL_ID] [--json]
-      melix bench run (--model-id MODEL_ID | --repo-id HF_REPO) [--suite SUITE ...] [--dataset-ref HF_DATASET[@REV]] [--hf-dataset-name NAME] [--hf-dataset-split SPLIT] [--prompt-feature NAME] [--text-feature NAME] [--image-feature NAME] [--source-image-feature NAME] [--mask-feature NAME] [--context-length N ...] [--generation-length N] [--batch-size N ...] [--repeats N] [--cache-profile MODE] [--reasoning-mode MODE] [--structured-output-mode MODE] [--sample-size N] [--batch-factor N] [--json]
+      melix bench run (--model-id MODEL_ID | --repo-id HF_REPO) [--suite SUITE ...] [--dataset-ref HF_DATASET[@REV]] [--hf-dataset-name NAME] [--hf-dataset-split SPLIT] [--prompt-feature NAME] [--text-feature NAME] [--image-feature NAME] [--source-image-feature NAME] [--mask-feature NAME] [--context-length N ...] [--generation-length N] [--batch-size N ...] [--repeats N] [--cache-profile MODE] [--reasoning-mode MODE] [--structured-output-mode MODE] [--sample-size N] [--batch-factor N] [--preflight-fit-check] [--allow-memory-risk] [--json]
       melix bench list [--json]
       melix bench export-csv --job-id JOB_ID --output PATH [--json]
       melix bench matrix run (--model-id MODEL_ID | --repo-id HF_REPO) --suite SUITE ... --context-length N ... --generation-length N ... --batch-size N ... --cache-profile MODE ... --reasoning-mode MODE ... --structured-output-mode MODE ... --concurrency N ... [--repeats N] (--requests N | --duration-seconds N) [--allow-large-matrix] [--json]
@@ -1625,6 +1646,35 @@ public enum MelixCLIParser {
     private static func parseDoctor(_ arguments: [String]) throws -> MelixCLICommand {
         let values = try ArgumentCursor(arguments: arguments).parse()
         return .doctor(.init(json: values.flags.contains("--json")))
+    }
+
+    private static func parseEstimate(_ arguments: [String]) throws -> MelixCLICommand {
+        guard let action = arguments.first else {
+            throw MelixCLIError.usage(Self.usageText)
+        }
+        switch action {
+        case "import":
+            var optionArguments = Array(arguments.dropFirst())
+            var repoID = ""
+            if let positionalRepoID = optionArguments.first, positionalRepoID.hasPrefix("--") == false {
+                repoID = positionalRepoID
+                optionArguments.removeFirst()
+            }
+            let values = try ArgumentCursor(arguments: optionArguments).parse()
+            if let optionRepoID = values.single["--repo-id"], optionRepoID.isEmpty == false {
+                if repoID.isEmpty == false, repoID != optionRepoID {
+                    throw MelixCLIError.usage("melix estimate import accepts only one Hugging Face repo id.")
+                }
+                repoID = optionRepoID
+            }
+            repoID = repoID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard repoID.isEmpty == false else {
+                throw MelixCLIError.missingRequired("HF_REPO or --repo-id is required for melix estimate import.")
+            }
+            return .estimateImport(.init(repoID: repoID, json: values.flags.contains("--json")))
+        default:
+            throw MelixCLIError.usage(Self.usageText)
+        }
     }
 
     private static func parseConvert(_ arguments: [String]) throws -> MelixCLICommand {
@@ -2846,6 +2896,8 @@ public enum MelixCLIParser {
                     reasoningMode: reasoningMode,
                     structuredOutputMode: structuredOutputMode,
                     parameters: parameters,
+                    preflightFitCheck: values.flags.contains("--preflight-fit-check"),
+                    allowMemoryRisk: values.flags.contains("--allow-memory-risk"),
                     json: values.flags.contains("--json")
                 )
             )
@@ -3560,6 +3612,8 @@ private struct ArgumentCursor {
             "--mask-prompt",
             "--gradient-checkpointing",
             "--allow-large-matrix",
+            "--preflight-fit-check",
+            "--allow-memory-risk",
             "--resume",
             "--dry-run",
         ]
@@ -3650,6 +3704,8 @@ public struct MelixCLIProcessExecutor: Sendable {
 
 public actor MelixCLIRunner {
     private static let defaultSpeculativeNumDraftTokens = 4
+    private static let memoryFitSafetyThresholdFraction = 0.60
+    private static let memoryFitSchemaVersion = "melix.memory_fit_receipt.v1"
 
     private let client: any ControlPlaneXPCClient
     private let operatorSessionStore: any MelixOperatorSessionStoring
@@ -3743,6 +3799,108 @@ public actor MelixCLIRunner {
 
     public func getHubModelCard(repoID: String) async throws -> Melix_Controlplane_V1_HubModelCard {
         try await client.getHubModelCard(repoID: repoID)
+    }
+
+    private func makeMemoryFitReceipt(
+        repoID: String,
+        targetKind: String
+    ) async throws -> MemoryFitReceipt {
+        let hubCardStart = DispatchTime.now()
+        let card = try await getHubModelCard(repoID: repoID)
+        let hubCardElapsedMS = elapsedMilliseconds(since: hubCardStart)
+        let receiptStart = DispatchTime.now()
+        let normalizedRepoID = card.repoID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? repoID.trimmingCharacters(in: .whitespacesAndNewlines)
+            : card.repoID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fitStatus = normalizedFitStatus(card.localFitStatus)
+        let totalUnifiedMemoryBytes = ProcessInfo.processInfo.physicalMemory
+        let safetyThresholdFraction = Self.memoryFitSafetyThresholdFraction
+        let safetyThresholdBytes = UInt64(Double(totalUnifiedMemoryBytes) * safetyThresholdFraction)
+        let unknownFields = memoryFitUnknownFields(card)
+        let assumptions = [
+            "ProcessInfo.physicalMemory is treated as Apple Silicon total unified memory.",
+            "estimated_active_memory_bytes reuses Hub estimated_resident_bytes.",
+            "estimated_disk_usage_bytes reuses Hub estimated_artifact_bytes.",
+            "fit_status and recommended_action reuse the model-ops Hub local-fit policy.",
+        ]
+        let receiptElapsedMS = elapsedMilliseconds(since: receiptStart)
+        let probe: [String: Any] = [
+            "name": "cli.memory_fit.estimate_import",
+            "hub_card_elapsed_ms": NSNumber(value: hubCardElapsedMS),
+            "receipt_elapsed_ms": NSNumber(value: receiptElapsedMS),
+        ]
+        let safetyThreshold: [String: Any] = [
+            "memory_headroom_fraction": NSNumber(value: safetyThresholdFraction),
+            "memory_headroom_bytes": NSNumber(value: safetyThresholdBytes),
+        ]
+        let payload: [String: Any] = [
+            "schema_version": Self.memoryFitSchemaVersion,
+            "target_kind": targetKind,
+            "repo_id": normalizedRepoID,
+            "pipeline_tag": card.pipelineTag,
+            "mlx_compatible": card.mlxCompatible,
+            "fit_status": fitStatus,
+            "reasons": card.localFitReasons,
+            "recommended_action": card.recommendedAction,
+            "total_unified_memory_bytes": NSNumber(value: totalUnifiedMemoryBytes),
+            "estimated_active_memory_bytes": NSNumber(value: card.estimatedResidentBytes),
+            "estimated_disk_usage_bytes": NSNumber(value: card.estimatedArtifactBytes),
+            "safety_threshold": safetyThreshold,
+            "assumptions": assumptions,
+            "unknown_fields": unknownFields,
+            "parameter_count": NSNumber(value: card.parameterCount),
+            "quantization_summary": card.quantizationSummary,
+            "probe": probe,
+        ]
+        return MemoryFitReceipt(
+            payload: payload,
+            targetKind: targetKind,
+            repoID: normalizedRepoID,
+            fitStatus: fitStatus,
+            reasons: card.localFitReasons,
+            recommendedAction: card.recommendedAction,
+            totalUnifiedMemoryBytes: totalUnifiedMemoryBytes,
+            estimatedActiveMemoryBytes: card.estimatedResidentBytes,
+            estimatedDiskUsageBytes: card.estimatedArtifactBytes,
+            safetyThresholdFraction: safetyThresholdFraction,
+            unknownFields: unknownFields,
+            assumptions: assumptions
+        )
+    }
+
+    private func memoryFitUnknownFields(_ card: Melix_Controlplane_V1_HubModelCard) -> [String] {
+        var fields: [String] = []
+        if card.estimatedResidentBytes == 0 {
+            fields.append("estimated_active_memory_bytes")
+        }
+        if card.estimatedArtifactBytes == 0 {
+            fields.append("estimated_disk_usage_bytes")
+        }
+        if normalizedFitStatus(card.localFitStatus) == "unknown" {
+            fields.append("fit_status")
+        }
+        if card.parameterCount == 0 {
+            fields.append("parameter_count")
+        }
+        if card.quantizationSummary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            fields.append("quantization_summary")
+        }
+        return fields
+    }
+
+    private func normalizedFitStatus(_ status: String) -> String {
+        let trimmed = status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return trimmed.isEmpty ? "unknown" : trimmed
+    }
+
+    private func enforceMemoryFitPreflight(_ receipt: MemoryFitReceipt, allowMemoryRisk: Bool) throws {
+        guard ["blocked", "heavy"].contains(receipt.fitStatus), allowMemoryRisk == false else {
+            return
+        }
+        let reasons = receipt.reasons.isEmpty ? "No reason was provided." : receipt.reasons.joined(separator: " ")
+        throw MelixCLIError.runtime(
+            "Memory fit preflight blocked benchmark for \(receipt.repoID): fit_status=\(receipt.fitStatus), estimated_active_memory_bytes=\(receipt.estimatedActiveMemoryBytes), estimated_disk_usage_bytes=\(receipt.estimatedDiskUsageBytes). Pass --allow-memory-risk to run anyway. Reasons: \(reasons)"
+        )
     }
 
     public func downloadHubModel(
@@ -3910,6 +4068,15 @@ public actor MelixCLIRunner {
     }
 
     public func runBenchmark(_ options: BenchRunOptions) async throws -> ControlPlaneBenchResult {
+        var parameters = options.parameters
+        if options.preflightFitCheck {
+            guard options.hfRepoID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
+                throw MelixCLIError.runtime("--preflight-fit-check is currently supported for melix bench run --repo-id targets.")
+            }
+            let receipt = try await makeMemoryFitReceipt(repoID: options.hfRepoID, targetKind: "benchmark")
+            try enforceMemoryFitPreflight(receipt, allowMemoryRisk: options.allowMemoryRisk)
+            parameters.merge(try receipt.benchmarkParameters(schemaVersion: Self.memoryFitSchemaVersion)) { _, new in new }
+        }
         if !options.modelID.isEmpty {
             _ = try await client.loadModel(modelID: options.modelID)
         }
@@ -3925,7 +4092,7 @@ public actor MelixCLIRunner {
                 cacheProfile: options.cacheProfile,
                 reasoningMode: options.reasoningMode,
                 structuredOutputMode: options.structuredOutputMode,
-                parameters: options.parameters
+                parameters: parameters
             )
         )
     }
@@ -4024,6 +4191,9 @@ public actor MelixCLIRunner {
                 return try prettyJSON(makeDoctorPayload(report))
             }
             return report.markdown.isEmpty ? "# Melix Doctor\n" : report.markdown
+        case .estimateImport(let options):
+            let receipt = try await makeMemoryFitReceipt(repoID: options.repoID, targetKind: "import")
+            return options.json ? try prettyJSON(receipt.payload) : renderMemoryFitReceipt(receipt)
         case .convert(let options):
             let result = try await performModelOperation(
                 modelID: options.modelID,
@@ -5974,6 +6144,22 @@ public actor MelixCLIRunner {
         ].joined(separator: "\n") + "\n"
     }
 
+    private func renderMemoryFitReceipt(_ receipt: MemoryFitReceipt) -> String {
+        [
+            "schema_version=\(Self.memoryFitSchemaVersion)",
+            "target_kind=\(receipt.targetKind)",
+            "repo_id=\(receipt.repoID)",
+            "fit_status=\(receipt.fitStatus)",
+            "total_unified_memory_bytes=\(receipt.totalUnifiedMemoryBytes)",
+            "estimated_active_memory_bytes=\(formatBinaryBytes(receipt.estimatedActiveMemoryBytes))",
+            "estimated_disk_usage_bytes=\(formatBinaryBytes(receipt.estimatedDiskUsageBytes))",
+            "safety_threshold_fraction=\(String(format: "%.2f", locale: Locale(identifier: "en_US_POSIX"), receipt.safetyThresholdFraction))",
+            "recommended_action=\(receipt.recommendedAction)",
+            "reasons=\(receipt.reasons.joined(separator: " | "))",
+            "unknown_fields=\(receipt.unknownFields.joined(separator: ","))",
+        ].joined(separator: "\n") + "\n"
+    }
+
     private func formatBinaryBytes(_ bytes: UInt64) -> String {
         let units = ["B", "KB", "MB", "GB", "TB"]
         var value = Double(bytes)
@@ -7723,6 +7909,45 @@ public actor MelixCLIRunner {
             return "top200.event-extraction.top20.v1"
         }
         return "\(suiteID).dev.v1"
+    }
+}
+
+private struct MemoryFitReceipt {
+    let payload: [String: Any]
+    let targetKind: String
+    let repoID: String
+    let fitStatus: String
+    let reasons: [String]
+    let recommendedAction: String
+    let totalUnifiedMemoryBytes: UInt64
+    let estimatedActiveMemoryBytes: UInt64
+    let estimatedDiskUsageBytes: UInt64
+    let safetyThresholdFraction: Double
+    let unknownFields: [String]
+    let assumptions: [String]
+
+    func benchmarkParameters(schemaVersion: String) throws -> [String: String] {
+        [
+            "memory_fit_schema_version": schemaVersion,
+            "memory_fit_target_kind": targetKind,
+            "memory_fit_repo_id": repoID,
+            "memory_fit_status": fitStatus,
+            "memory_fit_estimated_active_memory_bytes": String(estimatedActiveMemoryBytes),
+            "memory_fit_estimated_disk_usage_bytes": String(estimatedDiskUsageBytes),
+            "memory_fit_total_unified_memory_bytes": String(totalUnifiedMemoryBytes),
+            "memory_fit_safety_threshold_fraction": String(
+                format: "%.2f",
+                locale: Locale(identifier: "en_US_POSIX"),
+                safetyThresholdFraction
+            ),
+            "memory_fit_unknown_fields": unknownFields.joined(separator: ","),
+            "memory_fit_receipt_json": try compactJSONString(),
+        ]
+    }
+
+    private func compactJSONString() throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        return String(decoding: data, as: UTF8.self)
     }
 }
 

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -3825,13 +3825,13 @@ public actor MelixCLIRunner {
         ]
         let receiptElapsedMS = elapsedMilliseconds(since: receiptStart)
         let probe: [String: Any] = [
-            "name": "cli.memory_fit.estimate_import",
+            "name": "cli.memory_fit.\(targetKind)",
             "hub_card_elapsed_ms": NSNumber(value: hubCardElapsedMS),
             "receipt_elapsed_ms": NSNumber(value: receiptElapsedMS),
         ]
         let safetyThreshold: [String: Any] = [
-            "memory_headroom_fraction": NSNumber(value: safetyThresholdFraction),
-            "memory_headroom_bytes": NSNumber(value: safetyThresholdBytes),
+            "safety_threshold_fraction": NSNumber(value: safetyThresholdFraction),
+            "safety_threshold_bytes": NSNumber(value: safetyThresholdBytes),
         ]
         let payload: [String: Any] = [
             "schema_version": Self.memoryFitSchemaVersion,
@@ -3894,12 +3894,12 @@ public actor MelixCLIRunner {
     }
 
     private func enforceMemoryFitPreflight(_ receipt: MemoryFitReceipt, allowMemoryRisk: Bool) throws {
-        guard ["blocked", "heavy"].contains(receipt.fitStatus), allowMemoryRisk == false else {
+        guard ["blocked", "heavy"].contains(receipt.fitStatus), !allowMemoryRisk else {
             return
         }
         let reasons = receipt.reasons.isEmpty ? "No reason was provided." : receipt.reasons.joined(separator: " ")
         throw MelixCLIError.runtime(
-            "Memory fit preflight blocked benchmark for \(receipt.repoID): fit_status=\(receipt.fitStatus), estimated_active_memory_bytes=\(receipt.estimatedActiveMemoryBytes), estimated_disk_usage_bytes=\(receipt.estimatedDiskUsageBytes). Pass --allow-memory-risk to run anyway. Reasons: \(reasons)"
+            "Memory fit preflight blocked benchmark for \(receipt.repoID): fit_status=\(receipt.fitStatus), estimated_active_memory_bytes=\(formatBinaryBytes(receipt.estimatedActiveMemoryBytes)), estimated_disk_usage_bytes=\(formatBinaryBytes(receipt.estimatedDiskUsageBytes)). Pass --allow-memory-risk to run anyway. Reasons: \(reasons)"
         )
     }
 
@@ -6150,7 +6150,7 @@ public actor MelixCLIRunner {
             "target_kind=\(receipt.targetKind)",
             "repo_id=\(receipt.repoID)",
             "fit_status=\(receipt.fitStatus)",
-            "total_unified_memory_bytes=\(receipt.totalUnifiedMemoryBytes)",
+            "total_unified_memory_bytes=\(formatBinaryBytes(receipt.totalUnifiedMemoryBytes))",
             "estimated_active_memory_bytes=\(formatBinaryBytes(receipt.estimatedActiveMemoryBytes))",
             "estimated_disk_usage_bytes=\(formatBinaryBytes(receipt.estimatedDiskUsageBytes))",
             "safety_threshold_fraction=\(String(format: "%.2f", locale: Locale(identifier: "en_US_POSIX"), receipt.safetyThresholdFraction))",

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -6,6 +6,8 @@ public enum MelixCLICommandCodec {
         switch command {
         case .doctor:
             return "doctor"
+        case .estimateImport:
+            return "estimate.import"
         case .convert:
             return "convert"
         case .quantize:
@@ -174,6 +176,9 @@ public enum MelixCLICommandCodec {
         switch command {
         case .doctor(let options):
             arguments = ["doctor"]
+            json = options.json
+        case .estimateImport(let options):
+            arguments = ["estimate", "import", options.repoID]
             json = options.json
         case .convert(let options):
             arguments = ["convert"]
@@ -433,6 +438,12 @@ public enum MelixCLICommandCodec {
             appendOption("--structured-output-mode", value: options.structuredOutputMode, into: &arguments)
             appendOption("--sample-size", value: options.parameters["sample_size"], into: &arguments)
             appendOption("--batch-factor", value: options.parameters["batch_factor"], into: &arguments)
+            if options.preflightFitCheck {
+                arguments.append("--preflight-fit-check")
+            }
+            if options.allowMemoryRisk {
+                arguments.append("--allow-memory-risk")
+            }
             appendOption("--dataset-ref", value: options.parameters["dataset_ref"], into: &arguments)
             appendOption("--hf-dataset-name", value: options.parameters["hf_dataset_name"], into: &arguments)
             appendOption("--hf-dataset-split", value: options.parameters["hf_dataset_split"], into: &arguments)

--- a/docs/plans/2026-05-11-apple-silicon-memory-fit-receipts.md
+++ b/docs/plans/2026-05-11-apple-silicon-memory-fit-receipts.md
@@ -38,7 +38,7 @@ implement fallback collectors for other platforms.
 
 Every estimate receipt carries a `probe` object with:
 
-- `name`: `cli.memory_fit.estimate_import`
+- `name`: `cli.memory_fit.<target_kind>`
 - `hub_card_elapsed_ms`
 - `receipt_elapsed_ms`
 

--- a/docs/plans/2026-05-11-apple-silicon-memory-fit-receipts.md
+++ b/docs/plans/2026-05-11-apple-silicon-memory-fit-receipts.md
@@ -1,0 +1,79 @@
+# Apple Silicon Memory Fit Receipts
+
+## Scope
+
+This slice implements the first operator-facing unified-memory fit surface for
+issue #638. It stays on the existing Hub model-card contract and does not add
+new protobuf fields.
+
+The implemented surface is:
+
+- `melix estimate import <repo-id>` and `melix estimate import --repo-id <repo-id>`
+- JSON and text fit receipts for Hugging Face import candidates
+- optional `melix bench run --repo-id <repo-id> --preflight-fit-check`
+- `--allow-memory-risk` override for benchmark runs whose Hub estimate is
+  `heavy` or `blocked`
+- benchmark job parameter annotations that persist the fit receipt summary in
+  the existing benchmark artifact path
+
+Training and eval fit checks remain follow-up work for #638 because they need
+task-specific activation, optimizer, dataset-cache, and KV-cache estimators.
+
+## Design
+
+The CLI receipt reuses the Hub card local-fit evidence already produced by the
+Python model-ops worker:
+
+- `estimated_resident_bytes` becomes `estimated_active_memory_bytes`
+- `estimated_artifact_bytes` becomes `estimated_disk_usage_bytes`
+- `local_fit_status` becomes the receipt `fit_status`
+- `local_fit_reasons` become actionable receipt reasons
+
+The Swift CLI adds the local Mac `ProcessInfo.processInfo.physicalMemory` value
+as `total_unified_memory_bytes`. Melix is a macOS Apple Silicon application, so
+this slice treats that value as the unified-memory capacity and does not
+implement fallback collectors for other platforms.
+
+## Probes And Metrics
+
+Every estimate receipt carries a `probe` object with:
+
+- `name`: `cli.memory_fit.estimate_import`
+- `hub_card_elapsed_ms`
+- `receipt_elapsed_ms`
+
+Benchmark preflight stores stable memory-fit fields in benchmark parameters so
+the artifact export path can be inspected without re-running Hub discovery:
+
+- `memory_fit_schema_version`
+- `memory_fit_target_kind`
+- `memory_fit_repo_id`
+- `memory_fit_status`
+- `memory_fit_estimated_active_memory_bytes`
+- `memory_fit_estimated_disk_usage_bytes`
+- `memory_fit_total_unified_memory_bytes`
+- `memory_fit_safety_threshold_fraction`
+- `memory_fit_receipt_json`
+
+Success metrics for this slice:
+
+- estimate JSON includes assumptions and unknown fields
+- estimate text includes fit status, total memory, active memory estimate, disk
+  estimate, reasons, and override guidance
+- unsafe benchmark preflight blocks before `runBench` unless
+  `--allow-memory-risk` is set
+- override benchmark preflight forwards the fit receipt summary into
+  `ControlPlaneBenchRequest.parameters`
+
+## Verification
+
+Run focused Swift parser and runner tests for:
+
+- estimate import parsing and command-codec support
+- estimate import JSON/text rendering
+- benchmark preflight blocking behavior
+- benchmark preflight override parameter persistence
+
+Run changed-scope coverage for touched Swift CLI files when coverage tooling is
+available. If the local Swift coverage command is not available in this
+environment, report it explicitly in the PR evidence.

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -582,12 +582,27 @@ struct MelixCLIParserTests {
         #expect(alignmentArguments.contains("--candidate-generation-max-tokens"))
         #expect(alignmentArguments.contains("16"))
         #expect(try MelixCLIParser.parse(alignmentArguments) == alignmentCommand)
+
+        let preflightBenchCommand = MelixCLICommand.benchRun(
+            .init(
+                hfRepoID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                suites: ["smoke"],
+                preflightFitCheck: true,
+                allowMemoryRisk: true,
+                json: true
+            )
+        )
+        let preflightBenchArguments = try MelixCLICommandCodec.arguments(for: preflightBenchCommand)
+        #expect(preflightBenchArguments.contains("--preflight-fit-check"))
+        #expect(preflightBenchArguments.contains("--allow-memory-risk"))
+        #expect(try MelixCLIParser.parse(preflightBenchArguments) == preflightBenchCommand)
     }
 
     @Test("command codec exposes stable ids and supported argv mappings")
     func commandCodecExposesStableIDsAndSupportedArgvMappings() throws {
         let allCommands: [(MelixCLICommand, String)] = [
             (.doctor(.init()), "doctor"),
+            (.estimateImport(.init(repoID: "mlx/qwen", json: true)), "estimate.import"),
             (.convert(.init(modelID: "model", outputDir: "/tmp/out", targetFormat: "bundle", json: true)), "convert"),
             (.quantize(.init(modelID: "model", outputDir: "/tmp/out", quantProfileID: "q4", weightQuant: "int4", kvQuant: "int8", quantizationMode: "ptq", sourceArtifactKind: "base_model", sourceArtifactPath: "/tmp/model", calibrationDatasetURI: "/tmp/calibration", qualityDelta: "-0.01", latencyDelta: "-0.2", localInferenceSmokeMode: "runtime_generate", localInferenceSmokePrompt: "smoke", json: true)), "quantize"),
             (.upload(.init(modelID: "model", outputDir: "/tmp/out", targetRepo: "melix/model", artifactPath: "/tmp/model", artifactKind: "bundle", artifactManifestPath: "/tmp/model/manifest.json", json: true)), "upload"),
@@ -672,6 +687,7 @@ struct MelixCLIParserTests {
 
         let supportedCommands: [MelixCLICommand] = [
             .doctor(.init(json: true)),
+            .estimateImport(.init(repoID: "mlx/qwen", json: true)),
             .convert(.init(modelID: "model", outputDir: "/tmp/out", targetFormat: "bundle", json: true)),
             .quantize(.init(modelID: "model", outputDir: "/tmp/out", quantProfileID: "q4", weightQuant: "int4", kvQuant: "int8", quantizationMode: "ptq", sourceArtifactKind: "base_model", sourceArtifactPath: "/tmp/model", calibrationDatasetURI: "/tmp/calibration", qualityDelta: "-0.01", latencyDelta: "-0.2", localInferenceSmokeMode: "runtime_generate", localInferenceSmokePrompt: "smoke", json: true)),
             .upload(.init(modelID: "model", outputDir: "/tmp/out", targetRepo: "melix/model", artifactPath: "/tmp/model", artifactKind: "bundle", artifactManifestPath: "/tmp/model/manifest.json", json: true)),
@@ -751,6 +767,69 @@ struct MelixCLIParserTests {
                 #expect(error == .runtime("Command codec does not support \(MelixCLICommandCodec.commandID(for: command))."))
             }
         }
+    }
+
+    @Test("parses estimate import with positional and option repo ids")
+    func parsesEstimateImportCommand() throws {
+        let positionalCommand = try MelixCLIParser.parse([
+            "estimate",
+            "import",
+            "mlx-community/Qwen3.5-9B-MLX-4bit",
+            "--json",
+        ])
+        let optionCommand = try MelixCLIParser.parse([
+            "estimate",
+            "import",
+            "--repo-id", "mlx-community/Qwen3.5-9B-MLX-8bit",
+        ])
+
+        guard case .estimateImport(let positionalOptions) = positionalCommand else {
+            Issue.record("Expected estimateImport command")
+            return
+        }
+        guard case .estimateImport(let optionOptions) = optionCommand else {
+            Issue.record("Expected estimateImport command")
+            return
+        }
+
+        #expect(positionalOptions.repoID == "mlx-community/Qwen3.5-9B-MLX-4bit")
+        #expect(positionalOptions.json)
+        #expect(optionOptions.repoID == "mlx-community/Qwen3.5-9B-MLX-8bit")
+        #expect(optionOptions.json == false)
+    }
+
+    @Test("estimate import rejects missing conflicting and unknown inputs")
+    func estimateImportRejectsInvalidInputs() throws {
+        try assertError(
+            for: [
+                "estimate",
+            ],
+            equals: .usage(MelixCLIParser.usageText)
+        )
+        try assertError(
+            for: [
+                "estimate",
+                "import",
+            ],
+            equals: .missingRequired("HF_REPO or --repo-id is required for melix estimate import.")
+        )
+        try assertError(
+            for: [
+                "estimate",
+                "import",
+                "mlx-community/Qwen3.5-9B-MLX-4bit",
+                "--repo-id", "mlx-community/Qwen3.5-9B-MLX-8bit",
+            ],
+            equals: .usage("melix estimate import accepts only one Hugging Face repo id.")
+        )
+        try assertError(
+            for: [
+                "estimate",
+                "train",
+                "--model", "mlx-community/Qwen3.5-9B-MLX-4bit",
+            ],
+            equals: .usage(MelixCLIParser.usageText)
+        )
     }
 
     @Test("parses server snapshot and pause commands")
@@ -1792,6 +1871,31 @@ struct MelixCLIParserTests {
         #expect(options.modelID.isEmpty)
         #expect(options.hfRepoID == "unsloth/gemma-4-E4B-it-MLX-8bit")
         #expect(options.suites == ["smoke"])
+        #expect(options.preflightFitCheck == false)
+        #expect(options.allowMemoryRisk == false)
+        #expect(options.json)
+    }
+
+    @Test("parses bench run memory fit preflight flags")
+    func parsesBenchRunMemoryFitPreflightFlags() throws {
+        let command = try MelixCLIParser.parse([
+            "bench",
+            "run",
+            "--repo-id", "mlx-community/Qwen3.6-35B-A3B-4bit",
+            "--suite", "smoke",
+            "--preflight-fit-check",
+            "--allow-memory-risk",
+            "--json",
+        ])
+
+        guard case .benchRun(let options) = command else {
+            Issue.record("Expected benchRun command")
+            return
+        }
+
+        #expect(options.hfRepoID == "mlx-community/Qwen3.6-35B-A3B-4bit")
+        #expect(options.preflightFitCheck)
+        #expect(options.allowMemoryRisk)
         #expect(options.json)
     }
 

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -63,6 +63,99 @@ struct MelixCLIRunnerTests {
         #expect(output.contains("estimated_resident_bytes=5.28 GB"))
     }
 
+    @Test("estimate import renders a structured Apple Silicon memory fit receipt")
+    func estimateImportRendersStructuredMemoryFitReceipt() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setHubModelCard(
+            makeHubModelCard(
+                repoID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                localFitStatus: "heavy",
+                localFitReasons: [
+                    "Estimated resident memory exceeds the comfort budget.",
+                    "Quantization metadata was inferred from filename.",
+                ],
+                estimatedArtifactBytes: 22_000_000_000,
+                estimatedResidentBytes: 44_000_000_000,
+                recommendedAction: "Use --allow-memory-risk only when the Mac is otherwise idle."
+            )
+        )
+
+        let output = try await MelixCLIRunner(client: client).run(
+            .estimateImport(.init(repoID: "mlx-community/Qwen3.6-35B-A3B-4bit", json: true))
+        )
+        let payload = try #require(parseJSONObject(output))
+        let probe = try #require(payload["probe"] as? [String: Any])
+
+        #expect(await client.lastHubModelCardRepoID == "mlx-community/Qwen3.6-35B-A3B-4bit")
+        #expect(payload["schema_version"] as? String == "melix.memory_fit_receipt.v1")
+        #expect(payload["target_kind"] as? String == "import")
+        #expect(payload["repo_id"] as? String == "mlx-community/Qwen3.6-35B-A3B-4bit")
+        #expect(payload["fit_status"] as? String == "heavy")
+        #expect((payload["total_unified_memory_bytes"] as? NSNumber)?.uint64Value ?? 0 > 0)
+        #expect((payload["estimated_active_memory_bytes"] as? NSNumber)?.uint64Value == 44_000_000_000)
+        #expect((payload["estimated_disk_usage_bytes"] as? NSNumber)?.uint64Value == 22_000_000_000)
+        #expect(payload["recommended_action"] as? String == "Use --allow-memory-risk only when the Mac is otherwise idle.")
+        #expect((payload["assumptions"] as? [String])?.isEmpty == false)
+        #expect((payload["unknown_fields"] as? [String])?.contains("parameter_count") == true)
+        #expect(probe["name"] as? String == "cli.memory_fit.estimate_import")
+        #expect((probe["hub_card_elapsed_ms"] as? NSNumber)?.doubleValue ?? -1 >= 0)
+        #expect((probe["receipt_elapsed_ms"] as? NSNumber)?.doubleValue ?? -1 >= 0)
+    }
+
+    @Test("estimate import renders a readable memory fit receipt")
+    func estimateImportRendersReadableMemoryFitReceipt() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setHubModelCard(
+            makeHubModelCard(
+                repoID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+                localFitStatus: "good",
+                localFitReasons: ["Estimated resident memory fits the comfort budget."],
+                estimatedArtifactBytes: 5_000_000_000,
+                estimatedResidentBytes: 9_000_000_000,
+                recommendedAction: "Run import normally."
+            )
+        )
+
+        let output = try await MelixCLIRunner(client: client).run(
+            .estimateImport(.init(repoID: "mlx-community/Qwen3.5-9B-MLX-4bit"))
+        )
+
+        #expect(output.contains("target_kind=import"))
+        #expect(output.contains("repo_id=mlx-community/Qwen3.5-9B-MLX-4bit"))
+        #expect(output.contains("fit_status=good"))
+        #expect(output.contains("estimated_active_memory_bytes=8.38 GB"))
+        #expect(output.contains("estimated_disk_usage_bytes=4.66 GB"))
+        #expect(output.contains("recommended_action=Run import normally."))
+    }
+
+    @Test("estimate import reports unknown fields when Hub fit evidence is sparse")
+    func estimateImportReportsSparseHubUnknownFields() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setHubModelCard(
+            makeHubModelCard(
+                repoID: "mlx-community/metadata-light-model",
+                localFitStatus: "",
+                localFitReasons: [],
+                estimatedArtifactBytes: 0,
+                estimatedResidentBytes: 0,
+                recommendedAction: ""
+            )
+        )
+
+        let output = try await MelixCLIRunner(client: client).run(
+            .estimateImport(.init(repoID: "mlx-community/metadata-light-model", json: true))
+        )
+        let payload = try #require(parseJSONObject(output))
+        let unknownFields = try #require(payload["unknown_fields"] as? [String])
+
+        #expect(payload["fit_status"] as? String == "unknown")
+        #expect(unknownFields.contains("estimated_active_memory_bytes"))
+        #expect(unknownFields.contains("estimated_disk_usage_bytes"))
+        #expect(unknownFields.contains("fit_status"))
+        #expect(unknownFields.contains("parameter_count"))
+        #expect(unknownFields.contains("quantization_summary"))
+    }
+
     @Test("model download forwards the expected download operation payload")
     func modelDownloadForwardsExpectedOperationPayload() async throws {
         let client = StubControlPlaneXPCClient()
@@ -6249,6 +6342,116 @@ struct MelixCLIRunnerTests {
         #expect(payload["report_path"] as? String == "/tmp/melix/bench/job-vlm/report.md")
     }
 
+    @Test("bench run memory fit preflight blocks unsafe direct Hugging Face targets")
+    func benchRunMemoryFitPreflightBlocksUnsafeHFRepo() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setHubModelCard(
+            makeHubModelCard(
+                repoID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                localFitStatus: "blocked",
+                localFitReasons: ["No MLX compatibility signal."],
+                estimatedArtifactBytes: 24_000_000_000,
+                estimatedResidentBytes: 48_000_000_000,
+                recommendedAction: "Choose a smaller quantized model."
+            )
+        )
+
+        do {
+            _ = try await MelixCLIRunner(client: client).run(
+                .benchRun(
+                    .init(
+                        hfRepoID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                        suites: ["smoke"],
+                        preflightFitCheck: true
+                    )
+                )
+            )
+            Issue.record("Expected memory fit preflight to block the benchmark run.")
+        } catch let error as MelixCLIError {
+            guard case .runtime(let message) = error else {
+                Issue.record("Expected runtime error.")
+                return
+            }
+            #expect(message.contains("fit_status=blocked"))
+            #expect(message.contains("--allow-memory-risk"))
+            #expect(message.contains("No MLX compatibility signal."))
+        }
+
+        #expect(await client.lastBenchRequest == nil)
+    }
+
+    @Test("bench run memory fit preflight requires a direct Hugging Face repo target")
+    func benchRunMemoryFitPreflightRequiresHFRepo() async throws {
+        let client = StubControlPlaneXPCClient()
+
+        do {
+            _ = try await MelixCLIRunner(client: client).run(
+                .benchRun(
+                    .init(
+                        modelID: "melix-dev-text",
+                        suites: ["smoke"],
+                        preflightFitCheck: true
+                    )
+                )
+            )
+            Issue.record("Expected memory fit preflight to reject non-Hub benchmark targets.")
+        } catch let error as MelixCLIError {
+            guard case .runtime(let message) = error else {
+                Issue.record("Expected runtime error.")
+                return
+            }
+            #expect(message == "--preflight-fit-check is currently supported for melix bench run --repo-id targets.")
+        }
+
+        #expect(await client.lastBenchRequest == nil)
+    }
+
+    @Test("bench run memory risk override stores the fit receipt in benchmark parameters")
+    func benchRunMemoryRiskOverrideStoresFitReceiptParameters() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setHubModelCard(
+            makeHubModelCard(
+                repoID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                localFitStatus: "heavy",
+                localFitReasons: ["Estimated resident memory exceeds the comfort budget."],
+                estimatedArtifactBytes: 22_000_000_000,
+                estimatedResidentBytes: 44_000_000_000,
+                recommendedAction: "Use --allow-memory-risk only when the Mac is otherwise idle."
+            )
+        )
+        await client.setBenchResult(
+            .init(
+                reportPath: "/tmp/melix/bench/job-fit/report.md",
+                reportMarkdown: "# Melix Bench\n",
+                metrics: [:]
+            )
+        )
+
+        _ = try await MelixCLIRunner(client: client).run(
+            .benchRun(
+                .init(
+                    hfRepoID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                    suites: ["smoke"],
+                    preflightFitCheck: true,
+                    allowMemoryRisk: true
+                )
+            )
+        )
+        let benchRequest = try #require(await client.lastBenchRequest)
+        let receiptJSON = try #require(benchRequest.parameters["memory_fit_receipt_json"])
+        let receipt = try #require(parseJSONObject(receiptJSON))
+
+        #expect(benchRequest.hfRepoID == "mlx-community/Qwen3.6-35B-A3B-4bit")
+        #expect(benchRequest.parameters["memory_fit_schema_version"] == "melix.memory_fit_receipt.v1")
+        #expect(benchRequest.parameters["memory_fit_target_kind"] == "benchmark")
+        #expect(benchRequest.parameters["memory_fit_status"] == "heavy")
+        #expect(benchRequest.parameters["memory_fit_estimated_active_memory_bytes"] == "44000000000")
+        #expect(benchRequest.parameters["memory_fit_estimated_disk_usage_bytes"] == "22000000000")
+        #expect(benchRequest.parameters["memory_fit_safety_threshold_fraction"] == "0.60")
+        #expect(receipt["target_kind"] as? String == "benchmark")
+        #expect(receipt["fit_status"] as? String == "heavy")
+    }
+
     @Test("bench run returns plain markdown or the report path depending on the response")
     func benchRunReturnsPlainOutput() async throws {
         let client = StubControlPlaneXPCClient()
@@ -7883,6 +8086,7 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
     private(set) var lastServingDefaultsApplyRequest: ServingDefaultsApplyCall?
     private(set) var lastBenchRequest: ControlPlaneBenchRequest?
     private(set) var lastBenchMatrixRequest: ControlPlaneBenchMatrixRequest?
+    private(set) var lastHubModelCardRepoID: String?
     private(set) var evaluationRequests: [ControlPlaneEvaluationRequest] = []
     private(set) var loadedModelIDs: [String] = []
 
@@ -8162,7 +8366,7 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     func getHubModelCard(repoID: String) async throws -> Melix_Controlplane_V1_HubModelCard {
-        _ = repoID
+        lastHubModelCardRepoID = repoID
         return hubModelCard
     }
 
@@ -8346,6 +8550,34 @@ private func makeModelSummary(
         model.settings.ext["melix.activation_mode"] = activationMode
     }
     return model
+}
+
+private func makeHubModelCard(
+    repoID: String,
+    localFitStatus: String,
+    localFitReasons: [String],
+    estimatedArtifactBytes: UInt64,
+    estimatedResidentBytes: UInt64,
+    recommendedAction: String,
+    pipelineTag: String = "text-generation",
+    mlxCompatible: Bool = true,
+    parameterCount: UInt64 = 0,
+    quantizationSummary: String = ""
+) -> Melix_Controlplane_V1_HubModelCard {
+    var card = Melix_Controlplane_V1_HubModelCard()
+    card.repoID = repoID
+    card.author = repoID.split(separator: "/").first.map(String.init) ?? ""
+    card.modelName = repoID.split(separator: "/").dropFirst().first.map(String.init) ?? repoID
+    card.pipelineTag = pipelineTag
+    card.mlxCompatible = mlxCompatible
+    card.localFitStatus = localFitStatus
+    card.localFitReasons = localFitReasons
+    card.estimatedArtifactBytes = estimatedArtifactBytes
+    card.estimatedResidentBytes = estimatedResidentBytes
+    card.recommendedAction = recommendedAction
+    card.parameterCount = parameterCount
+    card.quantizationSummary = quantizationSummary
+    return card
 }
 
 private func makeModelOperationResult(

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -85,6 +85,7 @@ struct MelixCLIRunnerTests {
         )
         let payload = try #require(parseJSONObject(output))
         let probe = try #require(payload["probe"] as? [String: Any])
+        let safetyThreshold = try #require(payload["safety_threshold"] as? [String: Any])
 
         #expect(await client.lastHubModelCardRepoID == "mlx-community/Qwen3.6-35B-A3B-4bit")
         #expect(payload["schema_version"] as? String == "melix.memory_fit_receipt.v1")
@@ -97,9 +98,12 @@ struct MelixCLIRunnerTests {
         #expect(payload["recommended_action"] as? String == "Use --allow-memory-risk only when the Mac is otherwise idle.")
         #expect((payload["assumptions"] as? [String])?.isEmpty == false)
         #expect((payload["unknown_fields"] as? [String])?.contains("parameter_count") == true)
-        #expect(probe["name"] as? String == "cli.memory_fit.estimate_import")
+        #expect(probe["name"] as? String == "cli.memory_fit.import")
         #expect((probe["hub_card_elapsed_ms"] as? NSNumber)?.doubleValue ?? -1 >= 0)
         #expect((probe["receipt_elapsed_ms"] as? NSNumber)?.doubleValue ?? -1 >= 0)
+        #expect((safetyThreshold["safety_threshold_fraction"] as? NSNumber)?.doubleValue == 0.60)
+        #expect((safetyThreshold["safety_threshold_bytes"] as? NSNumber)?.uint64Value ?? 0 > 0)
+        #expect(safetyThreshold["memory_headroom_fraction"] == nil)
     }
 
     @Test("estimate import renders a readable memory fit receipt")
@@ -123,6 +127,8 @@ struct MelixCLIRunnerTests {
         #expect(output.contains("target_kind=import"))
         #expect(output.contains("repo_id=mlx-community/Qwen3.5-9B-MLX-4bit"))
         #expect(output.contains("fit_status=good"))
+        #expect(output.contains("total_unified_memory_bytes="))
+        #expect(output.contains("total_unified_memory_bytes=\(ProcessInfo.processInfo.physicalMemory)") == false)
         #expect(output.contains("estimated_active_memory_bytes=8.38 GB"))
         #expect(output.contains("estimated_disk_usage_bytes=4.66 GB"))
         #expect(output.contains("recommended_action=Run import normally."))
@@ -6373,6 +6379,8 @@ struct MelixCLIRunnerTests {
                 return
             }
             #expect(message.contains("fit_status=blocked"))
+            #expect(message.contains("estimated_active_memory_bytes=44.70 GB"))
+            #expect(message.contains("estimated_disk_usage_bytes=22.35 GB"))
             #expect(message.contains("--allow-memory-risk"))
             #expect(message.contains("No MLX compatibility signal."))
         }
@@ -6450,6 +6458,7 @@ struct MelixCLIRunnerTests {
         #expect(benchRequest.parameters["memory_fit_safety_threshold_fraction"] == "0.60")
         #expect(receipt["target_kind"] as? String == "benchmark")
         #expect(receipt["fit_status"] as? String == "heavy")
+        #expect((receipt["probe"] as? [String: Any])?["name"] as? String == "cli.memory_fit.benchmark")
     }
 
     @Test("bench run returns plain markdown or the report path depending on the response")


### PR DESCRIPTION
## Summary
- Refs #638.
- Add `melix estimate import` for Apple Silicon unified-memory fit receipts backed by existing Hub model-card local-fit evidence.
- Add optional `melix bench run --repo-id ... --preflight-fit-check` blocking with `--allow-memory-risk` override and persisted memory-fit receipt parameters.
- Document the first-slice plan, probes, success metrics, and deferred train/eval fit-check scope.

## Plan or Spec
- `docs/plans/2026-05-11-apple-silicon-memory-fit-receipts.md`

## Commands Run
```text
swift test --filter MelixCLIParserTests --filter MelixCLIRunnerTests/bench --filter MelixCLIRunnerTests/estimate
Result: passed, 99 tests.

swift test --enable-code-coverage --filter MelixCLIParserTests --filter MelixCLIRunnerTests/bench --filter MelixCLIRunnerTests/estimate
Result: passed, 99 tests; generated .build/arm64-apple-macosx/debug/codecov/default.profdata.

python3 scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main Sources/MelixCLICore/MelixCLI.swift Sources/MelixCLICore/MelixCLICommandCodec.swift
Result: TOTAL 100.00% (196/196).

git diff --check
Result: passed, no whitespace errors.

make swift-test
Result: failed in swift-test-text-worker because the local Swift MLX live-bridge test path could not load mlx.metallib ("MLX error: Failed to load the default metallib. library not found"). The preceding protocol shard passed; the failure is outside the changed CLI scope.
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 100.00% (196/196)` for `Sources/MelixCLICore/MelixCLI.swift` and `Sources/MelixCLICore/MelixCLICommandCodec.swift`.
- Probe metrics added to estimate receipts:
  - `probe.name=cli.memory_fit.<target_kind>`
  - `probe.hub_card_elapsed_ms`
  - `probe.receipt_elapsed_ms`
- Benchmark artifacts now receive memory-fit summary parameters, including `memory_fit_status`, estimated active/disk bytes, total unified memory bytes, safety threshold fraction, unknown fields, and compact `memory_fit_receipt_json`.

## Known Gaps
- This first slice covers import estimates and direct Hugging Face benchmark preflight only. Train/eval fit checks remain follow-up work for #638.
- `make bootstrap`, `make proto`, `make py-test`, and `make integration-test` were not run because this change does not modify bootstrap, protobuf, Python, or integration paths.
- Full `make swift-test` did not complete in this local environment because `swift-test-text-worker` requires a local Swift MLX metallib for a live-bridge path. Focused CLI tests and changed-line coverage passed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
