### PR TITLE
Support non-stream chat completions JSON

### DIFF
--- a/apps/macos-menubar/Tests/MenuBarTests/Phase8LoRAWindowSmokeTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/Phase8LoRAWindowSmokeTests.swift
@@ -80,7 +80,9 @@ struct Phase8LoRAWindowSmokeTests {
             )
         )
         await runnerClient.configureExportResult(
-            ControlPlaneExportResult(exportBundleJSON: makeBenchmarkExportBundleJSON())
+            ControlPlaneExportResult(
+                exportBundleJSON: phase8LoRAWindowExportBundleJSON(derivedModelID: derivedModelID)
+            )
         )
 
         let operatorStore = MelixOperatorSessionStore(
@@ -374,6 +376,12 @@ private func phase8LoRAWindowCompareResult(
     result.metrics = [metric]
     result.reportPath = "/tmp/melix/evaluation/runs/eval-compare-1/\(derivedModelID)-result.json"
     return ControlPlaneEvaluationResult(job: job, results: [result])
+}
+
+private func phase8LoRAWindowExportBundleJSON(derivedModelID: String) -> String {
+    makeBenchmarkExportBundleJSON()
+        .replacingOccurrences(of: "eval-newer", with: "eval-compare-1")
+        .replacingOccurrences(of: "melix-dev-text-lora", with: derivedModelID)
 }
 
 @MainActor

--- a/docs/control-plane-protocol.md
+++ b/docs/control-plane-protocol.md
@@ -678,7 +678,7 @@ The control plane protocol is richer than the public HTTP surface, but it must m
 
 | Public API | Control plane intent |
 |---|---|
-| `POST /v1/chat/completions` | parse request, bind session context, dispatch to scheduler |
+| `POST /v1/chat/completions` | parse request, bind session context, dispatch to scheduler, and return either SSE chunks or a buffered `chat.completion` JSON object |
 | `POST /v1/responses` | translate response semantics into internal request plus event stream |
 | `POST /v1/messages` | normalize messages, reasoning, and tool semantics |
 | `POST /v1/embeddings` | dispatch directly to embed-capable workers |

--- a/docs/plans/2026-05-12-chat-completions-non-stream-json.md
+++ b/docs/plans/2026-05-12-chat-completions-non-stream-json.md
@@ -1,0 +1,95 @@
+# Chat Completions Non-Stream JSON
+
+Date: 2026-05-12
+
+## Summary
+
+`POST /v1/chat/completions` must support the OpenAI-compatible non-streaming
+response shape when callers omit `stream` or send `"stream": false`. The current
+gateway always returns Server-Sent Events unless the caller explicitly sends
+`stream: false`, which is rejected with `stream_required`. That breaks clients
+that use chat completions for short auxiliary calls and expect a JSON object.
+
+## Scope
+
+- Keep `stream: true` chat completions on the existing SSE path.
+- Buffer worker execution events for `POST /v1/chat/completions` when
+  `stream` is omitted or false, then return one `chat.completion` JSON object.
+- Request worker usage accounting for buffered responses so the final JSON can
+  include `usage` when the worker reports it.
+- Preserve existing `stream_required` behavior for `/v1/completions`,
+  `/v1/responses`, and `/v1/messages`.
+- Add HTTP gateway unit tests for explicit `stream: false`, omitted `stream`,
+  and the existing streaming path.
+
+## Non-Goals
+
+- Add non-stream responses for every text endpoint.
+- Change worker RPC streaming semantics.
+- Add multi-choice buffering or tool-call reconstruction beyond preserving
+  existing stream behavior.
+- Change resume semantics; `resume_request_id` remains an SSE resume operation.
+
+## Design
+
+The worker still emits an ordered stream of `ExecuteEvent` messages. The HTTP
+gateway adds a chat-completions-only response path that consumes that stream,
+aggregates text deltas, records usage deltas, and uses the terminal completion
+event as the authoritative finish reason and assistant text when available.
+
+The JSON response shape is:
+
+```json
+{
+  "id": "<request_id>",
+  "object": "chat.completion",
+  "created": 1778520000,
+  "model": "<model_id>",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "<assistant text>"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 1,
+    "completion_tokens": 2,
+    "total_tokens": 3
+  }
+}
+```
+
+If no worker usage event is emitted, `usage` is omitted instead of fabricating
+zero-token accounting.
+
+## Metrics
+
+The HTTP gateway records:
+
+- `http.chat_completions_non_stream_request_count`
+- `http.chat_completions_non_stream_latency_ms`
+- `http.chat_completions_non_stream_completion_tokens`
+
+Success means the explicit and default non-stream tests exercise the new JSON
+path, the existing SSE test remains unchanged, and changed-line coverage for the
+edited Swift HTTP gateway scope is at least 95 percent.
+
+## Verification
+
+Run:
+
+```bash
+HOME="$(pwd)/.swift-home" \
+CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" \
+swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests
+
+HOME="$(pwd)/.swift-home" \
+CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" \
+swift test --package-path services/control-plane-swift --enable-code-coverage --filter OpenAIHandlerTests
+```
+
+Then report changed-scope coverage from the generated Swift coverage artifacts.

--- a/docs/plans/2026-05-12-chat-completions-non-stream-json.md
+++ b/docs/plans/2026-05-12-chat-completions-non-stream-json.md
@@ -36,6 +36,8 @@ The worker still emits an ordered stream of `ExecuteEvent` messages. The HTTP
 gateway adds a chat-completions-only response path that consumes that stream,
 aggregates text deltas, records usage deltas, and uses the terminal completion
 event as the authoritative finish reason and assistant text when available.
+When multiple worker usage events are observed, the latest event is treated as
+the authoritative cumulative token accounting snapshot.
 
 The JSON response shape is:
 
@@ -69,13 +71,22 @@ zero-token accounting.
 If the worker emits an error event while the gateway is buffering a non-stream
 chat completion, that error terminates aggregation immediately. The gateway
 returns the mapped worker error response and ignores any later stream events.
+Thrown stream aggregation failures are logged before the gateway returns the
+existing worker-unavailable JSON error response.
+
+### Compatibility Note
+
+This slice intentionally aligns `POST /v1/chat/completions` with the OpenAI
+default: omitting `stream` returns buffered JSON instead of SSE. Existing
+clients that depend on streaming must send `"stream": true`.
 
 ## Metrics
 
 The HTTP gateway records:
 
 - `http.chat_completions_non_stream_request_count`
-- `http.chat_completions_non_stream_latency_ms`
+- `http.chat_completions_non_stream_latency_ms` as the latest scalar latency sample
+- `http.chat_completions_non_stream_time_to_first_token_ms` as the latest internal first-token timing sample
 - `http.chat_completions_non_stream_completion_tokens` as a cumulative counter
 
 Success means the explicit and default non-stream tests exercise the new JSON

--- a/docs/plans/2026-05-12-chat-completions-non-stream-json.md
+++ b/docs/plans/2026-05-12-chat-completions-non-stream-json.md
@@ -66,13 +66,17 @@ The JSON response shape is:
 If no worker usage event is emitted, `usage` is omitted instead of fabricating
 zero-token accounting.
 
+If the worker emits an error event while the gateway is buffering a non-stream
+chat completion, that error terminates aggregation immediately. The gateway
+returns the mapped worker error response and ignores any later stream events.
+
 ## Metrics
 
 The HTTP gateway records:
 
 - `http.chat_completions_non_stream_request_count`
 - `http.chat_completions_non_stream_latency_ms`
-- `http.chat_completions_non_stream_completion_tokens`
+- `http.chat_completions_non_stream_completion_tokens` as a cumulative counter
 
 Success means the explicit and default non-stream tests exercise the new JSON
 path, the existing SSE test remains unchanged, and changed-line coverage for the

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MelixControlPlaneProtocol
 import MelixWorkerProtocol
+import OSLog
 
 public struct RichOutputSanitizationResult: Equatable, Sendable {
     public let text: String
@@ -254,6 +255,7 @@ private enum GatewayAuthorizationResolution {
 public struct OpenAIHandler: Sendable {
     private static let defaultSpeechStreamIntervalMs: UInt32 = 20
     private static let maxSpeechStreamIntervalMs: UInt32 = 1_000
+    private static let logger = Logger(subsystem: "Melix.ControlPlane", category: "OpenAIHandler")
 
     private let modelCatalog: ModelCatalog
     private let requestCoordinator: RequestCoordinator
@@ -272,6 +274,7 @@ public struct OpenAIHandler: Sendable {
     private let gatewayRuntimeBinding: GatewayRuntimeBinding
     private let persistentAuthSessionStore: PersistentAuthSessionStore?
     private let imageRequestTimeoutSeconds: UInt32
+    private let now: @Sendable () -> Date
     private let decoder: JSONDecoder
     private let encoder: JSONEncoder
 
@@ -293,6 +296,7 @@ public struct OpenAIHandler: Sendable {
         gatewayServingDefaultsStore: GatewayServingDefaultsStore? = nil,
         gatewayRuntimeBinding: GatewayRuntimeBinding = GatewayRuntimeBinding(host: "127.0.0.1", port: 11_434),
         persistentAuthSessionStore: PersistentAuthSessionStore? = nil,
+        now: @escaping @Sendable () -> Date = Date.init,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) {
         self.modelCatalog = modelCatalog
@@ -315,6 +319,7 @@ public struct OpenAIHandler: Sendable {
         self.gatewayRuntimeBinding = gatewayRuntimeBinding
         self.persistentAuthSessionStore = persistentAuthSessionStore
         self.imageRequestTimeoutSeconds = Self.resolveImageRequestTimeoutSeconds(environment: environment)
+        self.now = now
         self.decoder = JSONDecoder()
         self.encoder = JSONEncoder()
         self.encoder.outputFormatting = [.sortedKeys]
@@ -560,7 +565,7 @@ public struct OpenAIHandler: Sendable {
     }
 
     private func handleChatCompletions(_ request: HTTPRequest) async throws -> HTTPResponse {
-        let requestStartedAt = Date()
+        let requestStartedAt = now()
         do {
             let chatRequest = try decoder.decode(OpenAIChatCompletionsRequest.self, from: request.body)
             if let resumeRequestID = chatRequest.resumeRequestID?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -1728,6 +1733,7 @@ public struct OpenAIHandler: Sendable {
         workerRequest.stream = true
         workerRequest.returnUsage = true
         workerRequest.execution.ext["melix.stream.include_usage"] = "true"
+        workerRequest.execution.ext["melix.http.response_mode"] = "chat_completions_non_stream"
         let streamingTranslated = TranslatedChatRequest(
             requestID: translated.requestID,
             modelID: translated.modelID,
@@ -1752,8 +1758,7 @@ public struct OpenAIHandler: Sendable {
 
         do {
             let aggregate = try await aggregateChatCompletion(
-                stream: execution.stream,
-                startedAt: requestStartedAt
+                stream: execution.stream
             )
             if let workerError = aggregate.error {
                 return workerErrorResponse(workerError)
@@ -1773,10 +1778,14 @@ public struct OpenAIHandler: Sendable {
 
             let payload = chatCompletionJSONPayload(
                 execution: execution,
-                aggregate: aggregate
+                aggregate: aggregate,
+                requestStartedAt: requestStartedAt
             )
             return jsonResponse(statusCode: 200, payload: payload)
         } catch {
+            Self.logger.error(
+                "Non-stream chat completion aggregation failed requestID=\(execution.requestID, privacy: .public): \(String(describing: error), privacy: .public)"
+            )
             return workerUnavailableResponse()
         }
     }
@@ -1794,25 +1803,18 @@ public struct OpenAIHandler: Sendable {
     }
 
     private func aggregateChatCompletion(
-        stream: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>,
-        startedAt: Date
+        stream: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>
     ) async throws -> NonStreamChatCompletionAggregate {
         var aggregate = NonStreamChatCompletionAggregate()
         var tokenText = ""
-        var firstTokenSeen = false
 
         for try await event in stream {
             switch event.payload {
             case .tokenDelta(let delta):
-                if !firstTokenSeen {
-                    firstTokenSeen = true
-                    await metricsStore.set(
-                        max(Date().timeIntervalSince(startedAt) * 1000, 0.001),
-                        forKey: "http.ttfd_ms"
-                    )
-                }
                 tokenText += delta.text
             case .usageDelta(let usage):
+                // Worker usage events report final cumulative counts, so the
+                // latest event is authoritative if a runtime emits more than one.
                 aggregate.usage = NonStreamChatCompletionAggregate.Usage(
                     promptTokens: usage.promptTokens,
                     completionTokens: usage.completionTokens
@@ -1836,12 +1838,13 @@ public struct OpenAIHandler: Sendable {
 
     private func chatCompletionJSONPayload(
         execution: CoordinatedChatExecution,
-        aggregate: NonStreamChatCompletionAggregate
+        aggregate: NonStreamChatCompletionAggregate,
+        requestStartedAt: Date
     ) -> [String: Any] {
         var payload: [String: Any] = [
             "id": execution.requestID,
             "object": "chat.completion",
-            "created": Int(Date().timeIntervalSince1970),
+            "created": Int(requestStartedAt.timeIntervalSince1970),
             "model": execution.modelID,
             "choices": [
                 [

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -577,6 +577,12 @@ public struct OpenAIHandler: Sendable {
                 try translator.normalize(chatRequest)
             }
             let translated = try await translatedRequest(normalized)
+            guard translated.stream else {
+                return try await nonStreamChatCompletionsResponse(
+                    translated: translated,
+                    requestStartedAt: requestStartedAt
+                )
+            }
             return try await streamResponse(
                 translated: translated,
                 shape: .chatCompletions,
@@ -1642,7 +1648,7 @@ public struct OpenAIHandler: Sendable {
     private func translatedRequest(
         _ normalized: NormalizedTextRequest
     ) async throws -> TranslatedChatRequest {
-        guard normalized.stream else {
+        guard normalized.stream || normalized.endpoint == .chatCompletions else {
             throw HTTPRequestHandlingError.streamRequired
         }
         await RegistrySnapshotSync.syncModelsIfAvailable(
@@ -1712,6 +1718,151 @@ public struct OpenAIHandler: Sendable {
         )
         await recordShapingMetrics(for: translated, startedAt: shapingStartedAt)
         return translated
+    }
+
+    private func nonStreamChatCompletionsResponse(
+        translated: TranslatedChatRequest,
+        requestStartedAt: Date
+    ) async throws -> HTTPResponse {
+        var workerRequest = translated.workerRequest
+        workerRequest.stream = true
+        workerRequest.returnUsage = true
+        workerRequest.execution.ext["melix.stream.include_usage"] = "true"
+        let streamingTranslated = TranslatedChatRequest(
+            requestID: translated.requestID,
+            modelID: translated.modelID,
+            workerRequest: workerRequest,
+            stream: true
+        )
+
+        let execution: CoordinatedChatExecution
+        do {
+            execution = try await requestCoordinator.startChatCompletion(
+                streamingTranslated,
+                requestStartedAt: requestStartedAt
+            )
+        } catch let error as RequestCoordinatorError {
+            return jsonResponse(statusCode: error.statusCode, payload: [
+                "error": [
+                    "code": error.errorCode,
+                    "message": error.errorMessage,
+                ],
+            ])
+        }
+
+        do {
+            let aggregate = try await aggregateChatCompletion(
+                stream: execution.stream,
+                startedAt: requestStartedAt
+            )
+            if let workerError = aggregate.error {
+                return workerErrorResponse(workerError)
+            }
+
+            await metricsStore.increment("http.chat_completions_non_stream_request_count")
+            await metricsStore.set(
+                max(Date().timeIntervalSince(requestStartedAt) * 1000, 0.001),
+                forKey: "http.chat_completions_non_stream_latency_ms"
+            )
+            if let usage = aggregate.usage {
+                await metricsStore.set(
+                    Double(usage.completionTokens),
+                    forKey: "http.chat_completions_non_stream_completion_tokens"
+                )
+            }
+
+            let payload = chatCompletionJSONPayload(
+                execution: execution,
+                aggregate: aggregate
+            )
+            return jsonResponse(statusCode: 200, payload: payload)
+        } catch {
+            return workerUnavailableResponse()
+        }
+    }
+
+    private struct NonStreamChatCompletionAggregate {
+        struct Usage {
+            let promptTokens: UInt32
+            let completionTokens: UInt32
+        }
+
+        var assistantText = ""
+        var finishReason = "stop"
+        var usage: Usage?
+        var error: Melix_Worker_V1_ErrorStatus?
+    }
+
+    private func aggregateChatCompletion(
+        stream: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>,
+        startedAt: Date
+    ) async throws -> NonStreamChatCompletionAggregate {
+        var aggregate = NonStreamChatCompletionAggregate()
+        var tokenText = ""
+        var firstTokenSeen = false
+
+        for try await event in stream {
+            switch event.payload {
+            case .tokenDelta(let delta):
+                if !firstTokenSeen {
+                    firstTokenSeen = true
+                    await metricsStore.set(
+                        max(Date().timeIntervalSince(startedAt) * 1000, 0.001),
+                        forKey: "http.ttfd_ms"
+                    )
+                }
+                tokenText += delta.text
+            case .usageDelta(let usage):
+                aggregate.usage = NonStreamChatCompletionAggregate.Usage(
+                    promptTokens: usage.promptTokens,
+                    completionTokens: usage.completionTokens
+                )
+            case .completed(let completed):
+                aggregate.finishReason = completed.finishReason.isEmpty ? "stop" : completed.finishReason
+                aggregate.assistantText = completed.assistantText.isEmpty ? tokenText : completed.assistantText
+            case .error(let error):
+                aggregate.error = error.error
+            default:
+                continue
+            }
+        }
+
+        if aggregate.assistantText.isEmpty {
+            aggregate.assistantText = tokenText
+        }
+        return aggregate
+    }
+
+    private func chatCompletionJSONPayload(
+        execution: CoordinatedChatExecution,
+        aggregate: NonStreamChatCompletionAggregate
+    ) -> [String: Any] {
+        var payload: [String: Any] = [
+            "id": execution.requestID,
+            "object": "chat.completion",
+            "created": Int(Date().timeIntervalSince1970),
+            "model": execution.modelID,
+            "choices": [
+                [
+                    "index": 0,
+                    "message": [
+                        "role": "assistant",
+                        "content": aggregate.assistantText,
+                    ],
+                    "finish_reason": aggregate.finishReason,
+                ],
+            ],
+        ]
+
+        if let usage = aggregate.usage {
+            payload["usage"] = [
+                "prompt_tokens": Int(usage.promptTokens),
+                "completion_tokens": Int(usage.completionTokens),
+                "total_tokens": Int(usage.promptTokens) + Int(usage.completionTokens),
+            ]
+        }
+
+        return payload
     }
 
     private func recordShapingMetrics(

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -1765,9 +1765,9 @@ public struct OpenAIHandler: Sendable {
                 forKey: "http.chat_completions_non_stream_latency_ms"
             )
             if let usage = aggregate.usage {
-                await metricsStore.set(
-                    Double(usage.completionTokens),
-                    forKey: "http.chat_completions_non_stream_completion_tokens"
+                await metricsStore.increment(
+                    "http.chat_completions_non_stream_completion_tokens",
+                    by: Double(usage.completionTokens)
                 )
             }
 
@@ -1822,6 +1822,7 @@ public struct OpenAIHandler: Sendable {
                 aggregate.assistantText = completed.assistantText.isEmpty ? tokenText : completed.assistantText
             case .error(let error):
                 aggregate.error = error.error
+                return aggregate
             default:
                 continue
             }

--- a/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
+++ b/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
@@ -1652,7 +1652,7 @@ public struct ChatRequestTranslator: Sendable {
             endpoint: endpoint,
             model: model,
             messages: messages,
-            stream: stream ?? true,
+            stream: stream ?? (endpoint != .chatCompletions),
             includeUsage: includeUsage ?? false,
             temperature: temperature,
             topP: topP,

--- a/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
+++ b/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
@@ -868,6 +868,8 @@ public actor RequestCoordinator {
             executionHubs[requestID] = hub
             let metricsStore = self.metricsStore
             let now = self.now
+            let isBufferedChatCompletionsResponse =
+                request.workerRequest.execution.ext["melix.http.response_mode"] == "chat_completions_non_stream"
             let structuredOutputConfiguration = StructuredOutputConfiguration(
                 executionExt: request.workerRequest.execution.ext
             )
@@ -930,14 +932,19 @@ public actor RequestCoordinator {
                                 firstDeltaRecorded = true
                                 let ttftMs = now().timeIntervalSince(dispatchStartedAt) * 1000
                                 let followupTTFTMs = now().timeIntervalSince(requestMetricStartedAt) * 1000
+                                let ttftMetricKey = isBufferedChatCompletionsResponse
+                                    ? "http.chat_completions_non_stream_time_to_first_token_ms"
+                                    : "http.ttfd_ms"
                                 await metricsStore.set(
                                     ttftMs,
-                                    forKey: "http.ttfd_ms"
+                                    forKey: ttftMetricKey
                                 )
-                                await self.recordTTFTMetrics(
-                                    requestID: requestID,
-                                    ttftMs: followupTTFTMs
-                                )
+                                if !isBufferedChatCompletionsResponse {
+                                    await self.recordTTFTMetrics(
+                                        requestID: requestID,
+                                        ttftMs: followupTTFTMs
+                                    )
+                                }
                             }
                             switch outputEvent.payload {
                             case .reasoningDelta:

--- a/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
@@ -1540,6 +1540,41 @@ struct TextEndpointContractTests {
         #expect(responses.maxTokens == messages.maxTokens)
     }
 
+    @Test("chat completions default to non-stream while other text endpoints default to stream")
+    func chatCompletionsDefaultToNonStreamWhileOtherTextEndpointsDefaultToStream() throws {
+        let translator = ChatRequestTranslator()
+
+        let chat = try translator.normalize(
+            OpenAIChatCompletionsRequest(
+                model: "melix-dev-text",
+                messages: [.init(role: "user", content: "Hello")]
+            )
+        )
+        let completions = try translator.normalize(
+            OpenAICompletionsRequest(
+                model: "melix-dev-text",
+                prompt: "Hello"
+            )
+        )
+        let responses = try translator.normalize(
+            OpenAIResponsesRequest(
+                model: "melix-dev-text",
+                input: .text("Hello")
+            )
+        )
+        let messages = try translator.normalize(
+            MelixMessagesRequest(
+                model: "melix-dev-text",
+                messages: [.init(role: "user", content: "Hello")]
+            )
+        )
+
+        #expect(!chat.stream)
+        #expect(completions.stream)
+        #expect(responses.stream)
+        #expect(messages.stream)
+    }
+
     @Test("system and instructions fields align across chat, responses, and messages requests")
     func systemFieldsNormalizeConsistently() throws {
         let translator = ChatRequestTranslator()
@@ -1753,7 +1788,8 @@ struct TextEndpointContractTests {
         )
 
         #expect(translated.requestID == "req-chat-wrapper")
-        #expect(translated.workerRequest.stream)
+        #expect(!translated.stream)
+        #expect(!translated.workerRequest.stream)
         #expect(translated.workerRequest.sampling.temperature == 0.7)
         #expect(translated.workerRequest.sampling.topP == 1.0)
         #expect(translated.workerRequest.sampling.maxOutputTokens == 256)

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -1020,6 +1020,133 @@ struct OpenAIHandlerTests {
         #expect(payload.contains("\"prompt_tokens\":2") == false)
     }
 
+    @Test("POST /v1/chat/completions returns JSON when stream is false")
+    func postChatCompletionsReturnsJSONWhenStreamIsFalse() async throws {
+        let catalog = ModelCatalog(seedModels: [warmModel()])
+        let metricsStore = MetricsStore()
+        let workerClient = ScriptedWorkerClient(events: [
+            makeTokenEvent(requestID: "req-json", seq: 1, text: "Hel"),
+            makeTokenEvent(requestID: "req-json", seq: 2, text: "lo"),
+            makeUsageEvent(requestID: "req-json", seq: 3, promptTokens: 1, completionTokens: 2),
+            makeCompletedEvent(requestID: "req-json", seq: 4, finishReason: "stop", assistantText: "Hello"),
+        ])
+        let coordinator = RequestCoordinator(
+            workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+            abortRegistry: AbortRegistry(),
+            metricsStore: metricsStore
+        )
+        let handler = OpenAIHandler(
+            modelCatalog: catalog,
+            requestCoordinator: coordinator,
+            metricsStore: metricsStore,
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-json" })
+        )
+
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": false,
+              "messages": [
+                { "role": "user", "content": "Hello" }
+              ],
+              "temperature": 0.2,
+              "max_tokens": 16
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+
+        let request = try #require(await workerClient.lastGenerateRequest)
+        let payload = try await jsonPayload(from: response.body)
+        let choice = try #require((payload["choices"] as? [[String: Any]])?.first)
+        let message = try #require(choice["message"] as? [String: Any])
+        let usage = try #require(payload["usage"] as? [String: Any])
+        let metrics = await metricsStore.snapshot()
+
+        #expect(response.statusCode == 200)
+        #expect(response.headers["content-type"] == "application/json")
+        #expect(payload["id"] as? String == "req-json")
+        #expect(payload["object"] as? String == "chat.completion")
+        #expect(payload["model"] as? String == "melix-dev-text")
+        #expect(message["role"] as? String == "assistant")
+        #expect(message["content"] as? String == "Hello")
+        #expect(choice["finish_reason"] as? String == "stop")
+        #expect(usage["prompt_tokens"] as? Int == 1)
+        #expect(usage["completion_tokens"] as? Int == 2)
+        #expect(usage["total_tokens"] as? Int == 3)
+        #expect(request.stream)
+        #expect(request.returnUsage)
+        #expect(request.execution.ext["melix.stream.include_usage"] == "true")
+        #expect(metrics.values["http.chat_completions_non_stream_request_count", default: 0] == 1)
+        #expect(metrics.values["http.chat_completions_non_stream_latency_ms", default: 0] > 0)
+        #expect(metrics.values["http.chat_completions_non_stream_completion_tokens", default: 0] == 2)
+    }
+
+    @Test("POST /v1/chat/completions defaults to non-stream JSON when stream is omitted")
+    func postChatCompletionsDefaultsToNonStreamJSONWhenStreamIsOmitted() async throws {
+        let catalog = ModelCatalog(seedModels: [warmModel()])
+        let workerClient = ScriptedWorkerClient(events: [
+            makeTokenEvent(requestID: "req-json-default", seq: 1, text: "Default"),
+            makeTokenEvent(requestID: "req-json-default", seq: 2, text: " JSON"),
+            makeCompletedEvent(
+                requestID: "req-json-default",
+                seq: 3,
+                finishReason: "stop",
+                assistantText: ""
+            ),
+        ])
+        let handler = OpenAIHandler(
+            modelCatalog: catalog,
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-json-default" })
+        )
+
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "messages": [
+                { "role": "user", "content": "Default response" }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+
+        let request = try #require(await workerClient.lastGenerateRequest)
+        let payload = try await jsonPayload(from: response.body)
+        let choice = try #require((payload["choices"] as? [[String: Any]])?.first)
+        let message = try #require(choice["message"] as? [String: Any])
+
+        #expect(response.statusCode == 200)
+        #expect(response.headers["content-type"] == "application/json")
+        #expect(payload["object"] as? String == "chat.completion")
+        #expect(message["content"] as? String == "Default JSON")
+        #expect(payload["usage"] == nil)
+        #expect(request.stream)
+        #expect(request.returnUsage)
+    }
+
     @Test("POST /v1/chat/completions lazily loads a discovered text model before streaming")
     func postChatCompletionsLazilyLoadsDiscoveredTextModel() async throws {
         let catalog = ModelCatalog(seedModels: [ModelCatalog.devTextModel()])
@@ -6770,14 +6897,18 @@ struct OpenAIHandlerTests {
         #expect(body.contains("\"code\":\"not_found\""))
     }
 
-    @Test("non-stream chat requests return 400")
-    func nonStreamRequestsReturn400() async throws {
+    @Test("non-stream chat requests return JSON")
+    func nonStreamRequestsReturnJSON() async throws {
+        let workerClient = ScriptedWorkerClient(events: [
+            makeCompletedEvent(requestID: "req-non-stream-json", seq: 1, finishReason: "stop", assistantText: "Hello"),
+        ])
         let handler = OpenAIHandler(
             modelCatalog: ModelCatalog(seedModels: [warmModel()]),
             requestCoordinator: RequestCoordinator(
-                workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
                 abortRegistry: AbortRegistry()
-            )
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-non-stream-json" })
         )
         let body = try #require(
             """
@@ -6794,10 +6925,13 @@ struct OpenAIHandlerTests {
         let response = try await handler.handle(
             HTTPRequest(method: .post, path: "/v1/chat/completions", headers: [:], body: body)
         )
-        let payload = try await collectBody(response.body)
+        let payload = try await jsonPayload(from: response.body)
+        let choice = try #require((payload["choices"] as? [[String: Any]])?.first)
+        let message = try #require(choice["message"] as? [String: Any])
 
-        #expect(response.statusCode == 400)
-        #expect(payload.contains("\"code\":\"stream_required\""))
+        #expect(response.statusCode == 200)
+        #expect(payload["object"] as? String == "chat.completion")
+        #expect(message["content"] as? String == "Hello")
     }
 
     @Test("chat requests return 409 when the model is not ready")

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -1091,6 +1091,101 @@ struct OpenAIHandlerTests {
         #expect(metrics.values["http.chat_completions_non_stream_completion_tokens", default: 0] == 2)
     }
 
+    @Test("POST /v1/chat/completions accumulates non-stream completion token metrics")
+    func postChatCompletionsAccumulatesNonStreamCompletionTokenMetrics() async throws {
+        let catalog = ModelCatalog(seedModels: [warmModel()])
+        let metricsStore = MetricsStore()
+        let workerClient = ScriptedWorkerClient(events: [
+            makeUsageEvent(requestID: "req-json-metrics", seq: 1, promptTokens: 1, completionTokens: 2),
+            makeCompletedEvent(requestID: "req-json-metrics", seq: 2, finishReason: "stop", assistantText: "Hello"),
+        ])
+        let handler = OpenAIHandler(
+            modelCatalog: catalog,
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry(),
+                metricsStore: metricsStore
+            ),
+            metricsStore: metricsStore,
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-json-metrics" })
+        )
+
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": false,
+              "messages": [
+                { "role": "user", "content": "Hello" }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        _ = try await handler.handle(
+            HTTPRequest(method: .post, path: "/v1/chat/completions", headers: ["content-type": "application/json"], body: body)
+        )
+        _ = try await handler.handle(
+            HTTPRequest(method: .post, path: "/v1/chat/completions", headers: ["content-type": "application/json"], body: body)
+        )
+
+        let metrics = await metricsStore.snapshot()
+        #expect(metrics.values["http.chat_completions_non_stream_request_count", default: 0] == 2)
+        #expect(metrics.values["http.chat_completions_non_stream_completion_tokens", default: 0] == 4)
+    }
+
+    @Test("POST /v1/chat/completions stops non-stream aggregation on worker error")
+    func postChatCompletionsStopsNonStreamAggregationOnWorkerError() async throws {
+        let catalog = ModelCatalog(seedModels: [warmModel()])
+        let workerClient = ScriptedWorkerClient(events: [
+            makeTokenEvent(requestID: "req-json-error", seq: 1, text: "partial"),
+            makeErrorEvent(requestID: "req-json-error", seq: 2, code: "invalid_argument", message: "bad request"),
+            makeUsageEvent(requestID: "req-json-error", seq: 3, promptTokens: 10, completionTokens: 20),
+            makeCompletedEvent(requestID: "req-json-error", seq: 4, finishReason: "stop", assistantText: "must not win"),
+        ])
+        let metricsStore = MetricsStore()
+        let handler = OpenAIHandler(
+            modelCatalog: catalog,
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry(),
+                metricsStore: metricsStore
+            ),
+            metricsStore: metricsStore,
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-json-error" })
+        )
+
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": false,
+              "messages": [
+                { "role": "user", "content": "Bad request" }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let error = try #require(payload["error"] as? [String: Any])
+        let metrics = await metricsStore.snapshot()
+
+        #expect(response.statusCode == 400)
+        #expect(error["code"] as? String == "invalid_argument")
+        #expect(error["message"] as? String == "bad request")
+        #expect(metrics.values["http.chat_completions_non_stream_request_count", default: 0] == 0)
+        #expect(metrics.values["http.chat_completions_non_stream_completion_tokens", default: 0] == 0)
+    }
+
     @Test("POST /v1/chat/completions defaults to non-stream JSON when stream is omitted")
     func postChatCompletionsDefaultsToNonStreamJSONWhenStreamIsOmitted() async throws {
         let catalog = ModelCatalog(seedModels: [warmModel()])

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -1039,7 +1039,8 @@ struct OpenAIHandlerTests {
             modelCatalog: catalog,
             requestCoordinator: coordinator,
             metricsStore: metricsStore,
-            translator: ChatRequestTranslator(requestIDGenerator: { "req-json" })
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-json" }),
+            now: { Date(timeIntervalSince1970: 1_778_520_000) }
         )
 
         let body = try #require(
@@ -1076,6 +1077,7 @@ struct OpenAIHandlerTests {
         #expect(response.headers["content-type"] == "application/json")
         #expect(payload["id"] as? String == "req-json")
         #expect(payload["object"] as? String == "chat.completion")
+        #expect(payload["created"] as? Int == 1_778_520_000)
         #expect(payload["model"] as? String == "melix-dev-text")
         #expect(message["role"] as? String == "assistant")
         #expect(message["content"] as? String == "Hello")
@@ -1088,6 +1090,8 @@ struct OpenAIHandlerTests {
         #expect(request.execution.ext["melix.stream.include_usage"] == "true")
         #expect(metrics.values["http.chat_completions_non_stream_request_count", default: 0] == 1)
         #expect(metrics.values["http.chat_completions_non_stream_latency_ms", default: 0] > 0)
+        #expect(metrics.values["http.chat_completions_non_stream_time_to_first_token_ms", default: 0] > 0)
+        #expect(metrics.values["http.ttfd_ms", default: 0] == 0)
         #expect(metrics.values["http.chat_completions_non_stream_completion_tokens", default: 0] == 2)
     }
 
@@ -1132,6 +1136,58 @@ struct OpenAIHandlerTests {
         let metrics = await metricsStore.snapshot()
         #expect(metrics.values["http.chat_completions_non_stream_request_count", default: 0] == 2)
         #expect(metrics.values["http.chat_completions_non_stream_completion_tokens", default: 0] == 4)
+    }
+
+    @Test("POST /v1/chat/completions uses latest cumulative non-stream usage")
+    func postChatCompletionsUsesLatestCumulativeNonStreamUsage() async throws {
+        let catalog = ModelCatalog(seedModels: [warmModel()])
+        let metricsStore = MetricsStore()
+        let workerClient = ScriptedWorkerClient(events: [
+            makeTokenEvent(requestID: "req-json-usage", seq: 1, text: "Hello"),
+            makeUsageEvent(requestID: "req-json-usage", seq: 2, promptTokens: 1, completionTokens: 1),
+            makeUsageEvent(requestID: "req-json-usage", seq: 3, promptTokens: 3, completionTokens: 5),
+            makeCompletedEvent(requestID: "req-json-usage", seq: 4, finishReason: "stop", assistantText: "Hello"),
+        ])
+        let handler = OpenAIHandler(
+            modelCatalog: catalog,
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry(),
+                metricsStore: metricsStore
+            ),
+            metricsStore: metricsStore,
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-json-usage" })
+        )
+
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": false,
+              "messages": [
+                { "role": "user", "content": "Usage" }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let usage = try #require(payload["usage"] as? [String: Any])
+        let metrics = await metricsStore.snapshot()
+
+        #expect(response.statusCode == 200)
+        #expect(usage["prompt_tokens"] as? Int == 3)
+        #expect(usage["completion_tokens"] as? Int == 5)
+        #expect(usage["total_tokens"] as? Int == 8)
+        #expect(metrics.values["http.chat_completions_non_stream_completion_tokens", default: 0] == 5)
     }
 
     @Test("POST /v1/chat/completions stops non-stream aggregation on worker error")
@@ -1182,6 +1238,57 @@ struct OpenAIHandlerTests {
         #expect(response.statusCode == 400)
         #expect(error["code"] as? String == "invalid_argument")
         #expect(error["message"] as? String == "bad request")
+        #expect(metrics.values["http.chat_completions_non_stream_request_count", default: 0] == 0)
+        #expect(metrics.values["http.chat_completions_non_stream_completion_tokens", default: 0] == 0)
+    }
+
+    @Test("POST /v1/chat/completions maps non-stream aggregation failures to worker unavailable")
+    func postChatCompletionsMapsNonStreamAggregationFailuresToWorkerUnavailable() async throws {
+        let catalog = ModelCatalog(seedModels: [warmModel()])
+        let metricsStore = MetricsStore()
+        let workerClient = ScriptedWorkerClient(
+            events: [
+                makeTokenEvent(requestID: "req-json-throw", seq: 1, text: "partial"),
+            ],
+            streamFailure: OpenAIHandlerTestError(description: "stream exploded")
+        )
+        let handler = OpenAIHandler(
+            modelCatalog: catalog,
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry(),
+                metricsStore: metricsStore
+            ),
+            metricsStore: metricsStore,
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-json-throw" })
+        )
+
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": false,
+              "messages": [
+                { "role": "user", "content": "Fail" }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let error = try #require(payload["error"] as? [String: Any])
+        let metrics = await metricsStore.snapshot()
+
+        #expect(response.statusCode == 503)
+        #expect(error["code"] as? String == "worker_unavailable")
         #expect(metrics.values["http.chat_completions_non_stream_request_count", default: 0] == 0)
         #expect(metrics.values["http.chat_completions_non_stream_completion_tokens", default: 0] == 0)
     }
@@ -7401,6 +7508,7 @@ private func makeRegistrySnapshotManifestJSON(
 
 private actor ScriptedWorkerClient: WorkerRoutingClient, RuntimeIntrospectingWorkerClientProtocol {
     private let events: [Melix_Worker_V1_ExecuteEvent]
+    private let streamFailure: Error?
     private let loadModelHandle: String
     private let loadModelEstimatedResidentBytes: UInt64
     private let runtimeResidentBytes: UInt64
@@ -7414,6 +7522,7 @@ private actor ScriptedWorkerClient: WorkerRoutingClient, RuntimeIntrospectingWor
 
     init(
         events: [Melix_Worker_V1_ExecuteEvent],
+        streamFailure: Error? = nil,
         loadModelHandle: String = "melix-dev-text::swift",
         loadModelEstimatedResidentBytes: UInt64 = 0,
         runtimeResidentBytes: UInt64 = 0,
@@ -7424,6 +7533,7 @@ private actor ScriptedWorkerClient: WorkerRoutingClient, RuntimeIntrospectingWor
         runtimeStatsResponseOverride: Melix_Worker_V1_GetRuntimeStatsResponse? = nil
     ) {
         self.events = events
+        self.streamFailure = streamFailure
         self.loadModelHandle = loadModelHandle
         self.loadModelEstimatedResidentBytes = loadModelEstimatedResidentBytes
         self.runtimeResidentBytes = runtimeResidentBytes
@@ -7443,11 +7553,12 @@ private actor ScriptedWorkerClient: WorkerRoutingClient, RuntimeIntrospectingWor
     ) async throws -> AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error> {
         lastGenerateRequest = request
         let events = self.events
+        let streamFailure = self.streamFailure
         return AsyncThrowingStream { continuation in
             for event in events {
                 continuation.yield(event)
             }
-            continuation.finish()
+            continuation.finish(throwing: streamFailure)
         }
     }
 

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -996,30 +996,32 @@ final class WorkerScaffoldTests: XCTestCase {
 
     func testVendoredModelContainerSerialAccessCompactsQueuedWaiters() async throws {
         try await withTemporaryDefaultMetallib {
-            let container = makeLiveSwiftMLXModelContainer(promptTokens: [1, 2, 3])
-            let gate = WorkerScaffoldAsyncGate()
+            try await Device.withDefaultDevice(.cpu) {
+                let container = makeLiveSwiftMLXModelContainer(promptTokens: [1, 2, 3])
+                let gate = WorkerScaffoldAsyncGate()
 
-            let holder = Task {
-                await container.perform { _ in
-                    await gate.enterAndWait()
-                    return ()
+                let holder = Task {
+                    await container.perform { _ in
+                        await gate.enterAndWait()
+                        return ()
+                    }
                 }
-            }
-            await gate.waitUntilEntered()
+                await gate.waitUntilEntered()
 
-            let waiters = (0 ..< 40).map { _ in
-                Task {
-                    await container.decode(tokens: [1])
+                let waiters = (0 ..< 40).map { _ in
+                    Task {
+                        await container.decode(tokens: [1])
+                    }
                 }
-            }
 
-            try await Task.sleep(nanoseconds: 50_000_000)
-            await gate.open()
-            await holder.value
+                try await Task.sleep(nanoseconds: 50_000_000)
+                await gate.open()
+                await holder.value
 
-            for waiter in waiters {
-                let decoded = await waiter.value
-                XCTAssertEqual(decoded, "tok1")
+                for waiter in waiters {
+                    let decoded = await waiter.value
+                    XCTAssertEqual(decoded, "tok1")
+                }
             }
         }
     }

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -976,19 +976,21 @@ final class WorkerScaffoldTests: XCTestCase {
     @available(*, deprecated, message: "Exercises the deprecated ModelContainer chat-template compatibility shim.")
     func testVendoredModelContainerConvenienceMethodsUseSerialRead() async throws {
         try await withTemporaryDefaultMetallib {
-            let container = makeLiveSwiftMLXModelContainer(promptTokens: [4, 5, 6])
+            try await Device.withDefaultDevice(.cpu) {
+                let container = makeLiveSwiftMLXModelContainer(promptTokens: [4, 5, 6])
 
-            let prepared = try await container.prepare(input: UserInput(prompt: "hello"))
-            let decoded = await container.decode(tokens: [1, 2])
-            let encoded = await container.encode("tok3 tok4")
-            let templated = try await container.applyChatTemplate(messages: [
-                ["role": "user", "content": "hello"]
-            ])
+                let prepared = try await container.prepare(input: UserInput(prompt: "hello"))
+                let decoded = await container.decode(tokens: [1, 2])
+                let encoded = await container.encode("tok3 tok4")
+                let templated = try await container.applyChatTemplate(messages: [
+                    ["role": "user", "content": "hello"]
+                ])
 
-            XCTAssertEqual(prepared.text.tokens.size, 3)
-            XCTAssertEqual(decoded, "tok1 tok2")
-            XCTAssertEqual(encoded, [3, 4])
-            XCTAssertEqual(templated, [1, 2])
+                XCTAssertEqual(prepared.text.tokens.size, 3)
+                XCTAssertEqual(decoded, "tok1 tok2")
+                XCTAssertEqual(encoded, [3, 4])
+                XCTAssertEqual(templated, [1, 2])
+            }
         }
     }
 

--- a/tests/integration/test_phase6_operator_workflows.py
+++ b/tests/integration/test_phase6_operator_workflows.py
@@ -41,6 +41,18 @@ def _timed_post_json(
     return status, body, elapsed_ms
 
 
+def _chat_completions_tool_call_stream_success(status: int, payload: object) -> bool:
+    if not isinstance(payload, bytes):
+        return False
+    return (
+        status == 200
+        and b"event: message" in payload
+        and b"\"object\":\"chat.completion.chunk\"" in payload
+        and b"\"tool_calls\"" in payload
+        and b"\"name\":\"tools.vision\"" in payload
+    )
+
+
 def _start_image_fixture_server(payload: bytes, *, content_type: str = "image/png") -> tuple[ThreadingHTTPServer, str]:
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: N802
@@ -543,6 +555,7 @@ def test_multimodal_chat_streams_tool_calls_with_shared_parser_selection(tmp_pat
 
         assert status == 200
         assert b"event: message" in payload
+        assert b"\"object\":\"chat.completion.chunk\"" in payload
         assert b"\"tool_calls\"" in payload
         assert b"\"parser_mode\":\"qwen\"" in payload
         assert b"\"parser_namespaces\":[\"tools.vision\"]" in payload
@@ -589,6 +602,7 @@ def test_multimodal_chat_uses_model_default_parser_selection_for_llava_family(tm
 
         assert status == 200
         assert b"event: message" in payload
+        assert b"\"object\":\"chat.completion.chunk\"" in payload
         assert b"\"tool_calls\"" in payload
         assert b"\"parser_mode\":\"qwen\"" in payload
         assert b"\"parser_namespaces\":[\"tools.vision\"]" in payload
@@ -775,12 +789,7 @@ def test_phase6_vision_evidence_report_is_machine_readable(tmp_path: Path) -> No
             },
             vlm={
                 "request_latency_ms": tool_elapsed_ms,
-                "tool_call_success": (
-                    tool_status == 200
-                    and b"event: message" in tool_payload
-                    and b"\"tool_calls\"" in tool_payload
-                    and b"\"name\":\"tools.vision\"" in tool_payload
-                ),
+                "tool_call_success": _chat_completions_tool_call_stream_success(tool_status, tool_payload),
             },
             metrics_snapshot=read_metrics_export(stack.control_plane_metrics_path),
         )


### PR DESCRIPTION
## Summary
- Add OpenAI-compatible non-stream JSON responses for `POST /v1/chat/completions` when `stream` is omitted or `false`.
- Keep `stream: true` on the existing SSE path and preserve `stream_required` for `/v1/completions`, `/v1/responses`, and `/v1/messages`.
- Rebase onto current `main` after PR #873, resolving the overlapping integration/text-worker fixture updates and refreshing the protocol wording for the new chat-completions response modes.

## Plan or Spec
- `docs/plans/2026-05-12-chat-completions-non-stream-json.md`
- `docs/control-plane-protocol.md`
- Related broader milestone: #41 (`Milestone plan: structured streaming and reasoning continuity`). I did not find a separate dedicated GitHub issue for this exact non-stream chat-completions JSON slice, so the PR-local plan is the governing spec.

## Commands Run
```text
# Passed
git diff --check origin/main...HEAD
HOME="$(pwd)/.swift-home/control-plane-build" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex/control-plane-build" xcrun swift build --package-path services/control-plane-swift --product melix-control-plane

# Blocked by local toolchain environment
HOME="$(pwd)/.swift-home/control-plane-tests" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex/control-plane-tests" xcrun swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests|TextEndpointContractTests'
# Failed before running tests: no such module 'Testing'
```

## Coverage and Metrics
- Changed-scope coverage: N/A: this local Command Line Tools Swift installation does not provide the Swift Testing module, so the focused Swift tests fail at compile time on `import Testing` before producing coverage artifacts.
- Metrics added for the changed path: `http.chat_completions_non_stream_request_count`, `http.chat_completions_non_stream_latency_ms`, `http.chat_completions_non_stream_time_to_first_token_ms`, and `http.chat_completions_non_stream_completion_tokens`.
- Product build for the changed Swift control-plane package passed on the rebased branch.

## Known Gaps
- Focused Swift tests and changed-line coverage need to be rerun in CI or on a machine with a complete Xcode/Swift Testing toolchain.
- Non-stream JSON support is intentionally limited to `/v1/chat/completions`; the other text endpoints keep their current streaming-only behavior.
- Non-stream tool-call reconstruction remains out of scope per the plan; streaming tool-call compatibility is covered by the integration assertions.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema changed.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant local build was run; focused local tests were attempted and blocked by the missing Swift Testing module.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
