### PR TITLE
perf: fast-path code eval payload fields

### DIFF
--- a/docs/plans/2026-05-11-code-eval-payload-fast-path.md
+++ b/docs/plans/2026-05-11-code-eval-payload-fast-path.md
@@ -1,0 +1,68 @@
+# Code Evaluation Payload Fast-Path Plan
+
+## Goal
+
+Reduce avoidable JSON materialization when the Python code-evaluation parent process
+loads the sandbox runner result payload. The parent only needs the small fixed
+status field set emitted by the runner, while probe-sized payloads can contain
+large diagnostic metadata that should not be materialized on the hot path.
+
+## Scope
+
+This slice is intentionally limited to the Python code-evaluation payload loader
+and its direct regression coverage. It does not change sandbox execution,
+candidate compilation, test instrumentation, stdio truncation, or generated
+protocol artifacts.
+
+## Registered Probe
+
+Primary PR-scoped probe:
+
+- `code-eval-payload-json-bytes`
+  - `elapsed_ms_mean`: informational.
+  - `peak_bytes_mean`: lower is better, with the registered 5 percent warning
+    threshold.
+
+The affected path is already registered in `infra/perf/pr_scoped_probes.json`
+with focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Implementation Notes
+
+- Keep the byte-oriented payload read path so callers do not perform a separate
+  text decode before JSON handling.
+- Add a narrow fixed-field extractor for runner-shaped payloads containing the
+  result fields consumed by `run_python_code_evaluation`.
+- Fall back to full JSON decoding for non-runner payloads or escaped string
+  fields so the existing private helper semantics remain available to tests and
+  diagnostic callers.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_extracts_runner_fields_without_metadata_parse \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_escaped_fields \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_extracts_runner_fields_without_metadata_parse \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_escaped_fields \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/engine/code_eval_runner.py \
+  services/mlx-worker-python/tests/test_code_eval_runner.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/code_eval_payload_json_probe.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
+```

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -781,6 +781,71 @@ def test_load_payload_file_reads_payload_bytes_without_text_decode() -> None:
         payload_path.read_text()
 
 
+def test_load_payload_file_fast_path_extracts_runner_fields_without_metadata_parse() -> None:
+    payload_path = _BytesOnlyPayloadPath(
+        json.dumps(
+            {
+                "compile_status": "compiled",
+                "failure_detail": "",
+                "metadata": {f"case_{index}": "ignored" for index in range(128)},
+                "runtime_status": "ok",
+                "test_status": "passed",
+                "tests_passed": 7,
+                "tests_total": 7,
+                "timeout_status": "ok",
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    )
+
+    assert code_eval_runner._load_payload_file(payload_path) == {
+        "compile_status": "compiled",
+        "failure_detail": "",
+        "runtime_status": "ok",
+        "test_status": "passed",
+        "tests_passed": 7,
+        "tests_total": 7,
+        "timeout_status": "ok",
+    }
+    assert payload_path.read_bytes_calls == 1
+
+
+def test_load_payload_file_fast_path_falls_back_for_escaped_fields(tmp_path: Path) -> None:
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "failure_detail": "line one\\nline two",
+                "runtime_status": "error",
+                "test_status": "failed",
+                "tests_passed": 0,
+                "tests_total": 1,
+                "timeout_status": "ok",
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    assert code_eval_runner._load_payload_file(payload_path) == {
+        "failure_detail": "line one\\nline two",
+        "runtime_status": "error",
+        "test_status": "failed",
+        "tests_passed": 0,
+        "tests_total": 1,
+        "timeout_status": "ok",
+    }
+
+
+def test_payload_fast_path_field_extractors_cover_malformed_edges() -> None:
+    assert code_eval_runner._json_field_value_start(b'{"runtime_status" : "ok"}', "runtime_status") == 20
+    assert code_eval_runner._json_field_value_start(b'{"runtime_status" "ok"}', "runtime_status") is None
+    assert code_eval_runner._json_field_value_start(b'{"runtime_status": ', "runtime_status") is None
+    assert code_eval_runner._extract_json_string_field(b'{"failure_detail":"oops}', "failure_detail") is None
+    assert code_eval_runner._extract_json_int_field(b'{"tests_passed":-7}', "tests_passed") == -7
+    assert code_eval_runner._extract_json_int_field(b'{"tests_total": }', "tests_total") is None
+
+
 def test_code_exec_policy_support_and_output_summary_helpers() -> None:
     assert code_eval_runner.is_code_execution_policy_supported("disabled") is False
     assert "stdout tail: hello" in code_eval_runner._summarize_stdio(

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -272,14 +272,105 @@ def _load_payload_file(
     _decode_error=_JSON_DECODE_ERROR,
 ) -> dict[str, object] | None:
     try:
-        payload = _loads(payload_path.read_bytes())
+        payload_bytes = payload_path.read_bytes()
     except OSError:
         return None
+
+    fast_payload = _extract_code_eval_payload_fields(payload_bytes)
+    if fast_payload is not None:
+        return fast_payload
+
+    try:
+        payload = _loads(payload_bytes)
     except _decode_error:
         return None
     if not isinstance(payload, dict):
         return None
     return payload
+
+
+def _extract_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, object] | None:
+    stripped = payload_bytes.strip()
+    if not stripped.startswith(b"{") or not stripped.endswith(b"}"):
+        return None
+
+    payload: dict[str, object] = {}
+    for key in (
+        "compile_status",
+        "runtime_status",
+        "timeout_status",
+        "test_status",
+        "failure_detail",
+    ):
+        value = _extract_json_string_field(payload_bytes, key)
+        if value is not None:
+            payload[key] = value
+
+    for key in ("tests_passed", "tests_total"):
+        value = _extract_json_int_field(payload_bytes, key)
+        if value is None:
+            return None
+        payload[key] = value
+
+    required_string_keys = ("runtime_status", "timeout_status", "test_status", "failure_detail")
+    if all(key in payload for key in required_string_keys):
+        return payload
+    return None
+
+
+def _json_field_value_start(payload_bytes: bytes, key: str) -> int | None:
+    key_token = json.dumps(key, separators=(",", ":")).encode("utf-8")
+    key_index = payload_bytes.find(key_token)
+    if key_index < 0:
+        return None
+    cursor = key_index + len(key_token)
+    payload_length = len(payload_bytes)
+    while cursor < payload_length and payload_bytes[cursor] in b" \t\r\n":
+        cursor += 1
+    if cursor >= payload_length or payload_bytes[cursor] != ord(":"):
+        return None
+    cursor += 1
+    while cursor < payload_length and payload_bytes[cursor] in b" \t\r\n":
+        cursor += 1
+    if cursor >= payload_length:
+        return None
+    return cursor
+
+
+def _extract_json_string_field(payload_bytes: bytes, key: str) -> str | None:
+    start = _json_field_value_start(payload_bytes, key)
+    if start is None or payload_bytes[start] != ord('"'):
+        return None
+    cursor = start + 1
+    value_start = cursor
+    payload_length = len(payload_bytes)
+    while cursor < payload_length:
+        char = payload_bytes[cursor]
+        if char == ord('"'):
+            return payload_bytes[value_start:cursor].decode("utf-8")
+        if char == ord("\\"):
+            return None
+        cursor += 1
+    return None
+
+
+def _extract_json_int_field(payload_bytes: bytes, key: str) -> int | None:
+    start = _json_field_value_start(payload_bytes, key)
+    if start is None:
+        return None
+    cursor = start
+    payload_length = len(payload_bytes)
+    if cursor < payload_length and payload_bytes[cursor] == ord("-"):
+        cursor += 1
+    digit_start = cursor
+    while cursor < payload_length and ord("0") <= payload_bytes[cursor] <= ord("9"):
+        cursor += 1
+    if cursor == digit_start:
+        return None
+    try:
+        return int(payload_bytes[start:cursor])
+    except ValueError:  # pragma: no cover - digit scan above should prevent this.
+        return None
 
 
 def _read_limited_stdio(path: Path, byte_limit: int) -> tuple[str, int]:


### PR DESCRIPTION
## Summary
- Add a byte-level fast path for code-evaluation runner payloads so the parent process extracts only the fixed result fields it consumes.
- Preserve the full JSON fallback for non-runner payloads and escaped string fields.
- Add focused regression coverage for the fast path, fallback path, and malformed edge handling.

## Plan or Spec
- `docs/plans/2026-05-11-code-eval-payload-fast-path.md`
- Registered PR-scoped probe: `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
# Exit 0: 5 passed in 26.55s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
# Exit 0: {"elapsed_ms_mean": 2595.1118204143963, "iteration_count": 1200.0, "payload_bytes": 55474.0, "peak_bytes_mean": 440500.14285714284, "sample_count": 7.0}

