### PR TITLE
perf: parse startup versions in one pass

### DIFF
--- a/docs/plans/2026-05-10-startup-version-parse-single-pass.md
+++ b/docs/plans/2026-05-10-startup-version-parse-single-pass.md
@@ -1,0 +1,40 @@
+# Startup Version Parse Single-Pass Optimization
+
+## Scope
+
+This slice is Python-only under `services/mlx-worker-python` and is locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered PR-scoped performance probe.
+
+Affected files:
+
+- `services/mlx-worker-python/worker/productization/startup_signals.py`
+- `services/mlx-worker-python/tests/test_startup_signals.py`
+- `infra/perf/pr_scoped_probes.json` (existing registered probe)
+
+## Optimization hypothesis
+
+`normalized_version_parts()` previously trimmed version suffixes, split the cleaned version string, and applied a compiled regex to every segment. Startup update checks call this helper through `compare_versions()`. A single pass over the stripped version string can preserve the same behavior while avoiding the intermediate split list and per-segment regex match.
+
+The intended behavior stays unchanged:
+
+- optional leading `v` is ignored;
+- `+` build metadata and `-` prerelease suffixes stop parsing;
+- empty dotted segments are skipped;
+- leading decimal digits in each segment are parsed, non-numeric segments become `0`;
+- an empty result normalizes to `[0]`.
+
+## Registered probe
+
+Use the existing `startup-signals-version-compare-single-pass` registered probe in `infra/perf/pr_scoped_probes.json`. It includes focused `test_command`, `coverage_command`, and `probe_command` entries for `startup_signals.py` and validates repeated `compare_versions()` calls.
+
+## Verification plan
+
+Run locally on Linux:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report --include='services/mlx-worker-python/worker/productization/startup_signals.py'
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id startup-signals-version-compare-single-pass --base-repo <origin-main-worktree> --head-repo "$PWD" --output /tmp/startup-version-parse-probe.json
+```
+
+Success criteria: focused tests pass, changed-scope coverage is at least 95%, and the registered probe reports lower `elapsed_ms_mean` for head versus base without behavior regressions.

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -23,7 +23,6 @@ CRASH_PATTERNS = [
     "abort trap",
 ]
 _BYTE_WHITESPACE = bytes(value for value in range(256) if chr(value).isspace())
-_LEADING_VERSION_PART_RE = re.compile(r"(\d+)")
 
 
 @dataclass(frozen=True)
@@ -143,23 +142,34 @@ def compare_versions(left: str, right: str) -> int:
 
 def normalized_version_parts(value: str) -> list[int]:
     cleaned = value.strip()
-    if cleaned.startswith("v"):
-        cleaned = cleaned[1:]
-    plus_index = cleaned.find("+")
-    dash_index = cleaned.find("-")
-    suffix_index = len(cleaned)
-    if plus_index >= 0 and plus_index < suffix_index:
-        suffix_index = plus_index
-    if dash_index >= 0 and dash_index < suffix_index:
-        suffix_index = dash_index
-    cleaned = cleaned[:suffix_index]
+    start_index = 1 if cleaned.startswith("v") else 0
     normalized: list[int] = []
     append_part = normalized.append
-    for part in cleaned.split("."):
-        if not part:
+    current_value = 0
+    digit_seen = False
+    digit_prefix_active = True
+    part_has_chars = False
+
+    for character in cleaned[start_index:]:
+        if character == "+" or character == "-":
+            break
+        if character == ".":
+            if part_has_chars:
+                append_part(current_value if digit_seen else 0)
+            current_value = 0
+            digit_seen = False
+            digit_prefix_active = True
+            part_has_chars = False
             continue
-        digits = _LEADING_VERSION_PART_RE.match(part)
-        append_part(int(digits.group(1)) if digits else 0)
+        part_has_chars = True
+        if digit_prefix_active and character.isdigit():
+            current_value = current_value * 10 + int(character)
+            digit_seen = True
+        else:
+            digit_prefix_active = False
+
+    if part_has_chars:
+        append_part(current_value if digit_seen else 0)
     return normalized or [0]
 
 


### PR DESCRIPTION
## Summary
- Parse startup version strings in a single pass instead of slicing/splitting and regex-matching each version segment.
- Preserve the existing comparison semantics for leading `v`, `+`/`-` suffixes, empty segments, and non-numeric parts.
- Add the governing plan for this Python performance slice.

## Plan or Spec
- `docs/plans/2026-05-10-startup-version-parse-single-pass.md`

## Commands Run
```text
# Preflight / setup
cd /root/.hermes/profiles/coder/workspace/melix
git fetch origin main --prune
git worktree add -b perf/cron-registered-python-slice-20260510222659 /root/.hermes/profiles/coder/workspace/worktrees/melix-cron-registered-python-slice-20260510222659 origin/main

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics
# Result: 5 passed in 2.79s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_version_probe.py
# Result: 5 passed in 4.91s; TOTAL 22 0 100%

# Registered PR-scoped probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id startup-signals-version-compare-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-startup-version-parse-20260510222659 --head-repo "$PWD" --output /tmp/startup-version-parse-probe.json
# Result: ok; base elapsed_ms_mean=337.7517595820661, head elapsed_ms_mean=144.30114427315337

git diff --check
# Result: passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 22 0 100%`.
- Registered probe `startup-signals-version-compare-single-pass`:
  - `elapsed_ms_mean`: base `337.7517595820661` ms → head `144.30114427315337` ms (`-193.45061530891273` ms, `57.27%` lower, `2.34x` throughput-equivalent speedup).
  - `peak_bytes_mean`: base `1748.0` bytes → head `356.0` bytes.
  - `comparison_total`: base `-48.0`, head `-48.0`.
- CI PR-scoped performance validation is still required before merge.

## Known Gaps
- Local verification covers the Python startup-signals path on Linux only; no Swift/runtime effect is claimed.
- Full repository `make` gates were not run locally for this small Python slice; GitHub Actions is expected to run the repository gates and the registered PR-scoped performance workflow.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
