### PR TITLE
perf: aggregate vision media token frames

### DIFF
--- a/docs/plans/2026-05-11-vision-family-token-media-aggregation.md
+++ b/docs/plans/2026-05-11-vision-family-token-media-aggregation.md
@@ -1,0 +1,28 @@
+# Vision Family Token Media Aggregation Slice
+
+## Scope
+
+This Python-only performance slice keeps `ResolvedVisionFamilyConfig.prompt_token_count()` behavior unchanged while reducing per-frame arithmetic in media-token accounting.
+
+## Registered Probe
+
+The affected path is covered by the PR-scoped `vision-family-prompt-token-count-scan` probe in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/vision_family_adapters.py`
+- `services/mlx-worker-python/tests/test_vision_runtime.py`
+- `scripts/vision_family_prompt_token_count_probe.py`
+
+## Optimization Hypothesis
+
+The current prompt token path already caches prompt whitespace scans. Remaining hot work in this probe is media token aggregation across images and video frame policies. Keeping image minimum clamping inline and aggregating video frame counts once should reduce loop work while preserving the existing minimum-one-token semantics for empty or non-positive frame policies.
+
+## Verification Plan
+
+- Run the focused registered pytest command for `vision-family-prompt-token-count-scan`.
+- Run the registered changed-scope coverage command and require at least 95% for the touched scope.
+- Run the registered probe locally on Linux against `origin/main` and the head worktree.
+- Use GitHub Actions and the PR-scoped performance workflow as the merge gate.
+
+## Linux Boundary
+
+This slice changes Python worker code only and is locally verifiable on Linux. No Swift runtime performance claim is made.

--- a/services/mlx-worker-python/worker/runtime/vision_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/vision_family_adapters.py
@@ -82,19 +82,20 @@ class ResolvedVisionFamilyConfig:
         image_tokens = 0
         for image in prepared_request.images:
             token_count = len(image.bytes_data) // image_token_divisor
-            if token_count <= 1:
-                token_count = 1
-            image_tokens += token_count
+            image_tokens += token_count if token_count > 1 else 1
 
         video_frame_token_cost = self.video_frame_token_cost
         if video_frame_token_cost < 1:
             video_frame_token_cost = 1
-        video_tokens = 0
+        video_frame_count = 0
+        empty_video_frame_policies = 0
         for policy in prepared_request.video_frame_policies:
-            token_count = policy.effective_frame_count * video_frame_token_cost
-            if token_count <= 1:
-                token_count = 1
-            video_tokens += token_count
+            effective_frame_count = policy.effective_frame_count
+            if effective_frame_count > 0:
+                video_frame_count += effective_frame_count
+            else:
+                empty_video_frame_policies += 1
+        video_tokens = video_frame_count * video_frame_token_cost + empty_video_frame_policies
 
         total_tokens = prompt_tokens + image_tokens + video_tokens + self.prompt_token_bias
         return total_tokens if total_tokens > 1 else 1


### PR DESCRIPTION
## Summary
- Aggregates video frame token accounting in `ResolvedVisionFamilyConfig.prompt_token_count()` so positive frame counts are multiplied once per request instead of once per policy.
- Keeps the existing minimum-one-token behavior for small images and empty/non-positive video frame policies.
- Adds a governing plan for this Python-only registered performance slice.

## Plan or Spec
- `docs/plans/2026-05-11-vision-family-token-media-aggregation.md`
- Registered probe: `vision-family-prompt-token-count-scan` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_cached_prompt_scan services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_clamps_media_minimums services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics
# 5 passed in 1.44s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_cached_prompt_scan services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_clamps_media_minimums services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/vision_family_adapters.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/vision_family_prompt_token_count_probe.py
# 5 passed in 1.35s; TOTAL 8 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id vision-family-prompt-token-count-scan --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-vision-family-token-media-20260511123743 --head-repo "$PWD" --output /tmp/vision-family-token-probe.json
# head verification passed; base and head probes completed successfully

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 8 0 100%`).
- Local registered probe on Linux (`vision-family-prompt-token-count-scan`):
  - `elapsed_ms_mean`: base `13.915999293593424`, head `4.520002552973373`, delta `-9.395997 ms`, speedup `3.078759x` (`67.52%` lower).
  - `peak_bytes_mean`: base `251.42857142857142`, head `235.42857142857142`, delta `-16 bytes`.
  - `split_calls_mean`: base `0.0`, head `0.0`.
  - `token_count`: base `1309.0`, head `1309.0`.
- CI PR-scoped performance is still required as the merge gate for registered probe validation.

## Known Gaps
- None for the Python/Linux scope. No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
