### PR TITLE
perf: stream Swift binary resolution candidates

### DIFF
--- a/docs/plans/2026-05-11-swift-binary-resolution-streaming.md
+++ b/docs/plans/2026-05-11-swift-binary-resolution-streaming.md
@@ -1,0 +1,42 @@
+# Swift Binary Resolution Streaming Probe Slice
+
+## Scope
+
+This performance slice keeps the existing Swift integration binary lookup behavior but removes candidate-list materialization from the resolver used by `tests/integration/helpers.py`.
+
+Affected path:
+
+- `tests/integration/helpers.py`
+- `tests/integration/test_helper_binary_resolution.py`
+- `scripts/integration_swift_binary_resolution_probe.py`
+- `infra/perf/pr_scoped_probes.json` entry `integration-swift-binary-resolution-scandir`
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `integration-swift-binary-resolution-scandir`.
+
+Required focused commands:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json tests/integration/helpers.py tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/integration_swift_binary_resolution_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/integration_swift_binary_resolution_probe.py"; if [ -f "$SCRIPT" ]; then python3 "$SCRIPT"; else for PREFIX in "${MELIX_SWIFT_BINARY_RESOLUTION_HEAD_REPO:-}" "${GITHUB_WORKSPACE:-}/head" "../head"; do CANDIDATE="$PREFIX/$SCRIPT"; if [ -f "$CANDIDATE" ]; then python3 "$CANDIDATE"; exit $?; fi; done; echo "missing probe script fallback for $SCRIPT" >&2; exit 2; fi'
+```
+
+## Implementation Plan
+
+1. Preserve `_swift_product_binary_candidates()` for existing direct callers and regression coverage.
+2. Add a streaming resolver helper that considers the flat debug binary and each architecture-specific debug binary without building an executable candidate list.
+3. Keep the existing newest-mtime tie-breaker and the architecture-specific path preference for equal mtimes.
+4. Extend the focused integration-helper test to prove the public resolver no longer calls the candidate-list helper.
+5. Update the registered probe script so the new measurement exercises the public resolver instead of only the candidate factory.
+
+## Success Metrics
+
+- Focused tests pass.
+- Changed-scope coverage for touched Python lines is at least 95%.
+- The registered probe reports lower `elapsed_ms_mean` and/or `peak_bytes_mean` versus its legacy glob/list baseline.
+
+## Verification Boundary
+
+This is a Python integration-helper slice and is locally verifiable on Linux. It does not validate Swift runtime performance locally; the resolver path itself is Python and the registered PR-scoped probe remains the merge gate.

--- a/scripts/integration_swift_binary_resolution_probe.py
+++ b/scripts/integration_swift_binary_resolution_probe.py
@@ -38,14 +38,17 @@ def _resolve_from_candidates(candidates: list[Path]) -> Path:
     return max(executable_candidates, key=lambda candidate: (candidate.stat().st_mtime, len(candidate.parts)))
 
 
-def _run_once(build_root: Path, product_name: str, *, legacy: bool) -> tuple[float, int, int]:
+def _run_once(root: Path, build_root: Path, product_name: str, *, legacy: bool) -> tuple[float, int, int]:
     tracemalloc.start()
     started = time.perf_counter()
-    candidate_factory = getattr(helpers, "_swift_product_binary_candidates", _legacy_candidates)
     if legacy:
         resolved = _resolve_from_candidates(_legacy_candidates(build_root, product_name))
     else:
-        resolved = _resolve_from_candidates(candidate_factory(build_root, product_name))
+        resolved = helpers.resolve_swift_product_binary(
+            root,
+            package_path=Path("swift-probe"),
+            product_name=product_name,
+        )
     elapsed_ms = (time.perf_counter() - started) * 1000.0
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
@@ -60,7 +63,7 @@ def main() -> None:
     product_name = "melix-probe"
     root = Path(tempfile.mkdtemp(prefix="melix-swift-binary-probe-"))
     try:
-        build_root = root / ".build"
+        build_root = root / "swift-probe" / ".build"
         _write_executable(build_root / "debug" / product_name, 1)
         for index in range(triples):
             triple = build_root / f"triple-{index:05d}" / "debug" / product_name
@@ -71,10 +74,10 @@ def main() -> None:
         old_elapsed: list[float] = []
         old_peaks: list[float] = []
         for _ in range(samples):
-            elapsed, peak, _ = _run_once(build_root, product_name, legacy=True)
+            elapsed, peak, _ = _run_once(root, build_root, product_name, legacy=True)
             old_elapsed.append(elapsed)
             old_peaks.append(float(peak))
-            elapsed, peak, _ = _run_once(build_root, product_name, legacy=False)
+            elapsed, peak, _ = _run_once(root, build_root, product_name, legacy=False)
             new_elapsed.append(elapsed)
             new_peaks.append(float(peak))
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -443,20 +443,38 @@ def _swift_product_binary_candidates(build_root: Path, product_name: str) -> lis
     return candidates
 
 
+def _newest_executable_swift_product_binary(build_root: Path, product_name: str) -> Path | None:
+    newest_candidate: Path | None = None
+    newest_key: tuple[float, int] | None = None
+
+    def consider(candidate: Path) -> None:
+        nonlocal newest_candidate, newest_key
+        if not (candidate.is_file() and os.access(candidate, os.X_OK)):
+            return
+        candidate_key = (candidate.stat().st_mtime, len(candidate.parts))
+        if newest_key is None or candidate_key > newest_key:
+            newest_candidate = candidate
+            newest_key = candidate_key
+
+    consider(build_root / "debug" / product_name)
+    try:
+        entries = os.scandir(build_root)
+    except FileNotFoundError:
+        return newest_candidate
+
+    with entries:
+        for entry in entries:
+            if entry.is_dir(follow_symlinks=False):
+                consider(Path(entry.path) / "debug" / product_name)
+    return newest_candidate
+
+
 def resolve_scoped_swift_product_binary(repo_root: Path, *, scope: str, product_name: str) -> Path:
     layout = swift_root_package.swift_package_layout(repo_root, scope)
     build_root = layout.scratch_path
-    executable_candidates = [
-        candidate
-        for candidate in _swift_product_binary_candidates(build_root, product_name)
-        if candidate.is_file() and os.access(candidate, os.X_OK)
-    ]
-    if executable_candidates:
-        # Prefer architecture-specific SwiftPM outputs over flat debug outputs when mtimes tie.
-        return max(
-            executable_candidates,
-            key=lambda candidate: (candidate.stat().st_mtime, len(candidate.parts)),
-        )
+    resolved = _newest_executable_swift_product_binary(build_root, product_name)
+    if resolved is not None:
+        return resolved
 
     raise AssertionError(
         "Required Swift product binary is missing. "
@@ -467,16 +485,9 @@ def resolve_scoped_swift_product_binary(repo_root: Path, *, scope: str, product_
 
 def resolve_swift_product_binary(repo_root: Path, *, package_path: Path, product_name: str) -> Path:
     build_root = repo_root / package_path / ".build"
-    executable_candidates = [
-        candidate
-        for candidate in _swift_product_binary_candidates(build_root, product_name)
-        if candidate.is_file() and os.access(candidate, os.X_OK)
-    ]
-    if executable_candidates:
-        return max(
-            executable_candidates,
-            key=lambda candidate: (candidate.stat().st_mtime, len(candidate.parts)),
-        )
+    resolved = _newest_executable_swift_product_binary(build_root, product_name)
+    if resolved is not None:
+        return resolved
 
     raise AssertionError(
         "Required Swift product binary is missing. "

--- a/tests/integration/test_helper_binary_resolution.py
+++ b/tests/integration/test_helper_binary_resolution.py
@@ -21,6 +21,7 @@ def test_swift_product_binary_candidates_tolerates_missing_build_root(tmp_path: 
     assert helpers._swift_product_binary_candidates(build_root, "melix") == [
         build_root / "debug" / "melix"
     ]
+    assert helpers._newest_executable_swift_product_binary(build_root, "melix") is None
 
 
 def test_resolve_swift_product_binary_uses_scandir_fallback_without_path_glob(
@@ -74,6 +75,35 @@ def test_resolve_scoped_swift_product_binary_uses_scandir_fallback_without_path_
         repo_root,
         scope="cli",
         product_name="melix",
+    )
+
+    assert resolved == preferred
+
+
+def test_resolve_swift_product_binary_streams_candidates_without_candidate_list(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path
+    build_root = repo_root / "services" / "control-plane-swift" / ".build"
+    flat = build_root / "debug" / "melix-control-plane"
+    preferred = build_root / "arm64-apple-macosx" / "debug" / "melix-control-plane"
+    _write_executable(flat)
+    _write_executable(preferred)
+    os.utime(flat, (3, 3))
+    os.utime(preferred, (3, 3))
+
+    def fail_candidate_list(build_root: Path, product_name: str):
+        raise AssertionError("binary resolution should not allocate the candidate list")
+
+    monkeypatch.setattr(helpers, "_swift_product_binary_candidates", fail_candidate_list)
+    with pytest.raises(AssertionError, match="candidate list"):
+        helpers._swift_product_binary_candidates(build_root, "melix-control-plane")
+
+    resolved = helpers.resolve_swift_product_binary(
+        repo_root,
+        package_path=Path("services/control-plane-swift"),
+        product_name="melix-control-plane",
     )
 
     assert resolved == preferred


### PR DESCRIPTION
## Summary
- Stream Swift integration helper binary resolution instead of building an executable candidate list before selecting the newest product binary.
- Preserve the existing flat-debug and architecture-specific lookup semantics, including the architecture-specific tie preference when mtimes match.
- Update the registered probe script so `integration-swift-binary-resolution-scandir` measures the public resolver path.

## Plan or Spec
- `docs/plans/2026-05-11-swift-binary-resolution-streaming.md`
- Registered PR-scoped probe: `integration-swift-binary-resolution-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Branch baseline
cd /root/.hermes/profiles/coder/workspace
 git --git-dir=melix.git fetch origin main --prune
 git --git-dir=melix.git worktree add -b perf/cron-registered-python-slice-20260511101623 /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-slice-20260511101623 origin/main

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# Result: 7 passed in 0.73s; rerun under coverage: 7 passed in 0.34s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json tests/integration/helpers.py tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/integration_swift_binary_resolution_probe.py
# Result: TOTAL 48 0 100%

# Registered probe implementation, locally via direct script invocation (equivalent script path to registered command)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/integration_swift_binary_resolution_probe.py
# Result: {"candidate_count": 1501, "delta_ms_mean": -56.538902572356164, "elapsed_ms_mean": 98.85073881596327, "legacy_elapsed_ms_mean": 155.38964138831943, "legacy_peak_bytes_mean": 1679062.8, "peak_bytes_delta_mean": -1675388.6, "peak_bytes_mean": 3674.2, "samples": 5}

# Diff hygiene
git diff --check
# Result: pass
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 48 0 100%`).
- Local registered probe metrics: `legacy_elapsed_ms_mean=155.389641`, `elapsed_ms_mean=98.850739`, `delta_ms_mean=-56.538903`; `legacy_peak_bytes_mean=1679062.8`, `peak_bytes_mean=3674.2`, `peak_bytes_delta_mean=-1675388.6`, `candidate_count=1501`, `samples=5`.
- Registered CI probe validation is required before merge.

## Known Gaps
- Local Linux validation covers the Python integration-helper resolver and probe. It does not claim Swift runtime performance validation; the registered PR-scoped performance workflow is the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
