### PR TITLE
Persist run metadata and markdown reports

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1411,6 +1411,7 @@ public enum MelixCLICommand: Equatable, Sendable {
     case benchRun(BenchRunOptions)
     case benchList(BenchListOptions)
     case benchExportCSV(BenchExportCSVOptions)
+    case benchReport(RunReportOptions)
     case benchMatrixRun(BenchMatrixRunOptions)
     case benchMatrixList(BenchMatrixListOptions)
     case benchMatrixExportSummaryCSV(BenchExportCSVOptions)
@@ -1430,6 +1431,10 @@ public enum MelixCLICommand: Equatable, Sendable {
     case evalExportSummaryCSV(EvalExportOptions)
     case evalExportSamplesCSV(EvalExportOptions)
     case evalExportSamplesJSONL(EvalExportOptions)
+    case evalReport(RunReportOptions)
+    case runsList(RunsListOptions)
+    case runsShow(RunsShowOptions)
+    case runsExport(RunsExportOptions)
     case pipelineRun(PipelineRunOptions)
 }
 
@@ -1473,6 +1478,9 @@ public enum MelixCLIParser {
     }
 
     public static func requestedOutputFormat(_ arguments: [String]) -> MelixCLIOutputFormat {
+        if commandOwnsFormatOption(arguments) {
+            return .legacy
+        }
         if let format = try? extractOutputFormat(arguments).0 {
             return format
         }
@@ -1517,6 +1525,8 @@ public enum MelixCLIParser {
             return try parseBench(tail)
         case "eval":
             return try parseEval(tail)
+        case "runs":
+            return try parseRuns(tail)
         case "pipeline":
             return try parsePipeline(tail)
         default:
@@ -1584,6 +1594,7 @@ public enum MelixCLIParser {
       melix bench run (--model-id MODEL_ID | --repo-id HF_REPO) [--suite SUITE ...] [--dataset-ref HF_DATASET[@REV]] [--hf-dataset-name NAME] [--hf-dataset-split SPLIT] [--prompt-feature NAME] [--text-feature NAME] [--image-feature NAME] [--source-image-feature NAME] [--mask-feature NAME] [--context-length N ...] [--generation-length N] [--batch-size N ...] [--repeats N] [--cache-profile MODE] [--reasoning-mode MODE] [--structured-output-mode MODE] [--sample-size N] [--batch-factor N] [--preflight-fit-check] [--allow-memory-risk] [--json]
       melix bench list [--json]
       melix bench export-csv --job-id JOB_ID --output PATH [--json]
+      melix bench report --from PATH [--format markdown|json]
       melix bench matrix run (--model-id MODEL_ID | --repo-id HF_REPO) --suite SUITE ... --context-length N ... --generation-length N ... --batch-size N ... --cache-profile MODE ... --reasoning-mode MODE ... --structured-output-mode MODE ... --concurrency N ... [--repeats N] (--requests N | --duration-seconds N) [--allow-large-matrix] [--json]
       melix bench matrix list [--json]
       melix bench matrix export-summary-csv --job-id JOB_ID --output PATH [--json]
@@ -1603,6 +1614,10 @@ public enum MelixCLIParser {
       melix eval export-summary-csv --job-id JOB_ID --output PATH [--json]
       melix eval export-samples-csv --job-id JOB_ID --output PATH [--json]
       melix eval export-samples-jsonl --job-id JOB_ID --output PATH [--json]
+      melix eval report --from PATH [--format markdown|json]
+      melix runs list [--from PATH] [--json]
+      melix runs show RUN_ID [--from PATH] [--json]
+      melix runs export RUN_ID --format json|md [--from PATH] [--output PATH]
       melix pipeline run --file PIPELINE.json [--inputs INPUTS.json] [--receipt-dir PATH] [--trace-id ID] [--resume] [--from-step STEP_ID] [--dry-run] [--format json-v1]
 
     Notes:
@@ -1618,6 +1633,16 @@ public enum MelixCLIParser {
         var index = 0
         while index < arguments.count {
             let token = arguments[index]
+            if token == "--format", Self.commandOwnsFormatOption(arguments) {
+                let valueIndex = index + 1
+                guard valueIndex < arguments.count else {
+                    throw MelixCLIError.missingValue("--format")
+                }
+                stripped.append(token)
+                stripped.append(arguments[valueIndex])
+                index += 2
+                continue
+            }
             guard token == "--format" else {
                 stripped.append(token)
                 index += 1
@@ -1635,6 +1660,17 @@ public enum MelixCLIParser {
             index += 2
         }
         return (format, stripped)
+    }
+
+    private static func commandOwnsFormatOption(_ arguments: [String]) -> Bool {
+        guard arguments.count >= 2 else {
+            return false
+        }
+        let group = arguments[0]
+        let action = arguments[1]
+        return (group == "bench" && action == "report")
+            || (group == "eval" && action == "report")
+            || (group == "runs" && action == "export")
     }
 
     private static func traceID(for command: MelixCLICommand) -> String {
@@ -2918,6 +2954,12 @@ public enum MelixCLIParser {
                     json: values.flags.contains("--json")
                 )
             )
+        case "report":
+            let format = values.single["--format"] ?? "markdown"
+            guard let sourcePath = values.single["--from"], !sourcePath.isEmpty else {
+                throw MelixCLIError.missingRequired("--from is required for melix bench report.")
+            }
+            return .benchReport(RunReportOptions(sourcePath: sourcePath, format: format))
         default:
             throw MelixCLIError.usage(usageText)
         }
@@ -3137,6 +3179,14 @@ public enum MelixCLIParser {
                 multiValueOptions: ["--suite", "--target-model-id"]
             )
             return .evalExportSamplesJSONL(try parseEvalExportOptions(values, command: "melix eval export-samples-jsonl"))
+        case "report":
+            let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse(
+                multiValueOptions: ["--suite", "--target-model-id"]
+            )
+            guard let sourcePath = values.single["--from"], !sourcePath.isEmpty else {
+                throw MelixCLIError.missingRequired("--from is required for melix eval report.")
+            }
+            return .evalReport(RunReportOptions(sourcePath: sourcePath, format: values.single["--format"] ?? "markdown"))
         default:
             throw MelixCLIError.usage(usageText)
         }
@@ -3235,6 +3285,61 @@ public enum MelixCLIParser {
         default:
             throw MelixCLIError.usage(usageText)
         }
+    }
+
+    private static func parseRuns(_ arguments: [String]) throws -> MelixCLICommand {
+        guard let action = arguments.first else {
+            throw MelixCLIError.usage(usageText)
+        }
+        var optionArguments = Array(arguments.dropFirst())
+        switch action {
+        case "list":
+            let values = try ArgumentCursor(arguments: optionArguments).parse()
+            return .runsList(
+                RunsListOptions(
+                    sourcePath: values.single["--from"] ?? "",
+                    json: values.flags.contains("--json")
+                )
+            )
+        case "show":
+            let runID = try extractRunID(from: &optionArguments, command: "melix runs show")
+            let values = try ArgumentCursor(arguments: optionArguments).parse()
+            return .runsShow(
+                RunsShowOptions(
+                    runID: runID,
+                    sourcePath: values.single["--from"] ?? "",
+                    json: values.flags.contains("--json")
+                )
+            )
+        case "export":
+            let runID = try extractRunID(from: &optionArguments, command: "melix runs export")
+            let values = try ArgumentCursor(arguments: optionArguments).parse()
+            guard let format = values.single["--format"], !format.isEmpty else {
+                throw MelixCLIError.missingRequired("--format is required for melix runs export.")
+            }
+            return .runsExport(
+                RunsExportOptions(
+                    runID: runID,
+                    sourcePath: values.single["--from"] ?? "",
+                    format: format,
+                    outputPath: values.single["--output"] ?? ""
+                )
+            )
+        default:
+            throw MelixCLIError.usage(usageText)
+        }
+    }
+
+    private static func extractRunID(from arguments: inout [String], command: String) throws -> String {
+        guard let first = arguments.first, !first.hasPrefix("--") else {
+            throw MelixCLIError.missingRequired("RUN_ID is required for \(command).")
+        }
+        arguments.removeFirst()
+        let runID = first.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !runID.isEmpty else {
+            throw MelixCLIError.missingRequired("RUN_ID is required for \(command).")
+        }
+        return runID
     }
 
     private static func parsePipeline(_ arguments: [String]) throws -> MelixCLICommand {
@@ -5013,6 +5118,8 @@ public actor MelixCLIRunner {
                 )
             }
             return outputURL.path + "\n"
+        case .benchReport(let options):
+            return try renderRunReport(kind: "benchmark", options: options)
         case .benchMatrixRun(let options):
             let result = try await runBenchmarkMatrix(options)
             if options.json {
@@ -5173,6 +5280,32 @@ public actor MelixCLIRunner {
                 rowCount: { bundle in bundle.evaluationSampleRows(jobID: options.jobID).count },
                 contents: { bundle in try bundle.evaluationSamplesJSONL(jobID: options.jobID) }
             )
+        case .evalReport(let options):
+            return try renderRunReport(kind: "evaluation", options: options)
+        case .runsList(let options):
+            let records = try runRecordStore().loadRecords(sourcePath: options.sourcePath)
+            if options.json {
+                return try runRecordJSONString(records.map { $0.summaryPayload() })
+            }
+            return renderRunRecordList(records)
+        case .runsShow(let options):
+            let record = try runRecordStore().findRecord(runID: options.runID, sourcePath: options.sourcePath)
+            if options.json {
+                return try runRecordJSONString(record.payload)
+            }
+            return renderRunRecordMarkdown(record)
+        case .runsExport(let options):
+            let record = try runRecordStore().findRecord(runID: options.runID, sourcePath: options.sourcePath)
+            let output: String
+            switch options.format.lowercased() {
+            case "json":
+                output = try runRecordJSONString(record.payload)
+            case "md", "markdown":
+                output = renderRunRecordMarkdown(record)
+            default:
+                throw MelixCLIError.usage("Invalid value for --format. Expected json or md.")
+            }
+            return try writeRunRecordOutput(output, outputPath: options.outputPath)
         }
     }
 
@@ -5741,6 +5874,22 @@ public actor MelixCLIRunner {
 
     private func evaluationPromptStore() -> EvaluationPromptStore {
         EvaluationPromptStore(melixHome: MelixHome(environment: environment))
+    }
+
+    private func runRecordStore() -> MelixRunRecordStore {
+        MelixRunRecordStore(melixHome: MelixHome(environment: environment))
+    }
+
+    private func renderRunReport(kind: String, options: RunReportOptions) throws -> String {
+        let report = try runRecordStore().report(kind: kind, sourcePath: options.sourcePath)
+        switch options.format.lowercased() {
+        case "markdown", "md":
+            return report.markdown
+        case "json":
+            return try runRecordJSONString(report.payload)
+        default:
+            throw MelixCLIError.usage("Invalid value for --format. Expected markdown or json.")
+        }
     }
 
     private func evaluationPromptSnapshot(promptID: String, revisionID: String) throws -> EvaluationPromptSnapshot {

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -116,6 +116,8 @@ public enum MelixCLICommandCodec {
             return "bench.list"
         case .benchExportCSV:
             return "bench.export-csv"
+        case .benchReport:
+            return "bench.report"
         case .benchMatrixRun:
             return "bench.matrix.run"
         case .benchMatrixList:
@@ -154,6 +156,14 @@ public enum MelixCLICommandCodec {
             return "eval.export-samples-csv"
         case .evalExportSamplesJSONL:
             return "eval.export-samples-jsonl"
+        case .evalReport:
+            return "eval.report"
+        case .runsList:
+            return "runs.list"
+        case .runsShow:
+            return "runs.show"
+        case .runsExport:
+            return "runs.export"
         case .pipelineRun:
             return "pipeline.run"
         }
@@ -476,6 +486,11 @@ public enum MelixCLICommandCodec {
             arguments = ["bench", "export-csv"]
             appendExportOptions(options.jobID, options.outputPath, into: &arguments)
             json = options.json
+        case .benchReport(let options):
+            arguments = ["bench", "report"]
+            appendOption("--from", value: options.sourcePath, into: &arguments)
+            appendOption("--format", value: options.format, into: &arguments)
+            json = false
         case .benchMatrixExportSummaryCSV(let options):
             arguments = ["bench", "matrix", "export-summary-csv"]
             appendExportOptions(options.jobID, options.outputPath, into: &arguments)
@@ -544,6 +559,25 @@ public enum MelixCLICommandCodec {
             arguments = ["eval", "export-samples-jsonl"]
             appendExportOptions(options.jobID, options.outputPath, into: &arguments)
             json = options.json
+        case .evalReport(let options):
+            arguments = ["eval", "report"]
+            appendOption("--from", value: options.sourcePath, into: &arguments)
+            appendOption("--format", value: options.format, into: &arguments)
+            json = false
+        case .runsList(let options):
+            arguments = ["runs", "list"]
+            appendOption("--from", value: options.sourcePath, into: &arguments)
+            json = options.json
+        case .runsShow(let options):
+            arguments = ["runs", "show", options.runID]
+            appendOption("--from", value: options.sourcePath, into: &arguments)
+            json = options.json
+        case .runsExport(let options):
+            arguments = ["runs", "export", options.runID]
+            appendOption("--format", value: options.format, into: &arguments)
+            appendOption("--from", value: options.sourcePath, into: &arguments)
+            appendOption("--output", value: options.outputPath, into: &arguments)
+            json = false
         case .pipelineRun(let options):
             arguments = ["pipeline", "run"]
             appendOption("--file", value: options.filePath, into: &arguments)

--- a/Sources/MelixCLICore/MelixRunRecords.swift
+++ b/Sources/MelixCLICore/MelixRunRecords.swift
@@ -48,50 +48,28 @@ public struct RunReportOptions: Equatable, Sendable {
 
 struct MelixRunRecord {
     let payload: [String: Any]
+    private let envelope: MelixRunRecordEnvelope
     let path: String
 
-    var runID: String { stringValue("run_id") }
-    var runKind: String { stringValue("run_kind") }
-    var status: String { stringValue("status") }
-    var startedAtUnixMS: Int { intValue("started_at_unix_ms") }
-    var durationMS: Int { intValue("duration_ms") }
-
-    func stringValue(_ key: String) -> String {
-        payload[key].map { String(describing: $0) } ?? ""
+    init(payload: [String: Any], path: String) {
+        self.payload = payload
+        self.envelope = MelixRunRecordEnvelope(payload: payload)
+        self.path = path
     }
 
-    func intValue(_ key: String) -> Int {
-        if let value = payload[key] as? Int {
-            return value
-        }
-        if let value = payload[key] as? NSNumber {
-            return value.intValue
-        }
-        if let value = payload[key] as? String, let parsed = Int(value) {
-            return parsed
-        }
-        return 0
-    }
+    var runID: String { envelope.runID }
+    var runKind: String { envelope.runKind }
+    var status: String { envelope.status }
+    var startedAtUnixMS: Int { envelope.startedAtUnixMS }
+    var durationMS: Int { envelope.durationMS }
 
-    func dictionary(_ key: String) -> [String: Any] {
-        payload[key] as? [String: Any] ?? [:]
-    }
-
-    func array(_ key: String) -> [[String: Any]] {
-        payload[key] as? [[String: Any]] ?? []
-    }
-
-    var commandDisplay: String {
-        let command = dictionary("command")
-        return command["display"].map { String(describing: $0) } ?? ""
-    }
-
-    var target: [String: Any] { dictionary("target") }
-    var dataset: [String: Any] { dictionary("dataset") }
-    var environment: [String: Any] { dictionary("environment") }
-    var metrics: [[String: Any]] { array("metrics") }
-    var artifacts: [[String: Any]] { array("artifacts") }
-    var knownGaps: [String] { payload["known_gaps"] as? [String] ?? [] }
+    var commandDisplay: String { envelope.command.display }
+    var target: [String: Any] { envelope.target.payload }
+    var dataset: [String: Any] { envelope.dataset.payload }
+    var environment: [String: Any] { envelope.environment.payload }
+    var metrics: [[String: Any]] { envelope.metrics.map(\.payload) }
+    var artifacts: [[String: Any]] { envelope.artifacts.map(\.payload) }
+    var knownGaps: [String] { envelope.knownGaps }
 
     func summaryPayload() -> [String: Any] {
         [
@@ -105,9 +83,163 @@ struct MelixRunRecord {
             "source_repo": stringField(target, "source_repo"),
             "suite_ids": dataset["suite_ids"] ?? [],
             "dataset_id": stringField(dataset, "dataset_id", fallback: stringField(dataset, "dataset_ref")),
-            "artifact_root": stringValue("artifact_root"),
+            "artifact_root": envelope.artifactRoot,
             "record_path": path,
         ]
+    }
+}
+
+private struct MelixRunRecordEnvelope: Decodable {
+    let schemaVersion: String
+    let runID: String
+    let runKind: String
+    let status: String
+    let startedAtUnixMS: Int
+    let durationMS: Int
+    let command: DynamicRecord
+    let target: DynamicRecord
+    let dataset: DynamicRecord
+    let environment: DynamicRecord
+    let metrics: [DynamicRecord]
+    let artifacts: [DynamicRecord]
+    let knownGaps: [String]
+    let artifactRoot: String
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case runID = "run_id"
+        case runKind = "run_kind"
+        case status
+        case startedAtUnixMS = "started_at_unix_ms"
+        case durationMS = "duration_ms"
+        case command
+        case target
+        case dataset
+        case environment
+        case metrics
+        case artifacts
+        case knownGaps = "known_gaps"
+        case artifactRoot = "artifact_root"
+    }
+
+    init(payload: [String: Any]) {
+        self.schemaVersion = stringField(payload, "schema_version")
+        self.runID = stringField(payload, "run_id")
+        self.runKind = stringField(payload, "run_kind")
+        self.status = stringField(payload, "status")
+        self.startedAtUnixMS = intField(payload, "started_at_unix_ms")
+        self.durationMS = intField(payload, "duration_ms")
+        self.command = DynamicRecord(payload: payload["command"] as? [String: Any] ?? [:])
+        self.target = DynamicRecord(payload: payload["target"] as? [String: Any] ?? [:])
+        self.dataset = DynamicRecord(payload: payload["dataset"] as? [String: Any] ?? [:])
+        self.environment = DynamicRecord(payload: payload["environment"] as? [String: Any] ?? [:])
+        self.metrics = (payload["metrics"] as? [[String: Any]] ?? []).map(DynamicRecord.init(payload:))
+        self.artifacts = (payload["artifacts"] as? [[String: Any]] ?? []).map(DynamicRecord.init(payload:))
+        self.knownGaps = payload["known_gaps"] as? [String] ?? []
+        self.artifactRoot = stringField(payload, "artifact_root")
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.schemaVersion = try container.decodeIfPresent(String.self, forKey: .schemaVersion) ?? ""
+        self.runID = try container.decodeIfPresent(String.self, forKey: .runID) ?? ""
+        self.runKind = try container.decodeIfPresent(String.self, forKey: .runKind) ?? ""
+        self.status = try container.decodeIfPresent(String.self, forKey: .status) ?? ""
+        self.startedAtUnixMS = try container.decodeIntStringOrDefault(forKey: .startedAtUnixMS)
+        self.durationMS = try container.decodeIntStringOrDefault(forKey: .durationMS)
+        self.command = try container.decodeIfPresent(DynamicRecord.self, forKey: .command) ?? DynamicRecord(payload: [:])
+        self.target = try container.decodeIfPresent(DynamicRecord.self, forKey: .target) ?? DynamicRecord(payload: [:])
+        self.dataset = try container.decodeIfPresent(DynamicRecord.self, forKey: .dataset) ?? DynamicRecord(payload: [:])
+        self.environment = try container.decodeIfPresent(DynamicRecord.self, forKey: .environment) ?? DynamicRecord(payload: [:])
+        self.metrics = try container.decodeIfPresent([DynamicRecord].self, forKey: .metrics) ?? []
+        self.artifacts = try container.decodeIfPresent([DynamicRecord].self, forKey: .artifacts) ?? []
+        self.knownGaps = try container.decodeIfPresent([String].self, forKey: .knownGaps) ?? []
+        self.artifactRoot = try container.decodeIfPresent(String.self, forKey: .artifactRoot) ?? ""
+    }
+}
+
+private struct DynamicRecord: Decodable {
+    let payload: [String: Any]
+
+    var display: String {
+        stringField(payload, "display")
+    }
+
+    init(payload: [String: Any]) {
+        self.payload = payload
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(DynamicJSONValue.self)
+        self.payload = value.objectValue
+    }
+}
+
+private enum DynamicJSONValue: Decodable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case array([DynamicJSONValue])
+    case object([String: DynamicJSONValue])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([DynamicJSONValue].self) {
+            self = .array(value)
+        } else {
+            self = .object(try container.decode([String: DynamicJSONValue].self))
+        }
+    }
+
+    var anyValue: Any {
+        switch self {
+        case .string(let value):
+            return value
+        case .int(let value):
+            return value
+        case .double(let value):
+            return value
+        case .bool(let value):
+            return value
+        case .array(let values):
+            return values.map(\.anyValue)
+        case .object(let values):
+            return values.mapValues(\.anyValue)
+        case .null:
+            return NSNull()
+        }
+    }
+
+    var objectValue: [String: Any] {
+        if case .object(let values) = self {
+            return values.mapValues(\.anyValue)
+        }
+        return [:]
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func decodeIntStringOrDefault(forKey key: Key) throws -> Int {
+        if let value = try decodeIfPresent(Int.self, forKey: key) {
+            return value
+        }
+        if let value = try decodeIfPresent(String.self, forKey: key), let parsed = Int(value) {
+            return parsed
+        }
+        return 0
     }
 }
 
@@ -158,26 +290,58 @@ public final class MelixRunRecordStore {
             }
         }
         let scanMS = elapsedMilliseconds(since: scanStart)
-        let renderStart = DispatchTime.now()
         var payload = makeReportPayload(kind: kind, records: records, scanMS: scanMS, markdownRenderMS: 0)
-        _ = renderReportMarkdown(payload)
         payload["report_generation"] = [
             "record_scan_ms": scanMS,
-            "markdown_render_ms": elapsedMilliseconds(since: renderStart),
+            "markdown_render_ms": "__pending__",
         ]
-        let markdown = renderReportMarkdown(payload)
+        let renderStart = DispatchTime.now()
+        let pendingMarkdown = renderReportMarkdown(payload)
+        let markdownRenderMS = elapsedMilliseconds(since: renderStart)
+        payload["report_generation"] = makeReportGenerationPayload(recordScanMS: scanMS, markdownRenderMS: markdownRenderMS)
+        let markdown = pendingMarkdown.replacingOccurrences(
+            of: "markdown_render_ms=__pending__.",
+            with: "markdown_render_ms=\(markdownRenderMS)."
+        )
         return MelixRunReportResult(payload: payload, markdown: markdown)
     }
 
     private func sourceRoots(sourcePath: String) -> [URL] {
         let trimmed = sourcePath.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty {
-            return [URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath)]
+            return explicitSourceRoots(URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath))
         }
         return [
             melixHome.modelOpsJobsRootURL.appendingPathComponent("bench", isDirectory: true),
             melixHome.evaluationJobsRootURL,
         ]
+    }
+
+    private func explicitSourceRoots(_ url: URL) -> [URL] {
+        uniqueURLs([
+            url,
+            url.appendingPathComponent("jobs", isDirectory: true)
+                .appendingPathComponent("model-ops", isDirectory: true)
+                .appendingPathComponent("bench", isDirectory: true),
+            url.appendingPathComponent("jobs", isDirectory: true)
+                .appendingPathComponent("evaluation", isDirectory: true),
+            url.appendingPathComponent("model-ops", isDirectory: true)
+                .appendingPathComponent("bench", isDirectory: true),
+            url.appendingPathComponent("evaluation", isDirectory: true),
+            url.appendingPathComponent("bench", isDirectory: true),
+        ])
+    }
+
+    private func uniqueURLs(_ urls: [URL]) -> [URL] {
+        var seen: Set<String> = []
+        var result: [URL] = []
+        for url in urls {
+            let path = url.standardizedFileURL.path
+            if seen.insert(path).inserted {
+                result.append(url)
+            }
+        }
+        return result
     }
 
     private func loadRecords(at url: URL) throws -> [MelixRunRecord] {
@@ -192,22 +356,42 @@ public final class MelixRunRecordStore {
         if let rootRecord = try loadRecordFile(url.appendingPathComponent("run-record.json")) {
             records.append(rootRecord)
         }
-        guard let enumerator = fileManager.enumerator(
-            at: url,
-            includingPropertiesForKeys: [.isRegularFileKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return records
-        }
-        for case let candidateURL as URL in enumerator where candidateURL.lastPathComponent == "run-record.json" {
-            if candidateURL.path == url.appendingPathComponent("run-record.json").path {
-                continue
-            }
+        for candidateURL in try shallowRunRecordURLs(at: url) {
             if let record = try loadRecordFile(candidateURL) {
                 records.append(record)
             }
         }
         return records
+    }
+
+    private func shallowRunRecordURLs(at url: URL) throws -> [URL] {
+        let children = try fileManager.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        var candidates: [URL] = []
+        for child in children where isDirectory(child) {
+            candidates.append(child.appendingPathComponent("run-record.json"))
+            if ["matrix-runs", "runs"].contains(child.lastPathComponent) {
+                let grandchildren = try fileManager.contentsOfDirectory(
+                    at: child,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: [.skipsHiddenFiles]
+                )
+                candidates.append(
+                    contentsOf: grandchildren
+                        .filter(isDirectory)
+                        .map { $0.appendingPathComponent("run-record.json") }
+                )
+            }
+        }
+        return candidates
+    }
+
+    private func isDirectory(_ url: URL) -> Bool {
+        var isDirectory = ObjCBool(false)
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) && isDirectory.boolValue
     }
 
     private func loadRecordFile(_ url: URL) throws -> MelixRunRecord? {
@@ -221,6 +405,7 @@ public final class MelixRunRecordStore {
         else {
             return nil
         }
+        _ = try JSONDecoder().decode(MelixRunRecordEnvelope.self, from: data)
         return MelixRunRecord(payload: payload, path: url.path)
     }
 }
@@ -309,10 +494,7 @@ func makeReportPayload(
         "known_gaps": records.flatMap { record in
             record.knownGaps.map { ["run_id": record.runID, "gap": $0] }
         },
-        "report_generation": [
-            "record_scan_ms": scanMS,
-            "markdown_render_ms": markdownRenderMS,
-        ],
+        "report_generation": makeReportGenerationPayload(recordScanMS: scanMS, markdownRenderMS: markdownRenderMS),
     ]
 }
 
@@ -540,7 +722,7 @@ private func knownGapMarkdownLines(_ gaps: [String]) -> [String] {
 
 private func tableLines(headers: [String], rows: [[String]]) -> [String] {
     guard !rows.isEmpty else {
-        return ["No rows."]
+        return ["- None."]
     }
     let header = "| " + headers.map(markdownTableCell).joined(separator: " | ") + " |"
     let divider = "| " + headers.map { _ in "---" }.joined(separator: " | ") + " |"
@@ -577,6 +759,26 @@ private func stringField(_ payload: [String: Any], _ key: String, fallback: Stri
         return rendered.isEmpty ? fallback : rendered.joined(separator: ",")
     }
     return String(describing: value)
+}
+
+private func intField(_ payload: [String: Any], _ key: String) -> Int {
+    if let value = payload[key] as? Int {
+        return value
+    }
+    if let value = payload[key] as? NSNumber {
+        return value.intValue
+    }
+    if let value = payload[key] as? String, let parsed = Int(value) {
+        return parsed
+    }
+    return 0
+}
+
+private func makeReportGenerationPayload(recordScanMS: Double, markdownRenderMS: Double) -> [String: Any] {
+    [
+        "record_scan_ms": recordScanMS,
+        "markdown_render_ms": markdownRenderMS,
+    ]
 }
 
 private func markdownTableCell(_ value: String) -> String {

--- a/Sources/MelixCLICore/MelixRunRecords.swift
+++ b/Sources/MelixCLICore/MelixRunRecords.swift
@@ -1,0 +1,590 @@
+import Foundation
+
+public struct RunsListOptions: Equatable, Sendable {
+    public let sourcePath: String
+    public let json: Bool
+
+    public init(sourcePath: String = "", json: Bool = false) {
+        self.sourcePath = sourcePath
+        self.json = json
+    }
+}
+
+public struct RunsShowOptions: Equatable, Sendable {
+    public let runID: String
+    public let sourcePath: String
+    public let json: Bool
+
+    public init(runID: String, sourcePath: String = "", json: Bool = false) {
+        self.runID = runID
+        self.sourcePath = sourcePath
+        self.json = json
+    }
+}
+
+public struct RunsExportOptions: Equatable, Sendable {
+    public let runID: String
+    public let sourcePath: String
+    public let format: String
+    public let outputPath: String
+
+    public init(runID: String, sourcePath: String = "", format: String = "json", outputPath: String = "") {
+        self.runID = runID
+        self.sourcePath = sourcePath
+        self.format = format
+        self.outputPath = outputPath
+    }
+}
+
+public struct RunReportOptions: Equatable, Sendable {
+    public let sourcePath: String
+    public let format: String
+
+    public init(sourcePath: String, format: String = "markdown") {
+        self.sourcePath = sourcePath
+        self.format = format
+    }
+}
+
+struct MelixRunRecord {
+    let payload: [String: Any]
+    let path: String
+
+    var runID: String { stringValue("run_id") }
+    var runKind: String { stringValue("run_kind") }
+    var status: String { stringValue("status") }
+    var startedAtUnixMS: Int { intValue("started_at_unix_ms") }
+    var durationMS: Int { intValue("duration_ms") }
+
+    func stringValue(_ key: String) -> String {
+        payload[key].map { String(describing: $0) } ?? ""
+    }
+
+    func intValue(_ key: String) -> Int {
+        if let value = payload[key] as? Int {
+            return value
+        }
+        if let value = payload[key] as? NSNumber {
+            return value.intValue
+        }
+        if let value = payload[key] as? String, let parsed = Int(value) {
+            return parsed
+        }
+        return 0
+    }
+
+    func dictionary(_ key: String) -> [String: Any] {
+        payload[key] as? [String: Any] ?? [:]
+    }
+
+    func array(_ key: String) -> [[String: Any]] {
+        payload[key] as? [[String: Any]] ?? []
+    }
+
+    var commandDisplay: String {
+        let command = dictionary("command")
+        return command["display"].map { String(describing: $0) } ?? ""
+    }
+
+    var target: [String: Any] { dictionary("target") }
+    var dataset: [String: Any] { dictionary("dataset") }
+    var environment: [String: Any] { dictionary("environment") }
+    var metrics: [[String: Any]] { array("metrics") }
+    var artifacts: [[String: Any]] { array("artifacts") }
+    var knownGaps: [String] { payload["known_gaps"] as? [String] ?? [] }
+
+    func summaryPayload() -> [String: Any] {
+        [
+            "run_id": runID,
+            "run_kind": runKind,
+            "status": status,
+            "started_at_unix_ms": startedAtUnixMS,
+            "duration_ms": durationMS,
+            "model_id": stringField(target, "model_id", fallback: stringField(target, "base_model_id")),
+            "task_kind": stringField(target, "task_kind"),
+            "source_repo": stringField(target, "source_repo"),
+            "suite_ids": dataset["suite_ids"] ?? [],
+            "dataset_id": stringField(dataset, "dataset_id", fallback: stringField(dataset, "dataset_ref")),
+            "artifact_root": stringValue("artifact_root"),
+            "record_path": path,
+        ]
+    }
+}
+
+public struct MelixRunReportResult {
+    public let payload: [String: Any]
+    public let markdown: String
+}
+
+public final class MelixRunRecordStore {
+    private let melixHome: MelixHome
+    private let fileManager: FileManager
+
+    public init(melixHome: MelixHome, fileManager: FileManager = .default) {
+        self.melixHome = melixHome
+        self.fileManager = fileManager
+    }
+
+    func loadRecords(sourcePath: String = "") throws -> [MelixRunRecord] {
+        var records: [MelixRunRecord] = []
+        for url in sourceRoots(sourcePath: sourcePath) {
+            records.append(contentsOf: try loadRecords(at: url))
+        }
+        return records.sorted {
+            if $0.startedAtUnixMS == $1.startedAtUnixMS {
+                return $0.runID < $1.runID
+            }
+            return $0.startedAtUnixMS > $1.startedAtUnixMS
+        }
+    }
+
+    func findRecord(runID: String, sourcePath: String = "") throws -> MelixRunRecord {
+        guard let record = try loadRecords(sourcePath: sourcePath).first(where: { $0.runID == runID }) else {
+            throw MelixCLIError.runtime("No run record was found for \(runID).")
+        }
+        return record
+    }
+
+    func report(kind: String, sourcePath: String) throws -> MelixRunReportResult {
+        let scanStart = DispatchTime.now()
+        let records = try loadRecords(sourcePath: sourcePath).filter { record in
+            switch kind {
+            case "benchmark":
+                return record.runKind.hasPrefix("benchmark")
+            case "evaluation":
+                return record.runKind.hasPrefix("evaluation")
+            default:
+                return true
+            }
+        }
+        let scanMS = elapsedMilliseconds(since: scanStart)
+        let renderStart = DispatchTime.now()
+        var payload = makeReportPayload(kind: kind, records: records, scanMS: scanMS, markdownRenderMS: 0)
+        _ = renderReportMarkdown(payload)
+        payload["report_generation"] = [
+            "record_scan_ms": scanMS,
+            "markdown_render_ms": elapsedMilliseconds(since: renderStart),
+        ]
+        let markdown = renderReportMarkdown(payload)
+        return MelixRunReportResult(payload: payload, markdown: markdown)
+    }
+
+    private func sourceRoots(sourcePath: String) -> [URL] {
+        let trimmed = sourcePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            return [URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath)]
+        }
+        return [
+            melixHome.modelOpsJobsRootURL.appendingPathComponent("bench", isDirectory: true),
+            melixHome.evaluationJobsRootURL,
+        ]
+    }
+
+    private func loadRecords(at url: URL) throws -> [MelixRunRecord] {
+        var isDirectory = ObjCBool(false)
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return []
+        }
+        if !isDirectory.boolValue {
+            return try loadRecordFile(url).map { [$0] } ?? []
+        }
+        var records: [MelixRunRecord] = []
+        if let rootRecord = try loadRecordFile(url.appendingPathComponent("run-record.json")) {
+            records.append(rootRecord)
+        }
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return records
+        }
+        for case let candidateURL as URL in enumerator where candidateURL.lastPathComponent == "run-record.json" {
+            if candidateURL.path == url.appendingPathComponent("run-record.json").path {
+                continue
+            }
+            if let record = try loadRecordFile(candidateURL) {
+                records.append(record)
+            }
+        }
+        return records
+    }
+
+    private func loadRecordFile(_ url: URL) throws -> MelixRunRecord? {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return nil
+        }
+        let data = try Data(contentsOf: url)
+        let object = try JSONSerialization.jsonObject(with: data)
+        guard let payload = object as? [String: Any],
+              stringField(payload, "schema_version") == "melix.run_record.v1"
+        else {
+            return nil
+        }
+        return MelixRunRecord(payload: payload, path: url.path)
+    }
+}
+
+func renderRunRecordList(_ records: [MelixRunRecord]) -> String {
+    guard !records.isEmpty else {
+        return "No run records found.\n"
+    }
+    let rows = records.map { record in
+        let summary = record.summaryPayload()
+        return [
+            record.runID,
+            record.runKind,
+            record.status,
+            stringField(summary, "model_id", fallback: "-"),
+            stringField(summary, "task_kind", fallback: "-"),
+            suiteLabel(summary["suite_ids"]),
+            stringField(summary, "dataset_id", fallback: "-"),
+            String(record.startedAtUnixMS),
+            stringField(summary, "artifact_root", fallback: "-"),
+        ].joined(separator: "\t")
+    }
+    return ([
+        "run_id\trun_kind\tstatus\tmodel_id\ttask_kind\tsuites\tdataset\tstarted_at_unix_ms\tartifact_root",
+    ] + rows).joined(separator: "\n") + "\n"
+}
+
+func renderRunRecordMarkdown(_ record: MelixRunRecord) -> String {
+    var lines: [String] = [
+        "# Melix Run \(record.runID)",
+        "",
+        "## Environment",
+        "- Platform: \(markdownInline(stringField(record.environment, "platform", fallback: "unknown")))",
+        "- macOS: \(markdownInline(stringField(record.environment, "macos_version", fallback: "unknown")))",
+        "- Machine: \(markdownInline(stringField(record.environment, "machine", fallback: "unknown")))",
+        "- Processor: \(markdownInline(stringField(record.environment, "processor", fallback: "unknown")))",
+        "",
+        "## Target And Input",
+        "- Run kind: \(markdownInline(record.runKind))",
+        "- Status: \(markdownInline(record.status))",
+        "- Model: \(markdownInline(stringField(record.target, "model_id", fallback: stringField(record.target, "base_model_id", fallback: "-"))))",
+        "- Task: \(markdownInline(stringField(record.target, "task_kind", fallback: "-")))",
+        "- Source: \(markdownInline(stringField(record.target, "source_repo", fallback: "-")))",
+        "- Suites: \(markdownInline(suiteLabel(record.dataset["suite_ids"])))",
+        "- Dataset: \(markdownInline(stringField(record.dataset, "dataset_id", fallback: stringField(record.dataset, "dataset_ref", fallback: "-"))))",
+        "",
+    ]
+    lines.append(contentsOf: metricMarkdownLines(record.metrics))
+    lines.append(contentsOf: [
+        "",
+        "## Reproduction Command",
+        "```bash",
+        record.commandDisplay,
+        "```",
+        "",
+    ])
+    lines.append(contentsOf: artifactMarkdownLines(record.artifacts))
+    lines.append(contentsOf: knownGapMarkdownLines(record.knownGaps))
+    return lines.joined(separator: "\n") + "\n"
+}
+
+func makeReportPayload(
+    kind: String,
+    records: [MelixRunRecord],
+    scanMS: Double,
+    markdownRenderMS: Double
+) -> [String: Any] {
+    let completed = records.filter { $0.status == "completed" }.count
+    let failed = records.filter { $0.status == "failed" || $0.status == "error" }.count
+    return [
+        "schema_version": "melix.run_report.v1",
+        "report_kind": kind,
+        "generated_at_unix_ms": Int(Date().timeIntervalSince1970 * 1000),
+        "run_count": records.count,
+        "environment": records.map { environmentSummary($0) },
+        "model_backend_matrix": records.map { modelBackendRow($0) },
+        "dataset_task_matrix": records.map { datasetTaskRow($0) },
+        "metrics": records.flatMap { metricRows($0) },
+        "pass_fail_summary": [
+            "completed": completed,
+            "failed": failed,
+            "other": max(records.count - completed - failed, 0),
+        ],
+        "reproduction_commands": records.map { ["run_id": $0.runID, "command": $0.commandDisplay] },
+        "artifact_links": records.flatMap { artifactRows($0) },
+        "known_gaps": records.flatMap { record in
+            record.knownGaps.map { ["run_id": record.runID, "gap": $0] }
+        },
+        "report_generation": [
+            "record_scan_ms": scanMS,
+            "markdown_render_ms": markdownRenderMS,
+        ],
+    ]
+}
+
+func renderReportMarkdown(_ payload: [String: Any]) -> String {
+    let kind = stringField(payload, "report_kind", fallback: "runs")
+    var lines: [String] = [
+        "# Melix \(kind == "benchmark" ? "Benchmark" : kind == "evaluation" ? "Evaluation" : "Run") Report",
+        "",
+        "## Environment",
+    ]
+    lines.append(contentsOf: tableLines(
+        headers: ["Run", "Platform", "macOS", "Machine", "Processor"],
+        rows: (payload["environment"] as? [[String: Any]] ?? []).map {
+            [
+                stringField($0, "run_id"),
+                stringField($0, "platform"),
+                stringField($0, "macos_version"),
+                stringField($0, "machine"),
+                stringField($0, "processor"),
+            ]
+        }
+    ))
+    lines.append(contentsOf: [
+        "",
+        "## Model/Backend Matrix",
+    ])
+    lines.append(contentsOf: tableLines(
+        headers: ["Run", "Kind", "Model", "Source", "Task", "Runtime", "Status"],
+        rows: (payload["model_backend_matrix"] as? [[String: Any]] ?? []).map {
+            [
+                stringField($0, "run_id"),
+                stringField($0, "run_kind"),
+                stringField($0, "model_id"),
+                stringField($0, "source_repo"),
+                stringField($0, "task_kind"),
+                stringField($0, "runtime_backend"),
+                stringField($0, "status"),
+            ]
+        }
+    ))
+    lines.append(contentsOf: [
+        "",
+        "## Dataset/Task Matrix",
+    ])
+    lines.append(contentsOf: tableLines(
+        headers: ["Run", "Suites", "Dataset", "Sample Size", "Scoring"],
+        rows: (payload["dataset_task_matrix"] as? [[String: Any]] ?? []).map {
+            [
+                stringField($0, "run_id"),
+                stringField($0, "suite_ids"),
+                stringField($0, "dataset_id"),
+                stringField($0, "sample_size"),
+                stringField($0, "scoring_mode"),
+            ]
+        }
+    ))
+    lines.append(contentsOf: [
+        "",
+        "## Metrics Table",
+    ])
+    lines.append(contentsOf: tableLines(
+        headers: ["Run", "Metric", "Value", "Unit"],
+        rows: (payload["metrics"] as? [[String: Any]] ?? []).map {
+            [
+                stringField($0, "run_id"),
+                stringField($0, "name"),
+                stringField($0, "value"),
+                stringField($0, "unit"),
+            ]
+        }
+    ))
+    let summary = payload["pass_fail_summary"] as? [String: Any] ?? [:]
+    lines.append(contentsOf: [
+        "",
+        "## Pass/Fail Summary",
+        "- Completed: \(stringField(summary, "completed", fallback: "0"))",
+        "- Failed: \(stringField(summary, "failed", fallback: "0"))",
+        "- Other: \(stringField(summary, "other", fallback: "0"))",
+        "",
+        "## Reproduction Commands",
+    ])
+    for command in payload["reproduction_commands"] as? [[String: Any]] ?? [] {
+        lines.append(contentsOf: [
+            "### \(stringField(command, "run_id"))",
+            "```bash",
+            stringField(command, "command"),
+            "```",
+            "",
+        ])
+    }
+    lines.append("## Artifact Links")
+    lines.append(contentsOf: tableLines(
+        headers: ["Run", "Kind", "Path"],
+        rows: (payload["artifact_links"] as? [[String: Any]] ?? []).map {
+            [
+                stringField($0, "run_id"),
+                stringField($0, "kind"),
+                stringField($0, "path"),
+            ]
+        }
+    ))
+    lines.append(contentsOf: [
+        "",
+        "## Known Gaps",
+    ])
+    let gaps = payload["known_gaps"] as? [[String: Any]] ?? []
+    let generation = payload["report_generation"] as? [String: Any] ?? [:]
+    if gaps.isEmpty && generation.isEmpty {
+        lines.append("- None.")
+    } else {
+        for gap in gaps {
+            lines.append("- \(markdownInline(stringField(gap, "run_id"))): \(markdownInline(stringField(gap, "gap")))")
+        }
+    }
+    if generation.isEmpty == false {
+        let recordScanMS = stringField(generation, "record_scan_ms", fallback: "0")
+        let markdownRenderMS = stringField(generation, "markdown_render_ms", fallback: "0")
+        lines.append(
+            "- Report generation probe: record_scan_ms=\(recordScanMS), markdown_render_ms=\(markdownRenderMS)."
+        )
+    }
+    return lines.joined(separator: "\n") + "\n"
+}
+
+func runRecordJSONString(_ value: Any) throws -> String {
+    let data = try JSONSerialization.data(withJSONObject: value, options: [.prettyPrinted, .sortedKeys])
+    return (String(data: data, encoding: .utf8) ?? "") + "\n"
+}
+
+func writeRunRecordOutput(_ text: String, outputPath: String) throws -> String {
+    let trimmed = outputPath.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+        return text
+    }
+    let url = URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath)
+    try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true,
+        attributes: nil
+    )
+    try text.write(to: url, atomically: true, encoding: .utf8)
+    return url.path + "\n"
+}
+
+private func environmentSummary(_ record: MelixRunRecord) -> [String: Any] {
+    [
+        "run_id": record.runID,
+        "platform": stringField(record.environment, "platform"),
+        "macos_version": stringField(record.environment, "macos_version"),
+        "machine": stringField(record.environment, "machine"),
+        "processor": stringField(record.environment, "processor"),
+    ]
+}
+
+private func modelBackendRow(_ record: MelixRunRecord) -> [String: Any] {
+    [
+        "run_id": record.runID,
+        "run_kind": record.runKind,
+        "model_id": stringField(record.target, "model_id", fallback: stringField(record.target, "base_model_id")),
+        "source_repo": stringField(record.target, "source_repo"),
+        "task_kind": stringField(record.target, "task_kind"),
+        "runtime_backend": stringField(record.target, "runtime_backend"),
+        "status": record.status,
+    ]
+}
+
+private func datasetTaskRow(_ record: MelixRunRecord) -> [String: Any] {
+    [
+        "run_id": record.runID,
+        "suite_ids": suiteLabel(record.dataset["suite_ids"]),
+        "dataset_id": stringField(record.dataset, "dataset_id", fallback: stringField(record.dataset, "dataset_ref")),
+        "sample_size": stringField(record.dataset, "sample_size"),
+        "scoring_mode": stringField(record.dataset, "scoring_mode"),
+    ]
+}
+
+private func metricRows(_ record: MelixRunRecord) -> [[String: Any]] {
+    record.metrics.map { metric in
+        [
+            "run_id": record.runID,
+            "name": stringField(metric, "name"),
+            "value": stringField(metric, "value"),
+            "unit": stringField(metric, "unit"),
+        ]
+    }
+}
+
+private func artifactRows(_ record: MelixRunRecord) -> [[String: Any]] {
+    record.artifacts.map { artifact in
+        [
+            "run_id": record.runID,
+            "kind": stringField(artifact, "kind"),
+            "path": stringField(artifact, "path"),
+        ]
+    }
+}
+
+private func metricMarkdownLines(_ metrics: [[String: Any]]) -> [String] {
+    var lines = ["## Metrics"]
+    lines.append(contentsOf: tableLines(
+        headers: ["Metric", "Value", "Unit"],
+        rows: metrics.map { [stringField($0, "name"), stringField($0, "value"), stringField($0, "unit")] }
+    ))
+    return lines
+}
+
+private func artifactMarkdownLines(_ artifacts: [[String: Any]]) -> [String] {
+    var lines = ["## Artifact Links"]
+    lines.append(contentsOf: tableLines(
+        headers: ["Kind", "Path"],
+        rows: artifacts.map { [stringField($0, "kind"), stringField($0, "path")] }
+    ))
+    return lines
+}
+
+private func knownGapMarkdownLines(_ gaps: [String]) -> [String] {
+    var lines = ["", "## Known Gaps"]
+    if gaps.isEmpty {
+        lines.append("- None.")
+    } else {
+        lines.append(contentsOf: gaps.map { "- \(markdownInline($0))" })
+    }
+    return lines
+}
+
+private func tableLines(headers: [String], rows: [[String]]) -> [String] {
+    guard !rows.isEmpty else {
+        return ["No rows."]
+    }
+    let header = "| " + headers.map(markdownTableCell).joined(separator: " | ") + " |"
+    let divider = "| " + headers.map { _ in "---" }.joined(separator: " | ") + " |"
+    let body = rows.map { row in
+        "| " + row.map(markdownTableCell).joined(separator: " | ") + " |"
+    }
+    return [header, divider] + body
+}
+
+private func suiteLabel(_ value: Any?) -> String {
+    if let values = value as? [String] {
+        return values.isEmpty ? "-" : values.joined(separator: ",")
+    }
+    if let values = value as? [Any] {
+        let rendered = values.map { String(describing: $0) }.filter { !$0.isEmpty }
+        return rendered.isEmpty ? "-" : rendered.joined(separator: ",")
+    }
+    let rendered = value.map { String(describing: $0) } ?? ""
+    return rendered.isEmpty ? "-" : rendered
+}
+
+private func stringField(_ payload: [String: Any], _ key: String, fallback: String = "") -> String {
+    guard let value = payload[key] else {
+        return fallback
+    }
+    if let string = value as? String {
+        return string.isEmpty ? fallback : string
+    }
+    if let values = value as? [String] {
+        return values.isEmpty ? fallback : values.joined(separator: ",")
+    }
+    if let values = value as? [Any] {
+        let rendered = values.map { String(describing: $0) }.filter { !$0.isEmpty }
+        return rendered.isEmpty ? fallback : rendered.joined(separator: ",")
+    }
+    return String(describing: value)
+}
+
+private func markdownTableCell(_ value: String) -> String {
+    markdownInline(value.isEmpty ? "-" : value)
+        .replacingOccurrences(of: "|", with: "\\|")
+        .replacingOccurrences(of: "\n", with: " ")
+}
+
+private func markdownInline(_ value: String) -> String {
+    value.replacingOccurrences(of: "`", with: "\\`")
+}

