### PR TITLE
Fix OpenAI chat tools compatibility

### DIFF
--- a/docs/plans/2026-03-30-m3-7-xml-and-namespaced-tool-parsing.md
+++ b/docs/plans/2026-03-30-m3-7-xml-and-namespaced-tool-parsing.md
@@ -31,3 +31,27 @@ Extend tool parsing to support XML-style fallback formats and namespaced tool-ca
 
 - XML-style and namespaced tool-call formats can be parsed through the shared parser layer
 - fallback parsing behavior is observable and test-covered
+
+## 2026-05-12 OpenAI Chat Tools Compatibility Follow-up
+
+Hermes and OpenAI-compatible SDK clients depend on standard Chat Completions
+tool-call semantics. The `/v1/chat/completions` request path must decode
+OpenAI `tools` and `tool_choice`, translate function tools into worker
+`ToolConfig`, and select an explicit observable parser when a request provides
+tools but neither the request nor model metadata selects a parser.
+
+Chat Completions streaming tool-call deltas must be emitted as
+`chat.completion.chunk` frames on the standard message SSE channel with
+`choices[].delta.tool_calls`. Melix-native metadata may remain in the payload,
+but the primary frame shape must be consumable by OpenAI SDK stream parsers.
+
+The worker parser should also treat the `<|tool_call>...<tool_call|>` marker as
+a recoverable XML-family fallback when tool parsing is enabled, so raw tool
+markup is not exposed as assistant text.
+
+### Probes And Metrics
+
+- `http.openai_chat_tools_request_count`
+- `http.openai_chat_tools_configured_count`
+- existing `http.tool_parser_request_count` and parser-mode counters
+- worker `tool_call_markup_leak_count` and `malformed_tool_fragment_count`

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -1738,6 +1738,13 @@ public struct OpenAIHandler: Sendable {
             await metricsStore.increment("http.tool_parser_request_count")
             await metricsStore.increment("http.tool_parser_\(parserMode)_request_count")
         }
