### PR TITLE
Report model resident memory in evidence

### DIFF
--- a/docs/evidence-telemetry-report-contract.md
+++ b/docs/evidence-telemetry-report-contract.md
@@ -77,9 +77,24 @@ Required diagnostic fields:
 - `metrics`
 - `probe_timeline`
 - `telemetry_summary`
+- `model_memory_summary`
 - `artifacts`
 - `failure_summary`
 - `fallback_summary`
+
+`model_memory_summary` is the source of truth for model-level residency in
+benchmark and evaluation reports. It must distinguish:
+
+- `loaded_model_estimated_resident_bytes`: the selected loaded model handle's
+  resident estimate from worker registry accounting.
+- `runtime_stats_model_resident_bytes`: the worker registry's total
+  model-resident bytes for currently loaded models.
+- `load_rss_delta_bytes`: the current worker process RSS increase observed only
+  when the run itself lazily loaded a model.
+
+Apple Silicon host memory, process telemetry peaks, and benchmark
+`peak_memory_bytes` remain separate telemetry or runtime-probe signals and must
+not be presented as model-weight residency.
 
 ## Probe Timeline
 

--- a/docs/plans/2026-05-11-model-memory-reporting.md
+++ b/docs/plans/2026-05-11-model-memory-reporting.md
@@ -1,0 +1,49 @@
+# Model Memory Reporting In Benchmark And Evaluation Evidence
+
+## Summary
+
+Benchmark and evaluation reports must expose the model memory residency that
+Melix already tracks when a model is loaded into the worker registry. The report
+must not reuse process telemetry, host memory telemetry, or benchmark
+`peak_memory_bytes` as if those fields were model-weight residency.
+
+## Behavior
+
+- `run-evidence.json` records a top-level `model_memory_summary` object for
+  benchmark and evaluation runs.
+- `model_memory_summary` includes the loaded model handle, model id, runtime
+  kind, and the registry-reported model residency after the run resolves its
+  model.
+- `model_memory_summary.loaded_model_estimated_resident_bytes` records the
+  selected loaded model handle's resident estimate.
+- `model_memory_summary.runtime_stats_model_resident_bytes` records
+  `WorkerRegistry.runtime_stats().model_resident_bytes`, which is the total
+  model-resident accounting for loaded models in that worker.
+- `model_memory_summary.load_rss_delta_bytes` records the current worker
+  process RSS increase only when the run itself triggered a lazy model load.
+  Preloaded-handle runs leave this value absent or zero and rely on the registry
+  model-resident fields.
+- Derived comparison reports render model memory summaries in Markdown and CSV.
+
+## Measurement Notes
+
+Registry resident bytes are Melix's model-level accounting source of truth. The
+worker RSS delta is a diagnostic approximation for the process impact of a lazy
+load, and can include allocator, runtime, and framework overhead. Host
+`memory_used_bytes`, process telemetry peaks, and benchmark `peak_memory_bytes`
+remain separate telemetry and runtime-probe signals.
+
+## Verification
+
+- Python unit tests prove benchmark/evaluation run evidence round-trips
+  `model_memory_summary`.
+- Python unit tests prove benchmark and evaluation stores persist the summary.
+- Python unit tests prove comparison reports include model memory rows in
+  Markdown and CSV exports.
+- `make py-test` or a focused pytest subset covering the changed modules.
+
+## Metrics
+
+- Coverage: changed Python modules remain covered by focused unit tests.
+- Performance: memory summary collection is O(1) against
+  `WorkerRegistry.runtime_stats()` and does not scan loaded model collections.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -197,6 +197,23 @@ def _run_evidence(
             "external_provider_processes": [],
             "process_tree_summary": {"roles": ["primary_runtime", "control_plane", "worker"]},
         }
