### PR TITLE
perf: avoid swift binary resolver path parts

### DIFF
--- a/docs/plans/2026-05-11-swift-binary-resolution-streaming.md
+++ b/docs/plans/2026-05-11-swift-binary-resolution-streaming.md
@@ -26,10 +26,10 @@ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SWIFT_BINARY_RESOLUTION_
 ## Implementation Plan
 
 1. Preserve `_swift_product_binary_candidates()` for existing direct callers and regression coverage.
-2. Add a streaming resolver helper that considers the flat debug binary and each architecture-specific debug binary without building an executable candidate list.
-3. Keep the existing newest-mtime tie-breaker and the architecture-specific path preference for equal mtimes.
-4. Extend the focused integration-helper test to prove the public resolver no longer calls the candidate-list helper.
-5. Update the registered probe script so the new measurement exercises the public resolver instead of only the candidate factory.
+2. Keep the streaming resolver path that considers the flat debug binary and each architecture-specific debug binary without building an executable candidate list.
+3. Preserve the existing newest-mtime tie-breaker while replacing per-candidate `Path.parts` allocation with a constant flat/scoped depth rank.
+4. Extend focused integration-helper coverage to prove equal-mtime scoped candidates remain preferred without reading `Path.parts` during resolution.
+5. Measure the registered probe against the legacy glob/list baseline and accept only if elapsed and/or peak memory remain improved.
 
 ## Success Metrics
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -447,8 +447,10 @@ def _swift_product_binary_candidates(build_root: Path, product_name: str) -> lis
 def _newest_executable_swift_product_binary(build_root: Path, product_name: str) -> Path | None:
     newest_candidate: Path | None = None
     newest_key: tuple[float, int] | None = None
+    flat_depth = 0
+    scoped_depth = 1
 
-    def consider(candidate: Path) -> None:
+    def consider(candidate: Path, *, depth: int) -> None:
         nonlocal newest_candidate, newest_key
         try:
             candidate_stat = candidate.stat()
@@ -456,12 +458,12 @@ def _newest_executable_swift_product_binary(build_root: Path, product_name: str)
             return
         if not (stat.S_ISREG(candidate_stat.st_mode) and (candidate_stat.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))):
             return
-        candidate_key = (candidate_stat.st_mtime, len(candidate.parts))
+        candidate_key = (candidate_stat.st_mtime, depth)
         if newest_key is None or candidate_key > newest_key:
             newest_candidate = candidate
             newest_key = candidate_key
 
-    consider(build_root / "debug" / product_name)
+    consider(build_root / "debug" / product_name, depth=flat_depth)
     try:
         entries = os.scandir(build_root)
     except FileNotFoundError:
@@ -470,7 +472,7 @@ def _newest_executable_swift_product_binary(build_root: Path, product_name: str)
     with entries:
         for entry in entries:
             if entry.name != "debug" and entry.is_dir(follow_symlinks=False):
-                consider(Path(entry.path) / "debug" / product_name)
+                consider(Path(entry.path) / "debug" / product_name, depth=scoped_depth)
     return newest_candidate
 
 

--- a/tests/integration/test_helper_binary_resolution.py
+++ b/tests/integration/test_helper_binary_resolution.py
@@ -109,6 +109,33 @@ def test_resolve_swift_product_binary_streams_candidates_without_candidate_list(
     assert resolved == preferred
 
 
+def test_resolve_swift_product_binary_preserves_tie_breaker_without_path_parts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path
+    build_root = repo_root / "services" / "control-plane-swift" / ".build"
+    flat = build_root / "debug" / "melix-control-plane"
+    preferred = build_root / "arm64-apple-macosx" / "debug" / "melix-control-plane"
+    _write_executable(flat)
+    _write_executable(preferred)
+    os.utime(flat, (5, 5))
+    os.utime(preferred, (5, 5))
+
+    def fail_parts(self: Path):
+        raise AssertionError("binary resolution should not allocate Path.parts per candidate")
+
+    monkeypatch.setattr(Path, "parts", property(fail_parts))
+
+    resolved = helpers.resolve_swift_product_binary(
+        repo_root,
+        package_path=Path("services/control-plane-swift"),
+        product_name="melix-control-plane",
+    )
+
+    assert resolved == preferred
+
+
 def test_resolve_swift_product_binary_stats_each_candidate_once(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Avoid per-candidate `Path.parts` allocation in the Python Swift integration binary resolver.
- Preserve newest-mtime selection and the scoped-build preference for equal mtimes by using a constant flat/scoped depth rank.
- Add regression coverage that resolution still prefers scoped candidates without touching `Path.parts`.

## Plan or Spec
- `docs/plans/2026-05-11-swift-binary-resolution-streaming.md`
- Registered PR-scoped probe: `integration-swift-binary-resolution-scandir`.

## Commands Run
```text
# Baseline registered probe on origin/main worktree before the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/integration_swift_binary_resolution_probe.py
exit 0; {"candidate_count": 1501, "delta_ms_mean": -61.305240844376385, "elapsed_ms_mean": 78.7588421953842, "legacy_elapsed_ms_mean": 140.0640830397606, "legacy_peak_bytes_mean": 1678744.4, "peak_bytes_delta_mean": -1675113.4, "peak_bytes_mean": 3631.0, "samples": 5}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
exit 0; 9 passed in 0.63s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json tests/integration/helpers.py tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/integration_swift_binary_resolution_probe.py
exit 0; 9 passed in 0.37s; aggregate changed-line coverage 95%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/integration_swift_binary_resolution_probe.py
exit 0; {"candidate_count": 1501, "delta_ms_mean": -67.26286655757576, "elapsed_ms_mean": 79.64414982125163, "legacy_elapsed_ms_mean": 146.9070163788274, "legacy_peak_bytes_mean": 1679062.8, "peak_bytes_delta_mean": -1675388.6, "peak_bytes_mean": 3674.2, "samples": 5}

# Additional immediate-old vs new micro-comparison for this slice, using the old Path.parts resolver copied into a temporary local script (script removed before commit)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime_compare_binary_resolution.py
exit 0; old_newest mean=21.645836 ms; _newest_executable_swift_product_binary mean=18.600899 ms

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 95% aggregate over `tests/integration/helpers.py`, `tests/integration/test_helper_binary_resolution.py`, `services/mlx-worker-python/tests/test_pr_scoped_performance.py`, and `scripts/integration_swift_binary_resolution_probe.py`.
- Registered local probe after the change: `elapsed_ms_mean=79.64414982125163`, `legacy_elapsed_ms_mean=146.9070163788274`, `delta_ms_mean=-67.26286655757576`, `peak_bytes_mean=3674.2`, `legacy_peak_bytes_mean=1679062.8`, `candidate_count=1501`.
- Immediate old-vs-new micro-comparison for this exact slice: old resolver mean `21.645836 ms`, new resolver mean `18.600899 ms` (about 14.1% faster for the candidate-selection loop).
- CI must run the registered PR-scoped performance workflow and is the merge gate for probe validation.

## Known Gaps
- Local Linux validation covers the Python integration-helper resolver and probe only; it does not validate Swift runtime effects.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
