### PR TITLE
perf: reduce Swift binary resolver stats

### DIFF
--- a/docs/plans/2026-05-11-integration-swift-binary-resolution-scandir.md
+++ b/docs/plans/2026-05-11-integration-swift-binary-resolution-scandir.md
@@ -12,7 +12,10 @@ triple directory before executable filtering.
 Replace the fallback glob in `tests/integration/helpers.py` with a shared
 `os.scandir()` candidate enumerator. The direct `.build/debug/<product>` lookup remains
 first, and architecture-specific SwiftPM products are still selected by the existing
-`(mtime, path-depth)` preference.
+`(mtime, path-depth)` preference. Candidate validation should reuse one `Path.stat()`
+result for regular-file filtering and mtime comparison so the resolver does not restat
+executable candidates, and the scan should skip the already-checked top-level `debug`
+directory rather than probing a non-existent nested `debug/debug/<product>` path.
 
 ## Probe
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -454,7 +454,7 @@ def _newest_executable_swift_product_binary(build_root: Path, product_name: str)
             candidate_stat = candidate.stat()
         except OSError:
             return
-        if not (stat.S_ISREG(candidate_stat.st_mode) and os.access(candidate, os.X_OK)):
+        if not (stat.S_ISREG(candidate_stat.st_mode) and (candidate_stat.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))):
             return
         candidate_key = (candidate_stat.st_mtime, len(candidate.parts))
         if newest_key is None or candidate_key > newest_key:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,6 +4,7 @@ import json
 import os
 import signal
 import socket
+import stat
 import subprocess
 import sys
 import time
@@ -449,9 +450,13 @@ def _newest_executable_swift_product_binary(build_root: Path, product_name: str)
 
     def consider(candidate: Path) -> None:
         nonlocal newest_candidate, newest_key
-        if not (candidate.is_file() and os.access(candidate, os.X_OK)):
+        try:
+            candidate_stat = candidate.stat()
+        except OSError:
             return
-        candidate_key = (candidate.stat().st_mtime, len(candidate.parts))
+        if not (stat.S_ISREG(candidate_stat.st_mode) and os.access(candidate, os.X_OK)):
+            return
+        candidate_key = (candidate_stat.st_mtime, len(candidate.parts))
         if newest_key is None or candidate_key > newest_key:
             newest_candidate = candidate
             newest_key = candidate_key
@@ -464,7 +469,7 @@ def _newest_executable_swift_product_binary(build_root: Path, product_name: str)
 
     with entries:
         for entry in entries:
-            if entry.is_dir(follow_symlinks=False):
+            if entry.name != "debug" and entry.is_dir(follow_symlinks=False):
                 consider(Path(entry.path) / "debug" / product_name)
     return newest_candidate
 

--- a/tests/integration/test_helper_binary_resolution.py
+++ b/tests/integration/test_helper_binary_resolution.py
@@ -107,3 +107,37 @@ def test_resolve_swift_product_binary_streams_candidates_without_candidate_list(
     )
 
     assert resolved == preferred
+
+
+def test_resolve_swift_product_binary_stats_each_candidate_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path
+    build_root = repo_root / "services" / "mlx-text-worker-swift" / ".build"
+    flat = build_root / "debug" / "melix-text-worker-swift"
+    preferred = build_root / "arm64-apple-macosx" / "debug" / "melix-text-worker-swift"
+    _write_executable(flat)
+    _write_executable(preferred)
+    os.utime(flat, (1, 1))
+    os.utime(preferred, (2, 2))
+
+    original_stat = Path.stat
+    product_stats = 0
+
+    def counting_stat(self: Path, *args: object, **kwargs: object):
+        nonlocal product_stats
+        if self.name == "melix-text-worker-swift":
+            product_stats += 1
+        return original_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", counting_stat)
+
+    resolved = helpers.resolve_swift_product_binary(
+        repo_root,
+        package_path=Path("services/mlx-text-worker-swift"),
+        product_name="melix-text-worker-swift",
+    )
+
+    assert resolved == preferred
+    assert product_stats == 2


### PR DESCRIPTION
## Summary
- Reuse a single `Path.stat()` result while validating Swift product binary candidates in the integration helper resolver.
- Skip the already-checked top-level `.build/debug` directory during the triple scan to avoid probing `.build/debug/debug/<product>`.
- Add regression coverage proving product candidates are only statted once each.

## Plan or Spec
- `docs/plans/2026-05-11-integration-swift-binary-resolution-scandir.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics
# 8 passed in 0.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json tests/integration/helpers.py tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/integration_swift_binary_resolution_probe.py
# 8 passed; aggregate changed-line coverage TOTAL 27 1 96%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/integration_swift_binary_resolution_probe.py
# {"candidate_count": 1501, "delta_ms_mean": -60.54733020719141, "elapsed_ms_mean": 77.8280392056331, "legacy_elapsed_ms_mean": 138.3753694128245, "legacy_peak_bytes_mean": 1679062.8, "peak_bytes_delta_mean": -1675388.6, "peak_bytes_mean": 3674.2, "samples": 5}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id integration-swift-binary-resolution-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-swift-binary-stat-20260511135233 --head-repo "$PWD" --output /tmp/integration-swift-binary-resolution-scandir.json
# head verification ok; base_probe elapsed_ms_mean=93.88355722185224; head_probe elapsed_ms_mean=79.23975735902786

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 96% aggregate changed-line coverage before commit (`TOTAL 27 1 96%`).
- Registered probe: `integration-swift-binary-resolution-scandir`.
- Local registered probe comparison: base `elapsed_ms_mean=93.88355722185224`, head `elapsed_ms_mean=79.23975735902786`, delta `-14.64379986282438 ms` (~15.60% faster).
- Direct head probe: `elapsed_ms_mean=77.8280392056331`, `legacy_elapsed_ms_mean=138.3753694128245`, `candidate_count=1501`, `samples=5`.

## Known Gaps
- This is a Python integration-helper optimization validated on Linux. It does not claim Swift runtime performance effects; the registered PR-scoped performance workflow remains the CI validation gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
