### PR TITLE
perf: reduce code eval fallback line count allocation

### DIFF
--- a/docs/plans/2026-05-11-code-eval-nonblank-line-counter.md
+++ b/docs/plans/2026-05-11-code-eval-nonblank-line-counter.md
@@ -1,0 +1,23 @@
+# Code Evaluation Nonblank Line Counter Allocation Slice
+
+## Scope
+
+This Python performance slice is limited to the fallback test-counting path in `services/mlx-worker-python/worker/engine/code_eval_runner.py` when syntax-error or no-assert test payloads require counting nonblank lines.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `code-eval-test-count-nonblank-streaming` in `infra/perf/pr_scoped_probes.json`. The probe has focused `test_command`, `coverage_command`, and `probe_command` entries and measures peak traced allocation while preserving the expected nonblank-line count.
+
+## Optimization
+
+Replace the regular-expression `finditer` count with a streaming character scan that counts a line once when the first non-whitespace character is seen. This avoids regex match object allocation on large fallback test payloads while preserving `splitlines`-compatible nonblank-line semantics for spaces, tabs, `\n`, and `\r\n` inputs.
+
+## Verification Plan
+
+Run the registered focused test command, changed-scope coverage command, and registered probe locally on Linux before opening the PR. GitHub Actions PR-scoped performance remains the merge gate.
+
+## Success Metrics
+
+- Focused code-eval tests pass.
+- Changed executable line coverage for touched Python scope is at least 95%.
+- The registered `code-eval-test-count-nonblank-streaming` probe preserves `nonblank_line_count_mean=48000` and lowers `peak_bytes_mean` versus the origin/main baseline samples. The probe's elapsed metric is informational for this slice.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -6,7 +6,6 @@ from functools import lru_cache
 import json
 import os
 from pathlib import Path
-import re
 import shutil
 import subprocess
 import sys
@@ -17,7 +16,6 @@ import textwrap
 _DEFAULT_STDIO_LIMIT_BYTES = 32_768
 _JSON_LOADS = json.loads
 _JSON_DECODE_ERROR = json.JSONDecodeError
-_NONBLANK_TEST_LINE_RE = re.compile(r"\S[^\r\n]*(?:\r\n?|\n|$)")
 
 
 @dataclass(frozen=True)
@@ -256,7 +254,15 @@ def _count_tests(test_code: str) -> int:
 
 
 def _count_nonblank_test_lines(test_code: str) -> int:
-    return sum(1 for _ in _NONBLANK_TEST_LINE_RE.finditer(test_code))
+    count = 0
+    in_line = False
+    for char in test_code:
+        if char in "\r\n":
+            in_line = False
+        elif not in_line and not char.isspace():
+            count += 1
+            in_line = True
+    return count
 
 
 def _load_payload_file(


### PR DESCRIPTION
## Summary
- Replaces the code-eval fallback nonblank-line regex scan with a streaming character counter.
- Keeps syntax-error and no-assert fallback behavior unchanged while reducing traced peak allocation in the registered probe.

## Plan or Spec
- `docs/plans/2026-05-11-code-eval-nonblank-line-counter.md`

## Commands Run
```text
# Rejected candidate before this PR: stream assembler compact encoder reuse
# Baseline stream-assembler-parser-mode-cache: elapsed_ms_mean samples 4.135397510253824, 3.445144393481314, 3.3189429668709636
# Head stream-assembler-parser-mode-cache: elapsed_ms_mean samples 4.8931284982245415, 3.479018487269059, 3.370374281075783, 4.409887493238784, 3.9163005858426914
# Result: rejected and rolled back because elapsed did not improve.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_syntax_error_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics
# 8 passed in 0.58s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_syntax_error_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_test_count_probe.py
# 8 passed in 35.32s
# TOTAL 9 0 100%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 9 0 100%`.
- Registered probe: `code-eval-test-count-nonblank-streaming`.
- Baseline local probe samples on `origin/main`:
  - `peak_bytes_mean`: 2117.0, 2117.0, 2117.0
  - `elapsed_ms_mean`: 41.7077670406018, 43.065569180596086, 40.855150719705435 (informational)
  - `nonblank_line_count_mean`: 48000.0 for all samples
- Head local probe samples:
  - `peak_bytes_mean`: 112.0, 112.0, 112.0, 112.0, 112.0
  - `elapsed_ms_mean`: 51.68728939523654, 52.67593743545668, 50.050257289383026, 56.353350419418085, 53.64865285810083 (informational)
  - `nonblank_line_count_mean`: 48000.0 for all samples
- Metric decision: accepted for allocation reduction (`peak_bytes_mean` 2117.0 -> 112.0, -2005 bytes / -94.7%). Elapsed is informational for this registered probe and regressed locally, so the benefit is scoped to lower traced allocation.
- CI PR-scoped performance is required before merge.

## Known Gaps
- Local Linux validation cannot exercise macOS-only Swift behavior; this PR is Python-only.
- The registered probe's elapsed metric is informational and was slower locally; the accepted metric is reduced peak allocation only.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
