### PR TITLE
perf: scan Swift binary candidates with scandir

### DIFF
--- a/docs/plans/2026-05-11-integration-swift-binary-resolution-scandir.md
+++ b/docs/plans/2026-05-11-integration-swift-binary-resolution-scandir.md
@@ -1,0 +1,36 @@
+# Integration Swift Binary Resolution Scandir Slice
+
+## Context
+
+Integration acceptance helpers resolve SwiftPM product binaries from `.build` trees before
+starting end-to-end Melix stacks. The previous fallback used
+`Path.glob("*/debug/<product>")`, which asks pathlib to allocate candidate paths for every
+triple directory before executable filtering.
+
+## Slice
+
+Replace the fallback glob in `tests/integration/helpers.py` with a shared
+`os.scandir()` candidate enumerator. The direct `.build/debug/<product>` lookup remains
+first, and architecture-specific SwiftPM products are still selected by the existing
+`(mtime, path-depth)` preference.
+
+## Probe
+
+Registered PR-scoped probe: `integration-swift-binary-resolution-scandir`.
+
+The probe builds a synthetic SwiftPM `.build` tree with many triple directories, compares
+the legacy glob candidate enumerator with the new scandir enumerator, and reports:
+
+- `candidate_count`
+- `legacy_elapsed_ms_mean`
+- `elapsed_ms_mean`
+- `delta_ms_mean`
+- `legacy_peak_bytes_mean`
+- `peak_bytes_mean`
+- `peak_bytes_delta_mean`
+
+## Verification
+
+Focused tests cover both package-scoped and root/scoped binary resolution and monkeypatch
+`Path.glob` to fail, proving the fallback no longer depends on pathlib glob allocation.
+Changed-scope coverage and the registered probe are required before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3380,5 +3380,46 @@
         "warn_pct": 0.0
       }
     ]
+  },
+  {
+    "id": "integration-swift-binary-resolution-scandir",
+    "name": "Integration Swift binary resolution scandir fallback",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "tests/integration/helpers.py",
+      "tests/integration/test_helper_binary_resolution.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/integration_swift_binary_resolution_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json tests/integration/helpers.py tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/integration_swift_binary_resolution_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/integration_swift_binary_resolution_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for PREFIX in \"${MELIX_SWIFT_BINARY_RESOLUTION_HEAD_REPO:-}\" \"${GITHUB_WORKSPACE:-}/head\" \"../head\"; do CANDIDATE=\"$PREFIX/$SCRIPT\"; if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "delta_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      },
+      {
+        "key": "candidate_count",
+        "unit": "candidates",
+        "direction": "informational"
+      }
+    ]
   }
 ]

