### PR TITLE
[codex] Add agentic tool registry contract

### DIFF
--- a/docs/architecture-spec.md
+++ b/docs/architecture-spec.md
@@ -424,6 +424,16 @@ Workers should also expose operational tools as product features:
 
 These flows should be backed by the same runtime metadata model used by the control plane.
 
+### Agentic Tool Runtime
+
+Agentic training replay, online rollout, benchmark, and evaluation must share one
+worker-owned tool registry contract. The initial built-in registry lives in the
+Python worker runtime and exports deterministic OpenAI-compatible function
+schemas plus Melix `ToolConfig` metadata for image crop, layout parsing, text
+search, image search, visit, and local compute tools. The registry is a contract
+boundary only: concrete adapters, observation redaction, replay metadata, and
+evaluation routing are layered on top in separate implementation slices.
+
 ### Quantization
 
 V1 requires:

--- a/docs/plans/2026-05-11-opensearch-vl-tool-runtime-foundation.md
+++ b/docs/plans/2026-05-11-opensearch-vl-tool-runtime-foundation.md
@@ -1,0 +1,76 @@
+# OpenSearch-VL Tool Runtime Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the first unified tool runtime contract slice for the OpenSearch-VL alignment track: a deterministic Python worker tool registry contract that can later be reused by training replay, rollout, benchmark, and evaluation paths.
+
+**Architecture:** The Python worker runtime owns the initial registry contract because current agentic trace construction, deterministic VLM tooling hooks, and evaluation/benchmark evidence are worker-side. This slice defines stable tool descriptors and schema export helpers only. It does not execute tools, redact observations, or route evaluation/rollout through tools; those remain separate executable units.
+
+**Tech Stack:** Python 3.12, dataclasses, Melix worker protobuf `ToolConfig`, `pytest`.
+
+---
+
+## Scope
+
+- Covers GitHub issue #676 under direction #674 / milestone #675.
+- Defines canonical built-in tool names for image crop, layout parsing, text search, image search, visit, and local compute.
+- Adds deterministic registry validation and worker `ToolConfig` export.
+- Updates the architecture spec with the worker-side source-of-truth boundary for agentic tools.
+- Does not implement concrete adapters, network search, browser visits, Python execution, observation redaction, replay metadata, or evaluation routing.
+
+## Files
+
+- Create: `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- Create: `services/mlx-worker-python/tests/test_tool_registry.py`
+- Modify: `docs/architecture-spec.md`
+- Create: `docs/plans/2026-05-11-opensearch-vl-tool-runtime-foundation.md`
+
+## Metrics And Probes
+
+- `tool_registry.tool_count`: number of exported built-in tools.
+- `tool_registry.schema_bytes`: total serialized JSON schema bytes for the exported tool set.
+- `tool_registry.required_argument_count`: total required argument names across exported tools. The first built-in registry has seven required arguments and leaves execution policy knobs such as limits, extraction mode, and purpose optional.
+- Success metric: focused registry tests pass with changed-line coverage at or above 95 percent for the touched Python module.
+
+## Implementation Tasks
+
+### Task 1: Plan And Red Tests
+
+- [x] Add this plan under `docs/plans/`.
+- [x] Add focused tests for the built-in tool names and deterministic ordering.
+- [x] Add tests that exported JSON schemas are valid object schemas with required fields.
+- [x] Add tests for duplicate tool names and unknown requested names.
+- [x] Add tests for worker `ToolConfig` export metadata.
+- [x] Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py
+```
+
+Expected: fail until `worker.runtime.tool_registry` exists.
+
+### Task 2: Registry Contract Implementation
+
+- [x] Add frozen dataclass descriptors for tool arguments, tools, and registry metrics.
+- [x] Define built-in descriptors for `image_crop`, `layout_parse`, `text_search`, `image_search`, `visit`, and `local_compute`.
+- [x] Validate stable names, duplicate names, and requested-name filters.
+- [x] Export OpenAI-compatible function tool schemas and Melix worker `ToolConfig` metadata.
+- [x] Keep schema serialization deterministic with sorted keys and compact separators.
+
+### Task 3: Documentation And Verification
+
+- [x] Update `docs/architecture-spec.md` with the tool registry ownership boundary.
+- [x] Run the focused pytest command from Task 1 and confirm it passes.
+- [x] Run changed-line coverage for `worker/runtime/tool_registry.py`.
+- [x] Run `git diff --check`.
+- [x] Record metrics and verification output in PR evidence.
+
+## Success Criteria
+
+- The Python worker can export the six built-in tool contracts in a deterministic order.
+- The exported schemas are valid JSON object schemas with explicit required fields.
+- Duplicate registry entries and unknown requested tool names are rejected with actionable errors.
+- Worker `ToolConfig` includes schema format, schema version, toolset version, parser, and parser contract version.
+- Focused tests pass.
+- Changed-line coverage for `tool_registry.py` is at least 95 percent.
+- `git diff --check` passes.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from packages.protocol.python.worker.v1 import common_pb2
+
+from worker.runtime.tool_registry import (
+    BUILTIN_AGENTIC_TOOL_NAMES,
+    ToolArgumentDescriptor,
+    ToolDescriptor,
+    ToolRegistry,
+    ToolRegistryError,
+    built_in_tool_config,
+    built_in_tool_registry,
+)
+
+
+def test_built_in_agentic_tool_registry_exports_stable_contracts() -> None:
+    registry = built_in_tool_registry()
+
+    assert registry.names() == BUILTIN_AGENTIC_TOOL_NAMES
+    assert registry.metrics().tool_count == 6
+    assert registry.metrics().required_argument_count == 7
+    assert registry.metrics().schema_bytes > 0
+
+    schemas = registry.as_openai_tools()
+    assert [schema["function"]["name"] for schema in schemas] == list(BUILTIN_AGENTIC_TOOL_NAMES)
+    assert {schema["type"] for schema in schemas} == {"function"}
+
+
+def test_built_in_tool_schemas_are_object_contracts_with_required_arguments() -> None:
+    registry = built_in_tool_registry()
+
+    for tool in registry.tools:
+        parsed = json.loads(tool.json_schema())
+        assert parsed["type"] == "object"
+        assert parsed["additionalProperties"] is False
+        assert parsed["required"]
+        assert set(parsed["required"]).issubset(parsed["properties"])
+        assert parsed["x-melix-tool-kind"] == tool.tool_kind
+        assert parsed["x-melix-observation-kind"] == tool.observation_kind
+
+
+def test_tool_registry_rejects_duplicate_tool_names() -> None:
+    registry = built_in_tool_registry()
+
+    with pytest.raises(ToolRegistryError, match="Duplicate tool registry entry"):
+        ToolRegistry([registry.tools[0], registry.tools[0]])
+
+
+def test_tool_registry_rejects_unknown_requested_names() -> None:
+    registry = built_in_tool_registry()
+
+    with pytest.raises(ToolRegistryError, match="Unknown tool registry entry requested"):
+        registry.select(["image_crop", "missing_tool"])
+
+
+def test_tool_registry_selects_tools_in_registry_order() -> None:
+    registry = built_in_tool_registry()
+
+    selected = registry.select(["visit", "image_crop", "visit"])
+
+    assert selected.names() == ("image_crop", "visit")
+
+
+def test_tool_registry_exports_worker_tool_config_metadata() -> None:
+    config = built_in_tool_config(["image_crop", "local_compute"])
+
+    assert isinstance(config, common_pb2.ToolConfig)
+    assert config.schema_format == "openai-function"
+    assert config.schema_version == "melix.agentic_tool_registry.v1"
+    assert config.toolset_version == "melix.agentic_tools.builtin.v1"
+    assert config.parser == "qwen"
+    assert config.parser_contract_version == "melix.tool_parser.qwen.v1"
+    assert [tool.name for tool in config.tools] == ["image_crop", "local_compute"]
+
+    crop_schema = json.loads(config.tools[0].json_schema)
+    compute_schema = json.loads(config.tools[1].json_schema)
+    assert crop_schema["required"] == ["media_ref", "region"]
+    assert compute_schema["required"] == ["code"]
+
+
+def test_tool_argument_descriptor_rejects_blank_names() -> None:
+    with pytest.raises(ToolRegistryError, match="Tool argument names must be non-empty"):
+        ToolArgumentDescriptor(name=" ", json_type="string", description="Blank")
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {"name": "arg", "json_type": " ", "description": "Missing type"},
+            "Tool argument arg must declare a JSON type.",
+        ),
+        (
+            {"name": "arg", "json_type": "string", "description": " "},
+            "Tool argument arg must include a description.",
+        ),
+    ],
+)
+def test_tool_argument_descriptor_rejects_incomplete_contract_fields(
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ToolRegistryError, match=message):
+        ToolArgumentDescriptor(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {"name": "Bad-Name"},
+            "Invalid tool registry name: Bad-Name",
+        ),
+        (
+            {"description": " "},
+            "Tool valid_tool must include a description.",
+        ),
+        (
+            {"tool_kind": " "},
+            "Tool valid_tool must include a tool kind.",
+        ),
+        (
+            {"observation_kind": " "},
+            "Tool valid_tool must include an observation kind.",
+        ),
+        (
+            {"arguments": ()},
+            "Tool valid_tool must define at least one argument.",
+        ),
+        (
+            {
+                "arguments": (
+                    ToolArgumentDescriptor("query", "string", "Query."),
+                    ToolArgumentDescriptor("query", "string", "Duplicate query."),
+                )
+            },
+            "Duplicate argument query in tool registry entry valid_tool.",
+        ),
+    ],
+)
+def test_tool_descriptor_rejects_incomplete_contract_fields(
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    payload = {
+        "name": "valid_tool",
+        "description": "Valid tool.",
+        "tool_kind": "test.valid",
+        "observation_kind": "test_result",
+        "arguments": (ToolArgumentDescriptor("query", "string", "Query."),),
+    }
+    payload.update(kwargs)
+
+    with pytest.raises(ToolRegistryError, match=message):
+        ToolDescriptor(**payload)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"schema_version": " "}, "Tool registry schema_version must be non-empty."),
+        ({"toolset_version": " "}, "Tool registry toolset_version must be non-empty."),
+        ({"parser": " "}, "Tool registry parser must be non-empty."),
+        (
+            {"parser_contract_version": " "},
+            "Tool registry parser_contract_version must be non-empty.",
+        ),
+    ],
+)
+def test_tool_registry_rejects_incomplete_metadata(
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ToolRegistryError, match=message):
+        ToolRegistry([built_in_tool_registry().tools[0]], **kwargs)

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -28,6 +28,8 @@ def test_built_in_agentic_tool_registry_exports_stable_contracts() -> None:
     schemas = registry.as_openai_tools()
     assert [schema["function"]["name"] for schema in schemas] == list(BUILTIN_AGENTIC_TOOL_NAMES)
     assert {schema["type"] for schema in schemas} == {"function"}
