### PR TITLE
perf: fast decode stream token bytes

### DIFF
--- a/docs/plans/2026-05-11-stream-assembler-token-byte-fast-decode.md
+++ b/docs/plans/2026-05-11-stream-assembler-token-byte-fast-decode.md
@@ -1,0 +1,38 @@
+# Stream assembler token-byte fast decode
+
+## Scope
+
+Optimize exactly one Python hot path in `RequestStreamAssembler`: complete UTF-8 token-byte fragments that arrive without pending partial bytes.
+
+Affected files:
+
+- `services/mlx-worker-python/worker/runtime/stream_assembler.py`
+- `services/mlx-worker-python/tests/test_stream_assembler.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/stream_assembler_token_bytes_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Registered probe
+
+Register `stream-assembler-token-byte-fast-decode` in `infra/perf/pr_scoped_probes.json` with focused test, coverage, and command-json probe commands.
+
+The probe feeds many ASCII `token_bytes` fragments through a plain stream assembler and reports:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- `generated_token_count_mean`
+
+## Optimization
+
+When there are no pending partial token bytes, decode the incoming byte fragment directly with `bytes.decode("utf-8")`. Fall back to the existing incremental decoder path for split multibyte sequences or invalid bytes so behavior remains unchanged.
+
+## Verification
+
+Run the registered test command, changed-scope coverage command, and registered probe locally on Linux. Compare the registered probe against the pre-optimization baseline from the same worktree after adding the probe but before changing runtime behavior.
+
+## Success criteria
+
+- Focused stream assembler token-byte regression tests pass.
+- Changed-scope coverage remains at least 95% for touched executable files.
+- Local registered probe shows lower `elapsed_ms_mean` than the pre-optimization baseline.
+- PR-scoped performance CI selects and completes `stream-assembler-token-byte-fast-decode`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -561,6 +561,42 @@
     ]
   },
   {
+    "id": "stream-assembler-token-byte-fast-decode",
+    "name": "Stream assembler token-byte fast decode",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/stream_assembler.py",
+      "services/mlx-worker-python/tests/test_stream_assembler.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/stream_assembler_token_bytes_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_ascii_without_incremental_decoder services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_preserves_split_multibyte_sequence services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_ascii_without_incremental_decoder services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_preserves_split_multibyte_sequence services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_token_bytes_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/stream_assembler_token_bytes_probe.py ]; then python3 scripts/stream_assembler_token_bytes_probe.py; else python3 - <<\"PYPROBE\"\nfrom __future__ import annotations\nimport json, os, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.runtime.stream_assembler import RequestStreamAssembler, StreamFragment\nsample_count = int(os.environ.get(\"MELIX_STREAM_ASSEMBLER_TOKEN_BYTES_SAMPLES\", \"5\"))\ntoken_event_count = int(os.environ.get(\"MELIX_STREAM_ASSEMBLER_TOKEN_BYTES_EVENTS\", \"80000\"))\ntoken_payloads = tuple(f\"token-{index % 97} \".encode(\"utf-8\") for index in range(token_event_count))\nexpected_text = b\"\".join(token_payloads).decode(\"utf-8\")\nelapsed = []\npeaks = []\ngenerated_tokens = []\nchecksum = 0\nfor _ in range(sample_count):\n    assembler = RequestStreamAssembler(\"token-bytes-probe\", False, \"\", \"\")\n    tracemalloc.start()\n    started = time.perf_counter()\n    emitted_chars = 0\n    for payload in token_payloads:\n        for delta in assembler.accept(StreamFragment(token_bytes=payload)):\n            emitted_chars += len(delta.content_text)\n    completed = assembler.completed()\n    elapsed_ms = (time.perf_counter() - started) * 1000.0\n    _, peak = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    if completed.assistant_text != expected_text:\n        raise SystemExit(\"assembled token-byte text did not match expected text\")\n    if emitted_chars != len(expected_text):\n        raise SystemExit(\"unexpected emitted character count\")\n    if completed.metrics[\"byte_fallback_decode_error_count\"] != 0:\n        raise SystemExit(\"unexpected decode errors for ASCII token bytes\")\n    elapsed.append(elapsed_ms)\n    peaks.append(float(peak))\n    generated_tokens.append(float(completed.metrics[\"generated_token_count\"]))\n    checksum += len(completed.assistant_text)\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed), \"peak_bytes_mean\": statistics.fmean(peaks), \"generated_token_count_mean\": statistics.fmean(generated_tokens), \"token_event_count\": float(token_event_count), \"checksum\": float(checksum), \"sample_count\": float(sample_count)}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 10.0
+      },
+      {
+        "key": "generated_token_count_mean",
+        "unit": "tokens",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "benchmark-evaluation-report-running-aggregates",
     "name": "Benchmark evaluation report running aggregates",
     "runner": "ubuntu-latest",

--- a/scripts/stream_assembler_token_bytes_probe.py
+++ b/scripts/stream_assembler_token_bytes_probe.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime.stream_assembler import RequestStreamAssembler, StreamFragment
+
+
+def _measure(sample_count: int | None = None, token_event_count: int | None = None) -> dict[str, float]:
+    if sample_count is None:
+        sample_count = int(os.environ.get("MELIX_STREAM_ASSEMBLER_TOKEN_BYTES_SAMPLES", "5"))
+    if token_event_count is None:
+        token_event_count = int(os.environ.get("MELIX_STREAM_ASSEMBLER_TOKEN_BYTES_EVENTS", "80000"))
+
+    token_payloads = tuple(
+        f"token-{index % 97} ".encode("utf-8")
+        for index in range(token_event_count)
+    )
+    expected_text = b"".join(token_payloads).decode("utf-8")
+    elapsed: list[float] = []
+    peaks: list[float] = []
+    generated_tokens: list[float] = []
+    checksum = 0
+
+    for _ in range(sample_count):
+        assembler = RequestStreamAssembler("token-bytes-probe", False, "", "")
+        tracemalloc.start()
+        started = time.perf_counter()
+        emitted_chars = 0
+        for payload in token_payloads:
+            for delta in assembler.accept(StreamFragment(token_bytes=payload)):
+                emitted_chars += len(delta.content_text)
+        completed = assembler.completed()
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        if completed.assistant_text != expected_text:
+            raise SystemExit("assembled token-byte text did not match expected text")
+        if emitted_chars != len(expected_text):
+            raise SystemExit("unexpected emitted character count")
+        if completed.metrics["byte_fallback_decode_error_count"] != 0:
+            raise SystemExit("unexpected decode errors for ASCII token bytes")
+        elapsed.append(elapsed_ms)
+        peaks.append(float(peak))
+        generated_tokens.append(float(completed.metrics["generated_token_count"]))
+        checksum += len(completed.assistant_text)
+
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed),
+        "peak_bytes_mean": statistics.fmean(peaks),
+        "generated_token_count_mean": statistics.fmean(generated_tokens),
+        "token_event_count": float(token_event_count),
+        "checksum": float(checksum),
+        "sample_count": float(sample_count),
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(_measure(), sort_keys=True))

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -140,10 +140,11 @@ def test_scope_report_selects_stream_assembler_probe() -> None:
     )
 
     probe_ids = {probe["id"] for probe in scope["selected_probes"]}
-    assert scope["selected_count"] == 2
+    assert scope["selected_count"] == 3
     assert probe_ids == {
         "stream-assembler-parser-mode-cache",
         "stream-assembler-structural-prefix-cache",
+        "stream-assembler-token-byte-fast-decode",
     }
 
 
@@ -1616,6 +1617,27 @@ def test_stream_assembler_structural_prefix_probe_script_emits_metrics(
     assert metrics["peak_bytes_mean"] > 0
 
 
+def test_stream_assembler_token_bytes_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_STREAM_ASSEMBLER_TOKEN_BYTES_EVENTS", "8")
+    monkeypatch.setenv("MELIX_STREAM_ASSEMBLER_TOKEN_BYTES_SAMPLES", "1")
+
+    runpy.run_path(
+        str(REPO_ROOT / "scripts/stream_assembler_token_bytes_probe.py"),
+        run_name="__main__",
+    )
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["token_event_count"] == 8.0
+    assert metrics["generated_token_count_mean"] == 8.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["checksum"] > 0
+
+
 def test_runtime_utils_kwarg_cache_probe_script_emits_metrics(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -1973,6 +1995,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "integration-swift-binary-resolution-scandir",
         "benchmark-evaluation-report-running-aggregates",
         "stream-assembler-parser-mode-cache",
+        "stream-assembler-token-byte-fast-decode",
         "benchmark-export-run-scan-single-pass",
         "benchmark-queue-decoded-record-cache",
         "benchmark-store-matrix-streaming",

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -96,6 +96,62 @@ def test_plain_buffer_without_tag_marker_flushes_without_structural_scans(monkey
     assert completed.metrics["stream_short_reply_flush_count"] == 0
 
 
+def test_token_byte_delta_decodes_complete_ascii_without_incremental_decoder(monkeypatch) -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-token-byte-fast-path",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="",
+    )
+    decoder_calls = 0
+    original_decoder_factory = stream_assembler._UTF8_INCREMENTAL_DECODER
+
+    def tracked_decoder_factory():
+        nonlocal decoder_calls
+        decoder_calls += 1  # pragma: no cover - this fast-path guard must stay cold
+        return original_decoder_factory()  # pragma: no cover
+
+    monkeypatch.setattr(stream_assembler, "_UTF8_INCREMENTAL_DECODER", tracked_decoder_factory)
+
+    deltas = assembler.accept(StreamFragment(token_bytes=b"hello "))
+    deltas += assembler.accept(StreamFragment(token_bytes=b"world"))
+    completed = assembler.completed()
+
+    assert [delta.content_text for delta in deltas] == ["hello ", "world"]
+    assert completed.assistant_text == "hello world"
+    assert completed.metrics["generated_token_count"] == 2
+    assert completed.metrics["byte_fallback_decode_error_count"] == 0
+    assert decoder_calls == 0
+
+
+def test_token_byte_delta_preserves_split_multibyte_sequence(monkeypatch) -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-token-byte-split-multibyte",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="",
+    )
+    decoder_calls = 0
+    original_decoder_factory = stream_assembler._UTF8_INCREMENTAL_DECODER
+
+    def tracked_decoder_factory():
+        nonlocal decoder_calls
+        decoder_calls += 1
+        return original_decoder_factory()
+
+    monkeypatch.setattr(stream_assembler, "_UTF8_INCREMENTAL_DECODER", tracked_decoder_factory)
+
+    assert assembler.accept(StreamFragment(token_bytes="€".encode("utf-8")[:1])) == []
+    deltas = assembler.accept(StreamFragment(token_bytes="€".encode("utf-8")[1:]))
+    completed = assembler.completed()
+
+    assert [delta.content_text for delta in deltas] == ["€"]
+    assert completed.assistant_text == "€"
+    assert completed.metrics["generated_token_count"] == 2
+    assert completed.metrics["byte_fallback_merge_count"] == 1
+    assert decoder_calls == 2
+
+
 def test_plain_buffer_with_marker_still_holds_partial_structural_prefix() -> None:
     assembler = RequestStreamAssembler(
         request_id="req-marker-still-held",

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -287,6 +287,11 @@ class RequestStreamAssembler:
         if token_bytes is None:
             return None
         had_pending = bool(self._pending_token_bytes)
+        if not had_pending:
+            try:
+                return token_bytes.decode("utf-8")
+            except UnicodeDecodeError:
+                pass
         self._pending_token_bytes += token_bytes
         decoder = _UTF8_INCREMENTAL_DECODER()
         try:


### PR DESCRIPTION
## Summary
- Add the registered `stream-assembler-token-byte-fast-decode` PR-scoped probe for token-byte assembly.
- Fast-path complete UTF-8 token byte fragments with direct `bytes.decode("utf-8")` when no partial bytes are pending.
- Preserve the existing incremental decoder fallback for split multibyte and invalid byte sequences.

## Plan or Spec
- `docs/plans/2026-05-11-stream-assembler-token-byte-fast-decode.md`

## Commands Run
```text
# Baseline probe before runtime behavior change (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_token_bytes_probe.py
{"checksum": 3558750.0, "elapsed_ms_mean": 1937.1362584177405, "generated_token_count_mean": 80000.0, "peak_bytes_mean": 6128021.0, "sample_count": 5.0, "token_event_count": 80000.0}

