### PR TITLE
Add eval schema and hints reproducibility

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import MelixControlPlaneCore
 import MelixControlPlaneProtocol
@@ -3357,10 +3358,21 @@ public enum MelixCLIParser {
             parameters["remote_provider_extra_body_json"] = remoteExtraBodyJSON
         }
         if let schemaPath = values.single["--schema"], schemaPath.isEmpty == false {
-            parameters["schema_path"] = schemaPath
+            let file = try evaluationFileMetadata(path: schemaPath, option: "--schema")
+            parameters["schema_path"] = file.resolvedPath
+            parameters["schema_sha256"] = file.sha256
+            parameters["schema_size_bytes"] = String(file.sizeBytes)
         }
         if let hintsPath = values.single["--hints"], hintsPath.isEmpty == false {
-            parameters["hints_path"] = hintsPath
+            let file = try evaluationFileMetadata(path: hintsPath, option: "--hints")
+            guard let hintsText = String(data: file.data, encoding: .utf8) else {
+                throw MelixCLIError.usage("--hints must contain UTF-8 text.")
+            }
+            parameters["hints_path"] = file.resolvedPath
+            parameters["hints_sha256"] = file.sha256
+            parameters["hints_size_bytes"] = String(file.sizeBytes)
+            parameters["hints_format"] = evaluationHintsFormat(path: file.resolvedPath)
+            parameters["evaluation_hints_text"] = hintsText.trimmingCharacters(in: .whitespacesAndNewlines)
         }
         if let datasetRef = values.single["--dataset-ref"], datasetRef.isEmpty == false {
             let parsedRef = try parseDatasetReference(datasetRef)
@@ -3486,6 +3498,52 @@ public enum MelixCLIParser {
         }
         let canonicalData = try JSONSerialization.data(withJSONObject: parsed, options: [.sortedKeys])
         return String(decoding: canonicalData, as: UTF8.self)
+    }
+
+    private struct EvaluationFileMetadata {
+        let resolvedPath: String
+        let data: Data
+        let sha256: String
+        let sizeBytes: Int
+    }
+
+    private static func evaluationFileMetadata(path: String, option: String) throws -> EvaluationFileMetadata {
+        let expandedPath = (path as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: expandedPath)
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw MelixCLIError.usage("Failed to read \(option) at \(path): \(error.localizedDescription)")
+        }
+        let resolvedPath = url.resolvingSymlinksInPath().standardizedFileURL.path
+        return EvaluationFileMetadata(
+            resolvedPath: resolvedPath,
+            data: data,
+            sha256: sha256Hex(data),
+            sizeBytes: data.count
+        )
+    }
+
+    private static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    private static func evaluationHintsFormat(path: String) -> String {
+        switch URL(fileURLWithPath: path).pathExtension.lowercased() {
+        case "json":
+            return "json"
+        case "md":
+            return "markdown"
+        case "txt":
+            return "text"
+        case let suffix where suffix.isEmpty == false:
+            return suffix
+        default:
+            return "text"
+        }
     }
 
     private static func normalizedParameterKey(_ option: String) -> String {

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1587,14 +1587,14 @@ public enum MelixCLIParser {
       melix bench matrix list [--json]
       melix bench matrix export-summary-csv --job-id JOB_ID --output PATH [--json]
       melix bench matrix export-requests-csv --job-id JOB_ID --output PATH [--json]
-      melix eval run (--model-id MODEL_ID | --repo-id HF_REPO | --remote-server-id ID [--remote-model MODEL] ...) [--semantic-judge-remote-server-id ID] [--semantic-judge-model MODEL] [--remote-parallelism N] [--suite SUITE ...] [--dataset-id DATASET_ID] [--dataset-root PATH] [--source-csv PATH | --source-jsonl PATH | --hf-dataset-path REPO | --dataset-ref HF_DATASET[@REV]] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-dataset-split SPLIT] [--field-system-path PATH] [--field-input-text-path PATH] [--field-target-path PATH] [--field-sample-id-path PATH] [--profile-type TYPE] [--result-kind KIND] [--extraction-mode MODE] [--scoring-mode MODE] [--threshold N] [--output-schema-json JSON] [--ignored-path PATH ...] [--sample-size N] [--batch-factor N] [--seed N] [--few-shot N] [--code-exec-policy MODE] [--remote-extra-body-json JSON] [--eval-prompt-id ID] [--eval-prompt-revision REV] [--json]
+      melix eval run (--model-id MODEL_ID | --repo-id HF_REPO | --remote-server-id ID [--remote-model MODEL] ...) [--semantic-judge-remote-server-id ID] [--semantic-judge-model MODEL] [--remote-parallelism N] [--suite SUITE ...] [--dataset-id DATASET_ID] [--dataset-root PATH] [--source-csv PATH | --source-jsonl PATH | --hf-dataset-path REPO | --dataset-ref HF_DATASET[@REV]] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-dataset-split SPLIT] [--field-system-path PATH] [--field-input-text-path PATH] [--field-target-path PATH] [--field-sample-id-path PATH] [--profile-type TYPE] [--result-kind KIND] [--extraction-mode MODE] [--scoring-mode MODE] [--threshold N] [--schema PATH | --output-schema-json JSON] [--hints PATH] [--ignored-path PATH ...] [--sample-size N] [--batch-factor N] [--seed N] [--few-shot N] [--code-exec-policy MODE] [--remote-extra-body-json JSON] [--eval-prompt-id ID] [--eval-prompt-revision REV] [--json]
       melix eval prompt list [--json]
       melix eval prompt show --prompt-id ID [--revision-id REV] [--json]
       melix eval prompt create --prompt-id ID --title TITLE --system-prompt-file PATH [--json]
       melix eval prompt update --prompt-id ID --system-prompt-file PATH [--json]
       melix eval prompt freeze --prompt-id ID [--revision-id REV] [--json]
       melix eval prompt archive --prompt-id ID [--json]
-      melix eval compare (--model-id MODEL_ID | --repo-id HF_REPO) (--target-model-id MODEL_ID | --target-adapter ADAPTER_MANIFEST_PATH)... [--suite SUITE ...] [--dataset-id DATASET_ID] [--dataset-root PATH] [--source-csv PATH | --source-jsonl PATH | --hf-dataset-path REPO | --dataset-ref HF_DATASET[@REV]] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-dataset-split SPLIT] [--field-system-path PATH] [--field-input-text-path PATH] [--field-target-path PATH] [--field-sample-id-path PATH] [--profile-type TYPE] [--result-kind KIND] [--extraction-mode MODE] [--scoring-mode MODE] [--threshold N] [--output-schema-json JSON] [--ignored-path PATH ...] [--sample-size N] [--batch-factor N] [--seed N] [--few-shot N] [--code-exec-policy MODE] [--json]
+      melix eval compare (--model-id MODEL_ID | --repo-id HF_REPO) (--target-model-id MODEL_ID | --target-adapter ADAPTER_MANIFEST_PATH)... [--suite SUITE ...] [--dataset-id DATASET_ID] [--dataset-root PATH] [--source-csv PATH | --source-jsonl PATH | --hf-dataset-path REPO | --dataset-ref HF_DATASET[@REV]] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-dataset-split SPLIT] [--field-system-path PATH] [--field-input-text-path PATH] [--field-target-path PATH] [--field-sample-id-path PATH] [--profile-type TYPE] [--result-kind KIND] [--extraction-mode MODE] [--scoring-mode MODE] [--threshold N] [--schema PATH | --output-schema-json JSON] [--hints PATH] [--ignored-path PATH ...] [--sample-size N] [--batch-factor N] [--seed N] [--few-shot N] [--code-exec-policy MODE] [--json]
       melix eval compare export-summary-csv --job-id JOB_ID --output PATH [--json]
       melix eval compare export-samples-csv --job-id JOB_ID --output PATH [--json]
       melix eval compare export-samples-jsonl --job-id JOB_ID --output PATH [--json]