+    assert schemas[0]["x-melix-tool-kind"] == "vision.image_crop"
+    assert schemas[0]["x-melix-observation-kind"] == "image_region"
 
 
 def test_built_in_tool_schemas_are_object_contracts_with_required_arguments() -> None:
@@ -39,8 +41,8 @@ def test_built_in_tool_schemas_are_object_contracts_with_required_arguments() ->
         assert parsed["additionalProperties"] is False
         assert parsed["required"]
         assert set(parsed["required"]).issubset(parsed["properties"])
-        assert parsed["x-melix-tool-kind"] == tool.tool_kind
-        assert parsed["x-melix-observation-kind"] == tool.observation_kind
+        assert "x-melix-tool-kind" not in parsed
+        assert "x-melix-observation-kind" not in parsed
 
 
 def test_tool_registry_rejects_duplicate_tool_names() -> None:
@@ -57,12 +59,12 @@ def test_tool_registry_rejects_unknown_requested_names() -> None:
         registry.select(["image_crop", "missing_tool"])
 
 
-def test_tool_registry_selects_tools_in_registry_order() -> None:
+def test_tool_registry_selects_tools_in_requested_order() -> None:
     registry = built_in_tool_registry()
 
     selected = registry.select(["visit", "image_crop", "visit"])
 