# Focused verification after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_extracts_runner_fields_without_metadata_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_escaped_fields services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
# Exit 0: 8 passed in 2.11s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_extracts_runner_fields_without_metadata_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_escaped_fields services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py
# Exit 0: TOTAL 86 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
# Exit 0: {"elapsed_ms_mean": 248.6099350166374, "iteration_count": 1200.0, "payload_bytes": 55474.0, "peak_bytes_mean": 60425.0, "sample_count": 7.0}

git diff --check
# Exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py
# Exit 1: 35 passed, 8 failed because sandbox-exec is unavailable on this Linux host; the failures are macOS sandbox runtime tests unrelated to this payload-loader slice.
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 86 0 100%` from `scripts/changed_scope_coverage.py`.
- Registered local probe `code_eval_payload_json_probe.py`:
  - `elapsed_ms_mean`: 2595.1118 ms -> 248.6099 ms (`-2346.5019 ms`, `-90.42%`, `10.44x` faster).
  - `peak_bytes_mean`: 440500.14 bytes -> 60425.00 bytes (`-380075.14 bytes`, `-86.28%`).
- CI PR-scoped performance workflow is required as the registered probe validation source before merge.

## Known Gaps
- Full `test_code_eval_runner.py` cannot pass on this Linux runner because the macOS-only `sandbox-exec` binary is unavailable. Focused payload-loader tests and the registered Python probe pass locally.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