@@ -3356,6 +3356,12 @@ public enum MelixCLIParser {
         if let remoteExtraBodyJSON = values.single["--remote-extra-body-json"] {
             parameters["remote_provider_extra_body_json"] = remoteExtraBodyJSON
         }
+        if let schemaPath = values.single["--schema"], schemaPath.isEmpty == false {
+            parameters["schema_path"] = schemaPath
+        }
+        if let hintsPath = values.single["--hints"], hintsPath.isEmpty == false {
+            parameters["hints_path"] = hintsPath
+        }
         if let datasetRef = values.single["--dataset-ref"], datasetRef.isEmpty == false {
             let parsedRef = try parseDatasetReference(datasetRef)
             parameters["dataset_ref"] = datasetRef
@@ -3396,13 +3402,14 @@ public enum MelixCLIParser {
             targetPath: values.single["--field-target-path"] ?? "",
             sampleIDPath: values.single["--field-sample-id-path"] ?? ""
         )
+        let outputSchemaJSON = try parseEvaluationOutputSchemaJSON(values)
         let profile = ControlPlaneEvaluationRequest.Profile(
             profileType: values.single["--profile-type"] ?? "final_result",
             resultKind: values.single["--result-kind"] ?? "text",
             extractionMode: values.single["--extraction-mode"] ?? "heuristic_final",
             scoringMode: values.single["--scoring-mode"] ?? "",
             threshold: try parseDoubleValue(values.single["--threshold"], option: "--threshold", defaultValue: 1.0) ?? 1.0,
-            outputSchemaJSON: values.single["--output-schema-json"] ?? "",
+            outputSchemaJSON: outputSchemaJSON,
             ignoredPaths: values.multi["--ignored-path"] ?? []
         )
 
@@ -3445,6 +3452,40 @@ public enum MelixCLIParser {
         }
 
         return (source, fieldMapping, profile)
+    }
+
+    private static func parseEvaluationOutputSchemaJSON(_ values: ParsedArguments) throws -> String {
+        let schemaPath = values.single["--schema"] ?? ""
+        let inlineSchemaJSON = values.single["--output-schema-json"] ?? ""
+        guard schemaPath.isEmpty || inlineSchemaJSON.isEmpty else {
+            throw MelixCLIError.usage("--schema and --output-schema-json are mutually exclusive.")
+        }
+        guard schemaPath.isEmpty == false else {
+            return inlineSchemaJSON
+        }
+        return try canonicalJSONFileObject(path: schemaPath, option: "--schema")
+    }
+
+    private static func canonicalJSONFileObject(path: String, option: String) throws -> String {
+        let expandedPath = (path as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: expandedPath)
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw MelixCLIError.usage("Failed to read \(option) at \(path): \(error.localizedDescription)")
+        }
+        let parsed: Any
+        do {
+            parsed = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw MelixCLIError.usage("\(option) must contain valid JSON: \(error.localizedDescription)")
+        }
+        guard parsed is [String: Any] else {
+            throw MelixCLIError.usage("\(option) must contain a JSON object.")
+        }
+        let canonicalData = try JSONSerialization.data(withJSONObject: parsed, options: [.sortedKeys])
+        return String(decoding: canonicalData, as: UTF8.self)
     }
 
     private static func normalizedParameterKey(_ option: String) -> String {
@@ -5351,6 +5392,7 @@ public actor MelixCLIRunner {
             source: options.source,
             fieldMapping: options.fieldMapping,
             profile: options.profile,
+            schemaPath: options.parameters["schema_path"],
             into: &arguments
         )
         appendOption("--batch-factor", value: options.parameters["batch_factor"], into: &arguments)
@@ -5359,6 +5401,7 @@ public actor MelixCLIRunner {
         appendOption("--few-shot", value: options.parameters["few_shot"], into: &arguments)
         appendOption("--scoring-mode", value: options.parameters["scoring_mode"], into: &arguments)
         appendOption("--code-exec-policy", value: options.parameters["code_exec_policy"], into: &arguments)
+        appendOption("--hints", value: options.parameters["hints_path"], into: &arguments)
         arguments.append("--json")
         return arguments
     }
@@ -5367,6 +5410,7 @@ public actor MelixCLIRunner {
         source: ControlPlaneEvaluationRequest.Source,
         fieldMapping: ControlPlaneEvaluationRequest.FieldMapping,
         profile: ControlPlaneEvaluationRequest.Profile,
+        schemaPath: String? = nil,
         into arguments: inout [String]
     ) {
         switch source.kind {
@@ -5390,7 +5434,11 @@ public actor MelixCLIRunner {
         appendOption("--result-kind", value: profile.resultKind, into: &arguments)
         appendOption("--extraction-mode", value: profile.extractionMode, into: &arguments)
         appendOption("--threshold", value: String(profile.threshold), into: &arguments)
-        appendOption("--output-schema-json", value: profile.outputSchemaJSON, into: &arguments)
+        if let schemaPath, schemaPath.isEmpty == false {
+            appendOption("--schema", value: schemaPath, into: &arguments)
+        } else {
+            appendOption("--output-schema-json", value: profile.outputSchemaJSON, into: &arguments)
+        }
         appendMultiOption("--ignored-path", values: profile.ignoredPaths, into: &arguments)
     }
 

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -494,6 +494,7 @@ public enum MelixCLICommandCodec {
                 source: options.source,
                 fieldMapping: options.fieldMapping,
                 profile: options.profile,
+                schemaPath: options.parameters["schema_path"],
                 into: &arguments
             )
             appendEvalParameters(options.parameters, into: &arguments)
@@ -714,6 +715,7 @@ public enum MelixCLICommandCodec {
             ("scoring_mode", "--scoring-mode"),
             ("code_exec_policy", "--code-exec-policy"),
             ("remote_provider_extra_body_json", "--remote-extra-body-json"),
+            ("hints_path", "--hints"),
         ]
         for (key, option) in mapping {
             appendOption(option, value: parameters[key], into: &arguments)
@@ -724,6 +726,7 @@ public enum MelixCLICommandCodec {
         source: ControlPlaneEvaluationRequest.Source,
         fieldMapping: ControlPlaneEvaluationRequest.FieldMapping,
         profile: ControlPlaneEvaluationRequest.Profile,
+        schemaPath: String? = nil,
         into arguments: inout [String]
     ) {
         switch source.kind {
@@ -749,7 +752,11 @@ public enum MelixCLICommandCodec {
         if profile.threshold != 0 {
             appendOption("--threshold", value: String(profile.threshold), into: &arguments)
         }
-        appendOption("--output-schema-json", value: profile.outputSchemaJSON, into: &arguments)
+        if let schemaPath, schemaPath.isEmpty == false {
+            appendOption("--schema", value: schemaPath, into: &arguments)
+        } else {
+            appendOption("--output-schema-json", value: profile.outputSchemaJSON, into: &arguments)
+        }
         appendMultiOption("--ignored-path", values: profile.ignoredPaths, into: &arguments)
     }
 

--- a/docs/plans/2026-05-11-eval-schema-hints.md
+++ b/docs/plans/2026-05-11-eval-schema-hints.md
@@ -1,0 +1,71 @@
+# Eval Schema and Hints Reproducibility
+
+## Issue
+
+Refs #639.
+
+## Goal
+
+Make `melix eval run` and `melix eval compare` accept reproducibility inputs that are stable enough for later run reports:
+
+- `--schema <path>` loads a JSON schema file and feeds the existing structured result validation path.
+- `--hints <path>` loads task guidance from `.json`, `.md`, or `.txt` and appends it to live evaluation prompts.
+- Evaluation run metadata records schema and hints path, SHA-256, size, and format without persisting full hints text.
+- JSON schema validation covers nested objects, arrays, nullable fields, and invalid output.
+- Benchmark/evaluation comparison reports warn when baseline and candidate runs use different schema or hints hashes.
+
+## Design
+
+Use the current `EvaluationProfile.output_schema_json` path for schema content instead of adding a new protocol surface. The CLI reads `--schema`, validates that it is JSON, canonicalizes it with sorted keys, and passes it as `output_schema_json`. `--schema` and `--output-schema-json` are mutually exclusive so the receipt metadata is unambiguous.
+
+Use evaluation request parameters for reproducibility metadata:
+
+- `schema_path`
+- `hints_path`
+
+The Python worker resolves those paths, computes `schema_sha256`, `schema_size_bytes`, `hints_sha256`, `hints_size_bytes`, and `hints_format`, and keeps those in the persisted evaluation job parameters. The worker passes hints text only in memory to prompt construction.
+
+Benchmark/evaluation report generation compares the persisted schema and hints hashes from evaluation jobs and compare jobs. Hash mismatches make the report status `warning`, set comparison validity to `partial`, and render a reproducibility warning in Markdown output.
+
+## Probes and Metrics
+
+Reuse existing per-sample probes:
+
+- `eval.<suite>.sample_render_ms_mean`
+- `eval.<suite>.validation_ms_mean`
+- `eval.<suite>.scoring_ms_mean`
+- `eval.<suite>.raw_response_chars_mean`
+- `eval.<suite>.extracted_result_chars_mean`
+
+Add run-level metadata fields that make later report comparison deterministic:
+
+- `schema_sha256`
+- `schema_size_bytes`
+- `hints_sha256`
+- `hints_size_bytes`
+- `hints_format`
+- `hints_prompt_chars`
+
+Add report-level comparison warnings:
+
+- `evaluation_schema_sha256_mismatch`
+- `evaluation_hints_sha256_mismatch`
+
+Success criteria: schema/hints metadata is stable across reruns with unchanged files, validation failures remain machine-readable, and hints do not leak full text into persisted job parameters.
+
+## Implementation Steps
+
+1. Add CLI parsing and command-codec support for `--schema` and `--hints` on `eval run` and `eval compare`.
+2. Add worker metadata resolution for schema/hints paths and in-memory hints prompt injection.
+3. Expand JSON schema validation for nested objects, arrays, nullable fields, and additional property checks.
+4. Add report mismatch detection for schema/hints hashes.
+5. Add Swift parser/runner coverage and Python evaluation/report coverage.
+6. Run focused tests, changed-line coverage, diff checks, and PR evidence validation before publishing.
+
+## Verification Plan
+
+- `swift test --filter MelixCLIParserTests --filter MelixCLIRunnerTests/eval`
+- `swift test --enable-code-coverage --filter MelixCLIParserTests --filter MelixCLIRunnerTests/eval`
+- `uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_evaluation_core.py`
+- changed-line coverage for touched Swift and Python files
+- `git diff --check`

--- a/docs/plans/2026-05-11-eval-schema-hints.md
+++ b/docs/plans/2026-05-11-eval-schema-hints.md
@@ -16,14 +16,19 @@ Make `melix eval run` and `melix eval compare` accept reproducibility inputs tha
 
 ## Design
 
-Use the current `EvaluationProfile.output_schema_json` path for schema content instead of adding a new protocol surface. The CLI reads `--schema`, validates that it is JSON, canonicalizes it with sorted keys, and passes it as `output_schema_json`. `--schema` and `--output-schema-json` are mutually exclusive so the receipt metadata is unambiguous.
+Use the current `EvaluationProfile.output_schema_json` path for schema content instead of adding a new protocol surface. The CLI reads `--schema`, validates that it is JSON, canonicalizes it with sorted keys, computes its SHA-256 and byte size, and passes it as `output_schema_json`. `--schema` and `--output-schema-json` are mutually exclusive so the receipt metadata is unambiguous.
 
 Use evaluation request parameters for reproducibility metadata:
 
 - `schema_path`
+- `schema_sha256`
+- `schema_size_bytes`
 - `hints_path`
+- `hints_sha256`
+- `hints_size_bytes`
+- `hints_format`
 
-The Python worker resolves those paths, computes `schema_sha256`, `schema_size_bytes`, `hints_sha256`, `hints_size_bytes`, and `hints_format`, and keeps those in the persisted evaluation job parameters. The worker passes hints text only in memory to prompt construction.
+The CLI reads `--hints`, computes SHA-256, byte size, and format from the local file, and passes the hints text as transient `evaluation_hints_text`. The Python worker does not read schema or hints paths from its local filesystem; it preserves the CLI-supplied metadata in persisted evaluation job parameters and passes hints text only in memory to prompt construction.
 
 Benchmark/evaluation report generation compares the persisted schema and hints hashes from evaluation jobs and compare jobs. Hash mismatches make the report status `warning`, set comparison validity to `partial`, and render a reproducibility warning in Markdown output.
 
@@ -57,7 +62,7 @@ Success criteria: schema/hints metadata is stable across reruns with unchanged f
 
 1. Add CLI parsing and command-codec support for `--schema` and `--hints` on `eval run` and `eval compare`.
 2. Add worker metadata resolution for schema/hints paths and in-memory hints prompt injection.
-3. Expand JSON schema validation for nested objects, arrays, nullable fields, and additional property checks.
+3. Expand JSON schema validation for nested objects, arrays, nullable fields, `patternProperties`, and additional property checks.
 4. Add report mismatch detection for schema/hints hashes.
 5. Add Swift parser/runner coverage and Python evaluation/report coverage.
 6. Run focused tests, changed-line coverage, diff checks, and PR evidence validation before publishing.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -1605,6 +1605,97 @@ def test_report_renderers_are_stable_and_sticky_comment_is_marked() -> None:
     assert comment.endswith("\n")
 
 
+def test_report_warns_when_evaluation_schema_or_hints_hashes_differ() -> None:
+    baseline = {
+        "evaluation_jobs": [
+            {
+                "job_id": "eval-baseline",
+                "parameters": {
+                    "schema_sha256": "schema-a",
+                    "hints_sha256": "hints-a",
+                },
+            }
+        ]
+    }
+    candidate = {
+        "evaluation_jobs": [
+            {
+                "job_id": "eval-candidate",
+                "parameters": {
+                    "schema_sha256": "schema-b",
+                    "hints_sha256": "hints-b",
+                },
+            }
+        ]
+    }
+
+    report = build_benchmark_evaluation_report(
+        baseline=baseline,
+        candidate=candidate,
+    )
+    markdown = render_markdown_report(report)
+
+    assert report["summary"]["status"] == "warning"
+    assert report["summary"]["warning_count"] == 2
+    assert report["comparison"]["comparison_validity"] == "partial"
+    assert report["reproducibility_warnings"] == [
+        "evaluation_schema_sha256_mismatch:baseline=schema-a;candidate=schema-b",
+        "evaluation_hints_sha256_mismatch:baseline=hints-a;candidate=hints-b",
+    ]
+    assert report["non_blocking_warnings"] == report["reproducibility_warnings"]
+    assert "## Reproducibility Warnings" in markdown
+    assert "evaluation_schema_sha256_mismatch" in markdown
+    assert "evaluation_hints_sha256_mismatch" in markdown
+
+
+def test_report_accepts_matching_reproducibility_hashes_and_run_evidence_metadata() -> None:
+    matching = {
+        "evaluation_jobs": [
+            {
+                "job_id": "eval-a",
+                "parameters": {
+                    "schema_sha256": "schema-a",
+                    "hints_sha256": "hints-a",
+                },
+            }
+        ]
+    }
+    matching_report = build_benchmark_evaluation_report(
+        baseline=matching,
+        candidate=matching,
+    )
+
+    assert matching_report["reproducibility_warnings"] == []
+    assert matching_report["summary"]["warning_count"] == 0
+
+    missing_candidate_report = build_benchmark_evaluation_report(
+        baseline={
+            "evaluation_jobs": [{"job_id": "legacy", "parameters": "legacy"}],
+            "run_evidence": [
+                {"run_id": "bad-domain", "domain_results": {"evaluation": "legacy"}},
+                {
+                    "run_id": "evidence-eval",
+                    "domain_results": {
+                        "evaluation": {
+                            "job": {
+                                "parameters": {
+                                    "schema_sha256": "schema-from-evidence",
+                                }
+                            }
+                        }
+                    },
+                },
+            ],
+        },
+        candidate={},
+    )
+
+    assert missing_candidate_report["reproducibility_warnings"] == [
+        "evaluation_schema_sha256_mismatch:baseline=schema-from-evidence;candidate=missing"
+    ]
+    assert missing_candidate_report["summary"]["warning_count"] == 1
+
+
 def test_markdown_cell_escapes_table_control_characters() -> None:
     assert _markdown_cell("model`a|b\nc") == "model\\`a\\|b c"
 

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import builtins
+import hashlib
 import json
 from pathlib import Path
 import random
@@ -2429,6 +2430,87 @@ def test_worker_maintenance_service_run_evaluation_maps_request_task_metadata(
     assert len(backend.prompts) == 1
     assert "capital of france?" in backend.prompts[0]
     assert "Return only the final short answer." in backend.prompts[0]
+
+
+def test_worker_maintenance_service_records_schema_hints_metadata_without_persisting_hints_text(
+    tmp_path: Path,
+) -> None:
+    dataset_root = _write_dataset_package(
+        tmp_path=tmp_path,
+        dataset_id="math-dev",
+        suite_id="math",
+        samples=({"id": "sample-1", "prompt": "2+2?", "expected": "4"},),
+    )
+    schema_path = tmp_path / "result.schema.json"
+    schema_path.write_text(json.dumps({"type": "object", "required": ["answer"]}) + "\n", encoding="utf-8")
+    hints_path = tmp_path / "math-hints.md"
+    hints_text = "Prefer integer answers and keep the response short.\n"
+    hints_path.write_text(hints_text, encoding="utf-8")
+    backend = ScriptedEvaluationBackend(("Answer: 4",))
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=backend),
+        model_catalog=WorkerModelCatalog(),
+    )
+    loaded_model = registry.load_model(
+        common_pb2.ModelSpec(
+            model_id="melix-dev-text",
+            model_path=str(tmp_path / "models" / "melix-dev-text"),
+            model_kind="text",
+            revision="test",
+            tokenizer_hash="tok-test",
+            quant_profile_id="test",
+            parser_mode="text",
+            reasoning_mode="off",
+        )
+    )
+    service = WorkerMaintenanceService(registry, jobs_root=tmp_path / "model-ops")
+    request = maintenance_pb2.RunEvaluationRequest(
+        model_handle=loaded_model.handle,
+        suite_id="math",
+        dataset_id="math-dev",
+        dataset_root=str(dataset_root),
+        sample_size=1,
+        task_kind="text-generation",
+        parameters={
+            "schema_path": str(schema_path),
+            "hints_path": str(hints_path),
+        },
+    )
+
+    response = service.RunEvaluation(request, context=None)
+
+    assert response.ok is True
+    assert "Additional Hints:\nPrefer integer answers" in backend.prompts[0]
+    assert response.job.parameters["schema_path"] == str(schema_path.resolve())
+    assert response.job.parameters["schema_sha256"] == hashlib.sha256(schema_path.read_bytes()).hexdigest()
+    assert response.job.parameters["schema_size_bytes"] == str(schema_path.stat().st_size)
+    assert response.job.parameters["hints_path"] == str(hints_path.resolve())
+    assert response.job.parameters["hints_sha256"] == hashlib.sha256(hints_path.read_bytes()).hexdigest()
+    assert response.job.parameters["hints_size_bytes"] == str(hints_path.stat().st_size)
+    assert response.job.parameters["hints_format"] == "markdown"
+    assert response.job.parameters["hints_prompt_chars"] == str(len(hints_text.strip()))
+    assert "evaluation_hints_text" not in response.job.parameters
+    metrics = {metric.name: metric.value for metric in response.results[0].metrics}
+    assert metrics["eval.math.hints_prompt_chars"] == float(len(hints_text.strip()))
+
+
+def test_worker_maintenance_service_reproducibility_parameter_errors_and_hint_formats(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="evaluation schema file does not exist"):
+        WorkerMaintenanceService._attach_evaluation_reproducibility_parameters(
+            {"schema_path": str(tmp_path / "missing.schema.json")}
+        )
+
+    with pytest.raises(ValueError, match="evaluation hints file does not exist"):
+        WorkerMaintenanceService._attach_evaluation_reproducibility_parameters(
+            {"hints_path": str(tmp_path / "missing-hints.md")}
+        )
+
+    assert WorkerMaintenanceService._hints_format(tmp_path / "hints.json") == "json"
+    assert WorkerMaintenanceService._hints_format(tmp_path / "hints.md") == "markdown"
+    assert WorkerMaintenanceService._hints_format(tmp_path / "hints.txt") == "text"
+    assert WorkerMaintenanceService._hints_format(tmp_path / "hints") == "text"
 
 
 def test_worker_maintenance_service_run_evaluation_maps_compare_results(

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import builtins
-import hashlib
 import json
 from pathlib import Path
 import random
@@ -2432,7 +2431,7 @@ def test_worker_maintenance_service_run_evaluation_maps_request_task_metadata(
     assert "Return only the final short answer." in backend.prompts[0]
 
 
-def test_worker_maintenance_service_records_schema_hints_metadata_without_persisting_hints_text(
+def test_worker_maintenance_service_records_cli_supplied_schema_hints_metadata_without_persisting_hints_text(
     tmp_path: Path,
 ) -> None:
     dataset_root = _write_dataset_package(
@@ -2441,11 +2440,9 @@ def test_worker_maintenance_service_records_schema_hints_metadata_without_persis
         suite_id="math",
         samples=({"id": "sample-1", "prompt": "2+2?", "expected": "4"},),
     )
-    schema_path = tmp_path / "result.schema.json"
-    schema_path.write_text(json.dumps({"type": "object", "required": ["answer"]}) + "\n", encoding="utf-8")
-    hints_path = tmp_path / "math-hints.md"
+    schema_path = Path("/remote/eval/result.schema.json")
+    hints_path = Path("/remote/eval/math-hints.md")
     hints_text = "Prefer integer answers and keep the response short.\n"
-    hints_path.write_text(hints_text, encoding="utf-8")
     backend = ScriptedEvaluationBackend(("Answer: 4",))
     registry = WorkerRegistry(
         runtime=MLXTextRuntime(backend=backend),
@@ -2473,7 +2470,13 @@ def test_worker_maintenance_service_records_schema_hints_metadata_without_persis
         task_kind="text-generation",
         parameters={
             "schema_path": str(schema_path),
+            "schema_sha256": "schema-sha-from-cli",
+            "schema_size_bytes": "49",
             "hints_path": str(hints_path),
+            "hints_sha256": "hints-sha-from-cli",
+            "hints_size_bytes": str(len(hints_text.encode("utf-8"))),
+            "hints_format": "markdown",
+            "evaluation_hints_text": hints_text.strip(),
         },
     )
 
@@ -2481,12 +2484,12 @@ def test_worker_maintenance_service_records_schema_hints_metadata_without_persis
 
     assert response.ok is True
     assert "Additional Hints:\nPrefer integer answers" in backend.prompts[0]
-    assert response.job.parameters["schema_path"] == str(schema_path.resolve())
-    assert response.job.parameters["schema_sha256"] == hashlib.sha256(schema_path.read_bytes()).hexdigest()
-    assert response.job.parameters["schema_size_bytes"] == str(schema_path.stat().st_size)
-    assert response.job.parameters["hints_path"] == str(hints_path.resolve())
-    assert response.job.parameters["hints_sha256"] == hashlib.sha256(hints_path.read_bytes()).hexdigest()
-    assert response.job.parameters["hints_size_bytes"] == str(hints_path.stat().st_size)
+    assert response.job.parameters["schema_path"] == str(schema_path)
+    assert response.job.parameters["schema_sha256"] == "schema-sha-from-cli"
+    assert response.job.parameters["schema_size_bytes"] == "49"
+    assert response.job.parameters["hints_path"] == str(hints_path)
+    assert response.job.parameters["hints_sha256"] == "hints-sha-from-cli"
+    assert response.job.parameters["hints_size_bytes"] == str(len(hints_text.encode("utf-8")))
     assert response.job.parameters["hints_format"] == "markdown"
     assert response.job.parameters["hints_prompt_chars"] == str(len(hints_text.strip()))
     assert "evaluation_hints_text" not in response.job.parameters
@@ -2494,18 +2497,21 @@ def test_worker_maintenance_service_records_schema_hints_metadata_without_persis
     assert metrics["eval.math.hints_prompt_chars"] == float(len(hints_text.strip()))
 
 
-def test_worker_maintenance_service_reproducibility_parameter_errors_and_hint_formats(
+def test_worker_maintenance_service_reproducibility_parameters_do_not_require_worker_local_files(
     tmp_path: Path,
 ) -> None:
-    with pytest.raises(ValueError, match="evaluation schema file does not exist"):
-        WorkerMaintenanceService._attach_evaluation_reproducibility_parameters(
-            {"schema_path": str(tmp_path / "missing.schema.json")}
-        )
+    parameters = {
+        "schema_path": "/remote/eval/missing.schema.json",
+        "hints_path": "/remote/eval/missing-hints.md",
+    }
 
-    with pytest.raises(ValueError, match="evaluation hints file does not exist"):
-        WorkerMaintenanceService._attach_evaluation_reproducibility_parameters(
-            {"hints_path": str(tmp_path / "missing-hints.md")}
-        )
+    WorkerMaintenanceService._attach_evaluation_reproducibility_parameters(parameters)
+
+    assert parameters["schema_path"] == "/remote/eval/missing.schema.json"
+    assert "schema_sha256" not in parameters
+    assert parameters["hints_path"] == "/remote/eval/missing-hints.md"
+    assert parameters["hints_format"] == "markdown"
+    assert "hints_sha256" not in parameters
 
     assert WorkerMaintenanceService._hints_format(tmp_path / "hints.json") == "json"
     assert WorkerMaintenanceService._hints_format(tmp_path / "hints.md") == "markdown"

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -266,6 +266,114 @@ def test_score_final_result_rejects_invalid_json_shape_before_scoring() -> None:
     assert score.typed_score == 0.0
 
 
+def test_score_final_result_validates_nested_arrays_and_nullable_fields() -> None:
+    profile = EvaluationProfileDefinition(
+        profile_type="final_result",
+        result_kind="json",
+        extraction_mode="strict_full_response",
+        scoring_mode="json_field_match",
+        threshold=1.0,
+        output_schema={
+            "type": "object",
+            "required": ["answer", "items", "optional_note"],
+            "properties": {
+                "answer": {
+                    "type": "object",
+                    "required": ["value"],
+                    "properties": {
+                        "value": {"type": ["string", "null"]},
+                    },
+                    "additionalProperties": False,
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["label", "score"],
+                        "properties": {
+                            "label": {"type": "string"},
+                            "score": {"type": ["number", "null"]},
+                        },
+                    },
+                },
+                "optional_note": {"type": ["string", "null"]},
+            },
+        },
+    )
+    payload = {
+        "answer": {"value": None},
+        "items": [{"label": "A", "score": 0.5}],
+        "optional_note": None,
+    }
+
+    score = score_final_result(
+        extracted_result=json.dumps(payload),
+        target=json.dumps(payload),
+        profile=profile,
+    )
+    invalid = score_final_result(
+        extracted_result=json.dumps(
+            {
+                "answer": {"value": None, "extra": "unexpected"},
+                "items": [{"label": "A", "score": "high"}],
+                "optional_note": None,
+            }
+        ),
+        target=json.dumps(payload),
+        profile=profile,
+    )
+    invalid_array = score_final_result(
+        extracted_result=json.dumps(
+            {
+                "answer": {"value": None},
+                "items": [{"label": "A", "score": "high"}],
+                "optional_note": None,
+            }
+        ),
+        target=json.dumps(payload),
+        profile=profile,
+    )
+    missing_required = score_final_result(
+        extracted_result=json.dumps({"items": [], "optional_note": None}),
+        target=json.dumps(payload),
+        profile=profile,
+    )
+
+    assert score.validation_status == "validated"
+    assert score.typed_score == 1.0
+    assert invalid.validation_status == "schema_failed"
+    assert invalid.failure_reason == "unexpected_property:$.answer.extra"
+    assert invalid_array.validation_status == "schema_failed"
+    assert invalid_array.failure_reason == "type_mismatch:$.items[0].score"
+    assert missing_required.validation_status == "schema_failed"
+    assert missing_required.failure_reason == "missing_required:$.answer"
+
+
+def test_score_final_result_ignores_optional_schema_properties_without_dict_schemas() -> None:
+    profile = EvaluationProfileDefinition(
+        profile_type="final_result",
+        result_kind="json",
+        extraction_mode="strict_full_response",
+        scoring_mode="json_field_match",
+        threshold=1.0,
+        output_schema={
+            "type": "object",
+            "properties": {
+                "legacy": "string",
+                "missing_optional": {"type": "string"},
+            },
+        },
+    )
+
+    score = score_final_result(
+        extracted_result=json.dumps({"legacy": "ok"}),
+        target=json.dumps({"legacy": "ok"}),
+        profile=profile,
+    )
+
+    assert score.validation_status == "validated"
+
+
 def test_score_final_result_aggregates_wide_json_without_losing_ignored_paths() -> None:
     expected = {
         f"field_{index}": {

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -374,6 +374,48 @@ def test_score_final_result_ignores_optional_schema_properties_without_dict_sche
     assert score.validation_status == "validated"
 
 
+def test_score_final_result_validates_pattern_properties_with_closed_objects() -> None:
+    profile = EvaluationProfileDefinition(
+        profile_type="final_result",
+        result_kind="json",
+        extraction_mode="strict_full_response",
+        scoring_mode="json_field_match",
+        threshold=1.0,
+        output_schema={
+            "type": "object",
+            "properties": {
+                "label": {"type": "string"},
+            },
+            "patternProperties": {
+                "^metric_[0-9]+$": {"type": "number"},
+            },
+            "additionalProperties": False,
+        },
+    )
+
+    score = score_final_result(
+        extracted_result=json.dumps({"label": "ok", "metric_1": 0.5}),
+        target=json.dumps({"label": "ok", "metric_1": 0.5}),
+        profile=profile,
+    )
+    wrong_type = score_final_result(
+        extracted_result=json.dumps({"label": "ok", "metric_2": "high"}),
+        target=json.dumps({"label": "ok", "metric_2": 1.0}),
+        profile=profile,
+    )
+    unexpected = score_final_result(
+        extracted_result=json.dumps({"label": "ok", "note": "extra"}),
+        target=json.dumps({"label": "ok", "note": "extra"}),
+        profile=profile,
+    )
+
+    assert score.validation_status == "validated"
+    assert wrong_type.validation_status == "schema_failed"
+    assert wrong_type.failure_reason == "type_mismatch:$.metric_2"
+    assert unexpected.validation_status == "schema_failed"
+    assert unexpected.failure_reason == "unexpected_property:$.note"
+
+
 def test_score_final_result_aggregates_wide_json_without_losing_ignored_paths() -> None:
     expected = {
         f"field_{index}": {

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -414,6 +414,9 @@ class EvaluationCore:
         job_parameters = {"dataset_root": str(dataset_root)}
         if parameters:
             job_parameters.update(parameters)
+        hints_text = str(job_parameters.pop("evaluation_hints_text", "") or "").strip()
+        if hints_text:
+            job_parameters["hints_prompt_chars"] = str(len(hints_text))
         runtime_evidence = EvaluationCore._runtime_evidence_for_loaded_model(loaded_model)
         job_parameters.update(runtime_evidence)
         if EvaluationCore._truthy_parameter(job_parameters, "require_live_model"):
@@ -473,6 +476,7 @@ class EvaluationCore:
                 job_id=job_id,
                 run_root=run_root,
                 job_parameters=job_parameters,
+                hints_text=hints_text,
                 created_at_unix_ms=created_at_unix_ms,
                 resolved_code_exec_policy=resolved_code_exec_policy,
                 resolved_seed=resolved_seed,
@@ -496,6 +500,7 @@ class EvaluationCore:
                 seed=resolved_seed,
                 job_parameters=job_parameters,
                 profile=profile,
+                hints_text=hints_text,
             )
         except BaseException:
             telemetry_session.cancel()
@@ -573,6 +578,9 @@ class EvaluationCore:
             result_metrics[f"eval.{suite_id}.code_exec_fail_count"] = float(code_exec_fail_count)
             result_units[f"eval.{suite_id}.code_exec_pass_count"] = "count"
             result_units[f"eval.{suite_id}.code_exec_fail_count"] = "count"
+        if hints_text:
+            result_metrics[f"eval.{suite_id}.hints_prompt_chars"] = float(len(hints_text))
+            result_units[f"eval.{suite_id}.hints_prompt_chars"] = "chars"
 
         report_path = self._result_path(run_root if self._jobs_root is not None else dataset_root)
         output_dir = str(run_root) if self._jobs_root is not None else str(dataset_root)
@@ -950,6 +958,7 @@ class EvaluationCore:
         job_parameters.pop("eval_prompt_examples_json", None)
         job_parameters.pop("semantic_judge_api_key", None)
         job_parameters.pop("semantic_judge_base_url", None)
+        job_parameters.pop("evaluation_hints_text", None)
         event_dataset_root = parameters.get("event_dataset_root") or parameters.get(
             "evaluation_materialized_dataset_root",
             "",
@@ -1411,6 +1420,7 @@ class EvaluationCore:
         job_id: str,
         run_root: Path,
         job_parameters: dict[str, str],
+        hints_text: str,
         created_at_unix_ms: int,
         resolved_code_exec_policy: str,
         resolved_seed: int,
@@ -1451,6 +1461,7 @@ class EvaluationCore:
                 job_id=job_id,
                 run_root=run_root,
                 job_parameters=job_parameters,
+                hints_text=hints_text,
                 created_at_unix_ms=created_at_unix_ms,
                 resolved_code_exec_policy=resolved_code_exec_policy,
                 resolved_seed=resolved_seed,
@@ -1498,6 +1509,7 @@ class EvaluationCore:
         job_id: str,
         run_root: Path,
         job_parameters: dict[str, str],
+        hints_text: str,
         created_at_unix_ms: int,
         resolved_code_exec_policy: str,
         resolved_seed: int,
@@ -1537,6 +1549,7 @@ class EvaluationCore:
             code_exec_policy=resolved_code_exec_policy,
             seed=resolved_seed,
             job_parameters=job_parameters,
+            hints_text=hints_text,
             request_label=f"base:{resolved_model_id}",
         )
         compare_samples: list[EvaluationCompareSample] = []
@@ -1559,6 +1572,7 @@ class EvaluationCore:
                 code_exec_policy=resolved_code_exec_policy,
                 seed=resolved_seed,
                 job_parameters=job_parameters,
+                hints_text=hints_text,
                 request_label=f"target:{target_model_id}",
             )
             target_compare_samples = build_compare_samples(
@@ -1711,6 +1725,7 @@ class EvaluationCore:
         code_exec_policy: str,
         seed: int,
         job_parameters: dict[str, str],
+        hints_text: str = "",
         request_label: str = "",
     ) -> tuple[EvaluationSample, ...]:
         sample_records_list: list[EvaluationSample] = []
@@ -1732,6 +1747,7 @@ class EvaluationCore:
                     code_exec_policy=code_exec_policy,
                     seed=seed,
                     job_parameters=job_parameters,
+                    hints_text=hints_text,
                     request_label=request_label,
                 )
             )
@@ -2170,6 +2186,7 @@ class EvaluationCore:
         code_exec_policy: str,
         seed: int,
         job_parameters: dict[str, str],
+        hints_text: str = "",
         request_label: str = "",
     ) -> EvaluationSample:
         system_text = EvaluationCore._system_text_for_sample(sample)
@@ -2215,6 +2232,7 @@ class EvaluationCore:
                     few_shot_examples=few_shot_examples,
                     dataset_root=dataset_root,
                     task_kind=task_kind,
+                    hints_text=hints_text,
                 ),
                 expected=target,
                 result_kind=profile.result_kind,
@@ -2503,6 +2521,7 @@ class EvaluationCore:
         few_shot_examples: tuple[dict[str, object], ...] = (),
         dataset_root: Path | None = None,
         task_kind: str = "text-generation",
+        hints_text: str = "",
     ) -> list[common_pb2.ChatMessage]:
         if scoring_mode == "pass_at_1":
             instruction = "Return only executable Python code for the requested solution. Do not include explanations."
@@ -2519,6 +2538,9 @@ class EvaluationCore:
         resolved_system_text = instruction
         if system_text.strip():
             resolved_system_text = f"{instruction}\n\n{system_text.strip()}"
+        normalized_hints_text = hints_text.strip()
+        if normalized_hints_text:
+            resolved_system_text = f"{resolved_system_text}\n\nAdditional Hints:\n{normalized_hints_text}"
         messages = [
             common_pb2.ChatMessage(role="system", parts=[common_pb2.MessagePart(text=resolved_system_text)]),
         ]

--- a/services/mlx-worker-python/worker/grpc_server.py
+++ b/services/mlx-worker-python/worker/grpc_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import tempfile
@@ -347,6 +348,7 @@ class WorkerMaintenanceService(maintenance_pb2_grpc.MaintenanceServiceServicer):
     def RunEvaluation(self, request, context):
         try:
             parameters = dict(request.parameters)
+            self._attach_evaluation_reproducibility_parameters(parameters)
             parameters.setdefault("dataset_id", request.dataset_id)
             if request.task_kind:
                 parameters.setdefault("task_kind", request.task_kind)
@@ -553,6 +555,48 @@ class WorkerMaintenanceService(maintenance_pb2_grpc.MaintenanceServiceServicer):
 
     def _evaluation_materialization_root(self) -> Path:
         return (self._evaluation_jobs_root / "datasets").resolve()
+
+    @staticmethod
+    def _attach_evaluation_reproducibility_parameters(parameters: dict[str, str]) -> None:
+        schema_path = str(parameters.get("schema_path") or "").strip()
+        if schema_path:
+            resolved_schema_path = Path(schema_path).expanduser().resolve()
+            if not resolved_schema_path.is_file():
+                raise ValueError(f"evaluation schema file does not exist: {schema_path}")
+            parameters["schema_path"] = str(resolved_schema_path)
+            parameters["schema_sha256"] = WorkerMaintenanceService._sha256_for_path(resolved_schema_path)
+            parameters["schema_size_bytes"] = str(resolved_schema_path.stat().st_size)
+
+        hints_path = str(parameters.get("hints_path") or "").strip()
+        if hints_path:
+            resolved_hints_path = Path(hints_path).expanduser().resolve()
+            if not resolved_hints_path.is_file():
+                raise ValueError(f"evaluation hints file does not exist: {hints_path}")
+            hints_text = resolved_hints_path.read_text(encoding="utf-8")
+            parameters["hints_path"] = str(resolved_hints_path)
+            parameters["hints_sha256"] = WorkerMaintenanceService._sha256_for_path(resolved_hints_path)
+            parameters["hints_size_bytes"] = str(resolved_hints_path.stat().st_size)
+            parameters["hints_format"] = WorkerMaintenanceService._hints_format(resolved_hints_path)
+            parameters["evaluation_hints_text"] = hints_text.strip()
+
+    @staticmethod
+    def _sha256_for_path(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            while chunk := handle.read(chunk_size):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    @staticmethod
+    def _hints_format(path: Path) -> str:
+        suffix = path.suffix.lower()
+        if suffix == ".json":
+            return "json"
+        if suffix == ".md":
+            return "markdown"
+        if suffix == ".txt":
+            return "text"
+        return suffix.lstrip(".") or "text"
 
     @staticmethod
     def _evaluation_field_mapping_from_request(request) -> EvaluationFieldMapping:

--- a/services/mlx-worker-python/worker/grpc_server.py
+++ b/services/mlx-worker-python/worker/grpc_server.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import os
 import tempfile
@@ -558,34 +557,9 @@ class WorkerMaintenanceService(maintenance_pb2_grpc.MaintenanceServiceServicer):
 
     @staticmethod
     def _attach_evaluation_reproducibility_parameters(parameters: dict[str, str]) -> None:
-        schema_path = str(parameters.get("schema_path") or "").strip()
-        if schema_path:
-            resolved_schema_path = Path(schema_path).expanduser().resolve()
-            if not resolved_schema_path.is_file():
-                raise ValueError(f"evaluation schema file does not exist: {schema_path}")
-            parameters["schema_path"] = str(resolved_schema_path)
-            parameters["schema_sha256"] = WorkerMaintenanceService._sha256_for_path(resolved_schema_path)
-            parameters["schema_size_bytes"] = str(resolved_schema_path.stat().st_size)
-
         hints_path = str(parameters.get("hints_path") or "").strip()
-        if hints_path:
-            resolved_hints_path = Path(hints_path).expanduser().resolve()
-            if not resolved_hints_path.is_file():
-                raise ValueError(f"evaluation hints file does not exist: {hints_path}")
-            hints_text = resolved_hints_path.read_text(encoding="utf-8")
-            parameters["hints_path"] = str(resolved_hints_path)
-            parameters["hints_sha256"] = WorkerMaintenanceService._sha256_for_path(resolved_hints_path)
-            parameters["hints_size_bytes"] = str(resolved_hints_path.stat().st_size)
-            parameters["hints_format"] = WorkerMaintenanceService._hints_format(resolved_hints_path)
-            parameters["evaluation_hints_text"] = hints_text.strip()
-
-    @staticmethod
-    def _sha256_for_path(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
-        digest = hashlib.sha256()
-        with path.open("rb") as handle:
-            while chunk := handle.read(chunk_size):
-                digest.update(chunk)
-        return digest.hexdigest()
+        if hints_path and not str(parameters.get("hints_format") or "").strip():
+            parameters["hints_format"] = WorkerMaintenanceService._hints_format(Path(hints_path))
 
     @staticmethod
     def _hints_format(path: Path) -> str:

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -82,6 +82,10 @@ _MATRIX_SUMMARY_METRIC_KEYS = (
     "failed_count",
 )
 _EVALUATION_SUMMARY_METRIC_KEYS = ("failure_count", "duration_seconds")
+_EVALUATION_REPRODUCIBILITY_KEYS = (
+    ("schema_sha256", "schema"),
+    ("hints_sha256", "hints"),
+)
 _LOWER_IS_BETTER_METRIC_FRAGMENTS = (
     "latency",
     "ttft",
@@ -267,6 +271,10 @@ def build_benchmark_evaluation_report(
 ) -> dict[str, object]:
     baseline_metrics = _collect_metrics(baseline)
     candidate_metrics = _collect_metrics(candidate)
+    reproducibility_warnings = _evaluation_reproducibility_warnings(
+        baseline=baseline,
+        candidate=candidate,
+    )
     metric_names = sorted(set(baseline_metrics) | set(candidate_metrics))
     rows: list[dict[str, object]] = []
     warning_count = 0
@@ -286,6 +294,7 @@ def build_benchmark_evaluation_report(
             missing_count += 1
         elif row_status == "not_comparable":
             not_comparable_count += 1
+    warning_count += len(reproducibility_warnings)
     if warning_count:
         status = "warning"
     elif missing_count:
@@ -330,6 +339,7 @@ def build_benchmark_evaluation_report(
         targets=targets,
         baseline_evidence=baseline_evidence,
         candidate_evidence=candidate_evidence,
+        reproducibility_warnings=reproducibility_warnings,
     )
     gate_result = _gate_result(
         metric_rows=metric_rows,
@@ -368,12 +378,13 @@ def build_benchmark_evaluation_report(
         "telemetry_summary": telemetry_summary,
         "process_attribution": process_attribution,
         "comparison": comparison,
+        "reproducibility_warnings": reproducibility_warnings,
         "gate_result": gate_result,
         "artifacts": _default_artifacts(evidence_rows),
         "known_gaps": known_gaps,
         "instrumentation_gaps": instrumentation_gaps,
         "operator_notes": [],
-        "non_blocking_warnings": list(instrumentation_gaps),
+        "non_blocking_warnings": [*instrumentation_gaps, *reproducibility_warnings],
         "rows": rows,
     }
 
@@ -455,6 +466,7 @@ def render_markdown_report(report: dict[str, object]) -> str:
     probe_summary = report.get("probe_summary")
     if isinstance(probe_summary, dict):
         lines.extend(_render_probe_summary_markdown(probe_summary))
+    lines.extend(_render_reproducibility_warnings_markdown(report))
     lines.extend(_render_known_gaps_markdown(report))
     lines.extend(_render_artifacts_markdown(report.get("artifacts")))
     lines.append("")
@@ -803,12 +815,79 @@ def _report_gaps(
     return known_gaps, instrumentation_gaps
 
 
+def _evaluation_reproducibility_warnings(
+    *,
+    baseline: dict[str, object],
+    candidate: dict[str, object],
+) -> list[str]:
+    baseline_values = _evaluation_reproducibility_values(baseline)
+    candidate_values = _evaluation_reproducibility_values(candidate)
+    warnings: list[str] = []
+    for key, label in _EVALUATION_REPRODUCIBILITY_KEYS:
+        baseline_hashes = baseline_values.get(key, frozenset())
+        candidate_hashes = candidate_values.get(key, frozenset())
+        if not baseline_hashes and not candidate_hashes:
+            continue
+        if baseline_hashes == candidate_hashes:
+            continue
+        warnings.append(
+            f"evaluation_{label}_sha256_mismatch:"
+            f"baseline={_format_reproducibility_hashes(baseline_hashes)};"
+            f"candidate={_format_reproducibility_hashes(candidate_hashes)}"
+        )
+    return warnings
+
+
+def _evaluation_reproducibility_values(
+    bundle: dict[str, object],
+) -> dict[str, frozenset[str]]:
+    values: dict[str, set[str]] = {
+        key: set()
+        for key, _label in _EVALUATION_REPRODUCIBILITY_KEYS
+    }
+    for job in (
+        *_dict_rows(bundle.get("evaluation_jobs", [])),
+        *_dict_rows(bundle.get("evaluation_compare_jobs", [])),
+    ):
+        _collect_evaluation_reproducibility_parameters(values, job.get("parameters"))
+    for evidence in _dict_rows(bundle.get("run_evidence", [])):
+        domain_results = evidence.get("domain_results")
+        if not isinstance(domain_results, dict):
+            continue
+        evaluation_domain = domain_results.get("evaluation")
+        if not isinstance(evaluation_domain, dict):
+            continue
+        job = evaluation_domain.get("job")
+        if isinstance(job, dict):
+            _collect_evaluation_reproducibility_parameters(values, job.get("parameters"))
+    return {key: frozenset(item_values) for key, item_values in values.items()}
+
+
+def _collect_evaluation_reproducibility_parameters(
+    values: dict[str, set[str]],
+    parameters: object,
+) -> None:
+    if not isinstance(parameters, dict):
+        return
+    for key, _label in _EVALUATION_REPRODUCIBILITY_KEYS:
+        value = str(parameters.get(key) or "").strip()
+        if value:
+            values[key].add(value)
+
+
+def _format_reproducibility_hashes(values: frozenset[str]) -> str:
+    if not values:
+        return "missing"
+    return ",".join(sorted(values))
+
+
 def _comparison_section(
     *,
     metric_rows: list[dict[str, object]],
     targets: list[dict[str, object]],
     baseline_evidence: list[dict[str, object]],
     candidate_evidence: list[dict[str, object]],
+    reproducibility_warnings: list[str],
 ) -> dict[str, object]:
     metric_deltas = [_comparison_delta(row) for row in metric_rows]
     probe_deltas = [row for row in metric_deltas if str(row.get("metric") or "").startswith("probe.")]
@@ -825,7 +904,8 @@ def _comparison_section(
         "regressions": [row for row in metric_deltas if row.get("result") == "fail"],
         "improvements": [row for row in metric_deltas if _is_improvement(row)],
         "unchanged": [row for row in metric_deltas if _float_or_none(row.get("delta")) == 0.0],
-        "comparison_validity": "valid" if baseline_evidence and candidate_evidence else "partial",
+        "reproducibility_warnings": list(reproducibility_warnings),
+        "comparison_validity": "valid" if baseline_evidence and candidate_evidence and not reproducibility_warnings else "partial",
     }
 
 
@@ -1361,6 +1441,21 @@ def _render_telemetry_summary_markdown(telemetry_summary: object) -> list[str]:
             )
     if not has_rows:
         lines.append("| - | - | missing | - | - | - | telemetry_summary_missing |")
+    lines.append("")
+    return lines
+
+
+def _render_reproducibility_warnings_markdown(report: dict[str, object]) -> list[str]:
+    warnings = [
+        str(item)
+        for item in report.get("reproducibility_warnings", [])
+        if str(item).strip()
+    ] if isinstance(report.get("reproducibility_warnings"), list) else []
+    if not warnings:
+        return []
+    lines = ["", "## Reproducibility Warnings", ""]
+    for warning in warnings:
+        lines.append(f"- `{_markdown_cell(warning)}`")
     lines.append("")
     return lines
 

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -344,33 +344,71 @@ def _score_text_result(
 
 
 def _validate_json_schema(schema: dict[str, Any], payload: Any) -> str:
-    expected_type = schema.get("type")
-    if expected_type == "object":
-        if not isinstance(payload, dict):
-            return "root_type_mismatch"
-        for key in schema.get("required", []):
-            if key not in payload:
-                return f"missing_required:{key}"
+    return _validate_json_schema_at(schema, payload, path="$")
+
+
+def _validate_json_schema_at(schema: dict[str, Any], payload: Any, *, path: str) -> str:
+    expected_types = _schema_types(schema.get("type"))
+    if expected_types and not any(_matches_json_type(payload, expected_type) for expected_type in expected_types):
+        return "root_type_mismatch" if path == "$" else f"type_mismatch:{path}"
+
+    if isinstance(payload, dict) and (
+        "object" in expected_types or "properties" in schema or "required" in schema
+    ):
+        required = schema.get("required", [])
+        if isinstance(required, list):
+            for key in required:
+                key_text = str(key)
+                if key_text not in payload:
+                    return f"missing_required:{_json_schema_child_path(path, key_text)}"
         properties = schema.get("properties", {})
         if isinstance(properties, dict):
             for key, value in properties.items():
-                if key in payload:
-                    field_type = value.get("type") if isinstance(value, dict) else None
-                    if field_type and not _matches_json_type(payload[key], field_type):
-                        return f"type_mismatch:{key}"
+                if key not in payload or not isinstance(value, dict):
+                    continue
+                validation_error = _validate_json_schema_at(
+                    value,
+                    payload[key],
+                    path=_json_schema_child_path(path, str(key)),
+                )
+                if validation_error:
+                    return validation_error
+        if schema.get("additionalProperties") is False and isinstance(properties, dict):
+            allowed = {str(key) for key in properties.keys()}
+            for key in payload.keys():
+                key_text = str(key)
+                if key_text not in allowed:
+                    return f"unexpected_property:{_json_schema_child_path(path, key_text)}"
         return ""
-    if expected_type == "array":
-        if not isinstance(payload, list):
-            return "root_type_mismatch"
+
+    if isinstance(payload, list) and ("array" in expected_types or "items" in schema):
         item_schema = schema.get("items")
         if isinstance(item_schema, dict):
-            item_type = item_schema.get("type")
-            if item_type:
-                for item in payload:
-                    if not _matches_json_type(item, item_type):
-                        return "item_type_mismatch"
+            for index, item in enumerate(payload):
+                validation_error = _validate_json_schema_at(
+                    item_schema,
+                    item,
+                    path=f"{path}[{index}]",
+                )
+                if validation_error:
+                    return validation_error
         return ""
+
     return ""
+
+
+def _schema_types(raw_type: Any) -> tuple[str, ...]:
+    if isinstance(raw_type, str):
+        return (raw_type,)
+    if isinstance(raw_type, list):
+        return tuple(str(value) for value in raw_type if isinstance(value, str) and value)
+    return ()
+
+
+def _json_schema_child_path(path: str, key: str) -> str:
+    if path == "$":
+        return f"$.{key}"
+    return f"{path}.{key}"
 
 
 def _json_typed_score(*, expected: Any, actual: Any, ignored_paths: set[str], path: str = "") -> float:

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -373,11 +373,25 @@ def _validate_json_schema_at(schema: dict[str, Any], payload: Any, *, path: str)
                 )
                 if validation_error:
                     return validation_error
+        pattern_properties = schema.get("patternProperties", {})
+        if isinstance(pattern_properties, dict):
+            for key, value in payload.items():
+                key_text = str(key)
+                for pattern_schema in _json_schema_pattern_schemas(pattern_properties, key_text):
+                    if not isinstance(pattern_schema, dict):
+                        continue
+                    validation_error = _validate_json_schema_at(
+                        pattern_schema,
+                        value,
+                        path=_json_schema_child_path(path, key_text),
+                    )
+                    if validation_error:
+                        return validation_error
         if schema.get("additionalProperties") is False and isinstance(properties, dict):
             allowed = {str(key) for key in properties.keys()}
             for key in payload.keys():
                 key_text = str(key)
-                if key_text not in allowed:
+                if key_text not in allowed and not _matches_json_schema_pattern(pattern_properties, key_text):
                     return f"unexpected_property:{_json_schema_child_path(path, key_text)}"
         return ""
 
@@ -409,6 +423,23 @@ def _json_schema_child_path(path: str, key: str) -> str:
     if path == "$":
         return f"$.{key}"
     return f"{path}.{key}"
+
+
+def _json_schema_pattern_schemas(pattern_properties: dict[Any, Any], key: str) -> list[Any]:
+    matched: list[Any] = []
+    for pattern, pattern_schema in pattern_properties.items():
+        if not isinstance(pattern, str):
+            continue
+        try:
+            if re.search(pattern, key):
+                matched.append(pattern_schema)
+        except re.error:
+            continue
+    return matched
+
+
+def _matches_json_schema_pattern(pattern_properties: Any, key: str) -> bool:
+    return isinstance(pattern_properties, dict) and bool(_json_schema_pattern_schemas(pattern_properties, key))
 
 
 def _json_typed_score(*, expected: Any, actual: Any, ignored_paths: set[str], path: str = "") -> float:

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import Testing
 
@@ -635,7 +636,13 @@ struct MelixCLIParserTests {
         #expect(parsedEvalOptions.profile.resultKind == "json")
         #expect(parsedEvalOptions.profile.outputSchemaJSON == #"{"required":["answer"],"type":"object"}"#)
         #expect(parsedEvalOptions.parameters["schema_path"] == schemaPath.path)
+        #expect(parsedEvalOptions.parameters["schema_sha256"] == melixTestSHA256Hex(Data(#"{"type":"object","required":["answer"]}"#.utf8)))
+        #expect(parsedEvalOptions.parameters["schema_size_bytes"] == "39")
         #expect(parsedEvalOptions.parameters["hints_path"] == hintsPath.path)
+        #expect(parsedEvalOptions.parameters["hints_sha256"] == melixTestSHA256Hex(Data("Return the normalized answer.\n".utf8)))
+        #expect(parsedEvalOptions.parameters["hints_size_bytes"] == "30")
+        #expect(parsedEvalOptions.parameters["hints_format"] == "text")
+        #expect(parsedEvalOptions.parameters["evaluation_hints_text"] == "Return the normalized answer.")
         #expect(parsedEvalOptions.json)
     }
 
@@ -2421,7 +2428,13 @@ struct MelixCLIParserTests {
         #expect(options.profile.resultKind == "json")
         #expect(options.profile.outputSchemaJSON == #"{"required":["answer"],"type":"object"}"#)
         #expect(options.parameters["schema_path"] == schemaPath.path)
+        #expect(options.parameters["schema_sha256"] == melixTestSHA256Hex(Data(#"{"type":"object","required":["answer"]}"#.utf8)))
+        #expect(options.parameters["schema_size_bytes"] == "39")
         #expect(options.parameters["hints_path"] == hintsPath.path)
+        #expect(options.parameters["hints_sha256"] == melixTestSHA256Hex(Data("Prefer integer answers.\n".utf8)))
+        #expect(options.parameters["hints_size_bytes"] == "24")
+        #expect(options.parameters["hints_format"] == "markdown")
+        #expect(options.parameters["evaluation_hints_text"] == "Prefer integer answers.")
     }
 
     @Test("eval run schema file parser surfaces reproducibility input errors")
@@ -3197,4 +3210,10 @@ private func assertSchemaUsageError(schemaPath: String, contains expectedText: S
     } catch let error as MelixCLIError {
         #expect(error.errorDescription?.contains(expectedText) == true)
     }
+}
+
+private func melixTestSHA256Hex(_ data: Data) -> String {
+    SHA256.hash(data: data)
+        .map { String(format: "%02x", $0) }
+        .joined()
 }

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -9,6 +9,7 @@ struct MelixCLIParserTests {
     @Test("documents eval dataset root in usage text")
     func documentsEvalDatasetRootInUsageText() {
         #expect(MelixCLIParser.usageText.contains("[--dataset-root PATH]"))
+        #expect(MelixCLIParser.usageText.contains("[--schema PATH | --output-schema-json JSON] [--hints PATH]"))
         #expect(MelixCLIParser.usageText.contains("--hf-token passed to model or dataset hub download is saved"))
         #expect(MelixCLIParser.usageText.contains("--hf-dataset-revision overrides a revision embedded in --dataset-ref"))
     }
@@ -596,6 +597,46 @@ struct MelixCLIParserTests {
         #expect(preflightBenchArguments.contains("--preflight-fit-check"))
         #expect(preflightBenchArguments.contains("--allow-memory-risk"))
         #expect(try MelixCLIParser.parse(preflightBenchArguments) == preflightBenchCommand)
+
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let schemaPath = root.appendingPathComponent("result.schema.json")
+        let hintsPath = root.appendingPathComponent("math-hints.txt")
+        try #"{"type":"object","required":["answer"]}"#.write(to: schemaPath, atomically: true, encoding: .utf8)
+        try "Return the normalized answer.\n".write(to: hintsPath, atomically: true, encoding: .utf8)
+        let evalCommand = MelixCLICommand.evalRun(
+            .init(
+                modelID: "melix-dev-text",
+                suites: ["math"],
+                profile: .init(
+                    resultKind: "json",
+                    outputSchemaJSON: #"{"required":["answer"],"type":"object"}"#
+                ),
+                parameters: [
+                    "schema_path": schemaPath.path,
+                    "hints_path": hintsPath.path,
+                ],
+                json: true
+            )
+        )
+        let evalArguments = try MelixCLICommandCodec.arguments(for: evalCommand)
+        #expect(evalArguments.contains("--schema"))
+        #expect(evalArguments.contains(schemaPath.path))
+        #expect(evalArguments.contains("--hints"))
+        #expect(evalArguments.contains(hintsPath.path))
+        #expect(evalArguments.contains("--output-schema-json") == false)
+        guard case .evalRun(let parsedEvalOptions) = try MelixCLIParser.parse(evalArguments) else {
+            Issue.record("Expected evalRun command from codec arguments")
+            return
+        }
+        #expect(parsedEvalOptions.modelID == "melix-dev-text")
+        #expect(parsedEvalOptions.suites == ["math"])
+        #expect(parsedEvalOptions.profile.resultKind == "json")
+        #expect(parsedEvalOptions.profile.outputSchemaJSON == #"{"required":["answer"],"type":"object"}"#)
+        #expect(parsedEvalOptions.parameters["schema_path"] == schemaPath.path)
+        #expect(parsedEvalOptions.parameters["hints_path"] == hintsPath.path)
+        #expect(parsedEvalOptions.json)
     }
 
     @Test("command codec exposes stable ids and supported argv mappings")
@@ -2352,6 +2393,61 @@ struct MelixCLIParserTests {
         #expect(options.profile.ignoredPaths == ["metadata.trace_id"])
     }
 
+    @Test("parses eval run schema and hints files as reproducibility metadata")
+    func parsesEvalRunWithSchemaAndHintsFiles() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let schemaPath = root.appendingPathComponent("result.schema.json")
+        let hintsPath = root.appendingPathComponent("math-hints.md")
+        try #"{"type":"object","required":["answer"]}"#.write(to: schemaPath, atomically: true, encoding: .utf8)
+        try "Prefer integer answers.\n".write(to: hintsPath, atomically: true, encoding: .utf8)
+
+        let command = try MelixCLIParser.parse([
+            "eval",
+            "run",
+            "--model-id", "melix-dev-text",
+            "--suite", "math",
+            "--schema", schemaPath.path,
+            "--hints", hintsPath.path,
+            "--result-kind", "json",
+        ])
+
+        guard case .evalRun(let options) = command else {
+            Issue.record("Expected evalRun command")
+            return
+        }
+
+        #expect(options.profile.resultKind == "json")
+        #expect(options.profile.outputSchemaJSON == #"{"required":["answer"],"type":"object"}"#)
+        #expect(options.parameters["schema_path"] == schemaPath.path)
+        #expect(options.parameters["hints_path"] == hintsPath.path)
+    }
+
+    @Test("eval run schema file parser surfaces reproducibility input errors")
+    func evalRunSchemaFileParserSurfacesReproducibilityInputErrors() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let invalidJSONPath = root.appendingPathComponent("invalid.schema.json")
+        let arrayJSONPath = root.appendingPathComponent("array.schema.json")
+        try "{".write(to: invalidJSONPath, atomically: true, encoding: .utf8)
+        try #"["answer"]"#.write(to: arrayJSONPath, atomically: true, encoding: .utf8)
+
+        try assertSchemaUsageError(
+            schemaPath: root.appendingPathComponent("missing.schema.json").path,
+            contains: "Failed to read --schema"
+        )
+        try assertSchemaUsageError(
+            schemaPath: invalidJSONPath.path,
+            contains: "--schema must contain valid JSON"
+        )
+        try assertSchemaUsageError(
+            schemaPath: arrayJSONPath.path,
+            contains: "--schema must contain a JSON object."
+        )
+    }
+
     @Test("parses eval run with managed dataset reference")
     func parsesEvalRunWithManagedDatasetReference() throws {
         let command = try MelixCLIParser.parse([
@@ -3005,6 +3101,15 @@ struct MelixCLIParserTests {
         try assertError(for: ["eval"], equals: .usage(MelixCLIParser.usageText))
         try assertError(for: ["eval", "oops"], equals: .usage(MelixCLIParser.usageText))
         try assertError(
+            for: [
+                "eval", "run",
+                "--model-id", "melix-dev-text",
+                "--schema", "/tmp/result.schema.json",
+                "--output-schema-json", #"{"type":"object"}"#,
+            ],
+            equals: .usage("--schema and --output-schema-json are mutually exclusive.")
+        )
+        try assertError(
             for: ["eval", "export-summary-csv", "--output", "/tmp/out.csv"],
             equals: .missingRequired("--job-id is required for melix eval export-summary-csv.")
         )
@@ -3077,5 +3182,19 @@ private func assertError(
         Issue.record("Expected parser to throw for arguments: \(arguments)")
     } catch let error as MelixCLIError {
         #expect(error == expected)
+    }
+}
+
+private func assertSchemaUsageError(schemaPath: String, contains expectedText: String) throws {
+    do {
+        _ = try MelixCLIParser.parse([
+            "eval",
+            "run",
+            "--model-id", "melix-dev-text",
+            "--schema", schemaPath,
+        ])
+        Issue.record("Expected parser to throw for schema path: \(schemaPath)")
+    } catch let error as MelixCLIError {
+        #expect(error.errorDescription?.contains(expectedText) == true)
     }
 }

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -5738,6 +5738,8 @@ struct MelixCLIRunnerTests {
                 parameters: [
                     "batch_factor": "2",
                     "few_shot": "1",
+                    "hints_path": "/tmp/melix/eval/math-hints.md",
+                    "schema_path": "/tmp/melix/eval/result.schema.json",
                     "seed": "9",
                     "scoring_mode": "multiple_choice_accuracy",
                     "code_exec_policy": "sandboxed",
@@ -5756,6 +5758,10 @@ struct MelixCLIRunnerTests {
         #expect(command.contains("--batch-factor"))
         #expect(command.contains("2"))
         #expect(command.contains("--few-shot"))
+        #expect(command.contains("--schema"))
+        #expect(command.contains("/tmp/melix/eval/result.schema.json"))
+        #expect(command.contains("--hints"))
+        #expect(command.contains("/tmp/melix/eval/math-hints.md"))
         #expect(command.contains("--seed"))
         #expect(command.contains("--scoring-mode"))
         #expect(command.contains("--code-exec-policy"))
@@ -6875,10 +6881,16 @@ struct MelixCLIRunnerTests {
                     modelID: "melix-dev-text",
                     suites: ["mmlu", "gsm8k"],
                     sampleSize: 8,
+                    profile: .init(
+                        resultKind: "json",
+                        outputSchemaJSON: #"{"type":"object"}"#
+                    ),
                     parameters: [
                         "batch_factor": "2",
                         "dataset_root": "/tmp/mmlu-split-01",
                         "few_shot": "4",
+                        "hints_path": "/tmp/math-hints.md",
+                        "schema_path": "/tmp/result.schema.json",
                         "seed": "7",
                         "scoring_mode": "multiple_choice_accuracy",
                         "code_exec_policy": "sandboxed",
@@ -6897,9 +6909,13 @@ struct MelixCLIRunnerTests {
         #expect(requests[0].parameters["batch_factor"] == "2")
         #expect(requests[0].parameters["dataset_root"] == "/tmp/mmlu-split-01")
         #expect(requests[0].parameters["few_shot"] == "4")
+        #expect(requests[0].parameters["hints_path"] == "/tmp/math-hints.md")
+        #expect(requests[0].parameters["schema_path"] == "/tmp/result.schema.json")
         #expect(requests[0].parameters["seed"] == "7")
         #expect(requests[0].parameters["scoring_mode"] == "multiple_choice_accuracy")
         #expect(requests[0].parameters["code_exec_policy"] == "sandboxed")
+        #expect(requests[0].profile.resultKind == "json")
+        #expect(requests[0].profile.outputSchemaJSON == #"{"type":"object"}"#)
         #expect(requests[1].suiteID == "gsm8k")
         #expect(requests[1].datasetID == "gsm8k.dev.v1")
         let firstRun = try #require(payload.first as? [String: Any])


### PR DESCRIPTION
## Summary
- Add `melix eval run` and `melix eval compare` support for `--schema PATH` and `--hints PATH`.
- Compute schema/hints reproducibility metadata in the CLI so remote workers do not need access to local source files, while still avoiding persisted full hints text.
- Expand JSON schema validation for nested objects, arrays, nullable fields, required fields, `patternProperties`, and additional property failures.
- Add benchmark/evaluation report warnings when compared evaluation runs use different schema or hints hashes.

Closes #639.

## Plan or Spec
- `docs/plans/2026-05-11-eval-schema-hints.md`

## Commands Run
```text
python3 -m py_compile services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/worker/grpc_server.py services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_evaluation_core.py -k "schema_hints or reproducibility"
# 2 passed, 83 deselected in 0.42s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_evaluation_final_result.py -k "nested_arrays or pattern_properties or optional_schema"
# 3 passed, 28 deselected in 0.04s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=.runtime/coverage/.coverage-schema-hints uv run --frozen --project services/mlx-worker-python coverage run --source=services/mlx-worker-python/worker -m pytest services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py -q
# 164 passed in 7.63s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=.runtime/coverage/.coverage-schema-hints uv run --frozen --project services/mlx-worker-python coverage json -o .runtime/coverage/python-schema-hints.json
# wrote JSON report

swift test --filter MelixCLIParserTests
# 76 tests in 1 suite passed after 0.015s

swift test --enable-code-coverage --filter "MelixCLIParserTests|MelixCLIRunnerTests/eval|subprocessBackedEvaluationCompareBuildsPublicCLIArguments"
# 100 tests in 2 suites passed after 0.126s

python3 scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main Sources/MelixCLICore/MelixCLI.swift Sources/MelixCLICore/MelixCLICommandCodec.swift tests/MelixCLITests/MelixCLIParserTests.swift tests/MelixCLITests/MelixCLIRunnerTests.swift
# TOTAL 95.97% 238/248

python3 scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/python-schema-hints.json --diff-from origin/main services/mlx-worker-python/worker/grpc_server.py services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# TOTAL 97.12% 135/139

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo -q
# 1 passed in 17.56s

git diff --check
# passed
```

## Coverage and Metrics
- Swift changed-line coverage: `95.97%` (`238/248`) across touched Swift CLI source/tests.
- Python changed-line coverage: `97.12%` (`135/139`) across touched worker/report source/tests.
- Performance probe smoke: `test_probe_smokes_return_metrics_against_current_repo` passed, confirming current PR-scoped probe implementations produce metrics against this repo.
- Runtime probes/metadata added or preserved: `eval.<suite>.hints_prompt_chars`, `schema_sha256`, `schema_size_bytes`, `hints_sha256`, `hints_size_bytes`, `hints_format`, and report-level `evaluation_schema_sha256_mismatch` / `evaluation_hints_sha256_mismatch` warnings.

## Known Gaps
- Full repository `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run locally; this change does not touch dependencies, protobuf schemas, or integration stack startup. Focused Swift/Python/coverage/probe checks are listed above.
- No protocol or dependency changes; no generated artifacts or lockfiles are included.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