-    assert selected.names() == ("image_crop", "visit")
+    assert selected.names() == ("visit", "image_crop")
 
 
 def test_tool_registry_exports_worker_tool_config_metadata() -> None:
@@ -83,8 +85,49 @@ def test_tool_registry_exports_worker_tool_config_metadata() -> None:
 
 
 def test_tool_argument_descriptor_rejects_blank_names() -> None:
-    with pytest.raises(ToolRegistryError, match="Tool argument names must be non-empty"):
+    with pytest.raises(ToolRegistryError, match="Invalid tool argument name"):
         ToolArgumentDescriptor(name=" ", json_type="string", description="Blank")
+
+
+def test_tool_argument_descriptor_normalizes_exported_fields() -> None:
+    argument = ToolArgumentDescriptor(
+        name=" media_ref ",
+        json_type=" string ",
+        description=" Source image. ",
+    )
+
+    assert argument.name == "media_ref"
+    assert argument.json_schema() == {
+        "type": "string",
+        "description": "Source image.",
+    }
+
+
+def test_tool_descriptor_normalizes_exported_fields_and_caches_schema() -> None:
+    tool = ToolDescriptor(
+        name=" image_crop ",
+        description=" Crop image. ",
+        tool_kind=" vision.image_crop ",
+        observation_kind=" image_region ",
+        arguments=(ToolArgumentDescriptor("media_ref", "string", "Source image."),),
+    )
+
+    assert tool.name == "image_crop"
+    assert tool.description == "Crop image."
+    assert tool.tool_kind == "vision.image_crop"
+    assert tool.observation_kind == "image_region"
+    assert tool.json_schema() is tool.json_schema()
+    assert tool.as_openai_tool()["function"]["parameters"] == {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "media_ref": {
+                "type": "string",
+                "description": "Source image.",
+            },
+        },
+        "required": ["media_ref"],
+    }
 
 
 @pytest.mark.parametrize(
@@ -97,6 +140,10 @@ def test_tool_argument_descriptor_rejects_blank_names() -> None:
         (
             {"name": "arg", "json_type": "string", "description": " "},
             "Tool argument arg must include a description.",
+        ),
+        (
+            {"name": "bad-name", "json_type": "string", "description": "Invalid"},
+            "Invalid tool argument name: bad-name",
         ),
     ],
 )

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from packages.protocol.python.worker.v1 import common_pb2
@@ -37,17 +37,21 @@ class ToolArgumentDescriptor:
     required: bool = True
 
     def __post_init__(self) -> None:
-        if not self.name.strip():
-            raise ToolRegistryError("Tool argument names must be non-empty.")
-        if not self.json_type.strip():
+        normalized_name = self.name.strip()
+        if not _TOOL_NAME_RE.fullmatch(normalized_name):
+            raise ToolRegistryError(f"Invalid tool argument name: {self.name}")
+        object.__setattr__(self, "name", normalized_name)
+        object.__setattr__(self, "json_type", self.json_type.strip())
+        object.__setattr__(self, "description", self.description.strip())
+        if not self.json_type:
             raise ToolRegistryError(f"Tool argument {self.name} must declare a JSON type.")
-        if not self.description.strip():
+        if not self.description:
             raise ToolRegistryError(f"Tool argument {self.name} must include a description.")
 
     def json_schema(self) -> dict[str, Any]:
         return {
-            "type": self.json_type.strip(),
-            "description": self.description.strip(),
+            "type": self.json_type,
+            "description": self.description,
         }
 
 
@@ -58,16 +62,21 @@ class ToolDescriptor:
     tool_kind: str
     observation_kind: str
     arguments: tuple[ToolArgumentDescriptor, ...]
+    _cached_schema: str = field(default="", init=False, repr=False)
 
     def __post_init__(self) -> None:
         normalized_name = self.name.strip()
         if not _TOOL_NAME_RE.fullmatch(normalized_name):
             raise ToolRegistryError(f"Invalid tool registry name: {self.name}")
