### PR TITLE
perf: guard combined hub size hints

### DIFF
--- a/docs/plans/2026-05-11-hub-catalog-combined-size-hint-marker-guard.md
+++ b/docs/plans/2026-05-11-hub-catalog-combined-size-hint-marker-guard.md
@@ -1,0 +1,23 @@
+# Hub Catalog Combined Size-Hint Marker Guard
+
+## Scope
+
+This performance slice narrows `worker.model_ops.hub_catalog._size_hint_bytes` when Hub payloads provide multiple free-text fields (`description`, `readme`, and `cardData.description`) that contain byte-like values but no explicit `model size` marker.
+
+Affected registered probe:
+
+- `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`
+
+The probe already has focused `test_command`, `coverage_command`, and `probe_command` entries covering `services/mlx-worker-python/worker/model_ops/hub_catalog.py`, `services/mlx-worker-python/tests/test_hub_catalog.py`, and `scripts/hub_catalog_size_hint_probe.py`.
+
+## Plan
+
+1. Add regression coverage proving combined free-text fields without a model-size marker do not call the regex parser.
+2. Reuse `_may_contain_model_marker(...)` after joining multiple candidate fields and return `0` before `_size_hint_from_text(...)` when the marker is absent.
+3. Extend `scripts/hub_catalog_size_hint_probe.py` with a deterministic multi-field no-marker payload so the registered probe reports the parser-call reduction against `origin/main`.
+
+## Success Criteria
+
+- Focused Hub catalog tests pass on Linux.
+- Changed-scope coverage remains at or above 95%.
+- Registered probe shows fewer `size_hint_calls_mean` calls for the synthetic mixed payload workload while preserving matched hint counts/checksum semantics.

--- a/scripts/hub_catalog_size_hint_probe.py
+++ b/scripts/hub_catalog_size_hint_probe.py
@@ -18,14 +18,20 @@ import worker.model_ops.hub_catalog as hub_catalog
 
 def _payload(index: int) -> tuple[dict[str, Any], int]:
     value = 128 + (index % 2048)
-    mode = index % 4
+    mode = index % 5
     if mode == 0:
         return {"cardData": {}}, 0
     if mode == 1:
         return {"cardData": {"model_size": f"{value} MB"}}, value * 1024 * 1024
     if mode == 2:
         return {"cardData": {}, "readme": f"README\nMODEL SIZE | {value} kb\nother metadata"}, value * 1024
-    return {"cardData": {}, "description": f"description only {value} MB"}, 0
+    if mode == 3:
+        return {"cardData": {}, "description": f"description only {value} MB"}, 0
+    return {
+        "cardData": {"description": f"training corpus {value} kb"},
+        "description": f"tokenizer assets {value} MB",
+        "readme": f"adapter notes {value} MB",
+    }, 0
 
 
 def _run_sample(iterations: int) -> tuple[float, int, int, int]:

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -593,6 +593,16 @@ def test_size_hint_bytes_skips_explicit_parser_when_model_marker_absent(
 
     assert hub_catalog_module._size_hint_bytes({"description": "description only 512 MB"}) == 0
     assert hub_catalog_module._size_hint_bytes({"readme": "tokenizer size 12 MB"}) == 0
+    assert (
+        hub_catalog_module._size_hint_bytes(
+            {
+                "description": "tokenizer weights 512 MB",
+                "readme": "adapter assets 64 MB",
+                "cardData": {"description": "training corpus 12 MB"},
+            }
+        )
+        == 0
+    )
     parser.assert_not_called()
 
 

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -618,6 +618,8 @@ def _size_hint_bytes(payload: dict[str, Any]) -> int:
         for text in (description_text, readme_text, card_description_text)
         if text
     )
+    if not _may_contain_model_marker(text):
+        return 0
     return _size_hint_from_text(text, allow_bare=False)
 
 


### PR DESCRIPTION
## Summary
- Guard combined Hub catalog size-hint free-text fields with the existing model-marker check before running the explicit size-hint regex parser.
- Add regression coverage for multi-field no-marker payloads and extend the registered size-hint probe workload to measure the parser-call reduction.

## Plan or Spec
- `docs/plans/2026-05-11-hub-catalog-combined-size-hint-marker-guard.md`
- Registered PR-scoped probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
49 passed in 0.84s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
49 passed in 0.36s
TOTAL 7 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-hub-combined-size-hint-20260511194351 --head-repo "$PWD" --output /tmp/hub-size-hint-result.json
base elapsed_ms_mean=1781.5008385805413, size_hint_calls_mean=80000.0
head elapsed_ms_mean=1669.1259974148124, size_hint_calls_mean=40000.0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Local registered probe (`hub-catalog-size-hint-regex-precompile`):
  - `elapsed_ms_mean`: 1781.5008 ms → 1669.1260 ms (`-112.3748 ms`, ~6.31% faster).
  - `size_hint_calls_mean`: 80000.0 → 40000.0 (`-50.0%`).
  - `matched_hint_count`: 80000.0 → 80000.0.
  - `checksum`: 3424780288.0 → 3424780288.0.
- CI PR-scoped performance must run the same registered probe before merge.

## Known Gaps
- None. This is a Python-only slice locally verified on Linux; CI remains the source for required PR-gate validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