--- a/scripts/integration_swift_binary_resolution_probe.py
+++ b/scripts/integration_swift_binary_resolution_probe.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(os.environ.get("MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT", Path.cwd())).resolve()
+sys.path.insert(0, str(REPO_ROOT))
+
+from tests.integration import helpers  # noqa: E402
+
+
+def _write_executable(path: Path, mtime: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\n", encoding="utf-8")
+    path.chmod(0o755)
+    os.utime(path, (mtime, mtime))
+
+
+def _legacy_candidates(build_root: Path, product_name: str) -> list[Path]:
+    candidates = [build_root / "debug" / product_name]
+    candidates.extend(sorted(build_root.glob(f"*/debug/{product_name}")))
+    return candidates
+
+
+def _resolve_from_candidates(candidates: list[Path]) -> Path:
+    executable_candidates = [
+        candidate for candidate in candidates if candidate.is_file() and os.access(candidate, os.X_OK)
+    ]
+    if not executable_candidates:
+        raise RuntimeError("probe fixture did not create executable candidates")
+    return max(executable_candidates, key=lambda candidate: (candidate.stat().st_mtime, len(candidate.parts)))
+
+
+def _run_once(build_root: Path, product_name: str, *, legacy: bool) -> tuple[float, int, int]:
+    tracemalloc.start()
+    started = time.perf_counter()
+    candidate_factory = getattr(helpers, "_swift_product_binary_candidates", _legacy_candidates)
+    if legacy:
+        resolved = _resolve_from_candidates(_legacy_candidates(build_root, product_name))
+    else:
+        resolved = _resolve_from_candidates(candidate_factory(build_root, product_name))
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    if resolved.name != product_name:
+        raise RuntimeError(f"unexpected product resolved: {resolved}")
+    return elapsed_ms, peak, len(resolved.parts)
+
+
+def main() -> None:
+    triples = int(os.environ.get("MELIX_SWIFT_BINARY_RESOLUTION_TRIPLES", "1500"))
+    samples = int(os.environ.get("MELIX_SWIFT_BINARY_RESOLUTION_SAMPLES", "5"))
+    product_name = "melix-probe"
+    root = Path(tempfile.mkdtemp(prefix="melix-swift-binary-probe-"))
+    try:
+        build_root = root / ".build"
+        _write_executable(build_root / "debug" / product_name, 1)
+        for index in range(triples):
+            triple = build_root / f"triple-{index:05d}" / "debug" / product_name
+            _write_executable(triple, index + 2)
+
+        new_elapsed: list[float] = []
+        new_peaks: list[float] = []
+        old_elapsed: list[float] = []
+        old_peaks: list[float] = []
+        for _ in range(samples):
+            elapsed, peak, _ = _run_once(build_root, product_name, legacy=True)
+            old_elapsed.append(elapsed)
+            old_peaks.append(float(peak))
+            elapsed, peak, _ = _run_once(build_root, product_name, legacy=False)
+            new_elapsed.append(elapsed)
+            new_peaks.append(float(peak))
+
+        print(
+            json.dumps(
+                {
+                    "candidate_count": triples + 1,
+                    "samples": samples,
+                    "legacy_elapsed_ms_mean": statistics.fmean(old_elapsed),
+                    "elapsed_ms_mean": statistics.fmean(new_elapsed),
+                    "delta_ms_mean": statistics.fmean(new_elapsed) - statistics.fmean(old_elapsed),
+                    "legacy_peak_bytes_mean": statistics.fmean(old_peaks),
+                    "peak_bytes_mean": statistics.fmean(new_peaks),
+                    "peak_bytes_delta_mean": statistics.fmean(new_peaks) - statistics.fmean(old_peaks),
+                },
+                sort_keys=True,
+            )
+        )
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -169,6 +169,36 @@ def test_scope_report_selects_engine_generate_usage_probe() -> None:
     assert _selected_probe_ids(scope) == ["engine-generate-usage-token-elision"]
 
 
+def test_scope_report_selects_integration_swift_binary_resolution_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["tests/integration/helpers.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert _selected_probe_ids(scope) == ["integration-swift-binary-resolution-scandir"]
+
+
+def test_integration_swift_binary_resolution_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_SWIFT_BINARY_RESOLUTION_TRIPLES", "8")
+    monkeypatch.setenv("MELIX_SWIFT_BINARY_RESOLUTION_SAMPLES", "1")
+
+    runpy.run_path(
+        str(REPO_ROOT / "scripts/integration_swift_binary_resolution_probe.py"),
+        run_name="__main__",
+    )
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["candidate_count"] == 9
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["legacy_elapsed_ms_mean"] >= 0
+    assert "delta_ms_mean" in metrics
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_scope_report_selects_mlx_text_stop_kwarg_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -1917,6 +1947,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "hub-catalog-tag-normalization-single-pass",
         "hub-catalog-next-cursor-fast-parse",
         "hub-catalog-size-hint-regex-precompile",
+        "integration-swift-binary-resolution-scandir",
         "benchmark-evaluation-report-running-aggregates",
         "stream-assembler-parser-mode-cache",
         "benchmark-export-run-scan-single-pass",

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -424,15 +424,31 @@ def swift_package_command(
     )
 
 
+def _swift_product_binary_candidates(build_root: Path, product_name: str) -> list[Path]:
+    candidates = [build_root / "debug" / product_name]
+    try:
+        entries = sorted(
+            (
+                entry
+                for entry in os.scandir(build_root)
+                if entry.is_dir(follow_symlinks=False)
+            ),
+            key=lambda entry: entry.name,
+        )
+    except FileNotFoundError:
+        entries = []
+
+    for entry in entries:
+        candidates.append(Path(entry.path) / "debug" / product_name)
+    return candidates
+
+
 def resolve_scoped_swift_product_binary(repo_root: Path, *, scope: str, product_name: str) -> Path:
     layout = swift_root_package.swift_package_layout(repo_root, scope)
     build_root = layout.scratch_path
-    candidates = [build_root / "debug" / product_name]
-    candidates.extend(sorted(build_root.glob(f"*/debug/{product_name}")))
-
     executable_candidates = [
         candidate
-        for candidate in candidates
+        for candidate in _swift_product_binary_candidates(build_root, product_name)
         if candidate.is_file() and os.access(candidate, os.X_OK)
     ]
     if executable_candidates:
@@ -451,12 +467,9 @@ def resolve_scoped_swift_product_binary(repo_root: Path, *, scope: str, product_
 
 def resolve_swift_product_binary(repo_root: Path, *, package_path: Path, product_name: str) -> Path:
     build_root = repo_root / package_path / ".build"
-    candidates = [build_root / "debug" / product_name]
-    candidates.extend(sorted(build_root.glob(f"*/debug/{product_name}")))
-
     executable_candidates = [
         candidate
-        for candidate in candidates
+        for candidate in _swift_product_binary_candidates(build_root, product_name)
         if candidate.is_file() and os.access(candidate, os.X_OK)
     ]
     if executable_candidates:

--- a/tests/integration/test_helper_binary_resolution.py
+++ b/tests/integration/test_helper_binary_resolution.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import tests.integration.helpers as helpers
+
+
+def _write_executable(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_swift_product_binary_candidates_tolerates_missing_build_root(tmp_path: Path) -> None:
+    build_root = tmp_path / "missing-build"
+
+    assert helpers._swift_product_binary_candidates(build_root, "melix") == [
+        build_root / "debug" / "melix"
+    ]
+
+
+def test_resolve_swift_product_binary_uses_scandir_fallback_without_path_glob(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path
+    build_root = repo_root / "services" / "mlx-text-worker-swift" / ".build"
+    stale_flat = build_root / "debug" / "melix-text-worker-swift"
+    preferred = build_root / "arm64-apple-macosx" / "debug" / "melix-text-worker-swift"
+    _write_executable(stale_flat)
+    _write_executable(preferred)
+    os.utime(stale_flat, (1, 1))
+    os.utime(preferred, (2, 2))
+
+    def fail_glob(self: Path, pattern: str):
+        raise AssertionError(f"Path.glob should not be used for Swift binary resolution: {pattern}")
+
+    monkeypatch.setattr(Path, "glob", fail_glob)
+
+    resolved = helpers.resolve_swift_product_binary(
+        repo_root,
+        package_path=Path("services/mlx-text-worker-swift"),
+        product_name="melix-text-worker-swift",
+    )
+
+    assert resolved == preferred
+
+
+def test_resolve_scoped_swift_product_binary_uses_scandir_fallback_without_path_glob(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path
+    build_root = repo_root / ".swiftpm" / "build" / "cli"
+    preferred = build_root / "x86_64-apple-macosx" / "debug" / "melix"
+    _write_executable(preferred)
+
+    monkeypatch.setattr(
+        helpers.swift_root_package,
+        "swift_package_layout",
+        lambda repo_root, scope: SimpleNamespace(scratch_path=build_root),
+    )
+
+    def fail_glob(self: Path, pattern: str):
+        raise AssertionError(f"Path.glob should not be used for scoped Swift binary resolution: {pattern}")
+
+    monkeypatch.setattr(Path, "glob", fail_glob)
+
+    resolved = helpers.resolve_scoped_swift_product_binary(
+        repo_root,
+        scope="cli",
+        product_name="melix",
+    )
+
+    assert resolved == preferred


### PR DESCRIPTION
## Summary
- Replace integration Swift product fallback globbing with a shared `os.scandir()` candidate enumerator.
- Register and repair the PR-scoped performance probe for the affected integration helper path so base/head comparison works when the probe script is new on the PR branch.
- Add focused regression coverage proving both binary resolution helpers avoid `Path.glob()` fallback allocation.

## Plan or Spec
- `docs/plans/2026-05-11-integration-swift-binary-resolution-scandir.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 6 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json tests/integration/helpers.py tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/integration_swift_binary_resolution_probe.py
# exit 0; 6 passed; changed-scope coverage TOTAL 3 0 100%

MELIX_SWIFT_BINARY_RESOLUTION_HEAD_REPO="$PWD" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id integration-swift-binary-resolution-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-pr659-base-probe --head-repo "$PWD" --output .runtime/probes/integration-swift-binary-resolution-scandir-local-full.json
# exit 0; base_probe ok; head_probe ok; head elapsed_ms_mean=94.1463517723605, head legacy_elapsed_ms_mean=138.59398257918656

python3 -m json.tool infra/perf/pr_scoped_probes.json >/dev/null
# exit 0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` after the CI-follow-up fix.
- Local registered probe: `integration-swift-binary-resolution-scandir`.
- Local registered probe metrics: base elapsed_ms_mean=`135.87260218337178ms`; head elapsed_ms_mean=`94.1463517723605ms`; head legacy_elapsed_ms_mean=`138.59398257918656ms`; head delta_ms_mean=`-44.447630806826055ms`; speedup=`1.47x`; candidate_count=`1501`; head peak bytes delta=`-707385.2`.
- CI PR-scoped performance workflow is required to validate the registered probe in GitHub Actions before merge.

## Known Gaps
- This slice optimizes Python integration-test helper resolution only. It does not claim Swift runtime performance validation; Linux local evidence covers Python helper behavior and synthetic path enumeration.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