# RED regression test before runtime behavior change (exit 1, expected)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_ascii_without_incremental_decoder
FAILED ... assert 2 == 0

# Focused registered tests (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_ascii_without_incremental_decoder \
  services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_preserves_split_multibyte_sequence \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics
5 passed in 0.53s

# Changed-scope coverage (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
  services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_ascii_without_incremental_decoder \
  services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_preserves_split_multibyte_sequence \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics && \
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && \
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/runtime/stream_assembler.py \
  services/mlx-worker-python/tests/test_stream_assembler.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/stream_assembler_token_bytes_probe.py
TOTAL 47 0 100%

# Full stream assembler regression file (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py
45 passed in 0.07s

# Final registered probe (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_token_bytes_probe.py
{"checksum": 3558750.0, "elapsed_ms_mean": 1655.7288544252515, "generated_token_count_mean": 80000.0, "peak_bytes_mean": 6128021.0, "sample_count": 5.0, "token_event_count": 80000.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 47 0 100%`.
- Registered local probe: old_mean=1937.1362584177405 ms, new_mean=1655.7288544252515 ms, delta_ms=-281.407403992489, speedup=14.526980369586573%.
- CI must run the PR-scoped performance workflow and validate the registered `stream-assembler-token-byte-fast-decode` probe on the PR head.

## Known Gaps
- Python-only slice locally verified on Linux; no Swift runtime effect is claimed.
- Local timings are synthetic token-byte assembly measurements; final merge requires green GitHub Actions and the registered probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
