### PR TITLE
Define batch run config schema

### DIFF
--- a/Sources/MelixCLICore/MelixBatchRun.swift
+++ b/Sources/MelixCLICore/MelixBatchRun.swift
@@ -160,6 +160,31 @@ enum BatchRunModelListParser {
 }
 
 enum BatchRunConfigLoader {
+    private static let supportedKeys: Set<String> = [
+        "model_list",
+        "run_id",
+        "output_root",
+        "temp_root",
+        "start_index",
+        "max_models",
+        "judge_remote_server_id",
+        "judge_model",
+        "bench_suite",
+        "bench_context_length",
+        "bench_generation_length",
+        "bench_batch_size",
+        "bench_repeats",
+        "bench_sample_size",
+        "bench_batch_factor",
+        "eval_suite",
+        "eval_dataset_id",
+        "eval_scoring_mode",
+        "eval_sample_size",
+        "eval_batch_factor",
+        "continue_on_failure",
+        "restart_stack_per_model",
+    ]
+
     static func load(path: String) throws -> [String: String] {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.isEmpty == false else {
@@ -186,9 +211,32 @@ enum BatchRunConfigLoader {
             guard key.isEmpty == false else {
                 throw MelixCLIError.usage("Invalid batch config line \(lineNumber); key is empty.")
             }
-            values[key] = value
+            let keyString = String(key)
+            try validateKey(keyString, lineNumber: lineNumber)
+            values[keyString] = value
         }
         return values
+    }
+
+    private static func validateKey(_ key: String, lineNumber: Int) throws {
+        guard supportedKeys.contains(key) else {
+            if embedsRawSecret(key) {
+                throw MelixCLIError.usage(
+                    "Unsupported batch config key '\(key)' at line \(lineNumber). Batch configs must reference stored credentials by id instead of embedding raw secrets."
+                )
+            }
+            throw MelixCLIError.usage(
+                "Unsupported batch config key '\(key)' at line \(lineNumber). Supported keys: \(supportedKeys.sorted().joined(separator: ", "))."
+            )
+        }
+    }
+
+    private static func embedsRawSecret(_ key: String) -> Bool {
+        let lowered = key.lowercased()
+        return lowered.contains("api_key")
+            || lowered.contains("token")
+            || lowered.contains("secret")
+            || lowered.contains("password")
     }
 }
 

--- a/Sources/MelixCLICore/MelixBatchRun.swift
+++ b/Sources/MelixCLICore/MelixBatchRun.swift
@@ -161,29 +161,30 @@ enum BatchRunModelListParser {
 
 enum BatchRunConfigLoader {
     private static let supportedKeys: Set<String> = [
-        "model_list",
-        "run_id",
-        "output_root",
-        "temp_root",
-        "start_index",
-        "max_models",
-        "judge_remote_server_id",
-        "judge_model",
-        "bench_suite",
+        "bench_batch_factor",
+        "bench_batch_size",
         "bench_context_length",
         "bench_generation_length",
-        "bench_batch_size",
         "bench_repeats",
         "bench_sample_size",
-        "bench_batch_factor",
-        "eval_suite",
-        "eval_dataset_id",
-        "eval_scoring_mode",
-        "eval_sample_size",
-        "eval_batch_factor",
+        "bench_suite",
         "continue_on_failure",
+        "eval_batch_factor",
+        "eval_dataset_id",
+        "eval_sample_size",
+        "eval_scoring_mode",
+        "eval_suite",
+        "judge_model",
+        "judge_remote_server_id",
+        "max_models",
+        "model_list",
+        "output_root",
         "restart_stack_per_model",
+        "run_id",
+        "start_index",
+        "temp_root",
     ]
+    private static let secretKeySubstrings = ["api_key", "token", "secret", "password"]
 
     static func load(path: String) throws -> [String: String] {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -233,10 +234,7 @@ enum BatchRunConfigLoader {
 
     private static func embedsRawSecret(_ key: String) -> Bool {
         let lowered = key.lowercased()
-        return lowered.contains("api_key")
-            || lowered.contains("token")
-            || lowered.contains("secret")
-            || lowered.contains("password")
+        return secretKeySubstrings.contains { lowered.contains($0) }
     }
 }
 

--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -105,6 +105,48 @@ output directory. It must include at least:
 - `evaluation`
 - `models`
 
+### Batch Configuration File
+
+`melix batch run --config <path>` accepts a minimal UTF-8 YAML subset for
+operator-authored batch configuration. The supported subset is intentionally
+limited to top-level `key: value` scalar entries; nested objects, lists, anchors,
+and raw secret material are outside the batch-run config contract.
+
+The supported config file keys are:
+
+| Key | CLI Option | Environment Variable | Default | Purpose |
+|---|---|---|---|---|
+| `model_list` | `--models` | `MELIX_BATCH_MODEL_LIST` | required | Path to the UTF-8 model list. |
+| `run_id` | `--run-id` | `MELIX_RUN_ID` | UTC timestamp `yyyyMMdd-HHmmss` | Stable run identifier. |
+| `output_root` | `--output-root` | `MELIX_DOWNLOAD_ROOT` | `~/Downloads/melix-bench-eval-<run_id>` | Operator-visible bundle root. |
+| `temp_root` | `--temp-root` | `MELIX_RUN_TMP_ROOT` | `.runtime/bench-eval-run/<run_id>` | Worktree-local scratch run root. |
+| `start_index` | `--start-index` | `MELIX_START_INDEX` | `1` | 1-based model-list position to start from. |
+| `max_models` | `--max-models` | `MELIX_MAX_MODELS` | `0` | Maximum selected models; `0` means all remaining. |
+| `judge_remote_server_id` | `--judge-remote-server-id` | `MELIX_JUDGE_SERVER_ID` | `owlia-gpt-5-5-judge` | Stored remote-server id for semantic judging. |
+| `judge_model` | `--judge-model` | `MELIX_JUDGE_MODEL` | `gpt-5.5` | Remote model id used by the judge server. |
+| `bench_suite` | `--bench-suite` | `MELIX_BENCH_SUITE` | `smoke` | Benchmark suite id. |
+| `bench_context_length` | `--bench-context-length` | `MELIX_BENCH_CONTEXT_LENGTH` | `1024` | Benchmark prompt context length. |
+| `bench_generation_length` | `--bench-generation-length` | `MELIX_BENCH_GENERATION_LENGTH` | `128` | Benchmark generation length. |
+| `bench_batch_size` | `--bench-batch-size` | `MELIX_BENCH_BATCH_SIZE` | `1` | Benchmark batch size. |
+| `bench_repeats` | `--bench-repeats` | `MELIX_BENCH_REPEATS` | `1` | Benchmark repeat count. |
+| `bench_sample_size` | `--bench-sample-size` | `MELIX_BENCH_SAMPLE_SIZE` | `1` | Benchmark sample limit. |
+| `bench_batch_factor` | `--bench-batch-factor` | `MELIX_BENCH_BATCH_FACTOR` | `1` | Benchmark dataset batch factor. |
+| `eval_suite` | `--eval-suite` | `MELIX_EVAL_SUITE` | `event_extraction` | Evaluation suite id. |
+| `eval_dataset_id` | `--eval-dataset-id` | `MELIX_EVAL_DATASET_ID` | `top200.event-extraction.top20.v1` | Managed evaluation dataset id. |
+| `eval_scoring_mode` | `--eval-scoring-mode` | `MELIX_EVAL_SCORING_MODE` | `event_extraction_weighted_f1` | Evaluation scoring mode. |
+| `eval_sample_size` | `--eval-sample-size` | `MELIX_EVAL_SAMPLE_SIZE` | `20` | Evaluation sample limit. |
+| `eval_batch_factor` | `--eval-batch-factor` | `MELIX_EVAL_BATCH_FACTOR` | `1` | Evaluation batch factor. |
+| `continue_on_failure` | `--continue-on-failure` | `MELIX_CONTINUE_ON_FAILURE` | `true` | Whether one model failure allows the batch to continue. |
+| `restart_stack_per_model` | `--restart-stack-per-model` | `MELIX_RESTART_STACK_PER_MODEL` | `true` | Whether execution restarts the local stack between models. |
+
+Batch configs must reference stored credentials by id, not embed raw credential
+values. For semantic judging, `judge_remote_server_id` identifies a remote
+server already configured through the Melix remote-server store; any API key
+remains in the local secret store and never appears in the batch config,
+terminal summary, effective configuration artifact, or manifest. Config keys
+that look like raw secret fields, such as `*_api_key`, `*_token`, `*_secret`, or
+`*_password`, must be rejected before planning begins.
+
 ### Manifest Planning
 
 Batch-run planning must write `manifest.jsonl` in both the temporary run

--- a/docs/plans/2026-05-11-bench-eval-batch-run-foundation.md
+++ b/docs/plans/2026-05-11-bench-eval-batch-run-foundation.md
@@ -113,3 +113,34 @@ slices are implemented.
 - Resume missing benchmark or evaluation work from existing manifests.
 - Produce final terminal, Markdown, CSV, JSONL, and downloadable evidence
   bundles.
+
+## Issue 752 Config Schema Slice
+
+The follow-up config-schema slice closes the remaining `melix-batch.yaml`
+contract gap without expanding execution behavior.
+
+### Scope
+
+- Document every supported top-level `key: value` config field in
+  `docs/benchmark-evaluation-contract.md`.
+- Align each field with its CLI override, environment fallback, and default.
+- Define the credential rule: batch configs reference stored credential records
+  such as `judge_remote_server_id`; they never embed API keys or tokens.
+- Reject unsupported config keys so typos do not silently disappear from the
+  effective plan.
+- Reject config keys that look like raw secret carriers, including
+  `*_api_key`, `*_token`, `*_secret`, and `*_password`.
+
+### Metrics And Success Targets
+
+- The documented field set matches the current `BatchRunPlanner` resolver.
+- Secret-bearing values remain represented by stored credential ids rather than
+  raw key material.
+- Unsupported and raw-secret-looking config keys fail before any dry-run
+  artifacts are written.
+
+### Verification
+
+- Targeted Swift runner coverage for unsupported and secret-looking config keys.
+- `git diff --check`.
+- `xcrun swift build --product melix`.

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -483,16 +483,18 @@ struct MelixCLIRunnerTests {
         """.write(to: secretConfig, atomically: true, encoding: .utf8)
 
         let runner = MelixCLIRunner(environment: ["HOME": root.path])
-        await #expect(throws: MelixCLIError.usage(
-            "Unsupported batch config key 'unsupported_field' at line 2. Supported keys: bench_batch_factor, bench_batch_size, bench_context_length, bench_generation_length, bench_repeats, bench_sample_size, bench_suite, continue_on_failure, eval_batch_factor, eval_dataset_id, eval_sample_size, eval_scoring_mode, eval_suite, judge_model, judge_remote_server_id, max_models, model_list, output_root, restart_stack_per_model, run_id, start_index, temp_root."
-        )) {
+        let unknownMessage = try await requireUsageError {
             _ = try await runner.run(.batchRun(.init(modelListPath: "", configPath: unknownConfig.path, dryRun: true)))
         }
-        await #expect(throws: MelixCLIError.usage(
-            "Unsupported batch config key 'judge_api_key' at line 2. Batch configs must reference stored credentials by id instead of embedding raw secrets."
-        )) {
+        #expect(unknownMessage.starts(with: "Unsupported batch config key 'unsupported_field' at line 2."))
+        #expect(unknownMessage.contains("Supported keys:"))
+        #expect(unknownMessage.contains("model_list"))
+        #expect(unknownMessage.contains("judge_remote_server_id"))
+
+        let secretMessage = try await requireUsageError {
             _ = try await runner.run(.batchRun(.init(modelListPath: "", configPath: secretConfig.path, dryRun: true)))
         }
+        #expect(secretMessage == "Unsupported batch config key 'judge_api_key' at line 2. Batch configs must reference stored credentials by id instead of embedding raw secrets.")
     }
 
     @Test("json metric patching preserves user artifact strings that look like the old sentinel")
@@ -8333,6 +8335,23 @@ private final class EnvironmentRecorder: @unchecked Sendable {
 
     func record(_ environment: [String: String]) {
         self.environment = environment
+    }
+}
+
+private func requireUsageError(_ body: () async throws -> Void) async throws -> String {
+    do {
+        try await body()
+        Issue.record("Expected MelixCLIError.usage to be thrown.")
+        return ""
+    } catch let error as MelixCLIError {
+        guard case .usage(let message) = error else {
+            Issue.record("Expected MelixCLIError.usage, got \(error).")
+            return ""
+        }
+        return message
+    } catch {
+        Issue.record("Expected MelixCLIError.usage, got \(error).")
+        return ""
     }
 }
 

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -462,6 +462,39 @@ struct MelixCLIRunnerTests {
         #expect(benchmark["sample_size"] as? Int == 1)
     }
 
+    @Test("batch run config rejects unsupported and raw secret keys")
+    func batchRunConfigRejectsUnsupportedAndRawSecretKeys() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let modelList = root.appendingPathComponent("models.txt")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "mlx-community/Qwen3.5-9B-MLX-4bit\n".write(to: modelList, atomically: true, encoding: .utf8)
+
+        let unknownConfig = root.appendingPathComponent("unknown.yaml")
+        try """
+        model_list: \(modelList.path)
+        unsupported_field: value
+        """.write(to: unknownConfig, atomically: true, encoding: .utf8)
+
+        let secretConfig = root.appendingPathComponent("secret.yaml")
+        try """
+        model_list: \(modelList.path)
+        judge_api_key: sk-live-secret
+        """.write(to: secretConfig, atomically: true, encoding: .utf8)
+
+        let runner = MelixCLIRunner(environment: ["HOME": root.path])
+        await #expect(throws: MelixCLIError.usage(
+            "Unsupported batch config key 'unsupported_field' at line 2. Supported keys: bench_batch_factor, bench_batch_size, bench_context_length, bench_generation_length, bench_repeats, bench_sample_size, bench_suite, continue_on_failure, eval_batch_factor, eval_dataset_id, eval_sample_size, eval_scoring_mode, eval_suite, judge_model, judge_remote_server_id, max_models, model_list, output_root, restart_stack_per_model, run_id, start_index, temp_root."
+        )) {
+            _ = try await runner.run(.batchRun(.init(modelListPath: "", configPath: unknownConfig.path, dryRun: true)))
+        }
+        await #expect(throws: MelixCLIError.usage(
+            "Unsupported batch config key 'judge_api_key' at line 2. Batch configs must reference stored credentials by id instead of embedding raw secrets."
+        )) {
+            _ = try await runner.run(.batchRun(.init(modelListPath: "", configPath: secretConfig.path, dryRun: true)))
+        }
+    }
+
     @Test("json metric patching preserves user artifact strings that look like the old sentinel")
     func jsonMetricPatchingPreservesUserArtifactStringsThatLookLikeTheOldSentinel() throws {
         let sentinel = "9.9999999999989997e+99"


### PR DESCRIPTION
## Summary
- Document the supported melix-batch.yaml top-level fields, precedence hooks, defaults, and credential-reference rule.
- Reject unsupported batch config keys before planning so typos do not silently disappear.
- Reject raw-secret-looking config keys such as judge_api_key and add runner coverage for those failures.
- Address review feedback by sorting supported keys, centralizing secret-key substrings, and making schema-error assertions less brittle.

## Plan or Spec
- docs/benchmark-evaluation-contract.md
- docs/plans/2026-05-11-bench-eval-batch-run-foundation.md
- Closes #752

## Commands Run
```text
git diff --check
# passed before initial push and after review fixes

xcrun swift build --product melix
# passed before initial push and after review fixes: Build of product 'melix' complete

xcrun swift test --filter 'MelixCLIRunnerTests/(batchRunDryRunExplicitCLIDefaultsOverrideConfig|batchRunConfigRejectsUnsupportedAndRawSecretKeys)'
# blocked locally before executing tests with: no such module 'Testing'

xcrun swift test --filter 'MelixCLIRunnerTests/batchRunConfigRejectsUnsupportedAndRawSecretKeys'
# blocked locally before executing tests with: no such module 'Testing'

.build/debug/melix batch run --config .runtime/batch-config-schema-smoke/valid.yaml --dry-run
# passed before initial push and after review fixes: dry-run summary and artifact paths emitted

.build/debug/melix batch run --config .runtime/batch-config-schema-smoke/unknown.yaml --dry-run
# passed before initial push and after review fixes: failed with unsupported_field supported-key error

.build/debug/melix batch run --config .runtime/batch-config-schema-smoke/secret.yaml --dry-run
# passed before initial push and after review fixes: failed with raw-secret-key rejection for judge_api_key
```

## Coverage and Metrics
- Coverage: N/A. The focused Swift test commands were attempted, but this local toolchain cannot compile the repository test target because the Testing module is unavailable before the new tests execute.
- Metrics: batch config schema validation adds a constant-size key whitelist check during config parsing only. It does not touch non-dry-run execution, benchmark measurement loops, evaluation scoring, or artifact sync paths.

## Known Gaps
- Local Swift test execution remains blocked by the existing Testing module/toolchain issue; CI should provide the authoritative test result.
- Non-dry-run batch execution remains deferred to #755 and follow-up execution issues.
- Incremental manifest updates, artifact sync, and recovery remain tracked by #775 and related follow-ups.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.