### PR TITLE
Cover invalid batch model-list lines

### DIFF
--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -391,21 +391,29 @@ struct MelixCLIRunnerTests {
     @Test("batch model-list parser rejects invalid lines")
     func batchModelListParserRejectsInvalidLines() throws {
         #expect(throws: MelixCLIError.usage("Empty model index at 2.")) {
-            _ = try BatchRunModelListParser.parse(contents: """
-            mlx-community/Valid-4bit
-              |mlx-community/MissingIndex-4bit
-            """)
+            _ = try BatchRunModelListParser.parse(contents: "mlx-community/Valid-4bit\n  |mlx-community/MissingIndex-4bit\n")
         }
-        #expect(throws: MelixCLIError.usage("Empty repo id at 3.")) {
-            _ = try BatchRunModelListParser.parse(contents: """
-            mlx-community/Valid-4bit
-            # comments do not consume auto indexes
-            42|
-            """)
+        #expect(throws: MelixCLIError.usage("Empty repo id at 2.")) {
+            _ = try BatchRunModelListParser.parse(contents: "mlx-community/Valid-4bit\n42|\n")
         }
         #expect(throws: MelixCLIError.usage("Empty model index at 1.")) {
             _ = try BatchRunModelListParser.parse(contents: "|\n")
         }
+        #expect(throws: MelixCLIError.usage("Empty model index at 1.")) {
+            _ = try BatchRunModelListParser.parse(contents: "|")
+        }
+    }
+
+    @Test("batch model-list parser comments do not consume auto indexes")
+    func batchModelListParserCommentsDoNotConsumeAutoIndexes() throws {
+        let entries = try BatchRunModelListParser.parse(contents: """
+        mlx-community/Alpha-4bit
+        # comment
+        mlx-community/Beta-4bit
+        """)
+        #expect(entries.map(\.index) == ["01", "02"])
+        #expect(entries.map(\.repoID) == ["mlx-community/Alpha-4bit", "mlx-community/Beta-4bit"])
+        #expect(entries.map(\.sourceLine) == [1, 3])
     }
 
     @Test("batch run dry-run supports matching temp and output roots")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -388,6 +388,26 @@ struct MelixCLIRunnerTests {
         #expect(models[0]["repo_id"] as? String == "mlx-community/Ten-4bit")
     }
 
+    @Test("batch model-list parser rejects invalid lines")
+    func batchModelListParserRejectsInvalidLines() throws {
+        #expect(throws: MelixCLIError.usage("Empty model index at 2.")) {
+            _ = try BatchRunModelListParser.parse(contents: """
+            mlx-community/Valid-4bit
+              |mlx-community/MissingIndex-4bit
+            """)
+        }
+        #expect(throws: MelixCLIError.usage("Empty repo id at 3.")) {
+            _ = try BatchRunModelListParser.parse(contents: """
+            mlx-community/Valid-4bit
+            # comments do not consume auto indexes
+            42|
+            """)
+        }
+        #expect(throws: MelixCLIError.usage("Empty model index at 1.")) {
+            _ = try BatchRunModelListParser.parse(contents: "|\n")
+        }
+    }
+
     @Test("batch run dry-run supports matching temp and output roots")
     func batchRunDryRunSupportsMatchingTempAndOutputRoots() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)


### PR DESCRIPTION
## Summary
- Add targeted batch model-list parser coverage for empty display indexes and empty repo ids.
- Lock the current invalid-line usage errors so malformed `index|repo_id` entries fail before dry-run artifacts are written.
- Address review feedback by making fixtures explicit, separating comment auto-index coverage, and adding a no-trailing-newline sentinel.

## Plan or Spec
- `docs/benchmark-evaluation-contract.md`
- `docs/plans/2026-05-11-bench-eval-batch-run-foundation.md`
- Closes #758

## Commands Run
```text
git diff --check
# passed before initial push and after review fixes

xcrun swift build --product melix
# passed before initial push and after review fixes:
# Build of product 'melix' complete!

xcrun swift test --filter 'MelixCLIRunnerTests/batchModelListParserRejectsInvalidLines'
# blocked locally before the selected test ran:
# tests/MelixCLITests/DiskStreamingSmokeRunnerTests.swift:2:8: error: no such module 'Testing'

xcrun swift test --filter 'MelixCLIRunnerTests/batchModelListParser'
# blocked locally before the selected tests ran:
# tests/MelixCLITests/DiskStreamingSmokeRunnerTests.swift:2:8: error: no such module 'Testing'

.build/arm64-apple-macosx/debug/melix batch run --models .runtime/model-list-invalid-smoke/missing-index.txt --run-id invalid-index-smoke --temp-root .runtime/model-list-invalid-smoke/tmp-index --output-root .runtime/model-list-invalid-smoke/out-index --dry-run
# failed as expected before initial push and after review fixes:
# Empty model index at 2.

.build/arm64-apple-macosx/debug/melix batch run --models .runtime/model-list-invalid-smoke/missing-repo.txt --run-id invalid-repo-smoke --temp-root .runtime/model-list-invalid-smoke/tmp-repo --output-root .runtime/model-list-invalid-smoke/out-repo --dry-run
# failed as expected before initial push and after review fixes:
# Empty repo id at 3.
```

## Coverage and Metrics
- Coverage: N/A: this is a Swift test-only coverage slice, and local Swift test execution is blocked by the existing `import Testing` module resolution failure before the selected tests run.
- Metrics: N/A: this slice only adds parser regression coverage for existing validation behavior; it does not change runtime behavior or performance-sensitive code.

## Known Gaps
- The focused Swift tests could not execute locally because the current local toolchain cannot compile the test target's `import Testing` dependency. CI remains the validation gate for the added tests.
- Non-dry-run batch execution remains deferred to #755 and child execution issues.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. (N/A: this test-only slice covers existing documented model-list behavior.)
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run or attempted, with the local Swift Testing blocker recorded.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