--- a/docs/plans/2026-05-11-run-metadata-markdown-reports.md
+++ b/docs/plans/2026-05-11-run-metadata-markdown-reports.md
@@ -1,0 +1,63 @@
+# Run Metadata And Markdown Reports
+
+## Goal
+
+Persist operator-facing benchmark and evaluation run metadata and expose local
+offline commands that turn completed runs into GitHub-ready evidence.
+
+## Scope
+
+- Write `run-record.json` beside benchmark, benchmark matrix, evaluation, and
+  evaluation compare artifacts.
+- Add offline CLI surfaces:
+  - `melix runs list [--from PATH] [--json]`
+  - `melix runs show <id> [--from PATH] [--json]`
+  - `melix runs export <id> --format json|md [--from PATH] [--output PATH]`
+  - `melix bench report --from PATH --format markdown|json`
+  - `melix eval report --from PATH --format markdown|json`
+- Redact sensitive command parameters and request metadata before persistence.
+- Keep hosted telemetry, dashboards, and raw private dataset storage out of
+  scope.
+
+## Architecture
+
+The Python worker remains the execution truth and writes run records at the
+same point it writes benchmark/evaluation artifacts. The Swift CLI remains the
+operator surface and reads `run-record.json` directly from `$MELIX_HOME/jobs`
+or an explicit `--from` path, so `melix runs list --json` works without a
+running Melix service.
+
+`run-record.json` is an operator summary, not a replacement for
+`run-evidence.json`. It points back to evidence, report, CSV, JSONL, telemetry,
+and result artifacts while preserving the reproduction command, run identity,
+target/input summary, metrics, resource summary, and known gaps.
+
+Report commands derive Markdown and JSON from run records. Markdown output uses
+the issue-ready sections from issue #640: Environment, Model/backend matrix,
+Dataset/task matrix, Metrics table, Pass/fail summary, Reproduction commands,
+Artifact links, and Known gaps.
+
+## Probes And Metrics
+
+- Worker run-record persistence records a `run_record_write` probe with elapsed
+  milliseconds in each run record.
+- CLI report generation records `record_scan_ms` and `markdown_render_ms` in
+  JSON output and includes them in Markdown under Known gaps when the report is
+  generated without persisted timing.
+- Verification reports changed-line coverage for Swift CLI code and Python
+  worker/report code. A probe smoke is included when relevant local probe tests
+  are runnable.
+
+## Acceptance
+
+- Benchmark and evaluation stores write `run-record.json` for new completed
+  runs.
+- `melix runs list --json` reads local records from `$MELIX_HOME/jobs` without
+  calling the control plane.
+- `melix runs show` and `melix runs export` can render a single run as JSON or
+  Markdown.
+- `melix bench report --from ... --format markdown` and
+  `melix eval report --from ... --format markdown` include reproduction
+  commands, artifact paths, metrics, pass/fail summary, environment, and known
+  gaps.
+- Sensitive values are redacted in persisted metadata and rendered reports.

