### PR TITLE
perf: cache statistical evidence z values

### DIFF
--- a/docs/plans/2026-05-11-statistical-evidence-z-value-cache.md
+++ b/docs/plans/2026-05-11-statistical-evidence-z-value-cache.md
@@ -1,0 +1,42 @@
+# Statistical Evidence Z-Value Cache
+
+## Scope
+
+This Python-only performance slice is limited to the analytical confidence
+interval z-value helper in
+`services/mlx-worker-python/worker/productization/statistical_evidence.py`.
+It does not change bootstrap sampling, interval payload formatting, release-gate
+policy semantics, generated protocol artifacts, or Swift/macOS behavior.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`statistical-evidence-bootstrap-single-sort` in
+`infra/perf/pr_scoped_probes.json`. The entry includes focused
+`test_command`, `coverage_command`, and `probe_command` values and reports
+`elapsed_ms_mean`, `peak_bytes_mean`, `sorted_calls_mean`, and interval bounds.
+
+## Optimization
+
+Cache `_two_sided_normal_z_value(confidence_level)` with a small bounded
+`lru_cache` so repeated paired-statistical-evidence builds using the same
+confidence level reuse the same NormalDist inverse-CDF result. The helper keeps
+the existing confidence-level clamping behavior before calculating the cached
+result.
+
+## Verification plan
+
+- Run the registered focused pytest command locally on Linux.
+- Run the registered changed-scope coverage command locally on Linux and require
+  at least 95% for changed executable scope.
+- Run `scripts/statistical_evidence_bootstrap_probe.py` before and after the
+  change and compare `elapsed_ms_mean`, `peak_bytes_mean`, and
+  `sorted_calls_mean`.
+- Use the PR-scoped performance workflow as the merge gate after push.
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage remains at or above 95%.
+- The local registered probe preserves `sorted_calls_mean == 0.0` and interval
+  bounds while improving or staying within noise for `elapsed_ms_mean`.

--- a/services/mlx-worker-python/tests/test_statistical_evidence.py
+++ b/services/mlx-worker-python/tests/test_statistical_evidence.py
@@ -81,6 +81,7 @@ def test_build_paired_statistical_evidence_handles_empty_and_singleton_samples()
 
 
 def test_build_paired_statistical_evidence_keeps_full_confidence_intervals_finite() -> None:
+    statistical_evidence_module._two_sided_normal_z_value.cache_clear()
     evidence = build_paired_statistical_evidence(
         paired_outcomes=(1, 0, 1, 1, 0, 1),
         confidence_level=1.0,
@@ -91,6 +92,30 @@ def test_build_paired_statistical_evidence_keeps_full_confidence_intervals_finit
     assert math.isfinite(evidence["analytical"]["lower_bound"])
     assert math.isfinite(evidence["analytical"]["upper_bound"])
     assert evidence["analytical"]["lower_bound"] <= evidence["analytical"]["upper_bound"]
+
+
+def test_two_sided_normal_z_value_reuses_confidence_level_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    statistical_evidence_module._two_sided_normal_z_value.cache_clear()
+    calls: list[float] = []
+    original_inv_cdf = statistical_evidence_module._NORMAL_DIST.inv_cdf
+
+    class TrackingNormalDist:
+        def inv_cdf(self, percentile: float) -> float:
+            calls.append(percentile)
+            return original_inv_cdf(percentile)
+
+    monkeypatch.setattr(statistical_evidence_module, "_NORMAL_DIST", TrackingNormalDist())
+
+    first = statistical_evidence_module._two_sided_normal_z_value(0.95)
+    second = statistical_evidence_module._two_sided_normal_z_value(0.95)
+    third = statistical_evidence_module._two_sided_normal_z_value(0.99)
+
+    assert first == second
+    assert third > second
+    assert calls == [0.975, 0.995]
+    statistical_evidence_module._two_sided_normal_z_value.cache_clear()
 
 
 def test_bootstrap_interval_sorts_replicates_in_place(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import random
+from functools import lru_cache
 from statistics import NormalDist
 
 _NORMAL_DIST = NormalDist()
@@ -225,6 +226,7 @@ def _interval_sign(interval: dict[str, object]) -> int:
     return 0
 
 
+@lru_cache(maxsize=32)
 def _two_sided_normal_z_value(confidence_level: float) -> float:
     bounded_confidence = min(max(float(confidence_level), 0.0), 1.0)
     percentile = 0.5 + (bounded_confidence / 2.0)


### PR DESCRIPTION
## Summary
- Cache `_two_sided_normal_z_value(confidence_level)` with a small bounded `lru_cache` so repeated analytical interval builds reuse the NormalDist inverse-CDF result.
- Add a focused regression test proving repeated confidence-level lookups do not call `inv_cdf` again.

## Plan or Spec
- `docs/plans/2026-05-11-statistical-evidence-z-value-cache.md`

## Commands Run
```text
# Baseline probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_bootstrap_probe.py
# exit 0; {"elapsed_ms_mean": 137.69170802552253, "peak_bytes_mean": 47129.6, "sorted_calls_mean": 0.0, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics
# exit 0; 16 passed in 0.58s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_bootstrap_probe.py
# exit 0; TOTAL 19 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_bootstrap_probe.py
# exit 0; {"elapsed_ms_mean": 134.74725640844554, "peak_bytes_mean": 47216.0, "sorted_calls_mean": 0.0, ...}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 19 0 100%`.
- Registered local probe: `statistical-evidence-bootstrap-single-sort` via `scripts/statistical_evidence_bootstrap_probe.py`.
- Baseline: `elapsed_ms_mean=137.69170802552253`, `peak_bytes_mean=47129.6`, `sorted_calls_mean=0.0`.
- Head: `elapsed_ms_mean=134.74725640844554`, `peak_bytes_mean=47216.0`, `sorted_calls_mean=0.0`.
- Delta: `elapsed_ms_mean -2.94445161707699 ms` (`2.138%` faster); peak bytes +86.4 bytes (within noise); interval bounds unchanged.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Python-only slice validated locally on Linux; no Swift/macOS runtime effect is claimed.
- GitHub Actions PR-scoped performance is the merge gate for the registered probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts (`N/A`: no protocol changes).
- [x] Dependency changes include updated lockfiles (`N/A`: no dependency changes).
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
