### PR TITLE
perf: stream runtime weight file scans

### DIFF
--- a/docs/plans/2026-05-11-runtime-utils-top-level-weight-streaming.md
+++ b/docs/plans/2026-05-11-runtime-utils-top-level-weight-streaming.md
@@ -1,0 +1,34 @@
+# Runtime utils top-level weight streaming
+
+## Scope
+
+This Python-only slice narrows `worker.runtime.runtime_utils._top_level_weight_file_bytes()`.
+Flat local model bundles without a valid `model.safetensors.index.json` still need the same
+resident-byte estimate, but the fallback scan no longer needs to materialize the full
+`Path.iterdir()` result before measuring each top-level candidate.
+
+## Registered probe
+
+Register `runtime-utils-top-level-weight-streaming` in `infra/perf/pr_scoped_probes.json`.
+The probe builds a synthetic flat model bundle and repeatedly calls
+`estimate_model_weight_resident_bytes(...)`. It reports:
+
+- `elapsed_ms_mean` (`lower_is_better`)
+- `peak_bytes_mean` (`lower_is_better`)
+- workload guard rails: `file_count`, `iterations`, `expected_bytes`, and `checksum`
+
+The focused test and coverage commands cover the runtime utility behavior, PR-scoped probe
+selection, and the probe script smoke test.
+
+## Verification plan
+
+- Run the focused runtime-utils pytest selection.
+- Run changed-scope coverage for the touched runtime utility, tests, and probe script.
+- Run the registered probe locally on Linux and compare against `origin/main` before opening the PR.
+- Use the PR-scoped performance workflow as the merge gate after push.
+
+## Acceptance
+
+- Behavior remains unchanged for indexed bundles, flat bundles, missing paths, and stat/list errors.
+- `_top_level_weight_file_bytes()` streams `Path.iterdir()` entries instead of materializing a tuple.
+- Local registered probe shows lower peak allocation and no worse resident-byte guard rails.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -265,6 +265,37 @@
     ]
   },
   {
+    "id": "runtime-utils-top-level-weight-streaming",
+    "name": "Runtime utils top-level weight streaming",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/runtime_utils.py",
+      "services/mlx-worker-python/tests/test_runtime_utils.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/runtime_utils_top_level_weights_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_top_level_weights_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/runtime_utils_top_level_weights_probe.py ]; then python3 scripts/runtime_utils_top_level_weights_probe.py; else python3 - <<\"PYPROBE\"\nimport json, os, statistics, sys, tempfile, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd(); sys.path.insert(0, str(repo_root)); sys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.runtime.runtime_utils import estimate_model_weight_resident_bytes\nfile_count = int(os.environ.get(\"MELIX_RUNTIME_UTILS_WEIGHT_FILES\", \"3000\")); iterations = int(os.environ.get(\"MELIX_RUNTIME_UTILS_WEIGHT_ITERATIONS\", \"8\")); sample_count = int(os.environ.get(\"MELIX_RUNTIME_UTILS_WEIGHT_SAMPLES\", \"5\"))\ndef build(root):\n    bundle = root / \"flat-model\"; bundle.mkdir(); expected = 0\n    for index in range(file_count):\n        suffix = \".safetensors\" if index % 2 == 0 else \".txt\"; payload = b\"w\" * ((index % 17) + 1); path = bundle / f\"artifact-{index:05d}{suffix}\"; path.write_bytes(payload)\n        if suffix == \".safetensors\": expected += len(payload)\n    return bundle, expected\nelapsed = []; peaks = []; checksum = 0; expected = 0\nwith tempfile.TemporaryDirectory() as directory:\n    bundle, expected = build(Path(directory))\n    for _ in range(sample_count):\n        tracemalloc.start(); started = time.perf_counter(); checksum = 0\n        for _ in range(iterations):\n            observed = estimate_model_weight_resident_bytes(str(bundle))\n            if observed != expected: raise RuntimeError(f\"unexpected resident byte estimate: {observed} != {expected}\")\n            checksum += observed\n        elapsed.append((time.perf_counter() - started) * 1000.0); _, peak = tracemalloc.get_traced_memory(); tracemalloc.stop(); peaks.append(float(peak))\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed), \"peak_bytes_mean\": statistics.fmean(peaks), \"file_count\": float(file_count), \"iterations\": float(iterations), \"expected_bytes\": float(expected), \"checksum\": float(checksum)}, sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "mlx-text-stop-kwarg-signature-cache",
     "name": "MLX text stop kwarg signature cache",
     "runner": "ubuntu-latest",

--- a/scripts/runtime_utils_top_level_weights_probe.py
+++ b/scripts/runtime_utils_top_level_weights_probe.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime.runtime_utils import estimate_model_weight_resident_bytes
+
+
+def _build_bundle(root: Path, file_count: int) -> tuple[Path, int]:
+    bundle = root / "flat-model"
+    bundle.mkdir()
+    expected = 0
+    for index in range(file_count):
+        suffix = ".safetensors" if index % 2 == 0 else ".txt"
+        payload = b"w" * ((index % 17) + 1)
+        path = bundle / f"artifact-{index:05d}{suffix}"
+        path.write_bytes(payload)
+        if suffix == ".safetensors":
+            expected += len(payload)
+    return bundle, expected
+
+
+def _sample(bundle: Path, expected: int, iterations: int) -> tuple[float, int, int]:
+    started = time.perf_counter()
+    checksum = 0
+    for _ in range(iterations):
+        observed = estimate_model_weight_resident_bytes(str(bundle))
+        if observed != expected:
+            raise RuntimeError(f"unexpected resident byte estimate: {observed} != {expected}")
+        checksum += observed
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    return elapsed_ms, checksum, expected
+
+
+def main() -> int:
+    file_count = int(os.environ.get("MELIX_RUNTIME_UTILS_WEIGHT_FILES", "3000"))
+    iterations = int(os.environ.get("MELIX_RUNTIME_UTILS_WEIGHT_ITERATIONS", "8"))
+    sample_count = int(os.environ.get("MELIX_RUNTIME_UTILS_WEIGHT_SAMPLES", "5"))
+    elapsed: list[float] = []
+    peaks: list[float] = []
+    checksum = 0
+    expected = 0
+    with tempfile.TemporaryDirectory() as directory:
+        bundle, expected = _build_bundle(Path(directory), file_count)
+        for _ in range(sample_count):
+            tracemalloc.start()
+            elapsed_ms, checksum, expected = _sample(bundle, expected, iterations)
+            _, peak = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            elapsed.append(elapsed_ms)
+            peaks.append(float(peak))
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed),
+                "peak_bytes_mean": statistics.fmean(peaks),
+                "file_count": float(file_count),
+                "iterations": float(iterations),
+                "expected_bytes": float(expected),
+                "checksum": float(checksum),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -154,10 +154,11 @@ def test_scope_report_selects_runtime_utils_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/runtime/runtime_utils.py"],
     )
 