-        if not self.description.strip():
+        object.__setattr__(self, "name", normalized_name)
+        object.__setattr__(self, "description", self.description.strip())
+        object.__setattr__(self, "tool_kind", self.tool_kind.strip())
+        object.__setattr__(self, "observation_kind", self.observation_kind.strip())
+        if not self.description:
             raise ToolRegistryError(f"Tool {normalized_name} must include a description.")
-        if not self.tool_kind.strip():
+        if not self.tool_kind:
             raise ToolRegistryError(f"Tool {normalized_name} must include a tool kind.")
-        if not self.observation_kind.strip():
+        if not self.observation_kind:
             raise ToolRegistryError(f"Tool {normalized_name} must include an observation kind.")
         if not self.arguments:
             raise ToolRegistryError(f"Tool {normalized_name} must define at least one argument.")
@@ -78,6 +87,7 @@ class ToolDescriptor:
                     f"Duplicate argument {argument.name} in tool registry entry {normalized_name}."
                 )
             argument_names.add(argument.name)
+        object.__setattr__(self, "_cached_schema", _COMPACT_SORTED_JSON_ENCODER.encode(self.schema_payload()))
 
     @property
     def required_arguments(self) -> tuple[str, ...]:
@@ -92,12 +102,10 @@ class ToolDescriptor:
                 for argument in self.arguments
             },
             "required": list(self.required_arguments),
-            "x-melix-tool-kind": self.tool_kind,
-            "x-melix-observation-kind": self.observation_kind,
         }
 
     def json_schema(self) -> str:
-        return _COMPACT_SORTED_JSON_ENCODER.encode(self.schema_payload())
+        return self._cached_schema
 
     def as_openai_tool(self) -> dict[str, Any]:
         return {
@@ -107,6 +115,8 @@ class ToolDescriptor:
                 "description": self.description,
                 "parameters": self.schema_payload(),
             },
+            "x-melix-tool-kind": self.tool_kind,
+            "x-melix-observation-kind": self.observation_kind,
         }
 
     def as_worker_tool_definition(self) -> common_pb2.ToolDefinition:
@@ -157,12 +167,13 @@ class ToolRegistry:
 
     def select(self, names: list[str] | tuple[str, ...]) -> ToolRegistry:
         requested_names = tuple(dict.fromkeys(name.strip() for name in names if name.strip()))
-        known_names = set(self.names())
+        tool_by_name = {tool.name: tool for tool in self._tools}
+        known_names = set(tool_by_name)
         missing_names = [name for name in requested_names if name not in known_names]
         if missing_names:
             joined = ", ".join(missing_names)
             raise ToolRegistryError(f"Unknown tool registry entry requested: {joined}")
