### PR TITLE
[codex] Add agentic tool observation contract

### DIFF
--- a/docs/architecture-spec.md
+++ b/docs/architecture-spec.md
@@ -431,8 +431,17 @@ worker-owned tool registry contract. The initial built-in registry lives in the
 Python worker runtime and exports deterministic OpenAI-compatible function
 schemas plus Melix `ToolConfig` metadata for image crop, layout parsing, text
 search, image search, visit, and local compute tools. The registry is a contract
-boundary only: concrete adapters, observation redaction, replay metadata, and
-evaluation routing are layered on top in separate implementation slices.
+boundary only: concrete adapters and evaluation routing are layered on top in
+separate implementation slices.
+
+Tool observations must cross the same worker-owned boundary before they are
+persisted into training traces, benchmark artifacts, or evaluation evidence. The
+observation contract sanitizes nested payload text through configured exact
+redaction terms, enforces UTF-8 byte limits without invalid text, records
+completed/timeout/failed status metadata, and emits deterministic replay
+fingerprints over the sanitized payload plus call identity. Downstream consumers
+must treat the sanitized observation record as the durable source of truth rather
+than re-reading raw adapter output.
 
 ### Quantization
 

--- a/docs/plans/2026-05-11-opensearch-vl-tool-observation-contract.md
+++ b/docs/plans/2026-05-11-opensearch-vl-tool-observation-contract.md
@@ -1,0 +1,85 @@
+# OpenSearch-VL Tool Observation Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the next unified tool runtime contract slice for the OpenSearch-VL alignment track: a deterministic Python worker observation contract for sanitized tool outputs shared by training replay, rollout, benchmark, and evaluation paths.
+
+**Architecture:** The Python worker runtime owns observation normalization because tool execution outputs enter the system before they are persisted into agentic traces, benchmark artifacts, or evaluation evidence. This slice defines the contract boundary only: redaction, UTF-8 byte limits, timeout status metadata, deterministic replay fingerprints, and metrics. It does not implement concrete tool adapters or route existing evaluation jobs through those tools.
+
+**Tech Stack:** Python 3.12, dataclasses, hashlib, deterministic JSON encoding, `pytest`.
+
+---
+
+## Scope
+
+- Covers GitHub issue #677 under direction #674 / milestone #675.
+- Defines a worker runtime helper for converting raw tool observation payloads into sanitized records.
+- Applies configured exact redaction terms across nested observation strings.
+- Enforces UTF-8 byte limits without producing invalid text.
+- Normalizes explicit status values for completed, timeout, and failed observations.
+- Emits deterministic replay metadata and a stable fingerprint over the sanitized payload and call identity.
+- Updates the architecture spec with the observation contract boundary.
+- Does not implement concrete adapters, network search, browser visits, Python execution, or evaluation routing.
+
+## Files
+
+- Create: `services/mlx-worker-python/worker/runtime/tool_observation.py`
+- Create: `services/mlx-worker-python/tests/test_tool_observation.py`
+- Modify: `docs/architecture-spec.md`
+- Create: `docs/plans/2026-05-11-opensearch-vl-tool-observation-contract.md`
+
+## Metrics And Probes
+
+- `tool_observation.record_count`: number of normalized observation records emitted.
+- `tool_observation.redacted_value_count`: number of configured term replacements applied.
+- `tool_observation.truncated_count`: number of records where a text field exceeded the byte limit.
+- `tool_observation.timeout_count`: number of records normalized with timeout status.
+- `tool_observation.emitted_bytes`: UTF-8 bytes emitted after redaction and truncation.
+- Success metric: focused observation tests pass with changed-line coverage at or above 95 percent for the touched Python module.
+
+## Implementation Tasks
+
+### Task 1: Plan And Red Tests
+
+- [x] Add this plan under `docs/plans/`.
+- [x] Add focused tests for nested exact redaction without leaking configured terms.
+- [x] Add tests that byte limits truncate UTF-8 safely and record emitted/original bytes.
+- [x] Add tests that timeout status records explicit timeout metadata.
+- [x] Add tests that replay fingerprints are stable for identical sanitized records and change when payloads differ.
+- [x] Add tests that invalid policies and statuses are rejected.
+- [x] Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_observation.py
+```
+
+Expected: fail until `worker.runtime.tool_observation` exists.
+
+### Task 2: Observation Contract Implementation
+
+- [x] Add frozen dataclasses for observation policy, record metrics, replay metadata, and normalized records.
+- [x] Validate non-empty tool name, tool call id, observation kind, schema version, and supported statuses.
+- [x] Recursively sanitize dictionary, list, tuple, scalar, and text observation payloads.
+- [x] Apply exact redaction terms before byte limiting so leaked values never influence emitted text.
+- [x] Enforce per-string UTF-8 byte limits without splitting multi-byte characters.
+- [x] Emit deterministic replay metadata with schema version, policy hash, payload hash, and fingerprint.
+- [x] Expose a compact agentic-trace observation payload helper for downstream persistence.
+
+### Task 3: Documentation And Verification
+
+- [x] Update `docs/architecture-spec.md` with the worker-owned observation contract boundary.
+- [x] Run the focused pytest command from Task 1 and confirm it passes.
+- [x] Run changed-line coverage for `worker/runtime/tool_observation.py`.
+- [x] Run `git diff --check`.
+- [x] Record metrics and verification output in PR evidence.
+
+## Success Criteria
+
+- The Python worker can normalize a raw tool observation into a deterministic sanitized record.
+- Configured redaction terms do not appear in emitted nested observation text.
+- UTF-8 byte limits preserve valid text and expose truncation metrics.
+- Timeout status is explicit and includes timeout metadata.
+- Replay fingerprints are stable across identical sanitized observations and change with sanitized payload changes.
+- Focused tests pass.
+- Changed-line coverage for `tool_observation.py` is at least 95 percent.
+- `git diff --check` passes.

--- a/services/mlx-worker-python/tests/test_tool_observation.py
+++ b/services/mlx-worker-python/tests/test_tool_observation.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from worker.runtime.tool_observation import (
+    TOOL_OBSERVATION_SCHEMA_VERSION,
+    ToolObservationError,
+    ToolObservationPolicy,
+    normalize_tool_observation,
+)
+
+
+def test_tool_observation_redacts_nested_payload_strings_without_leaking_terms() -> None:
+    policy = ToolObservationPolicy(redaction_terms=("GOLD-SECRET", "oracle-token"))
+
+    record = normalize_tool_observation(
+        tool_name="image_crop",
+        tool_call_id="call-1",
+        observation_kind="image_region",
+        status="completed",
+        payload={
+            "text": "Visible label GOLD-SECRET.",
+            "oracle-token-key": "key should redact too",
+            "items": [
+                {"caption": "oracle-token appears twice: oracle-token"},
+                "safe value",
+            ],
+        },
+        policy=policy,
+    )
+
+    emitted = record.as_agentic_trace_observation()
+    serialized = json.dumps(emitted, sort_keys=True)
+    assert "GOLD-SECRET" not in serialized
+    assert "oracle-token" not in serialized
+    assert emitted["payload"]["text"] == "Visible label [REDACTED]."
+    assert emitted["payload"]["[REDACTED]-key"] == "key should redact too"
+    assert emitted["payload"]["items"][0]["caption"] == "[REDACTED] appears twice: [REDACTED]"
+    assert emitted["metrics"]["tool_observation.redacted_value_count"] == 4
+    assert emitted["metrics"]["tool_observation.truncated_count"] == 0
+
+
+def test_tool_observation_truncates_utf8_safely_and_records_byte_metrics() -> None:
+    record = normalize_tool_observation(
+        tool_name="visit",
+        tool_call_id="call-2",
+        observation_kind="page_extract",
+        status="completed",
+        payload="AB界CD",
+        policy=ToolObservationPolicy(max_text_bytes=4),
+    )
+
+    emitted = record.as_agentic_trace_observation()
+    assert emitted["payload"] == {"text": "AB"}
+    assert emitted["metrics"]["tool_observation.original_bytes"] == len("AB界CD".encode("utf-8"))
+    assert emitted["metrics"]["tool_observation.emitted_bytes"] == 2
+    assert emitted["metrics"]["tool_observation.truncated_count"] == 1
+
+
+def test_tool_observation_timeout_status_records_explicit_metadata() -> None:
+    record = normalize_tool_observation(
+        tool_name="local_compute",
+        tool_call_id="call-timeout",
+        observation_kind="compute_result",
+        status="timeout",
+        payload={"text": "Timed out before result."},
+        policy=ToolObservationPolicy(timeout_ms=250),
+    )
+
+    emitted = record.as_agentic_trace_observation()
+    assert emitted["status"] == "timeout"
+    assert emitted["timeout_ms"] == 250
+    assert emitted["metrics"]["tool_observation.timeout_count"] == 1
+    assert emitted["metrics"]["tool_observation.record_count"] == 1
+
+
+def test_tool_observation_replay_fingerprint_is_stable_for_sanitized_payload() -> None:
+    policy = ToolObservationPolicy(redaction_terms=("SECRET",))
+    first = normalize_tool_observation(
+        tool_name="text_search",
+        tool_call_id="call-3",
+        observation_kind="search_results",
+        status="completed",
+        payload={"text": "result SECRET"},
+        policy=policy,
+    )
+    second = normalize_tool_observation(
+        tool_name="text_search",
+        tool_call_id="call-3",
+        observation_kind="search_results",
+        status="completed",
+        payload={"text": "result SECRET"},
+        policy=policy,
+    )
+    changed = normalize_tool_observation(
+        tool_name="text_search",
+        tool_call_id="call-3",
+        observation_kind="search_results",
+        status="completed",
+        payload={"text": "different SECRET"},
+        policy=policy,
+    )
+
+    assert first.replay.schema_version == TOOL_OBSERVATION_SCHEMA_VERSION
+    assert first.replay.fingerprint == second.replay.fingerprint
+    assert first.replay.payload_hash == second.replay.payload_hash
+    assert first.replay.payload_hash != changed.replay.payload_hash
+    assert first.replay.fingerprint != changed.replay.fingerprint
+
+
+def test_tool_observation_replay_fingerprint_changes_with_call_identity() -> None:
+    first = normalize_tool_observation(
+        tool_name="text_search",
+        tool_call_id="call-a",
+        observation_kind="search_results",
+        status="completed",
+        payload={"text": "same"},
+    )
+    second = normalize_tool_observation(
+        tool_name="text_search",
+        tool_call_id="call-b",
+        observation_kind="search_results",
+        status="completed",
+        payload={"text": "same"},
+    )
+
+    assert first.replay.payload_hash == second.replay.payload_hash
+    assert first.replay.fingerprint != second.replay.fingerprint
+
+
+def test_tool_observation_policy_hash_changes_with_redaction_terms() -> None:
+    first = ToolObservationPolicy(redaction_terms=("SECRET-A",))
+    second = ToolObservationPolicy(redaction_terms=("SECRET-B",))
+
+    assert first.policy_hash() != second.policy_hash()
+
+
+@pytest.mark.parametrize(
+    ("policy_kwargs", "message"),
+    [
+        ({"max_text_bytes": 0}, "Tool observation max_text_bytes must be positive."),
+        ({"timeout_ms": 0}, "Tool observation timeout_ms must be positive when set."),
+        ({"replay_seed": " "}, "Tool observation replay_seed must be non-empty."),
+    ],
+)
+def test_tool_observation_policy_rejects_invalid_values(
+    policy_kwargs: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ToolObservationError, match=message):
+        ToolObservationPolicy(**policy_kwargs)
+
+
+def test_tool_observation_rejects_invalid_status() -> None:
+    with pytest.raises(ToolObservationError, match="Unsupported tool observation status"):
+        normalize_tool_observation(
+            tool_name="visit",
+            tool_call_id="call-4",
+            observation_kind="page_extract",
+            status="cancelled",  # type: ignore[arg-type]
+            payload={"text": "cancelled"},
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "kwargs"),
+    [
+        ("tool_name", {"tool_name": " "}),
+        ("tool_call_id", {"tool_call_id": " "}),
+        ("observation_kind", {"observation_kind": " "}),
+        ("schema_version", {"schema_version": " "}),
+    ],
+)
+def test_tool_observation_rejects_blank_identity_fields(
+    field_name: str,
+    kwargs: dict[str, str],
+) -> None:
+    payload = {
+        "tool_name": "visit",
+        "tool_call_id": "call-5",
+        "observation_kind": "page_extract",
+        "status": "completed",
+        "payload": {"text": "ok"},
+    }
+    payload.update(kwargs)
+
+    with pytest.raises(ToolObservationError, match=f"Tool observation {field_name} must be non-empty."):
+        normalize_tool_observation(**payload)
+
+
+@pytest.mark.parametrize("payload", ["", "  ", {}, []])
+def test_tool_observation_rejects_empty_payload(payload: object) -> None:
+    with pytest.raises(ToolObservationError, match="Tool observation payload must be non-empty."):
+        normalize_tool_observation(
+            tool_name="visit",
+            tool_call_id="call-6",
+            observation_kind="page_extract",
+            status="completed",
+            payload=payload,
+        )

--- a/services/mlx-worker-python/worker/runtime/tool_observation.py
+++ b/services/mlx-worker-python/worker/runtime/tool_observation.py
@@ -36,7 +36,11 @@ class ToolObservationPolicy:
         if self.timeout_ms is not None and self.timeout_ms <= 0:
             raise ToolObservationError("Tool observation timeout_ms must be positive when set.")
         normalized_terms = tuple(
-            dict.fromkeys(term for term in (term.strip() for term in self.redaction_terms) if term)
+            sorted(
+                dict.fromkeys(term for term in (term.strip() for term in self.redaction_terms) if term),
+                key=len,
+                reverse=True,
+            )
         )
         object.__setattr__(self, "redaction_terms", normalized_terms)
         object.__setattr__(self, "replay_seed", self.replay_seed.strip())

--- a/services/mlx-worker-python/worker/runtime/tool_observation.py
+++ b/services/mlx-worker-python/worker/runtime/tool_observation.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+TOOL_OBSERVATION_SCHEMA_VERSION = "melix.agentic_tool_observation.v1"
+SUPPORTED_TOOL_OBSERVATION_STATUSES = ("completed", "timeout", "failed")
+DEFAULT_TOOL_OBSERVATION_TEXT_BYTE_LIMIT = 8192
+
+ToolObservationStatus = Literal["completed", "timeout", "failed"]
+
+_COMPACT_SORTED_JSON_ENCODER = json.JSONEncoder(
+    ensure_ascii=False,
+    separators=(",", ":"),
+    sort_keys=True,
+)
+
+
+class ToolObservationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ToolObservationPolicy:
+    max_text_bytes: int = DEFAULT_TOOL_OBSERVATION_TEXT_BYTE_LIMIT
+    redaction_terms: tuple[str, ...] = ()
+    timeout_ms: int | None = None
+    replay_seed: str = "melix.tool_observation.v1"
+
+    def __post_init__(self) -> None:
+        if self.max_text_bytes <= 0:
+            raise ToolObservationError("Tool observation max_text_bytes must be positive.")
+        if self.timeout_ms is not None and self.timeout_ms <= 0:
+            raise ToolObservationError("Tool observation timeout_ms must be positive when set.")
+        normalized_terms = tuple(
+            dict.fromkeys(term for term in (term.strip() for term in self.redaction_terms) if term)
+        )
+        object.__setattr__(self, "redaction_terms", normalized_terms)
+        object.__setattr__(self, "replay_seed", self.replay_seed.strip())
+        if not self.replay_seed:
+            raise ToolObservationError("Tool observation replay_seed must be non-empty.")
+
+    def fingerprint_payload(self) -> dict[str, Any]:
+        return {
+            "max_text_bytes": self.max_text_bytes,
+            "redaction_term_count": len(self.redaction_terms),
+            "redaction_terms_hash": _sha256_json(self.redaction_terms),
+            "timeout_ms": self.timeout_ms,
+            "replay_seed": self.replay_seed,
+        }
+
+    def policy_hash(self) -> str:
+        return _sha256_json(self.fingerprint_payload())
+
+
+@dataclass(frozen=True)
+class ToolObservationMetrics:
+    record_count: int
+    redacted_value_count: int
+    truncated_count: int
+    timeout_count: int
+    original_bytes: int
+    emitted_bytes: int
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "tool_observation.record_count": self.record_count,
+            "tool_observation.redacted_value_count": self.redacted_value_count,
+            "tool_observation.truncated_count": self.truncated_count,
+            "tool_observation.timeout_count": self.timeout_count,
+            "tool_observation.original_bytes": self.original_bytes,
+            "tool_observation.emitted_bytes": self.emitted_bytes,
+        }
+
+
+@dataclass(frozen=True)
+class ToolObservationReplayMetadata:
+    schema_version: str
+    policy_hash: str
+    payload_hash: str
+    fingerprint: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "schema_version": self.schema_version,
+            "policy_hash": self.policy_hash,
+            "payload_hash": self.payload_hash,
+            "fingerprint": self.fingerprint,
+        }
+
+
+@dataclass(frozen=True)
+class ToolObservationRecord:
+    tool_name: str
+    tool_call_id: str
+    observation_kind: str
+    status: ToolObservationStatus
+    payload: dict[str, Any]
+    metrics: ToolObservationMetrics
+    replay: ToolObservationReplayMetadata
+    timeout_ms: int | None = None
+
+    def as_agentic_trace_observation(self) -> dict[str, Any]:
+        observation: dict[str, Any] = {
+            "schema_version": self.replay.schema_version,
+            "tool_name": self.tool_name,
+            "tool_call_id": self.tool_call_id,
+            "observation_kind": self.observation_kind,
+            "status": self.status,
+            "payload": self.payload,
+            "metrics": self.metrics.as_dict(),
+            "replay": self.replay.as_dict(),
+        }
+        if self.timeout_ms is not None:
+            observation["timeout_ms"] = self.timeout_ms
+        return observation
+
+
+@dataclass(frozen=True)
+class _SanitizedPayload:
+    value: Any
+    redacted_value_count: int
+    truncated_count: int
+    original_bytes: int
+    emitted_bytes: int
+
+
+def normalize_tool_observation(
+    *,
+    tool_name: str,
+    tool_call_id: str,
+    observation_kind: str,
+    status: ToolObservationStatus,
+    payload: Any,
+    policy: ToolObservationPolicy | None = None,
+    schema_version: str = TOOL_OBSERVATION_SCHEMA_VERSION,
+) -> ToolObservationRecord:
+    normalized_tool_name = _required_text(tool_name, "tool_name")
+    normalized_tool_call_id = _required_text(tool_call_id, "tool_call_id")
+    normalized_observation_kind = _required_text(observation_kind, "observation_kind")
+    normalized_status = _normalize_status(status)
+    normalized_schema_version = _required_text(schema_version, "schema_version")
+    observation_policy = policy or ToolObservationPolicy()
+
+    sanitized = _sanitize_payload(payload, observation_policy)
+    normalized_payload = _payload_dict(sanitized.value)
+    timeout_ms = observation_policy.timeout_ms if normalized_status == "timeout" else None
+    metrics = ToolObservationMetrics(
+        record_count=1,
+        redacted_value_count=sanitized.redacted_value_count,
+        truncated_count=sanitized.truncated_count,
+        timeout_count=1 if normalized_status == "timeout" else 0,
+        original_bytes=sanitized.original_bytes,
+        emitted_bytes=sanitized.emitted_bytes,
+    )
+    replay = _build_replay_metadata(
+        schema_version=normalized_schema_version,
+        policy=observation_policy,
+        tool_name=normalized_tool_name,
+        tool_call_id=normalized_tool_call_id,
+        observation_kind=normalized_observation_kind,
+        status=normalized_status,
+        payload=normalized_payload,
+    )
+    return ToolObservationRecord(
+        tool_name=normalized_tool_name,
+        tool_call_id=normalized_tool_call_id,
+        observation_kind=normalized_observation_kind,
+        status=normalized_status,
+        payload=normalized_payload,
+        metrics=metrics,
+        replay=replay,
+        timeout_ms=timeout_ms,
+    )
+
+
+def _sanitize_payload(value: Any, policy: ToolObservationPolicy) -> _SanitizedPayload:
+    if isinstance(value, dict):
+        sanitized_items: dict[str, Any] = {}
+        totals = _SanitizedPayload({}, 0, 0, 0, 0)
+        for raw_key, raw_item in value.items():
+            key = _sanitize_text(str(raw_key), policy)
+            item = _sanitize_payload(raw_item, policy)
+            if key.value in sanitized_items:
+                raise ToolObservationError(f"Duplicate sanitized observation payload key: {key.value}")
+            sanitized_items[key.value] = item.value
+            totals = _merge_sanitized(totals, key, sanitized_items)
+            totals = _merge_sanitized(totals, item, sanitized_items)
+        return totals
+    if isinstance(value, (list, tuple)):
+        sanitized_values: list[Any] = []
+        totals = _SanitizedPayload([], 0, 0, 0, 0)
+        for raw_item in value:
+            item = _sanitize_payload(raw_item, policy)
+            sanitized_values.append(item.value)
+            totals = _merge_sanitized(totals, item, sanitized_values)
+        return totals
+    if isinstance(value, str):
+        return _sanitize_text(value, policy)
+    if value is None or isinstance(value, (bool, int, float)):
+        return _SanitizedPayload(value, 0, 0, 0, 0)
+    return _sanitize_text(str(value), policy)
+
+
+def _sanitize_text(value: str, policy: ToolObservationPolicy) -> _SanitizedPayload:
+    original_bytes = len(value.encode("utf-8"))
+    redacted = value
+    redacted_value_count = 0
+    for term in policy.redaction_terms:
+        replacement_count = redacted.count(term)
+        if replacement_count:
+            redacted = redacted.replace(term, "[REDACTED]")
+            redacted_value_count += replacement_count
+    truncated, was_truncated = _truncate_utf8(redacted, policy.max_text_bytes)
+    return _SanitizedPayload(
+        value=truncated,
+        redacted_value_count=redacted_value_count,
+        truncated_count=1 if was_truncated else 0,
+        original_bytes=original_bytes,
+        emitted_bytes=len(truncated.encode("utf-8")),
+    )
+
+
+def _truncate_utf8(value: str, max_bytes: int) -> tuple[str, bool]:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value, False
+    truncated = encoded[:max_bytes].decode("utf-8", errors="ignore")
+    return truncated, True
+
+
+def _merge_sanitized(
+    totals: _SanitizedPayload,
+    item: _SanitizedPayload,
+    merged_value: Any,
+) -> _SanitizedPayload:
+    return _SanitizedPayload(
+        value=merged_value,
+        redacted_value_count=totals.redacted_value_count + item.redacted_value_count,
+        truncated_count=totals.truncated_count + item.truncated_count,
+        original_bytes=totals.original_bytes + item.original_bytes,
+        emitted_bytes=totals.emitted_bytes + item.emitted_bytes,
+    )
+
+
+def _payload_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict) and value:
+        return value
+    if isinstance(value, str) and value.strip():
+        return {"text": value}
+    if isinstance(value, list) and value:
+        return {"items": value}
+    raise ToolObservationError("Tool observation payload must be non-empty.")
+
+
+def _build_replay_metadata(
+    *,
+    schema_version: str,
+    policy: ToolObservationPolicy,
+    tool_name: str,
+    tool_call_id: str,
+    observation_kind: str,
+    status: ToolObservationStatus,
+    payload: dict[str, Any],
+) -> ToolObservationReplayMetadata:
+    payload_hash = _sha256_json(payload)
+    policy_hash = policy.policy_hash()
+    fingerprint = _sha256_json(
+        {
+            "schema_version": schema_version,
+            "policy_hash": policy_hash,
+            "payload_hash": payload_hash,
+            "tool_name": tool_name,
+            "tool_call_id": tool_call_id,
+            "observation_kind": observation_kind,
+            "status": status,
+            "replay_seed": policy.replay_seed,
+        }
+    )
+    return ToolObservationReplayMetadata(
+        schema_version=schema_version,
+        policy_hash=policy_hash,
+        payload_hash=payload_hash,
+        fingerprint=fingerprint,
+    )
+
+
+def _normalize_status(status: str) -> ToolObservationStatus:
+    normalized_status = status.strip()
+    if normalized_status not in SUPPORTED_TOOL_OBSERVATION_STATUSES:
+        joined = ", ".join(SUPPORTED_TOOL_OBSERVATION_STATUSES)
+        raise ToolObservationError(f"Unsupported tool observation status: {status}. Expected one of: {joined}.")
+    return normalized_status  # type: ignore[return-value]
+
+
+def _required_text(value: str, field_name: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ToolObservationError(f"Tool observation {field_name} must be non-empty.")
+    return normalized_value
+
+
+def _sha256_json(payload: Any) -> str:
+    encoded = _COMPACT_SORTED_JSON_ENCODER.encode(payload).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+__all__ = [
+    "DEFAULT_TOOL_OBSERVATION_TEXT_BYTE_LIMIT",
+    "SUPPORTED_TOOL_OBSERVATION_STATUSES",
+    "TOOL_OBSERVATION_SCHEMA_VERSION",
+    "ToolObservationError",
+    "ToolObservationMetrics",
+    "ToolObservationPolicy",
+    "ToolObservationRecord",
+    "ToolObservationReplayMetadata",
+    "ToolObservationStatus",
+    "normalize_tool_observation",
+]

--- a/services/mlx-worker-python/worker/runtime/tool_observation.py
+++ b/services/mlx-worker-python/worker/runtime/tool_observation.py
@@ -253,6 +253,8 @@ def _payload_dict(value: Any) -> dict[str, Any]:
         return {"text": value}
     if isinstance(value, list) and value:
         return {"items": value}
+    if value is not None and isinstance(value, (bool, int, float)):
+        return {"value": value}
     raise ToolObservationError("Tool observation payload must be non-empty.")
 
 


### PR DESCRIPTION
## Summary
- Add a worker-owned tool observation contract for sanitized OpenSearch-VL agentic tool outputs.
- Normalize nested observation payloads with exact redaction, UTF-8 byte limits, status metrics, and deterministic replay fingerprints.
- Update the OpenSearch-VL tool runtime plan and architecture spec with the observation boundary.

## Plan or Spec
- `docs/plans/2026-05-11-opensearch-vl-tool-observation-contract.md`
- `docs/architecture-spec.md`
- GitHub issue: Closes #677

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_observation.py
..................                                                       [100%]
18 passed in 0.03s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --source=worker.runtime.tool_observation -m pytest -q services/mlx-worker-python/tests/test_tool_observation.py
..................                                                       [100%]
18 passed in 0.04s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage report
Name                                                            Stmts   Miss  Cover
-----------------------------------------------------------------------------------
services/mlx-worker-python/worker/runtime/tool_observation.py     158      5    97%
-----------------------------------------------------------------------------------
TOTAL                                                             158      5    97%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json -o coverage.json
Wrote JSON report to coverage.json

python3 scripts/python_changed_line_coverage.py --coverage-json coverage.json --diff-from origin/main services/mlx-worker-python/worker/runtime/tool_observation.py
services/mlx-worker-python/worker/runtime/tool_observation.py	96.84%	153/158
TOTAL	96.84%	153/158

git diff --check
passed
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/runtime/tool_observation.py` 96.84% changed-line coverage (`153/158` measurable changed lines).
- Module coverage: `services/mlx-worker-python/worker/runtime/tool_observation.py` 97%.
- Metrics defined by the contract and covered in focused tests:
  - `tool_observation.record_count`
  - `tool_observation.redacted_value_count`
  - `tool_observation.truncated_count`
  - `tool_observation.timeout_count`
  - `tool_observation.original_bytes`
  - `tool_observation.emitted_bytes`

## Known Gaps
- Concrete tool adapters and evaluation/benchmark routing remain deferred to later executable units.
- No protobuf or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
