### PR TITLE
Add bench eval batch dry-run foundation

### DIFF
--- a/Sources/MelixCLICore/MelixBatchRun.swift
+++ b/Sources/MelixCLICore/MelixBatchRun.swift
@@ -1,0 +1,649 @@
+import Foundation
+
+public struct BatchRunOptions: Equatable, Sendable {
+    public let modelListPath: String
+    public let configPath: String
+    public let runID: String
+    public let outputRoot: String
+    public let tempRoot: String
+    public let startIndex: Int
+    public let maxModels: Int
+    public let judgeRemoteServerID: String
+    public let judgeModelID: String
+    public let benchSuite: String
+    public let benchContextLength: UInt32
+    public let benchGenerationLength: UInt32
+    public let benchBatchSize: UInt32
+    public let benchRepeats: UInt32
+    public let benchSampleSize: UInt32
+    public let benchBatchFactor: UInt32
+    public let evalSuite: String
+    public let evalDatasetID: String
+    public let evalScoringMode: String
+    public let evalSampleSize: UInt32
+    public let evalBatchFactor: UInt32
+    public let continueOnFailure: Bool
+    public let restartStackPerModel: Bool
+    public let dryRun: Bool
+    public let json: Bool
+    public let explicitOptions: Set<String>
+
+    public init(
+        modelListPath: String,
+        configPath: String = "",
+        runID: String = "",
+        outputRoot: String = "",
+        tempRoot: String = "",
+        startIndex: Int = 1,
+        maxModels: Int = 0,
+        judgeRemoteServerID: String = "",
+        judgeModelID: String = "",
+        benchSuite: String = "",
+        benchContextLength: UInt32 = 0,
+        benchGenerationLength: UInt32 = 0,
+        benchBatchSize: UInt32 = 0,
+        benchRepeats: UInt32 = 0,
+        benchSampleSize: UInt32 = 0,
+        benchBatchFactor: UInt32 = 0,
+        evalSuite: String = "",
+        evalDatasetID: String = "",
+        evalScoringMode: String = "",
+        evalSampleSize: UInt32 = 0,
+        evalBatchFactor: UInt32 = 0,
+        continueOnFailure: Bool = true,
+        restartStackPerModel: Bool = true,
+        dryRun: Bool = false,
+        json: Bool = false,
+        explicitOptions: Set<String> = []
+    ) {
+        self.modelListPath = modelListPath
+        self.configPath = configPath
+        self.runID = runID
+        self.outputRoot = outputRoot
+        self.tempRoot = tempRoot
+        self.startIndex = startIndex
+        self.maxModels = maxModels
+        self.judgeRemoteServerID = judgeRemoteServerID
+        self.judgeModelID = judgeModelID
+        self.benchSuite = benchSuite
+        self.benchContextLength = benchContextLength
+        self.benchGenerationLength = benchGenerationLength
+        self.benchBatchSize = benchBatchSize
+        self.benchRepeats = benchRepeats
+        self.benchSampleSize = benchSampleSize
+        self.benchBatchFactor = benchBatchFactor
+        self.evalSuite = evalSuite
+        self.evalDatasetID = evalDatasetID
+        self.evalScoringMode = evalScoringMode
+        self.evalSampleSize = evalSampleSize
+        self.evalBatchFactor = evalBatchFactor
+        self.continueOnFailure = continueOnFailure
+        self.restartStackPerModel = restartStackPerModel
+        self.dryRun = dryRun
+        self.json = json
+        self.explicitOptions = explicitOptions
+    }
+}
+
+struct BatchRunModelEntry: Equatable {
+    let index: String
+    let repoID: String
+    let sourceLine: Int
+}
+
+struct BatchRunEffectiveConfig: Equatable {
+    let runID: String
+    let modelListPath: String
+    let configPath: String
+    let outputRoot: String
+    let tempRoot: String
+    let startIndex: Int
+    let maxModels: Int
+    let judgeRemoteServerID: String
+    let judgeModelID: String
+    let benchSuite: String
+    let benchContextLength: UInt32
+    let benchGenerationLength: UInt32
+    let benchBatchSize: UInt32
+    let benchRepeats: UInt32
+    let benchSampleSize: UInt32
+    let benchBatchFactor: UInt32
+    let evalSuite: String
+    let evalDatasetID: String
+    let evalScoringMode: String
+    let evalSampleSize: UInt32
+    let evalBatchFactor: UInt32
+    let continueOnFailure: Bool
+    let restartStackPerModel: Bool
+    let dryRun: Bool
+    let isSubsetRun: Bool
+}
+
+struct BatchRunPlan: Equatable {
+    let config: BatchRunEffectiveConfig
+    let models: [BatchRunModelEntry]
+    let selectedModels: [BatchRunModelEntry]
+    let manifestPath: String
+    let effectiveConfigPath: String
+}
+
+enum BatchRunModelListParser {
+    static func parse(contents: String) throws -> [BatchRunModelEntry] {
+        var entries: [BatchRunModelEntry] = []
+        var autoIndex = 1
+        for (offset, rawLine) in contents.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
+            let lineNumber = offset + 1
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard line.isEmpty == false, line.hasPrefix("#") == false else {
+                continue
+            }
+            let index: String
+            let repoID: String
+            if let separator = line.firstIndex(of: "|") {
+                index = line[..<separator].trimmingCharacters(in: .whitespacesAndNewlines)
+                repoID = line[line.index(after: separator)...].trimmingCharacters(in: .whitespacesAndNewlines)
+            } else {
+                index = String(format: "%02d", autoIndex)
+                repoID = line
+            }
+            guard index.isEmpty == false else {
+                throw MelixCLIError.usage("Empty model index at \(lineNumber).")
+            }
+            guard repoID.isEmpty == false else {
+                throw MelixCLIError.usage("Empty repo id at \(lineNumber).")
+            }
+            entries.append(BatchRunModelEntry(index: index, repoID: repoID, sourceLine: lineNumber))
+            autoIndex += 1
+        }
+        return entries
+    }
+}
+
+enum BatchRunConfigLoader {
+    static func load(path: String) throws -> [String: String] {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else {
+            return [:]
+        }
+        let text = try String(contentsOfFile: trimmed, encoding: .utf8)
+        var values: [String: String] = [:]
+        for (offset, rawLine) in text.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
+            let lineNumber = offset + 1
+            var line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard line.isEmpty == false, line.hasPrefix("#") == false else {
+                continue
+            }
+            if let comment = line.firstIndex(of: "#") {
+                line = line[..<comment].trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            guard let separator = line.firstIndex(of: ":") else {
+                throw MelixCLIError.usage("Invalid batch config line \(lineNumber); expected key: value.")
+            }
+            let key = line[..<separator].trimmingCharacters(in: .whitespacesAndNewlines)
+            let value = line[line.index(after: separator)...]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            guard key.isEmpty == false else {
+                throw MelixCLIError.usage("Invalid batch config line \(lineNumber); key is empty.")
+            }
+            values[key] = value
+        }
+        return values
+    }
+}
+
+enum BatchRunPlanner {
+    static func makePlan(options: BatchRunOptions, environment: [String: String]) throws -> BatchRunPlan {
+        let configValues = try BatchRunConfigLoader.load(path: options.configPath)
+        let modelListPath = nonEmpty(options.modelListPath, configValues["model_list"], environment["MELIX_BATCH_MODEL_LIST"])
+        guard modelListPath.isEmpty == false else {
+            throw MelixCLIError.missingRequired("--models is required for melix batch run.")
+        }
+        let modelText = try String(contentsOfFile: modelListPath, encoding: .utf8)
+        let models = try BatchRunModelListParser.parse(contents: modelText)
+        guard models.isEmpty == false else {
+            throw MelixCLIError.usage("Model list \(modelListPath) does not contain any models.")
+        }
+
+        let runID = nonEmpty(
+            options.runID,
+            configValues["run_id"],
+            environment["MELIX_RUN_ID"],
+            timestampRunID()
+        )
+        let outputRoot = nonEmpty(
+            options.outputRoot,
+            configValues["output_root"],
+            environment["MELIX_DOWNLOAD_ROOT"],
+            "\(homeDirectory(environment: environment))/Downloads/melix-bench-eval-\(runID)"
+        )
+        let tempRoot = nonEmpty(
+            options.tempRoot,
+            configValues["temp_root"],
+            environment["MELIX_RUN_TMP_ROOT"],
+            "\(FileManager.default.currentDirectoryPath)/.runtime/bench-eval-run/\(runID)"
+        )
+        let startIndex = try intValue(
+            explicit: options.startIndex,
+            explicitWasProvided: options.explicitOptions.contains("--start-index"),
+            keys: ["start_index"],
+            configValues: configValues,
+            environmentValue: environment["MELIX_START_INDEX"],
+            defaultValue: 1,
+            option: "--start-index"
+        )
+        let maxModels = try intValue(
+            explicit: options.maxModels,
+            explicitWasProvided: options.explicitOptions.contains("--max-models"),
+            keys: ["max_models"],
+            configValues: configValues,
+            environmentValue: environment["MELIX_MAX_MODELS"],
+            defaultValue: 0,
+            option: "--max-models"
+        )
+        let config = BatchRunEffectiveConfig(
+            runID: runID,
+            modelListPath: modelListPath,
+            configPath: options.configPath,
+            outputRoot: outputRoot,
+            tempRoot: tempRoot,
+            startIndex: max(1, startIndex),
+            maxModels: max(0, maxModels),
+            judgeRemoteServerID: nonEmpty(
+                options.judgeRemoteServerID,
+                configValues["judge_remote_server_id"],
+                environment["MELIX_JUDGE_SERVER_ID"],
+                "owlia-gpt-5-5-judge"
+            ),
+            judgeModelID: nonEmpty(
+                options.judgeModelID,
+                configValues["judge_model"],
+                environment["MELIX_JUDGE_MODEL"],
+                "gpt-5.5"
+            ),
+            benchSuite: nonEmpty(options.benchSuite, configValues["bench_suite"], environment["MELIX_BENCH_SUITE"], "smoke"),
+            benchContextLength: try uint32Value(
+                explicit: options.benchContextLength,
+                explicitWasProvided: options.explicitOptions.contains("--bench-context-length"),
+                configValue: configValues["bench_context_length"],
+                environmentValue: environment["MELIX_BENCH_CONTEXT_LENGTH"],
+                defaultValue: 1024,
+                option: "--bench-context-length"
+            ),
+            benchGenerationLength: try uint32Value(
+                explicit: options.benchGenerationLength,
+                explicitWasProvided: options.explicitOptions.contains("--bench-generation-length"),
+                configValue: configValues["bench_generation_length"],
+                environmentValue: environment["MELIX_BENCH_GENERATION_LENGTH"],
+                defaultValue: 128,
+                option: "--bench-generation-length"
+            ),
+            benchBatchSize: try uint32Value(
+                explicit: options.benchBatchSize,
+                explicitWasProvided: options.explicitOptions.contains("--bench-batch-size"),
+                configValue: configValues["bench_batch_size"],
+                environmentValue: environment["MELIX_BENCH_BATCH_SIZE"],
+                defaultValue: 1,
+                option: "--bench-batch-size"
+            ),
+            benchRepeats: try uint32Value(
+                explicit: options.benchRepeats,
+                explicitWasProvided: options.explicitOptions.contains("--bench-repeats"),
+                configValue: configValues["bench_repeats"],
+                environmentValue: environment["MELIX_BENCH_REPEATS"],
+                defaultValue: 1,
+                option: "--bench-repeats"
+            ),
+            benchSampleSize: try uint32Value(
+                explicit: options.benchSampleSize,
+                explicitWasProvided: options.explicitOptions.contains("--bench-sample-size"),
+                configValue: configValues["bench_sample_size"],
+                environmentValue: environment["MELIX_BENCH_SAMPLE_SIZE"],
+                defaultValue: 1,
+                option: "--bench-sample-size"
+            ),
+            benchBatchFactor: try uint32Value(
+                explicit: options.benchBatchFactor,
+                explicitWasProvided: options.explicitOptions.contains("--bench-batch-factor"),
+                configValue: configValues["bench_batch_factor"],
+                environmentValue: environment["MELIX_BENCH_BATCH_FACTOR"],
+                defaultValue: 1,
+                option: "--bench-batch-factor"
+            ),
+            evalSuite: nonEmpty(options.evalSuite, configValues["eval_suite"], environment["MELIX_EVAL_SUITE"], "event_extraction"),
+            evalDatasetID: nonEmpty(
+                options.evalDatasetID,
+                configValues["eval_dataset_id"],
+                environment["MELIX_EVAL_DATASET_ID"],
+                "top200.event-extraction.top20.v1"
+            ),
+            evalScoringMode: nonEmpty(
+                options.evalScoringMode,
+                configValues["eval_scoring_mode"],
+                environment["MELIX_EVAL_SCORING_MODE"],
+                "event_extraction_weighted_f1"
+            ),
+            evalSampleSize: try uint32Value(
+                explicit: options.evalSampleSize,
+                explicitWasProvided: options.explicitOptions.contains("--eval-sample-size"),
+                configValue: configValues["eval_sample_size"],
+                environmentValue: environment["MELIX_EVAL_SAMPLE_SIZE"],
+                defaultValue: 20,
+                option: "--eval-sample-size"
+            ),
+            evalBatchFactor: try uint32Value(
+                explicit: options.evalBatchFactor,
+                explicitWasProvided: options.explicitOptions.contains("--eval-batch-factor"),
+                configValue: configValues["eval_batch_factor"],
+                environmentValue: environment["MELIX_EVAL_BATCH_FACTOR"],
+                defaultValue: 1,
+                option: "--eval-batch-factor"
+            ),
+            continueOnFailure: try boolValue(
+                explicit: options.continueOnFailure,
+                explicitWasProvided: options.explicitOptions.contains("--continue-on-failure"),
+                configValue: configValues["continue_on_failure"],
+                environmentValue: environment["MELIX_CONTINUE_ON_FAILURE"],
+                defaultValue: true,
+                option: "--continue-on-failure"
+            ),
+            restartStackPerModel: try boolValue(
+                explicit: options.restartStackPerModel,
+                explicitWasProvided: options.explicitOptions.contains("--restart-stack-per-model"),
+                configValue: configValues["restart_stack_per_model"],
+                environmentValue: environment["MELIX_RESTART_STACK_PER_MODEL"],
+                defaultValue: true,
+                option: "--restart-stack-per-model"
+            ),
+            dryRun: options.dryRun,
+            isSubsetRun: max(1, startIndex) > 1 || max(0, maxModels) > 0
+        )
+
+        let selected = selectModels(models, startIndex: config.startIndex, maxModels: config.maxModels)
+        return BatchRunPlan(
+            config: config,
+            models: models,
+            selectedModels: selected,
+            manifestPath: URL(fileURLWithPath: tempRoot).appendingPathComponent("manifest.jsonl").path,
+            effectiveConfigPath: URL(fileURLWithPath: tempRoot).appendingPathComponent("effective-config.json").path
+        )
+    }
+
+    private static func selectModels(
+        _ models: [BatchRunModelEntry],
+        startIndex: Int,
+        maxModels: Int
+    ) -> [BatchRunModelEntry] {
+        let filtered = models.filter { (Int($0.index) ?? 0) >= startIndex }
+        guard maxModels > 0 else {
+            return filtered
+        }
+        return Array(filtered.prefix(maxModels))
+    }
+
+    private static func nonEmpty(_ values: String?...) -> String {
+        for value in values {
+            let trimmed = (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty == false {
+                return trimmed
+            }
+        }
+        return ""
+    }
+
+    private static func homeDirectory(environment: [String: String]) -> String {
+        nonEmpty(environment["HOME"], FileManager.default.homeDirectoryForCurrentUser.path)
+    }
+
+    private static func timestampRunID() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return formatter.string(from: Date())
+    }
+
+    private static func intValue(
+        explicit: Int,
+        explicitWasProvided: Bool,
+        keys: [String],
+        configValues: [String: String],
+        environmentValue: String?,
+        defaultValue: Int,
+        option: String
+    ) throws -> Int {
+        if explicitWasProvided {
+            return explicit
+        }
+        for key in keys {
+            if let value = configValues[key], value.isEmpty == false {
+                guard let parsed = Int(value) else {
+                    throw MelixCLIError.usage("Invalid value for \(option): \(value).")
+                }
+                return parsed
+            }
+        }
+        if let environmentValue, environmentValue.isEmpty == false {
+            guard let parsed = Int(environmentValue) else {
+                throw MelixCLIError.usage("Invalid value for \(option): \(environmentValue).")
+            }
+            return parsed
+        }
+        return defaultValue
+    }
+
+    private static func uint32Value(
+        explicit: UInt32,
+        explicitWasProvided: Bool,
+        configValue: String?,
+        environmentValue: String?,
+        defaultValue: UInt32,
+        option: String
+    ) throws -> UInt32 {
+        if explicitWasProvided {
+            return explicit
+        }
+        let raw = nonEmpty(configValue, environmentValue)
+        guard raw.isEmpty == false else {
+            return defaultValue
+        }
+        guard let parsed = UInt32(raw) else {
+            throw MelixCLIError.usage("Invalid value for \(option): \(raw).")
+        }
+        return parsed
+    }
+
+    private static func boolValue(
+        explicit: Bool,
+        explicitWasProvided: Bool,
+        configValue: String?,
+        environmentValue: String?,
+        defaultValue: Bool,
+        option: String
+    ) throws -> Bool {
+        if explicitWasProvided {
+            return explicit
+        }
+        let raw = nonEmpty(configValue, environmentValue)
+        guard raw.isEmpty == false else {
+            return defaultValue
+        }
+        switch raw.lowercased() {
+        case "1", "true", "yes", "y":
+            return true
+        case "0", "false", "no", "n":
+            return false
+        default:
+            throw MelixCLIError.usage("Invalid value for \(option): \(raw).")
+        }
+    }
+}
+
+enum BatchRunArtifacts {
+    static func writeFoundationArtifacts(plan: BatchRunPlan) throws {
+        let tempRoot = URL(fileURLWithPath: plan.config.tempRoot)
+        let outputRoot = URL(fileURLWithPath: plan.config.outputRoot)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outputRoot, withIntermediateDirectories: true)
+        try jsonData(effectiveConfigPayload(plan: plan)).write(
+            to: URL(fileURLWithPath: plan.effectiveConfigPath),
+            options: .atomic
+        )
+        try manifestText(plan: plan).write(
+            to: URL(fileURLWithPath: plan.manifestPath),
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.copyItemReplacingExisting(
+            at: URL(fileURLWithPath: plan.effectiveConfigPath),
+            to: outputRoot.appendingPathComponent("effective-config.json")
+        )
+        try FileManager.default.copyItemReplacingExisting(
+            at: URL(fileURLWithPath: plan.manifestPath),
+            to: outputRoot.appendingPathComponent("manifest.jsonl")
+        )
+    }
+
+    static func effectiveConfigPayload(plan: BatchRunPlan) -> [String: Any] {
+        let config = plan.config
+        return [
+            "schema_version": "melix.batch.effective_config.v1",
+            "run_id": config.runID,
+            "model_list": config.modelListPath,
+            "config_path": config.configPath,
+            "output_root": config.outputRoot,
+            "temp_root": config.tempRoot,
+            "start_index": config.startIndex,
+            "max_models": config.maxModels,
+            "selected_model_count": plan.selectedModels.count,
+            "total_model_count": plan.models.count,
+            "is_subset_run": config.isSubsetRun,
+            "dry_run": config.dryRun,
+            "continue_on_failure": config.continueOnFailure,
+            "restart_stack_per_model": config.restartStackPerModel,
+            "judge": [
+                "remote_server_id": config.judgeRemoteServerID,
+                "model": config.judgeModelID,
+            ],
+            "benchmark": [
+                "suite": config.benchSuite,
+                "context_length": NSNumber(value: config.benchContextLength),
+                "generation_length": NSNumber(value: config.benchGenerationLength),
+                "batch_size": NSNumber(value: config.benchBatchSize),
+                "repeats": NSNumber(value: config.benchRepeats),
+                "sample_size": NSNumber(value: config.benchSampleSize),
+                "batch_factor": NSNumber(value: config.benchBatchFactor),
+            ],
+            "evaluation": [
+                "suite": config.evalSuite,
+                "dataset_id": config.evalDatasetID,
+                "scoring_mode": config.evalScoringMode,
+                "sample_size": NSNumber(value: config.evalSampleSize),
+                "batch_factor": NSNumber(value: config.evalBatchFactor),
+            ],
+            "models": plan.selectedModels.map(modelPayload),
+        ]
+    }
+
+    static func manifestText(plan: BatchRunPlan) throws -> String {
+        try plan.selectedModels.map { model in
+            let modelDir = URL(fileURLWithPath: plan.config.outputRoot)
+                .appendingPathComponent(modelSlug(index: model.index, repoID: model.repoID))
+                .path
+            let payload: [String: Any] = [
+                "schema_version": "melix.batch.manifest_entry.v1",
+                "run_id": plan.config.runID,
+                "model_index": model.index,
+                "repo_id": model.repoID,
+                "source_line": model.sourceLine,
+                "status": "planned",
+                "model_dir": modelDir,
+                "steps": [
+                    "hub_check": stepPayload(),
+                    "benchmark": stepPayload(),
+                    "evaluation": stepPayload(),
+                    "exports": stepPayload(),
+                    "artifact_copy": stepPayload(),
+                ],
+            ]
+            return String(decoding: try compactJSONData(payload), as: UTF8.self)
+        }.joined(separator: "\n") + "\n"
+    }
+
+    static func renderTextSummary(plan: BatchRunPlan) -> String {
+        var lines: [String] = []
+        lines.append("Melix batch run dry-run")
+        lines.append("run_id=\(plan.config.runID)")
+        lines.append("models=\(plan.selectedModels.count)/\(plan.models.count)")
+        if plan.config.isSubsetRun {
+            lines.append("subset=start_index:\(plan.config.startIndex),max_models:\(plan.config.maxModels)")
+        }
+        lines.append("temp_root=\(plan.config.tempRoot)")
+        lines.append("output_root=\(plan.config.outputRoot)")
+        lines.append("judge=\(plan.config.judgeRemoteServerID)/\(plan.config.judgeModelID)")
+        lines.append("restart_stack_per_model=\(plan.config.restartStackPerModel)")
+        lines.append("continue_on_failure=\(plan.config.continueOnFailure)")
+        lines.append("effective_config=\(plan.effectiveConfigPath)")
+        lines.append("manifest=\(plan.manifestPath)")
+        for (offset, model) in plan.selectedModels.enumerated() {
+            lines.append("[\(offset + 1)/\(plan.selectedModels.count)] PLAN \(model.index) \(model.repoID)")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func modelPayload(_ model: BatchRunModelEntry) -> [String: Any] {
+        [
+            "index": model.index,
+            "repo_id": model.repoID,
+            "source_line": model.sourceLine,
+            "slug": modelSlug(index: model.index, repoID: model.repoID),
+        ]
+    }
+
+    private static func stepPayload() -> [String: Any] {
+        [
+            "status": "pending",
+            "job_id": "",
+            "stdout_path": "",
+            "stderr_path": "",
+            "artifact_path": "",
+            "failure_category": "",
+        ]
+    }
+
+    private static func modelSlug(index: String, repoID: String) -> String {
+        let raw = "\(index)-\(repoID)"
+        var slug = ""
+        var lastWasDash = false
+        for scalar in raw.lowercased().unicodeScalars {
+            let allowed = CharacterSet.alphanumerics.contains(scalar)
+                || scalar == "."
+                || scalar == "_"
+            if allowed {
+                slug.unicodeScalars.append(scalar)
+                lastWasDash = false
+            } else if lastWasDash == false {
+                slug.append("-")
+                lastWasDash = true
+            }
+        }
+        return slug.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+
+    private static func jsonData(_ payload: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    private static func compactJSONData(_ payload: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+    }
+}
+
+private extension FileManager {
+    func copyItemReplacingExisting(at sourceURL: URL, to destinationURL: URL) throws {
+        if fileExists(atPath: destinationURL.path) {
+            try removeItem(at: destinationURL)
+        }
+        try copyItem(at: sourceURL, to: destinationURL)
+    }
+}

--- a/Sources/MelixCLICore/MelixBatchRun.swift
+++ b/Sources/MelixCLICore/MelixBatchRun.swift
@@ -374,7 +374,8 @@ enum BatchRunPlanner {
         startIndex: Int,
         maxModels: Int
     ) -> [BatchRunModelEntry] {
-        let filtered = models.filter { (Int($0.index) ?? 0) >= startIndex }
+        let start = max(0, startIndex - 1)
+        let filtered = start < models.count ? Array(models[start...]) : []
         guard maxModels > 0 else {
             return filtered
         }
@@ -641,7 +642,12 @@ enum BatchRunArtifacts {
 
 private extension FileManager {
     func copyItemReplacingExisting(at sourceURL: URL, to destinationURL: URL) throws {
-        if fileExists(atPath: destinationURL.path) {
+        let sourcePath = sourceURL.standardizedFileURL.path
+        let destinationPath = destinationURL.standardizedFileURL.path
+        guard sourcePath != destinationPath else {
+            return
+        }
+        if fileExists(atPath: destinationPath) {
             try removeItem(at: destinationURL)
         }
         try copyItem(at: sourceURL, to: destinationURL)

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1432,6 +1432,7 @@ public enum MelixCLICommand: Equatable, Sendable {
     case evalExportSamplesCSV(EvalExportOptions)
     case evalExportSamplesJSONL(EvalExportOptions)
     case evalReport(RunReportOptions)
+    case batchRun(BatchRunOptions)
     case runsList(RunsListOptions)
     case runsShow(RunsShowOptions)
     case runsExport(RunsExportOptions)
@@ -1525,6 +1526,8 @@ public enum MelixCLIParser {
             return try parseBench(tail)
         case "eval":
             return try parseEval(tail)
+        case "batch":
+            return try parseBatch(tail)
         case "runs":
             return try parseRuns(tail)
         case "pipeline":
@@ -1615,6 +1618,7 @@ public enum MelixCLIParser {
       melix eval export-samples-csv --job-id JOB_ID --output PATH [--json]
       melix eval export-samples-jsonl --job-id JOB_ID --output PATH [--json]
       melix eval report --from PATH [--format markdown|json]
+      melix batch run --models PATH [--config PATH] [--run-id ID] [--output-root PATH] [--temp-root PATH] [--start-index N] [--max-models N] [--judge-remote-server-id ID] [--judge-model MODEL] [--bench-suite SUITE] [--bench-context-length N] [--bench-generation-length N] [--bench-batch-size N] [--bench-repeats N] [--bench-sample-size N] [--bench-batch-factor N] [--eval-suite SUITE] [--eval-dataset-id ID] [--eval-scoring-mode MODE] [--eval-sample-size N] [--eval-batch-factor N] [--continue-on-failure true|false] [--restart-stack-per-model true|false] --dry-run [--json]
       melix runs list [--from PATH] [--json]
       melix runs show RUN_ID [--from PATH] [--json]
       melix runs export RUN_ID --format json|md [--from PATH] [--output PATH]
@@ -3192,6 +3196,59 @@ public enum MelixCLIParser {
         }
     }
 
+    private static func parseBatch(_ arguments: [String]) throws -> MelixCLICommand {
+        guard let action = arguments.first else {
+            throw MelixCLIError.usage(usageText)
+        }
+        let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse()
+        switch action {
+        case "run":
+            let explicitOptions = Set(values.single.keys).union(values.flags)
+            let continueOnFailure = try parseRequiredBooleanValue(
+                values.single["--continue-on-failure"],
+                option: "--continue-on-failure",
+                defaultValue: true
+            )
+            let restartStackPerModel = try parseRequiredBooleanValue(
+                values.single["--restart-stack-per-model"],
+                option: "--restart-stack-per-model",
+                defaultValue: true
+            )
+            return .batchRun(
+                BatchRunOptions(
+                    modelListPath: values.single["--models"] ?? "",
+                    configPath: values.single["--config"] ?? "",
+                    runID: values.single["--run-id"] ?? "",
+                    outputRoot: values.single["--output-root"] ?? "",
+                    tempRoot: values.single["--temp-root"] ?? "",
+                    startIndex: try parseIntValue(values.single["--start-index"], option: "--start-index", defaultValue: 1) ?? 1,
+                    maxModels: try parseNonNegativeIntValue(values.single["--max-models"], option: "--max-models", defaultValue: 0),
+                    judgeRemoteServerID: values.single["--judge-remote-server-id"] ?? "",
+                    judgeModelID: values.single["--judge-model"] ?? "",
+                    benchSuite: values.single["--bench-suite"] ?? "",
+                    benchContextLength: try parseUInt32Value(values.single["--bench-context-length"], option: "--bench-context-length") ?? 0,
+                    benchGenerationLength: try parseUInt32Value(values.single["--bench-generation-length"], option: "--bench-generation-length") ?? 0,
+                    benchBatchSize: try parseUInt32Value(values.single["--bench-batch-size"], option: "--bench-batch-size") ?? 0,
+                    benchRepeats: try parseUInt32Value(values.single["--bench-repeats"], option: "--bench-repeats") ?? 0,
+                    benchSampleSize: try parseUInt32Value(values.single["--bench-sample-size"], option: "--bench-sample-size") ?? 0,
+                    benchBatchFactor: try parseUInt32Value(values.single["--bench-batch-factor"], option: "--bench-batch-factor") ?? 0,
+                    evalSuite: values.single["--eval-suite"] ?? "",
+                    evalDatasetID: values.single["--eval-dataset-id"] ?? "",
+                    evalScoringMode: values.single["--eval-scoring-mode"] ?? "",
+                    evalSampleSize: try parseUInt32Value(values.single["--eval-sample-size"], option: "--eval-sample-size") ?? 0,
+                    evalBatchFactor: try parseUInt32Value(values.single["--eval-batch-factor"], option: "--eval-batch-factor") ?? 0,
+                    continueOnFailure: continueOnFailure,
+                    restartStackPerModel: restartStackPerModel,
+                    dryRun: values.flags.contains("--dry-run"),
+                    json: values.flags.contains("--json"),
+                    explicitOptions: explicitOptions
+                )
+            )
+        default:
+            throw MelixCLIError.usage(usageText)
+        }
+    }
+
     private static func parseEvalRemoteTargets(
         remoteServerIDs: [String],
         remoteModelIDs: [String]
@@ -3718,6 +3775,20 @@ public enum MelixCLIParser {
             _ = option
             return nil
         }
+    }
+
+    private static func parseRequiredBooleanValue(
+        _ value: String?,
+        option: String,
+        defaultValue: Bool
+    ) throws -> Bool {
+        guard let value else {
+            return defaultValue
+        }
+        guard let parsed = parseBooleanValue(value, option: option) else {
+            throw MelixCLIError.usage("Invalid value for \(option). Expected true or false.")
+        }
+        return parsed
     }
 
     private static func parseUInt32List(
@@ -4389,6 +4460,8 @@ public actor MelixCLIRunner {
         switch command {
         case .pipelineRun(let options):
             return try await runPipeline(options)
+        case .batchRun(let options):
+            return try runBatch(options)
         case .doctor(let options):
             let report = try await client.runDoctor()
             if options.json {
@@ -5813,6 +5886,8 @@ public actor MelixCLIRunner {
             return options.remoteServerID.isEmpty
         case .evalRun(let options):
             return Self.effectiveRemoteTargetOptions(for: options).isEmpty
+        case .batchRun:
+            return false
         default:
             return false
         }
@@ -8157,6 +8232,18 @@ public actor MelixCLIRunner {
         encoder.keyEncodingStrategy = .convertToSnakeCase
         let data = try encoder.encode(payload)
         return String(decoding: data, as: UTF8.self) + "\n"
+    }
+
+    private func runBatch(_ options: BatchRunOptions) throws -> String {
+        guard options.dryRun else {
+            throw MelixCLIError.runtime("melix batch run currently supports --dry-run only; execution is tracked in #755 and follow-up issues.")
+        }
+        let plan = try BatchRunPlanner.makePlan(options: options, environment: environment)
+        try BatchRunArtifacts.writeFoundationArtifacts(plan: plan)
+        if options.json {
+            return try prettyJSON(BatchRunArtifacts.effectiveConfigPayload(plan: plan))
+        }
+        return BatchRunArtifacts.renderTextSummary(plan: plan)
     }
 
     private static func defaultEvaluationDatasetID(for suiteID: String) -> String {

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -158,6 +158,8 @@ public enum MelixCLICommandCodec {
             return "eval.export-samples-jsonl"
         case .evalReport:
             return "eval.report"
+        case .batchRun:
+            return "batch.run"
         case .runsList:
             return "runs.list"
         case .runsShow:
@@ -564,6 +566,47 @@ public enum MelixCLICommandCodec {
             appendOption("--from", value: options.sourcePath, into: &arguments)
             appendOption("--format", value: options.format, into: &arguments)
             json = false
+        case .batchRun(let options):
+            arguments = ["batch", "run"]
+            appendOption("--models", value: options.modelListPath, into: &arguments)
+            appendOption("--config", value: options.configPath, into: &arguments)
+            appendOption("--run-id", value: options.runID, into: &arguments)
+            appendOption("--output-root", value: options.outputRoot, into: &arguments)
+            appendOption("--temp-root", value: options.tempRoot, into: &arguments)
+            appendInt(
+                "--start-index",
+                value: options.startIndex,
+                defaultValue: 1,
+                force: options.explicitOptions.contains("--start-index"),
+                into: &arguments
+            )
+            appendInt(
+                "--max-models",
+                value: options.maxModels,
+                defaultValue: 0,
+                force: options.explicitOptions.contains("--max-models"),
+                into: &arguments
+            )
+            appendOption("--judge-remote-server-id", value: options.judgeRemoteServerID, into: &arguments)
+            appendOption("--judge-model", value: options.judgeModelID, into: &arguments)
+            appendOption("--bench-suite", value: options.benchSuite, into: &arguments)
+            appendUInt32("--bench-context-length", value: options.benchContextLength, defaultValue: 0, force: options.explicitOptions.contains("--bench-context-length"), into: &arguments)
+            appendUInt32("--bench-generation-length", value: options.benchGenerationLength, defaultValue: 0, force: options.explicitOptions.contains("--bench-generation-length"), into: &arguments)
+            appendUInt32("--bench-batch-size", value: options.benchBatchSize, defaultValue: 0, force: options.explicitOptions.contains("--bench-batch-size"), into: &arguments)
+            appendUInt32("--bench-repeats", value: options.benchRepeats, defaultValue: 0, force: options.explicitOptions.contains("--bench-repeats"), into: &arguments)
+            appendUInt32("--bench-sample-size", value: options.benchSampleSize, defaultValue: 0, force: options.explicitOptions.contains("--bench-sample-size"), into: &arguments)
+            appendUInt32("--bench-batch-factor", value: options.benchBatchFactor, defaultValue: 0, force: options.explicitOptions.contains("--bench-batch-factor"), into: &arguments)
+            appendOption("--eval-suite", value: options.evalSuite, into: &arguments)
+            appendOption("--eval-dataset-id", value: options.evalDatasetID, into: &arguments)
+            appendOption("--eval-scoring-mode", value: options.evalScoringMode, into: &arguments)
+            appendUInt32("--eval-sample-size", value: options.evalSampleSize, defaultValue: 0, force: options.explicitOptions.contains("--eval-sample-size"), into: &arguments)
+            appendUInt32("--eval-batch-factor", value: options.evalBatchFactor, defaultValue: 0, force: options.explicitOptions.contains("--eval-batch-factor"), into: &arguments)
+            appendBool("--continue-on-failure", value: options.continueOnFailure, defaultValue: true, force: options.explicitOptions.contains("--continue-on-failure"), into: &arguments)
+            appendBool("--restart-stack-per-model", value: options.restartStackPerModel, defaultValue: true, force: options.explicitOptions.contains("--restart-stack-per-model"), into: &arguments)
+            if options.dryRun {
+                arguments.append("--dry-run")
+            }
+            json = options.json
         case .runsList(let options):
             arguments = ["runs", "list"]
             appendOption("--from", value: options.sourcePath, into: &arguments)
@@ -667,11 +710,32 @@ public enum MelixCLICommandCodec {
         arguments.append(contentsOf: [option, String(value)])
     }
 
+    private static func appendInt(_ option: String, value: Int, defaultValue: Int, force: Bool, into arguments: inout [String]) {
+        guard force || value != defaultValue else {
+            return
+        }
+        arguments.append(contentsOf: [option, String(value)])
+    }
+
     private static func appendPositiveUInt32(_ option: String, value: UInt32, into arguments: inout [String]) {
         guard value > 0 else {
             return
         }
         arguments.append(contentsOf: [option, String(value)])
+    }
+
+    private static func appendUInt32(_ option: String, value: UInt32, defaultValue: UInt32, force: Bool, into arguments: inout [String]) {
+        guard force || value != defaultValue else {
+            return
+        }
+        arguments.append(contentsOf: [option, String(value)])
+    }
+
+    private static func appendBool(_ option: String, value: Bool, defaultValue: Bool, force: Bool, into arguments: inout [String]) {
+        guard force || value != defaultValue else {
+            return
+        }
+        arguments.append(contentsOf: [option, value ? "true" : "false"])
     }
 
     private static func appendMultiOption(_ option: String, values: [String], into arguments: inout [String]) {

--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -26,12 +26,119 @@ This contract applies to:
 - the native Window UI
 - control-plane request and response payloads
 - persisted benchmark and evaluation runs
+- combined benchmark and evaluation batch-run planning artifacts
 - export formats used for CSV and JSONL artifacts
 
 This contract does not define:
 
-- one-command combined benchmark plus evaluation runs
 - leaderboard or community-submission APIs
+
+## Combined Batch Run Planning
+
+Melix may expose `melix batch run` as an operator-facing orchestration surface
+for repeated benchmark plus evaluation sweeps over a model list. This surface
+does not replace the canonical `bench` and `eval` product semantics; it plans,
+records, and eventually dispatches those existing product commands for each
+selected model.
+
+The initial supported execution mode is:
+
+- `melix batch run --models <path> --dry-run`
+
+The dry-run mode must not contact Hugging Face, start a Melix runtime stack, or
+submit benchmark or evaluation jobs. It must validate and normalize inputs,
+materialize planning artifacts, and print a compact terminal summary.
+
+### Model List Contract
+
+The model list is a UTF-8 text file. Each non-empty, non-comment line selects
+one model. Melix must preserve duplicate entries because repeated runs may be
+intentional for reliability or variance checks.
+
+Supported line forms are:
+
+- `<hf_repo_id>`
+- `<model_index>|<hf_repo_id>`
+
+For lines without an explicit index, Melix assigns a zero-padded two digit
+index in file order. Explicit indexes are preserved as provided. The normalized
+model entry must include:
+
+- `index`
+- `repo_id`
+- `source_line`
+
+### Effective Configuration
+
+Batch-run planning must resolve one effective configuration before any per-model
+work begins. Resolution precedence is:
+
+1. CLI option
+2. config file value
+3. environment variable
+4. Melix default
+
+The effective configuration artifact must be written as
+`effective-config.json` in both the temporary run directory and the operator
+output directory. It must include at least:
+
+- `schema_version`
+- `run_id`
+- `model_list`
+- `output_root`
+- `temp_root`
+- `start_index`
+- `max_models`
+- `selected_model_count`
+- `total_model_count`
+- `is_subset_run`
+- `dry_run`
+- `continue_on_failure`
+- `restart_stack_per_model`
+- `judge`
+- `benchmark`
+- `evaluation`
+- `models`
+
+### Manifest Planning
+
+Batch-run planning must write `manifest.jsonl` in both the temporary run
+directory and the operator output directory. Each selected model receives one
+JSONL record with `schema_version: melix.batch.manifest_entry.v1`.
+
+The initial dry-run manifest entry status is `planned`. Per-step statuses start
+as `pending` for:
+
+- `hub_check`
+- `benchmark`
+- `evaluation`
+- `exports`
+- `artifact_copy`
+
+Future non-dry-run execution may update model status to:
+
+- `running`
+- `succeeded`
+- `failed`
+- `partial_success`
+- `recovered`
+
+`partial_success` is reserved for models where one product line, such as
+benchmarking or evaluation, completed and produced auditable artifacts while
+another product line failed.
+
+### Terminal Summary
+
+Dry-run terminal output must show:
+
+- `run_id`
+- selected and total model counts
+- subset controls when present
+- temporary and output roots
+- judge server and judge model
+- failure-continuation and per-model stack restart policy
+- effective configuration and manifest paths
+- one compact `PLAN` line per selected model
 
 ## Product Split
 

--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -68,6 +68,11 @@ model entry must include:
 - `repo_id`
 - `source_line`
 
+Subset selection uses 1-based model-list positions, not the model entry's
+display `index` value. `start_index: 2` starts with the second selected line in
+the normalized model list even when explicit display indexes are non-numeric or
+non-contiguous.
+
 ### Effective Configuration
 
 Batch-run planning must resolve one effective configuration before any per-model

--- a/docs/plans/2026-05-11-bench-eval-batch-run-foundation.md
+++ b/docs/plans/2026-05-11-bench-eval-batch-run-foundation.md
@@ -1,0 +1,113 @@
+# Bench Eval Batch Run Foundation
+
+## Goal
+
+Add the first durable foundation for operator benchmark plus evaluation batch
+runs: a documented `melix batch run --dry-run` command that normalizes model
+lists, resolves effective run configuration, writes initial planning artifacts,
+and prints a compact operator summary without starting any runtime work.
+
+## Governing Issues
+
+This slice advances the first recommended execution group:
+
+- #746 Define the canonical batch run contract and artifact shape
+- #770 Define manifest schema and status lifecycle
+- #756 Implement file-driven model list ingestion
+- #758 Add effective configuration resolver
+- #759 Add per-model staging directory layout
+- #775 Define resume and subset selection contract
+- #768 Add terminal progress summary format
+- #850 Document the batch-run operator quickstart
+
+Follow-up execution, resume, health, reporting, and UX work remains tracked in
+the existing sub-issues under #745, #769, #793, #817, and #837.
+
+## Scope
+
+- Extend `docs/benchmark-evaluation-contract.md` with combined batch-run
+  planning semantics.
+- Add a written plan for the foundation slice.
+- Add a new `melix batch run` CLI command surface.
+- Support `--dry-run` as the only executable mode in this slice.
+- Parse text model lists while preserving duplicate entries.
+- Support explicit `index|repo_id` model entries and auto-indexed repo-only
+  entries.
+- Resolve effective configuration from CLI options, config file values,
+  environment variables, and Melix defaults.
+- Support subset planning through `--start-index` and `--max-models`.
+- Write `effective-config.json` and `manifest.jsonl` to both temporary and
+  operator output roots.
+- Print a compact terminal plan summary.
+- Cover parser and runner behavior with targeted Swift tests.
+
+## Non-Goals
+
+- Running Hugging Face reachability checks.
+- Starting or restarting Melix runtime stacks.
+- Dispatching benchmark or evaluation jobs.
+- Resuming partial runs from prior manifests.
+- Producing final CSV, Markdown, or evidence bundles.
+- Adding Window UI surfaces.
+
+## Architecture
+
+The CLI owns the planning surface for this foundation slice. It does not create
+new benchmark or evaluation semantics; it records how existing `bench` and
+`eval` work will be orchestrated in later slices.
+
+`BatchRunPlanner` builds an immutable `BatchRunPlan` by resolving:
+
+- model list path
+- run id
+- temporary and output roots
+- subset controls
+- judge server and model
+- benchmark suite controls
+- evaluation suite controls
+- failure-continuation behavior
+- per-model stack restart behavior
+
+`BatchRunArtifacts` writes two planning artifacts:
+
+- `effective-config.json`
+- `manifest.jsonl`
+
+The temporary run directory remains the working source for future execution.
+The operator output directory receives a copy immediately so an interrupted run
+still leaves inspectable evidence outside transient worker state.
+
+## Metrics And Success Targets
+
+- Model-list parsing preserves duplicates and records source line numbers.
+- Dry-run planning writes one manifest row per selected model.
+- `effective-config.json` records selected and total model counts.
+- Subset selection is deterministic for `--start-index` and `--max-models`.
+- Dry-run command completion does not require a running Melix development
+  stack, network access, or local model downloads.
+- Non-dry-run execution returns a clear unsupported-mode error until the
+  execution sub-issues land.
+
+## Verification
+
+- Swift parser test for `melix batch run --dry-run` option decoding.
+- Swift runner test for dry-run artifact generation and subset selection.
+- `git diff --check`.
+- Targeted Swift test invocation for the touched CLI tests.
+
+## Rollout
+
+This command is safe to expose behind the required `--dry-run` flag because it
+only performs local validation and artifact writes. Operator runbooks can begin
+using it to inspect batch plans before the execution, resume, and reporting
+slices are implemented.
+
+## Known Follow-Ups
+
+- Implement per-model hub preflight and staging directories beyond planned
+  manifest paths.
+- Dispatch `bench run` and `eval run` per model.
+- Persist in-progress and terminal manifest status updates.
+- Resume missing benchmark or evaluation work from existing manifests.
+- Produce final terminal, Markdown, CSV, JSONL, and downloadable evidence
+  bundles.

--- a/docs/plans/2026-05-11-bench-eval-batch-run-foundation.md
+++ b/docs/plans/2026-05-11-bench-eval-batch-run-foundation.md
@@ -35,7 +35,9 @@ the existing sub-issues under #745, #769, #793, #817, and #837.
   entries.
 - Resolve effective configuration from CLI options, config file values,
   environment variables, and Melix defaults.
-- Support subset planning through `--start-index` and `--max-models`.
+- Support subset planning through `--start-index` and `--max-models`, where
+  `--start-index` is a 1-based model-list position independent of display
+  model indexes.
 - Write `effective-config.json` and `manifest.jsonl` to both temporary and
   operator output roots.
 - Print a compact terminal plan summary.

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -2047,6 +2047,61 @@ struct MelixCLIParserTests {
         )
     }
 
+    @Test("parses batch run dry-run foundation options")
+    func parsesBatchRunDryRunFoundationOptions() throws {
+        #expect(MelixCLIParser.usageText.contains("melix batch run --models PATH"))
+
+        let command = try MelixCLIParser.parse([
+            "batch", "run",
+            "--models", "/tmp/models.txt",
+            "--config", "/tmp/melix-batch.yaml",
+            "--run-id", "run-1",
+            "--output-root", "/tmp/downloads",
+            "--temp-root", "/tmp/runtime",
+            "--start-index", "2",
+            "--max-models", "3",
+            "--judge-remote-server-id", "judge",
+            "--judge-model", "gpt-test",
+            "--bench-suite", "smoke",
+            "--bench-context-length", "2048",
+            "--bench-generation-length", "256",
+            "--bench-batch-size", "2",
+            "--bench-repeats", "4",
+            "--bench-sample-size", "5",
+            "--bench-batch-factor", "6",
+            "--eval-suite", "event_extraction",
+            "--eval-dataset-id", "events.v1",
+            "--eval-scoring-mode", "event_extraction_weighted_f1",
+            "--eval-sample-size", "7",
+            "--eval-batch-factor", "8",
+            "--continue-on-failure", "false",
+            "--restart-stack-per-model", "false",
+            "--dry-run",
+            "--json",
+        ])
+
+        guard case .batchRun(let options) = command else {
+            Issue.record("Expected batchRun command")
+            return
+        }
+
+        #expect(options.modelListPath == "/tmp/models.txt")
+        #expect(options.configPath == "/tmp/melix-batch.yaml")
+        #expect(options.runID == "run-1")
+        #expect(options.outputRoot == "/tmp/downloads")
+        #expect(options.tempRoot == "/tmp/runtime")
+        #expect(options.startIndex == 2)
+        #expect(options.maxModels == 3)
+        #expect(options.judgeRemoteServerID == "judge")
+        #expect(options.judgeModelID == "gpt-test")
+        #expect(options.benchContextLength == 2048)
+        #expect(options.evalSampleSize == 7)
+        #expect(options.continueOnFailure == false)
+        #expect(options.restartStackPerModel == false)
+        #expect(options.dryRun)
+        #expect(options.json)
+    }
+
     @Test("parses bench list and export-csv commands")
     func parsesBenchListAndExportCSVCommands() throws {
         let listCommand = try MelixCLIParser.parse([

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -336,7 +336,7 @@ struct MelixCLIRunnerTests {
         #expect(FileManager.default.fileExists(atPath: copiedConfigPath.path))
         #expect(FileManager.default.fileExists(atPath: copiedManifestPath.path))
 
-        let effectiveConfig = try #require(parseJSONFile(effectiveConfigPath.path))
+        let effectiveConfig = try #require(try parseJSONFile(effectiveConfigPath.path))
         #expect(effectiveConfig["schema_version"] as? String == "melix.batch.effective_config.v1")
         #expect(effectiveConfig["run_id"] as? String == "dry-run-1")
         #expect(effectiveConfig["selected_model_count"] as? Int == 1)
@@ -381,7 +381,7 @@ struct MelixCLIRunnerTests {
             dryRun: true
         )))
 
-        let effectiveConfig = try #require(parseJSONFile(tempRoot.appendingPathComponent("effective-config.json").path))
+        let effectiveConfig = try #require(try parseJSONFile(tempRoot.appendingPathComponent("effective-config.json").path))
         let models = try #require(effectiveConfig["models"] as? [[String: Any]])
         #expect(models.count == 1)
         #expect(models[0]["index"] as? String == "10")
@@ -453,7 +453,7 @@ struct MelixCLIRunnerTests {
         let runner = MelixCLIRunner(environment: ["HOME": root.path])
         _ = try await runner.run(command)
 
-        let effectiveConfig = try #require(parseJSONFile(tempRoot.appendingPathComponent("effective-config.json").path))
+        let effectiveConfig = try #require(try parseJSONFile(tempRoot.appendingPathComponent("effective-config.json").path))
         #expect(effectiveConfig["selected_model_count"] as? Int == 3)
         #expect(effectiveConfig["max_models"] as? Int == 0)
         #expect(effectiveConfig["continue_on_failure"] as? Bool == true)

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -318,7 +318,7 @@ struct MelixCLIRunnerTests {
             runID: "dry-run-1",
             outputRoot: outputRoot.path,
             tempRoot: tempRoot.path,
-            startIndex: 7,
+            startIndex: 2,
             maxModels: 1,
             dryRun: true
         )))
@@ -354,6 +354,66 @@ struct MelixCLIRunnerTests {
         #expect(manifestEntry["status"] as? String == "planned")
         #expect(manifestEntry["model_index"] as? String == "07")
         #expect(manifestEntry["repo_id"] as? String == "unsloth/Qwen3.6-27B-UD-MLX-4bit")
+    }
+
+    @Test("batch run dry-run start index is positional")
+    func batchRunDryRunStartIndexIsPositional() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let modelList = root.appendingPathComponent("models.txt")
+        let tempRoot = root.appendingPathComponent("tmp-run")
+        let outputRoot = root.appendingPathComponent("downloads")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try """
+        A|mlx-community/Alpha-4bit
+        10|mlx-community/Ten-4bit
+        20|mlx-community/Twenty-4bit
+        """.write(to: modelList, atomically: true, encoding: .utf8)
+
+        let runner = MelixCLIRunner(environment: ["HOME": root.path])
+        _ = try await runner.run(.batchRun(.init(
+            modelListPath: modelList.path,
+            runID: "dry-run-positional",
+            outputRoot: outputRoot.path,
+            tempRoot: tempRoot.path,
+            startIndex: 2,
+            maxModels: 1,
+            dryRun: true
+        )))
+
+        let effectiveConfig = try #require(parseJSONFile(tempRoot.appendingPathComponent("effective-config.json").path))
+        let models = try #require(effectiveConfig["models"] as? [[String: Any]])
+        #expect(models.count == 1)
+        #expect(models[0]["index"] as? String == "10")
+        #expect(models[0]["repo_id"] as? String == "mlx-community/Ten-4bit")
+    }
+
+    @Test("batch run dry-run supports matching temp and output roots")
+    func batchRunDryRunSupportsMatchingTempAndOutputRoots() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let modelList = root.appendingPathComponent("models.txt")
+        let runRoot = root.appendingPathComponent("same-root")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try """
+        mlx-community/Qwen3.5-9B-MLX-4bit
+        """.write(to: modelList, atomically: true, encoding: .utf8)
+
+        let runner = MelixCLIRunner(environment: ["HOME": root.path])
+        _ = try await runner.run(.batchRun(.init(
+            modelListPath: modelList.path,
+            runID: "dry-run-same-root",
+            outputRoot: runRoot.path,
+            tempRoot: runRoot.path,
+            dryRun: true
+        )))
+
+        let effectiveConfigPath = runRoot.appendingPathComponent("effective-config.json")
+        let manifestPath = runRoot.appendingPathComponent("manifest.jsonl")
+        #expect(FileManager.default.fileExists(atPath: effectiveConfigPath.path))
+        #expect(FileManager.default.fileExists(atPath: manifestPath.path))
+        let manifest = try String(contentsOf: manifestPath, encoding: .utf8)
+        #expect(manifest.split(separator: "\n").count == 1)
     }
 
     @Test("batch run dry-run explicit CLI defaults override config")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -297,6 +297,111 @@ struct MelixCLIRunnerTests {
         #expect(MelixCLIJSONMetricPatch.literal(for: -1) == "0.0000000000000000e+00")
     }
 
+    @Test("batch run dry-run writes effective config and manifest artifacts")
+    func batchRunDryRunWritesEffectiveConfigAndManifestArtifacts() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let modelList = root.appendingPathComponent("models.txt")
+        let tempRoot = root.appendingPathComponent("tmp-run")
+        let outputRoot = root.appendingPathComponent("downloads")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try """
+        # preserve comments and duplicates
+        mlx-community/Qwen3.5-9B-MLX-4bit
+        07|unsloth/Qwen3.6-27B-UD-MLX-4bit
+        08|unsloth/Qwen3.6-27B-UD-MLX-4bit
+        """.write(to: modelList, atomically: true, encoding: .utf8)
+
+        let runner = MelixCLIRunner(environment: ["HOME": root.path])
+        let output = try await runner.run(.batchRun(.init(
+            modelListPath: modelList.path,
+            runID: "dry-run-1",
+            outputRoot: outputRoot.path,
+            tempRoot: tempRoot.path,
+            startIndex: 7,
+            maxModels: 1,
+            dryRun: true
+        )))
+
+        #expect(output.contains("Melix batch run dry-run"))
+        #expect(output.contains("models=1/3"))
+        #expect(output.contains("[1/1] PLAN 07 unsloth/Qwen3.6-27B-UD-MLX-4bit"))
+
+        let effectiveConfigPath = tempRoot.appendingPathComponent("effective-config.json")
+        let manifestPath = tempRoot.appendingPathComponent("manifest.jsonl")
+        let copiedConfigPath = outputRoot.appendingPathComponent("effective-config.json")
+        let copiedManifestPath = outputRoot.appendingPathComponent("manifest.jsonl")
+        #expect(FileManager.default.fileExists(atPath: effectiveConfigPath.path))
+        #expect(FileManager.default.fileExists(atPath: manifestPath.path))
+        #expect(FileManager.default.fileExists(atPath: copiedConfigPath.path))
+        #expect(FileManager.default.fileExists(atPath: copiedManifestPath.path))
+
+        let effectiveConfig = try #require(parseJSONFile(effectiveConfigPath.path))
+        #expect(effectiveConfig["schema_version"] as? String == "melix.batch.effective_config.v1")
+        #expect(effectiveConfig["run_id"] as? String == "dry-run-1")
+        #expect(effectiveConfig["selected_model_count"] as? Int == 1)
+        #expect(effectiveConfig["total_model_count"] as? Int == 3)
+        #expect(effectiveConfig["is_subset_run"] as? Bool == true)
+        let models = try #require(effectiveConfig["models"] as? [[String: Any]])
+        #expect(models.count == 1)
+        #expect(models[0]["index"] as? String == "07")
+        #expect(models[0]["repo_id"] as? String == "unsloth/Qwen3.6-27B-UD-MLX-4bit")
+
+        let manifest = try String(contentsOf: manifestPath, encoding: .utf8)
+        let manifestLines = manifest.split(separator: "\n")
+        #expect(manifestLines.count == 1)
+        let manifestEntry = try #require(parseJSONObject(String(manifestLines[0])))
+        #expect(manifestEntry["status"] as? String == "planned")
+        #expect(manifestEntry["model_index"] as? String == "07")
+        #expect(manifestEntry["repo_id"] as? String == "unsloth/Qwen3.6-27B-UD-MLX-4bit")
+    }
+
+    @Test("batch run dry-run explicit CLI defaults override config")
+    func batchRunDryRunExplicitCLIDefaultsOverrideConfig() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let modelList = root.appendingPathComponent("models.txt")
+        let config = root.appendingPathComponent("batch.yaml")
+        let tempRoot = root.appendingPathComponent("tmp-run")
+        let outputRoot = root.appendingPathComponent("downloads")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try """
+        mlx-community/Qwen3.5-9B-MLX-4bit
+        07|unsloth/Qwen3.6-27B-UD-MLX-4bit
+        08|unsloth/Qwen3.6-27B-UD-MLX-4bit
+        """.write(to: modelList, atomically: true, encoding: .utf8)
+        try """
+        max_models: 1
+        continue_on_failure: false
+        restart_stack_per_model: false
+        bench_sample_size: 9
+        """.write(to: config, atomically: true, encoding: .utf8)
+
+        let command = try MelixCLIParser.parse([
+            "batch", "run",
+            "--models", modelList.path,
+            "--config", config.path,
+            "--run-id", "dry-run-precedence",
+            "--output-root", outputRoot.path,
+            "--temp-root", tempRoot.path,
+            "--max-models", "0",
+            "--continue-on-failure", "true",
+            "--restart-stack-per-model", "true",
+            "--bench-sample-size", "1",
+            "--dry-run",
+        ])
+        let runner = MelixCLIRunner(environment: ["HOME": root.path])
+        _ = try await runner.run(command)
+
+        let effectiveConfig = try #require(parseJSONFile(tempRoot.appendingPathComponent("effective-config.json").path))
+        #expect(effectiveConfig["selected_model_count"] as? Int == 3)
+        #expect(effectiveConfig["max_models"] as? Int == 0)
+        #expect(effectiveConfig["continue_on_failure"] as? Bool == true)
+        #expect(effectiveConfig["restart_stack_per_model"] as? Bool == true)
+        let benchmark = try #require(effectiveConfig["benchmark"] as? [String: Any])
+        #expect(benchmark["sample_size"] as? Int == 1)
+    }
+
     @Test("json metric patching preserves user artifact strings that look like the old sentinel")
     func jsonMetricPatchingPreservesUserArtifactStringsThatLookLikeTheOldSentinel() throws {
         let sentinel = "9.9999999999989997e+99"


### PR DESCRIPTION
## Summary
- Add `melix batch run --dry-run` as the first operator-facing benchmark plus evaluation batch-run foundation.
- Normalize model lists, preserve duplicate entries, resolve effective configuration, and write `effective-config.json` plus `manifest.jsonl` to temp and output roots.
- Document the batch-run contract and implementation plan, with parser and runner tests for dry-run artifacts, CLI/config precedence, positional subset selection, and same-root artifact handling.

## Plan or Spec
- `docs/benchmark-evaluation-contract.md`
- `docs/plans/2026-05-11-bench-eval-batch-run-foundation.md`
- Issues: #746, #770, #756, #758, #759, #775, #768, #850

## Commands Run
```text
git diff --check
# passed

xcrun swift build --product melix
# passed: Build of product 'melix' complete.

.build/arm64-apple-macosx/debug/melix batch run --models .runtime/batch-run-smoke/models.txt --config .runtime/batch-run-smoke/config.yaml --run-id smoke-20260511 --temp-root .runtime/batch-run-smoke/tmp --output-root .runtime/batch-run-smoke/out --start-index 1 --max-models 0 --continue-on-failure true --restart-stack-per-model true --bench-sample-size 1 --dry-run
# passed: selected 3/3 models, wrote effective-config.json and manifest.jsonl, and manifest row count was 3.
# verified explicit CLI defaults overrode config values for max_models, continue_on_failure, restart_stack_per_model, and benchmark sample_size.

.build/arm64-apple-macosx/debug/melix batch run --models .runtime/batch-run-smoke/models.txt --continue-on-failure maybe --dry-run
# failed as expected: Invalid value for --continue-on-failure. Expected true or false.

.build/arm64-apple-macosx/debug/melix batch run --models .runtime/pr-feedback-smoke/models.txt --run-id feedback-positional --temp-root .runtime/pr-feedback-smoke/same-root --output-root .runtime/pr-feedback-smoke/same-root --start-index 2 --max-models 1 --dry-run
# passed: selected positional model 2 (`10|mlx-community/Ten-4bit`) despite non-numeric/non-contiguous display indexes, and preserved both artifacts when temp/output roots matched.

xcrun swift test --filter MelixCLIParserTests
# failed before selected tests ran: tests/MelixCLITests/DiskStreamingSmokeRunnerTests.swift:2:8: error: no such module 'Testing'

xcrun swift test --filter MelixCLIRunnerTests
# failed before selected tests ran: tests/MelixCLITests/DiskStreamingSmokeRunnerTests.swift:2:8: error: no such module 'Testing'
```

## Coverage and Metrics
- Coverage: N/A: changed-scope Swift test coverage is not measurable locally because the MelixCLITests target fails during compilation on the existing `DiskStreamingSmokeRunnerTests.swift` `import Testing` module error before these tests execute.
- Metrics: N/A: this slice is dry-run planning only and intentionally does not start runtime stacks, contact Hugging Face, or submit benchmark/evaluation jobs. Local smoke evidence verified artifact generation, selected-model counts, manifest row counts, CLI precedence behavior, positional subset selection, and same-root artifact handling.

## Known Gaps
- Non-dry-run execution intentionally returns an unsupported-mode error; execution, resume, health checks, and reporting remain in follow-up issues.
- Full targeted Swift tests are locally blocked by the existing `import Testing` module issue described above.
- No protocol or dependency changes are included.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run or attempted, with the local Swift Testing blocker recorded.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
