### PR TITLE
perf: trim event extraction fenced json without line list

### DIFF
--- a/docs/plans/2026-05-11-event-extraction-response-json-fence-trim.md
+++ b/docs/plans/2026-05-11-event-extraction-response-json-fence-trim.md
@@ -1,0 +1,42 @@
+# Event Extraction Response JSON Fence Trim Slice
+
+## Scope
+
+This Python-only performance slice is limited to
+`services/mlx-worker-python/worker/productization/event_extraction.py`, specifically
+`_parse_response_json(...)` when an LLM response starts with a Markdown code fence.
+It does not change event scoring, semantic matching, generated protocol artifacts,
+or Swift/macOS runtime behavior.
+
+## Registered Probe
+
+Registered PR-scoped probe: `event-extraction-response-json-fence-trim` in
+`infra/perf/pr_scoped_probes.json`.
+
+The probe provides focused:
+
+- `test_command` for the fenced JSON parser regression tests and probe dispatch tests.
+- `coverage_command` for changed-scope coverage across the parser, tests, registry, and probe script.
+- `probe_command` for a synthetic partially fenced JSON response that previously required
+  `splitlines()` plus `"\n".join(...)` before JSON parsing.
+
+Metrics:
+
+- `elapsed_ms_mean` (lower is better)
+- `peak_bytes_mean` (lower is better)
+- `event_count` (informational)
+
+## Implementation Plan
+
+1. Preserve parser behavior for complete fenced JSON, partially fenced JSON, and plain JSON responses.
+2. Replace the fallback `splitlines()`/join path with index-based trimming so large partially fenced
+   responses avoid allocating a full line list.
+3. Keep the slice local to the parser, regression tests, probe script, and PR-scoped probe registry.
+4. Verify locally on Linux with the registered focused test command, coverage command, and registered probe.
+
+## Acceptance Criteria
+
+- Focused event-extraction parser tests pass.
+- Changed-scope coverage is at least 95%.
+- The registered probe reports improved or directionally neutral elapsed time and no guard-rail failures.
+- CI PR-scoped performance selects and passes `event-extraction-response-json-fence-trim`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2981,6 +2981,43 @@
     "notes": "Compares cached normalized group-actor aliases against rebuilding the alias normalization set while expanding semantic actor values."
   },
   {
+    "id": "event-extraction-response-json-fence-trim",
+    "name": "Event extraction fenced JSON trim",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/event_extraction.py",
+      "services/mlx-worker-python/tests/test_event_extraction.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/event_extraction_response_json_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_response_json_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_response_json_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_response_json_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/event_extraction_response_json_probe.py ]; then python3 scripts/event_extraction_response_json_probe.py; else python3 - <<\"PYPROBE\"\nimport json, os, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nrepo=Path.cwd(); sys.path.insert(0,str(repo)); sys.path.insert(0,str(repo/\"services/mlx-worker-python\"))\nfrom worker.productization import event_extraction as m\ndef env(name, default):\n    return max(1, int(os.getenv(name, str(default))))\nevent_count=env(\"MELIX_EVENT_RESPONSE_JSON_PROBE_EVENT_COUNT\",1600); iterations=env(\"MELIX_EVENT_RESPONSE_JSON_PROBE_ITERATIONS\",80); samples=env(\"MELIX_EVENT_RESPONSE_JSON_PROBE_SAMPLES\",5)\nevents=[{\"event_type\":\"delivery\",\"trigger\":f\"delivered-{i}\",\"arguments\":{\"actor\":[\"courier\",f\"team-{i%8}\"],\"item\":[f\"crate-{i}\"],\"destination\":[f\"dock-{i%13}\"]}} for i in range(event_count)]\nresponse=\"```json\\n\"+json.dumps({\"events\":events}, ensure_ascii=False, separators=(\",\",\":\"))\nelapsed=[]; peaks=[]; checksum=0\nfor _ in range(samples):\n    tracemalloc.start(); start=time.perf_counter()\n    for _i in range(iterations):\n        payload=m._parse_response_json(response); parsed=payload.get(\"events\")\n        if not isinstance(parsed, list) or len(parsed) != event_count: raise AssertionError(\"unexpected parsed payload\")\n        checksum += len(parsed)\n    elapsed.append((time.perf_counter()-start)*1000.0); _, peak=tracemalloc.get_traced_memory(); tracemalloc.stop(); peaks.append(float(peak))\nprint(json.dumps({\"elapsed_ms_mean\":statistics.fmean(elapsed),\"peak_bytes_mean\":statistics.fmean(peaks),\"event_count\":float(event_count),\"iterations_per_sample\":float(iterations),\"sample_count\":float(samples),\"checksum\":float(checksum)}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "event_count",
+        "unit": "events",
+        "direction": "informational"
+      }
+    ],
+    "notes": "Compares fenced event-extraction JSON response trimming without materializing splitlines for partially fenced model responses."
+  },
+  {
     "id": "mlx-audio-wav-streaming-pcm",
     "name": "MLX audio WAV PCM streaming",
     "runner": "ubuntu-latest",

--- a/scripts/event_extraction_response_json_probe.py
+++ b/scripts/event_extraction_response_json_probe.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Synthetic probe for event-extraction fenced JSON response parsing."""
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path.cwd()
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.productization import event_extraction as event_extraction_module  # noqa: E402
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return max(1, int(value))
+
+
+def _response(event_count: int) -> str:
+    events = [
+        {
+            "event_type": "delivery",
+            "trigger": f"delivered-{index}",
+            "arguments": {
+                "actor": ["courier", f"team-{index % 8}"],
+                "item": [f"crate-{index}"],
+                "destination": [f"dock-{index % 13}"],
+            },
+        }
+        for index in range(event_count)
+    ]
+    # The missing closing fence follows the existing permissive parser path for
+    # partially fenced model responses and used to require splitlines()+join().
+    return "```json\n" + json.dumps({"events": events}, ensure_ascii=False, separators=(",", ":"))
+
+
+def run_probe(*, event_count: int = 1600, iterations: int = 80, samples: int = 5) -> dict[str, float]:
+    response = _response(event_count)
+    elapsed_ms: list[float] = []
+    peak_bytes: list[float] = []
+    checksum = 0
+    for _ in range(samples):
+        tracemalloc.start()
+        started = time.perf_counter()
+        for _index in range(iterations):
+            payload = event_extraction_module._parse_response_json(response)
+            events = payload.get("events")
+            if not isinstance(events, list) or len(events) != event_count:
+                raise AssertionError("event-extraction response JSON probe parsed an unexpected payload")
+            checksum += len(events)
+        elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_bytes.append(float(peak))
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_ms),
+        "peak_bytes_mean": statistics.fmean(peak_bytes),
+        "event_count": float(event_count),
+        "iterations_per_sample": float(iterations),
+        "sample_count": float(samples),
+        "checksum": float(checksum),
+    }
+
+
+def main() -> int:
+    metrics = run_probe(
+        event_count=_env_int("MELIX_EVENT_RESPONSE_JSON_PROBE_EVENT_COUNT", 1600),
+        iterations=_env_int("MELIX_EVENT_RESPONSE_JSON_PROBE_ITERATIONS", 80),
+        samples=_env_int("MELIX_EVENT_RESPONSE_JSON_PROBE_SAMPLES", 5),
+    )
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_event_extraction.py
+++ b/services/mlx-worker-python/tests/test_event_extraction.py
@@ -125,6 +125,20 @@ def test_local_event_extraction_disables_thinking_template_kwargs() -> None:
     assert raw_text.startswith("{")
 
 
+def test_parse_response_json_trims_partial_fenced_json_without_line_list() -> None:
+    response = '```json\n{"events": [{"event_type": "delivery"}]}'
+
+    assert event_extraction_module._parse_response_json(response) == {
+        "events": [{"event_type": "delivery"}]
+    }
+
+
+def test_parse_response_json_trims_closing_fence_with_trailing_space() -> None:
+    response = '```json\n{"events": []}\n```   '
+
+    assert event_extraction_module._parse_response_json(response) == {"events": []}
+
+
 def test_local_event_extraction_parse_errors_keep_raw_response_for_diagnostics(tmp_path: Path) -> None:
     source = tmp_path / "top200_final.jsonl"
     _write_jsonl(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -109,11 +109,12 @@ def test_scope_report_selects_event_extraction_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/productization/event_extraction.py"],
     )
 
-    assert scope["selected_count"] == 3
+    assert scope["selected_count"] == 4
     assert {probe["id"] for probe in scope["selected_probes"]} == {
         "event-extraction-alignment-accepted-edge-cache",
         "event-extraction-semantic-value-group-cache",
         "event-extraction-group-actor-alias-cache",
+        "event-extraction-response-json-fence-trim",
     }
 
 
@@ -1371,6 +1372,27 @@ def test_event_extraction_actor_alias_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0
 
 
+def test_event_extraction_response_json_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_EVENT_RESPONSE_JSON_PROBE_EVENT_COUNT", "4")
+    monkeypatch.setenv("MELIX_EVENT_RESPONSE_JSON_PROBE_ITERATIONS", "3")
+    monkeypatch.setenv("MELIX_EVENT_RESPONSE_JSON_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(REPO_ROOT / "scripts/event_extraction_response_json_probe.py"), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["event_count"] == 4.0
+    assert metrics["iterations_per_sample"] == 3.0
+    assert metrics["sample_count"] == 1.0
+    assert metrics["checksum"] == 12.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_hub_catalog_tag_normalization_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -1944,6 +1966,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "event-extraction-alignment-accepted-edge-cache",
         "event-extraction-semantic-value-group-cache",
         "event-extraction-group-actor-alias-cache",
+        "event-extraction-response-json-fence-trim",
         "hub-catalog-tag-normalization-single-pass",
         "hub-catalog-next-cursor-fast-parse",
         "hub-catalog-size-hint-regex-precompile",

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2805,15 +2805,13 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
     stripped = response_text.strip()
     if stripped.startswith("```"):
         newline_index = stripped.find("\n")
-        if newline_index >= 0 and stripped.endswith("```"):
-            stripped = stripped[newline_index + 1 : -3].strip()
-        else:
-            lines = stripped.splitlines()
-            if lines and lines[0].startswith("```"):
-                lines = lines[1:]
-            if lines and lines[-1].strip() == "```":
-                lines = lines[:-1]
-            stripped = "\n".join(lines).strip()
+        if newline_index >= 0:
+            body = stripped[newline_index + 1 :]
+            if body.endswith("```"):
+                body = body[:-3]
+            else:
+                body = body.rstrip()
+            stripped = body.strip()
     parsed = json.loads(stripped)
     if not isinstance(parsed, dict):
         raise ValueError("LLM response must be a JSON object")


### PR DESCRIPTION
## Summary
- Optimizes event-extraction fenced JSON parsing by replacing the partially fenced fallback `splitlines()` + join path with index-based trimming.
- Adds a dedicated PR-scoped performance probe for the response JSON fence-trim path.
- Adds focused parser/probe regression tests and a governing plan for this Python-only slice.

## Plan or Spec
- `docs/plans/2026-05-11-event-extraction-response-json-fence-trim.md`

## Commands Run
```text
# focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_response_json_probe_script_emits_metrics
# exit 0; 5 passed in 0.63s

# changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_response_json_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_response_json_probe.py
# exit 0; TOTAL 27 0 100%

# local head probe smoke
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_response_json_probe.py
# exit 0; elapsed_ms_mean=1222.603, peak_bytes_mean=3227320.8

# registered probe comparison against origin/main worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id event-extraction-response-json-fence-trim --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-event-response-json-20260511080021 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-cron-python-slice-20260511080021 --output /tmp/event_response_json_probe_2.json
# exit 0; base elapsed_ms_mean=1489.006, head elapsed_ms_mean=1364.959

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 27 0 100%`).
- Registered probe: `event-extraction-response-json-fence-trim`.
- Local probe comparison: `old_mean=1489.006ms`, `new_mean=1364.959ms`, `delta_ms=-124.047`, `speedup=8.33%`.
- Peak bytes: `old=3227384.8`, `new=3227320.8`, `delta=-64.0`.
- CI PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- Local validation is Linux/Python-only. No Swift or macOS runtime effect is claimed for this slice.
- The microbenchmark has normal timing variance; CI PR-scoped performance remains the authoritative registered-probe gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