-        selected = [tool for tool in self._tools if tool.name in requested_names]
+        selected = [tool_by_name[name] for name in requested_names]
         return ToolRegistry(
             selected,
             schema_version=self._schema_version,

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from packages.protocol.python.worker.v1 import common_pb2
+
+
+_COMPACT_SORTED_JSON_ENCODER = json.JSONEncoder(separators=(",", ":"), sort_keys=True)
+_TOOL_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+TOOL_REGISTRY_SCHEMA_VERSION = "melix.agentic_tool_registry.v1"
+BUILTIN_TOOLSET_VERSION = "melix.agentic_tools.builtin.v1"
+DEFAULT_TOOL_PARSER = "qwen"
+DEFAULT_TOOL_PARSER_CONTRACT_VERSION = "melix.tool_parser.qwen.v1"
+BUILTIN_AGENTIC_TOOL_NAMES = (
+    "image_crop",
+    "layout_parse",
+    "text_search",
+    "image_search",
+    "visit",
+    "local_compute",
+)
+
+
+class ToolRegistryError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ToolArgumentDescriptor:
+    name: str
+    json_type: str
+    description: str
+    required: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ToolRegistryError("Tool argument names must be non-empty.")
+        if not self.json_type.strip():
+            raise ToolRegistryError(f"Tool argument {self.name} must declare a JSON type.")
+        if not self.description.strip():
+            raise ToolRegistryError(f"Tool argument {self.name} must include a description.")
+
+    def json_schema(self) -> dict[str, Any]:
+        return {
+            "type": self.json_type.strip(),
+            "description": self.description.strip(),
+        }
+
+
+@dataclass(frozen=True)
+class ToolDescriptor:
+    name: str
+    description: str
+    tool_kind: str
+    observation_kind: str
+    arguments: tuple[ToolArgumentDescriptor, ...]
+
+    def __post_init__(self) -> None:
+        normalized_name = self.name.strip()
+        if not _TOOL_NAME_RE.fullmatch(normalized_name):
+            raise ToolRegistryError(f"Invalid tool registry name: {self.name}")
+        if not self.description.strip():
+            raise ToolRegistryError(f"Tool {normalized_name} must include a description.")
+        if not self.tool_kind.strip():
+            raise ToolRegistryError(f"Tool {normalized_name} must include a tool kind.")
+        if not self.observation_kind.strip():
+            raise ToolRegistryError(f"Tool {normalized_name} must include an observation kind.")
+        if not self.arguments:
+            raise ToolRegistryError(f"Tool {normalized_name} must define at least one argument.")
+        argument_names: set[str] = set()
+        for argument in self.arguments:
+            if argument.name in argument_names:
+                raise ToolRegistryError(
+                    f"Duplicate argument {argument.name} in tool registry entry {normalized_name}."
+                )
+            argument_names.add(argument.name)
+
+    @property
+    def required_arguments(self) -> tuple[str, ...]:
+        return tuple(argument.name for argument in self.arguments if argument.required)
+
+    def schema_payload(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                argument.name: argument.json_schema()
+                for argument in self.arguments
+            },
+            "required": list(self.required_arguments),
+            "x-melix-tool-kind": self.tool_kind,
+            "x-melix-observation-kind": self.observation_kind,
+        }
+
+    def json_schema(self) -> str:
+        return _COMPACT_SORTED_JSON_ENCODER.encode(self.schema_payload())
+
+    def as_openai_tool(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.schema_payload(),
+            },
+        }
+
+    def as_worker_tool_definition(self) -> common_pb2.ToolDefinition:
+        return common_pb2.ToolDefinition(
+            name=self.name,
+            description=self.description,
+            json_schema=self.json_schema(),
+        )
+
+
+@dataclass(frozen=True)
+class ToolRegistryMetrics:
+    tool_count: int
+    schema_bytes: int
+    required_argument_count: int
+
+
+class ToolRegistry:
+    def __init__(
+        self,
+        tools: list[ToolDescriptor] | tuple[ToolDescriptor, ...],
+        *,
+        schema_version: str = TOOL_REGISTRY_SCHEMA_VERSION,
+        toolset_version: str = BUILTIN_TOOLSET_VERSION,
+        parser: str = DEFAULT_TOOL_PARSER,
+        parser_contract_version: str = DEFAULT_TOOL_PARSER_CONTRACT_VERSION,
+    ) -> None:
+        self._tools = tuple(tools)
+        self._schema_version = schema_version.strip()
+        self._toolset_version = toolset_version.strip()
+        self._parser = parser.strip()
+        self._parser_contract_version = parser_contract_version.strip()
+        self._validate()
+
+    @property
+    def tools(self) -> tuple[ToolDescriptor, ...]:
+        return self._tools
+
+    def names(self) -> tuple[str, ...]:
+        return tuple(tool.name for tool in self._tools)
+
+    def metrics(self) -> ToolRegistryMetrics:
+        return ToolRegistryMetrics(
+            tool_count=len(self._tools),
+            schema_bytes=sum(len(tool.json_schema().encode("utf-8")) for tool in self._tools),
+            required_argument_count=sum(len(tool.required_arguments) for tool in self._tools),
+        )
+
+    def select(self, names: list[str] | tuple[str, ...]) -> ToolRegistry:
+        requested_names = tuple(dict.fromkeys(name.strip() for name in names if name.strip()))
+        known_names = set(self.names())
+        missing_names = [name for name in requested_names if name not in known_names]
+        if missing_names:
+            joined = ", ".join(missing_names)
+            raise ToolRegistryError(f"Unknown tool registry entry requested: {joined}")
+        selected = [tool for tool in self._tools if tool.name in requested_names]
+        return ToolRegistry(
+            selected,
+            schema_version=self._schema_version,
+            toolset_version=self._toolset_version,
+            parser=self._parser,
+            parser_contract_version=self._parser_contract_version,
+        )
+
+    def as_openai_tools(self) -> list[dict[str, Any]]:
+        return [tool.as_openai_tool() for tool in self._tools]
+
+    def as_worker_tool_config(self) -> common_pb2.ToolConfig:
+        return common_pb2.ToolConfig(
+            tools=[tool.as_worker_tool_definition() for tool in self._tools],
+            schema_format="openai-function",
+            schema_version=self._schema_version,
+            toolset_version=self._toolset_version,
+            parser=self._parser,
+            parser_contract_version=self._parser_contract_version,
+        )
+
+    def _validate(self) -> None:
+        if not self._schema_version:
+            raise ToolRegistryError("Tool registry schema_version must be non-empty.")
+        if not self._toolset_version:
+            raise ToolRegistryError("Tool registry toolset_version must be non-empty.")
+        if not self._parser:
+            raise ToolRegistryError("Tool registry parser must be non-empty.")
+        if not self._parser_contract_version:
+            raise ToolRegistryError("Tool registry parser_contract_version must be non-empty.")
+        seen_names: set[str] = set()
+        for tool in self._tools:
+            if tool.name in seen_names:
+                raise ToolRegistryError(f"Duplicate tool registry entry: {tool.name}")
+            seen_names.add(tool.name)
+
+
+def built_in_tool_registry() -> ToolRegistry:
+    return ToolRegistry(_BUILTIN_AGENTIC_TOOLS)
+
+
+def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> common_pb2.ToolConfig:
+    registry = built_in_tool_registry()
+    if names is not None:
+        registry = registry.select(names)
+    return registry.as_worker_tool_config()
+
+
+def _arg(
+    name: str,
+    json_type: str,
+    description: str,
+    *,
+    required: bool = True,
+) -> ToolArgumentDescriptor:
+    return ToolArgumentDescriptor(
+        name=name,
+        json_type=json_type,
+        description=description,
+        required=required,
+    )
+
+
+_BUILTIN_AGENTIC_TOOLS = (
+    ToolDescriptor(
+        name="image_crop",
+        description="Crop or inspect a bounded region from a referenced image.",
+        tool_kind="vision.image_crop",
+        observation_kind="image_region",
+        arguments=(
+            _arg("media_ref", "string", "Identifier or URI for the source image."),
+            _arg("region", "string", "Crop region as a named area or normalized box."),
+            _arg("purpose", "string", "Reason the crop is needed for the current step.", required=False),
+        ),
+    ),
+    ToolDescriptor(
+        name="layout_parse",
+        description="Extract visual layout elements from an image or document page.",
+        tool_kind="vision.layout_parse",
+        observation_kind="layout_elements",
+        arguments=(
+            _arg("media_ref", "string", "Identifier or URI for the source image or document."),
+            _arg("detail_level", "string", "Requested layout detail such as blocks, lines, or tables.", required=False),
+        ),
+    ),
+    ToolDescriptor(
+        name="text_search",
+        description="Search a local text corpus or fixture-backed index.",
+        tool_kind="retrieval.text_search",
+        observation_kind="search_results",
+        arguments=(
+            _arg("query", "string", "Text query to search for."),
+            _arg("corpus_ref", "string", "Optional local corpus or fixture identifier.", required=False),
+            _arg("max_results", "integer", "Maximum number of search results to return.", required=False),
+        ),
+    ),
+    ToolDescriptor(
+        name="image_search",
+        description="Search local image evidence or fixture-backed image indexes.",
+        tool_kind="retrieval.image_search",
+        observation_kind="image_search_results",
+        arguments=(
+            _arg("query", "string", "Visual or textual query for image search."),
+            _arg("corpus_ref", "string", "Optional image corpus or fixture identifier.", required=False),
+            _arg("max_results", "integer", "Maximum number of image results to return.", required=False),
+        ),
+    ),
+    ToolDescriptor(
+        name="visit",
+        description="Visit a local URL or fixture-backed page and return extracted content.",
+        tool_kind="browser.visit",
+        observation_kind="page_extract",
+        arguments=(
+            _arg("url", "string", "URL or fixture URL to visit."),
+            _arg("extract", "string", "Extraction mode such as text, links, or screenshot.", required=False),
+        ),
+    ),
+    ToolDescriptor(
+        name="local_compute",
+        description="Run deterministic local compute for parsing, arithmetic, or data shaping.",
+        tool_kind="compute.local",
+        observation_kind="compute_result",
+        arguments=(
+            _arg("code", "string", "Small deterministic compute snippet or expression."),
+            _arg("timeout_ms", "integer", "Maximum execution time in milliseconds.", required=False),
+        ),
+    ),
+)
+
+
+__all__ = [
+    "BUILTIN_AGENTIC_TOOL_NAMES",
+    "BUILTIN_TOOLSET_VERSION",
+    "DEFAULT_TOOL_PARSER",
+    "DEFAULT_TOOL_PARSER_CONTRACT_VERSION",
+    "TOOL_REGISTRY_SCHEMA_VERSION",
+    "ToolArgumentDescriptor",
+    "ToolDescriptor",
+    "ToolRegistry",
+    "ToolRegistryError",
+    "ToolRegistryMetrics",
+    "built_in_tool_config",
+    "built_in_tool_registry",
+]


