### PR TITLE
perf: reuse hub size hint multipliers

### DIFF
--- a/docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md
+++ b/docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md
@@ -1,8 +1,8 @@
-# Hub Catalog Empty Size-Hint Fast Path
+# Hub Catalog Size-Hint Multiplier Constants
 
 ## Goal
 
-Avoid redundant regex work when Hub catalog metadata has no model-size hint text.
+Avoid repeated power-expression evaluation while parsing Hub catalog model-size hints by reusing module-level byte multiplier constants for KB, MB, and GB units.
 
 ## Touched Files
 
@@ -17,18 +17,18 @@ This slice is Python-only and can be verified locally on Linux with focused pyte
 
 Use the existing registered probe:
 
-- `hub-catalog-tag-normalization-single-pass`
+- `hub-catalog-size-hint-regex-precompile`
 
-The probe builds a large synthetic Hub catalog page with empty `cardData`, which exercises the hot no-size-hint path.
+The probe builds synthetic Hub catalog size-hint payloads and exercises both direct `cardData.model_size` parsing and labeled text parsing. The registered probe has focused `test_command`, `coverage_command`, and `probe_command` entries in `infra/perf/pr_scoped_probes.json`.
 
 ## Success Metrics
 
 - Focused Hub catalog tests pass.
 - Changed executable line coverage for touched Python scope is at least 95%.
-- The local base-vs-head probe reports no behavior drift and ideally lower elapsed time for the empty-card workload.
+- The local base-vs-head registered probe reports behavior parity and lower mean elapsed time for the size-hint workload.
 
 ## Implementation Plan
 
-1. Add an early return to `_size_hint_from_text(...)` for empty text before selecting/searching the regex pattern.
-2. Add a focused regression test that proves empty text returns `0` without invoking either compiled regex object.
-3. Run focused pytest, changed-scope coverage, `git diff --check`, and the existing local probe before opening the PR.
+1. Add module-level byte multiplier constants and reuse them in `_direct_size_hint_from_text(...)` and `_size_hint_from_text(...)`.
+2. Extend the focused size-hint parser test to cover KB, fractional MB, and GB through both direct and regex-backed paths.
+3. Run focused pytest, changed-scope coverage, `git diff --check`, and the registered local probe before opening the PR.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -635,11 +635,17 @@ def test_size_hint_bytes_falls_back_for_labeled_direct_card_model_size(
     parser.assert_called_once_with("Model size: 7 MB", allow_bare=True)
 
 
-def test_direct_size_hint_parser_covers_units_and_invalid_values() -> None:
+def test_size_hint_parsers_cover_units_and_invalid_values() -> None:
     assert hub_catalog_module._direct_size_hint_from_text("512 kb") == 512 * KB
+    assert hub_catalog_module._direct_size_hint_from_text("1.5 MB") == int(1.5 * MB)
+    assert hub_catalog_module._direct_size_hint_from_text("2 GB") == 2 * GB
     assert hub_catalog_module._direct_size_hint_from_text("512 tb") == 0
     assert hub_catalog_module._direct_size_hint_from_text("not-a-number MB") == 0
     assert hub_catalog_module._direct_size_hint_from_text("model size 512 MB") == 0
+
+    assert _size_hint_from_text("Model size: 512 kb", allow_bare=False) == 512 * KB
+    assert _size_hint_from_text("Model size: 1.5 MB", allow_bare=False) == int(1.5 * MB)
+    assert _size_hint_from_text("Model size: 2 GB", allow_bare=False) == 2 * GB
 
 
 @pytest.mark.parametrize(

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -15,6 +15,10 @@ from worker.productization.device_identity import collect_device_identity
 MEMORY_COMFORT_BUDGET_FACTOR = 0.60
 RESIDENT_MEMORY_OVERHEAD_FACTOR = 1.35
 
+_SIZE_HINT_KB = 1024
+_SIZE_HINT_MB = _SIZE_HINT_KB * 1024
+_SIZE_HINT_GB = _SIZE_HINT_MB * 1024
+
 _BARE_SIZE_HINT_RE = re.compile(r"(?:model\s+size\s*[:|]?\s*)?(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
 _EXPLICIT_SIZE_HINT_RE = re.compile(r"\bmodel\s+size\s*[:|]?\s*(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
 _QUANTIZATION_ALIASES = (
@@ -624,11 +628,11 @@ def _direct_size_hint_from_text(text: str) -> int:
     value_text, unit_text = parts
     unit = unit_text.lower()
     if unit == "kb":
-        multiplier = 1024
+        multiplier = _SIZE_HINT_KB
     elif unit == "mb":
-        multiplier = 1024 ** 2
+        multiplier = _SIZE_HINT_MB
     elif unit == "gb":
-        multiplier = 1024 ** 3
+        multiplier = _SIZE_HINT_GB
     else:
         return 0
     try:
@@ -648,11 +652,11 @@ def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:
     value = float(match.group(1))
     unit = match.group(2).lower()
     if unit == "kb":
-        multiplier = 1024
+        multiplier = _SIZE_HINT_KB
     elif unit == "mb":
-        multiplier = 1024 ** 2
+        multiplier = _SIZE_HINT_MB
     else:
-        multiplier = 1024 ** 3
+        multiplier = _SIZE_HINT_GB
     return int(value * multiplier)
 
 


### PR DESCRIPTION
## Summary
- Reuse module-level KB/MB/GB multiplier constants in Hub catalog size-hint parsing.
- Extend focused parser coverage across direct and regex-backed KB, fractional MB, and GB cases.

## Plan or Spec
- docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md

## Commands Run
```text
$ git status --short && git branch --show-current
# clean worktree on perf/hub-size-multiplier-constant-20260510200627 before edits

$ python3 - <<'PY'
import json
items=json.load(open('infra/perf/pr_scoped_probes.json'))
for it in items:
    if it['id']=='hub-catalog-size-hint-regex-precompile':
        print('probe ok', it['id'])
        print('watch', it['watch_globs'])
        print('test_command=', it['test_command'])
        print('coverage_command=', it['coverage_command'])
        print('probe_command=', it['probe_command'][:400])
PY
# exit 0; registered probe has focused test_command, coverage_command, and probe_command

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# exit 0; 49 passed in 0.80s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# exit 0; 49 passed; TOTAL 15 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-hub-size-multiplier-constant-20260510200627 --head-repo "$PWD" --output /tmp/hub_size_multiplier_probe.json
# exit 0; base/head verification and probes passed

$ git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (15 measurable changed lines, 15 covered, 0 missed).
- Registered local probe `hub-catalog-size-hint-regex-precompile`:
  - base elapsed_ms_mean=1346.8956195982173
  - head elapsed_ms_mean=1270.553627400659
  - delta_ms=-76.34199219755828
  - speedup=1.060086
  - size_hint_calls_mean unchanged at 50000.0
- GitHub Actions PR-scoped performance validation is required before merge.

## Known Gaps
- None. This is a Python-only slice and was locally verified on Linux; CI remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