+    model_memory_summary = {
+        "runtime_model_handle": f"{run_id}-model::1",
+        "runtime_model_id": "mlx-community/test-model",
+        "runtime_kind": "text",
+        "runtime_name": "mlx-text",
+        "loaded_model_estimated_resident_bytes": 4096,
+        "runtime_stats_model_resident_bytes": 4096,
+        "runtime_stats_resident_bytes": 5120,
+        "runtime_stats_cache_resident_bytes": 1024,
+        "runtime_stats_kv_cache_bytes": 0,
+        "runtime_stats_memory_headroom_bytes": 0,
+        "load_triggered_by_run": True,
+        "load_rss_before_bytes": 10000,
+        "load_rss_after_bytes": 15000,
+        "load_rss_delta_bytes": 5000,
+        "measurement_scope": "worker_registry",
+    }
     return {
         "schema_version": "melix.run_evidence.v1",
         "run_id": run_id,
@@ -228,6 +245,7 @@ def _run_evidence(
         "metrics": [{"name": "decode_ms", "value": decode_ms, "unit": "ms"}],
         "probe_timeline": probes,
         "telemetry_summary": telemetry_summary,
+        "model_memory_summary": model_memory_summary,
         "artifacts": [{"kind": "probe_timeline", "path": "probes.jsonl", "role": "diagnostic"}],
         "failure_summary": {"failed": status == "failed"},
         "fallback_summary": {"fallback_count": fallback_count},
@@ -1243,6 +1261,9 @@ def test_report_builder_adds_contract_sections_from_run_evidence() -> None:
     assert report["runs"][0]["trace_id"] == "base-run:trace"
     assert report["targets"][0]["target_model_id"] == "mlx-community/test-model"
     assert report["telemetry_summary"]["candidate"][0]["collector_status"] == "partial"
+    assert report["model_memory_summary"]["candidate"][0]["runtime_model_handle"] == "head-run-model::1"
+    assert report["model_memory_summary"]["candidate"][0]["runtime_stats_model_resident_bytes"] == 4096
+    assert report["model_memory_summary"]["candidate"][0]["load_rss_delta_bytes"] == 5000
     assert report["process_attribution"]["candidate"][0]["primary_runtime_process"]["pid"] == 101
     assert report["comparison"]["comparison_validity"] == "valid"
     assert report["gate_result"]["overall_result"] == "fail"
@@ -1258,7 +1279,45 @@ def test_report_builder_adds_contract_sections_from_run_evidence() -> None:
     assert "## Report Identity" in markdown
     assert "## Gate Summary" in markdown
     assert "## Telemetry Summary" in markdown
+    assert "## Model Memory Summary" in markdown
+    assert "Registry Model Resident" in markdown
     assert "powermetrics_failed:fixture" in markdown
+
+
+def test_model_memory_report_helpers_ignore_missing_or_nonnumeric_values() -> None:
+    assert benchmark_evaluation_report._model_memory_csv_rows({}) == []
+    assert benchmark_evaluation_report._render_model_memory_summary_markdown([]) == []
+
+    report = build_benchmark_evaluation_report(
+        baseline={
+            "run_evidence": [
+                {
+                    **_run_evidence(
+                        run_id="base-run",
+                        run_kind="serving_benchmark",
+                        decode_ms=10.0,
+                        status="completed",
+                    ),
+                    "model_memory_summary": {"runtime_model_handle": "base::1", "bad": "not-a-number"},
+                }
+            ]
+        },
+        candidate={
+            "run_evidence": [
+                {
+                    **_run_evidence(
+                        run_id="head-run",
+                        run_kind="serving_benchmark",
+                        decode_ms=10.0,
+                        status="completed",
+                    ),
+                    "model_memory_summary": {"runtime_model_handle": "head::1", "bad": "not-a-number"},
+                }
+            ]
+        },
+    )
+
+    assert all("model_memory.serving_benchmark.bad_mean" != row["metric"] for row in report["metrics"])
 
 
 def test_report_verifier_rejects_missing_required_sections() -> None:
@@ -1893,6 +1952,10 @@ def test_write_report_outputs_writes_json_and_markdown(tmp_path: Path) -> None:
     assert "average_system_power_w" in outputs["telemetry_summary_csv"].read_text(
         encoding="utf-8"
     )
+    assert "runtime_stats_model_resident_bytes" in outputs["model_memory_csv"].read_text(
+        encoding="utf-8"
+    )
+    assert "## Model Memory Summary" in outputs["markdown"].read_text(encoding="utf-8")
     assert "primary_runtime_process" in outputs["processes_csv"].read_text(encoding="utf-8")
     assert "overall_result" not in outputs["gate_results_csv"].read_text(encoding="utf-8")
     assert "telemetry" in outputs["comparison_deltas_csv"].read_text(encoding="utf-8")

--- a/services/mlx-worker-python/tests/test_benchmark_store.py
+++ b/services/mlx-worker-python/tests/test_benchmark_store.py
@@ -55,6 +55,19 @@ def test_persist_serving_benchmark_writes_expected_artifact_names_and_payloads(
         jobs_root=jobs_root,
         job=job,
         results=results,
+        model_memory_summary={
+            "runtime_model_handle": "melix-dev-text::1",
+            "runtime_model_id": "melix-dev-text",
+            "runtime_kind": "text",
+            "runtime_name": "fast-benchmark",
+            "loaded_model_estimated_resident_bytes": 4096,
+            "runtime_stats_model_resident_bytes": 4096,
+            "runtime_stats_resident_bytes": 4096,
+            "load_triggered_by_run": True,
+            "load_rss_before_bytes": 100_000_000,
+            "load_rss_after_bytes": 120_000_000,
+            "load_rss_delta_bytes": 20_000_000,
+        },
         context_rows=(
             {
                 "job_id": "bench-123",
@@ -100,6 +113,10 @@ def test_persist_serving_benchmark_writes_expected_artifact_names_and_payloads(
     assert evidence["telemetry_summary"]["time_series_path"] == "telemetry-samples.jsonl"
     assert evidence["telemetry_summary"]["average_system_power_w"] == 15.0
     assert evidence["telemetry_summary"]["process_attribution"]["primary_runtime_process"]["pid"] == 102
+    assert evidence["model_memory_summary"]["runtime_model_handle"] == "melix-dev-text::1"
+    assert evidence["model_memory_summary"]["loaded_model_estimated_resident_bytes"] == 4096
+    assert evidence["model_memory_summary"]["runtime_stats_model_resident_bytes"] == 4096
+    assert evidence["model_memory_summary"]["load_rss_delta_bytes"] == 20_000_000
     run_record = json.loads(persisted["run_record"].read_text(encoding="utf-8"))
     assert run_record["schema_version"] == "melix.run_record.v1"
     assert run_record["run_id"] == "bench-123"

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -740,6 +740,7 @@ def test_run_local_suite_executes_packaged_dataset_and_persists_result(tmp_path:
     assert run.result.failure_count == 0
     assert run.result.duration_seconds >= 0.0
     assert run.job.job_id == "eval-0001"
+    assert run.persisted_paths["evidence"] == jobs_root / "runs" / "eval-0001" / "run-evidence.json"
     assert run.persisted_paths["job"] == jobs_root / "runs" / "eval-0001" / "evaluation-job.json"
     assert run.persisted_paths["result"] == jobs_root / "runs" / "eval-0001" / "evaluation-result.json"
     assert run.persisted_paths["summary_json"] == jobs_root / "runs" / "eval-0001" / "evaluation-summary.json"
@@ -751,6 +752,10 @@ def test_run_local_suite_executes_packaged_dataset_and_persists_result(tmp_path:
         json.loads(run.persisted_paths["summary_json"].read_text(encoding="utf-8"))["primary_score_name"]
         == "typed_score_mean"
     )
+    evidence_payload = json.loads(run.persisted_paths["evidence"].read_text(encoding="utf-8"))
+    assert evidence_payload["model_memory_summary"]["runtime_model_handle"] == registry.handle
+    assert evidence_payload["model_memory_summary"]["runtime_model_id"] == "persisted-eval-model"
+    assert evidence_payload["model_memory_summary"]["runtime_stats_model_resident_bytes"] == 0
     assert (
         "job_id,task_kind,source_repo,model_id,suite_id,dataset_id,primary_score_name,"
         "primary_score_value,sample_size,extraction_success_count,validation_success_count,"
@@ -2316,6 +2321,24 @@ def test_evaluation_helpers_cover_timeout_fallback_and_digit_choice_resolution()
 
 def test_loaded_model_lookup_returns_none_without_handle_or_registry() -> None:
     assert EvaluationCore()._loaded_model_for_execution(None) is None
+
+
+def test_evaluation_model_memory_summary_uses_registry_runtime_stats() -> None:
+    backend = ScriptedEvaluationBackend(("A",))
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=backend),
+        model_catalog=WorkerModelCatalog(),
+    )
+    loaded = registry.load_model(WorkerModelCatalog.dev_text_model())
+    runner = EvaluationCore(registry=registry)
+
+    summary = runner._model_memory_summary(loaded_model=loaded)
+
+    assert summary["runtime_model_handle"] == loaded.handle
+    assert summary["runtime_model_id"] == "melix-dev-text"
+    assert summary["loaded_model_estimated_resident_bytes"] == 1024
+    assert summary["runtime_stats_model_resident_bytes"] == 1024
+    assert summary["load_triggered_by_run"] is False
 
 
 def test_release_runtime_memory_returns_when_mlx_is_unavailable(monkeypatch) -> None:

--- a/services/mlx-worker-python/tests/test_evaluation_store.py
+++ b/services/mlx-worker-python/tests/test_evaluation_store.py
@@ -176,6 +176,16 @@ def test_persist_result_writes_expected_artifact_names_and_payloads(tmp_path: Pa
         job=job,
         result=result,
         samples=(sample,),
+        model_memory_summary={
+            "runtime_model_handle": "melix-dev-text::1",
+            "runtime_model_id": "melix-dev-text",
+            "runtime_kind": "text",
+            "runtime_name": "deterministic-text",
+            "loaded_model_estimated_resident_bytes": 4096,
+            "runtime_stats_model_resident_bytes": 4096,
+            "runtime_stats_resident_bytes": 4096,
+            "load_triggered_by_run": False,
+        },
     )
 
     assert persisted["job"] == run_root / "evaluation-job.json"
@@ -205,6 +215,9 @@ def test_persist_result_writes_expected_artifact_names_and_payloads(tmp_path: Pa
     assert phases[-1] == "artifact_write"
     assert evidence["telemetry_summary"]["collector_status"] == "collected"
     assert evidence["telemetry_summary"]["average_cpu_power_w"] == 7.5
+    assert evidence["model_memory_summary"]["runtime_model_handle"] == "melix-dev-text::1"
+    assert evidence["model_memory_summary"]["runtime_stats_model_resident_bytes"] == 4096
+    assert evidence["model_memory_summary"]["load_triggered_by_run"] is False
     assert persisted["summary_csv"].read_text(encoding="utf-8").startswith(
         "job_id,task_kind,source_repo,model_id,suite_id,dataset_id,primary_score_name,primary_score_value,sample_size,extraction_success_count,validation_success_count,scored_sample_count,failure_count,duration_seconds,created_at_unix_ms\n"
     )

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -59,7 +59,12 @@ from worker.productization.benchmark_store import BenchmarkStore
 from worker.productization.benchmark_suites import BenchmarkSuiteCatalog
 from worker.model_registry.catalog import WorkerModelCatalog
 from worker.registry import WorkerRegistry
-from worker.engine.maintenance_core import BenchSample, ImageBenchSample, MaintenanceCore
+from worker.engine.maintenance_core import (
+    BenchSample,
+    BenchmarkLoadedModelResolution,
+    ImageBenchSample,
+    MaintenanceCore,
+)
 from worker.engine import maintenance_core as maintenance_core_module
 from worker.runtime.deterministic_backend import DeterministicTextBackend
 from worker.runtime.mlx_vlm_runtime import AutoMLXVLMBackend, MLXVLMRuntime
@@ -4615,10 +4620,17 @@ def test_run_bench_measures_runtime_behavior_from_loaded_backend(tmp_path: Path)
     assert phases[-1] == "artifact_write"
     assert evidence["telemetry_summary"]["collector_status"] == "collected"
     assert evidence["telemetry_summary"]["time_series_path"] == "telemetry-samples.jsonl"
+    assert evidence["model_memory_summary"]["runtime_model_handle"] == loaded.handle
+    assert evidence["model_memory_summary"]["loaded_model_estimated_resident_bytes"] == loaded.estimated_resident_bytes
+    assert evidence["model_memory_summary"]["runtime_stats_model_resident_bytes"] == loaded.estimated_resident_bytes
+    assert evidence["model_memory_summary"]["load_triggered_by_run"] is False
     assert summary["parameters"]["runtime_live_model"] == "true"
     assert summary["parameters"]["runtime_name"] == "fast-benchmark"
     assert summary["parameters"]["runtime_model_handle"] == loaded.handle
     assert "runtime_name: fast-benchmark" in report
+    assert "## Model Memory" in report
+    assert f"runtime_model_handle: {loaded.handle}" in report
+    assert "runtime_stats_model_resident_bytes: 1024" in report
 
 
 def test_run_bench_persists_report_without_reading_report_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -5040,6 +5052,73 @@ def test_resolve_benchmark_loaded_model_reuses_existing_handle(tmp_path: Path) -
 
     assert lazy_handle == ""
     assert resolved.handle == loaded.handle
+
+
+def test_current_process_rss_bytes_uses_resource_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "read_text", lambda *args, **kwargs: (_ for _ in ()).throw(OSError("missing proc")))
+    monkeypatch.setattr(
+        maintenance_core_module.subprocess,
+        "check_output",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("ps unavailable")),
+    )
+    monkeypatch.setattr(maintenance_core_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        maintenance_core_module.resource,
+        "getrusage",
+        lambda _kind: SimpleNamespace(ru_maxrss=1234),
+    )
+
+    assert MaintenanceCore._current_process_rss_bytes() == 1234
+
+
+def test_current_process_rss_bytes_returns_zero_when_fallback_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "read_text", lambda *args, **kwargs: (_ for _ in ()).throw(OSError("missing proc")))
+    monkeypatch.setattr(
+        maintenance_core_module.subprocess,
+        "check_output",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("ps unavailable")),
+    )
+    monkeypatch.setattr(
+        maintenance_core_module.resource,
+        "getrusage",
+        lambda _kind: (_ for _ in ()).throw(RuntimeError("resource unavailable")),
+    )
+
+    assert MaintenanceCore._current_process_rss_bytes() == 0
+
+
+def test_run_bench_records_lazy_model_load_memory_summary(tmp_path: Path) -> None:
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=FastBenchmarkBackend()),
+        model_catalog=WorkerModelCatalog(),
+    )
+    service = build_service(tmp_path, registry=registry)
+
+    events = list(
+        service.RunBench(
+            maintenance_pb2.RunBenchRequest(
+                model_handle="melix-dev-text",
+                suites=["smoke"],
+            ),
+            context=None,
+        )
+    )
+
+    evidence_path = Path(events[-1].completed.evidence_path)
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    memory = evidence["model_memory_summary"]
+
+    assert memory["runtime_model_handle"].startswith("melix-dev-text::")
+    assert memory["runtime_model_id"] == "melix-dev-text"
+    assert memory["loaded_model_estimated_resident_bytes"] > 0
+    assert memory["runtime_stats_model_resident_bytes"] >= memory["loaded_model_estimated_resident_bytes"]
+    assert memory["load_triggered_by_run"] is True
+    assert memory["load_rss_after_bytes"] >= 0
+    assert memory["load_rss_delta_bytes"] >= 0
 
 
 def test_resolve_benchmark_loaded_model_raises_typed_error_for_unknown_model(tmp_path: Path) -> None:
@@ -7326,7 +7405,12 @@ def test_bench_events_rejects_unsupported_task_family_after_suite_resolution(tmp
         runtime_model={},
     )
     fake_suite = SimpleNamespace(suite_id="smoke", metadata=lambda: {}, cases=())
-    core._resolve_benchmark_loaded_model = lambda model_handle: ("", fake_loaded_model)  # type: ignore[method-assign]
+    core._resolve_benchmark_loaded_model = lambda model_handle: BenchmarkLoadedModelResolution(  # type: ignore[method-assign]
+        lazy_model_handle="",
+        loaded_model=fake_loaded_model,
+        load_rss_before_bytes=0,
+        load_rss_after_bytes=0,
+    )
     core._benchmark_suite_catalog.resolve_suite = lambda *args, **kwargs: fake_suite  # type: ignore[method-assign]
 
     with pytest.raises(ModelOperationError) as error:

--- a/services/mlx-worker-python/tests/test_mlx_backend.py
+++ b/services/mlx-worker-python/tests/test_mlx_backend.py
@@ -1023,14 +1023,19 @@ def test_auto_backend_surfaces_import_failure_during_lazy_runtime_resolution(mon
     assert backend.runtime_name == "mlx-unavailable"
 
 
-def test_auto_backend_reports_zero_resident_bytes_estimate() -> None:
+def test_auto_backend_estimates_resident_bytes_from_model_weights(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "model.safetensors").write_bytes(b"weights")
     backend = AutoMLXBackend(
         load_fn=lambda model_source, **kwargs: (object(), FakeTokenizer()),
         stream_generate_fn=lambda *args, **kwargs: iter(()),
         sampler_factory=lambda **kwargs: "sampler",
     )
+    model_spec = WorkerModelCatalog.dev_text_model()
+    model_spec.model_path = str(model_dir)
 
-    assert backend.estimate_resident_bytes(WorkerModelCatalog.dev_text_model()) == 0
+    assert backend.estimate_resident_bytes(model_spec) == len(b"weights")
 
 
 def test_runtime_name_falls_back_when_backend_has_no_runtime_name() -> None:

--- a/services/mlx-worker-python/tests/test_run_evidence.py
+++ b/services/mlx-worker-python/tests/test_run_evidence.py
@@ -8,6 +8,7 @@ from worker.productization.run_evidence import (
     RUN_EVIDENCE_SCHEMA_VERSION,
     RunEvidenceArtifact,
     RunEvidenceEnvelope,
+    RunEvidenceModelMemorySummary,
     RunEvidenceMetric,
     RunEvidenceProbe,
     RunEvidenceValidationError,
@@ -37,6 +38,8 @@ def test_run_evidence_roundtrips_completed_failed_cancelled_and_fallback_runs() 
         assert payload["telemetry_summary"]["telemetry_failures"] == [
             "apple_silicon_telemetry_collection_missing"
         ]
+        assert payload["model_memory_summary"]["runtime_model_handle"] == "melix-dev-text::1"
+        assert payload["model_memory_summary"]["runtime_stats_model_resident_bytes"] == 8192
         if status == "fallback":
             assert payload["fallback_summary"]["fallback_count"] == 1
 
@@ -67,6 +70,7 @@ def test_run_evidence_validator_rejects_malformed_required_values() -> None:
             "metrics": {},
             "probe_timeline": [],
             "telemetry_summary": [],
+            "model_memory_summary": [],
             "artifacts": [],
             "failure_summary": [],
             "fallback_summary": [],
@@ -83,6 +87,7 @@ def test_run_evidence_validator_rejects_malformed_required_values() -> None:
     assert "metrics must be a list" in errors
     assert "probe_timeline must be a non-empty list" in errors
     assert "telemetry_summary must be an object" in errors
+    assert "model_memory_summary must be an object" in errors
     assert "artifacts must be a non-empty list" in errors
     assert "failure_summary must be an object" in errors
     assert "fallback_summary must be an object" in errors
@@ -421,6 +426,19 @@ def _evidence(*, status: str) -> RunEvidenceEnvelope:
             ),
         ),
         telemetry_summary=default_telemetry_summary(),
+        model_memory_summary=RunEvidenceModelMemorySummary(
+            runtime_model_handle="melix-dev-text::1",
+            runtime_model_id="melix-dev-text",
+            runtime_kind="text",
+            runtime_name="deterministic-text",
+            loaded_model_estimated_resident_bytes=4096,
+            runtime_stats_resident_bytes=8192,
+            runtime_stats_model_resident_bytes=8192,
+            load_triggered_by_run=True,
+            load_rss_before_bytes=1000,
+            load_rss_after_bytes=5000,
+            load_rss_delta_bytes=4000,
+        ),
         artifacts=(
             RunEvidenceArtifact(
                 kind="result",

--- a/services/mlx-worker-python/tests/test_runtime_utils.py
+++ b/services/mlx-worker-python/tests/test_runtime_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import inspect
+import json
 from typing import Any
 
 import pytest
@@ -224,3 +225,102 @@ def test_installed_package_version_caches_missing_lookups(monkeypatch: pytest.Mo
     assert version_calls == 1
 
     runtime_utils.clear_installed_package_version_cache()
+
+
+def test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards(tmp_path) -> None:
+    bundle = tmp_path / "indexed-model"
+    bundle.mkdir()
+    shard_a = bundle / "model-00001-of-00002.safetensors"
+    shard_b = bundle / "model-00002-of-00002.safetensors"
+    shard_a.write_bytes(b"a" * 7)
+    shard_b.write_bytes(b"b" * 11)
+    (bundle / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "layers.0.weight": shard_a.name,
+                    "layers.empty.weight": "",
+                    "layers.1.weight": shard_b.name,
+                    "layers.2.weight": shard_a.name,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (bundle / "tokenizer.json").write_text("{}", encoding="utf-8")
+
+    assert runtime_utils.estimate_model_weight_resident_bytes(str(bundle)) == 18
+
+
+def test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights(tmp_path) -> None:
+    bundle = tmp_path / "flat-model"
+    bundle.mkdir()
+    (bundle / "model.safetensors.index.json").write_text("{not-json", encoding="utf-8")
+    (bundle / "model.safetensors").write_bytes(b"weights")
+    (bundle / "adapter.npz").write_bytes(b"adapter")
+    (bundle / "README.md").write_text("ignore", encoding="utf-8")
+    nested = bundle / "nested"
+    nested.mkdir()
+    (nested / "ignored.safetensors").write_bytes(b"ignored")
+
+    assert runtime_utils.estimate_model_weight_resident_bytes(str(bundle)) == len(b"weightsadapter")
+
+
+def test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert runtime_utils.estimate_model_weight_resident_bytes("") == 0
+    missing_weight_map = tmp_path / "missing-weight-map"
+    missing_weight_map.mkdir()
+    (missing_weight_map / "model.safetensors.index.json").write_text("{}", encoding="utf-8")
+    assert runtime_utils.estimate_model_weight_resident_bytes(str(missing_weight_map)) == 0
+
+    original_is_file = runtime_utils.Path.is_file
+    original_is_dir = runtime_utils.Path.is_dir
+    original_iterdir = runtime_utils.Path.iterdir
+    unreadable_path = tmp_path / "unreadable"
+    unreadable_path.mkdir()
+
+    def fake_is_file(path):
+        if path == unreadable_path:
+            raise OSError("no file check")
+        return original_is_file(path)
+
+    def fake_is_dir(path):
+        if path == missing_weight_map:
+            return True
+        return original_is_dir(path)
+
+    def fake_iterdir(path):
+        if path == missing_weight_map:
+            raise OSError("no list")
+        return original_iterdir(path)
+
+    monkeypatch.setattr(runtime_utils.Path, "is_file", fake_is_file)
+    monkeypatch.setattr(runtime_utils.Path, "is_dir", fake_is_dir)
+    monkeypatch.setattr(runtime_utils.Path, "iterdir", fake_iterdir)
+
+    assert runtime_utils.estimate_model_weight_resident_bytes(str(unreadable_path)) == 0
+    assert runtime_utils.estimate_model_weight_resident_bytes(str(missing_weight_map)) == 0
+
+
+def test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    weight_file = tmp_path / "model.safetensors"
+    weight_file.write_bytes(b"abc")
+    assert runtime_utils.estimate_model_weight_resident_bytes(str(weight_file)) == 3
+    assert runtime_utils.estimate_model_weight_resident_bytes(str(tmp_path / "missing")) == 0
+
+    original_stat = runtime_utils.Path.stat
+
+    def fake_stat(path):
+        if path == weight_file:
+            raise OSError("no stat")
+        return original_stat(path)
+
+    monkeypatch.setattr(runtime_utils.Path, "stat", fake_stat)
+
+    assert runtime_utils.estimate_model_weight_resident_bytes(str(weight_file)) == 0

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -648,6 +648,7 @@ class EvaluationCore:
                 result=result,
                 samples=sample_records,
                 telemetry_collection=telemetry_collection,
+                model_memory_summary=self._model_memory_summary(loaded_model=loaded_model),
             )
             self._queue_store.transition(
                 queue_root=queue_root,
@@ -1088,6 +1089,7 @@ class EvaluationCore:
                 job=job,
                 result=result,
                 samples=(),
+                model_memory_summary=self._model_memory_summary(loaded_model=loaded_model),
             )
             self._queue_store.transition(
                 queue_root=queue_root,
@@ -1899,6 +1901,33 @@ class EvaluationCore:
         if not model_handle or self._registry is None:
             return None
         return self._registry.get_loaded_model(model_handle)
+
+    def _model_memory_summary(self, *, loaded_model) -> dict[str, object]:
+        if loaded_model is None or self._registry is None:
+            return {}
+        runtime_stats = getattr(self._registry, "runtime_stats", None)
+        stats = runtime_stats() if callable(runtime_stats) else None
+        runtime = getattr(loaded_model, "runtime", None)
+        spec = getattr(loaded_model, "spec", None)
+        return {
+            "runtime_model_handle": str(getattr(loaded_model, "handle", "") or ""),
+            "runtime_model_id": str(getattr(spec, "model_id", "") or ""),
+            "runtime_kind": str(getattr(loaded_model, "runtime_kind", "") or ""),
+            "runtime_name": str(getattr(runtime, "runtime_name", "") or ""),
+            "loaded_model_estimated_resident_bytes": int(
+                getattr(loaded_model, "estimated_resident_bytes", 0) or 0
+            ),
+            "runtime_stats_resident_bytes": int(getattr(stats, "resident_bytes", 0) or 0),
+            "runtime_stats_model_resident_bytes": int(getattr(stats, "model_resident_bytes", 0) or 0),
+            "runtime_stats_cache_resident_bytes": int(getattr(stats, "cache_resident_bytes", 0) or 0),
+            "runtime_stats_kv_cache_bytes": int(getattr(stats, "kv_cache_bytes", 0) or 0),
+            "runtime_stats_memory_headroom_bytes": int(getattr(stats, "memory_headroom_bytes", 0) or 0),
+            "load_triggered_by_run": False,
+            "load_rss_before_bytes": 0,
+            "load_rss_after_bytes": 0,
+            "load_rss_delta_bytes": 0,
+            "measurement_scope": "worker_registry",
+        }
 
     @staticmethod
     def _truthy_parameter(parameters: dict[str, str], key: str) -> bool:

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -8,7 +8,10 @@ import logging
 import math
 import os
 from pathlib import Path
+import resource
 import shutil
+import subprocess
+import sys
 from threading import Event
 import time
 from typing import Any, Iterator, NoReturn
@@ -119,6 +122,22 @@ class ModelOperationManifestResult:
     manifest: dict[str, Any]
     manifest_path: Path
     output_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class BenchmarkLoadedModelResolution:
+    lazy_model_handle: str
+    loaded_model: Any
+    load_rss_before_bytes: int
+    load_rss_after_bytes: int
+
+    @property
+    def load_triggered_by_run(self) -> bool:
+        return bool(self.lazy_model_handle)
+
+    def __iter__(self):
+        yield self.lazy_model_handle
+        yield self.loaded_model
 
 
 def _split_capability_values(raw_value: str) -> list[str]:
@@ -1214,7 +1233,9 @@ class MaintenanceCore:
             self._benchmark_store = BenchmarkStore()
         telemetry_session = self._benchmark_store.start_telemetry_session(run_id=job.job_id)
         try:
-            lazy_model_handle, loaded_model = self._resolve_benchmark_loaded_model(request.model_handle)
+            resolved_model = self._resolve_benchmark_loaded_model(request.model_handle)
+            lazy_model_handle = resolved_model.lazy_model_handle
+            loaded_model = resolved_model.loaded_model
             runtime_evidence = self._runtime_evidence_for_loaded_model(loaded_model)
             parameters.update(runtime_evidence)
             if self._truthy_parameter(parameters, "require_live_model"):
@@ -1318,6 +1339,12 @@ class MaintenanceCore:
                 metrics,
                 task_kind=task_kind,
                 parameters=parameters,
+                model_memory_summary=self._model_memory_summary(
+                    loaded_model=loaded_model,
+                    load_triggered_by_run=resolved_model.load_triggered_by_run,
+                    load_rss_before_bytes=resolved_model.load_rss_before_bytes,
+                    load_rss_after_bytes=resolved_model.load_rss_after_bytes,
+                ),
             )
             report_path.write_text(report_markdown, encoding="utf-8")
             job_record = build_serving_benchmark_job(
@@ -1363,6 +1390,12 @@ class MaintenanceCore:
                 context_rows=text_context_rows,
                 batch_rows=text_batch_rows,
                 telemetry_collection=telemetry_collection,
+                model_memory_summary=self._model_memory_summary(
+                    loaded_model=loaded_model,
+                    load_triggered_by_run=resolved_model.load_triggered_by_run,
+                    load_rss_before_bytes=resolved_model.load_rss_before_bytes,
+                    load_rss_after_bytes=resolved_model.load_rss_after_bytes,
+                ),
             )
             (output_dir / "bench-summary.json").write_text(
                 json.dumps(job_record.to_dict(), indent=2) + "\n",
@@ -1461,7 +1494,9 @@ class MaintenanceCore:
         lazy_model_handle = ""
         loaded_model = None
         try:
-            lazy_model_handle, loaded_model = self._resolve_benchmark_loaded_model(request.model_handle)
+            resolved_model = self._resolve_benchmark_loaded_model(request.model_handle)
+            lazy_model_handle = resolved_model.lazy_model_handle
+            loaded_model = resolved_model.loaded_model
             runtime_evidence = self._runtime_evidence_for_loaded_model(loaded_model)
             matrix_parameters = {**queue_parameters, **runtime_evidence}
             task_kind = self._resolved_benchmark_matrix_task_kind(
@@ -2218,11 +2253,17 @@ class MaintenanceCore:
             ),
         ]
 
-    def _resolve_benchmark_loaded_model(self, model_handle: str):
+    def _resolve_benchmark_loaded_model(self, model_handle: str) -> BenchmarkLoadedModelResolution:
         if model_handle:
             loaded_model = self._registry.get_loaded_model(model_handle)
             if loaded_model is not None:
-                return "", loaded_model
+                rss_bytes = self._current_process_rss_bytes()
+                return BenchmarkLoadedModelResolution(
+                    lazy_model_handle="",
+                    loaded_model=loaded_model,
+                    load_rss_before_bytes=rss_bytes,
+                    load_rss_after_bytes=rss_bytes,
+                )
 
         model_id = model_handle.split("::", 1)[0] if model_handle else "melix-dev-text"
         model_spec = self._registry.model_catalog.get(model_id)
@@ -2232,8 +2273,80 @@ class MaintenanceCore:
                 message="Unknown benchmark model.",
                 details={"model_id": model_id},
             )
+        load_rss_before_bytes = self._current_process_rss_bytes()
         loaded_model = self._registry.load_model(model_spec)
-        return loaded_model.handle, loaded_model
+        load_rss_after_bytes = self._current_process_rss_bytes()
+        return BenchmarkLoadedModelResolution(
+            lazy_model_handle=loaded_model.handle,
+            loaded_model=loaded_model,
+            load_rss_before_bytes=load_rss_before_bytes,
+            load_rss_after_bytes=load_rss_after_bytes,
+        )
+
+    @staticmethod
+    def _current_process_rss_bytes() -> int:
+        statm_path = Path(f"/proc/{os.getpid()}/statm")
+        try:
+            parts = statm_path.read_text(encoding="ascii").split()
+            if len(parts) >= 2:
+                resident_pages = int(parts[1])
+                page_size = int(os.sysconf("SC_PAGE_SIZE"))
+                return max(resident_pages * page_size, 0)
+        except (OSError, ValueError):
+            pass
+        try:
+            output = subprocess.check_output(
+                ["ps", "-o", "rss=", "-p", str(os.getpid())],
+                text=True,
+                timeout=1.0,
+            )
+            rss_kib = int(output.strip().splitlines()[-1])
+            return max(rss_kib * 1024, 0)
+        except (OSError, subprocess.SubprocessError, ValueError, IndexError):
+            pass
+        try:
+            rss = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+        except Exception:
+            return 0
+        if rss <= 0:
+            return 0
+        if sys.platform == "darwin":
+            return rss
+        return rss * 1024
+
+    def _model_memory_summary(
+        self,
+        *,
+        loaded_model,
+        load_triggered_by_run: bool = False,
+        load_rss_before_bytes: int = 0,
+        load_rss_after_bytes: int = 0,
+    ) -> dict[str, object]:
+        stats = self._registry.runtime_stats()
+        runtime = getattr(loaded_model, "runtime", None)
+        spec = getattr(loaded_model, "spec", None)
+        return {
+            "runtime_model_handle": str(getattr(loaded_model, "handle", "") or ""),
+            "runtime_model_id": str(getattr(spec, "model_id", "") or ""),
+            "runtime_kind": str(getattr(loaded_model, "runtime_kind", "") or ""),
+            "runtime_name": str(getattr(runtime, "runtime_name", "") or ""),
+            "loaded_model_estimated_resident_bytes": int(
+                getattr(loaded_model, "estimated_resident_bytes", 0) or 0
+            ),
+            "runtime_stats_resident_bytes": int(getattr(stats, "resident_bytes", 0) or 0),
+            "runtime_stats_model_resident_bytes": int(getattr(stats, "model_resident_bytes", 0) or 0),
+            "runtime_stats_cache_resident_bytes": int(getattr(stats, "cache_resident_bytes", 0) or 0),
+            "runtime_stats_kv_cache_bytes": int(getattr(stats, "kv_cache_bytes", 0) or 0),
+            "runtime_stats_memory_headroom_bytes": int(getattr(stats, "memory_headroom_bytes", 0) or 0),
+            "load_triggered_by_run": bool(load_triggered_by_run),
+            "load_rss_before_bytes": max(int(load_rss_before_bytes or 0), 0),
+            "load_rss_after_bytes": max(int(load_rss_after_bytes or 0), 0),
+            "load_rss_delta_bytes": max(
+                int(load_rss_after_bytes or 0) - int(load_rss_before_bytes or 0),
+                0,
+            ) if load_triggered_by_run else 0,
+            "measurement_scope": "worker_registry",
+        }
 
     @staticmethod
     def _truthy_parameter(parameters: dict[str, str], key: str) -> bool:
@@ -3810,8 +3923,10 @@ class MaintenanceCore:
         *,
         task_kind: str,
         parameters: dict[str, str] | None = None,
+        model_memory_summary: dict[str, object] | None = None,
     ) -> str:
         parameters = parameters or {}
+        model_memory_summary = model_memory_summary or {}
         lines = [
             "# Melix Bench",
             "",
@@ -3824,6 +3939,19 @@ class MaintenanceCore:
             f"- runtime_live_model: {parameters.get('runtime_live_model', '')}",
             "",
         ]
+        if model_memory_summary:
+            lines.extend(
+                [
+                    "## Model Memory",
+                    "",
+                    f"- runtime_model_handle: {model_memory_summary.get('runtime_model_handle', '')}",
+                    f"- loaded_model_estimated_resident_bytes: {model_memory_summary.get('loaded_model_estimated_resident_bytes', 0)}",
+                    f"- runtime_stats_model_resident_bytes: {model_memory_summary.get('runtime_stats_model_resident_bytes', 0)}",
+                    f"- load_triggered_by_run: {model_memory_summary.get('load_triggered_by_run', False)}",
+                    f"- load_rss_delta_bytes: {model_memory_summary.get('load_rss_delta_bytes', 0)}",
+                    "",
+                ]
+            )
         for metric in metrics:
             lines.append(f"- {metric.name}: {metric.value:.2f} {metric.unit}")
         return "\n".join(lines) + "\n"

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -1998,7 +1998,7 @@ def _collect_run_evidence_model_memory_metrics(metrics: dict[str, object], rows:
             )
     for (run_kind, key), aggregate in aggregates_by_key.items():
         total, count = aggregate
-        metrics[f"model_memory.{run_kind}.{key}_mean"] = total / count
+        metrics[f"model_memory.{run_kind}.{key}_mean"] = total / count if count > 0 else 0.0
 
 
 def _update_numeric_aggregate(

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -229,6 +229,7 @@ _CSV_EXPORT_NAMES = (
     "metrics",
     "probe_phases",
     "telemetry_summary",
+    "model_memory",
     "processes",
     "gate_results",
     "comparison_deltas",
@@ -325,6 +326,10 @@ def build_benchmark_evaluation_report(
         "baseline": _telemetry_summaries("baseline", baseline_evidence),
         "candidate": _telemetry_summaries("candidate", candidate_evidence),
     }
+    model_memory_summary = {
+        "baseline": _model_memory_summaries("baseline", baseline_evidence),
+        "candidate": _model_memory_summaries("candidate", candidate_evidence),
+    }
     process_attribution = {
         "baseline": _process_attribution_summaries("baseline", baseline_evidence),
         "candidate": _process_attribution_summaries("candidate", candidate_evidence),
@@ -376,6 +381,7 @@ def build_benchmark_evaluation_report(
         "probe_summary": probe_summary,
         "probe_timeline_summary": probe_summary,
         "telemetry_summary": telemetry_summary,
+        "model_memory_summary": model_memory_summary,
         "process_attribution": process_attribution,
         "comparison": comparison,
         "reproducibility_warnings": reproducibility_warnings,
@@ -441,6 +447,7 @@ def render_markdown_report(report: dict[str, object]) -> str:
     lines.extend(_render_run_summary_markdown(report.get("runs")))
     lines.extend(_render_gate_summary_markdown(report.get("gate_result")))
     lines.extend(_render_telemetry_summary_markdown(report.get("telemetry_summary")))
+    lines.extend(_render_model_memory_summary_markdown(report.get("model_memory_summary")))
     lines.extend(
         [
             "## Result Metrics",
@@ -743,6 +750,44 @@ def _telemetry_summaries(side: str, evidence_rows: list[dict[str, object]]) -> l
         process_attribution = telemetry.get("process_attribution")
         if isinstance(process_attribution, dict):
             summary["process_attribution"] = dict(process_attribution)
+        summaries.append(summary)
+    return summaries
+
+
+def _model_memory_summaries(side: str, evidence_rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    summaries: list[dict[str, object]] = []
+    for evidence in evidence_rows:
+        memory = evidence.get("model_memory_summary")
+        if not isinstance(memory, dict):
+            continue
+        summary = {
+            "side": side,
+            "run_id": str(evidence.get("run_id") or ""),
+            "run_kind": str(evidence.get("run_kind") or ""),
+            "runtime_model_handle": str(memory.get("runtime_model_handle") or ""),
+            "runtime_model_id": str(memory.get("runtime_model_id") or ""),
+            "runtime_kind": str(memory.get("runtime_kind") or ""),
+            "runtime_name": str(memory.get("runtime_name") or ""),
+            "loaded_model_estimated_resident_bytes": _int_or_none(
+                memory.get("loaded_model_estimated_resident_bytes")
+            ) or 0,
+            "runtime_stats_model_resident_bytes": _int_or_none(
+                memory.get("runtime_stats_model_resident_bytes")
+            ) or 0,
+            "runtime_stats_resident_bytes": _int_or_none(memory.get("runtime_stats_resident_bytes")) or 0,
+            "runtime_stats_cache_resident_bytes": _int_or_none(
+                memory.get("runtime_stats_cache_resident_bytes")
+            ) or 0,
+            "runtime_stats_kv_cache_bytes": _int_or_none(memory.get("runtime_stats_kv_cache_bytes")) or 0,
+            "runtime_stats_memory_headroom_bytes": _int_or_none(
+                memory.get("runtime_stats_memory_headroom_bytes")
+            ) or 0,
+            "load_triggered_by_run": bool(memory.get("load_triggered_by_run")),
+            "load_rss_delta_bytes": _int_or_none(memory.get("load_rss_delta_bytes")) or 0,
+            "load_rss_before_bytes": _int_or_none(memory.get("load_rss_before_bytes")) or 0,
+            "load_rss_after_bytes": _int_or_none(memory.get("load_rss_after_bytes")) or 0,
+            "measurement_scope": str(memory.get("measurement_scope") or "worker_registry"),
+        }
         summaries.append(summary)
     return summaries
 
@@ -1174,6 +1219,30 @@ def _write_report_csv_outputs(report: dict[str, object], csv_paths: dict[str, Pa
         ),
     )
     _write_csv(
+        csv_paths["model_memory"],
+        _model_memory_csv_rows(report),
+        (
+            "side",
+            "run_id",
+            "run_kind",
+            "runtime_model_handle",
+            "runtime_model_id",
+            "runtime_kind",
+            "runtime_name",
+            "loaded_model_estimated_resident_bytes",
+            "runtime_stats_model_resident_bytes",
+            "runtime_stats_resident_bytes",
+            "runtime_stats_cache_resident_bytes",
+            "runtime_stats_kv_cache_bytes",
+            "runtime_stats_memory_headroom_bytes",
+            "load_triggered_by_run",
+            "load_rss_delta_bytes",
+            "load_rss_before_bytes",
+            "load_rss_after_bytes",
+            "measurement_scope",
+        ),
+    )
+    _write_csv(
         csv_paths["processes"],
         _process_csv_rows(report),
         (
@@ -1300,6 +1369,16 @@ def _telemetry_csv_rows(report: dict[str, object]) -> list[dict[str, object]]:
     rows: list[dict[str, object]] = []
     for side in ("baseline", "candidate"):
         rows.extend(_dict_list(telemetry_summary.get(side)))
+    return rows
+
+
+def _model_memory_csv_rows(report: dict[str, object]) -> list[dict[str, object]]:
+    model_memory_summary = report.get("model_memory_summary")
+    if not isinstance(model_memory_summary, dict):
+        return []
+    rows: list[dict[str, object]] = []
+    for side in ("baseline", "candidate"):
+        rows.extend(_dict_list(model_memory_summary.get(side)))
     return rows
 
 
@@ -1441,6 +1520,43 @@ def _render_telemetry_summary_markdown(telemetry_summary: object) -> list[str]:
             )
     if not has_rows:
         lines.append("| - | - | missing | - | - | - | telemetry_summary_missing |")
+    lines.append("")
+    return lines
+
+
+def _render_model_memory_summary_markdown(model_memory_summary: object) -> list[str]:
+    if not isinstance(model_memory_summary, dict):
+        return []
+    rows = [
+        row
+        for side in ("baseline", "candidate")
+        for row in _dict_list(model_memory_summary.get(side))
+    ]
+    if not rows:
+        return []
+    lines = [
+        "## Model Memory Summary",
+        "",
+        "| Side | Run ID | Model | Runtime | Loaded Model Resident | Registry Model Resident | Load RSS Delta | Scope |",
+        "| --- | --- | --- | --- | ---: | ---: | ---: | --- |",
+    ]
+    for row in rows:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _markdown_cell(row.get("side", "")),
+                    _markdown_cell(row.get("run_id", "")),
+                    _markdown_cell(row.get("runtime_model_id", "")),
+                    _markdown_cell(row.get("runtime_name") or row.get("runtime_kind", "")),
+                    _markdown_cell(_format_value(row.get("loaded_model_estimated_resident_bytes"))),
+                    _markdown_cell(_format_value(row.get("runtime_stats_model_resident_bytes"))),
+                    _markdown_cell(_format_value(row.get("load_rss_delta_bytes"))),
+                    _markdown_cell(row.get("measurement_scope", "")),
+                ]
+            )
+            + " |"
+        )
     lines.append("")
     return lines
 
@@ -1593,6 +1709,7 @@ def _collect_metrics(bundle: dict[str, object]) -> dict[str, object]:
     _collect_evaluation_sample_probe_metrics(metrics, bundle.get("evaluation_samples", []))
     _collect_run_evidence_probe_metrics(metrics, bundle.get("run_evidence", []))
     _collect_run_evidence_telemetry_metrics(metrics, bundle.get("run_evidence", []))
+    _collect_run_evidence_model_memory_metrics(metrics, bundle.get("run_evidence", []))
     return metrics
 
 
@@ -1853,6 +1970,35 @@ def _collect_run_evidence_telemetry_metrics(metrics: dict[str, object], rows: ob
         metrics[f"telemetry.{run_kind}.{key}_mean"] = total / count
     for run_kind, count in failure_counts.items():
         metrics[f"telemetry.{run_kind}.telemetry_failure_count"] = float(count)
+
+
+def _collect_run_evidence_model_memory_metrics(metrics: dict[str, object], rows: object) -> None:
+    aggregates_by_key: dict[tuple[str, str], _NumericAggregate] = {}
+    for evidence in _dict_rows(rows):
+        run_kind = str(evidence.get("run_kind", "")).strip() or "run"
+        memory = evidence.get("model_memory_summary")
+        if not isinstance(memory, dict):
+            continue
+        for key, raw_value in memory.items():
+            if key in {
+                "runtime_model_handle",
+                "runtime_model_id",
+                "runtime_kind",
+                "runtime_name",
+                "measurement_scope",
+            }:
+                continue
+            value = _float_or_none(raw_value)
+            if value is None:
+                continue
+            aggregate_key = (run_kind, key)
+            aggregates_by_key[aggregate_key] = _update_numeric_aggregate(
+                aggregates_by_key.get(aggregate_key),
+                value,
+            )
+    for (run_kind, key), aggregate in aggregates_by_key.items():
+        total, count = aggregate
+        metrics[f"model_memory.{run_kind}.{key}_mean"] = total / count
 
 
 def _update_numeric_aggregate(

--- a/services/mlx-worker-python/worker/productization/benchmark_store.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_store.py
@@ -48,6 +48,7 @@ class BenchmarkStore:
         context_rows: Iterable[dict[str, object]] = (),
         batch_rows: Iterable[dict[str, object]] = (),
         telemetry_collection: Any | None = None,
+        model_memory_summary: dict[str, object] | None = None,
     ) -> dict[str, Path]:
         artifact_write_started_at_monotonic_ms = monotonic_ms()
         jobs_root.mkdir(parents=True, exist_ok=True)
@@ -99,6 +100,7 @@ class BenchmarkStore:
             batch_rows=batch_rows_tuple,
             telemetry_summary=telemetry_collection.summary,
             telemetry_probes=telemetry_collection.probes,
+            model_memory_summary=model_memory_summary,
         )
         evidence_payload = evidence.to_dict()
         assert_valid_run_evidence_payload(evidence_payload)

--- a/services/mlx-worker-python/worker/productization/evaluation_store.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_store.py
@@ -43,6 +43,7 @@ class EvaluationStore:
         result: EvaluationResult,
         samples: tuple[EvaluationSample, ...] = (),
         telemetry_collection: Any | None = None,
+        model_memory_summary: dict[str, object] | None = None,
     ) -> dict[str, Path]:
         artifact_write_started_at_monotonic_ms = monotonic_ms()
         run_root = Path(job.output_dir) if job.output_dir else jobs_root
@@ -103,6 +104,7 @@ class EvaluationStore:
             samples=samples,
             telemetry_summary=telemetry_collection.summary,
             telemetry_probes=telemetry_collection.probes,
+            model_memory_summary=model_memory_summary,
         )
         evidence_payload = evidence.to_dict()
         assert_valid_run_evidence_payload(evidence_payload)

--- a/services/mlx-worker-python/worker/productization/run_evidence.py
+++ b/services/mlx-worker-python/worker/productization/run_evidence.py
@@ -305,6 +305,64 @@ class RunEvidenceTelemetrySummary:
 
 
 @dataclass(frozen=True)
+class RunEvidenceModelMemorySummary:
+    runtime_model_handle: str = ""
+    runtime_model_id: str = ""
+    runtime_kind: str = ""
+    runtime_name: str = ""
+    loaded_model_estimated_resident_bytes: int = 0
+    runtime_stats_resident_bytes: int = 0
+    runtime_stats_model_resident_bytes: int = 0
+    runtime_stats_cache_resident_bytes: int = 0
+    runtime_stats_kv_cache_bytes: int = 0
+    runtime_stats_memory_headroom_bytes: int = 0
+    load_triggered_by_run: bool = False
+    load_rss_before_bytes: int = 0
+    load_rss_after_bytes: int = 0
+    load_rss_delta_bytes: int = 0
+    measurement_scope: str = "worker_registry"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "runtime_model_handle": self.runtime_model_handle,
+            "runtime_model_id": self.runtime_model_id,
+            "runtime_kind": self.runtime_kind,
+            "runtime_name": self.runtime_name,
+            "loaded_model_estimated_resident_bytes": self.loaded_model_estimated_resident_bytes,
+            "runtime_stats_resident_bytes": self.runtime_stats_resident_bytes,
+            "runtime_stats_model_resident_bytes": self.runtime_stats_model_resident_bytes,
+            "runtime_stats_cache_resident_bytes": self.runtime_stats_cache_resident_bytes,
+            "runtime_stats_kv_cache_bytes": self.runtime_stats_kv_cache_bytes,
+            "runtime_stats_memory_headroom_bytes": self.runtime_stats_memory_headroom_bytes,
+            "load_triggered_by_run": self.load_triggered_by_run,
+            "load_rss_before_bytes": self.load_rss_before_bytes,
+            "load_rss_after_bytes": self.load_rss_after_bytes,
+            "load_rss_delta_bytes": self.load_rss_delta_bytes,
+            "measurement_scope": self.measurement_scope,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, object]) -> RunEvidenceModelMemorySummary:
+        return cls(
+            runtime_model_handle=str(payload.get("runtime_model_handle") or ""),
+            runtime_model_id=str(payload.get("runtime_model_id") or ""),
+            runtime_kind=str(payload.get("runtime_kind") or ""),
+            runtime_name=str(payload.get("runtime_name") or ""),
+            loaded_model_estimated_resident_bytes=_int_value(payload.get("loaded_model_estimated_resident_bytes")),
+            runtime_stats_resident_bytes=_int_value(payload.get("runtime_stats_resident_bytes")),
+            runtime_stats_model_resident_bytes=_int_value(payload.get("runtime_stats_model_resident_bytes")),
+            runtime_stats_cache_resident_bytes=_int_value(payload.get("runtime_stats_cache_resident_bytes")),
+            runtime_stats_kv_cache_bytes=_int_value(payload.get("runtime_stats_kv_cache_bytes")),
+            runtime_stats_memory_headroom_bytes=_int_value(payload.get("runtime_stats_memory_headroom_bytes")),
+            load_triggered_by_run=bool(payload.get("load_triggered_by_run")),
+            load_rss_before_bytes=_int_value(payload.get("load_rss_before_bytes")),
+            load_rss_after_bytes=_int_value(payload.get("load_rss_after_bytes")),
+            load_rss_delta_bytes=_int_value(payload.get("load_rss_delta_bytes")),
+            measurement_scope=str(payload.get("measurement_scope") or "worker_registry"),
+        )
+
+
+@dataclass(frozen=True)
 class RunEvidenceEnvelope:
     run_id: str
     run_kind: str
@@ -322,6 +380,7 @@ class RunEvidenceEnvelope:
     metrics: tuple[RunEvidenceMetric, ...]
     probe_timeline: tuple[RunEvidenceProbe, ...]
     telemetry_summary: RunEvidenceTelemetrySummary
+    model_memory_summary: RunEvidenceModelMemorySummary
     artifacts: tuple[RunEvidenceArtifact, ...]
     melix_commit: str = ""
     git_branch: str = ""
@@ -373,6 +432,7 @@ class RunEvidenceEnvelope:
             "metrics": [metric.to_dict() for metric in self.metrics],
             "probe_timeline": [probe.to_dict() for probe in self.probe_timeline],
             "telemetry_summary": self.telemetry_summary.to_dict(),
+            "model_memory_summary": self.model_memory_summary.to_dict(),
             "artifacts": [artifact.to_dict() for artifact in self.artifacts],
             "failure_summary": dict(self.failure_summary),
             "fallback_summary": dict(self.fallback_summary),
@@ -386,6 +446,7 @@ class RunEvidenceEnvelope:
         probes = payload.get("probe_timeline")
         artifacts = payload.get("artifacts")
         telemetry = payload.get("telemetry_summary")
+        model_memory = payload.get("model_memory_summary")
         return cls(
             schema_version=str(payload.get("schema_version") or ""),
             run_id=str(payload.get("run_id") or ""),
@@ -427,6 +488,9 @@ class RunEvidenceEnvelope:
             telemetry_summary=RunEvidenceTelemetrySummary.from_dict(telemetry)
             if isinstance(telemetry, dict)
             else RunEvidenceTelemetrySummary(collector_status=""),
+            model_memory_summary=RunEvidenceModelMemorySummary.from_dict(model_memory)
+            if isinstance(model_memory, dict)
+            else RunEvidenceModelMemorySummary(),
             artifacts=tuple(
                 RunEvidenceArtifact.from_dict(item)
                 for item in artifacts
@@ -447,6 +511,20 @@ def default_telemetry_summary() -> RunEvidenceTelemetrySummary:
     )
 
 
+def default_model_memory_summary() -> RunEvidenceModelMemorySummary:
+    return RunEvidenceModelMemorySummary()
+
+
+def _model_memory_summary(
+    summary: RunEvidenceModelMemorySummary | dict[str, object] | None,
+) -> RunEvidenceModelMemorySummary:
+    if isinstance(summary, RunEvidenceModelMemorySummary):
+        return summary
+    if isinstance(summary, dict):
+        return RunEvidenceModelMemorySummary.from_dict(summary)
+    return default_model_memory_summary()
+
+
 def build_serving_benchmark_run_evidence(
     *,
     job: Any,
@@ -459,6 +537,7 @@ def build_serving_benchmark_run_evidence(
     batch_rows: Iterable[dict[str, object]] = (),
     telemetry_summary: RunEvidenceTelemetrySummary | None = None,
     telemetry_probes: Iterable[RunEvidenceProbe] = (),
+    model_memory_summary: RunEvidenceModelMemorySummary | dict[str, object] | None = None,
     command: str = "melix bench run",
     repo_root: Path | None = None,
 ) -> RunEvidenceEnvelope:
@@ -557,6 +636,7 @@ def build_serving_benchmark_run_evidence(
         metrics=metrics,
         probe_timeline=probe_timeline,
         telemetry_summary=telemetry_summary or default_telemetry_summary(),
+        model_memory_summary=_model_memory_summary(model_memory_summary),
         artifacts=artifacts,
         failure_summary=_failure_summary(job.status),
         fallback_summary=_fallback_summary(job.parameters),
@@ -581,6 +661,7 @@ def build_evaluation_run_evidence(
     samples: Iterable[Any] = (),
     telemetry_summary: RunEvidenceTelemetrySummary | None = None,
     telemetry_probes: Iterable[RunEvidenceProbe] = (),
+    model_memory_summary: RunEvidenceModelMemorySummary | dict[str, object] | None = None,
     command: str = "melix eval run",
     repo_root: Path | None = None,
 ) -> RunEvidenceEnvelope:
@@ -673,6 +754,7 @@ def build_evaluation_run_evidence(
         metrics=metrics,
         probe_timeline=probe_timeline,
         telemetry_summary=telemetry_summary or default_telemetry_summary(),
+        model_memory_summary=_model_memory_summary(model_memory_summary),
         artifacts=artifacts,
         failure_summary=_failure_summary(job.status, failure_count=result.failure_count),
         fallback_summary=_fallback_summary(job.parameters),
@@ -1306,6 +1388,7 @@ def validate_run_evidence_payload(payload: dict[str, object]) -> list[str]:
         "metrics",
         "probe_timeline",
         "telemetry_summary",
+        "model_memory_summary",
         "artifacts",
         "failure_summary",
         "fallback_summary",
@@ -1331,6 +1414,8 @@ def validate_run_evidence_payload(payload: dict[str, object]) -> list[str]:
         errors.append("probe_timeline must be a non-empty list")
     if not isinstance(payload.get("telemetry_summary"), dict):
         errors.append("telemetry_summary must be an object")
+    if "model_memory_summary" in payload and not isinstance(payload.get("model_memory_summary"), dict):
+        errors.append("model_memory_summary must be an object")
     if not isinstance(payload.get("artifacts"), list) or not payload.get("artifacts"):
         errors.append("artifacts must be a non-empty list")
     if not isinstance(payload.get("failure_summary"), dict):

--- a/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
@@ -12,6 +12,7 @@ from typing import Any
 from worker.runtime.mlx_executor import MLXRuntimeExecutor
 from worker.runtime.runtime_utils import (
     callable_accepts_kwarg as _callable_accepts_kwarg,
+    estimate_model_weight_resident_bytes as _estimate_model_weight_resident_bytes,
     first_declared_kwarg as _first_declared_kwarg,
     installed_package_version as _installed_package_version,
 )
@@ -601,7 +602,7 @@ class AutoMLXBackend:
         }
 
     def estimate_resident_bytes(self, model_spec) -> int:
-        return 0
+        return _estimate_model_weight_resident_bytes(str(getattr(model_spec, "model_path", "") or ""))
 
     def score_response(
         self,

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -4,7 +4,12 @@ from dataclasses import dataclass
 from functools import lru_cache
 import importlib.metadata
 import inspect
+import json
+from pathlib import Path
 from typing import Any
+
+
+_MODEL_WEIGHT_SUFFIXES = (".safetensors", ".npz", ".bin", ".gguf")
 
 
 @dataclass(frozen=True)
@@ -114,3 +119,67 @@ def installed_package_version(package_name: str) -> str:
 
 def clear_installed_package_version_cache() -> None:
     installed_package_version.cache_clear()
+
+
+def estimate_model_weight_resident_bytes(model_path: str) -> int:
+    """Estimate model resident bytes from local weight artifacts."""
+    if not str(model_path or "").strip():
+        return 0
+    root = Path(model_path).expanduser()
+    try:
+        if root.is_file():
+            return _weight_file_size(root)
+        if not root.is_dir():
+            return 0
+    except OSError:
+        return 0
+
+    indexed_size = _indexed_safetensors_shard_bytes(root)
+    if indexed_size > 0:
+        return indexed_size
+    return _top_level_weight_file_bytes(root)
+
+
+def _indexed_safetensors_shard_bytes(model_dir: Path) -> int:
+    index_path = model_dir / "model.safetensors.index.json"
+    try:
+        payload = json.loads(index_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return 0
+    weight_map = payload.get("weight_map")
+    if not isinstance(weight_map, dict):
+        return 0
+    total = 0
+    seen: set[str] = set()
+    for raw_shard in weight_map.values():
+        shard_name = str(raw_shard or "").strip()
+        if not shard_name or shard_name in seen:
+            continue
+        seen.add(shard_name)
+        shard_path = Path(shard_name)
+        if not shard_path.is_absolute():
+            shard_path = model_dir / shard_path
+        total += _weight_file_size(shard_path)
+    return total
+
+
+def _top_level_weight_file_bytes(model_dir: Path) -> int:
+    total = 0
+    try:
+        entries = tuple(model_dir.iterdir())
+    except OSError:
+        return 0
+    for path in entries:
+        total += _weight_file_size(path)
+    return total
+
+
+def _weight_file_size(path: Path) -> int:
+    if path.suffix.lower() not in _MODEL_WEIGHT_SUFFIXES:
+        return 0
+    try:
+        if not path.is_file():
+            return 0
+        return max(int(path.stat().st_size), 0)
+    except OSError:
+        return 0


### PR DESCRIPTION
## Summary
- Add model memory reporting to benchmark and evaluation run evidence so reports show worker-registry model residency instead of process or host memory proxies.
- Render model memory in bench Markdown, comparison Markdown, and CSV exports.
- Estimate MLX text resident bytes from local model weight artifacts so real HF cache models no longer report zero resident bytes.

## Plan or Spec
- `docs/plans/2026-05-11-model-memory-reporting.md`
- `docs/evidence-telemetry-report-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_run_evidence.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_mlx_backend.py::test_auto_backend_estimates_resident_bytes_from_model_weights services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_model_memory_summary_uses_registry_runtime_stats services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_executes_packaged_dataset_and_persists_result services/mlx-worker-python/tests/test_maintenance_service.py::test_bench_events_rejects_unsupported_task_family_after_suite_resolution services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_measures_runtime_behavior_from_loaded_backend services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_records_lazy_model_load_memory_summary services/mlx-worker-python/tests/test_maintenance_service.py::test_resolve_benchmark_loaded_model_reuses_existing_handle services/mlx-worker-python/tests/test_maintenance_service.py::test_current_process_rss_bytes_uses_resource_fallback services/mlx-worker-python/tests/test_maintenance_service.py::test_current_process_rss_bytes_returns_zero_when_fallback_fails services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_reuses_single_sorted_latency_vectors
# 103 passed in 5.20s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o /private/tmp/model-memory-pr-coverage.json
# Wrote JSON report to /private/tmp/model-memory-pr-coverage.json

.venv/bin/python scripts/python_changed_line_coverage.py --coverage-json /private/tmp/model-memory-pr-coverage.json --diff-from origin/main services/mlx-worker-python/worker/productization/run_evidence.py services/mlx-worker-python/worker/productization/benchmark_store.py services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/tests/test_run_evidence.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_mlx_backend.py
# TOTAL 96.60% 341/353

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/mlx_vlm_gemma4_weight_presence_probe.py
# peak_bytes_mean=124.8, visited_names_mean=1999960.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_sample_probe_means_aggregate_multiple_fields_in_one_pass services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_executes_packaged_dataset_and_persists_result services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_primes_from_highest_existing_run_directory services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_only_scans_existing_runs_once_per_process services/mlx-worker-python/tests/test_evaluation_core.py::test_next_job_id_skips_conflicting_cached_index_and_non_directory_entries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_sample_probe_aggregation_probe services/mlx-worker-python/tests/test_event_extraction.py::test_event_extraction_dialogue_diagnostics_uses_top_k_for_slowest_dialogues
# 10 passed in 15.19s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_sample_probe_means_aggregate_multiple_fields_in_one_pass services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_executes_packaged_dataset_and_persists_result services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_sample_probe_aggregation_probe services/mlx-worker-python/tests/test_event_extraction.py::test_event_extraction_dialogue_diagnostics_uses_top_k_for_slowest_dialogues
# 6 passed in 14.18s

git diff --check
# passed

MELIX_SERVICE_INSTANCE_NAME=model-mem-smoke MELIX_HTTP_PORT=12436 MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/model-mem-smoke" MELIX_HOME="$PWD/.runtime/home-model-mem-smoke" bash scripts/dev_up.sh --prefer-built
# Melix local stack is ready.

source .runtime/sidecars/model-mem-smoke/env.sh && .build/debug/melix bench run --model-id 'mlx-community/Qwen3.5-9B-MLX-4bit' --suite smoke --context-length 64 --generation-length 8 --batch-size 1 --repeats 1 --json
# completed: loaded_model_estimated_resident_bytes=5950221072, runtime_stats_model_resident_bytes=5950246416

MELIX_RUNTIME_DIR="$PWD/.runtime/sidecars/model-mem-smoke" bash scripts/dev_down.sh
# Melix local stack is stopped.
```

## Coverage and Metrics
- Changed-scope coverage: `96.60%` (`353` measurable changed lines, `341` covered, `12` missed).
- MLX-VLM Gemma4 weight-presence probe after removing the unrelated VLM runtime diff: `peak_bytes_mean=124.8`, `visited_names_mean=1999960.0`.
- Evaluation scoped probes: local focused coverage for `evaluation-job-id-high-water-mark` and `evaluation-sample-probe-aggregation` now passes after making model-memory summary compatible with custom registries that do not expose `runtime_stats()`.
- Real-model smoke: `mlx-community/Qwen3.5-9B-MLX-4bit` reports `loaded_model_estimated_resident_bytes=5950221072` and `runtime_stats_model_resident_bytes=5950246416`.
- Bench smoke metrics from the same run: `bench.smoke.ttft_ms=378.51 ms`, `bench.smoke.tokens_per_second=111.67 tok/s`.

## Known Gaps
- Full repository gates other than `make py-test` (`make bootstrap`, `make proto`, `make swift-test`, `make integration-test`) were not run in this local pass; focused Python coverage and one real-model smoke were run instead.
- Local `make py-test` was run outside the Codex sandbox and reached `2268 passed, 14 skipped` with one unrelated local failure in `test_dataset_catalog_string_stem_matches_pathlib_for_split_names`; this workspace's `.venv` is Python 3.14, while the GitHub `python-tests` runner uses Python 3.12.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts: N/A, no protobuf/schema changes.
- [x] Dependency changes include updated lockfiles: N/A, no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