-    assert scope["selected_count"] == 2
+    assert scope["selected_count"] == 3
     assert _selected_probe_ids(scope) == [
         "runtime-utils-kwarg-signature-cache",
         "runtime-utils-package-version-cache",
+        "runtime-utils-top-level-weight-streaming",
     ]
 
 
@@ -1673,6 +1674,30 @@ def test_runtime_utils_package_version_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0
 
 
+def test_runtime_utils_top_level_weights_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_RUNTIME_UTILS_WEIGHT_FILES", "8")
+    monkeypatch.setenv("MELIX_RUNTIME_UTILS_WEIGHT_ITERATIONS", "2")
+    monkeypatch.setenv("MELIX_RUNTIME_UTILS_WEIGHT_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/runtime_utils_top_level_weights_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["file_count"] == 8.0
+    assert metrics["iterations"] == 2.0
+    assert metrics["expected_bytes"] > 0
+    assert metrics["checksum"] == metrics["expected_bytes"] * metrics["iterations"]
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_mlx_text_stop_kwarg_signature_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -2017,6 +2042,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "rerank-core-top-k-heap-selection",
         "runtime-utils-kwarg-signature-cache",
         "runtime-utils-package-version-cache",
+        "runtime-utils-top-level-weight-streaming",
         "mlx-text-stop-kwarg-signature-cache",
         "mlx-text-stop-filter-prefix-cache",
         "mlx-audio-wav-streaming-pcm",

--- a/services/mlx-worker-python/tests/test_runtime_utils.py
+++ b/services/mlx-worker-python/tests/test_runtime_utils.py
@@ -266,6 +266,48 @@ def test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights(tm
     assert runtime_utils.estimate_model_weight_resident_bytes(str(bundle)) == len(b"weightsadapter")
 
 
+def test_top_level_weight_file_bytes_streams_iterdir_entries(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = tmp_path / "flat-model"
+    bundle.mkdir()
+    first = bundle / "model.safetensors"
+    second = bundle / "adapter.npz"
+    log: list[str] = []
+
+    class TrackedIterator:
+        def __init__(self) -> None:
+            self._entries = iter((first, second))
+
+        def __iter__(self) -> "TrackedIterator":
+            return self
+
+        def __next__(self) -> Path:
+            entry = next(self._entries)
+            log.append(f"next:{entry.name}")
+            return entry
+
+    def fake_iterdir(path: Path) -> TrackedIterator:
+        assert path == bundle
+        return TrackedIterator()
+
+    def fake_weight_file_size(path: Path) -> int:
+        log.append(f"size:{path.name}")
+        return 7 if path == first else 11
+
+    monkeypatch.setattr(runtime_utils.Path, "iterdir", fake_iterdir)
+    monkeypatch.setattr(runtime_utils, "_weight_file_size", fake_weight_file_size)
+
+    assert runtime_utils._top_level_weight_file_bytes(bundle) == 18
+    assert log == [
+        "next:model.safetensors",
+        "size:model.safetensors",
+        "next:adapter.npz",
+        "size:adapter.npz",
+    ]
+
+
 def test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -166,7 +166,7 @@ def _indexed_safetensors_shard_bytes(model_dir: Path) -> int:
 def _top_level_weight_file_bytes(model_dir: Path) -> int:
     total = 0
     try:
-        entries = tuple(model_dir.iterdir())
+        entries = model_dir.iterdir()
     except OSError:
         return 0
     for path in entries:


### PR DESCRIPTION
## Summary
- Stream top-level flat model weight scans in `runtime_utils._top_level_weight_file_bytes()` instead of materializing `Path.iterdir()` into a tuple.
- Add a focused regression test proving size accounting interleaves iteration with file sizing.
- Register `runtime-utils-top-level-weight-streaming` with focused test, coverage, and command-json probe support.

## Plan or Spec
- `docs/plans/2026-05-11-runtime-utils-top-level-weight-streaming.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/probes.json — exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics — 8 passed, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_top_level_weights_probe.py — 8 passed; changed-scope coverage 100%; exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-utils-top-level-weight-streaming --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-runtime-utils-weight-20260511113418 --head-repo "$PWD" --output /tmp/runtime-utils-top-level-weight-streaming-run.json — exit 0

git diff --check — exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (41/41 measurable changed lines).
- Registered local probe `runtime-utils-top-level-weight-streaming`:
  - `elapsed_ms_mean`: base 432.005 ms → head 400.960 ms (`delta_ms=-31.045`, `speedup=1.077x`).
  - `peak_bytes_mean`: base 1,354,952.2 bytes → head 216,539.8 bytes (`delta=-1,138,412.4`).
  - Guard rails stable: `file_count=3000`, `iterations=8`, `expected_bytes=13480`, `checksum=107840`.

## Known Gaps
- Full repository `make py-test` / `make integration-test` not run locally; this slice uses the registered focused probe and coverage gate. CI is the final PR-scoped performance validation and merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