--- a/services/mlx-worker-python/tests/test_benchmark_store.py
+++ b/services/mlx-worker-python/tests/test_benchmark_store.py
@@ -78,6 +78,7 @@ def test_persist_serving_benchmark_writes_expected_artifact_names_and_payloads(
     assert persisted["context_rows_jsonl"] == jobs_root / "bench-context-rows.jsonl"
     assert persisted["telemetry_jsonl"] == jobs_root / "telemetry-samples.jsonl"
     assert persisted["evidence"] == jobs_root / "run-evidence.json"
+    assert persisted["run_record"] == jobs_root / "run-record.json"
     assert json.loads(persisted["job"].read_text(encoding="utf-8")) == job.to_dict()
     expected_results = {result.suite: result.to_dict() for result in results}
 
@@ -99,6 +100,17 @@ def test_persist_serving_benchmark_writes_expected_artifact_names_and_payloads(
     assert evidence["telemetry_summary"]["time_series_path"] == "telemetry-samples.jsonl"
     assert evidence["telemetry_summary"]["average_system_power_w"] == 15.0
     assert evidence["telemetry_summary"]["process_attribution"]["primary_runtime_process"]["pid"] == 102
+    run_record = json.loads(persisted["run_record"].read_text(encoding="utf-8"))
+    assert run_record["schema_version"] == "melix.run_record.v1"
+    assert run_record["run_id"] == "bench-123"
+    assert run_record["run_kind"] == "benchmark"
+    assert run_record["command"]["display"].startswith("melix bench run --model-id melix-dev-text")
+    assert {artifact["kind"] for artifact in run_record["artifacts"]} >= {
+        "evidence",
+        "run_record",
+        "telemetry_jsonl",
+    }
+    assert run_record["probes"][0]["phase"] == "run_record_write"
 
 
 def test_persist_benchmark_matrix_writes_job_summary_request_and_csv_artifacts(
@@ -186,6 +198,7 @@ def test_persist_benchmark_matrix_writes_job_summary_request_and_csv_artifacts(
     assert persisted["summary_csv"] == jobs_root / "bench-matrix-summary.csv"
     assert persisted["requests_jsonl"] == jobs_root / "bench-matrix-requests.jsonl"
     assert persisted["requests_csv"] == jobs_root / "bench-matrix-requests.csv"
+    assert persisted["run_record"] == jobs_root / "run-record.json"
     assert json.loads(persisted["job"].read_text(encoding="utf-8")) == job.to_dict()
     assert [
         json.loads(line)
@@ -205,6 +218,13 @@ def test_persist_benchmark_matrix_writes_job_summary_request_and_csv_artifacts(
     assert "job_id,cell_id,task_kind,suite_id,context_length,generation_length" in persisted["requests_csv"].read_text(
         encoding="utf-8"
     )
+    run_record = json.loads(persisted["run_record"].read_text(encoding="utf-8"))
+    assert run_record["schema_version"] == "melix.run_record.v1"
+    assert run_record["run_kind"] == "benchmark_matrix"
+    assert run_record["resources"]["peak_memory_bytes"] == 2_147_483_648
+    assert run_record["metrics"][0]["name"] == "benchmark_matrix.decode_tokens_per_second_mean"
+    assert run_record["known_gaps"] == ["Apple Silicon telemetry artifact was not present for this run."]
+    assert run_record["probes"][0]["phase"] == "run_record_write"
 
 
 def test_persist_benchmark_matrix_serializes_each_row_once_per_persist(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_evaluation_store.py
+++ b/services/mlx-worker-python/tests/test_evaluation_store.py
@@ -186,6 +186,7 @@ def test_persist_result_writes_expected_artifact_names_and_payloads(tmp_path: Pa
     assert persisted["samples_csv"] == run_root / "evaluation-samples.csv"
     assert persisted["telemetry_jsonl"] == run_root / "telemetry-samples.jsonl"
     assert persisted["evidence"] == run_root / "run-evidence.json"
+    assert persisted["run_record"] == run_root / "run-record.json"
     assert json.loads(persisted["job"].read_text(encoding="utf-8")) == job.to_dict()
     assert json.loads(persisted["result"].read_text(encoding="utf-8")) == result.to_dict()
     assert json.loads(persisted["summary_json"].read_text(encoding="utf-8"))["scored_sample_count"] == 2
@@ -207,6 +208,15 @@ def test_persist_result_writes_expected_artifact_names_and_payloads(tmp_path: Pa
     assert persisted["summary_csv"].read_text(encoding="utf-8").startswith(
         "job_id,task_kind,source_repo,model_id,suite_id,dataset_id,primary_score_name,primary_score_value,sample_size,extraction_success_count,validation_success_count,scored_sample_count,failure_count,duration_seconds,created_at_unix_ms\n"
     )
+    run_record = json.loads(persisted["run_record"].read_text(encoding="utf-8"))
+    assert run_record["schema_version"] == "melix.run_record.v1"
+    assert run_record["run_id"] == "eval-local"
+    assert run_record["run_kind"] == "evaluation"
+    assert run_record["command"]["display"].startswith("melix eval run --model-id melix-dev-text")
+    assert run_record["evaluation"]["primary_score_name"] == "normalized_exact_match"
+    assert run_record["evaluation"]["pass_count"] == 2
+    assert run_record["metrics"][0] == {"name": "eval.mmlu.accuracy", "value": 1.0, "unit": "ratio"}
+    assert run_record["probes"][0]["phase"] == "run_record_write"
     samples_header = persisted["samples_csv"].read_text(encoding="utf-8").splitlines()[0]
     assert samples_header.startswith(
         "id,task_kind,target,extracted_result,input_text,raw_response,typed_score,time_s,extraction_status,validation_status,failure_reason,input_modalities,media_references,code_language,code_entry_point,code_compile_status,code_runtime_status,code_timeout_status,code_test_status,code_tests_passed,code_tests_total,code_failure_detail,category_label,subject_label"
@@ -817,6 +827,7 @@ def test_persist_compare_result_writes_expected_compare_artifact_names_and_paylo
     assert persisted["summary_csv"] == run_root / "evaluation-compare-summary.csv"
     assert persisted["samples_jsonl"] == run_root / "evaluation-compare-samples.jsonl"
     assert persisted["report_markdown"] == run_root / "evaluation-compare-report.md"
+    assert persisted["run_record"] == run_root / "run-record.json"
     assert json.loads(persisted["job"].read_text(encoding="utf-8")) == compare_job.to_dict()
     summary_payload = json.loads(persisted["summary_json"].read_text(encoding="utf-8"))
     assert summary_payload["job_id"] == "eval-compare-1"
@@ -838,6 +849,14 @@ def test_persist_compare_result_writes_expected_compare_artifact_names_and_paylo
     assert "Bootstrap CI" in report_markdown
     assert "Analytical CI" in report_markdown
     assert "Category Breakdown" in report_markdown
+    run_record = json.loads(persisted["run_record"].read_text(encoding="utf-8"))
+    assert run_record["schema_version"] == "melix.run_record.v1"
+    assert run_record["run_kind"] == "evaluation_compare"
+    assert run_record["target"]["base_model_id"] == "melix-dev-text"
+    assert run_record["evaluation"]["win_count"] == 1
+    assert run_record["evaluation"]["verdicts"] == ["improvement"]
+    assert run_record["known_gaps"] == ["Apple Silicon telemetry artifact was not present for this run."]
+    assert run_record["probes"][0]["phase"] == "run_record_write"
 
 
 def test_persist_compare_result_preserves_code_execution_evidence(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_run_records.py
+++ b/services/mlx-worker-python/tests/test_run_records.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from worker.productization import run_records
 from worker.productization.run_records import (
     attach_run_record_write_probe,
+    build_evaluation_run_record,
     build_serving_benchmark_run_record,
     write_run_record,
 )
@@ -158,6 +159,49 @@ def test_run_record_builders_cover_reproducibility_fallbacks_and_repo_targets(
     ]
 
 
+def test_evaluation_run_record_keeps_explicit_zero_reproduction_options(
+    tmp_path: Path,
+) -> None:
+    job = SimpleNamespace(
+        job_id="eval-zero",
+        model_id="melix-dev-text",
+        task_kind="text-generation",
+        source_repo="",
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_size=0,
+        scoring_mode="exact_match",
+        few_shot=0,
+        seed=0,
+        code_exec_policy="disabled",
+        parameters={},
+        status="completed",
+        created_at_unix_ms=100,
+        updated_at_unix_ms=120,
+    )
+    result = SimpleNamespace(
+        metrics=(),
+        primary_score_name="exact_match",
+        primary_score_value=0.0,
+        scored_sample_count=0,
+        failure_count=0,
+        duration_seconds=0.0,
+    )
+
+    record = build_evaluation_run_record(
+        job=job,
+        result=result,
+        artifact_root=tmp_path,
+        artifact_paths={"telemetry_jsonl": tmp_path / "telemetry.jsonl"},
+    )
+
+    assert record["command"]["display"] == (
+        "melix eval run --model-id melix-dev-text --suite mmlu "
+        "--dataset-id mmlu-dev --sample-size 0 --scoring-mode exact_match "
+        "--few-shot 0 --seed 0 --code-exec-policy disabled"
+    )
+
+
 def test_run_record_helper_fallbacks(monkeypatch) -> None:
     assert run_records._split_parameter_list(("1024", "", "2048")) == ["1024", "2048"]
     assert run_records._split_parameter_list("cold, warm,,") == ["cold", "warm"]
@@ -176,3 +220,19 @@ def test_run_record_helper_fallbacks(monkeypatch) -> None:
     assert run_records._apple_processor_name() == "fallback-processor"
     assert run_records._git_output(Path("/tmp"), "rev-parse", "HEAD") == ""
     assert run_records._git_dirty(Path("/tmp")) is False
+
+
+def test_repo_root_falls_back_to_project_marker_when_git_is_unavailable(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    nested = tmp_path / "services" / "mlx-worker-python" / "worker"
+    nested.mkdir(parents=True)
+    (tmp_path / ".git").mkdir()
+
+    def fail_run(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("subprocess unavailable")
+
+    monkeypatch.setattr(run_records.subprocess, "run", fail_run)
+
+    assert run_records._repo_root(start=nested) == tmp_path

--- a/services/mlx-worker-python/tests/test_run_records.py
+++ b/services/mlx-worker-python/tests/test_run_records.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+import platform
+from pathlib import Path
+from types import SimpleNamespace
+
+from worker.productization import run_records
+from worker.productization.run_records import (
+    attach_run_record_write_probe,
+    build_serving_benchmark_run_record,
+    write_run_record,
+)
+
+
+def test_serving_benchmark_run_record_redacts_sensitive_parameters_and_writes_probe(
+    tmp_path: Path,
+) -> None:
+    job = SimpleNamespace(
+        job_id="bench-secret",
+        model_id="melix-dev-text",
+        task_kind="text-generation",
+        source_repo="HuggingFaceH4/ultrachat_200k",
+        suites=("smoke",),
+        context_lengths=(16,),
+        generation_length=8,
+        batch_sizes=(1,),
+        repeats=1,
+        cache_profile="cold",
+        reasoning_mode="disabled",
+        structured_output_mode="plain_text",
+        parameters={
+            "api_key": "sk-abcdefghi",
+            "dataset_ref": "org/private-eval@main",
+            "sample_size": "4",
+            "batch_factor": "1",
+            "schema_sha256": "abc123",
+            "schema_size_bytes": "32",
+            "hints_sha256": "def456",
+            "hints_size_bytes": "24",
+            "hints_format": "text",
+            "request_metadata": {
+                "authorization": "Bearer local-secret",
+                "trace_id": "trace-1",
+            },
+        },
+        status="completed",
+        created_at_unix_ms=100,
+        updated_at_unix_ms=150,
+    )
+    result = SimpleNamespace(
+        metrics=(
+            SimpleNamespace(name="bench.smoke.ttft_ms", value=12.5, unit="ms"),
+            SimpleNamespace(name="bench.smoke.peak_memory_bytes", value=4096, unit="bytes"),
+        )
+    )
+    artifact_paths = {
+        "evidence": tmp_path / "run-evidence.json",
+        "telemetry_jsonl": tmp_path / "telemetry-samples.jsonl",
+    }
+
+    record = build_serving_benchmark_run_record(
+        job=job,
+        results=(result,),
+        artifact_root=tmp_path,
+        artifact_paths=artifact_paths,
+    )
+
+    assert record["schema_version"] == "melix.run_record.v1"
+    assert record["run_id"] == "bench-secret"
+    assert record["run_kind"] == "benchmark"
+    assert record["parameters"]["api_key"] == "[REDACTED]"
+    assert record["parameters"]["request_metadata"] == {
+        "authorization": "[REDACTED]",
+        "trace_id": "trace-1",
+    }
+    assert record["command"]["redacted"] is True
+    assert record["command"]["display"].startswith("melix bench run --model-id melix-dev-text")
+    assert record["resources"]["peak_memory_bytes"] == 4096
+    assert record["reproducibility"] == {
+        "schema_sha256": "abc123",
+        "schema_size_bytes": "32",
+        "hints_sha256": "def456",
+        "hints_size_bytes": "24",
+        "hints_format": "text",
+    }
+    assert "Sensitive command or request values were redacted" in record["known_gaps"][0]
+    assert "sk-abcdefghi" not in json.dumps(record)
+    assert "local-secret" not in json.dumps(record)
+
+    record_path = tmp_path / "run-record.json"
+    persisted_path = write_run_record(
+        record_path,
+        attach_run_record_write_probe(record, duration_ms=1.23456),
+    )
+    payload = json.loads(record_path.read_text(encoding="utf-8"))
+
+    assert persisted_path == record_path
+    assert payload["probes"] == [
+        {
+            "component": "worker.productization.run_records",
+            "phase": "run_record_write",
+            "duration_ms": 1.2346,
+            "status": "completed",
+        }
+    ]
+
+
+def test_run_record_builders_cover_reproducibility_fallbacks_and_repo_targets(
+    tmp_path: Path,
+) -> None:
+    job = SimpleNamespace(
+        job_id="bench-repo",
+        model_id="",
+        task_kind="text-generation",
+        source_repo="mlx-community/model",
+        suites=("smoke",),
+        context_lengths=(),
+        generation_length=0,
+        batch_sizes=(),
+        repeats=0,
+        cache_profile="",
+        reasoning_mode="",
+        structured_output_mode="",
+        parameters={
+            "notes": ["safe", "ghp_secret12345"],
+            "request_id": "sk-abcdefghi",
+        },
+        status="completed",
+        created_at_unix_ms=100,
+        updated_at_unix_ms=90,
+    )
+    duplicate_metric = SimpleNamespace(name="bench.smoke.ttft_ms", value=12.5, unit="ms")
+
+    record = build_serving_benchmark_run_record(
+        job=job,
+        results=(SimpleNamespace(metrics=(duplicate_metric, duplicate_metric)),),
+        artifact_root=tmp_path / "root",
+        artifact_paths={"external": tmp_path / "outside.json"},
+    )
+
+    assert record["duration_ms"] == 0
+    assert record["command"]["display"] == "melix bench run --repo-id mlx-community/model --suite smoke"
+    assert record["parameters"]["notes"] == ["safe", "[REDACTED]"]
+    assert record["parameters"]["request_id"] == "[REDACTED]"
+    assert record["artifacts"] == [
+        {
+            "kind": "external",
+            "path": str(tmp_path / "outside.json"),
+            "relative_path": "",
+        }
+    ]
+    assert record["metrics"] == [{"name": "bench.smoke.ttft_ms", "value": 12.5, "unit": "ms"}]
+    assert record["resources"]["peak_memory_bytes"] is None
+    assert record["known_gaps"] == [
+        "Apple Silicon telemetry artifact was not present for this run.",
+        "Sensitive command or request values were redacted from the persisted run record.",
+    ]
+
+
+def test_run_record_helper_fallbacks(monkeypatch) -> None:
+    assert run_records._split_parameter_list(("1024", "", "2048")) == ["1024", "2048"]
+    assert run_records._split_parameter_list("cold, warm,,") == ["cold", "warm"]
+    assert run_records._matrix_values_from_rows((), "unknown") == []
+    assert run_records._int_or_none("not-a-number") is None
+    assert run_records._float_or_none("not-a-number") is None
+
+    def fail_run(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("subprocess unavailable")
+
+    monkeypatch.setattr(run_records.subprocess, "run", fail_run)
+    monkeypatch.setattr(platform, "processor", lambda: "fallback-processor")
+    run_records._apple_processor_name.cache_clear()
+    run_records._melix_identity.cache_clear()
+
+    assert run_records._apple_processor_name() == "fallback-processor"
+    assert run_records._git_output(Path("/tmp"), "rev-parse", "HEAD") == ""
+    assert run_records._git_dirty(Path("/tmp")) is False

--- a/services/mlx-worker-python/worker/productization/benchmark_store.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_store.py
@@ -24,6 +24,12 @@ from worker.productization.run_evidence import (
     build_serving_benchmark_run_evidence,
     monotonic_ms,
 )
+from worker.productization.run_records import (
+    attach_run_record_write_probe,
+    build_benchmark_matrix_run_record,
+    build_serving_benchmark_run_record,
+    write_run_record,
+)
 
 
 class BenchmarkStore:
@@ -102,6 +108,24 @@ class BenchmarkStore:
         )
         persisted["evidence"] = evidence_path
 
+        record_started_at_monotonic_ms = monotonic_ms()
+        record_path = jobs_root / "run-record.json"
+        record_paths = {**persisted, "run_record": record_path}
+        record = build_serving_benchmark_run_record(
+            job=job,
+            results=results,
+            artifact_root=jobs_root,
+            artifact_paths=record_paths,
+        )
+        write_run_record(
+            record_path,
+            attach_run_record_write_probe(
+                record,
+                duration_ms=monotonic_ms() - record_started_at_monotonic_ms,
+            ),
+        )
+        persisted["run_record"] = record_path
+
         return persisted
 
     @staticmethod
@@ -159,13 +183,31 @@ class BenchmarkStore:
             fieldnames=_canonical_benchmark_matrix_request_columns(),
         )
 
-        return {
+        persisted = {
             "job": job_path,
             "summary_jsonl": summary_jsonl_path,
             "summary_csv": summary_csv_path,
             "requests_jsonl": requests_jsonl_path,
             "requests_csv": requests_csv_path,
         }
+        record_started_at_monotonic_ms = monotonic_ms()
+        record_path = jobs_root / "run-record.json"
+        record_paths = {**persisted, "run_record": record_path}
+        record = build_benchmark_matrix_run_record(
+            job=job,
+            summary_rows=summary_rows,
+            artifact_root=jobs_root,
+            artifact_paths=record_paths,
+        )
+        write_run_record(
+            record_path,
+            attach_run_record_write_probe(
+                record,
+                duration_ms=monotonic_ms() - record_started_at_monotonic_ms,
+            ),
+        )
+        persisted["run_record"] = record_path
+        return persisted
 
     @staticmethod
     def _write_jsonl_and_csv(

--- a/services/mlx-worker-python/worker/productization/evaluation_store.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_store.py
@@ -20,6 +20,12 @@ from worker.productization.run_evidence import (
     build_evaluation_run_evidence,
     monotonic_ms,
 )
+from worker.productization.run_records import (
+    attach_run_record_write_probe,
+    build_evaluation_compare_run_record,
+    build_evaluation_run_record,
+    write_run_record,
+)
 
 
 class EvaluationStore:
@@ -105,6 +111,23 @@ class EvaluationStore:
             encoding="utf-8",
         )
         persisted["evidence"] = evidence_path
+        record_started_at_monotonic_ms = monotonic_ms()
+        record_path = run_root / "run-record.json"
+        record_paths = {**persisted, "run_record": record_path}
+        record = build_evaluation_run_record(
+            job=job,
+            result=result,
+            artifact_root=run_root,
+            artifact_paths=record_paths,
+        )
+        write_run_record(
+            record_path,
+            attach_run_record_write_probe(
+                record,
+                duration_ms=monotonic_ms() - record_started_at_monotonic_ms,
+            ),
+        )
+        persisted["run_record"] = record_path
         return persisted
 
     def persist_compare_result(
@@ -143,13 +166,31 @@ class EvaluationStore:
             encoding="utf-8",
         )
 
-        return {
+        persisted = {
             "job": job_path,
             "summary_json": summary_json_path,
             "summary_csv": summary_csv_path,
             "samples_jsonl": samples_jsonl_path,
             "report_markdown": report_markdown_path,
         }
+        record_started_at_monotonic_ms = monotonic_ms()
+        record_path = run_root / "run-record.json"
+        record_paths = {**persisted, "run_record": record_path}
+        record = build_evaluation_compare_run_record(
+            job=job,
+            summaries=summaries,
+            artifact_root=run_root,
+            artifact_paths=record_paths,
+        )
+        write_run_record(
+            record_path,
+            attach_run_record_write_probe(
+                record,
+                duration_ms=monotonic_ms() - record_started_at_monotonic_ms,
+            ),
+        )
+        persisted["run_record"] = record_path
+        return persisted
 
     @staticmethod
     def _write_jsonl(path: Path, rows: Iterable[object]) -> None:

--- a/services/mlx-worker-python/worker/productization/run_records.py
+++ b/services/mlx-worker-python/worker/productization/run_records.py
@@ -287,10 +287,10 @@ def _serving_benchmark_argv(*, job: Any, parameters: Mapping[str, object]) -> li
         _append_option(argv, "--suite", suite)
     for context_length in getattr(job, "context_lengths", ()):
         _append_option(argv, "--context-length", context_length)
-    _append_option(argv, "--generation-length", getattr(job, "generation_length", 0))
+    _append_option(argv, "--generation-length", getattr(job, "generation_length", 0), skip_zero=True)
     for batch_size in getattr(job, "batch_sizes", ()):
         _append_option(argv, "--batch-size", batch_size)
-    _append_option(argv, "--repeats", getattr(job, "repeats", 0))
+    _append_option(argv, "--repeats", getattr(job, "repeats", 0), skip_zero=True)
     _append_option(argv, "--cache-profile", getattr(job, "cache_profile", ""))
     _append_option(argv, "--reasoning-mode", getattr(job, "reasoning_mode", ""))
     _append_option(argv, "--structured-output-mode", getattr(job, "structured_output_mode", ""))
@@ -364,11 +364,13 @@ def _append_target(argv: list[str], *, model_id: str, source_repo: str) -> None:
         _append_option(argv, "--repo-id", source_repo)
 
 
-def _append_option(argv: list[str], option: str, value: object) -> None:
+def _append_option(argv: list[str], option: str, value: object, *, skip_zero: bool = False) -> None:
     if value is None:
         return
     string_value = str(value).strip()
-    if not string_value or string_value == "0":
+    if not string_value:
+        return
+    if skip_zero and string_value == "0":
         return
     argv.extend([option, string_value])
 
@@ -608,13 +610,37 @@ def _apple_processor_name() -> str:
 
 @lru_cache(maxsize=1)
 def _melix_identity() -> dict[str, object]:
-    repo_root = Path(__file__).resolve().parents[4]
+    repo_root = _repo_root()
     return {
         "git_commit": _git_output(repo_root, "rev-parse", "HEAD"),
         "git_branch": _git_output(repo_root, "rev-parse", "--abbrev-ref", "HEAD"),
         "dirty_worktree": _git_dirty(repo_root),
         "version": "",
     }
+
+
+def _repo_root(start: Path | None = None) -> Path:
+    start_path = (start or Path(__file__)).resolve()
+    cursor = start_path if start_path.is_dir() else start_path.parent
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=cursor,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+        )
+    except Exception:
+        completed = None
+    if completed is not None and completed.returncode == 0:
+        path = completed.stdout.strip()
+        if path:
+            return Path(path)
+    for candidate in (cursor, *cursor.parents):
+        if (candidate / ".git").exists() or (candidate / "AGENTS.md").exists():
+            return candidate
+    return Path(__file__).resolve().parents[4]
 
 
 def _git_output(repo_root: Path, *args: str) -> str:

--- a/services/mlx-worker-python/worker/productization/run_records.py
+++ b/services/mlx-worker-python/worker/productization/run_records.py
@@ -1,0 +1,665 @@
+from __future__ import annotations
+
+from functools import lru_cache
+import json
+import platform
+import re
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping
+
+
+RUN_RECORD_SCHEMA_VERSION = "melix.run_record.v1"
+
+_SENSITIVE_KEY_RE = re.compile(
+    r"(api[_-]?key|auth|bearer|credential|password|secret|token)",
+    re.IGNORECASE,
+)
+_SENSITIVE_VALUE_RE = re.compile(
+    r"^(sk-[A-Za-z0-9_\-]{8,}|Bearer\s+\S+|gh[pousr]_[A-Za-z0-9_]{8,})$",
+    re.IGNORECASE,
+)
+
+
+def build_serving_benchmark_run_record(
+    *,
+    job: Any,
+    results: tuple[Any, ...],
+    artifact_root: Path,
+    artifact_paths: Mapping[str, Path],
+) -> dict[str, object]:
+    parameters = _redacted_mapping(getattr(job, "parameters", {}))
+    suites = list(getattr(job, "suites", ()))
+    metrics = _benchmark_metrics(results)
+    return _base_record(
+        run_id=str(getattr(job, "job_id", "")),
+        run_kind="benchmark",
+        status=str(getattr(job, "status", "")),
+        started_at_unix_ms=int(getattr(job, "created_at_unix_ms", 0) or 0),
+        ended_at_unix_ms=int(getattr(job, "updated_at_unix_ms", 0) or 0),
+        artifact_root=artifact_root,
+        command=_command_payload(
+            _serving_benchmark_argv(job=job, parameters=parameters),
+            redacted=_has_redaction(parameters),
+        ),
+        target={
+            "model_id": str(getattr(job, "model_id", "")),
+            "task_kind": str(getattr(job, "task_kind", "")),
+            "source_repo": str(getattr(job, "source_repo", "")),
+            "runtime_backend": str(parameters.get("runtime_kind", "")),
+        },
+        dataset={
+            "suite_ids": suites,
+            "dataset_ref": str(parameters.get("dataset_ref", "")),
+            "sample_size": _int_or_none(parameters.get("sample_size")),
+            "batch_factor": _int_or_none(parameters.get("batch_factor")),
+        },
+        parameters=parameters,
+        metrics=metrics,
+        resources={
+            "peak_memory_bytes": _max_metric_value(metrics, "peak_memory_bytes"),
+            "estimated_active_memory_bytes": _int_or_none(
+                parameters.get("memory_fit_estimated_active_memory_bytes")
+            ),
+            "estimated_disk_usage_bytes": _int_or_none(
+                parameters.get("memory_fit_estimated_disk_usage_bytes")
+            ),
+        },
+        artifacts=_artifact_entries(artifact_root=artifact_root, artifact_paths=artifact_paths),
+        known_gaps=_known_gaps(parameters=parameters, telemetry_path=artifact_paths.get("telemetry_jsonl")),
+    )
+
+
+def build_benchmark_matrix_run_record(
+    *,
+    job: Any,
+    summary_rows: tuple[Any, ...],
+    artifact_root: Path,
+    artifact_paths: Mapping[str, Path],
+) -> dict[str, object]:
+    parameters = _redacted_mapping(getattr(job, "parameters", {}))
+    metrics = _benchmark_matrix_metrics(summary_rows)
+    return _base_record(
+        run_id=str(getattr(job, "job_id", "")),
+        run_kind="benchmark_matrix",
+        status=str(getattr(job, "status", "")),
+        started_at_unix_ms=int(getattr(job, "created_at_unix_ms", 0) or 0),
+        ended_at_unix_ms=int(getattr(job, "updated_at_unix_ms", 0) or 0),
+        artifact_root=artifact_root,
+        command=_command_payload(
+            _benchmark_matrix_argv(job=job, summary_rows=summary_rows),
+            redacted=_has_redaction(parameters),
+        ),
+        target={
+            "model_id": str(getattr(job, "model_id", "")),
+            "task_kind": str(getattr(job, "task_kind", "")),
+            "source_repo": str(getattr(job, "source_repo", "")),
+            "runtime_backend": str(parameters.get("runtime_kind", "")),
+        },
+        dataset={
+            "suite_ids": list(getattr(job, "suite_ids", ())),
+            "sample_size": _int_or_none(parameters.get("sample_size")),
+            "batch_factor": _int_or_none(parameters.get("batch_factor")),
+        },
+        parameters=parameters,
+        metrics=metrics,
+        resources={"peak_memory_bytes": _max_metric_value(metrics, "peak_memory_bytes")},
+        artifacts=_artifact_entries(artifact_root=artifact_root, artifact_paths=artifact_paths),
+        known_gaps=_known_gaps(parameters=parameters, telemetry_path=artifact_paths.get("telemetry_jsonl")),
+    )
+
+
+def build_evaluation_run_record(
+    *,
+    job: Any,
+    result: Any,
+    artifact_root: Path,
+    artifact_paths: Mapping[str, Path],
+) -> dict[str, object]:
+    parameters = _redacted_mapping(getattr(job, "parameters", {}))
+    metrics = _metric_values(getattr(result, "metrics", ()))
+    return _base_record(
+        run_id=str(getattr(job, "job_id", "")),
+        run_kind="evaluation",
+        status=str(getattr(job, "status", "")),
+        started_at_unix_ms=int(getattr(job, "created_at_unix_ms", 0) or 0),
+        ended_at_unix_ms=int(getattr(job, "updated_at_unix_ms", 0) or 0),
+        artifact_root=artifact_root,
+        command=_command_payload(
+            _evaluation_argv(job=job),
+            redacted=_has_redaction(parameters),
+        ),
+        target={
+            "model_id": str(getattr(job, "model_id", "")),
+            "task_kind": str(getattr(job, "task_kind", "")),
+            "source_repo": str(getattr(job, "source_repo", "")),
+            "runtime_backend": str(parameters.get("runtime_kind", "")),
+        },
+        dataset={
+            "suite_ids": [str(getattr(job, "suite_id", ""))],
+            "dataset_id": str(getattr(job, "dataset_id", "")),
+            "sample_size": int(getattr(job, "sample_size", 0) or 0),
+            "scoring_mode": str(getattr(job, "scoring_mode", "")),
+        },
+        parameters=parameters,
+        metrics=metrics,
+        resources={"peak_memory_bytes": _int_or_none(parameters.get("peak_memory_bytes"))},
+        artifacts=_artifact_entries(artifact_root=artifact_root, artifact_paths=artifact_paths),
+        known_gaps=_known_gaps(parameters=parameters, telemetry_path=artifact_paths.get("telemetry_jsonl")),
+        evaluation={
+            "primary_score_name": str(getattr(result, "primary_score_name", "")),
+            "primary_score_value": float(getattr(result, "primary_score_value", 0.0) or 0.0),
+            "pass_count": int(getattr(result, "scored_sample_count", 0) or 0)
+            - int(getattr(result, "failure_count", 0) or 0),
+            "failure_count": int(getattr(result, "failure_count", 0) or 0),
+            "duration_seconds": float(getattr(result, "duration_seconds", 0.0) or 0.0),
+        },
+    )
+
+
+def build_evaluation_compare_run_record(
+    *,
+    job: Any,
+    summaries: tuple[Any, ...],
+    artifact_root: Path,
+    artifact_paths: Mapping[str, Path],
+) -> dict[str, object]:
+    parameters = _redacted_mapping(getattr(job, "parameters", {}))
+    metrics = _evaluation_compare_metrics(summaries)
+    return _base_record(
+        run_id=str(getattr(job, "job_id", "")),
+        run_kind="evaluation_compare",
+        status=str(getattr(job, "status", "")),
+        started_at_unix_ms=int(getattr(job, "created_at_unix_ms", 0) or 0),
+        ended_at_unix_ms=int(getattr(job, "updated_at_unix_ms", 0) or 0),
+        artifact_root=artifact_root,
+        command=_command_payload(
+            _evaluation_compare_argv(job=job),
+            redacted=_has_redaction(parameters),
+        ),
+        target={
+            "base_model_id": str(getattr(job, "base_model_id", "")),
+            "target_model_ids": list(getattr(job, "target_model_ids", ())),
+            "task_kind": str(getattr(job, "task_kind", "")),
+            "source_repo": str(getattr(job, "source_repo", "")),
+            "runtime_backend": str(parameters.get("runtime_kind", "")),
+        },
+        dataset={
+            "suite_ids": [str(getattr(job, "suite_id", ""))],
+            "dataset_id": str(getattr(job, "dataset_id", "")),
+            "sample_size": int(getattr(job, "sample_size", 0) or 0),
+            "scoring_mode": str(getattr(job, "scoring_mode", "")),
+        },
+        parameters=parameters,
+        metrics=metrics,
+        resources={"peak_memory_bytes": _int_or_none(parameters.get("peak_memory_bytes"))},
+        artifacts=_artifact_entries(artifact_root=artifact_root, artifact_paths=artifact_paths),
+        known_gaps=_known_gaps(parameters=parameters, telemetry_path=artifact_paths.get("telemetry_jsonl")),
+        evaluation={
+            "win_count": sum(int(getattr(summary, "win_count", 0) or 0) for summary in summaries),
+            "loss_count": sum(int(getattr(summary, "loss_count", 0) or 0) for summary in summaries),
+            "tie_count": sum(int(getattr(summary, "tie_count", 0) or 0) for summary in summaries),
+            "regression_count": sum(int(getattr(summary, "regression_count", 0) or 0) for summary in summaries),
+            "verdicts": sorted({str(getattr(summary, "verdict", "")) for summary in summaries if str(getattr(summary, "verdict", ""))}),
+        },
+    )
+
+
+def attach_run_record_write_probe(record: dict[str, object], *, duration_ms: float) -> dict[str, object]:
+    payload = dict(record)
+    probes = list(payload.get("probes", [])) if isinstance(payload.get("probes"), list) else []
+    probes.append(
+        {
+            "component": "worker.productization.run_records",
+            "phase": "run_record_write",
+            "duration_ms": round(float(duration_ms), 4),
+            "status": "completed",
+        }
+    )
+    payload["probes"] = probes
+    return payload
+
+
+def write_run_record(path: Path, record: Mapping[str, object]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(dict(record), indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _base_record(
+    *,
+    run_id: str,
+    run_kind: str,
+    status: str,
+    started_at_unix_ms: int,
+    ended_at_unix_ms: int,
+    artifact_root: Path,
+    command: dict[str, object],
+    target: dict[str, object],
+    dataset: dict[str, object],
+    parameters: dict[str, object],
+    metrics: list[dict[str, object]],
+    resources: dict[str, object],
+    artifacts: list[dict[str, object]],
+    known_gaps: list[str],
+    evaluation: dict[str, object] | None = None,
+) -> dict[str, object]:
+    record: dict[str, object] = {
+        "schema_version": RUN_RECORD_SCHEMA_VERSION,
+        "run_id": run_id,
+        "run_kind": run_kind,
+        "status": status,
+        "started_at_unix_ms": started_at_unix_ms,
+        "ended_at_unix_ms": ended_at_unix_ms,
+        "duration_ms": max(0, ended_at_unix_ms - started_at_unix_ms),
+        "command": command,
+        "melix": _melix_identity(),
+        "environment": _environment_summary(),
+        "target": target,
+        "dataset": dataset,
+        "parameters": parameters,
+        "reproducibility": _reproducibility(parameters),
+        "metrics": metrics,
+        "resources": resources,
+        "artifact_root": str(artifact_root),
+        "artifacts": artifacts,
+        "known_gaps": known_gaps,
+        "probes": [],
+    }
+    if evaluation is not None:
+        record["evaluation"] = evaluation
+    return record
+
+
+def _command_payload(argv: list[str], *, redacted: bool) -> dict[str, object]:
+    return {
+        "argv": argv,
+        "display": shlex.join(argv),
+        "redacted": redacted,
+    }
+
+
+def _serving_benchmark_argv(*, job: Any, parameters: Mapping[str, object]) -> list[str]:
+    argv = ["melix", "bench", "run"]
+    _append_target(argv, model_id=str(getattr(job, "model_id", "")), source_repo=str(getattr(job, "source_repo", "")))
+    for suite in getattr(job, "suites", ()):
+        _append_option(argv, "--suite", suite)
+    for context_length in getattr(job, "context_lengths", ()):
+        _append_option(argv, "--context-length", context_length)
+    _append_option(argv, "--generation-length", getattr(job, "generation_length", 0))
+    for batch_size in getattr(job, "batch_sizes", ()):
+        _append_option(argv, "--batch-size", batch_size)
+    _append_option(argv, "--repeats", getattr(job, "repeats", 0))
+    _append_option(argv, "--cache-profile", getattr(job, "cache_profile", ""))
+    _append_option(argv, "--reasoning-mode", getattr(job, "reasoning_mode", ""))
+    _append_option(argv, "--structured-output-mode", getattr(job, "structured_output_mode", ""))
+    _append_option(argv, "--sample-size", parameters.get("sample_size"))
+    _append_option(argv, "--batch-factor", parameters.get("batch_factor"))
+    _append_option(argv, "--dataset-ref", parameters.get("dataset_ref"))
+    return argv
+
+
+def _benchmark_matrix_argv(*, job: Any, summary_rows: tuple[Any, ...]) -> list[str]:
+    argv = ["melix", "bench", "matrix", "run"]
+    _append_target(argv, model_id=str(getattr(job, "model_id", "")), source_repo=str(getattr(job, "source_repo", "")))
+    _append_option(argv, "--task-kind", getattr(job, "task_kind", ""))
+    for suite in getattr(job, "suite_ids", ()):
+        _append_option(argv, "--suite", suite)
+    parameters = getattr(job, "parameters", {})
+    for key, option in (
+        ("context_lengths", "--context-length"),
+        ("generation_lengths", "--generation-length"),
+        ("batch_sizes", "--batch-size"),
+        ("cache_profiles", "--cache-profile"),
+        ("reasoning_modes", "--reasoning-mode"),
+        ("structured_output_modes", "--structured-output-mode"),
+        ("concurrency_levels", "--concurrency"),
+    ):
+        values = _split_parameter_list(parameters.get(key, ""))
+        if not values:
+            values = _matrix_values_from_rows(summary_rows, key)
+        for value in values:
+            _append_option(argv, option, value)
+    _append_option(argv, "--repeats", parameters.get("repeats") or _first_matrix_value(summary_rows, "repeats"))
+    _append_option(argv, "--requests", parameters.get("requests") or _first_matrix_value(summary_rows, "requests"))
+    _append_option(
+        argv,
+        "--duration-seconds",
+        parameters.get("duration_seconds") or _first_matrix_value(summary_rows, "duration_seconds"),
+    )
+    return argv
+
+
+def _evaluation_argv(*, job: Any) -> list[str]:
+    argv = ["melix", "eval", "run"]
+    _append_target(argv, model_id=str(getattr(job, "model_id", "")), source_repo=str(getattr(job, "source_repo", "")))
+    _append_option(argv, "--suite", getattr(job, "suite_id", ""))
+    _append_option(argv, "--dataset-id", getattr(job, "dataset_id", ""))
+    _append_option(argv, "--sample-size", getattr(job, "sample_size", 0))
+    parameters = getattr(job, "parameters", {})
+    _append_option(argv, "--scoring-mode", getattr(job, "scoring_mode", ""))
+    _append_option(argv, "--few-shot", getattr(job, "few_shot", 0))
+    _append_option(argv, "--seed", getattr(job, "seed", 0))
+    _append_option(argv, "--code-exec-policy", getattr(job, "code_exec_policy", ""))
+    _append_option(argv, "--dataset-ref", parameters.get("dataset_ref", ""))
+    return argv
+
+
+def _evaluation_compare_argv(*, job: Any) -> list[str]:
+    argv = ["melix", "eval", "compare"]
+    _append_option(argv, "--base-model-id", getattr(job, "base_model_id", ""))
+    for target_model_id in getattr(job, "target_model_ids", ()):
+        _append_option(argv, "--target-model-id", target_model_id)
+    _append_option(argv, "--suite", getattr(job, "suite_id", ""))
+    _append_option(argv, "--dataset-id", getattr(job, "dataset_id", ""))
+    _append_option(argv, "--sample-size", getattr(job, "sample_size", 0))
+    return argv
+
+
+def _append_target(argv: list[str], *, model_id: str, source_repo: str) -> None:
+    if model_id:
+        _append_option(argv, "--model-id", model_id)
+    elif source_repo and not source_repo.startswith("remote:"):
+        _append_option(argv, "--repo-id", source_repo)
+
+
+def _append_option(argv: list[str], option: str, value: object) -> None:
+    if value is None:
+        return
+    string_value = str(value).strip()
+    if not string_value or string_value == "0":
+        return
+    argv.extend([option, string_value])
+
+
+def _split_parameter_list(value: object) -> list[str]:
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value if str(item).strip()]
+    text = str(value or "").strip()
+    if not text:
+        return []
+    return [part.strip() for part in text.split(",") if part.strip()]
+
+
+def _matrix_values_from_rows(summary_rows: tuple[Any, ...], key: str) -> list[str]:
+    field_by_key = {
+        "context_lengths": "context_length",
+        "generation_lengths": "generation_length",
+        "batch_sizes": "batch_size",
+        "cache_profiles": "cache_profile",
+        "reasoning_modes": "reasoning_mode",
+        "structured_output_modes": "structured_output_mode",
+        "concurrency_levels": "concurrency_level",
+    }
+    field = field_by_key.get(key, "")
+    if not field:
+        return []
+    values = {
+        str(getattr(row, field, "")).strip()
+        for row in summary_rows
+        if str(getattr(row, field, "")).strip()
+    }
+    return sorted(values)
+
+
+def _first_matrix_value(summary_rows: tuple[Any, ...], field: str) -> object:
+    for row in summary_rows:
+        value = getattr(row, field, None)
+        if value not in (None, "", 0):
+            return value
+    return ""
+
+
+def _benchmark_metrics(results: tuple[Any, ...]) -> list[dict[str, object]]:
+    metrics: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for result in results:
+        for metric in getattr(result, "metrics", ()):
+            payload = _metric_payload(metric)
+            key = str(payload["name"])
+            if key in seen:
+                continue
+            seen.add(key)
+            metrics.append(payload)
+    return metrics
+
+
+def _benchmark_matrix_metrics(summary_rows: tuple[Any, ...]) -> list[dict[str, object]]:
+    aggregates: dict[str, list[float]] = {}
+    for row in summary_rows:
+        for key in (
+            "ttft_mean_ms",
+            "request_latency_mean_ms",
+            "prefill_tokens_per_second_mean",
+            "decode_tokens_per_second_mean",
+            "throughput_requests_per_second",
+            "throughput_tokens_per_second",
+            "success_rate",
+            "peak_memory_bytes_max",
+            "queue_wait_mean_ms",
+            "queue_wait_p95_ms",
+        ):
+            value = _float_or_none(getattr(row, key, None))
+            if value is not None:
+                aggregates.setdefault(f"benchmark_matrix.{key}", []).append(value)
+    metrics: list[dict[str, object]] = []
+    for name, values in sorted(aggregates.items()):
+        metrics.append(
+            {
+                "name": name,
+                "value": round(sum(values) / max(len(values), 1), 4),
+                "unit": _unit_for_metric(name),
+            }
+        )
+    return metrics
+
+
+def _evaluation_compare_metrics(summaries: tuple[Any, ...]) -> list[dict[str, object]]:
+    metrics: list[dict[str, object]] = []
+    for summary in summaries:
+        target_model_id = str(getattr(summary, "target_model_id", "target"))
+        for metric in getattr(summary, "metrics", ()):
+            payload = _metric_payload(metric)
+            payload["name"] = f"{target_model_id}.{payload['name']}"
+            metrics.append(payload)
+    return metrics
+
+
+def _metric_values(metrics: tuple[Any, ...]) -> list[dict[str, object]]:
+    return [_metric_payload(metric) for metric in metrics]
+
+
+def _metric_payload(metric: Any) -> dict[str, object]:
+    return {
+        "name": str(getattr(metric, "name", "")),
+        "value": float(getattr(metric, "value", 0.0) or 0.0),
+        "unit": str(getattr(metric, "unit", "")),
+    }
+
+
+def _unit_for_metric(name: str) -> str:
+    if name.endswith("_ms") or "_ms_" in name:
+        return "ms"
+    if "tokens_per_second" in name or "requests_per_second" in name:
+        return "/s"
+    if name.endswith("_bytes") or "_bytes_" in name:
+        return "bytes"
+    return ""
+
+
+def _max_metric_value(metrics: list[dict[str, object]], fragment: str) -> int | None:
+    values = [
+        _float_or_none(metric.get("value"))
+        for metric in metrics
+        if fragment in str(metric.get("name", ""))
+    ]
+    values = [value for value in values if value is not None]
+    if not values:
+        return None
+    return int(max(values))
+
+
+def _artifact_entries(*, artifact_root: Path, artifact_paths: Mapping[str, Path]) -> list[dict[str, object]]:
+    entries: list[dict[str, object]] = []
+    for kind, path in sorted(artifact_paths.items()):
+        path_obj = Path(path)
+        try:
+            relative_path = str(path_obj.relative_to(artifact_root))
+        except ValueError:
+            relative_path = ""
+        entries.append(
+            {
+                "kind": kind,
+                "path": str(path_obj),
+                "relative_path": relative_path,
+            }
+        )
+    return entries
+
+
+def _redacted_mapping(parameters: Mapping[str, object]) -> dict[str, object]:
+    redacted: dict[str, object] = {}
+    for key, value in sorted(parameters.items()):
+        key_text = str(key)
+        redacted[key_text] = _redacted_value(key_text, value)
+    return redacted
+
+
+def _redacted_value(key: str, value: object) -> object:
+    if _is_sensitive(key, value):
+        return "[REDACTED]"
+    if isinstance(value, Mapping):
+        return {str(child_key): _redacted_value(str(child_key), child_value) for child_key, child_value in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_redacted_value(key, child_value) for child_value in value]
+    return value
+
+
+def _is_sensitive(key: str, value: object) -> bool:
+    if _SENSITIVE_KEY_RE.search(key):
+        return True
+    if isinstance(value, str) and _SENSITIVE_VALUE_RE.match(value.strip()):
+        return True
+    return False
+
+
+def _has_redaction(parameters: Mapping[str, object]) -> bool:
+    return any(_contains_redaction(value) for value in parameters.values())
+
+
+def _contains_redaction(value: object) -> bool:
+    if str(value) == "[REDACTED]":
+        return True
+    if isinstance(value, Mapping):
+        return any(_contains_redaction(child_value) for child_value in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_contains_redaction(child_value) for child_value in value)
+    return False
+
+
+def _reproducibility(parameters: Mapping[str, object]) -> dict[str, object]:
+    keys = (
+        "schema_sha256",
+        "schema_size_bytes",
+        "hints_sha256",
+        "hints_size_bytes",
+        "hints_format",
+        "prompt_template_digest",
+        "input_digest",
+    )
+    return {key: parameters[key] for key in keys if parameters.get(key) not in (None, "")}
+
+
+def _known_gaps(*, parameters: Mapping[str, object], telemetry_path: Path | None) -> list[str]:
+    gaps: list[str] = []
+    if telemetry_path is None or not str(telemetry_path):
+        gaps.append("Apple Silicon telemetry artifact was not present for this run.")
+    if _has_redaction(parameters):
+        gaps.append("Sensitive command or request values were redacted from the persisted run record.")
+    return gaps
+
+
+def _environment_summary() -> dict[str, object]:
+    mac_version = platform.mac_ver()[0]
+    return {
+        "platform": platform.system() or "unknown",
+        "macos_version": mac_version,
+        "machine": platform.machine(),
+        "processor": _apple_processor_name(),
+    }
+
+
+@lru_cache(maxsize=1)
+def _apple_processor_name() -> str:
+    try:
+        completed = subprocess.run(
+            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+        )
+    except Exception:
+        return platform.processor()
+    value = completed.stdout.strip()
+    return value or platform.processor()
+
+
+@lru_cache(maxsize=1)
+def _melix_identity() -> dict[str, object]:
+    repo_root = Path(__file__).resolve().parents[4]
+    return {
+        "git_commit": _git_output(repo_root, "rev-parse", "HEAD"),
+        "git_branch": _git_output(repo_root, "rev-parse", "--abbrev-ref", "HEAD"),
+        "dirty_worktree": _git_dirty(repo_root),
+        "version": "",
+    }
+
+
+def _git_output(repo_root: Path, *args: str) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+        )
+    except Exception:
+        return ""
+    return completed.stdout.strip() if completed.returncode == 0 else ""
+
+
+def _git_dirty(repo_root: Path) -> bool:
+    try:
+        completed = subprocess.run(
+            ["git", "status", "--short"],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+        )
+    except Exception:
+        return False
+    return bool(completed.stdout.strip()) if completed.returncode == 0 else False
+
+
+def _int_or_none(value: object) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _float_or_none(value: object) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -13,6 +13,8 @@ struct MelixCLIParserTests {
         #expect(MelixCLIParser.usageText.contains("[--schema PATH | --output-schema-json JSON] [--hints PATH]"))
         #expect(MelixCLIParser.usageText.contains("--hf-token passed to model or dataset hub download is saved"))
         #expect(MelixCLIParser.usageText.contains("--hf-dataset-revision overrides a revision embedded in --dataset-ref"))
+        #expect(MelixCLIParser.usageText.contains("melix runs list [--from PATH] [--json]"))
+        #expect(MelixCLIParser.usageText.contains("melix bench report --from PATH [--format markdown|json]"))
     }
 
     @Test("documents and parses remote server direct target commands")
@@ -482,7 +484,30 @@ struct MelixCLIParserTests {
             "doctor",
             "--format", "json-v1",
         ]) == .jsonV1)
+        #expect(MelixCLIParser.requestedOutputFormat([
+            "bench",
+            "report",
+            "--from", "/tmp/bench",
+            "--format", "json",
+        ]) == .legacy)
         #expect(MelixCLIParser.requestedOutputFormat(["doctor"]) == .legacy)
+    }
+
+    @Test("parse invocation lets report commands own their local format option")
+    func parseInvocationLetsReportCommandsOwnTheirLocalFormatOption() throws {
+        let invocation = try MelixCLIParser.parseInvocation([
+            "bench",
+            "report",
+            "--from", "/tmp/bench",
+            "--format", "json",
+        ])
+
+        #expect(invocation.outputFormat == .legacy)
+        #expect(invocation.command == .benchReport(.init(sourcePath: "/tmp/bench", format: "json")))
+
+        #expect(throws: MelixCLIError.missingValue("--format")) {
+            _ = try MelixCLIParser.parseInvocation(["bench", "report", "--format"])
+        }
     }
 
     @Test("command codec round trips typed command arguments")
@@ -706,6 +731,7 @@ struct MelixCLIParserTests {
             (.benchRun(.init(modelID: "model", suites: ["smoke"], contextLengths: [1024], generationLength: 128, batchSizes: [1], repeats: 2, cacheProfile: "cold", reasoningMode: "disabled", structuredOutputMode: "disabled", parameters: ["sample_size": "4", "batch_factor": "1"], json: true)), "bench.run"),
             (.benchList(.init(json: true)), "bench.list"),
             (.benchExportCSV(.init(jobID: "bench-1", outputPath: "/tmp/bench.csv", json: true)), "bench.export-csv"),
+            (.benchReport(.init(sourcePath: "/tmp/bench", format: "json")), "bench.report"),
             (.benchMatrixRun(.init(modelID: "model", taskKind: "text-generation", suites: ["smoke"], contextLengths: [1024], generationLengths: [128], batchSizes: [1], cacheProfiles: ["cold"], reasoningModes: ["disabled"], structuredOutputModes: ["disabled"], concurrencyLevels: [1], repeats: 2, requests: 4, allowLargeMatrix: true, json: true)), "bench.matrix.run"),
             (.benchMatrixList(.init(json: true)), "bench.matrix.list"),
             (.benchMatrixExportSummaryCSV(.init(jobID: "matrix-1", outputPath: "/tmp/matrix.csv", json: true)), "bench.matrix.export-summary-csv"),
@@ -726,6 +752,10 @@ struct MelixCLIParserTests {
             (.evalExportSummaryCSV(.init(jobID: "eval-1", outputPath: "/tmp/eval.csv", json: true)), "eval.export-summary-csv"),
             (.evalExportSamplesCSV(.init(jobID: "eval-1", outputPath: "/tmp/eval-samples.csv", json: true)), "eval.export-samples-csv"),
             (.evalExportSamplesJSONL(.init(jobID: "eval-1", outputPath: "/tmp/eval-samples.jsonl", json: true)), "eval.export-samples-jsonl"),
+            (.evalReport(.init(sourcePath: "/tmp/eval", format: "markdown")), "eval.report"),
+            (.runsList(.init(sourcePath: "/tmp/runs", json: true)), "runs.list"),
+            (.runsShow(.init(runID: "bench-1", sourcePath: "/tmp/runs", json: true)), "runs.show"),
+            (.runsExport(.init(runID: "bench-1", sourcePath: "/tmp/runs", format: "md", outputPath: "/tmp/run.md")), "runs.export"),
             (.pipelineRun(.init(filePath: "/tmp/pipeline.json", inputsPath: "/tmp/inputs.json", receiptDir: "/tmp/receipts", traceID: "trace", resume: true, fromStepID: "chat", dryRun: true)), "pipeline.run"),
         ]
 
@@ -800,6 +830,19 @@ struct MelixCLIParserTests {
                 #expect(MelixCLICommandCodec.commandID(for: jsonCommand) == MelixCLICommandCodec.commandID(for: command))
                 #expect(try MelixCLICommandCodec.arguments(for: jsonCommand).contains("--json"))
             }
+        }
+
+        let formatOwningCommands: [MelixCLICommand] = [
+            .benchReport(.init(sourcePath: "/tmp/bench", format: "json")),
+            .evalReport(.init(sourcePath: "/tmp/eval", format: "markdown")),
+            .runsList(.init(sourcePath: "/tmp/runs", json: true)),
+            .runsShow(.init(runID: "bench-1", sourcePath: "/tmp/runs", json: true)),
+            .runsExport(.init(runID: "bench-1", sourcePath: "/tmp/runs", format: "md", outputPath: "/tmp/run.md")),
+        ]
+        for command in formatOwningCommands {
+            let arguments = try MelixCLICommandCodec.arguments(for: command)
+            #expect(arguments.isEmpty == false)
+            #expect(try MelixCLIParser.parse(arguments) == command)
         }
 
         let unsupported: [MelixCLICommand] = [
@@ -2018,6 +2061,12 @@ struct MelixCLIParserTests {
             "--output", "/tmp/melix/bench-1.csv",
             "--json",
         ])
+        let reportCommand = try MelixCLIParser.parse([
+            "bench",
+            "report",
+            "--from", "/tmp/melix/bench/runs",
+            "--format", "json",
+        ])
 
         guard case .benchList(let listOptions) = listCommand else {
             Issue.record("Expected benchList command")
@@ -2027,11 +2076,17 @@ struct MelixCLIParserTests {
             Issue.record("Expected benchExportCSV command")
             return
         }
+        guard case .benchReport(let reportOptions) = reportCommand else {
+            Issue.record("Expected benchReport command")
+            return
+        }
 
         #expect(listOptions.json)
         #expect(exportOptions.jobID == "bench-1")
         #expect(exportOptions.outputPath == "/tmp/melix/bench-1.csv")
         #expect(exportOptions.json)
+        #expect(reportOptions.sourcePath == "/tmp/melix/bench/runs")
+        #expect(reportOptions.format == "json")
     }
 
     @Test("parses bench matrix run with canonical sweep and load-budget inputs")
@@ -2747,6 +2802,12 @@ struct MelixCLIParserTests {
             "--output", "/tmp/melix/eval-compare-1-samples.jsonl",
             "--json",
         ])
+        let reportCommand = try MelixCLIParser.parse([
+            "eval",
+            "report",
+            "--from", "/tmp/melix/evaluation/runs",
+            "--format", "markdown",
+        ])
 
         guard case .evalList(let listOptions) = listCommand else {
             Issue.record("Expected evalList command")
@@ -2768,6 +2829,10 @@ struct MelixCLIParserTests {
             Issue.record("Expected evalCompareExportSamplesJSONL command")
             return
         }
+        guard case .evalReport(let reportOptions) = reportCommand else {
+            Issue.record("Expected evalReport command")
+            return
+        }
 
         #expect(listOptions.json)
         #expect(summaryOptions.jobID == "eval-1")
@@ -2782,6 +2847,56 @@ struct MelixCLIParserTests {
         #expect(compareSamplesOptions.jobID == "eval-compare-1")
         #expect(compareSamplesOptions.outputPath == "/tmp/melix/eval-compare-1-samples.jsonl")
         #expect(compareSamplesOptions.json)
+        #expect(reportOptions.sourcePath == "/tmp/melix/evaluation/runs")
+        #expect(reportOptions.format == "markdown")
+    }
+
+    @Test("parses offline run record commands")
+    func parsesOfflineRunRecordCommands() throws {
+        let listCommand = try MelixCLIParser.parse([
+            "runs",
+            "list",
+            "--from", "/tmp/melix/jobs",
+            "--json",
+        ])
+        let showCommand = try MelixCLIParser.parse([
+            "runs",
+            "show",
+            "bench-1",
+            "--from", "/tmp/melix/jobs",
+            "--json",
+        ])
+        let exportCommand = try MelixCLIParser.parse([
+            "runs",
+            "export",
+            "bench-1",
+            "--format", "md",
+            "--from", "/tmp/melix/jobs",
+            "--output", "/tmp/melix/bench-1.md",
+        ])
+
+        guard case .runsList(let listOptions) = listCommand else {
+            Issue.record("Expected runsList command")
+            return
+        }
+        guard case .runsShow(let showOptions) = showCommand else {
+            Issue.record("Expected runsShow command")
+            return
+        }
+        guard case .runsExport(let exportOptions) = exportCommand else {
+            Issue.record("Expected runsExport command")
+            return
+        }
+
+        #expect(listOptions.sourcePath == "/tmp/melix/jobs")
+        #expect(listOptions.json)
+        #expect(showOptions.runID == "bench-1")
+        #expect(showOptions.sourcePath == "/tmp/melix/jobs")
+        #expect(showOptions.json)
+        #expect(exportOptions.runID == "bench-1")
+        #expect(exportOptions.format == "md")
+        #expect(exportOptions.sourcePath == "/tmp/melix/jobs")
+        #expect(exportOptions.outputPath == "/tmp/melix/bench-1.md")
     }
 
     @Test("parses lora activate with explicit alias and adapter path")
@@ -3130,6 +3245,28 @@ struct MelixCLIParserTests {
             for: ["eval", "export-samples-csv", "--job-id", "eval-1"],
             equals: .missingRequired("--output is required for melix eval export-samples-csv.")
         )
+        try assertError(
+            for: ["bench", "report"],
+            equals: .missingRequired("--from is required for melix bench report.")
+        )
+        try assertError(
+            for: ["eval", "report"],
+            equals: .missingRequired("--from is required for melix eval report.")
+        )
+        try assertError(
+            for: ["runs", "show"],
+            equals: .missingRequired("RUN_ID is required for melix runs show.")
+        )
+        try assertError(
+            for: ["runs", "show", " "],
+            equals: .missingRequired("RUN_ID is required for melix runs show.")
+        )
+        try assertError(
+            for: ["runs", "export", "bench-1"],
+            equals: .missingRequired("--format is required for melix runs export.")
+        )
+        try assertError(for: ["runs"], equals: .usage(MelixCLIParser.usageText))
+        try assertError(for: ["runs", "oops"], equals: .usage(MelixCLIParser.usageText))
     }
 
     @Test("surfaces malformed option errors")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -7688,6 +7688,194 @@ struct MelixCLIRunnerTests {
         }
     }
 
+    @Test("offline run record commands list show export and report local artifacts")
+    func offlineRunRecordCommandsListShowExportAndReportLocalArtifacts() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-run-records-\(UUID().uuidString)")
+        let sourceRoot = root.appendingPathComponent("records", isDirectory: true)
+        let benchRunRoot = sourceRoot.appendingPathComponent("bench-1", isDirectory: true)
+        let evalRunRoot = sourceRoot.appendingPathComponent("eval-1", isDirectory: true)
+        try FileManager.default.createDirectory(at: benchRunRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: evalRunRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try writeJSONObjectForTest(
+            makeRunRecordPayloadForTest(
+                runID: "bench-1",
+                runKind: "benchmark",
+                runRoot: benchRunRoot,
+                startedAtUnixMS: 200
+            ),
+            to: benchRunRoot.appendingPathComponent("run-record.json")
+        )
+        try writeJSONObjectForTest(
+            makeRunRecordPayloadForTest(
+                runID: "eval-1",
+                runKind: "evaluation",
+                runRoot: evalRunRoot,
+                startedAtUnixMS: 100,
+                metricName: "eval.mmlu.accuracy",
+                metricUnit: "ratio"
+            ),
+            to: evalRunRoot.appendingPathComponent("run-record.json")
+        )
+
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: ["MELIX_HOME": root.path]
+        )
+
+        let listJSON = try await runner.run(.runsList(.init(sourcePath: sourceRoot.path, json: true)))
+        let listPayload = try #require(parseJSONArray(listJSON) as? [[String: Any]])
+        #expect(listPayload.count == 2)
+        #expect(listPayload[0]["run_id"] as? String == "bench-1")
+        #expect(listPayload[1]["run_id"] as? String == "eval-1")
+
+        let listText = try await runner.run(.runsList(.init(sourcePath: sourceRoot.path)))
+        #expect(listText.contains("run_id\trun_kind\tstatus"))
+        #expect(listText.contains("bench-1\tbenchmark\tcompleted"))
+
+        let showMarkdown = try await runner.run(.runsShow(.init(runID: "bench-1", sourcePath: sourceRoot.path)))
+        #expect(showMarkdown.contains("# Melix Run bench-1"))
+        #expect(showMarkdown.contains("## Reproduction Command"))
+        #expect(showMarkdown.contains("melix bench run --model-id melix-dev-text"))
+
+        let showJSON = try await runner.run(.runsShow(.init(runID: "bench-1", sourcePath: sourceRoot.path, json: true)))
+        #expect(parseJSONObject(showJSON)?["run_id"] as? String == "bench-1")
+
+        let fileSourceMarkdown = try await runner.run(
+            .runsShow(
+                .init(
+                    runID: "bench-1",
+                    sourcePath: benchRunRoot.appendingPathComponent("run-record.json").path
+                )
+            )
+        )
+        #expect(fileSourceMarkdown.contains("# Melix Run bench-1"))
+
+        let exportURL = root.appendingPathComponent("exports/bench-1.md")
+        let exportOutput = try await runner.run(
+            .runsExport(.init(runID: "bench-1", sourcePath: sourceRoot.path, format: "md", outputPath: exportURL.path))
+        )
+        #expect(exportOutput == exportURL.path + "\n")
+        #expect(try String(contentsOf: exportURL, encoding: .utf8).contains("# Melix Run bench-1"))
+
+        let exportJSON = try await runner.run(.runsExport(.init(runID: "bench-1", sourcePath: sourceRoot.path, format: "json")))
+        #expect(parseJSONObject(exportJSON)?["run_id"] as? String == "bench-1")
+
+        let benchReportMarkdown = try await runner.run(.benchReport(.init(sourcePath: sourceRoot.path)))
+        #expect(benchReportMarkdown.contains("# Melix Benchmark Report"))
+        #expect(benchReportMarkdown.contains("| bench-1 | benchmark | melix-dev-text |"))
+        #expect(benchReportMarkdown.contains("record_scan_ms="))
+        #expect(benchReportMarkdown.contains("markdown_render_ms="))
+        #expect(benchReportMarkdown.contains("eval-1") == false)
+
+        let evalReportJSON = try await runner.run(.evalReport(.init(sourcePath: sourceRoot.path, format: "json")))
+        let evalReportPayload = try #require(parseJSONObject(evalReportJSON))
+        let generation = try #require(evalReportPayload["report_generation"] as? [String: Any])
+        #expect(evalReportPayload["report_kind"] as? String == "evaluation")
+        #expect(evalReportPayload["run_count"] as? Int == 1)
+        #expect(generation["record_scan_ms"] != nil)
+        #expect(generation["markdown_render_ms"] != nil)
+
+        let emptyList = try await runner.run(.runsList(.init(sourcePath: root.appendingPathComponent("missing").path)))
+        #expect(emptyList == "No run records found.\n")
+
+        do {
+            _ = try await runner.run(.runsExport(.init(runID: "bench-1", sourcePath: sourceRoot.path, format: "txt")))
+            Issue.record("Expected runs export to reject an unsupported format.")
+        } catch let error as MelixCLIError {
+            #expect(error == .usage("Invalid value for --format. Expected json or md."))
+        }
+
+        do {
+            _ = try await runner.run(.benchReport(.init(sourcePath: sourceRoot.path, format: "txt")))
+            Issue.record("Expected bench report to reject an unsupported format.")
+        } catch let error as MelixCLIError {
+            #expect(error == .usage("Invalid value for --format. Expected markdown or json."))
+        }
+    }
+
+    @Test("run record store handles default roots invalid records and render fallbacks")
+    func runRecordStoreHandlesDefaultRootsInvalidRecordsAndRenderFallbacks() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-run-record-store-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let melixHome = MelixHome(environment: ["MELIX_HOME": root.path])
+        let store = MelixRunRecordStore(melixHome: melixHome)
+        let benchRunRoot = melixHome.modelOpsJobsRootURL
+            .appendingPathComponent("bench", isDirectory: true)
+            .appendingPathComponent("bench-a", isDirectory: true)
+        let evalRunRoot = melixHome.evaluationJobsRootURL
+            .appendingPathComponent("eval-a", isDirectory: true)
+        try FileManager.default.createDirectory(at: benchRunRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: evalRunRoot, withIntermediateDirectories: true)
+        try writeJSONObjectForTest(
+            makeRunRecordPayloadForTest(runID: "bench-a", runKind: "benchmark", runRoot: benchRunRoot, startedAtUnixMS: 10),
+            to: benchRunRoot.appendingPathComponent("run-record.json")
+        )
+        try writeJSONObjectForTest(
+            makeRunRecordPayloadForTest(runID: "eval-a", runKind: "evaluation", runRoot: evalRunRoot, startedAtUnixMS: 10),
+            to: evalRunRoot.appendingPathComponent("run-record.json")
+        )
+
+        let defaultRecords = try store.loadRecords()
+        #expect(defaultRecords.map(\.runID) == ["bench-a", "eval-a"])
+        #expect(try store.report(kind: "runs", sourcePath: root.path).payload["run_count"] as? Int == 2)
+
+        let invalidRoot = root.appendingPathComponent("invalid", isDirectory: true)
+        try FileManager.default.createDirectory(at: invalidRoot, withIntermediateDirectories: true)
+        try writeJSONObjectForTest(
+            ["schema_version": "other", "run_id": "ignored"],
+            to: invalidRoot.appendingPathComponent("run-record.json")
+        )
+        #expect(try store.loadRecords(sourcePath: invalidRoot.path).isEmpty)
+
+        do {
+            _ = try store.findRecord(runID: "missing", sourcePath: root.path)
+            Issue.record("Expected missing run record lookup to fail.")
+        } catch let error as MelixCLIError {
+            #expect(error == .runtime("No run record was found for missing."))
+        }
+
+        #expect(MelixRunRecord(payload: [:], path: "").startedAtUnixMS == 0)
+        let directRecord = MelixRunRecord(
+            payload: [
+                "run_id": "direct",
+                "run_kind": "evaluation_compare",
+                "status": "completed",
+                "started_at_unix_ms": NSNumber(value: 42),
+                "duration_ms": "7",
+                "command": ["display": "melix eval compare --base-model-id base"],
+                "environment": ["platform": "Darwin"],
+                "target": [
+                    "base_model_id": "base",
+                    "task_kind": [1, "text-generation"],
+                    "model_id": ["model-a", "model-b"],
+                ],
+                "dataset": [
+                    "suite_ids": ["mmlu", "gsm8k"],
+                    "dataset_ref": "dataset/ref",
+                    "sample_size": ["2"],
+                ],
+                "metrics": [],
+                "artifacts": [],
+                "known_gaps": [],
+                "artifact_root": "",
+            ],
+            path: "/tmp/run-record.json"
+        )
+
+        #expect(directRecord.startedAtUnixMS == 42)
+        #expect(directRecord.durationMS == 7)
+        #expect(renderRunRecordList([directRecord]).contains("model-a,model-b"))
+        #expect(renderRunRecordMarkdown(directRecord).contains("- None."))
+        #expect(renderRunRecordMarkdown(directRecord).contains("No rows."))
+        #expect(renderReportMarkdown(["report_kind": "runs"]).contains("- None."))
+        #expect(try writeRunRecordOutput("inline\n", outputPath: "") == "inline\n")
+    }
+
     @Test("stub control-plane client covers auxiliary protocol helpers used by the CLI tests")
     func stubControlPlaneClientCoversAuxiliaryHelpers() async throws {
         let client = StubControlPlaneXPCClient()
@@ -8784,6 +8972,100 @@ private func parseJSONArray(_ text: String) -> [Any]? {
 private func parseJSONFile(_ path: String) throws -> [String: Any]? {
     let data = try Data(contentsOf: URL(fileURLWithPath: path))
     return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+}
+
+private func makeRunRecordPayloadForTest(
+    runID: String,
+    runKind: String,
+    runRoot: URL,
+    startedAtUnixMS: Int,
+    metricName: String = "bench.smoke.ttft_ms",
+    metricUnit: String = "ms"
+) -> [String: Any] {
+    let evaluation = runKind.hasPrefix("evaluation")
+    let suiteID = evaluation ? "mmlu" : "smoke"
+    let datasetID = evaluation ? "mmlu.dev.v1" : "ultrachat.smoke"
+    let command = evaluation
+        ? "melix eval run --model-id melix-dev-text --suite mmlu --dataset-id mmlu.dev.v1 --sample-size 2"
+        : "melix bench run --model-id melix-dev-text --suite smoke --sample-size 2"
+    return [
+        "schema_version": "melix.run_record.v1",
+        "run_id": runID,
+        "run_kind": runKind,
+        "status": "completed",
+        "started_at_unix_ms": startedAtUnixMS,
+        "ended_at_unix_ms": startedAtUnixMS + 50,
+        "duration_ms": 50,
+        "command": [
+            "argv": command.split(separator: " ").map(String.init),
+            "display": command,
+            "redacted": false,
+        ],
+        "melix": [
+            "git_commit": "abcdef",
+            "git_branch": "codex/test",
+            "dirty_worktree": false,
+            "version": "",
+        ],
+        "environment": [
+            "platform": "Darwin",
+            "macos_version": "15.5",
+            "machine": "arm64",
+            "processor": "Apple M4 Max",
+        ],
+        "target": [
+            "model_id": "melix-dev-text",
+            "task_kind": "text-generation",
+            "source_repo": "HuggingFaceH4/ultrachat_200k",
+            "runtime_backend": "mlx",
+        ],
+        "dataset": [
+            "suite_ids": [suiteID],
+            "dataset_id": datasetID,
+            "sample_size": 2,
+            "scoring_mode": evaluation ? "normalized_exact_match" : "",
+        ],
+        "parameters": [
+            "sample_size": "2",
+        ],
+        "reproducibility": [
+            "schema_sha256": "schema-digest",
+        ],
+        "metrics": [
+            [
+                "name": metricName,
+                "value": evaluation ? 0.75 : 24.5,
+                "unit": metricUnit,
+            ],
+        ],
+        "resources": [
+            "peak_memory_bytes": 1024,
+        ],
+        "artifact_root": runRoot.path,
+        "artifacts": [
+            [
+                "kind": evaluation ? "summary_json" : "evidence",
+                "path": runRoot.appendingPathComponent(evaluation ? "evaluation-summary.json" : "run-evidence.json").path,
+                "relative_path": evaluation ? "evaluation-summary.json" : "run-evidence.json",
+            ],
+            [
+                "kind": "run_record",
+                "path": runRoot.appendingPathComponent("run-record.json").path,
+                "relative_path": "run-record.json",
+            ],
+        ],
+        "known_gaps": [
+            "Apple Silicon telemetry artifact was not present for this run.",
+        ],
+        "probes": [
+            [
+                "component": "worker.productization.run_records",
+                "phase": "run_record_write",
+                "duration_ms": 0.1,
+                "status": "completed",
+            ],
+        ],
+    ]
 }
 
 private struct NonMelixPipelineTestError: Error, CustomStringConvertible {

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -7815,6 +7815,19 @@ struct MelixCLIRunnerTests {
             makeRunRecordPayloadForTest(runID: "bench-a", runKind: "benchmark", runRoot: benchRunRoot, startedAtUnixMS: 10),
             to: benchRunRoot.appendingPathComponent("run-record.json")
         )
+        let nestedArtifactRoot = benchRunRoot
+            .appendingPathComponent("artifacts", isDirectory: true)
+            .appendingPathComponent("checkpoint", isDirectory: true)
+        try FileManager.default.createDirectory(at: nestedArtifactRoot, withIntermediateDirectories: true)
+        try writeJSONObjectForTest(
+            makeRunRecordPayloadForTest(
+                runID: "nested-artifact",
+                runKind: "benchmark",
+                runRoot: nestedArtifactRoot,
+                startedAtUnixMS: 30
+            ),
+            to: nestedArtifactRoot.appendingPathComponent("run-record.json")
+        )
         try writeJSONObjectForTest(
             makeRunRecordPayloadForTest(runID: "eval-a", runKind: "evaluation", runRoot: evalRunRoot, startedAtUnixMS: 10),
             to: evalRunRoot.appendingPathComponent("run-record.json")
@@ -7822,6 +7835,7 @@ struct MelixCLIRunnerTests {
 
         let defaultRecords = try store.loadRecords()
         #expect(defaultRecords.map(\.runID) == ["bench-a", "eval-a"])
+        #expect(defaultRecords.contains { $0.runID == "nested-artifact" } == false)
         #expect(try store.report(kind: "runs", sourcePath: root.path).payload["run_count"] as? Int == 2)
 
         let invalidRoot = root.appendingPathComponent("invalid", isDirectory: true)
@@ -7871,7 +7885,8 @@ struct MelixCLIRunnerTests {
         #expect(directRecord.durationMS == 7)
         #expect(renderRunRecordList([directRecord]).contains("model-a,model-b"))
         #expect(renderRunRecordMarkdown(directRecord).contains("- None."))
-        #expect(renderRunRecordMarkdown(directRecord).contains("No rows."))
+        #expect(renderRunRecordMarkdown(directRecord).contains("- None."))
+        #expect(renderRunRecordMarkdown(directRecord).contains("No rows.") == false)
         #expect(renderReportMarkdown(["report_kind": "runs"]).contains("- None."))
         #expect(try writeRunRecordOutput("inline\n", outputPath: "") == "inline\n")
     }


### PR DESCRIPTION
## Summary
- Persist local `run-record.json` metadata for benchmark, benchmark matrix, evaluation, and evaluation compare artifacts.
- Add offline CLI commands for listing, showing, exporting, and rendering Markdown/JSON reports from run records.
- Redact sensitive command/request metadata and include report-generation probes for later Melix performance debugging.

Closes #640.

## Plan or Spec
- `docs/plans/2026-05-11-run-metadata-markdown-reports.md`

## Commands Run
```text
PYTHONPATH=/Users/ChenYu/Documents/Github/melix/.worktrees/issue-640-run-reports:/Users/ChenYu/Documents/Github/melix/.worktrees/issue-640-run-reports/services/mlx-worker-python UV_CACHE_DIR=/Users/ChenYu/Documents/Github/melix/.worktrees/issue-640-run-reports/.uv-cache uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_run_records.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_evaluation_store.py -q
Result: passed, 22 tests.

PYTHONPATH=/Users/ChenYu/Documents/Github/melix/.worktrees/issue-640-run-reports:/Users/ChenYu/Documents/Github/melix/.worktrees/issue-640-run-reports/services/mlx-worker-python UV_CACHE_DIR=/Users/ChenYu/Documents/Github/melix/.worktrees/issue-640-run-reports/.uv-cache uv run --project services/mlx-worker-python --extra mlx coverage run --source=services/mlx-worker-python/worker/productization -m pytest services/mlx-worker-python/tests/test_run_records.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_evaluation_store.py -q
Result: passed, 22 tests.

PYTHONPATH=/Users/ChenYu/Documents/Github/melix/.worktrees/issue-640-run-reports:/Users/ChenYu/Documents/Github/melix/.worktrees/issue-640-run-reports/services/mlx-worker-python UV_CACHE_DIR=/Users/ChenYu/Documents/Github/melix/.worktrees/issue-640-run-reports/.uv-cache uv run --project services/mlx-worker-python --extra mlx coverage json -o .runtime/coverage/issue-640-python-coverage.json
Result: wrote .runtime/coverage/issue-640-python-coverage.json.

python3 scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/issue-640-python-coverage.json --diff-from origin/main services/mlx-worker-python/worker/productization/benchmark_store.py services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/run_records.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_run_records.py
Result: passed, TOTAL 99.38% (321/323).

swift test --filter 'MelixCLIParserTests|MelixCLIRunnerTests/offlineRunRecordCommandsListShowExportAndReportLocalArtifacts'
Result: passed, 78 tests.

swift test --filter 'MelixCLIParserTests|MelixCLIRunnerTests/offlineRunRecordCommandsListShowExportAndReportLocalArtifacts|MelixCLIRunnerTests/runRecordStoreHandlesDefaultRootsInvalidRecordsAndRenderFallbacks'
Result: passed, 80 tests.

swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests/offlineRunRecordCommandsListShowExportAndReportLocalArtifacts|MelixCLIRunnerTests/runRecordStoreHandlesDefaultRootsInvalidRecordsAndRenderFallbacks'
Result: passed, 80 tests.

python3 scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main Sources/MelixCLICore/MelixCLI.swift Sources/MelixCLICore/MelixCLICommandCodec.swift Sources/MelixCLICore/MelixRunRecords.swift tests/MelixCLITests/MelixCLIParserTests.swift tests/MelixCLITests/MelixCLIRunnerTests.swift
Result: passed, TOTAL 96.75% (1189/1229).

git diff --check
Result: passed.
```

## Coverage and Metrics
- Python changed-line coverage: 99.38% (321/323) for the worker productization run-record path.
- Swift changed-line coverage: 96.75% (1189/1229) for CLI parsing, offline run record commands, and report rendering.
- Metrics/probes added:
  - Worker persistence writes a `run_record_write` probe with elapsed milliseconds in each `run-record.json`.
  - CLI reports include `record_scan_ms` and `markdown_render_ms` in JSON output and Markdown output.

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally in this worktree; focused Python/Swift tests and changed-line coverage were run for the touched scope.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
