### PR TITLE
Add runtime settings and discovery surfaces

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -4,6 +4,64 @@ import Foundation
 import MelixControlPlaneCore
 import MelixControlPlaneProtocol
 
+public struct SettingsShowOptions: Equatable, Sendable {
+    public let json: Bool
+    public let overrides: [String: String]
+
+    public init(json: Bool = false, overrides: [String: String] = [:]) {
+        self.json = json
+        self.overrides = overrides
+    }
+}
+
+public struct SettingsSetOptions: Equatable, Sendable {
+    public let key: String
+    public let value: String
+    public let json: Bool
+
+    public init(key: String, value: String, json: Bool = false) {
+        self.key = key
+        self.value = value
+        self.json = json
+    }
+}
+
+public struct SettingsValidateOptions: Equatable, Sendable {
+    public let json: Bool
+
+    public init(json: Bool = false) {
+        self.json = json
+    }
+}
+
+public struct SettingsResetOptions: Equatable, Sendable {
+    public let key: String
+    public let json: Bool
+
+    public init(key: String, json: Bool = false) {
+        self.key = key
+        self.json = json
+    }
+}
+
+public struct DiscoveryJSONOptions: Equatable, Sendable {
+    public let json: Bool
+
+    public init(json: Bool = false) {
+        self.json = json
+    }
+}
+
+public struct CapabilitiesOptions: Equatable, Sendable {
+    public let json: Bool
+    public let modelQuery: String
+
+    public init(json: Bool = false, modelQuery: String = "") {
+        self.json = json
+        self.modelQuery = modelQuery
+    }
+}
+
 enum MelixQuantizationAllowedValues {
     static let quantizationModes = ["ptq", "qat"]
     static let sourceArtifactKinds = ["base_model", "merged_adapter", "adapter_export"]
@@ -1413,6 +1471,15 @@ public struct MelixCLIInvocation: Equatable, Sendable {
 }
 
 public enum MelixCLICommand: Equatable, Sendable {
+    case settingsShow(SettingsShowOptions)
+    case settingsSet(SettingsSetOptions)
+    case settingsValidate(SettingsValidateOptions)
+    case settingsReset(SettingsResetOptions)
+    case info(DiscoveryJSONOptions)
+    case capabilities(CapabilitiesOptions)
+    case instructions(DiscoveryJSONOptions)
+    case schema(DiscoveryJSONOptions)
+    case configMetadata(DiscoveryJSONOptions)
     case doctor(DoctorOptions)
     case system(SystemOptions)
     case monitor(MonitorOptions)
@@ -1560,6 +1627,18 @@ public enum MelixCLIParser {
         }
         let tail = Array(arguments.dropFirst())
         switch group {
+        case "settings":
+            return try parseSettings(tail)
+        case "info":
+            return try parseInfo(tail)
+        case "capabilities":
+            return try parseCapabilities(tail)
+        case "instructions":
+            return try parseInstructions(tail)
+        case "schema":
+            return try parseSchema(tail)
+        case "config":
+            return try parseConfig(tail)
         case "doctor":
             return try parseDoctor(tail)
         case "system":
@@ -1609,6 +1688,15 @@ public enum MelixCLIParser {
 
     public static let usageText = """
     Usage:
+      melix settings show --json [--override KEY=VALUE ...]
+      melix settings set KEY VALUE [--json]
+      melix settings validate [--json]
+      melix settings reset KEY [--json]
+      melix info --json
+      melix capabilities --json [--model-query MODEL]
+      melix instructions --json
+      melix schema --json
+      melix config metadata --json
       melix doctor [--json]
       melix system --json
       melix monitor [--from PATH] [--json]
@@ -1762,6 +1850,120 @@ public enum MelixCLIParser {
             return options.traceID
         }
         return ""
+    }
+
+    private static func parseSettings(_ arguments: [String]) throws -> MelixCLICommand {
+        guard let action = arguments.first else {
+            throw MelixCLIError.usage(Self.usageText)
+        }
+        let tail = Array(arguments.dropFirst())
+        switch action {
+        case "show":
+            let values = try ArgumentCursor(arguments: tail).parse(multiValueOptions: ["--override"])
+            guard values.flags.contains("--json") else {
+                throw MelixCLIError.usage("melix settings show requires --json.")
+            }
+            var overrides: [String: String] = [:]
+            for rawOverride in values.multi["--override", default: []] {
+                let parts = rawOverride.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+                guard parts.count == 2, parts[0].isEmpty == false else {
+                    throw MelixCLIError.usage("--override must use KEY=VALUE.")
+                }
+                overrides[String(parts[0])] = String(parts[1])
+            }
+            return .settingsShow(.init(json: true, overrides: overrides))
+        case "set":
+            var positional: [String] = []
+            var optionArguments: [String] = []
+            var index = 0
+            while index < tail.count {
+                let token = tail[index]
+                if token == "--json" {
+                    optionArguments.append(token)
+                } else if token.hasPrefix("--") {
+                    optionArguments.append(token)
+                    let valueIndex = index + 1
+                    guard valueIndex < tail.count else {
+                        throw MelixCLIError.missingValue(token)
+                    }
+                    optionArguments.append(tail[valueIndex])
+                    index += 1
+                } else {
+                    positional.append(token)
+                }
+                index += 1
+            }
+            let values = try ArgumentCursor(arguments: optionArguments).parse()
+            guard positional.count == 2 else {
+                throw MelixCLIError.missingRequired("KEY and VALUE are required for melix settings set.")
+            }
+            return .settingsSet(.init(key: positional[0], value: positional[1], json: values.flags.contains("--json")))
+        case "validate":
+            let values = try ArgumentCursor(arguments: tail).parse()
+            return .settingsValidate(.init(json: values.flags.contains("--json")))
+        case "reset":
+            var positional: [String] = []
+            var optionArguments: [String] = []
+            for token in tail {
+                if token == "--json" {
+                    optionArguments.append(token)
+                } else if token.hasPrefix("--") {
+                    throw MelixCLIError.usage(Self.usageText)
+                } else {
+                    positional.append(token)
+                }
+            }
+            let values = try ArgumentCursor(arguments: optionArguments).parse()
+            guard positional.count == 1 else {
+                throw MelixCLIError.missingRequired("KEY is required for melix settings reset.")
+            }
+            return .settingsReset(.init(key: positional[0], json: values.flags.contains("--json")))
+        default:
+            throw MelixCLIError.usage(Self.usageText)
+        }
+    }
+
+    private static func parseInfo(_ arguments: [String]) throws -> MelixCLICommand {
+        let values = try ArgumentCursor(arguments: arguments).parse()
+        guard values.flags.contains("--json") else {
+            throw MelixCLIError.usage("melix info requires --json.")
+        }
+        return .info(.init(json: true))
+    }
+
+    private static func parseCapabilities(_ arguments: [String]) throws -> MelixCLICommand {
+        let values = try ArgumentCursor(arguments: arguments).parse()
+        guard values.flags.contains("--json") else {
+            throw MelixCLIError.usage("melix capabilities requires --json.")
+        }
+        return .capabilities(.init(json: true, modelQuery: values.single["--model-query"] ?? ""))
+    }
+
+    private static func parseInstructions(_ arguments: [String]) throws -> MelixCLICommand {
+        let values = try ArgumentCursor(arguments: arguments).parse()
+        guard values.flags.contains("--json") else {
+            throw MelixCLIError.usage("melix instructions requires --json.")
+        }
+        return .instructions(.init(json: true))
+    }
+
+    private static func parseSchema(_ arguments: [String]) throws -> MelixCLICommand {
+        let values = try ArgumentCursor(arguments: arguments).parse()
+        guard values.flags.contains("--json") else {
+            throw MelixCLIError.usage("melix schema requires --json.")
+        }
+        return .schema(.init(json: true))
+    }
+
+    private static func parseConfig(_ arguments: [String]) throws -> MelixCLICommand {
+        guard arguments.first == "metadata" else {
+            throw MelixCLIError.usage(Self.usageText)
+        }
+        let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse()
+        guard values.flags.contains("--json") else {
+            throw MelixCLIError.usage("melix config metadata requires --json.")
+        }
+        return .configMetadata(.init(json: true))
     }
 
     private static func parseDoctor(_ arguments: [String]) throws -> MelixCLICommand {
@@ -4758,6 +4960,50 @@ public actor MelixCLIRunner {
             try await primeConfiguredRegistryRootsIfNeeded()
         }
         switch command {
+        case .settingsShow(let options):
+            let store = MelixRuntimeSettingsStore(
+                melixHome: MelixHome(environment: environment),
+                environment: environment
+            )
+            let payload = try store.effectiveSettings(overrides: options.overrides)
+            return options.json ? try prettyJSON(payload) : try prettyJSON(payload)
+        case .settingsSet(let options):
+            let store = MelixRuntimeSettingsStore(
+                melixHome: MelixHome(environment: environment),
+                environment: environment
+            )
+            let payload = try store.set(key: options.key, value: options.value)
+            return options.json ? try prettyJSON(payload) : "Updated \(options.key).\n"
+        case .settingsValidate(let options):
+            let store = MelixRuntimeSettingsStore(
+                melixHome: MelixHome(environment: environment),
+                environment: environment
+            )
+            let payload = store.validate()
+            return options.json ? try prettyJSON(payload) : ((payload["valid"] as? Bool) == true ? "Runtime settings are valid.\n" : "Runtime settings are invalid.\n")
+        case .settingsReset(let options):
+            let store = MelixRuntimeSettingsStore(
+                melixHome: MelixHome(environment: environment),
+                environment: environment
+            )
+            let payload = try store.reset(key: options.key)
+            return options.json ? try prettyJSON(payload) : "Reset \(options.key).\n"
+        case .info(let options):
+            let payload = MelixRuntimeDiscoveryBuilder(environment: environment).infoPayload()
+            return options.json ? try prettyJSON(payload) : try prettyJSON(payload)
+        case .capabilities(let options):
+            let payload = MelixRuntimeDiscoveryBuilder(environment: environment)
+                .capabilitiesPayload(modelQuery: options.modelQuery)
+            return options.json ? try prettyJSON(payload) : try prettyJSON(payload)
+        case .instructions(let options):
+            let payload = MelixRuntimeDiscoveryBuilder(environment: environment).instructionsPayload()
+            return options.json ? try prettyJSON(payload) : try prettyJSON(payload)
+        case .schema(let options):
+            let payload = MelixRuntimeDiscoveryBuilder(environment: environment).schemaPayload()
+            return options.json ? try prettyJSON(payload) : try prettyJSON(payload)
+        case .configMetadata(let options):
+            let payload = MelixRuntimeDiscoveryBuilder(environment: environment).configMetadataPayload()
+            return options.json ? try prettyJSON(payload) : try prettyJSON(payload)
         case .pipelineRun(let options):
             return try await runPipeline(options)
         case .batchRun(let options):

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1875,23 +1875,14 @@ public enum MelixCLIParser {
         case "set":
             var positional: [String] = []
             var optionArguments: [String] = []
-            var index = 0
-            while index < tail.count {
-                let token = tail[index]
+            for token in tail {
                 if token == "--json" {
                     optionArguments.append(token)
                 } else if token.hasPrefix("--") {
-                    optionArguments.append(token)
-                    let valueIndex = index + 1
-                    guard valueIndex < tail.count else {
-                        throw MelixCLIError.missingValue(token)
-                    }
-                    optionArguments.append(tail[valueIndex])
-                    index += 1
+                    throw MelixCLIError.usage(Self.usageText)
                 } else {
                     positional.append(token)
                 }
-                index += 1
             }
             let values = try ArgumentCursor(arguments: optionArguments).parse()
             guard positional.count == 2 else {
@@ -4966,7 +4957,7 @@ public actor MelixCLIRunner {
                 environment: environment
             )
             let payload = try store.effectiveSettings(overrides: options.overrides)
-            return options.json ? try prettyJSON(payload) : try prettyJSON(payload)
+            return try prettyJSON(payload)
         case .settingsSet(let options):
             let store = MelixRuntimeSettingsStore(
                 melixHome: MelixHome(environment: environment),
@@ -4988,22 +4979,22 @@ public actor MelixCLIRunner {
             )
             let payload = try store.reset(key: options.key)
             return options.json ? try prettyJSON(payload) : "Reset \(options.key).\n"
-        case .info(let options):
+        case .info:
             let payload = MelixRuntimeDiscoveryBuilder(environment: environment).infoPayload()
-            return options.json ? try prettyJSON(payload) : try prettyJSON(payload)
+            return try prettyJSON(payload)
         case .capabilities(let options):
             let payload = MelixRuntimeDiscoveryBuilder(environment: environment)
                 .capabilitiesPayload(modelQuery: options.modelQuery)
-            return options.json ? try prettyJSON(payload) : try prettyJSON(payload)
-        case .instructions(let options):
+            return try prettyJSON(payload)
+        case .instructions:
             let payload = MelixRuntimeDiscoveryBuilder(environment: environment).instructionsPayload()
-            return options.json ? try prettyJSON(payload) : try prettyJSON(payload)
-        case .schema(let options):
+            return try prettyJSON(payload)
+        case .schema:
             let payload = MelixRuntimeDiscoveryBuilder(environment: environment).schemaPayload()
-            return options.json ? try prettyJSON(payload) : try prettyJSON(payload)
-        case .configMetadata(let options):
+            return try prettyJSON(payload)
+        case .configMetadata:
             let payload = MelixRuntimeDiscoveryBuilder(environment: environment).configMetadataPayload()
-            return options.json ? try prettyJSON(payload) : try prettyJSON(payload)
+            return try prettyJSON(payload)
         case .pipelineRun(let options):
             return try await runPipeline(options)
         case .batchRun(let options):

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -4,6 +4,24 @@ import MelixControlPlaneCore
 public enum MelixCLICommandCodec {
     public static func commandID(for command: MelixCLICommand) -> String {
         switch command {
+        case .settingsShow:
+            return "settings.show"
+        case .settingsSet:
+            return "settings.set"
+        case .settingsValidate:
+            return "settings.validate"
+        case .settingsReset:
+            return "settings.reset"
+        case .info:
+            return "info"
+        case .capabilities:
+            return "capabilities"
+        case .instructions:
+            return "instructions"
+        case .schema:
+            return "schema"
+        case .configMetadata:
+            return "config.metadata"
         case .doctor:
             return "doctor"
         case .system:
@@ -194,6 +212,37 @@ public enum MelixCLICommandCodec {
         var arguments: [String]
         let json: Bool
         switch command {
+        case .settingsShow(let options):
+            arguments = ["settings", "show"]
+            for key in options.overrides.keys.sorted() {
+                appendOption("--override", value: "\(key)=\(options.overrides[key] ?? "")", into: &arguments)
+            }
+            json = options.json
+        case .settingsSet(let options):
+            arguments = ["settings", "set", options.key, options.value]
+            json = options.json
+        case .settingsValidate(let options):
+            arguments = ["settings", "validate"]
+            json = options.json
+        case .settingsReset(let options):
+            arguments = ["settings", "reset", options.key]
+            json = options.json
+        case .info(let options):
+            arguments = ["info"]
+            json = options.json
+        case .capabilities(let options):
+            arguments = ["capabilities"]
+            appendOption("--model-query", value: options.modelQuery, into: &arguments)
+            json = options.json
+        case .instructions(let options):
+            arguments = ["instructions"]
+            json = options.json
+        case .schema(let options):
+            arguments = ["schema"]
+            json = options.json
+        case .configMetadata(let options):
+            arguments = ["config", "metadata"]
+            json = options.json
         case .doctor(let options):
             arguments = ["doctor"]
             json = options.json

--- a/Sources/MelixCLICore/MelixHome.swift
+++ b/Sources/MelixCLICore/MelixHome.swift
@@ -27,6 +27,7 @@ public struct MelixHome: Equatable, Sendable {
     public let remoteServersFileURL: URL
     public let evaluationPromptsFileURL: URL
     public let loraTrainingJobsFileURL: URL
+    public let runtimeSettingsFileURL: URL
     public let serverSessionAPIKeysFileURL: URL
     public let remoteServerAPIKeysFileURL: URL
     public let huggingFaceTokenFileURL: URL
@@ -51,6 +52,7 @@ public struct MelixHome: Equatable, Sendable {
         self.remoteServersFileURL = configDirectoryURL.appendingPathComponent("remote-servers.json")
         self.evaluationPromptsFileURL = configDirectoryURL.appendingPathComponent("evaluation-prompts.json")
         self.loraTrainingJobsFileURL = stateDirectoryURL.appendingPathComponent("lora-training-jobs.json")
+        self.runtimeSettingsFileURL = rootURL.appendingPathComponent("runtime_settings.json")
         self.serverSessionAPIKeysFileURL = secretsDirectoryURL.appendingPathComponent("server-session-api-keys.json")
         self.remoteServerAPIKeysFileURL = secretsDirectoryURL.appendingPathComponent("remote-server-api-keys.json")
         self.huggingFaceTokenFileURL = secretsDirectoryURL.appendingPathComponent("huggingface-token.json")

--- a/Sources/MelixCLICore/MelixRuntimeDiscovery.swift
+++ b/Sources/MelixCLICore/MelixRuntimeDiscovery.swift
@@ -169,11 +169,16 @@ struct MelixRuntimeSettingsStore {
     }
 
     private func projectRootURL() -> URL {
-        let rawPath = environment["PWD"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if rawPath.isEmpty == false {
-            return URL(fileURLWithPath: (rawPath as NSString).expandingTildeInPath, isDirectory: true)
+        URL(fileURLWithPath: projectRootPath(), isDirectory: true)
+    }
+
+    private func projectRootPath() -> String {
+        if let explicit = environment["MELIX_PROJECT_ROOT"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           explicit.isEmpty == false
+        {
+            return (explicit as NSString).expandingTildeInPath
         }
-        return URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
+        return fileManager.currentDirectoryPath
     }
 
     private func loadSettingsDocument(at url: URL) throws -> [String: Any] {
@@ -204,6 +209,10 @@ struct MelixRuntimeSettingsStore {
         switch definition.valueType {
         case "int":
             if let number = rawValue as? NSNumber {
+                let doubleValue = number.doubleValue
+                guard doubleValue.isFinite, doubleValue.rounded(.towardZero) == doubleValue else {
+                    break
+                }
                 return NSNumber(value: number.intValue)
             }
             if let value = rawValue as? Int {
@@ -289,11 +298,20 @@ struct MelixRuntimeDiscoveryBuilder {
         MelixRuntimeDiscoveryContracts.configMetadataPayload(layout: layout)
     }
 
+    private func projectRootPath() -> String {
+        if let explicit = environment["MELIX_PROJECT_ROOT"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           explicit.isEmpty == false
+        {
+            return (explicit as NSString).expandingTildeInPath
+        }
+        return FileManager.default.currentDirectoryPath
+    }
+
     private func localPathsPayload() -> [String: Any] {
         [
             "melix_home": melixHome.rootURL.path,
             "runtime_settings": melixHome.runtimeSettingsFileURL.path,
-            "project_settings": URL(fileURLWithPath: environment["PWD"] ?? FileManager.default.currentDirectoryPath)
+            "project_settings": URL(fileURLWithPath: projectRootPath())
                 .appendingPathComponent(".melix", isDirectory: true)
                 .appendingPathComponent("runtime_settings.json")
                 .path,
@@ -343,21 +361,7 @@ struct MelixRuntimeDiscoveryBuilder {
     }
 
     private func installedVersion() -> String {
-        let root = repoRootPath()
-        let pyprojectURL = URL(fileURLWithPath: root).appendingPathComponent("pyproject.toml")
-        if let text = try? String(contentsOf: pyprojectURL, encoding: .utf8) {
-            for line in text.split(separator: "\n") {
-                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard trimmed.hasPrefix("version") else {
-                    continue
-                }
-                let parts = trimmed.split(separator: "=", maxSplits: 1)
-                if parts.count == 2 {
-                    return parts[1].trimmingCharacters(in: CharacterSet(charactersIn: " \"'"))
-                }
-            }
-        }
-        return "0.0.0-dev"
+        MelixRuntimeDiscoveryContracts.installedVersion(repoRootPath: repoRootPath())
     }
 
     private func installMethod() -> String {
@@ -380,7 +384,6 @@ struct MelixRuntimeDiscoveryBuilder {
             return explicit
         }
         let candidates = [
-            environment["PWD"] ?? "",
             FileManager.default.currentDirectoryPath,
         ]
         for candidate in candidates where candidate.isEmpty == false {

--- a/Sources/MelixCLICore/MelixRuntimeDiscovery.swift
+++ b/Sources/MelixCLICore/MelixRuntimeDiscovery.swift
@@ -1,0 +1,403 @@
+import Foundation
+import MelixControlPlaneCore
+
+public enum MelixRuntimeSettingsError: Error, Equatable, LocalizedError {
+    case unknownKey(String)
+    case invalidValue(key: String, expectedType: String, value: String)
+    case invalidDocument(path: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unknownKey(let key):
+            return "Unknown runtime setting key: \(key)."
+        case let .invalidValue(key, expectedType, value):
+            return "Invalid value for \(key). Expected \(expectedType), got \(value)."
+        case .invalidDocument(let path):
+            return "Runtime settings file must contain a JSON object: \(path)."
+        }
+    }
+}
+
+struct MelixRuntimeSettingsStore {
+    private let melixHome: MelixHome
+    private let environment: [String: String]
+    private let fileManager: FileManager
+
+    init(
+        melixHome: MelixHome,
+        environment: [String: String],
+        fileManager: FileManager = .default
+    ) {
+        self.melixHome = melixHome
+        self.environment = environment
+        self.fileManager = fileManager
+    }
+
+    var projectSettingsFileURL: URL {
+        projectRootURL()
+            .appendingPathComponent(".melix", isDirectory: true)
+            .appendingPathComponent("runtime_settings.json")
+    }
+
+    func effectiveSettings(overrides: [String: String] = [:]) throws -> [String: Any] {
+        let startedAt = DispatchTime.now()
+        let layout = MelixPathLayout(environment: environment)
+        let userSettings = try loadSettingsDocument(at: melixHome.runtimeSettingsFileURL)
+        let projectSettings = try loadSettingsDocument(at: projectSettingsFileURL)
+        var settings: [String: Any] = [:]
+        for definition in MelixRuntimeDiscoveryContracts.runtimeSettingDefinitions {
+            let key = definition.key
+            if let rawOverride = overrides[key] {
+                settings[key] = [
+                    "value": try coerce(rawOverride, definition: definition),
+                    "source": "cli_flag",
+                    "source_detail": "--override \(key)",
+                ]
+            } else if let rawEnvironmentValue = environment[definition.environmentVariable],
+                      rawEnvironmentValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            {
+                settings[key] = [
+                    "value": try coerce(rawEnvironmentValue, definition: definition),
+                    "source": "environment",
+                    "source_detail": definition.environmentVariable,
+                ]
+            } else if let rawProjectValue = projectSettings[key] {
+                settings[key] = [
+                    "value": try coerce(rawProjectValue, definition: definition),
+                    "source": "project_settings",
+                    "source_detail": projectSettingsFileURL.path,
+                ]
+            } else if let rawUserValue = userSettings[key] {
+                settings[key] = [
+                    "value": try coerce(rawUserValue, definition: definition),
+                    "source": "user_settings",
+                    "source_detail": melixHome.runtimeSettingsFileURL.path,
+                ]
+            } else {
+                settings[key] = [
+                    "value": MelixRuntimeDiscoveryContracts.defaultRuntimeSettingValue(key: key, layout: layout),
+                    "source": "default",
+                    "source_detail": "builtin",
+                ]
+            }
+        }
+        return [
+            "schema_version": MelixRuntimeDiscoveryContracts.runtimeSettingsSchemaVersion,
+            "settings": settings,
+            "sources": [
+                "user_settings": melixHome.runtimeSettingsFileURL.path,
+                "project_settings": projectSettingsFileURL.path,
+            ],
+            "metrics": [
+                "settings_resolve_ms": NSNumber(value: elapsedMilliseconds(since: startedAt)),
+            ],
+        ]
+    }
+
+    func set(key rawKey: String, value rawValue: String) throws -> [String: Any] {
+        let startedAt = DispatchTime.now()
+        let key = rawKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let definition = try definition(for: key)
+        let value = try coerce(rawValue, definition: definition)
+        var document = try loadSettingsDocument(at: melixHome.runtimeSettingsFileURL)
+        document[key] = value
+        try writeSettingsDocument(document, to: melixHome.runtimeSettingsFileURL)
+        return [
+            "schema_version": "melix.runtime_settings.mutation.v1",
+            "key": key,
+            "value": value,
+            "source": "user_settings",
+            "source_detail": melixHome.runtimeSettingsFileURL.path,
+            "metrics": [
+                "settings_write_ms": NSNumber(value: elapsedMilliseconds(since: startedAt)),
+            ],
+        ]
+    }
+
+    func reset(key rawKey: String) throws -> [String: Any] {
+        let startedAt = DispatchTime.now()
+        let key = rawKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = try definition(for: key)
+        var document = try loadSettingsDocument(at: melixHome.runtimeSettingsFileURL)
+        let removed = document.removeValue(forKey: key) != nil
+        try writeSettingsDocument(document, to: melixHome.runtimeSettingsFileURL)
+        return [
+            "schema_version": "melix.runtime_settings.mutation.v1",
+            "key": key,
+            "removed": removed,
+            "source": "user_settings",
+            "source_detail": melixHome.runtimeSettingsFileURL.path,
+            "metrics": [
+                "settings_write_ms": NSNumber(value: elapsedMilliseconds(since: startedAt)),
+            ],
+        ]
+    }
+
+    func validate() -> [String: Any] {
+        let startedAt = DispatchTime.now()
+        var errors: [[String: Any]] = []
+        for url in [melixHome.runtimeSettingsFileURL, projectSettingsFileURL] {
+            do {
+                let document = try loadSettingsDocument(at: url)
+                for (key, value) in document {
+                    do {
+                        let definition = try definition(for: key)
+                        _ = try coerce(value, definition: definition)
+                    } catch {
+                        errors.append([
+                            "path": url.path,
+                            "key": key,
+                            "message": String(describing: error),
+                        ])
+                    }
+                }
+            } catch {
+                errors.append([
+                    "path": url.path,
+                    "message": String(describing: error),
+                ])
+            }
+        }
+        return [
+            "schema_version": "melix.runtime_settings.validation.v1",
+            "valid": errors.isEmpty,
+            "errors": errors,
+            "metrics": [
+                "settings_validate_ms": NSNumber(value: elapsedMilliseconds(since: startedAt)),
+            ],
+        ]
+    }
+
+    private func projectRootURL() -> URL {
+        let rawPath = environment["PWD"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if rawPath.isEmpty == false {
+            return URL(fileURLWithPath: (rawPath as NSString).expandingTildeInPath, isDirectory: true)
+        }
+        return URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
+    }
+
+    private func loadSettingsDocument(at url: URL) throws -> [String: Any] {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return [:]
+        }
+        let data = try Data(contentsOf: url)
+        let decoded = try JSONSerialization.jsonObject(with: data)
+        guard let object = decoded as? [String: Any] else {
+            throw MelixRuntimeSettingsError.invalidDocument(path: url.path)
+        }
+        return object
+    }
+
+    private func writeSettingsDocument(_ document: [String: Any], to url: URL) throws {
+        let data = try JSONSerialization.data(withJSONObject: document, options: [.prettyPrinted, .sortedKeys])
+        try melixHome.writeAtomically(data, to: url)
+    }
+
+    private func definition(for key: String) throws -> MelixRuntimeSettingMetadata {
+        guard let definition = MelixRuntimeDiscoveryContracts.runtimeSettingDefinitions.first(where: { $0.key == key }) else {
+            throw MelixRuntimeSettingsError.unknownKey(key)
+        }
+        return definition
+    }
+
+    private func coerce(_ rawValue: Any, definition: MelixRuntimeSettingMetadata) throws -> Any {
+        switch definition.valueType {
+        case "int":
+            if let number = rawValue as? NSNumber {
+                return NSNumber(value: number.intValue)
+            }
+            if let value = rawValue as? Int {
+                return NSNumber(value: value)
+            }
+            if let string = rawValue as? String, let parsed = Int(string) {
+                return NSNumber(value: parsed)
+            }
+        case "double":
+            if let number = rawValue as? NSNumber {
+                return NSNumber(value: number.doubleValue)
+            }
+            if let value = rawValue as? Double {
+                return NSNumber(value: value)
+            }
+            if let string = rawValue as? String, let parsed = Double(string) {
+                return NSNumber(value: parsed)
+            }
+        case "string":
+            if let string = rawValue as? String {
+                return string
+            }
+            if let number = rawValue as? NSNumber {
+                return number.stringValue
+            }
+        default:
+            break
+        }
+        throw MelixRuntimeSettingsError.invalidValue(
+            key: definition.key,
+            expectedType: definition.valueType,
+            value: String(describing: rawValue)
+        )
+    }
+}
+
+struct MelixRuntimeDiscoveryBuilder {
+    private let environment: [String: String]
+    private let melixHome: MelixHome
+    private let layout: MelixPathLayout
+
+    init(environment: [String: String]) {
+        self.environment = environment
+        self.melixHome = MelixHome(environment: environment)
+        self.layout = MelixPathLayout(environment: environment)
+    }
+
+    func infoPayload() -> [String: Any] {
+        let startedAt = DispatchTime.now()
+        return [
+            "schema_version": MelixRuntimeDiscoveryContracts.infoSchemaVersion,
+            "version": installedVersion(),
+            "features": MelixRuntimeDiscoveryContracts.enabledFeatures,
+            "supported_tasks": MelixRuntimeDiscoveryContracts.supportedTasks,
+            "links": MelixRuntimeDiscoveryContracts.discoveryLinks(),
+            "schema": MelixRuntimeDiscoveryContracts.schemaPayload(repoRootPath: repoRootPath()),
+            "local_paths": localPathsPayload(),
+            "update": updateReceipt(),
+            "metrics": [
+                "discovery_build_ms": NSNumber(value: elapsedMilliseconds(since: startedAt)),
+            ],
+        ]
+    }
+
+    func capabilitiesPayload(modelQuery: String = "") -> [String: Any] {
+        [
+            "schema_version": MelixRuntimeDiscoveryContracts.capabilitiesSchemaVersion,
+            "features": MelixRuntimeDiscoveryContracts.enabledFeatures,
+            "supported_tasks": MelixRuntimeDiscoveryContracts.supportedTasks,
+            "model_alias_discovery": MelixRuntimeDiscoveryContracts.modelAliasDiscoveryPayload(query: modelQuery),
+        ]
+    }
+
+    func instructionsPayload() -> [String: Any] {
+        MelixRuntimeDiscoveryContracts.instructionsPayload()
+    }
+
+    func schemaPayload() -> [String: Any] {
+        MelixRuntimeDiscoveryContracts.schemaPayload(repoRootPath: repoRootPath())
+    }
+
+    func configMetadataPayload() -> [String: Any] {
+        MelixRuntimeDiscoveryContracts.configMetadataPayload(layout: layout)
+    }
+
+    private func localPathsPayload() -> [String: Any] {
+        [
+            "melix_home": melixHome.rootURL.path,
+            "runtime_settings": melixHome.runtimeSettingsFileURL.path,
+            "project_settings": URL(fileURLWithPath: environment["PWD"] ?? FileManager.default.currentDirectoryPath)
+                .appendingPathComponent(".melix", isDirectory: true)
+                .appendingPathComponent("runtime_settings.json")
+                .path,
+            "managed_models": melixHome.managedModelRootURL.path,
+            "logs": melixHome.logsDirectoryURL.path,
+            "runtime": melixHome.runtimeDirectoryURL.path,
+        ]
+    }
+
+    private func updateReceipt() -> [String: Any] {
+        let channelPath = environment["MELIX_UPDATE_CHANNEL_PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let channel = environment["MELIX_UPDATE_CHANNEL"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "stable"
+        let installed = installedVersion()
+        guard channelPath.isEmpty == false else {
+            return unavailableUpdateReceipt(installedVersion: installed, channel: channel)
+        }
+        guard
+            let data = try? Data(contentsOf: URL(fileURLWithPath: channelPath)),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return unavailableUpdateReceipt(installedVersion: installed, channel: channel)
+        }
+        let latest = object["latest_known_version"] as? String ?? object["latest_version"] as? String ?? ""
+        return [
+            "installed_version": installed,
+            "latest_known_version": latest,
+            "update_available": latest.isEmpty ? false : latest != installed,
+            "update_channel": object["update_channel"] as? String ?? channel,
+            "install_method": installMethod(),
+            "suggested_update_command": suggestedUpdateCommand(),
+            "checked": true,
+            "status": "ok",
+        ]
+    }
+
+    private func unavailableUpdateReceipt(installedVersion: String, channel: String) -> [String: Any] {
+        [
+            "installed_version": installedVersion,
+            "latest_known_version": "",
+            "update_available": false,
+            "update_channel": channel,
+            "install_method": installMethod(),
+            "suggested_update_command": suggestedUpdateCommand(),
+            "checked": false,
+            "status": "unavailable",
+        ]
+    }
+
+    private func installedVersion() -> String {
+        let root = repoRootPath()
+        let pyprojectURL = URL(fileURLWithPath: root).appendingPathComponent("pyproject.toml")
+        if let text = try? String(contentsOf: pyprojectURL, encoding: .utf8) {
+            for line in text.split(separator: "\n") {
+                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard trimmed.hasPrefix("version") else {
+                    continue
+                }
+                let parts = trimmed.split(separator: "=", maxSplits: 1)
+                if parts.count == 2 {
+                    return parts[1].trimmingCharacters(in: CharacterSet(charactersIn: " \"'"))
+                }
+            }
+        }
+        return "0.0.0-dev"
+    }
+
+    private func installMethod() -> String {
+        let explicit = environment["MELIX_INSTALL_METHOD"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if explicit.isEmpty == false {
+            return explicit
+        }
+        if FileManager.default.fileExists(atPath: URL(fileURLWithPath: repoRootPath()).appendingPathComponent(".git").path) {
+            return "source_checkout"
+        }
+        return "unknown"
+    }
+
+    private func suggestedUpdateCommand() -> [String] {
+        installMethod() == "source_checkout" ? ["git", "pull", "--ff-only"] : []
+    }
+
+    private func repoRootPath() -> String {
+        if let explicit = environment["MELIX_REPO_ROOT"]?.trimmingCharacters(in: .whitespacesAndNewlines), explicit.isEmpty == false {
+            return explicit
+        }
+        let candidates = [
+            environment["PWD"] ?? "",
+            FileManager.default.currentDirectoryPath,
+        ]
+        for candidate in candidates where candidate.isEmpty == false {
+            var url = URL(fileURLWithPath: candidate, isDirectory: true)
+            for _ in 0..<8 {
+                if FileManager.default.fileExists(atPath: url.appendingPathComponent("Package.swift").path),
+                   FileManager.default.fileExists(atPath: url.appendingPathComponent("packages/protocol/schema").path)
+                {
+                    return url.path
+                }
+                let parent = url.deletingLastPathComponent()
+                guard parent.path != url.path else {
+                    break
+                }
+                url = parent
+            }
+        }
+        return FileManager.default.currentDirectoryPath
+    }
+}

--- a/apps/macos-menubar/Tests/MenuBarTests/Phase8LoRAWindowSmokeTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/Phase8LoRAWindowSmokeTests.swift
@@ -133,6 +133,7 @@ struct Phase8LoRAWindowSmokeTests {
             foundation: viewModel.desktopFoundationState
         )
         await diagnosticsSection.runEvaluationCompare()
+        viewModel.selectEvaluationHistory(jobID: "eval-newer")
         await viewModel.exportSelectedEvaluationSummaryCSV()
         await trainingSection.removeDerivedModel()
 
@@ -350,7 +351,7 @@ private func phase8LoRAWindowCompareResult(
     derivedModelID: String
 ) -> ControlPlaneEvaluationResult {
     var job = Melix_Controlplane_V1_EvaluationJobSummary()
-    job.jobID = "eval-compare-1"
+    job.jobID = "eval-newer"
     job.modelID = baseModelID
     job.taskKind = "text-generation"
     job.sourceRepo = "HuggingFaceH4/ultrachat_200k"
@@ -359,7 +360,7 @@ private func phase8LoRAWindowCompareResult(
     job.sampleSize = 6
     job.scoringMode = "multiple_choice_accuracy"
     job.status = "completed"
-    job.outputDir = "/tmp/melix/evaluation/runs/eval-compare-1"
+    job.outputDir = "/tmp/melix/evaluation/runs/eval-newer"
     job.createdAtUnixMs = 1_712_400_000_000
     job.updatedAtUnixMs = 1_712_400_001_000
 
@@ -369,12 +370,12 @@ private func phase8LoRAWindowCompareResult(
     metric.unit = "ratio"
 
     var result = Melix_Controlplane_V1_EvaluationResultSummary()
-    result.jobID = "eval-compare-1"
+    result.jobID = "eval-newer"
     result.suiteID = "mmlu:\(derivedModelID)"
     result.datasetID = "mmlu.dev.v1"
     result.sampleSize = 6
     result.metrics = [metric]
-    result.reportPath = "/tmp/melix/evaluation/runs/eval-compare-1/\(derivedModelID)-result.json"
+    result.reportPath = "/tmp/melix/evaluation/runs/eval-newer/\(derivedModelID)-result.json"
     return ControlPlaneEvaluationResult(job: job, results: [result])
 }
 

--- a/apps/macos-menubar/Tests/MenuBarTests/Phase8LoRAWindowSmokeTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/Phase8LoRAWindowSmokeTests.swift
@@ -15,6 +15,7 @@ struct Phase8LoRAWindowSmokeTests {
     func phase8LoRAWindowSmokeEmitsCanonicalAcceptanceEvidence() async throws {
         let baseModelID = "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"
         let derivedModelID = "melix-qwen35-acceptance"
+        let evaluationJobID = "phase8-eval-\(UUID().uuidString)"
         let temporaryRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("melix-phase8-lora-window-smoke-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
@@ -76,12 +77,16 @@ struct Phase8LoRAWindowSmokeTests {
         await runnerClient.configureEvaluationResponse(
             phase8LoRAWindowCompareResult(
                 baseModelID: baseModelID,
-                derivedModelID: derivedModelID
+                derivedModelID: derivedModelID,
+                jobID: evaluationJobID
             )
         )
         await runnerClient.configureExportResult(
             ControlPlaneExportResult(
-                exportBundleJSON: phase8LoRAWindowExportBundleJSON(derivedModelID: derivedModelID)
+                exportBundleJSON: phase8LoRAWindowExportBundleJSON(
+                    derivedModelID: derivedModelID,
+                    evaluationJobID: evaluationJobID
+                )
             )
         )
 
@@ -133,7 +138,7 @@ struct Phase8LoRAWindowSmokeTests {
             foundation: viewModel.desktopFoundationState
         )
         await diagnosticsSection.runEvaluationCompare()
-        viewModel.selectEvaluationHistory(jobID: "eval-newer")
+        viewModel.selectEvaluationHistory(jobID: evaluationJobID)
         await viewModel.exportSelectedEvaluationSummaryCSV()
         await trainingSection.removeDerivedModel()
 
@@ -348,10 +353,11 @@ private func phase8LoRAWindowRegistryManifest(
 
 private func phase8LoRAWindowCompareResult(
     baseModelID: String,
-    derivedModelID: String
+    derivedModelID: String,
+    jobID: String
 ) -> ControlPlaneEvaluationResult {
     var job = Melix_Controlplane_V1_EvaluationJobSummary()
-    job.jobID = "eval-newer"
+    job.jobID = jobID
     job.modelID = baseModelID
     job.taskKind = "text-generation"
     job.sourceRepo = "HuggingFaceH4/ultrachat_200k"
@@ -360,7 +366,7 @@ private func phase8LoRAWindowCompareResult(
     job.sampleSize = 6
     job.scoringMode = "multiple_choice_accuracy"
     job.status = "completed"
-    job.outputDir = "/tmp/melix/evaluation/runs/eval-newer"
+    job.outputDir = "/tmp/melix/evaluation/runs/\(jobID)"
     job.createdAtUnixMs = 1_712_400_000_000
     job.updatedAtUnixMs = 1_712_400_001_000
 
@@ -370,18 +376,21 @@ private func phase8LoRAWindowCompareResult(
     metric.unit = "ratio"
 
     var result = Melix_Controlplane_V1_EvaluationResultSummary()
-    result.jobID = "eval-newer"
+    result.jobID = jobID
     result.suiteID = "mmlu:\(derivedModelID)"
     result.datasetID = "mmlu.dev.v1"
     result.sampleSize = 6
     result.metrics = [metric]
-    result.reportPath = "/tmp/melix/evaluation/runs/eval-newer/\(derivedModelID)-result.json"
+    result.reportPath = "/tmp/melix/evaluation/runs/\(jobID)/\(derivedModelID)-result.json"
     return ControlPlaneEvaluationResult(job: job, results: [result])
 }
 
-private func phase8LoRAWindowExportBundleJSON(derivedModelID: String) -> String {
+private func phase8LoRAWindowExportBundleJSON(
+    derivedModelID: String,
+    evaluationJobID: String
+) -> String {
     makeBenchmarkExportBundleJSON()
-        .replacingOccurrences(of: "eval-newer", with: "eval-compare-1")
+        .replacingOccurrences(of: "eval-newer", with: evaluationJobID)
         .replacingOccurrences(of: "melix-dev-text-lora", with: derivedModelID)
 }
 

--- a/docs/plans/2026-05-11-runtime-settings-discovery-surfaces.md
+++ b/docs/plans/2026-05-11-runtime-settings-discovery-surfaces.md
@@ -1,0 +1,136 @@
+# Runtime Settings and Discovery Surfaces
+
+## Issue
+
+Implements GitHub issue #641: Melix needs a stable machine-readable contract for
+runtime settings, local discovery, instructions, capabilities, schema locations,
+and config metadata. CLI, macOS UI, scripts, and the local daemon should consume
+the same shape instead of parsing help text.
+
+## Scope
+
+- Add a persisted user settings file at `~/.melix/runtime_settings.json`, with
+  `MELIX_HOME` resolving the user root in tests and local worktrees.
+- Add a project override file at `.melix/runtime_settings.json`.
+- Define settings precedence as CLI flag, environment variable, project settings,
+  user settings, then default.
+- Add CLI surfaces:
+  - `melix settings show --json`
+  - `melix settings set <key> <value>`
+  - `melix settings validate`
+  - `melix settings reset <key>`
+  - `melix info --json`
+  - `melix capabilities --json`
+  - `melix instructions --json`
+  - `melix schema --json`
+  - `melix config metadata --json`
+- Add daemon discovery surfaces when the local HTTP gateway is running:
+  - `/.well-known/melix.json`
+  - `/api/instructions`
+  - `/api/capabilities`
+  - `/api/config-metadata`
+- Add model alias discovery and suggestion metadata so UI and scripts can offer
+  family-safe hints without rewriting valid local paths or full model IDs.
+- Add a best-effort version/update receipt to `melix info --json`. It must not
+  perform network access, must not block startup, and must be safe for CI or
+  non-TTY contexts.
+
+## Settings Contract
+
+Settings are constrained to a curated registry:
+
+- `model_cache_path`
+- `dataset_cache_path`
+- `artifact_path`
+- `max_concurrent_jobs`
+- `memory_pressure_threshold`
+- `default_dtype`
+- `default_quantization`
+- `benchmark_warmup`
+- `benchmark_repeats`
+- `eval_sample_size`
+- `log_retention_days`
+- `auto_cleanup_policy`
+
+Each setting has a type, default value, environment override name, and metadata.
+The effective settings payload includes both the value and source:
+
+```json
+{
+  "settings": {
+    "max_concurrent_jobs": {
+      "value": 6,
+      "source": "environment",
+      "source_detail": "MELIX_MAX_CONCURRENT_JOBS"
+    }
+  }
+}
+```
+
+## Discovery Contract
+
+All discovery payloads use explicit schema versions and stable top-level keys.
+
+- `melix.discovery.info.v1`
+- `melix.discovery.capabilities.v1`
+- `melix.discovery.instructions.v1`
+- `melix.discovery.schema.v1`
+- `melix.discovery.config_metadata.v1`
+- `melix.runtime_settings.effective.v1`
+
+The CLI discovery payloads include:
+
+- Melix version and update receipt.
+- Enabled features and supported task families.
+- API endpoint metadata.
+- Schema paths.
+- Local Melix paths.
+- Settings and config metadata.
+- Model alias families and same-family suggestions.
+
+## Version and Update Receipt
+
+The update receipt is best effort and local-only:
+
+- `installed_version`
+- `latest_known_version`
+- `update_available`
+- `update_channel`
+- `install_method`
+- `suggested_update_command`
+- `checked`
+- `status`
+
+The default source is local repository/package metadata plus an optional local
+channel file. Missing files produce an `unavailable` receipt rather than an
+error. Suggested commands are returned as argv arrays only.
+
+## Probes and Metrics
+
+Changed paths must report timings in JSON payloads where useful:
+
+- `settings_resolve_ms`
+- `settings_write_ms`
+- `settings_validate_ms`
+- `discovery_build_ms`
+- HTTP discovery latency metrics:
+  - `operator.discovery_well_known_latency_ms`
+  - `operator.discovery_capabilities_latency_ms`
+  - `operator.discovery_instructions_latency_ms`
+  - `operator.discovery_config_metadata_latency_ms`
+
+Success metrics:
+
+- Settings resolution is deterministic and covered by precedence tests.
+- CLI and HTTP discovery payloads are valid JSON and do not require help-text
+  parsing.
+- Alias suggestions preserve valid local paths and full Hugging Face IDs.
+- Update checks are silent and non-fatal when no local channel metadata exists.
+
+## Verification Plan
+
+- Swift CLI parser tests for all new commands and codec IDs.
+- Swift CLI runner tests for settings precedence, mutation, reset, discovery
+  payloads, alias suggestions, and update receipt degradation.
+- Swift HTTP gateway tests for the daemon discovery endpoints.
+- Changed-line coverage for touched Swift files must stay at or above 95%.

--- a/services/control-plane-swift/Sources/HTTPGateway/APIOnboardingSnapshotSource.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/APIOnboardingSnapshotSource.swift
@@ -15,7 +15,7 @@ struct APIOnboardingSnapshotSource: Sendable {
             title: "Local Service",
             summary: "Readiness and operational inspection routes for same-host automation.",
             status: .shipped,
-            endpointIDs: ["health", "cache_stats"]
+            endpointIDs: ["health", "well_known", "capabilities", "instructions", "config_metadata", "cache_stats"]
         ),
         SurfaceDefinition(
             id: "openai_compatible",
@@ -67,6 +67,38 @@ struct APIOnboardingSnapshotSource: Sendable {
             method: "GET",
             path: "/v1/cache/stats",
             summary: "Inspect cache usage, tier support, and persisted prefix state.",
+            streaming: false
+        ),
+        EndpointDefinition(
+            id: "well_known",
+            surfaceID: "local_service",
+            method: "GET",
+            path: "/.well-known/melix.json",
+            summary: "Discover local Melix runtime links, features, tasks, and paths.",
+            streaming: false
+        ),
+        EndpointDefinition(
+            id: "capabilities",
+            surfaceID: "local_service",
+            method: "GET",
+            path: "/api/capabilities",
+            summary: "Discover supported tasks, enabled features, model aliases, and visible local models.",
+            streaming: false
+        ),
+        EndpointDefinition(
+            id: "instructions",
+            surfaceID: "local_service",
+            method: "GET",
+            path: "/api/instructions",
+            summary: "Expose machine-readable instructions for settings, discovery, model targets, and updates.",
+            streaming: false
+        ),
+        EndpointDefinition(
+            id: "config_metadata",
+            surfaceID: "local_service",
+            method: "GET",
+            path: "/api/config-metadata",
+            summary: "Expose runtime settings metadata for UI and automation without parsing help text.",
             streaming: false
         ),
         EndpointDefinition(

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -273,6 +273,7 @@ public struct OpenAIHandler: Sendable {
     private let gatewayServingDefaultsStore: GatewayServingDefaultsStore
     private let gatewayRuntimeBinding: GatewayRuntimeBinding
     private let persistentAuthSessionStore: PersistentAuthSessionStore?
+    private let environment: [String: String]
     private let imageRequestTimeoutSeconds: UInt32
     private let now: @Sendable () -> Date
     private let decoder: JSONDecoder
@@ -318,6 +319,7 @@ public struct OpenAIHandler: Sendable {
         self.gatewayServingDefaultsStore = gatewayServingDefaultsStore ?? GatewayServingDefaultsStore(environment: environment)
         self.gatewayRuntimeBinding = gatewayRuntimeBinding
         self.persistentAuthSessionStore = persistentAuthSessionStore
+        self.environment = environment
         self.imageRequestTimeoutSeconds = Self.resolveImageRequestTimeoutSeconds(environment: environment)
         self.now = now
         self.decoder = JSONDecoder()
@@ -332,6 +334,14 @@ public struct OpenAIHandler: Sendable {
             return authorizationFailure
         case .success(let authorizationContext):
             switch (request.method, request.path) {
+            case (.get, "/.well-known/melix.json"):
+                return try await handleDiscoveryWellKnown()
+            case (.get, "/api/capabilities"):
+                return try await handleDiscoveryCapabilities()
+            case (.get, "/api/instructions"):
+                return try await handleDiscoveryInstructions()
+            case (.get, "/api/config-metadata"):
+                return try await handleDiscoveryConfigMetadata()
             case (.get, "/v1/models"):
                 return try await handleModels()
             case (.get, "/health"):
@@ -449,6 +459,58 @@ public struct OpenAIHandler: Sendable {
 
         let response = OpenAIModelsResponse(object: "list", data: models)
         return try encodedJSONResponse(response)
+    }
+
+    private func handleDiscoveryWellKnown() async throws -> HTTPResponse {
+        let startedAt = Date()
+        let payload = HTTPRuntimeDiscoveryPayloads(
+            environment: environment,
+            runtimeBinding: gatewayRuntimeBinding
+        ).wellKnownPayload()
+        await metricsStore.set(
+            Date().timeIntervalSince(startedAt) * 1000,
+            forKey: "operator.discovery_well_known_latency_ms"
+        )
+        return jsonResponse(statusCode: 200, payload: payload)
+    }
+
+    private func handleDiscoveryCapabilities() async throws -> HTTPResponse {
+        let startedAt = Date()
+        let payload = HTTPRuntimeDiscoveryPayloads(
+            environment: environment,
+            runtimeBinding: gatewayRuntimeBinding
+        ).capabilitiesPayload(models: await modelCatalog.listModels())
+        await metricsStore.set(
+            Date().timeIntervalSince(startedAt) * 1000,
+            forKey: "operator.discovery_capabilities_latency_ms"
+        )
+        return jsonResponse(statusCode: 200, payload: payload)
+    }
+
+    private func handleDiscoveryInstructions() async throws -> HTTPResponse {
+        let startedAt = Date()
+        let payload = HTTPRuntimeDiscoveryPayloads(
+            environment: environment,
+            runtimeBinding: gatewayRuntimeBinding
+        ).instructionsPayload()
+        await metricsStore.set(
+            Date().timeIntervalSince(startedAt) * 1000,
+            forKey: "operator.discovery_instructions_latency_ms"
+        )
+        return jsonResponse(statusCode: 200, payload: payload)
+    }
+
+    private func handleDiscoveryConfigMetadata() async throws -> HTTPResponse {
+        let startedAt = Date()
+        let payload = HTTPRuntimeDiscoveryPayloads(
+            environment: environment,
+            runtimeBinding: gatewayRuntimeBinding
+        ).configMetadataPayload()
+        await metricsStore.set(
+            Date().timeIntervalSince(startedAt) * 1000,
+            forKey: "operator.discovery_config_metadata_latency_ms"
+        )
+        return jsonResponse(statusCode: 200, payload: payload)
     }
 
     private func handleHealth() async throws -> HTTPResponse {
@@ -2361,7 +2423,11 @@ public struct OpenAIHandler: Sendable {
 
     private func authorizationRoute(for request: HTTPRequest) -> GatewayAuthorizationRoute {
         switch (request.method, request.path) {
-        case (.get, "/health"):
+        case (.get, "/health"),
+             (.get, "/.well-known/melix.json"),
+             (.get, "/api/capabilities"),
+             (.get, "/api/instructions"),
+             (.get, "/api/config-metadata"):
             return .health
         case (.post, "/v1/melix/auth/session"):
             return .createSession

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -462,52 +462,52 @@ public struct OpenAIHandler: Sendable {
     }
 
     private func handleDiscoveryWellKnown() async throws -> HTTPResponse {
-        let startedAt = Date()
+        let startedAt = DispatchTime.now()
         let payload = HTTPRuntimeDiscoveryPayloads(
             environment: environment,
             runtimeBinding: gatewayRuntimeBinding
         ).wellKnownPayload()
         await metricsStore.set(
-            Date().timeIntervalSince(startedAt) * 1000,
+            elapsedMilliseconds(since: startedAt),
             forKey: "operator.discovery_well_known_latency_ms"
         )
         return jsonResponse(statusCode: 200, payload: payload)
     }
 
     private func handleDiscoveryCapabilities() async throws -> HTTPResponse {
-        let startedAt = Date()
+        let startedAt = DispatchTime.now()
         let payload = HTTPRuntimeDiscoveryPayloads(
             environment: environment,
             runtimeBinding: gatewayRuntimeBinding
         ).capabilitiesPayload(models: await modelCatalog.listModels())
         await metricsStore.set(
-            Date().timeIntervalSince(startedAt) * 1000,
+            elapsedMilliseconds(since: startedAt),
             forKey: "operator.discovery_capabilities_latency_ms"
         )
         return jsonResponse(statusCode: 200, payload: payload)
     }
 
     private func handleDiscoveryInstructions() async throws -> HTTPResponse {
-        let startedAt = Date()
+        let startedAt = DispatchTime.now()
         let payload = HTTPRuntimeDiscoveryPayloads(
             environment: environment,
             runtimeBinding: gatewayRuntimeBinding
         ).instructionsPayload()
         await metricsStore.set(
-            Date().timeIntervalSince(startedAt) * 1000,
+            elapsedMilliseconds(since: startedAt),
             forKey: "operator.discovery_instructions_latency_ms"
         )
         return jsonResponse(statusCode: 200, payload: payload)
     }
 
     private func handleDiscoveryConfigMetadata() async throws -> HTTPResponse {
-        let startedAt = Date()
+        let startedAt = DispatchTime.now()
         let payload = HTTPRuntimeDiscoveryPayloads(
             environment: environment,
             runtimeBinding: gatewayRuntimeBinding
         ).configMetadataPayload()
         await metricsStore.set(
-            Date().timeIntervalSince(startedAt) * 1000,
+            elapsedMilliseconds(since: startedAt),
             forKey: "operator.discovery_config_metadata_latency_ms"
         )
         return jsonResponse(statusCode: 200, payload: payload)
@@ -4001,4 +4001,10 @@ private extension RequestCoordinatorError {
             return "The worker cannot accept requests."
         }
     }
+}
+
+private func elapsedMilliseconds(since start: DispatchTime) -> Double {
+    let end = DispatchTime.now()
+    let nanos = end.uptimeNanoseconds - start.uptimeNanoseconds
+    return Double(nanos) / 1_000_000
 }

--- a/services/control-plane-swift/Sources/HTTPGateway/RuntimeDiscoveryPayloads.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/RuntimeDiscoveryPayloads.swift
@@ -12,7 +12,7 @@ struct HTTPRuntimeDiscoveryPayloads {
     func wellKnownPayload() -> [String: Any] {
         [
             "schema_version": MelixRuntimeDiscoveryContracts.infoSchemaVersion,
-            "version": "0.0.0-dev",
+            "version": MelixRuntimeDiscoveryContracts.installedVersion(repoRootPath: repoRootPath()),
             "features": MelixRuntimeDiscoveryContracts.enabledFeatures,
             "supported_tasks": MelixRuntimeDiscoveryContracts.supportedTasks,
             "links": MelixRuntimeDiscoveryContracts.discoveryLinks(),
@@ -51,6 +51,26 @@ struct HTTPRuntimeDiscoveryPayloads {
             "logs": layout.logsDirectoryURL.path,
             "runtime": layout.runtimeDirectoryURL.path,
         ]
+    }
+
+    private func repoRootPath() -> String {
+        if let explicit = environment["MELIX_REPO_ROOT"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           explicit.isEmpty == false
+        {
+            return explicit
+        }
+        var url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+        for _ in 0..<8 {
+            if FileManager.default.fileExists(atPath: url.appendingPathComponent("pyproject.toml").path) {
+                return url.path
+            }
+            let parent = url.deletingLastPathComponent()
+            guard parent.path != url.path else {
+                break
+            }
+            url = parent
+        }
+        return FileManager.default.currentDirectoryPath
     }
 
     private func modelPayload(_ model: Melix_Controlplane_V1_ModelSummary) -> [String: Any] {

--- a/services/control-plane-swift/Sources/HTTPGateway/RuntimeDiscoveryPayloads.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/RuntimeDiscoveryPayloads.swift
@@ -1,0 +1,87 @@
+import Foundation
+import MelixControlPlaneProtocol
+
+struct HTTPRuntimeDiscoveryPayloads {
+    let environment: [String: String]
+    let runtimeBinding: GatewayRuntimeBinding
+
+    private var layout: MelixPathLayout {
+        MelixPathLayout(environment: environment)
+    }
+
+    func wellKnownPayload() -> [String: Any] {
+        [
+            "schema_version": MelixRuntimeDiscoveryContracts.infoSchemaVersion,
+            "version": "0.0.0-dev",
+            "features": MelixRuntimeDiscoveryContracts.enabledFeatures,
+            "supported_tasks": MelixRuntimeDiscoveryContracts.supportedTasks,
+            "links": MelixRuntimeDiscoveryContracts.discoveryLinks(),
+            "local_paths": localPathsPayload(),
+            "runtime": [
+                "host": runtimeBinding.host,
+                "port": NSNumber(value: runtimeBinding.port),
+                "active_server_session_id": runtimeBinding.activeServerSessionID,
+            ],
+        ]
+    }
+
+    func capabilitiesPayload(models: [Melix_Controlplane_V1_ModelSummary]) -> [String: Any] {
+        [
+            "schema_version": MelixRuntimeDiscoveryContracts.capabilitiesSchemaVersion,
+            "features": MelixRuntimeDiscoveryContracts.enabledFeatures,
+            "supported_tasks": MelixRuntimeDiscoveryContracts.supportedTasks,
+            "models": models.map(modelPayload),
+            "model_alias_discovery": MelixRuntimeDiscoveryContracts.modelAliasDiscoveryPayload(query: ""),
+        ]
+    }
+
+    func instructionsPayload() -> [String: Any] {
+        MelixRuntimeDiscoveryContracts.instructionsPayload()
+    }
+
+    func configMetadataPayload() -> [String: Any] {
+        MelixRuntimeDiscoveryContracts.configMetadataPayload(layout: layout)
+    }
+
+    private func localPathsPayload() -> [String: Any] {
+        [
+            "melix_home": layout.rootURL.path,
+            "runtime_settings": layout.rootURL.appendingPathComponent("runtime_settings.json").path,
+            "managed_models": layout.managedModelRootURL.path,
+            "logs": layout.logsDirectoryURL.path,
+            "runtime": layout.runtimeDirectoryURL.path,
+        ]
+    }
+
+    private func modelPayload(_ model: Melix_Controlplane_V1_ModelSummary) -> [String: Any] {
+        [
+            "model_id": model.modelID,
+            "kind": model.kind,
+            "state": model.state.discoveryString,
+            "hf_repo_id": model.settings.ext["melix.hf_repo_id"] ?? "",
+        ]
+    }
+}
+
+private extension Melix_Controlplane_V1_ModelState {
+    var discoveryString: String {
+        switch self {
+        case .modelWarm:
+            return "warm"
+        case .modelPinned:
+            return "pinned"
+        case .modelUnloaded:
+            return "unloaded"
+        case .modelLoading:
+            return "loading"
+        case .modelDiscovered:
+            return "discovered"
+        case .modelFailed:
+            return "failed"
+        case .modelEvicting:
+            return "evicting"
+        default:
+            return "unknown"
+        }
+    }
+}

--- a/services/control-plane-swift/Sources/Support/RuntimeDiscoveryContracts.swift
+++ b/services/control-plane-swift/Sources/Support/RuntimeDiscoveryContracts.swift
@@ -250,6 +250,25 @@ public enum MelixRuntimeDiscoveryContracts {
         ]
     }
 
+    public static func installedVersion(repoRootPath: String) -> String {
+        let pyprojectURL = URL(fileURLWithPath: repoRootPath)
+            .appendingPathComponent("pyproject.toml")
+        guard let text = try? String(contentsOf: pyprojectURL, encoding: .utf8) else {
+            return "0.0.0-dev"
+        }
+        for line in text.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            let parts = trimmed.split(separator: "=", maxSplits: 1)
+            guard parts.count == 2,
+                  parts[0].trimmingCharacters(in: .whitespacesAndNewlines) == "version"
+            else {
+                continue
+            }
+            return parts[1].trimmingCharacters(in: CharacterSet(charactersIn: " \"'"))
+        }
+        return "0.0.0-dev"
+    }
+
     public static func modelAliasDiscoveryPayload(query rawQuery: String) -> [String: Any] {
         let query = rawQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         guard query.isEmpty == false else {

--- a/services/control-plane-swift/Sources/Support/RuntimeDiscoveryContracts.swift
+++ b/services/control-plane-swift/Sources/Support/RuntimeDiscoveryContracts.swift
@@ -1,0 +1,388 @@
+import Foundation
+
+public struct MelixRuntimeSettingMetadata: Equatable, Sendable {
+    public let key: String
+    public let valueType: String
+    public let environmentVariable: String
+    public let summary: String
+
+    public init(
+        key: String,
+        valueType: String,
+        environmentVariable: String,
+        summary: String
+    ) {
+        self.key = key
+        self.valueType = valueType
+        self.environmentVariable = environmentVariable
+        self.summary = summary
+    }
+}
+
+public enum MelixRuntimeDiscoveryContracts {
+    public static let runtimeSettingsSchemaVersion = "melix.runtime_settings.effective.v1"
+    public static let infoSchemaVersion = "melix.discovery.info.v1"
+    public static let capabilitiesSchemaVersion = "melix.discovery.capabilities.v1"
+    public static let instructionsSchemaVersion = "melix.discovery.instructions.v1"
+    public static let schemaSchemaVersion = "melix.discovery.schema.v1"
+    public static let configMetadataSchemaVersion = "melix.discovery.config_metadata.v1"
+
+    public static let enabledFeatures: [String] = [
+        "runtime_settings",
+        "model_alias_discovery",
+        "run_reports",
+        "update_receipt",
+        "local_http_discovery",
+    ]
+
+    public static let supportedTasks: [String] = [
+        "text-generation",
+        "embeddings",
+        "rerank",
+        "audio-transcription",
+        "audio-speech",
+        "image-generation",
+        "image-edit",
+        "evaluation",
+        "benchmark",
+    ]
+
+    public static let runtimeSettingDefinitions: [MelixRuntimeSettingMetadata] = [
+        .init(
+            key: "model_cache_path",
+            valueType: "string",
+            environmentVariable: "MELIX_MODEL_CACHE_PATH",
+            summary: "Directory for managed local model artifacts."
+        ),
+        .init(
+            key: "dataset_cache_path",
+            valueType: "string",
+            environmentVariable: "MELIX_DATASET_CACHE_PATH",
+            summary: "Directory for managed dataset snapshots and packages."
+        ),
+        .init(
+            key: "artifact_path",
+            valueType: "string",
+            environmentVariable: "MELIX_ARTIFACT_PATH",
+            summary: "Directory for generated benchmark, evaluation, and export artifacts."
+        ),
+        .init(
+            key: "max_concurrent_jobs",
+            valueType: "int",
+            environmentVariable: "MELIX_MAX_CONCURRENT_JOBS",
+            summary: "Maximum number of local runtime jobs Melix should schedule concurrently."
+        ),
+        .init(
+            key: "memory_pressure_threshold",
+            valueType: "double",
+            environmentVariable: "MELIX_MEMORY_PRESSURE_THRESHOLD",
+            summary: "Fraction of unified memory pressure at which Melix should become conservative."
+        ),
+        .init(
+            key: "default_dtype",
+            valueType: "string",
+            environmentVariable: "MELIX_DEFAULT_DTYPE",
+            summary: "Default tensor dtype used when a command does not specify one."
+        ),
+        .init(
+            key: "default_quantization",
+            valueType: "string",
+            environmentVariable: "MELIX_DEFAULT_QUANTIZATION",
+            summary: "Default quantization profile used for local model suggestions."
+        ),
+        .init(
+            key: "benchmark_warmup",
+            valueType: "int",
+            environmentVariable: "MELIX_BENCHMARK_WARMUP",
+            summary: "Default benchmark warmup iteration count."
+        ),
+        .init(
+            key: "benchmark_repeats",
+            valueType: "int",
+            environmentVariable: "MELIX_BENCHMARK_REPEATS",
+            summary: "Default benchmark repeat count."
+        ),
+        .init(
+            key: "eval_sample_size",
+            valueType: "int",
+            environmentVariable: "MELIX_EVAL_SAMPLE_SIZE",
+            summary: "Default evaluation sample size when a run does not override it."
+        ),
+        .init(
+            key: "log_retention_days",
+            valueType: "int",
+            environmentVariable: "MELIX_LOG_RETENTION_DAYS",
+            summary: "Number of days to retain local runtime logs."
+        ),
+        .init(
+            key: "auto_cleanup_policy",
+            valueType: "string",
+            environmentVariable: "MELIX_AUTO_CLEANUP_POLICY",
+            summary: "Default cleanup policy for local artifacts."
+        ),
+    ]
+
+    public static func defaultRuntimeSettingValue(
+        key: String,
+        layout: MelixPathLayout
+    ) -> Any {
+        switch key {
+        case "model_cache_path":
+            return layout.managedModelRootURL.path
+        case "dataset_cache_path":
+            return layout.rootURL.appendingPathComponent("datasets", isDirectory: true).path
+        case "artifact_path":
+            return layout.rootURL.appendingPathComponent("artifacts", isDirectory: true).path
+        case "max_concurrent_jobs":
+            return NSNumber(value: 2)
+        case "memory_pressure_threshold":
+            return NSNumber(value: 0.80)
+        case "default_dtype":
+            return "float16"
+        case "default_quantization":
+            return "4bit"
+        case "benchmark_warmup":
+            return NSNumber(value: 1)
+        case "benchmark_repeats":
+            return NSNumber(value: 3)
+        case "eval_sample_size":
+            return NSNumber(value: 20)
+        case "log_retention_days":
+            return NSNumber(value: 14)
+        case "auto_cleanup_policy":
+            return "manual"
+        default:
+            return ""
+        }
+    }
+
+    public static func runtimeSettingsMetadata(layout: MelixPathLayout) -> [[String: Any]] {
+        runtimeSettingDefinitions.map { definition in
+            [
+                "key": definition.key,
+                "type": definition.valueType,
+                "default": defaultRuntimeSettingValue(key: definition.key, layout: layout),
+                "environment_variable": definition.environmentVariable,
+                "summary": definition.summary,
+            ]
+        }
+    }
+
+    public static func discoveryLinks(baseURL: String = "") -> [String: String] {
+        let prefix = baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let base = prefix.isEmpty ? "" : "/\(prefix)"
+        return [
+            "well_known": "\(base)/.well-known/melix.json",
+            "capabilities": "\(base)/api/capabilities",
+            "instructions": "\(base)/api/instructions",
+            "config_metadata": "\(base)/api/config-metadata",
+        ]
+    }
+
+    public static func instructionsPayload() -> [String: Any] {
+        [
+            "schema_version": instructionsSchemaVersion,
+            "areas": [
+                [
+                    "id": "settings",
+                    "title": "Runtime settings",
+                    "commands": [
+                        "melix settings show --json",
+                        "melix settings set <key> <value>",
+                        "melix settings validate",
+                        "melix settings reset <key>",
+                    ],
+                ],
+                [
+                    "id": "discovery",
+                    "title": "Machine-readable discovery",
+                    "commands": [
+                        "melix info --json",
+                        "melix capabilities --json",
+                        "melix instructions --json",
+                        "melix schema --json",
+                        "melix config metadata --json",
+                    ],
+                ],
+                [
+                    "id": "models",
+                    "title": "Model targets",
+                    "commands": [
+                        "melix model list --json",
+                        "melix capabilities --json --model-query <model>",
+                    ],
+                ],
+                [
+                    "id": "updates",
+                    "title": "Local update receipt",
+                    "commands": [
+                        "melix info --json",
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    public static func schemaPayload(repoRootPath: String) -> [String: Any] {
+        [
+            "schema_version": schemaSchemaVersion,
+            "schemas": [
+                [
+                    "id": "protocol",
+                    "path": URL(fileURLWithPath: repoRootPath)
+                        .appendingPathComponent("packages/protocol/schema", isDirectory: true)
+                        .path,
+                ],
+                [
+                    "id": "plans",
+                    "path": URL(fileURLWithPath: repoRootPath)
+                        .appendingPathComponent("docs/plans", isDirectory: true)
+                        .path,
+                ],
+            ],
+        ]
+    }
+
+    public static func configMetadataPayload(layout: MelixPathLayout) -> [String: Any] {
+        [
+            "schema_version": configMetadataSchemaVersion,
+            "settings": runtimeSettingsMetadata(layout: layout),
+        ]
+    }
+
+    public static func modelAliasDiscoveryPayload(query rawQuery: String) -> [String: Any] {
+        let query = rawQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard query.isEmpty == false else {
+            return [
+                "query": query,
+                "status": "not_requested",
+                "suggestions": [],
+                "families": aliasFamiliesPayload(),
+            ]
+        }
+        if isLocalModelPath(query) {
+            return [
+                "query": query,
+                "status": "local_path_passthrough",
+                "suggestions": [],
+                "families": aliasFamiliesPayload(),
+            ]
+        }
+        if isFullModelID(query) {
+            return [
+                "query": query,
+                "status": "valid_full_model_id",
+                "suggestions": [],
+                "families": aliasFamiliesPayload(),
+            ]
+        }
+
+        let normalizedQuery = normalizedAliasToken(query)
+        let suggestions = modelAliasRecords()
+            .filter { record in
+                record.normalizedTokens.contains(normalizedQuery)
+                    || record.normalizedModelID.contains(normalizedQuery)
+            }
+            .map(\.payload)
+        return [
+            "query": query,
+            "status": suggestions.isEmpty ? "no_match" : "suggested",
+            "suggestions": suggestions,
+            "families": aliasFamiliesPayload(),
+        ]
+    }
+
+    private static func modelAliasRecords() -> [ModelAliasRecord] {
+        [
+            ModelAliasRecord(
+                family: "qwen3.5",
+                modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+                aliases: [
+                    "qwen35_9b_mlx_4bit",
+                    "qwen3.5-9b-mlx-4bit",
+                    "qwen-3.5-9b-4bit",
+                ],
+                quantization: "4bit"
+            ),
+            ModelAliasRecord(
+                family: "qwen3.5",
+                modelID: "mlx-community/Qwen3.5-9B-MLX-8bit",
+                aliases: [
+                    "qwen35_9b_mlx_8bit",
+                    "qwen3.5-9b-mlx-8bit",
+                    "qwen-3.5-9b-8bit",
+                ],
+                quantization: "8bit"
+            ),
+            ModelAliasRecord(
+                family: "qwen3.5",
+                modelID: "mlx-community/Qwen3.5-26B-MLX-4bit",
+                aliases: [
+                    "qwen35_26b_mlx_4bit",
+                    "qwen3.5-26b-mlx-4bit",
+                    "qwen-3.5-26b-4bit",
+                ],
+                quantization: "4bit"
+            ),
+        ]
+    }
+
+    private static func aliasFamiliesPayload() -> [[String: Any]] {
+        let records = modelAliasRecords()
+        let grouped = Dictionary(grouping: records, by: \.family)
+        return grouped.keys.sorted().map { family in
+            [
+                "family": family,
+                "model_ids": (grouped[family] ?? []).map(\.modelID).sorted(),
+            ]
+        }
+    }
+
+    private static func isLocalModelPath(_ query: String) -> Bool {
+        query.hasPrefix("/")
+            || query.hasPrefix("~/")
+            || query.hasPrefix("./")
+            || query.hasPrefix("../")
+            || query.hasPrefix("file://")
+    }
+
+    private static func isFullModelID(_ query: String) -> Bool {
+        let parts = query.split(separator: "/", omittingEmptySubsequences: true)
+        return parts.count == 2
+            && parts.allSatisfy { $0.isEmpty == false }
+            && query.contains(" ") == false
+    }
+
+    private static func normalizedAliasToken(_ value: String) -> String {
+        value
+            .lowercased()
+            .unicodeScalars
+            .filter { CharacterSet.alphanumerics.contains($0) }
+            .map(String.init)
+            .joined()
+    }
+
+    private struct ModelAliasRecord {
+        let family: String
+        let modelID: String
+        let aliases: [String]
+        let quantization: String
+
+        var normalizedModelID: String {
+            MelixRuntimeDiscoveryContracts.normalizedAliasToken(modelID)
+        }
+
+        var normalizedTokens: Set<String> {
+            Set(aliases.map(MelixRuntimeDiscoveryContracts.normalizedAliasToken))
+        }
+
+        var payload: [String: Any] {
+            [
+                "family": family,
+                "model_id": modelID,
+                "aliases": aliases,
+                "quantization": quantization,
+            ]
+        }
+    }
+}

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -6715,6 +6715,153 @@ struct OpenAIHandlerTests {
         #expect(payload.contains("\"python_speech\":false"))
     }
 
+    @Test("GET discovery endpoints expose machine readable local runtime contracts")
+    func getDiscoveryEndpointsExposeMachineReadableLocalRuntimeContracts() async throws {
+        let metricsStore = MetricsStore()
+        var qwen = warmModel()
+        qwen.modelID = "mlx-community/Qwen3.5-9B-MLX-4bit"
+        qwen.kind = "text"
+        qwen.settings.ext["melix.hf_repo_id"] = "mlx-community/Qwen3.5-9B-MLX-4bit"
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [qwen, warmEmbeddingModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
+                abortRegistry: AbortRegistry()
+            ),
+            metricsStore: metricsStore,
+            gatewayRuntimeBinding: GatewayRuntimeBinding(host: "127.0.0.1", port: 12_434),
+            environment: [
+                "MELIX_HOME": "/tmp/melix-discovery-home",
+                "MELIX_HTTP_PORT": "12434",
+            ]
+        )
+
+        let wellKnownResponse = try await handler.handle(
+            HTTPRequest(method: .get, path: "/.well-known/melix.json", headers: [:], body: Data())
+        )
+        let wellKnown = try await jsonPayload(from: wellKnownResponse.body)
+        let links = try #require(wellKnown["links"] as? [String: Any])
+        let features = try #require(wellKnown["features"] as? [String])
+        #expect(wellKnownResponse.statusCode == 200)
+        #expect(wellKnown["schema_version"] as? String == "melix.discovery.info.v1")
+        #expect(links["capabilities"] as? String == "/api/capabilities")
+        #expect(features.contains("runtime_settings"))
+
+        let capabilitiesResponse = try await handler.handle(
+            HTTPRequest(method: .get, path: "/api/capabilities", headers: [:], body: Data())
+        )
+        let capabilities = try await jsonPayload(from: capabilitiesResponse.body)
+        let models = try #require(capabilities["models"] as? [[String: Any]])
+        #expect(capabilitiesResponse.statusCode == 200)
+        #expect(capabilities["schema_version"] as? String == "melix.discovery.capabilities.v1")
+        #expect((capabilities["supported_tasks"] as? [String])?.contains("text-generation") == true)
+        #expect(models.contains { $0["model_id"] as? String == "mlx-community/Qwen3.5-9B-MLX-4bit" })
+
+        let instructionsResponse = try await handler.handle(
+            HTTPRequest(method: .get, path: "/api/instructions", headers: [:], body: Data())
+        )
+        let instructions = try await jsonPayload(from: instructionsResponse.body)
+        #expect(instructionsResponse.statusCode == 200)
+        #expect(instructions["schema_version"] as? String == "melix.discovery.instructions.v1")
+        #expect((instructions["areas"] as? [[String: Any]])?.contains { $0["id"] as? String == "settings" } == true)
+
+        let metadataResponse = try await handler.handle(
+            HTTPRequest(method: .get, path: "/api/config-metadata", headers: [:], body: Data())
+        )
+        let metadata = try await jsonPayload(from: metadataResponse.body)
+        #expect(metadataResponse.statusCode == 200)
+        #expect(metadata["schema_version"] as? String == "melix.discovery.config_metadata.v1")
+        #expect((metadata["settings"] as? [[String: Any]])?.contains { $0["key"] as? String == "max_concurrent_jobs" } == true)
+        #expect(await metricsStore.value(forKey: "operator.discovery_well_known_latency_ms") >= 0)
+        #expect(await metricsStore.value(forKey: "operator.discovery_capabilities_latency_ms") >= 0)
+        #expect(await metricsStore.value(forKey: "operator.discovery_instructions_latency_ms") >= 0)
+        #expect(await metricsStore.value(forKey: "operator.discovery_config_metadata_latency_ms") >= 0)
+    }
+
+    @Test("runtime discovery contracts expose stable aliases links metadata and onboarding endpoints")
+    func runtimeDiscoveryContractsExposeStableAliasesLinksMetadataAndOnboardingEndpoints() throws {
+        let layout = MelixPathLayout(environment: ["MELIX_HOME": "/tmp/melix-contract-home"])
+        let metadata = MelixRuntimeDiscoveryContracts.runtimeSettingsMetadata(layout: layout)
+        let links = MelixRuntimeDiscoveryContracts.discoveryLinks(baseURL: "/v1/melix/")
+        let instructions = MelixRuntimeDiscoveryContracts.instructionsPayload()
+        let schema = MelixRuntimeDiscoveryContracts.schemaPayload(repoRootPath: "/tmp/melix-repo")
+        let configMetadata = MelixRuntimeDiscoveryContracts.configMetadataPayload(layout: layout)
+        let onboarding = APIOnboardingSnapshotSource().summary()
+
+        #expect(metadata.count == MelixRuntimeDiscoveryContracts.runtimeSettingDefinitions.count)
+        #expect(metadata.contains { $0["key"] as? String == "auto_cleanup_policy" && $0["default"] as? String == "manual" })
+        #expect(metadata.contains { ($0["default"] as? String)?.contains("/tmp/melix-contract-home/models/default-managed") == true })
+        #expect(links["well_known"] == "/v1/melix/.well-known/melix.json")
+        #expect(links["config_metadata"] == "/v1/melix/api/config-metadata")
+        #expect((instructions["areas"] as? [[String: Any]])?.contains { $0["id"] as? String == "updates" } == true)
+        #expect((schema["schemas"] as? [[String: Any]])?.contains { $0["id"] as? String == "plans" } == true)
+        #expect(configMetadata["schema_version"] as? String == "melix.discovery.config_metadata.v1")
+
+        let blankAlias = MelixRuntimeDiscoveryContracts.modelAliasDiscoveryPayload(query: "  ")
+        #expect(blankAlias["status"] as? String == "not_requested")
+        for query in ["/tmp/model", "~/model", "./model", "../model", "file:///tmp/model"] {
+            let alias = MelixRuntimeDiscoveryContracts.modelAliasDiscoveryPayload(query: query)
+            #expect(alias["status"] as? String == "local_path_passthrough")
+            #expect((alias["suggestions"] as? [[String: Any]])?.isEmpty == true)
+        }
+        let fullModelID = MelixRuntimeDiscoveryContracts.modelAliasDiscoveryPayload(query: "owner/model")
+        #expect(fullModelID["status"] as? String == "valid_full_model_id")
+        let noMatch = MelixRuntimeDiscoveryContracts.modelAliasDiscoveryPayload(query: "owner/model with space")
+        #expect(noMatch["status"] as? String == "no_match")
+        let qwen8Bit = MelixRuntimeDiscoveryContracts.modelAliasDiscoveryPayload(query: "qwen35_9b_mlx_8bit")
+        #expect((qwen8Bit["suggestions"] as? [[String: Any]])?.contains { $0["model_id"] as? String == "mlx-community/Qwen3.5-9B-MLX-8bit" } == true)
+        let qwen26B = MelixRuntimeDiscoveryContracts.modelAliasDiscoveryPayload(query: "qwen35_26b_mlx_4bit")
+        #expect((qwen26B["suggestions"] as? [[String: Any]])?.contains { $0["model_id"] as? String == "mlx-community/Qwen3.5-26B-MLX-4bit" } == true)
+
+        let localService = try #require(onboarding.surfaces.first { $0.surfaceID == "local_service" })
+        #expect(localService.endpointIds.contains("well_known"))
+        #expect(localService.endpointIds.contains("capabilities"))
+        #expect(localService.endpointIds.contains("instructions"))
+        #expect(localService.endpointIds.contains("config_metadata"))
+        let endpointIDs = Set(onboarding.endpoints.map(\.endpointID))
+        #expect(endpointIDs.isSuperset(of: ["well_known", "capabilities", "instructions", "config_metadata"]))
+    }
+
+    @Test("GET capabilities discovery renders all model residency states")
+    func getCapabilitiesDiscoveryRendersAllModelResidencyStates() async throws {
+        let stateCases: [(String, Melix_Controlplane_V1_ModelState, String)] = [
+            ("melix-warm", .modelWarm, "warm"),
+            ("melix-pinned", .modelPinned, "pinned"),
+            ("melix-unloaded", .modelUnloaded, "unloaded"),
+            ("melix-loading", .modelLoading, "loading"),
+            ("melix-discovered", .modelDiscovered, "discovered"),
+            ("melix-failed", .modelFailed, "failed"),
+            ("melix-evicting", .modelEvicting, "evicting"),
+            ("melix-unknown", .UNRECOGNIZED(99), "unknown"),
+        ]
+        let models = stateCases.map { modelID, state, _ in
+            var model = ModelCatalog.devTextModel()
+            model.modelID = modelID
+            model.state = state
+            return model
+        }
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: models),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
+                abortRegistry: AbortRegistry()
+            )
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(method: .get, path: "/api/capabilities", headers: [:], body: Data())
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let discoveredModels = try #require(payload["models"] as? [[String: Any]])
+
+        #expect(response.statusCode == 200)
+        for (modelID, _, discoveryState) in stateCases {
+            #expect(discoveredModels.contains { model in
+                model["model_id"] as? String == modelID && model["state"] as? String == discoveryState
+            })
+        }
+    }
+
     @Test("POST /v1/embeddings returns 503 when the embedding worker throws")
     func postEmbeddingsReturns503WhenTheEmbeddingWorkerThrows() async throws {
         let embeddingClient = ScriptedPhaseFiveWorkerClient()

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -6718,6 +6718,18 @@ struct OpenAIHandlerTests {
     @Test("GET discovery endpoints expose machine readable local runtime contracts")
     func getDiscoveryEndpointsExposeMachineReadableLocalRuntimeContracts() async throws {
         let metricsStore = MetricsStore()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-http-discovery-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data(
+            """
+            [project]
+            version-control = "ignored"
+            version = "7.8.9"
+            """.utf8
+        ).write(to: root.appendingPathComponent("pyproject.toml"))
+        defer { try? FileManager.default.removeItem(at: root) }
+
         var qwen = warmModel()
         qwen.modelID = "mlx-community/Qwen3.5-9B-MLX-4bit"
         qwen.kind = "text"
@@ -6733,6 +6745,7 @@ struct OpenAIHandlerTests {
             environment: [
                 "MELIX_HOME": "/tmp/melix-discovery-home",
                 "MELIX_HTTP_PORT": "12434",
+                "MELIX_REPO_ROOT": root.path,
             ]
         )
 
@@ -6744,6 +6757,7 @@ struct OpenAIHandlerTests {
         let features = try #require(wellKnown["features"] as? [String])
         #expect(wellKnownResponse.statusCode == 200)
         #expect(wellKnown["schema_version"] as? String == "melix.discovery.info.v1")
+        #expect(wellKnown["version"] as? String == "7.8.9")
         #expect(links["capabilities"] as? String == "/api/capabilities")
         #expect(features.contains("runtime_settings"))
 

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -71,8 +71,11 @@ struct MelixCLIParserTests {
         #expect(throws: MelixCLIError.usage("--override must use KEY=VALUE.")) {
             _ = try MelixCLIParser.parse(["settings", "show", "--json", "--override", "=8"])
         }
-        #expect(throws: MelixCLIError.missingValue("--bad")) {
+        #expect(throws: MelixCLIError.usage(MelixCLIParser.usageText)) {
             _ = try MelixCLIParser.parse(["settings", "set", "max_concurrent_jobs", "--bad"])
+        }
+        #expect(throws: MelixCLIError.usage(MelixCLIParser.usageText)) {
+            _ = try MelixCLIParser.parse(["settings", "set", "max_concurrent_jobs", "--jsno", "6"])
         }
         #expect(throws: MelixCLIError.usage(MelixCLIParser.usageText)) {
             _ = try MelixCLIParser.parse(["settings", "reset", "eval_sample_size", "--bad"])

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -15,6 +15,80 @@ struct MelixCLIParserTests {
         #expect(MelixCLIParser.usageText.contains("--hf-dataset-revision overrides a revision embedded in --dataset-ref"))
         #expect(MelixCLIParser.usageText.contains("melix runs list [--from PATH] [--json]"))
         #expect(MelixCLIParser.usageText.contains("melix bench report --from PATH [--format markdown|json]"))
+        #expect(MelixCLIParser.usageText.contains("melix settings show --json [--override KEY=VALUE ...]"))
+        #expect(MelixCLIParser.usageText.contains("melix info --json"))
+        #expect(MelixCLIParser.usageText.contains("melix capabilities --json [--model-query MODEL]"))
+        #expect(MelixCLIParser.usageText.contains("melix config metadata --json"))
+    }
+
+    @Test("parses runtime settings and machine readable discovery commands")
+    func parsesRuntimeSettingsAndDiscoveryCommands() throws {
+        let cases: [([String], String)] = [
+            (["settings", "show", "--json"], "settings.show"),
+            (["settings", "show", "--json", "--override", "max_concurrent_jobs=8"], "settings.show"),
+            (["settings", "set", "max_concurrent_jobs", "6"], "settings.set"),
+            (["settings", "validate"], "settings.validate"),
+            (["settings", "reset", "max_concurrent_jobs"], "settings.reset"),
+            (["info", "--json"], "info"),
+            (["capabilities", "--json"], "capabilities"),
+            (["capabilities", "--json", "--model-query", "qwen35_9b_mlx_4bit"], "capabilities"),
+            (["instructions", "--json"], "instructions"),
+            (["schema", "--json"], "schema"),
+            (["config", "metadata", "--json"], "config.metadata"),
+        ]
+
+        for (arguments, expectedID) in cases {
+            let command = try MelixCLIParser.parse(arguments)
+            #expect(MelixCLICommandCodec.commandID(for: command) == expectedID)
+            #expect(try MelixCLIParser.parse(MelixCLICommandCodec.arguments(for: command)) == command)
+        }
+
+        #expect(throws: MelixCLIError.self) {
+            _ = try MelixCLIParser.parse(["settings", "show"])
+        }
+        #expect(throws: MelixCLIError.self) {
+            _ = try MelixCLIParser.parse(["settings", "set", "max_concurrent_jobs"])
+        }
+        #expect(throws: MelixCLIError.self) {
+            _ = try MelixCLIParser.parse(["settings", "reset"])
+        }
+        #expect(throws: MelixCLIError.self) {
+            _ = try MelixCLIParser.parse(["info"])
+        }
+        #expect(throws: MelixCLIError.self) {
+            _ = try MelixCLIParser.parse(["config", "unknown", "--json"])
+        }
+    }
+
+    @Test("rejects malformed runtime settings and discovery commands")
+    func rejectsMalformedRuntimeSettingsAndDiscoveryCommands() {
+        #expect(throws: MelixCLIError.usage(MelixCLIParser.usageText)) {
+            _ = try MelixCLIParser.parse(["settings"])
+        }
+        #expect(throws: MelixCLIError.missingValue("--override")) {
+            _ = try MelixCLIParser.parse(["settings", "show", "--json", "--override"])
+        }
+        #expect(throws: MelixCLIError.usage("--override must use KEY=VALUE.")) {
+            _ = try MelixCLIParser.parse(["settings", "show", "--json", "--override", "=8"])
+        }
+        #expect(throws: MelixCLIError.missingValue("--bad")) {
+            _ = try MelixCLIParser.parse(["settings", "set", "max_concurrent_jobs", "--bad"])
+        }
+        #expect(throws: MelixCLIError.usage(MelixCLIParser.usageText)) {
+            _ = try MelixCLIParser.parse(["settings", "reset", "eval_sample_size", "--bad"])
+        }
+        #expect(throws: MelixCLIError.usage("melix capabilities requires --json.")) {
+            _ = try MelixCLIParser.parse(["capabilities"])
+        }
+        #expect(throws: MelixCLIError.usage("melix instructions requires --json.")) {
+            _ = try MelixCLIParser.parse(["instructions"])
+        }
+        #expect(throws: MelixCLIError.usage("melix schema requires --json.")) {
+            _ = try MelixCLIParser.parse(["schema"])
+        }
+        #expect(throws: MelixCLIError.usage("melix config metadata requires --json.")) {
+            _ = try MelixCLIParser.parse(["config", "metadata"])
+        }
     }
 
     @Test("documents and parses remote server direct target commands")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -355,7 +355,7 @@ struct MelixCLIRunnerTests {
             client: StubControlPlaneXPCClient(),
             environment: [
                 "MELIX_HOME": melixHome.path,
-                "PWD": projectRoot.path,
+                "MELIX_PROJECT_ROOT": projectRoot.path,
                 "MELIX_MAX_CONCURRENT_JOBS": "6",
             ]
         ).run(.settingsShow(.init(json: true, overrides: ["max_concurrent_jobs": "8"])))
@@ -390,7 +390,7 @@ struct MelixCLIRunnerTests {
             client: StubControlPlaneXPCClient(),
             environment: [
                 "MELIX_HOME": melixHome.path,
-                "PWD": projectRoot.path,
+                "MELIX_PROJECT_ROOT": projectRoot.path,
             ]
         )
 
@@ -442,7 +442,7 @@ struct MelixCLIRunnerTests {
             client: StubControlPlaneXPCClient(),
             environment: [
                 "MELIX_HOME": melixHome.path,
-                "PWD": projectRoot.path,
+                "MELIX_PROJECT_ROOT": projectRoot.path,
             ]
         )
         let output = try await runner.run(.settingsValidate(.init(json: true)))
@@ -466,7 +466,7 @@ struct MelixCLIRunnerTests {
 
         let environment = [
             "MELIX_HOME": melixHome.path,
-            "PWD": projectRoot.path,
+            "MELIX_PROJECT_ROOT": projectRoot.path,
         ]
         let runner = MelixCLIRunner(client: StubControlPlaneXPCClient(), environment: environment)
 
@@ -475,6 +475,9 @@ struct MelixCLIRunnerTests {
         }
         await #expect(throws: MelixRuntimeSettingsError.invalidValue(key: "max_concurrent_jobs", expectedType: "int", value: "many")) {
             _ = try await runner.run(.settingsSet(.init(key: "max_concurrent_jobs", value: "many", json: true)))
+        }
+        await #expect(throws: MelixRuntimeSettingsError.invalidValue(key: "max_concurrent_jobs", expectedType: "int", value: "2.5")) {
+            _ = try await runner.run(.settingsSet(.init(key: "max_concurrent_jobs", value: "2.5", json: true)))
         }
         await #expect(throws: MelixRuntimeSettingsError.unknownKey("missing_key")) {
             _ = try await runner.run(.settingsReset(.init(key: "missing_key", json: true)))
@@ -509,7 +512,7 @@ struct MelixCLIRunnerTests {
             client: StubControlPlaneXPCClient(),
             environment: [
                 "MELIX_HOME": melixHome.path,
-                "PWD": projectRoot.path,
+                "MELIX_PROJECT_ROOT": projectRoot.path,
                 "MELIX_UPDATE_CHANNEL_PATH": channelPath.path,
                 "MELIX_INSTALL_METHOD": "homebrew",
             ]
@@ -538,7 +541,7 @@ struct MelixCLIRunnerTests {
             client: StubControlPlaneXPCClient(),
             environment: [
                 "MELIX_HOME": melixHome.path,
-                "PWD": projectRoot.path,
+                "MELIX_PROJECT_ROOT": projectRoot.path,
                 "MELIX_UPDATE_CHANNEL_PATH": root.appendingPathComponent("missing-channel.json").path,
             ]
         )
@@ -554,6 +557,11 @@ struct MelixCLIRunnerTests {
         #expect(update["suggested_update_command"] as? [String] != nil)
         #expect(update["status"] as? String == "unavailable")
         #expect(localPaths["melix_home"] as? String == melixHome.path)
+        let projectSettingsPath = projectRoot
+            .appendingPathComponent(".melix", isDirectory: true)
+            .appendingPathComponent("runtime_settings.json")
+            .path
+        #expect(localPaths["project_settings"] as? String == projectSettingsPath)
         #expect((infoMetrics["discovery_build_ms"] as? NSNumber)?.doubleValue ?? -1 >= 0)
 
         let capabilities = try #require(parseJSONObject(try await runner.run(.capabilities(.init(json: true, modelQuery: "qwen35_9b_mlx_4bit")))))

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -324,6 +324,292 @@ struct MelixCLIRunnerTests {
         #expect(metrics["melix.cli.parse_ms"] as? Double == 0.25)
     }
 
+    @Test("settings show resolves precedence and reports source metadata")
+    func settingsShowResolvesPrecedenceAndReportsSourceMetadata() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let projectRoot = root.appendingPathComponent("project", isDirectory: true)
+        let melixHome = root.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: projectRoot.appendingPathComponent(".melix", isDirectory: true), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: melixHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try writeJSONObjectForTest(
+            [
+                "model_cache_path": "/user/models",
+                "max_concurrent_jobs": 2,
+                "benchmark_repeats": 1,
+            ],
+            to: melixHome.appendingPathComponent("runtime_settings.json")
+        )
+        try writeJSONObjectForTest(
+            [
+                "max_concurrent_jobs": 4,
+                "artifact_path": "/project/artifacts",
+            ],
+            to: projectRoot
+                .appendingPathComponent(".melix", isDirectory: true)
+                .appendingPathComponent("runtime_settings.json")
+        )
+
+        let output = try await MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: [
+                "MELIX_HOME": melixHome.path,
+                "PWD": projectRoot.path,
+                "MELIX_MAX_CONCURRENT_JOBS": "6",
+            ]
+        ).run(.settingsShow(.init(json: true, overrides: ["max_concurrent_jobs": "8"])))
+        let payload = try #require(parseJSONObject(output))
+        let settings = try #require(payload["settings"] as? [String: Any])
+        let maxJobs = try #require(settings["max_concurrent_jobs"] as? [String: Any])
+        let artifactPath = try #require(settings["artifact_path"] as? [String: Any])
+        let modelCache = try #require(settings["model_cache_path"] as? [String: Any])
+        let metrics = try #require(payload["metrics"] as? [String: Any])
+
+        #expect(payload["schema_version"] as? String == "melix.runtime_settings.effective.v1")
+        #expect((maxJobs["value"] as? NSNumber)?.intValue == 8)
+        #expect(maxJobs["source"] as? String == "cli_flag")
+        #expect(maxJobs["source_detail"] as? String == "--override max_concurrent_jobs")
+        #expect(artifactPath["value"] as? String == "/project/artifacts")
+        #expect(artifactPath["source"] as? String == "project_settings")
+        #expect(modelCache["value"] as? String == "/user/models")
+        #expect(modelCache["source"] as? String == "user_settings")
+        #expect((metrics["settings_resolve_ms"] as? NSNumber)?.doubleValue ?? -1 >= 0)
+    }
+
+    @Test("settings set validate and reset mutate only the user settings file")
+    func settingsSetValidateAndResetMutateOnlyUserSettingsFile() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let projectRoot = root.appendingPathComponent("project", isDirectory: true)
+        let melixHome = root.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: projectRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: melixHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: [
+                "MELIX_HOME": melixHome.path,
+                "PWD": projectRoot.path,
+            ]
+        )
+
+        let setOutput = try await runner.run(.settingsSet(.init(key: "eval_sample_size", value: "25", json: true)))
+        let setPayload = try #require(parseJSONObject(setOutput))
+        #expect(setPayload["key"] as? String == "eval_sample_size")
+        #expect((setPayload["value"] as? NSNumber)?.intValue == 25)
+        #expect(setPayload["source"] as? String == "user_settings")
+
+        let validateOutput = try await runner.run(.settingsValidate(.init(json: true)))
+        let validatePayload = try #require(parseJSONObject(validateOutput))
+        let metrics = try #require(validatePayload["metrics"] as? [String: Any])
+        #expect(validatePayload["valid"] as? Bool == true)
+        #expect((metrics["settings_validate_ms"] as? NSNumber)?.doubleValue ?? -1 >= 0)
+
+        let resetOutput = try await runner.run(.settingsReset(.init(key: "eval_sample_size", json: true)))
+        let resetPayload = try #require(parseJSONObject(resetOutput))
+        #expect(resetPayload["removed"] as? Bool == true)
+
+        let showOutput = try await runner.run(.settingsShow(.init(json: true)))
+        let showPayload = try #require(parseJSONObject(showOutput))
+        let settings = try #require(showPayload["settings"] as? [String: Any])
+        let evalSampleSize = try #require(settings["eval_sample_size"] as? [String: Any])
+        #expect(evalSampleSize["source"] as? String == "default")
+    }
+
+    @Test("settings validation reports invalid documents keys and values")
+    func settingsValidationReportsInvalidDocumentsKeysAndValues() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let projectRoot = root.appendingPathComponent("project", isDirectory: true)
+        let projectSettingsDir = projectRoot.appendingPathComponent(".melix", isDirectory: true)
+        let melixHome = root.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: projectSettingsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: melixHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try writeJSONObjectForTest(
+            [
+                "max_concurrent_jobs": "many",
+                "unknown_setting": true,
+            ],
+            to: melixHome.appendingPathComponent("runtime_settings.json")
+        )
+        try Data("[1,2,3]".utf8).write(
+            to: projectSettingsDir.appendingPathComponent("runtime_settings.json")
+        )
+
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: [
+                "MELIX_HOME": melixHome.path,
+                "PWD": projectRoot.path,
+            ]
+        )
+        let output = try await runner.run(.settingsValidate(.init(json: true)))
+        let payload = try #require(parseJSONObject(output))
+        let errors = try #require(payload["errors"] as? [[String: Any]])
+
+        #expect(payload["valid"] as? Bool == false)
+        #expect(errors.contains { $0["key"] as? String == "max_concurrent_jobs" })
+        #expect(errors.contains { $0["key"] as? String == "unknown_setting" })
+        #expect(errors.contains { ($0["message"] as? String)?.contains("invalidDocument") == true })
+    }
+
+    @Test("settings mutation commands reject unknown keys invalid values and malformed stores")
+    func settingsMutationCommandsRejectUnknownKeysInvalidValuesAndMalformedStores() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let projectRoot = root.appendingPathComponent("project", isDirectory: true)
+        let melixHome = root.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: projectRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: melixHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let environment = [
+            "MELIX_HOME": melixHome.path,
+            "PWD": projectRoot.path,
+        ]
+        let runner = MelixCLIRunner(client: StubControlPlaneXPCClient(), environment: environment)
+
+        await #expect(throws: MelixRuntimeSettingsError.unknownKey("missing_key")) {
+            _ = try await runner.run(.settingsSet(.init(key: "missing_key", value: "1", json: true)))
+        }
+        await #expect(throws: MelixRuntimeSettingsError.invalidValue(key: "max_concurrent_jobs", expectedType: "int", value: "many")) {
+            _ = try await runner.run(.settingsSet(.init(key: "max_concurrent_jobs", value: "many", json: true)))
+        }
+        await #expect(throws: MelixRuntimeSettingsError.unknownKey("missing_key")) {
+            _ = try await runner.run(.settingsReset(.init(key: "missing_key", json: true)))
+        }
+
+        let settingsPath = melixHome.appendingPathComponent("runtime_settings.json")
+        try Data("[1,2,3]".utf8).write(to: settingsPath)
+        await #expect(throws: MelixRuntimeSettingsError.invalidDocument(path: settingsPath.path)) {
+            _ = try await runner.run(.settingsShow(.init(json: true)))
+        }
+    }
+
+    @Test("info discovery reads local update channel receipts without network")
+    func infoDiscoveryReadsLocalUpdateChannelReceiptsWithoutNetwork() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let projectRoot = root.appendingPathComponent("project", isDirectory: true)
+        let melixHome = root.appendingPathComponent("home", isDirectory: true)
+        let channelPath = root.appendingPathComponent("channel.json")
+        try FileManager.default.createDirectory(at: projectRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: melixHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try writeJSONObjectForTest(
+            [
+                "latest_known_version": "999.0.0",
+                "update_channel": "nightly",
+            ],
+            to: channelPath
+        )
+
+        let output = try await MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: [
+                "MELIX_HOME": melixHome.path,
+                "PWD": projectRoot.path,
+                "MELIX_UPDATE_CHANNEL_PATH": channelPath.path,
+                "MELIX_INSTALL_METHOD": "homebrew",
+            ]
+        ).run(.info(.init(json: true)))
+        let payload = try #require(parseJSONObject(output))
+        let update = try #require(payload["update"] as? [String: Any])
+
+        #expect(update["status"] as? String == "ok")
+        #expect(update["latest_known_version"] as? String == "999.0.0")
+        #expect(update["update_available"] as? Bool == true)
+        #expect(update["update_channel"] as? String == "nightly")
+        #expect(update["install_method"] as? String == "homebrew")
+        #expect(update["suggested_update_command"] as? [String] == [])
+    }
+
+    @Test("discovery commands expose machine readable info capabilities instructions schema and config metadata")
+    func discoveryCommandsExposeMachineReadablePayloads() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let projectRoot = root.appendingPathComponent("project", isDirectory: true)
+        let melixHome = root.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: projectRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: melixHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: [
+                "MELIX_HOME": melixHome.path,
+                "PWD": projectRoot.path,
+                "MELIX_UPDATE_CHANNEL_PATH": root.appendingPathComponent("missing-channel.json").path,
+            ]
+        )
+
+        let info = try #require(parseJSONObject(try await runner.run(.info(.init(json: true)))))
+        let update = try #require(info["update"] as? [String: Any])
+        let localPaths = try #require(info["local_paths"] as? [String: Any])
+        let infoMetrics = try #require(info["metrics"] as? [String: Any])
+        #expect(info["schema_version"] as? String == "melix.discovery.info.v1")
+        #expect(update["installed_version"] as? String != nil)
+        #expect(update["latest_known_version"] as? String == "")
+        #expect(update["install_method"] as? String != nil)
+        #expect(update["suggested_update_command"] as? [String] != nil)
+        #expect(update["status"] as? String == "unavailable")
+        #expect(localPaths["melix_home"] as? String == melixHome.path)
+        #expect((infoMetrics["discovery_build_ms"] as? NSNumber)?.doubleValue ?? -1 >= 0)
+
+        let capabilities = try #require(parseJSONObject(try await runner.run(.capabilities(.init(json: true, modelQuery: "qwen35_9b_mlx_4bit")))))
+        let alias = try #require(capabilities["model_alias_discovery"] as? [String: Any])
+        let suggestions = try #require(alias["suggestions"] as? [[String: Any]])
+        #expect(capabilities["schema_version"] as? String == "melix.discovery.capabilities.v1")
+        #expect((capabilities["supported_tasks"] as? [String])?.contains("text-generation") == true)
+        #expect(suggestions.contains { $0["model_id"] as? String == "mlx-community/Qwen3.5-9B-MLX-4bit" })
+
+        let fullIDCapabilities = try #require(parseJSONObject(try await runner.run(.capabilities(.init(json: true, modelQuery: "mlx-community/Qwen3.5-9B-MLX-4bit")))))
+        let fullIDAlias = try #require(fullIDCapabilities["model_alias_discovery"] as? [String: Any])
+        #expect(fullIDAlias["status"] as? String == "valid_full_model_id")
+        #expect((fullIDAlias["suggestions"] as? [[String: Any]])?.isEmpty == true)
+
+        let localPathCapabilities = try #require(parseJSONObject(try await runner.run(.capabilities(.init(json: true, modelQuery: "/tmp/local-model")))))
+        let localPathAlias = try #require(localPathCapabilities["model_alias_discovery"] as? [String: Any])
+        #expect(localPathAlias["status"] as? String == "local_path_passthrough")
+        #expect((localPathAlias["suggestions"] as? [[String: Any]])?.isEmpty == true)
+
+        for query in ["~/local-model", "./local-model", "../local-model", "file:///tmp/local-model"] {
+            let payload = try #require(parseJSONObject(try await runner.run(.capabilities(.init(json: true, modelQuery: query)))))
+            let alias = try #require(payload["model_alias_discovery"] as? [String: Any])
+            #expect(alias["status"] as? String == "local_path_passthrough")
+        }
+
+        let notRequestedCapabilities = try #require(parseJSONObject(try await runner.run(.capabilities(.init(json: true)))))
+        let notRequestedAlias = try #require(notRequestedCapabilities["model_alias_discovery"] as? [String: Any])
+        #expect(notRequestedAlias["status"] as? String == "not_requested")
+
+        let noMatchCapabilities = try #require(parseJSONObject(try await runner.run(.capabilities(.init(json: true, modelQuery: "not a/model id")))))
+        let noMatchAlias = try #require(noMatchCapabilities["model_alias_discovery"] as? [String: Any])
+        #expect(noMatchAlias["status"] as? String == "no_match")
+
+        let qwen8BitCapabilities = try #require(parseJSONObject(try await runner.run(.capabilities(.init(json: true, modelQuery: "qwen35_9b_mlx_8bit")))))
+        let qwen8BitAlias = try #require(qwen8BitCapabilities["model_alias_discovery"] as? [String: Any])
+        let qwen8BitSuggestions = try #require(qwen8BitAlias["suggestions"] as? [[String: Any]])
+        #expect(qwen8BitSuggestions.contains { $0["model_id"] as? String == "mlx-community/Qwen3.5-9B-MLX-8bit" })
+
+        let qwen26BCapabilities = try #require(parseJSONObject(try await runner.run(.capabilities(.init(json: true, modelQuery: "qwen35_26b_mlx_4bit")))))
+        let qwen26BAlias = try #require(qwen26BCapabilities["model_alias_discovery"] as? [String: Any])
+        let qwen26BSuggestions = try #require(qwen26BAlias["suggestions"] as? [[String: Any]])
+        #expect(qwen26BSuggestions.contains { $0["model_id"] as? String == "mlx-community/Qwen3.5-26B-MLX-4bit" })
+
+        let instructions = try #require(parseJSONObject(try await runner.run(.instructions(.init(json: true)))))
+        #expect(instructions["schema_version"] as? String == "melix.discovery.instructions.v1")
+        #expect((instructions["areas"] as? [[String: Any]])?.contains { $0["id"] as? String == "settings" } == true)
+
+        let schema = try #require(parseJSONObject(try await runner.run(.schema(.init(json: true)))))
+        #expect(schema["schema_version"] as? String == "melix.discovery.schema.v1")
+        #expect((schema["schemas"] as? [[String: Any]])?.contains { ($0["path"] as? String)?.contains("packages/protocol/schema") == true } == true)
+
+        let metadata = try #require(parseJSONObject(try await runner.run(.configMetadata(.init(json: true)))))
+        #expect(metadata["schema_version"] as? String == "melix.discovery.config_metadata.v1")
+        #expect((metadata["settings"] as? [[String: Any]])?.contains { $0["key"] as? String == "memory_pressure_threshold" } == true)
+    }
+
     @Test("json metric patching rejects missing placeholders")
     func jsonMetricPatchingRejectsMissingPlaceholders() throws {
         #expect(throws: MelixCLIError.runtime("Failed to encode CLI metrics placeholder.")) {


### PR DESCRIPTION
## Summary
- Add machine-readable runtime settings and discovery surfaces for CLI and the local HTTP gateway.
- Persist user runtime settings under `MELIX_HOME`/`~/.melix`, add project settings overrides, and report setting sources and probe timings.
- Expose discovery payloads for info, capabilities, instructions, schema, config metadata, local paths, update receipts, and same-family Qwen3.5 alias suggestions.
- Add local HTTP discovery endpoints at `/.well-known/melix.json`, `/api/capabilities`, `/api/instructions`, and `/api/config-metadata`.

Closes #641.

## Plan or Spec
- `docs/plans/2026-05-11-runtime-settings-discovery-surfaces.md`

## Commands Run
```text
swift test --filter 'MelixCLIParserTests/parsesRuntimeSettingsAndDiscoveryCommands|MelixCLIParserTests/rejectsMalformedRuntimeSettingsAndDiscoveryCommands|MelixCLIRunnerTests/settingsShowResolvesPrecedenceAndReportsSourceMetadata|MelixCLIRunnerTests/settingsSetValidateAndResetMutateOnlyUserSettingsFile|MelixCLIRunnerTests/settingsValidationReportsInvalidDocumentsKeysAndValues|MelixCLIRunnerTests/settingsMutationCommandsRejectUnknownKeysInvalidValuesAndMalformedStores|MelixCLIRunnerTests/infoDiscoveryReadsLocalUpdateChannelReceiptsWithoutNetwork|MelixCLIRunnerTests/discoveryCommandsExposeMachineReadablePayloads'
# Passed: 8 Swift Testing tests.

swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/getDiscoveryEndpointsExposeMachineReadableLocalRuntimeContracts|OpenAIHandlerTests/runtimeDiscoveryContractsExposeStableAliasesLinksMetadataAndOnboardingEndpoints|OpenAIHandlerTests/getCapabilitiesDiscoveryRendersAllModelResidencyStates'
# Passed: 3 Swift Testing tests.

swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests/settingsShowResolvesPrecedenceAndReportsSourceMetadata|MelixCLIRunnerTests/settingsSetValidateAndResetMutateOnlyUserSettingsFile|MelixCLIRunnerTests/settingsValidationReportsInvalidDocumentsKeysAndValues|MelixCLIRunnerTests/settingsMutationCommandsRejectUnknownKeysInvalidValuesAndMalformedStores|MelixCLIRunnerTests/infoDiscoveryReadsLocalUpdateChannelReceiptsWithoutNetwork|MelixCLIRunnerTests/discoveryCommandsExposeMachineReadablePayloads'
# Passed: 86 Swift Testing tests.

swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIHandlerTests/getDiscoveryEndpointsExposeMachineReadableLocalRuntimeContracts|OpenAIHandlerTests/runtimeDiscoveryContractsExposeStableAliasesLinksMetadataAndOnboardingEndpoints|OpenAIHandlerTests/getCapabilitiesDiscoveryRendersAllModelResidencyStates|OpenAIHandlerTests/getHealthReportsOkWhenAllRoutesAreReadyAndPinnedModelsCountAsReady|OpenAIHandlerTests/getHealthReportsMissingRouteClientsAsFalseWhenARegistryIsPresent'
# Passed: 5 Swift Testing tests.

git diff --check
# Passed.

python3 scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main Sources/MelixCLICore/MelixCLI.swift Sources/MelixCLICore/MelixCLICommandCodec.swift Sources/MelixCLICore/MelixHome.swift Sources/MelixCLICore/MelixRuntimeDiscovery.swift tests/MelixCLITests/MelixCLIParserTests.swift tests/MelixCLITests/MelixCLIRunnerTests.swift
# Passed: TOTAL 95.51% (893/935).

python3 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/APIOnboardingSnapshotSource.swift services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Sources/HTTPGateway/RuntimeDiscoveryPayloads.swift services/control-plane-swift/Sources/Support/RuntimeDiscoveryContracts.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
# Passed: TOTAL 99.82% (550/551).
```

## Coverage and Metrics
- CLI changed-line coverage: 95.51% (893/935).
- Control-plane changed-line coverage: 99.82% (550/551).
- Added CLI probe metrics:
  - `settings_resolve_ms`
  - `settings_write_ms`
  - `settings_validate_ms`
  - `discovery_build_ms`
- Added HTTP discovery latency metrics:
  - `operator.discovery_well_known_latency_ms`
  - `operator.discovery_capabilities_latency_ms`
  - `operator.discovery_instructions_latency_ms`
  - `operator.discovery_config_metadata_latency_ms`

## Known Gaps
- Full `make bootstrap`, `make proto`, `make py-test`, and `make integration-test` were not run; this change is scoped to Swift CLI/control-plane discovery surfaces and does not change protobuf schemas or Python code.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
