### PR TITLE
perf: fast-path OCR single-image token count

### DIFF
--- a/services/mlx-worker-python/tests/test_vision_runtime.py
+++ b/services/mlx-worker-python/tests/test_vision_runtime.py
@@ -157,6 +157,33 @@ def test_ocr_token_count_scans_whitespace_without_split_list() -> None:
         request.images[0].byte_length // 8,
     )
 
+    fallback_request = PreparedVisionRequest(
+        prompt_text=prompt_text,
+        images=[
+            request.images[0],
+            PreparedImageInput(
+                bytes_data=b"x",
+                source_kind="inline",
+                reference="inline:second.txt",
+                mime_type="text/plain",
+                format="txt",
+                filename="second.txt",
+                sha256_hex="b" * 64,
+            ),
+        ],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=129,
+        preprocess_peak_memory_bytes=129,
+        prompt_hash_hex="p" * 64,
+        multimodal_hash_hex="m" * 64,
+    )
+    assert runtime.prompt_token_count(fallback_request) == len(prompt_text.split()) + max(
+        1,
+        fallback_request.images[0].byte_length // 8,
+    ) + max(1, fallback_request.images[1].byte_length // 8)
+
 
 def test_vision_family_prompt_token_count_clamps_media_minimums() -> None:
     family_config = ResolvedVisionFamilyConfig(

--- a/services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py
@@ -66,7 +66,11 @@ class DeterministicOCRRuntime:
 
     def prompt_token_count(self, prepared_request: PreparedVisionRequest) -> int:
         prompt_tokens = _whitespace_token_count(prepared_request.prompt_text)
-        image_tokens = sum(max(1, image.byte_length // 8) for image in prepared_request.images)
+        images = prepared_request.images
+        if len(images) == 1:
+            image_tokens = max(1, images[0].byte_length // 8)
+        else:
+            image_tokens = sum(max(1, image.byte_length // 8) for image in images)
         return max(1, prompt_tokens + image_tokens)
 
     def generate_tokens(


### PR DESCRIPTION
## Summary
- Add a single-image fast path in deterministic OCR prompt-token accounting to avoid generator setup on the normal OCR request shape.
- Keep the multi-image fallback behavior covered in the existing OCR token-count test.

## Plan or Spec
- N/A: this is a scoped registered performance-slice implementation for the existing `deterministic-ocr-token-count-scan` PR-scoped probe; no product behavior or workflow changes.

## Commands Run
```text
# baseline probe before code change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py
exit 0: {"checksum": 80000000.0, "elapsed_ms_mean": 363.834159, "iterations": 80000.0, "peak_bytes_mean": 595.2, "sample_count": 5.0, "token_count": 200.0}

# focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_ocr_text_from_inline_image_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics
exit 0: 5 passed in 1.39s

# changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_ocr_text_from_inline_image_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_ocr_token_count_probe.py
exit 0: TOTAL 6 0 100%

# registered probe after code change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py
exit 0: {"checksum": 80000000.0, "elapsed_ms_mean": 276.270225, "iterations": 80000.0, "peak_bytes_mean": 163.2, "sample_count": 5.0, "token_count": 200.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 6 0 100%`).
- Registered local probe: `deterministic-ocr-token-count-scan`.
- Probe delta: `elapsed_ms_mean` 363.834159 -> 276.270225 ms (delta -87.563934 ms, speedup 1.34x); `peak_bytes_mean` 595.2 -> 163.2 bytes (delta -432.0 bytes).
- CI PR-scoped performance workflow is required as the registered probe validation source before merge.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or no behavior/workflow docs were needed.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