### PR DESCRIPTION
## Summary
- Add a deterministic Python worker tool registry contract for the OpenSearch-VL agentic runtime direction.
- Export built-in contracts for `image_crop`, `layout_parse`, `text_search`, `image_search`, `visit`, and `local_compute` as OpenAI-compatible function schemas and Melix worker `ToolConfig`.
- Document the worker-owned registry boundary in the architecture spec.

## Plan or Spec
- `docs/plans/2026-05-11-opensearch-vl-tool-runtime-foundation.md`
- `docs/architecture-spec.md`
- GitHub issue: #676

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py
22 passed in 0.04s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --source worker.runtime.tool_registry -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py
22 passed in 0.05s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage report --include 'services/mlx-worker-python/worker/runtime/tool_registry.py'
services/mlx-worker-python/worker/runtime/tool_registry.py: 100% statement coverage

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json -o coverage.json
Wrote JSON report to coverage.json

python3 scripts/python_changed_line_coverage.py --coverage-json coverage.json --diff-from origin/main services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py
TOTAL 100.00% 134/134

git diff --check
passed

git diff --check --cached
passed
```

## Coverage and Metrics
- Changed-line coverage: `100.00%` (`134/134`) for the Python tool registry source.
- Statement coverage: `100%` for `services/mlx-worker-python/worker/runtime/tool_registry.py`.
- Metrics:
  - `tool_registry.tool_count`: `6`
  - `tool_registry.required_argument_count`: `7`
  - `tool_registry.schema_bytes`: `1845`

## Known Gaps
- Concrete deterministic adapters are deferred to #679/#680.
- Observation redaction, byte limits, timeout status, and replay metadata are deferred to #677.
- Evaluation and rollout routing through the unified tools are deferred to #682/#683.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