+        if translated.workerRequest.execution.ext["melix.tool_config.source"] == "openai_chat_tools" {
+            await metricsStore.increment("http.openai_chat_tools_request_count")
+            if let rawToolCount = translated.workerRequest.execution.ext["melix.tool_config.tool_count"],
+               let toolCount = Double(rawToolCount) {
+                await metricsStore.set(toolCount, forKey: "http.openai_chat_tools_configured_count")
+            }
+        }
         if translated.workerRequest.execution.ext["melix.mcp.source_ids"] != nil {
             await metricsStore.increment("mcp.tool_injection_count")
             let namespaceCount = translated.workerRequest.execution.ext["melix.tool_parser.namespaces"]?

--- a/services/control-plane-swift/Sources/HTTPGateway/SSE/SSEStreamWriter.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/SSE/SSEStreamWriter.swift
@@ -329,7 +329,7 @@ public struct SSEStreamWriter: Sendable {
             let payload = mergeToolParserMetadata(
                 into: [
                     "id": requestID,
-                    "object": "chat.completion.tool_call.delta",
+                    "object": "chat.completion.chunk",
                     "created": Int(now().timeIntervalSince1970),
                     "model": modelID,
                     "choices": [
@@ -338,6 +338,7 @@ public struct SSEStreamWriter: Sendable {
                             "delta": [
                                 "tool_calls": [
                                     [
+                                        "index": 0,
                                         "id": toolCall.callID,
                                         "type": "function",
                                         "function": [
@@ -354,7 +355,7 @@ public struct SSEStreamWriter: Sendable {
                 toolParser: toolParser
             )
             return frame(
-                event: "tool_call",
+                event: "message",
                 json: payload
             )
         case .heartbeat(let heartbeat):

--- a/services/control-plane-swift/Sources/HTTPGateway/SSE/SSEStreamWriter.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/SSE/SSEStreamWriter.swift
@@ -338,7 +338,7 @@ public struct SSEStreamWriter: Sendable {
                             "delta": [
                                 "tool_calls": [
                                     [
-                                        "index": 0,
+                                        "index": max(0, Int(toolCall.fragmentIndex) - 1),
                                         "id": toolCall.callID,
                                         "type": "function",
                                         "function": [

--- a/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
+++ b/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
@@ -107,7 +107,7 @@ public struct NormalizedToolDefinition: Sendable, Equatable {
     ) {
         self.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedDescription = description?.trimmingCharacters(in: .whitespacesAndNewlines)
-        self.description = trimmedDescription?.isEmpty == false ? trimmedDescription! : ""
+        self.description = trimmedDescription.flatMap { $0.isEmpty ? nil : $0 } ?? ""
         let trimmedSchema = jsonSchema.trimmingCharacters(in: .whitespacesAndNewlines)
         self.jsonSchema = trimmedSchema.isEmpty ? "{}" : trimmedSchema
     }

--- a/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
+++ b/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
@@ -95,6 +95,24 @@ public struct NormalizedTextMessage: Sendable, Equatable {
     }
 }
 
+public struct NormalizedToolDefinition: Sendable, Equatable {
+    public let name: String
+    public let description: String
+    public let jsonSchema: String
+
+    public init(
+        name: String,
+        description: String? = nil,
+        jsonSchema: String = "{}"
+    ) {
+        self.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedDescription = description?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.description = trimmedDescription?.isEmpty == false ? trimmedDescription! : ""
+        let trimmedSchema = jsonSchema.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.jsonSchema = trimmedSchema.isEmpty ? "{}" : trimmedSchema
+    }
+}
+
 public struct NormalizedTextRequest: Sendable, Equatable {
     public let endpoint: TextEndpointKind
     public let model: String
@@ -120,6 +138,8 @@ public struct NormalizedTextRequest: Sendable, Equatable {
     public let thinking: MelixMessagesThinkingConfig?
     public let structuredOutput: StructuredOutputConfiguration?
     public let toolParser: ToolParserSelection?
+    public let tools: [NormalizedToolDefinition]
+    public let toolChoice: String?
     public let chatTemplate: ChatTemplateSelection?
 
     public init(
@@ -147,6 +167,8 @@ public struct NormalizedTextRequest: Sendable, Equatable {
         thinking: MelixMessagesThinkingConfig? = nil,
         structuredOutput: StructuredOutputConfiguration? = nil,
         toolParser: ToolParserSelection? = nil,
+        tools: [NormalizedToolDefinition] = [],
+        toolChoice: String? = nil,
         chatTemplate: ChatTemplateSelection? = nil
     ) {
         self.endpoint = endpoint
@@ -174,6 +196,9 @@ public struct NormalizedTextRequest: Sendable, Equatable {
         self.thinking = thinking
         self.structuredOutput = structuredOutput?.isEnabled == true ? structuredOutput : nil
         self.toolParser = toolParser
+        self.tools = tools.filter { !$0.name.isEmpty }
+        let trimmedToolChoice = toolChoice?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.toolChoice = trimmedToolChoice?.isEmpty == false ? trimmedToolChoice : nil
         self.chatTemplate = chatTemplate
     }
 }
@@ -221,6 +246,8 @@ public struct ShapedTextRequest: Sendable, Equatable {
     public let reasoningHistoryStripCount: Int
     public let structuredOutput: StructuredOutputConfiguration?
     public let toolParser: ToolParserSelection?
+    public let tools: [NormalizedToolDefinition]
+    public let toolChoice: String?
     public let toolParserSuppressedReason: String?
     public let chatTemplate: ResolvedChatTemplatePolicy?
     public let ocrPolicy: ResolvedOCRExecutionPolicy?
@@ -266,6 +293,86 @@ public struct OpenAIStreamOptions: Codable, Sendable, Equatable {
 
     public init(includeUsage: Bool? = nil) {
         self.includeUsage = includeUsage
+    }
+}
+
+public enum OpenAIChatToolChoice: Codable, Sendable, Equatable {
+    case mode(String)
+    case structured(StructuredJSONValue)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let mode = try? container.decode(String.self) {
+            self = .mode(mode)
+            return
+        }
+        self = .structured(try container.decode(StructuredJSONValue.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case let .mode(mode):
+            try container.encode(mode)
+        case let .structured(value):
+            try container.encode(value)
+        }
+    }
+
+    public var normalizedValue: String? {
+        switch self {
+        case let .mode(mode):
+            let trimmed = mode.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        case let .structured(value):
+            return try? value.canonicalJSONString()
+        }
+    }
+}
+
+public struct OpenAIChatTool: Codable, Sendable, Equatable {
+    public struct FunctionDefinition: Codable, Sendable, Equatable {
+        public let name: String
+        public let description: String?
+        public let parameters: StructuredJSONValue?
+
+        public init(
+            name: String,
+            description: String? = nil,
+            parameters: StructuredJSONValue? = nil
+        ) {
+            self.name = name
+            self.description = description
+            self.parameters = parameters
+        }
+    }
+
+    public let type: String
+    public let function: FunctionDefinition?
+
+    public init(
+        type: String,
+        function: FunctionDefinition? = nil
+    ) {
+        self.type = type
+        self.function = function
+    }
+
+    public func normalizedDefinition() throws -> NormalizedToolDefinition? {
+        guard type.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "function",
+              let function
+        else {
+            return nil
+        }
+        let name = function.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            return nil
+        }
+        return NormalizedToolDefinition(
+            name: name,
+            description: function.description,
+            jsonSchema: try function.parameters?.canonicalJSONString() ?? "{}"
+        )
     }
 }
 
@@ -381,6 +488,8 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
     public let workflowNodeID: String?
     public let responseFormat: StructuredOutputRequestFormat?
     public let toolParser: ToolParserRequestConfiguration?
+    public let tools: [OpenAIChatTool]?
+    public let toolChoice: OpenAIChatToolChoice?
     public let chatTemplateKwargs: ChatTemplateRequestConfiguration?
 
     enum CodingKeys: String, CodingKey {
@@ -407,6 +516,8 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         case workflowNodeID = "workflow_node_id"
         case responseFormat = "response_format"
         case toolParser = "tool_parser"
+        case tools
+        case toolChoice = "tool_choice"
         case chatTemplateKwargs = "chat_template_kwargs"
     }
 
@@ -433,6 +544,8 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         workflowNodeID: String? = nil,
         responseFormat: StructuredOutputRequestFormat? = nil,
         toolParser: ToolParserRequestConfiguration? = nil,
+        tools: [OpenAIChatTool]? = nil,
+        toolChoice: OpenAIChatToolChoice? = nil,
         chatTemplateKwargs: ChatTemplateRequestConfiguration? = nil
     ) {
         self.model = model
@@ -457,6 +570,8 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         self.workflowNodeID = workflowNodeID
         self.responseFormat = responseFormat
         self.toolParser = toolParser
+        self.tools = tools
+        self.toolChoice = toolChoice
         self.chatTemplateKwargs = chatTemplateKwargs
     }
 
@@ -484,6 +599,8 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         self.workflowNodeID = try container.decodeIfPresent(String.self, forKey: .workflowNodeID)
         self.responseFormat = try container.decodeIfPresent(StructuredOutputRequestFormat.self, forKey: .responseFormat)
         self.toolParser = try container.decodeIfPresent(ToolParserRequestConfiguration.self, forKey: .toolParser)
+        self.tools = try container.decodeIfPresent([OpenAIChatTool].self, forKey: .tools)
+        self.toolChoice = try container.decodeIfPresent(OpenAIChatToolChoice.self, forKey: .toolChoice)
         self.chatTemplateKwargs = try container.decodeIfPresent(ChatTemplateRequestConfiguration.self, forKey: .chatTemplateKwargs)
     }
 
@@ -511,6 +628,8 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         try container.encodeIfPresent(workflowNodeID, forKey: .workflowNodeID)
         try container.encodeIfPresent(responseFormat, forKey: .responseFormat)
         try container.encodeIfPresent(toolParser, forKey: .toolParser)
+        try container.encodeIfPresent(tools, forKey: .tools)
+        try container.encodeIfPresent(toolChoice, forKey: .toolChoice)
         try container.encodeIfPresent(chatTemplateKwargs, forKey: .chatTemplateKwargs)
     }
 
@@ -524,6 +643,16 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         get throws {
             try toolParser?.resolvedSelection()
         }
+    }
+
+    public var normalizedTools: [NormalizedToolDefinition] {
+        get throws {
+            try (tools ?? []).compactMap { try $0.normalizedDefinition() }
+        }
+    }
+
+    public var normalizedToolChoice: String? {
+        toolChoice?.normalizedValue
     }
 
     public var chatTemplateSelection: ChatTemplateSelection? {
@@ -1311,6 +1440,8 @@ public struct ChatRequestTranslator: Sendable {
             reasoningEffort: request.reasoningEffort,
             structuredOutput: try request.structuredOutputConfiguration,
             toolParser: try request.toolParserSelection,
+            tools: try request.normalizedTools,
+            toolChoice: request.normalizedToolChoice,
             chatTemplate: request.chatTemplateSelection
         )
     }
@@ -1352,6 +1483,8 @@ public struct ChatRequestTranslator: Sendable {
             reasoningEffort: request.reasoningEffort,
             structuredOutput: try request.structuredOutputConfiguration,
             toolParser: try request.toolParserSelection,
+            tools: try request.normalizedTools,
+            toolChoice: request.normalizedToolChoice,
             chatTemplate: request.chatTemplateSelection
         )
     }
@@ -1511,6 +1644,8 @@ public struct ChatRequestTranslator: Sendable {
         thinking: MelixMessagesThinkingConfig? = nil,
         structuredOutput: StructuredOutputConfiguration? = nil,
         toolParser: ToolParserSelection? = nil,
+        tools: [NormalizedToolDefinition] = [],
+        toolChoice: String? = nil,
         chatTemplate: ChatTemplateSelection? = nil
     ) -> NormalizedTextRequest {
         NormalizedTextRequest(
@@ -1538,6 +1673,8 @@ public struct ChatRequestTranslator: Sendable {
             thinking: thinking,
             structuredOutput: structuredOutput,
             toolParser: toolParser,
+            tools: tools,
+            toolChoice: toolChoice,
             chatTemplate: chatTemplate
         )
     }
@@ -1683,6 +1820,15 @@ public struct ChatRequestTranslator: Sendable {
                 generateRequest.execution.ext["melix.mcp.source_ids"] = toolParser.mcpSourceIDs.joined(separator: ",")
             }
         }
+        if !shapedRequest.tools.isEmpty {
+            generateRequest.execution.toolConfig = Self.workerToolConfig(
+                tools: shapedRequest.tools,
+                toolChoice: shapedRequest.toolChoice,
+                toolParser: shapedRequest.toolParser
+            )
+            generateRequest.execution.ext["melix.tool_config.source"] = "openai_chat_tools"
+            generateRequest.execution.ext["melix.tool_config.tool_count"] = String(shapedRequest.tools.count)
+        }
         if let toolParserSuppressedReason = shapedRequest.toolParserSuppressedReason {
             generateRequest.execution.ext["melix.tool_parser.suppressed_reason"] = toolParserSuppressedReason
         }
@@ -1817,6 +1963,28 @@ public struct ChatRequestTranslator: Sendable {
             workerRequest: generateRequest,
             stream: generateRequest.stream
         )
+    }
+
+    private static func workerToolConfig(
+        tools: [NormalizedToolDefinition],
+        toolChoice: String?,
+        toolParser: ToolParserSelection?
+    ) -> Melix_Worker_V1_ToolConfig {
+        var config = Melix_Worker_V1_ToolConfig()
+        config.schemaFormat = "openai_chat_tools"
+        config.schemaVersion = "2024-06"
+        config.toolsetVersion = "1"
+        config.parser = toolParser?.mode.rawValue ?? ""
+        config.parserContractVersion = "melix.tool-parser.v1"
+        config.toolChoice = toolChoice ?? ""
+        config.tools = tools.map { tool in
+            var definition = Melix_Worker_V1_ToolDefinition()
+            definition.name = tool.name
+            definition.description_p = tool.description
+            definition.jsonSchema = tool.jsonSchema
+            return definition
+        }
+        return config
     }
 }
 

--- a/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
+++ b/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
@@ -304,11 +304,12 @@ public struct TextRequestShaper: Sendable {
             resolvedToolParser = nil
             toolParserSuppressedReason = "structured_output_json_without_tools"
         } else {
-            resolvedToolParser = toolParserRegistry.resolve(
+            let resolvedParser = toolParserRegistry.resolve(
                 requested: request.toolParser,
                 modelDefault: modelToolParser,
                 mcpToolCatalog: mcpToolCatalog
             )
+            resolvedToolParser = resolvedParser ?? Self.openAIToolsParserSelection(for: request)
             toolParserSuppressedReason = nil
         }
         let partialMode = resolvePartialMode(
@@ -359,6 +360,8 @@ public struct TextRequestShaper: Sendable {
             reasoningHistoryStripCount: sanitizedHistory.stripCount,
             structuredOutput: request.structuredOutput,
             toolParser: resolvedToolParser,
+            tools: request.tools,
+            toolChoice: request.toolChoice,
             toolParserSuppressedReason: toolParserSuppressedReason,
             chatTemplate: resolvedChatTemplate,
             ocrPolicy: resolvedOCRPolicy,
@@ -423,6 +426,7 @@ public struct TextRequestShaper: Sendable {
         mcpToolCatalog: MCPToolCatalog
     ) -> Bool {
         guard request.toolParser == nil,
+              request.tools.isEmpty,
               mcpToolCatalog.resolvedNamespaces.isEmpty,
               let structuredOutput = request.structuredOutput,
               structuredOutput.mode == .jsonObject || structuredOutput.mode == .jsonSchema
@@ -430,6 +434,15 @@ public struct TextRequestShaper: Sendable {
             return false
         }
         return true
+    }
+
+    private static func openAIToolsParserSelection(
+        for request: NormalizedTextRequest
+    ) -> ToolParserSelection? {
+        guard !request.tools.isEmpty else {
+            return nil
+        }
+        return ToolParserSelection(mode: .xml, source: "openai_tools")
     }
 
     private func sanitizeReasoningHistory(messages: [NormalizedTextMessage]) -> HistorySanitizationResult {

--- a/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
@@ -50,6 +50,137 @@ struct TextEndpointContractTests {
         #expect(decoded.includeUsage == true)
     }
 
+    @Test("OpenAI chat tools flow into worker ToolConfig and select a parser")
+    func openAIChatToolsFlowIntoWorkerToolConfig() throws {
+        let request = try JSONDecoder().decode(
+            OpenAIChatCompletionsRequest.self,
+            from: Data(
+                """
+                {
+                  "model": "melix-dev-text",
+                  "stream": true,
+                  "messages": [
+                    { "role": "user", "content": "Check auth." }
+                  ],
+                  "tools": [
+                    {
+                      "type": "function",
+                      "function": {
+                        "name": "terminal",
+                        "description": "Run a shell command.",
+                        "parameters": {
+                          "type": "object",
+                          "properties": {
+                            "command": { "type": "string" }
+                          },
+                          "required": ["command"]
+                        }
+                      }
+                    }
+                  ],
+                  "tool_choice": "auto"
+                }
+                """.utf8
+            )
+        )
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-openai-tools" })
+        let normalized = try translator.normalize(request)
+        let translated = try translator.translate(normalized, modelHandle: "melix-dev-text::swift")
+        let workerRequest = translated.workerRequest
+
+        #expect(normalized.tools.map(\.name) == ["terminal"])
+        #expect(normalized.toolChoice == "auto")
+        #expect(workerRequest.execution.hasToolConfig)
+        #expect(workerRequest.execution.toolConfig.schemaFormat == "openai_chat_tools")
+        #expect(workerRequest.execution.toolConfig.schemaVersion == "2024-06")
+        #expect(workerRequest.execution.toolConfig.parser == "xml")
+        #expect(workerRequest.execution.toolConfig.toolChoice == "auto")
+        #expect(workerRequest.execution.toolConfig.tools.count == 1)
+        #expect(workerRequest.execution.toolConfig.tools[0].name == "terminal")
+        #expect(workerRequest.execution.toolConfig.tools[0].description_p == "Run a shell command.")
+        #expect(workerRequest.execution.toolConfig.tools[0].jsonSchema.contains("\"command\""))
+        #expect(workerRequest.execution.ext["melix.tool_parser.mode"] == "xml")
+        #expect(workerRequest.execution.ext["melix.tool_parser.source"] == "openai_tools")
+        #expect(workerRequest.execution.ext["melix.tool_config.source"] == "openai_chat_tools")
+        #expect(workerRequest.execution.ext["melix.tool_config.tool_count"] == "1")
+    }
+
+    @Test("OpenAI chat tools normalize structured choices and filter invalid entries")
+    func openAIChatToolsNormalizeStructuredChoicesAndFilterInvalidEntries() throws {
+        let decoder = JSONDecoder()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let request = try decoder.decode(
+            OpenAIChatCompletionsRequest.self,
+            from: Data(
+                """
+                {
+                  "model": "melix-dev-text",
+                  "messages": [
+                    { "role": "user", "content": "Check auth." }
+                  ],
+                  "tools": [
+                    {
+                      "type": "function",
+                      "function": {
+                        "name": " terminal ",
+                        "description": " ",
+                        "parameters": {
+                          "type": "object",
+                          "properties": {
+                            "command": { "type": "string" }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "retrieval",
+                      "function": { "name": "ignored" }
+                    },
+                    {
+                      "type": "function",
+                      "function": { "name": " " }
+                    }
+                  ],
+                  "tool_choice": {
+                    "type": "function",
+                    "function": { "name": "terminal" }
+                  }
+                }
+                """.utf8
+            )
+        )
+
+        #expect(request.normalizedToolChoice == "{\"function\":{\"name\":\"terminal\"},\"type\":\"function\"}")
+        let structuredChoice = try #require(request.toolChoice)
+        let structuredChoiceJSON = String(decoding: try encoder.encode(structuredChoice), as: UTF8.self)
+        #expect(structuredChoiceJSON == "{\"function\":{\"name\":\"terminal\"},\"type\":\"function\"}")
+
+        let modeChoice = OpenAIChatToolChoice.mode(" required ")
+        #expect(modeChoice.normalizedValue == "required")
+        #expect(String(decoding: try encoder.encode(modeChoice), as: UTF8.self) == "\" required \"")
+        #expect(OpenAIChatToolChoice.mode(" ").normalizedValue == nil)
+
+        let normalizedTools = try request.normalizedTools
+        #expect(normalizedTools.count == 1)
+        #expect(normalizedTools[0].name == "terminal")
+        #expect(normalizedTools[0].description == "")
+        #expect(normalizedTools[0].jsonSchema.contains("\"command\""))
+
+        let defaultSchemaTool = OpenAIChatTool(
+            type: "function",
+            function: .init(name: "ping")
+        )
+        let defaultSchemaDefinition = try #require(try defaultSchemaTool.normalizedDefinition())
+        #expect(defaultSchemaDefinition.name == "ping")
+        #expect(defaultSchemaDefinition.jsonSchema == "{}")
+
+        let unsupportedTool = OpenAIChatTool(type: "web_search")
+        #expect(try unsupportedTool.normalizedDefinition() == nil)
+        let blankFunctionTool = OpenAIChatTool(type: "function", function: .init(name: " "))
+        #expect(try blankFunctionTool.normalizedDefinition() == nil)
+    }
+
     @Test("reasoning controls decode across shipped text endpoints")
     func reasoningControlsDecodeAcrossShippedTextEndpoints() throws {
         let decoder = JSONDecoder()

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/HTTPGatewayTestSupport.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/HTTPGatewayTestSupport.swift
@@ -63,7 +63,8 @@ func makeToolCallEvent(
     seq: UInt64,
     callID: String,
     toolName: String,
-    argumentsJSONFragment: String
+    argumentsJSONFragment: String,
+    fragmentIndex: UInt32 = 1
 ) -> Melix_Worker_V1_ExecuteEvent {
     var event = Melix_Worker_V1_ExecuteEvent()
     event.requestID = requestID
@@ -73,6 +74,7 @@ func makeToolCallEvent(
     event.toolCallDelta.callID = callID
     event.toolCallDelta.toolName = toolName
     event.toolCallDelta.argumentsJsonFragment = argumentsJSONFragment
+    event.toolCallDelta.fragmentIndex = fragmentIndex
     return event
 }
 

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -774,7 +774,8 @@ struct OpenAIHandlerTests {
                 seq: 1,
                 callID: "req-openai-tools-tool-1",
                 toolName: "terminal",
-                argumentsJSONFragment: "{\"command\":\"gh auth status\"}"
+                argumentsJSONFragment: "{\"command\":\"gh auth status\"}",
+                fragmentIndex: 2
             ),
             makeCompletedEvent(
                 requestID: "req-openai-tools",
@@ -846,6 +847,7 @@ struct OpenAIHandlerTests {
         #expect(payload.contains("event: message"))
         #expect(payload.contains("\"object\":\"chat.completion.chunk\""))
         #expect(payload.contains("\"tool_calls\""))
+        #expect(payload.contains("\"index\":1"))
         #expect(payload.contains("\"name\":\"terminal\""))
         #expect(payload.contains("\"arguments\":\"{\\\"command\\\":\\\"gh auth status\\\"}\""))
         #expect(!payload.contains("event: tool_call"))

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -765,6 +765,94 @@ struct OpenAIHandlerTests {
         #expect(payload.contains("data: [DONE]"))
     }
 
+    @Test("POST /v1/chat/completions forwards OpenAI tools and emits SDK-compatible tool deltas")
+    func postChatCompletionsForwardsOpenAIToolsAndToolDeltas() async throws {
+        let catalog = ModelCatalog(seedModels: [warmModel()])
+        let workerClient = ScriptedWorkerClient(events: [
+            makeToolCallEvent(
+                requestID: "req-openai-tools",
+                seq: 1,
+                callID: "req-openai-tools-tool-1",
+                toolName: "terminal",
+                argumentsJSONFragment: "{\"command\":\"gh auth status\"}"
+            ),
+            makeCompletedEvent(
+                requestID: "req-openai-tools",
+                seq: 2,
+                finishReason: "tool_calls",
+                assistantText: ""
+            ),
+        ])
+        let metricsStore = MetricsStore()
+        let handler = OpenAIHandler(
+            modelCatalog: catalog,
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            metricsStore: metricsStore,
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-openai-tools" }),
+            sseWriter: SSEStreamWriter(now: { Date(timeIntervalSince1970: 123) })
+        )
+
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": true,
+              "messages": [
+                { "role": "user", "content": "Check gh auth." }
+              ],
+              "tools": [
+                {
+                  "type": "function",
+                  "function": {
+                    "name": "terminal",
+                    "description": "Run a shell command.",
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "command": { "type": "string" }
+                      },
+                      "required": ["command"]
+                    }
+                  }
+                }
+              ],
+              "tool_choice": "auto"
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        let request = try #require(await workerClient.lastGenerateRequest)
+        let payload = try await collectBody(response.body)
+        let metrics = await metricsStore.snapshot()
+
+        #expect(response.statusCode == 200)
+        #expect(request.execution.hasToolConfig)
+        #expect(request.execution.toolConfig.tools.map(\.name) == ["terminal"])
+        #expect(request.execution.toolConfig.parser == "xml")
+        #expect(request.execution.toolConfig.toolChoice == "auto")
+        #expect(request.execution.ext["melix.tool_parser.mode"] == "xml")
+        #expect(request.execution.ext["melix.tool_config.source"] == "openai_chat_tools")
+        #expect(payload.contains("event: message"))
+        #expect(payload.contains("\"object\":\"chat.completion.chunk\""))
+        #expect(payload.contains("\"tool_calls\""))
+        #expect(payload.contains("\"name\":\"terminal\""))
+        #expect(payload.contains("\"arguments\":\"{\\\"command\\\":\\\"gh auth status\\\"}\""))
+        #expect(!payload.contains("event: tool_call"))
+        #expect(metrics.values["http.openai_chat_tools_request_count"] == 1)
+        #expect(metrics.values["http.openai_chat_tools_configured_count"] == 1)
+    }
+
     @Test("POST /v1/chat/completions lazy-loads text-only VLM requests through the Python VLM route")
     func postChatCompletionsLazyLoadsTextOnlyVLMRequestsThroughPythonVLMRoute() async throws {
         let catalog = ModelCatalog(seedModels: [ModelCatalog.devTextModel(), ModelCatalog.devVLMModel()])

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/SSEStreamWriterTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/SSEStreamWriterTests.swift
@@ -507,7 +507,8 @@ struct SSEStreamWriterTests {
                 seq: 2,
                 callID: "tool-1",
                 toolName: "search",
-                argumentsJSONFragment: "{\"q\":\"melix\"}"
+                argumentsJSONFragment: "{\"q\":\"melix\"}",
+                fragmentIndex: 2
             ))
             continuation.yield(makeCompletedEvent(requestID: "chat-deltas", seq: 3, finishReason: "stop", assistantText: "done"))
             continuation.finish()
@@ -528,7 +529,7 @@ struct SSEStreamWriterTests {
         #expect(payload.contains("\"reasoning\":\"think\""))
         #expect(payload.contains("\"object\":\"chat.completion.chunk\""))
         #expect(payload.contains("\"tool_calls\""))
-        #expect(payload.contains("\"index\":0"))
+        #expect(payload.contains("\"index\":1"))
         #expect(payload.contains("\"name\":\"search\""))
         #expect(payload.contains("\"arguments\":\"{\\\"q\\\":\\\"melix\\\"}\""))
         #expect(payload.contains("\"parser_mode\":\"qwen\""))

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/SSEStreamWriterTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/SSEStreamWriterTests.swift
@@ -526,8 +526,9 @@ struct SSEStreamWriterTests {
         #expect(payload.contains("event: reasoning"))
         #expect(payload.contains("\"object\":\"chat.completion.reasoning.delta\""))
         #expect(payload.contains("\"reasoning\":\"think\""))
-        #expect(payload.contains("event: tool_call"))
-        #expect(payload.contains("\"object\":\"chat.completion.tool_call.delta\""))
+        #expect(payload.contains("\"object\":\"chat.completion.chunk\""))
+        #expect(payload.contains("\"tool_calls\""))
+        #expect(payload.contains("\"index\":0"))
         #expect(payload.contains("\"name\":\"search\""))
         #expect(payload.contains("\"arguments\":\"{\\\"q\\\":\\\"melix\\\"}\""))
         #expect(payload.contains("\"parser_mode\":\"qwen\""))
@@ -535,7 +536,8 @@ struct SSEStreamWriterTests {
         #expect(payload.contains("\"parser_fallback_mode\":\"xml\""))
         #expect(orderedRanges(in: payload, needles: [
             "event: reasoning",
-            "event: tool_call",
+            "event: message",
+            "\"tool_calls\"",
             "event: message",
             "data: [DONE]",
         ]))

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -16,6 +16,10 @@ def test_structural_tag_prefixes_are_cached_per_parser_mode() -> None:
         RequestStreamAssembler._TOOL_OPEN[:index]
         for index in range(1, len(RequestStreamAssembler._TOOL_OPEN))
     )
+    pipe_tool_prefixes = tuple(
+        RequestStreamAssembler._PIPE_TOOL_OPEN[:index]
+        for index in range(1, len(RequestStreamAssembler._PIPE_TOOL_OPEN))
+    )
 
     tool_enabled = RequestStreamAssembler(
         request_id="req-prefixes-tools",
@@ -30,10 +34,14 @@ def test_structural_tag_prefixes_are_cached_per_parser_mode() -> None:
         tool_parser_mode="",
     )
 
-    assert tool_enabled._structural_tag_prefixes == think_prefixes + tool_prefixes
+    assert tool_enabled._structural_tag_prefixes == (
+        think_prefixes + tool_prefixes + pipe_tool_prefixes
+    )
     assert tool_enabled._structural_tag_prefixes is tool_enabled._structural_tag_prefixes
-    assert tool_enabled._structural_tag_prefixes_reversed == tuple(
-        reversed(think_prefixes + tool_prefixes)
+    assert tool_enabled._structural_tag_prefixes_reversed == (
+        tuple(reversed(pipe_tool_prefixes))
+        + tuple(reversed(tool_prefixes))
+        + tuple(reversed(think_prefixes))
     )
     assert (
         tool_enabled._structural_tag_prefixes_reversed
@@ -172,6 +180,183 @@ def test_plain_buffer_with_marker_still_holds_partial_structural_prefix() -> Non
     assert [delta.tool_call.tool_name for delta in second if delta.tool_call] == ["search"]
     assert completed.assistant_text == "alpha"
     assert completed.metrics["stream_prefix_hold_chars"] == len("<tool_ca")
+
+
+def test_pipe_tool_call_marker_is_parsed_without_public_markup_leak() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-pipe-tool-call",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="xml",
+    )
+
+    deltas = assembler.accept(
+        StreamFragment(
+            raw_text=(
+                '<|tool_call>call:native_mcp:execute_command{"command":"gh auth status"}'
+                "<tool_call|>"
+            )
+        )
+    )
+    completed = assembler.completed()
+    calls = [delta.tool_call for delta in deltas if delta.tool_call]
+
+    assert len(calls) == 1
+    assert calls[0].tool_name == "native_mcp:execute_command"
+    assert calls[0].arguments_json_fragment == '{"command":"gh auth status"}'
+    assert completed.assistant_text == ""
+    assert completed.metrics["tool_call_markup_leak_count"] == 0
+
+
+def test_pipe_tool_call_relaxed_object_arguments_are_parsed() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-pipe-tool-call-relaxed",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="xml",
+    )
+
+    deltas = assembler.accept(
+        StreamFragment(
+            raw_text=(
+                '<|tool_call>call:native_mcp:execute_command{command: "gh auth status"}'
+                "<tool_call|>"
+            )
+        )
+    )
+    calls = [delta.tool_call for delta in deltas if delta.tool_call]
+
+    assert len(calls) == 1
+    assert calls[0].arguments_json_fragment == '{"command":"gh auth status"}'
+
+
+def test_pipe_tool_call_marker_wins_when_it_appears_before_legacy_marker() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-pipe-tool-call-first",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="xml",
+    )
+    assembler._buffer = (
+        '<|tool_call>call:native_mcp:execute_command{"command":"gh auth status"}'
+        "<tool_call|>"
+        '<tool_call>{"name":"search","arguments":{}}</tool_call>'
+    )
+
+    assert assembler._next_structural_tag() == (
+        RequestStreamAssembler._PIPE_TOOL_OPEN,
+        0,
+    )
+
+
+def test_pipe_tool_call_marker_wins_when_it_appears_before_thinking_marker() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-pipe-tool-call-before-think",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="xml",
+    )
+    assembler._buffer = (
+        '<|tool_call>call:native_mcp:execute_command{"command":"gh auth status"}'
+        "<tool_call|><think>later</think>"
+    )
+
+    assert assembler._next_structural_tag() == (
+        RequestStreamAssembler._PIPE_TOOL_OPEN,
+        0,
+    )
+
+
+def test_pipe_tool_call_partial_prefix_is_held() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-pipe-tool-call-prefix",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="xml",
+    )
+
+    first = assembler.accept(StreamFragment(raw_text="alpha<|tool_ca"))
+    second = assembler.accept(
+        StreamFragment(
+            raw_text=(
+                'alpha<|tool_call>call:native_mcp:execute_command{"command":"gh auth status"}'
+                "<tool_call|>"
+            )
+        )
+    )
+    completed = assembler.completed()
+
+    assert [delta.content_text for delta in first if delta.content_text] == ["alpha"]
+    assert [delta.tool_call.tool_name for delta in second if delta.tool_call] == [
+        "native_mcp:execute_command"
+    ]
+    assert completed.assistant_text == "alpha"
+    assert completed.metrics["stream_prefix_hold_chars"] == len("<|tool_ca")
+
+
+def test_pipe_tool_call_markup_in_public_content_is_counted_as_leak() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-pipe-tool-call-leak",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="xml",
+    )
+
+    deltas = assembler.accept(StreamFragment(raw_text="visible <|tool_callx"))
+    completed = assembler.completed()
+
+    assert [delta.content_text for delta in deltas if delta.content_text] == [
+        "visible <|tool_callx"
+    ]
+    assert completed.metrics["tool_call_markup_leak_count"] == 1
+
+
+def test_pipe_tool_call_malformed_relaxed_arguments_are_skipped() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-pipe-tool-call-malformed",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="xml",
+    )
+
+    deltas = assembler.accept(
+        StreamFragment(
+            raw_text=(
+                "<|tool_call>call:native_mcp:execute_command{command}"
+                "<tool_call|>"
+            )
+        )
+    )
+    completed = assembler.completed()
+
+    assert [delta.tool_call for delta in deltas if delta.tool_call] == []
+    assert completed.metrics["malformed_tool_fragment_count"] == 1
+    assert completed.metrics["tool_call_markup_leak_count"] == 0
+
+
+def test_relaxed_pipe_tool_call_arguments_parse_scalar_types() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-pipe-tool-call-scalars",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="xml",
+    )
+
+    parsed = assembler._parse_relaxed_object_arguments(
+        "{text: bare, count: 2, ratio: 1.5, enabled: true, disabled: false, empty: null}"
+    )
+
+    assert parsed == {
+        "text": "bare",
+        "count": 2,
+        "ratio": 1.5,
+        "enabled": True,
+        "disabled": False,
+        "empty": None,
+    }
+    assert assembler._parse_relaxed_object_arguments("{}") == {}
+    assert assembler._parse_relaxed_object_arguments("not-an-object") is None
+    assert assembler._parse_relaxed_object_arguments("{: missing}") is None
 
 
 def test_partial_structural_tag_suffix_checks_only_last_marker_candidate() -> None:

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -230,6 +230,31 @@ def test_pipe_tool_call_relaxed_object_arguments_are_parsed() -> None:
     assert calls[0].arguments_json_fragment == '{"command":"gh auth status"}'
 
 
+def test_pipe_tool_call_relaxed_object_arguments_preserve_quoted_commas() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-pipe-tool-call-commas",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="xml",
+    )
+
+    deltas = assembler.accept(
+        StreamFragment(
+            raw_text=(
+                '<|tool_call>call:native_mcp:execute_command{'
+                'command: "printf \\"hello, world\\"", note: \'alpha, beta\', count: 2'
+                "}<tool_call|>"
+            )
+        )
+    )
+    calls = [delta.tool_call for delta in deltas if delta.tool_call]
+
+    assert len(calls) == 1
+    assert calls[0].arguments_json_fragment == (
+        '{"command":"printf \\"hello, world\\"","count":2,"note":"alpha, beta"}'
+    )
+
+
 def test_pipe_tool_call_marker_wins_when_it_appears_before_legacy_marker() -> None:
     assembler = RequestStreamAssembler(
         request_id="req-pipe-tool-call-first",

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, replace
 from functools import lru_cache
 import json
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 _UTF8_INCREMENTAL_DECODER = codecs.getincrementaldecoder("utf-8")
@@ -87,11 +88,21 @@ class RequestStreamAssembler:
     _THINK_CLOSE = "</think>"
     _TOOL_OPEN = "<tool_call>"
     _TOOL_CLOSE = "</tool_call>"
+    _PIPE_TOOL_OPEN = "<|tool_call>"
+    _PIPE_TOOL_CLOSE = "<tool_call|>"
     _THINK_PREFIXES = tuple("<think>"[:index] for index in range(1, len("<think>")))
     _TOOL_PREFIXES = tuple("<tool_call>"[:index] for index in range(1, len("<tool_call>")))
+    _PIPE_TOOL_PREFIXES = tuple(
+        "<|tool_call>"[:index] for index in range(1, len("<|tool_call>"))
+    )
     _THINK_PREFIXES_REVERSED = tuple(reversed(_THINK_PREFIXES))
     _TOOL_PREFIXES_REVERSED = tuple(reversed(_TOOL_PREFIXES))
+    _PIPE_TOOL_PREFIXES_REVERSED = tuple(reversed(_PIPE_TOOL_PREFIXES))
     _VISIBLE_TAIL_MARKERS = ("\nFinal answer", "\nFinal:", "\nAnswer:", "\nAssistant:", "\nResult:")
+    _PIPE_CALL_RE = re.compile(
+        r"^\s*call:(?P<name>[A-Za-z0-9_.:-]+)\s*(?P<args>\{.*\})\s*$",
+        re.DOTALL,
+    )
 
     def __init__(
         self,
@@ -116,9 +127,13 @@ class RequestStreamAssembler:
         self._structural_tag_prefixes_reversed_value = self._THINK_PREFIXES_REVERSED
         if self._tool_parsing_enabled_value:
             self._request_context_mode_value = "tool_parser"
-            self._structural_tag_prefixes_value = self._THINK_PREFIXES + self._TOOL_PREFIXES
+            self._structural_tag_prefixes_value = (
+                self._THINK_PREFIXES + self._TOOL_PREFIXES + self._PIPE_TOOL_PREFIXES
+            )
             self._structural_tag_prefixes_reversed_value = (
-                self._TOOL_PREFIXES_REVERSED + self._THINK_PREFIXES_REVERSED
+                self._PIPE_TOOL_PREFIXES_REVERSED
+                + self._TOOL_PREFIXES_REVERSED
+                + self._THINK_PREFIXES_REVERSED
             )
         elif self._is_json_structured_output_value:
             self._request_context_mode_value = "structured_json"
@@ -422,15 +437,18 @@ class RequestStreamAssembler:
                     self._metrics["reasoning_parser_bypassed_count"] += 1
                 continue
 
-            if tag == self._TOOL_OPEN:
-                close_index = self._buffer.find(self._TOOL_CLOSE, len(self._TOOL_OPEN))
+            if tag in {self._TOOL_OPEN, self._PIPE_TOOL_OPEN}:
+                close_tag = (
+                    self._PIPE_TOOL_CLOSE if tag == self._PIPE_TOOL_OPEN else self._TOOL_CLOSE
+                )
+                close_index = self._buffer.find(close_tag, len(tag))
                 if close_index < 0:
                     if final:
                         self._metrics["malformed_tool_fragment_count"] += 1
                         self._buffer = ""
                     break
-                body = self._buffer[len(self._TOOL_OPEN) : close_index]
-                self._buffer = self._buffer[close_index + len(self._TOOL_CLOSE) :]
+                body = self._buffer[len(tag) : close_index]
+                self._buffer = self._buffer[close_index + len(close_tag) :]
                 tool_delta = self._tool_delta(body)
                 if tool_delta is not None:
                     deltas.append(AssemblyDelta(raw_text=body, tool_call=tool_delta))
@@ -462,11 +480,22 @@ class RequestStreamAssembler:
             return None if think_index < 0 else (self._THINK_OPEN, think_index)
 
         tool_index = self._buffer.find(self._TOOL_OPEN)
+        pipe_tool_index = self._buffer.find(self._PIPE_TOOL_OPEN)
         if think_index < 0:
-            return None if tool_index < 0 else (self._TOOL_OPEN, tool_index)
-        if tool_index < 0 or think_index <= tool_index:
-            return (self._THINK_OPEN, think_index)
-        return (self._TOOL_OPEN, tool_index)
+            if tool_index < 0 and pipe_tool_index < 0:
+                return None
+            if tool_index < 0:
+                return (self._PIPE_TOOL_OPEN, pipe_tool_index)
+            if pipe_tool_index < 0 or tool_index <= pipe_tool_index:
+                return (self._TOOL_OPEN, tool_index)
+            return (self._PIPE_TOOL_OPEN, pipe_tool_index)
+
+        candidates = [(self._THINK_OPEN, think_index)]
+        if tool_index >= 0:
+            candidates.append((self._TOOL_OPEN, tool_index))
+        if pipe_tool_index >= 0:
+            candidates.append((self._PIPE_TOOL_OPEN, pipe_tool_index))
+        return min(candidates, key=lambda item: item[1])
 
     def _has_partial_structural_tag_suffix(self) -> bool:
         return bool(self._partial_structural_tag_suffix())
@@ -479,6 +508,9 @@ class RequestStreamAssembler:
         suffix = self._buffer[marker_index:]
         if self._tool_parsing_enabled_value and 0 < len(suffix) < len(self._TOOL_OPEN):
             if self._TOOL_OPEN.startswith(suffix):
+                return suffix
+        if self._tool_parsing_enabled_value and 0 < len(suffix) < len(self._PIPE_TOOL_OPEN):
+            if self._PIPE_TOOL_OPEN.startswith(suffix):
                 return suffix
         if 0 < len(suffix) < len(self._THINK_OPEN) and self._THINK_OPEN.startswith(
             suffix
@@ -493,16 +525,16 @@ class RequestStreamAssembler:
         )
 
     def _content_delta(self, content: str) -> AssemblyDelta:
-        if self._tool_parsing_enabled_value and "<tool_call" in content:
+        if self._tool_parsing_enabled_value and (
+            "<tool_call" in content or "<|tool_call" in content
+        ):
             self._metrics["tool_call_markup_leak_count"] += 1
         self._assistant_parts.append(content)
         return AssemblyDelta(content_text=content, raw_text=content)
 
     def _tool_delta(self, body: str) -> AssembledToolCall | None:
-        try:
-            payload = json.loads(body)
-        except json.JSONDecodeError:
-            self._metrics["malformed_tool_fragment_count"] += 1
+        payload = self._parse_tool_body(body)
+        if payload is None:
             return None
 
         if not isinstance(payload, dict):
@@ -542,6 +574,68 @@ class RequestStreamAssembler:
             fragment_index=self._tool_fragment_index,
             parser_mode=self._tool_parser_mode,
         )
+
+    def _parse_tool_body(self, body: str) -> dict[str, object] | list[object] | None:
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            return self._parse_pipe_tool_body(body)
+
+    def _parse_pipe_tool_body(self, body: str) -> dict[str, object] | None:
+        match = self._PIPE_CALL_RE.match(body)
+        if match is None:
+            self._metrics["malformed_tool_fragment_count"] += 1
+            return None
+        try:
+            arguments = json.loads(match.group("args"))
+        except json.JSONDecodeError:
+            arguments = self._parse_relaxed_object_arguments(match.group("args"))
+            if arguments is None:
+                self._metrics["malformed_tool_fragment_count"] += 1
+                return None
+        if not isinstance(arguments, dict):
+            self._metrics["malformed_tool_fragment_count"] += 1
+            return None
+        return {
+            "name": match.group("name"),
+            "arguments": arguments,
+        }
+
+    def _parse_relaxed_object_arguments(self, text: str) -> dict[str, object] | None:
+        stripped = text.strip()
+        if not (stripped.startswith("{") and stripped.endswith("}")):
+            return None
+        content = stripped[1:-1].strip()
+        if not content:
+            return {}
+        values: dict[str, object] = {}
+        for item in content.split(","):
+            if ":" not in item:
+                return None
+            key, value = item.split(":", 1)
+            normalized_key = key.strip().strip("\"'")
+            if not normalized_key:
+                return None
+            values[normalized_key] = self._parse_relaxed_scalar(value.strip())
+        return values
+
+    @staticmethod
+    def _parse_relaxed_scalar(value: str) -> object:
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            return value[1:-1]
+        lowered = value.lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        if lowered == "null":
+            return None
+        try:
+            if any(marker in value for marker in (".", "e", "E")):
+                return float(value)
+            return int(value)
+        except ValueError:
+            return value
 
     def _first_json_delimiter(self, text: str) -> int | None:
         object_index = text.find("{")

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -437,10 +437,8 @@ class RequestStreamAssembler:
                     self._metrics["reasoning_parser_bypassed_count"] += 1
                 continue
 
-            if tag in {self._TOOL_OPEN, self._PIPE_TOOL_OPEN}:
-                close_tag = (
-                    self._PIPE_TOOL_CLOSE if tag == self._PIPE_TOOL_OPEN else self._TOOL_CLOSE
-                )
+            if tag == self._TOOL_OPEN or tag == self._PIPE_TOOL_OPEN:
+                close_tag = self._PIPE_TOOL_CLOSE if tag == self._PIPE_TOOL_OPEN else self._TOOL_CLOSE
                 close_index = self._buffer.find(close_tag, len(tag))
                 if close_index < 0:
                     if final:
@@ -609,10 +607,12 @@ class RequestStreamAssembler:
         if not content:
             return {}
         values: dict[str, object] = {}
-        for item in content.split(","):
-            if ":" not in item:
+        for item in self._split_relaxed_object_items(content):
+            separator_index = self._relaxed_key_value_separator(item)
+            if separator_index is None:
                 return None
-            key, value = item.split(":", 1)
+            key = item[:separator_index]
+            value = item[separator_index + 1 :]
             normalized_key = key.strip().strip("\"'")
             if not normalized_key:
                 return None
@@ -620,9 +620,53 @@ class RequestStreamAssembler:
         return values
 
     @staticmethod
+    def _split_relaxed_object_items(content: str) -> list[str]:
+        items: list[str] = []
+        start = 0
+        quote: str | None = None
+        escaped = False
+        for index, char in enumerate(content):
+            if quote is not None:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == quote:
+                    quote = None
+                continue
+            if char == '"' or char == "'":
+                quote = char
+                continue
+            if char == ",":
+                items.append(content[start:index].strip())
+                start = index + 1
+        items.append(content[start:].strip())
+        return items
+
+    @staticmethod
+    def _relaxed_key_value_separator(item: str) -> int | None:
+        quote: str | None = None
+        escaped = False
+        for index, char in enumerate(item):
+            if quote is not None:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == quote:
+                    quote = None
+                continue
+            if char == '"' or char == "'":
+                quote = char
+                continue
+            if char == ":":
+                return index
+        return None
+
+    @staticmethod
     def _parse_relaxed_scalar(value: str) -> object:
         if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-            return value[1:-1]
+            return RequestStreamAssembler._unescape_relaxed_quoted_string(value[1:-1])
         lowered = value.lower()
         if lowered == "true":
             return True
@@ -636,6 +680,31 @@ class RequestStreamAssembler:
             return int(value)
         except ValueError:
             return value
+
+    @staticmethod
+    def _unescape_relaxed_quoted_string(value: str) -> str:
+        if "\\" not in value:
+            return value
+        decoded: list[str] = []
+        escaped = False
+        escapes = {
+            "n": "\n",
+            "r": "\r",
+            "t": "\t",
+            "b": "\b",
+            "f": "\f",
+        }
+        for char in value:
+            if escaped:
+                decoded.append(escapes.get(char, char))
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            else:
+                decoded.append(char)
+        if escaped:
+            decoded.append("\\")
+        return "".join(decoded)
 
     def _first_json_delimiter(self, text: str) -> int | None:
         object_index = text.find("{")


### PR DESCRIPTION
## Summary
- Decode OpenAI Chat Completions `tools` and `tool_choice`, carry them through text shaping, and populate worker `ToolConfig` so chat-template native tools are available to model generation.
- Emit chat-completion tool deltas as SDK-compatible `chat.completion.chunk` `choices[].delta.tool_calls` frames instead of a custom chat `tool_call` event.
- Parse Qwen-style pipe tool markers (`<|tool_call>...<tool_call|>`) in the worker stream assembler so leaked fallback markup becomes structured tool deltas instead of assistant text.
- Add OpenAI tools request metrics and update the governing tool parsing plan with probes and success criteria.

## Plan or Spec
- `docs/plans/2026-03-30-m3-7-xml-and-namespaced-tool-parsing.md`

## Commands Run
```text
# Python worker parser and native template tool injection
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_generate_stream.py::test_generate_injects_tool_config_as_native_template_tools_when_absent -q
=> 54 passed in 0.13s

# Python changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage erase && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --source=worker.runtime.stream_assembler -m pytest services/mlx-worker-python/tests/test_stream_assembler.py -q && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage report --include='*/worker/runtime/stream_assembler.py'
=> 53 passed; stream_assembler.py 98% coverage (434/442)

# Control-plane build
xcrun swift build --package-path services/control-plane-swift --product melix-control-plane
=> passed

# Focused Swift control-plane coverage run
DYLD_FRAMEWORK_PATH=/Library/Developer/CommandLineTools/Library/Developer/Frameworks DYLD_LIBRARY_PATH=/Library/Developer/CommandLineTools/Library/Developer/usr/lib xcrun swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'TextEndpointContractTests|SSEStreamWriterTests|OpenAIHandlerTests/postChatCompletionsForwardsOpenAIToolsAndToolDeltas' -Xswiftc -F -Xswiftc /Library/Developer/CommandLineTools/Library/Developer/Frameworks -Xswiftc -load-plugin-library -Xswiftc /Library/Developer/CommandLineTools/usr/lib/swift/host/plugins/testing/libTestingMacros.dylib -Xlinker -rpath -Xlinker /Library/Developer/CommandLineTools/Library/Developer/Frameworks -Xlinker -rpath -Xlinker /Library/Developer/CommandLineTools/Library/Developer/usr/lib
=> 69 tests in 3 suites passed

# Swift changed-line coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Sources/HTTPGateway/SSE/SSEStreamWriter.swift services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift services/control-plane-swift/Sources/Requests/TextRequestShaper.swift services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift services/control-plane-swift/Tests/HTTPGatewayTests/SSEStreamWriterTests.swift
=> TOTAL 100.00% (344/344)

# Whitespace and patch sanity
 git diff --check
=> passed
```

## Coverage and Metrics
- Python changed-scope coverage: `services/mlx-worker-python/worker/runtime/stream_assembler.py` 98% (`434/442`).
- Swift changed-line coverage: 100% (`344/344`) across the touched control-plane source and test files listed above.
- Metrics report:
  - Adds `http.openai_chat_tools_request_count` for OpenAI chat requests that configure worker tools.
  - Adds `http.openai_chat_tools_configured_count` gauge with configured tool count.
  - Existing parser metrics continue to cover `tool_call_markup_leak_count` and `malformed_tool_fragment_count`; pipe marker tests assert fallback markup is not leaked to public assistant content.
  - Existing worker metric `native_tool_exemplar_injected_count` is exercised by the native template tools injection test.

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally; this PR used focused control-plane and worker verification for the touched scope.
- Local Swift tests required explicit Swift Testing framework/plugin paths because this machine's CommandLineTools setup does not auto-load Swift Testing macros.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
