### PR TITLE
perf: elide lora reward variance list

### DIFF
--- a/docs/plans/2026-05-05-lora-reward-summary-minmax.md
+++ b/docs/plans/2026-05-05-lora-reward-summary-minmax.md
@@ -28,3 +28,7 @@ Register `lora-reward-summary-candidate-minmax` in the PR-scoped performance reg
 - Focused LoRA reward summary tests pass.
 - Changed executable line coverage is at least 95%.
 - Local probe shows fewer sort calls and improved or non-regressive elapsed time versus `origin/main`.
+
+## Follow-up total-cache slice
+
+The 2026-05-10 follow-up slice keeps the registered `lora-reward-summary-candidate-minmax` probe and further reduces summary aggregation overhead. `_reward_summary(...)` already maintains running candidate-group variance totals; this slice removes the now-redundant variance list append and uses the existing score list length for reward mean. The summary schema and percentile behavior stay unchanged.

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -503,7 +503,6 @@ def _reward_summary(samples: list[dict[str, Any]]) -> dict[str, float | int]:
     scores: list[float] = []
     score_total = 0.0
     candidate_group_margins: list[float] = []
-    candidate_group_variances: list[float] = []
     candidate_group_margin_total = 0.0
     candidate_group_variance_total = 0.0
     for sample in samples:
@@ -541,14 +540,13 @@ def _reward_summary(samples: list[dict[str, Any]]) -> dict[str, float | int]:
                 candidate_score_square_total / candidate_score_count
             ) - (group_mean * group_mean)
             candidate_group_margins.append(candidate_group_margin)
-            candidate_group_variances.append(candidate_group_variance)
             candidate_group_margin_total += candidate_group_margin
             candidate_group_variance_total += candidate_group_variance
     if not scores:
         return {}
     ordered = sorted(scores)
     summary: dict[str, float | int] = {
-        "reward_mean": score_total / len(ordered),
+        "reward_mean": score_total / len(scores),
         "reward_p50": _percentile_value(ordered, 0.5),
         "reward_p95": _percentile_value(ordered, 0.95),
     }


### PR DESCRIPTION
## Summary
- Removes the redundant LoRA reward summary `candidate_group_variances` list append.
- Reuses the existing score list length for `reward_mean` after sorting, preserving summary semantics while trimming aggregation overhead.

## Plan or Spec
- `docs/plans/2026-05-05-lora-reward-summary-minmax.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alias services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file
# 9 passed in 1.90s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alias services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file
# 9 passed in 3.33s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_reward_summary_probe.py
# TOTAL 0 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id lora-reward-summary-candidate-minmax --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-lora-reward-total-cache-20260510193656 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-lora-reward-total-cache-20260510193656 --output /tmp/lora_reward_total_cache_probe_final.json
# head verification ok; base/head probes ok
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (aggregate measurable changed lines: 0, registry command reports `TOTAL 0 0 100%`).
- Registered probe: `lora-reward-summary-candidate-minmax`.
- Local Linux registered probe metrics:
  - `elapsed_ms_mean`: base `46.41142749460414` ms → head `45.42933075572364` ms (`delta_ms=-0.9820967388805002`, `speedup_pct=2.1160666497376757`).
  - `sorted_calls_mean`: base `2.0` → head `2.0`.
- CI PR-scoped performance remains the merge gate for the registered probe report.

## Known Gaps
- None. This is a Python-only worker path and was locally verified on Linux; CI must still publish the registered PR-scoped performance result before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
