### PR TITLE
perf: elide text family metadata copy

### DIFF
--- a/docs/plans/2026-05-11-text-family-metadata-copy-elision.md
+++ b/docs/plans/2026-05-11-text-family-metadata-copy-elision.md
@@ -1,0 +1,25 @@
+# Text Family Metadata Copy Elision
+
+## Context
+
+`resolve_text_family_config()` is used while resolving text model adapter metadata. The existing registered probe `text-family-config-copy-elision` already covers the config payload mapping path and focused tests for `services/mlx-worker-python/worker/runtime/text_family_adapters.py`.
+
+## Slice
+
+This slice keeps the existing behavior but avoids eagerly copying the metadata mapping passed to `resolve_text_family_config()`. The function only reads metadata values, so a read-only mapping is sufficient and preserves support for custom mapping implementations.
+
+## Probe
+
+The existing registered PR-scoped probe remains the governing performance signal:
+
+- `infra/perf/pr_scoped_probes.json` id: `text-family-config-copy-elision`
+- focused tests: `services/mlx-worker-python/tests/test_text_family_adapters.py`
+- script: `scripts/text_family_config_probe.py`
+
+The probe now also emits `metadata_copy_calls_mean` so CI can detect regressions in the metadata mapping fast path.
+
+## Success Criteria
+
+- Focused text-family adapter tests pass.
+- Changed-scope coverage for the touched Python files remains at least 95%.
+- Registered probe completes successfully and reports `metadata_copy_calls_mean=0.0`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -404,6 +404,12 @@
         "unit": "calls",
         "direction": "lower_is_better",
         "warn_pct": 0.0
+      },
+      {
+        "key": "metadata_copy_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
       }
     ]
   },

--- a/scripts/text_family_config_probe.py
+++ b/scripts/text_family_config_probe.py
@@ -35,6 +35,25 @@ class CopyCountingConfig(Mapping[str, Any]):
         return self._payload.keys()
 
 
+class CopyCountingMetadata(Mapping[str, str]):
+    def __init__(self, payload: Mapping[str, str]) -> None:
+        self._payload = dict(payload)
+        self.copy_attempts = 0
+
+    def __getitem__(self, key: str) -> str:
+        return self._payload[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._payload)
+
+    def __len__(self) -> int:
+        return len(self._payload)
+
+    def keys(self):  # type: ignore[override]
+        self.copy_attempts += 1
+        return self._payload.keys()
+
+
 def _payload() -> dict[str, Any]:
     payload: dict[str, Any] = {f"unused_{index}": index for index in range(2048)}
     payload.update(
@@ -50,9 +69,14 @@ def _payload() -> dict[str, Any]:
     return payload
 
 
-def _run_sample(*, iterations: int) -> tuple[float, int, int]:
+def _run_sample(*, iterations: int) -> tuple[float, int, int, int]:
     config = CopyCountingConfig(_payload())
-    metadata = {"text_family_id": "qwen3moe"}
+    metadata = CopyCountingMetadata(
+        {
+            **{f"unused_metadata_{index}": str(index) for index in range(2048)},
+            "text_family_id": "qwen3moe",
+        }
+    )
     checksum = 0
     tracemalloc.start()
     started = time.perf_counter()
@@ -73,25 +97,33 @@ def _run_sample(*, iterations: int) -> tuple[float, int, int]:
     tracemalloc.stop()
     if checksum != iterations * 130:
         raise AssertionError(f"unexpected checksum: {checksum}")
-    return elapsed_ms, peak_bytes, config.copy_attempts
+    metadata_copy_attempts = metadata.copy_attempts
+    if "text_family_id" not in set(metadata) or len(metadata) != 2049:
+        raise AssertionError("unexpected metadata mapping contents")  # pragma: no cover
+    if dict(metadata)["text_family_id"] != "qwen3moe":
+        raise AssertionError("unexpected metadata mapping value")  # pragma: no cover
+    return elapsed_ms, peak_bytes, config.copy_attempts, metadata_copy_attempts
 
 
 def main() -> None:
     iterations = 10_000
     elapsed: list[float] = []
     peak: list[int] = []
-    copy_calls: list[int] = []
+    config_copy_calls: list[int] = []
+    metadata_copy_calls: list[int] = []
     for _ in range(5):
-        elapsed_ms, peak_bytes, copies = _run_sample(iterations=iterations)
+        elapsed_ms, peak_bytes, config_copies, metadata_copies = _run_sample(iterations=iterations)
         elapsed.append(elapsed_ms)
         peak.append(peak_bytes)
-        copy_calls.append(copies)
+        config_copy_calls.append(config_copies)
+        metadata_copy_calls.append(metadata_copies)
     print(
         json.dumps(
             {
                 "elapsed_ms_mean": statistics.fmean(elapsed),
                 "peak_bytes_mean": statistics.fmean(peak),
-                "config_copy_calls_mean": statistics.fmean(copy_calls),
+                "config_copy_calls_mean": statistics.fmean(config_copy_calls),
+                "metadata_copy_calls_mean": statistics.fmean(metadata_copy_calls),
                 "iterations": iterations,
             },
             sort_keys=True,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2003,6 +2003,7 @@ def test_text_family_config_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] > 0
     assert metrics["peak_bytes_mean"] > 0
     assert metrics["config_copy_calls_mean"] == 0.0
+    assert metrics["metadata_copy_calls_mean"] == 0.0
     assert metrics["iterations"] == 10_000
 
 

--- a/services/mlx-worker-python/tests/test_text_family_adapters.py
+++ b/services/mlx-worker-python/tests/test_text_family_adapters.py
@@ -32,6 +32,25 @@ class _CopyCountingConfig(Mapping[str, Any]):
         return self._payload.keys()
 
 
+class _CopyCountingMetadata(Mapping[str, str]):
+    def __init__(self, payload: Mapping[str, str]) -> None:
+        self._payload = dict(payload)
+        self.copy_attempts = 0
+
+    def __getitem__(self, key: str) -> str:
+        return self._payload[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._payload)
+
+    def __len__(self) -> int:
+        return len(self._payload)
+
+    def keys(self):  # type: ignore[override]
+        self.copy_attempts += 1
+        return self._payload.keys()
+
+
 def test_split_csv_short_circuits_empty_values_without_split() -> None:
     class NoSplitEmpty(str):
         def split(self, *args: object, **kwargs: object) -> list[str]:  # pragma: no cover
@@ -257,6 +276,33 @@ def test_resolve_text_family_config_prefers_live_config_over_stale_expert_metada
 def test_inferred_expert_count_preserves_config_before_family_default() -> None:
     assert _inferred_expert_count({"num_experts": 4}, default=128) == 4
     assert _inferred_expert_count({}, default=128) == 128
+
+
+def test_resolve_text_family_config_reads_metadata_mapping_without_copying() -> None:
+    metadata = _CopyCountingMetadata(
+        {
+            **{f"unused_{index}": str(index) for index in range(512)},
+            "text_family_id": "qwen3moe",
+            "melix.capability.supported_parsers": "text,qwen",
+            "tool_parser_xml_fallback": "true",
+        }
+    )
+
+    resolved = resolve_text_family_config(
+        metadata,
+        model_path="models/qwen3-moe-128e",
+        config_payload={"model_type": "qwen3_moe", "num_local_experts": 128},
+        default_route_kind="swift_text",
+    )
+
+    assert resolved.family_id == "qwen3moe"
+    assert resolved.supported_parsers == ("text", "qwen")
+    assert resolved.tool_parser_xml_fallback is True
+    assert metadata.copy_attempts == 0
+    assert list(metadata)[:1] == ["unused_0"]
+    assert len(metadata) == 515
+    assert dict(metadata)["text_family_id"] == "qwen3moe"
+    assert metadata.copy_attempts == 1
 
 
 def test_resolve_text_family_config_reads_config_mapping_without_copying() -> None:

--- a/services/mlx-worker-python/worker/runtime/text_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/text_family_adapters.py
@@ -90,6 +90,7 @@ class ResolvedTextFamilyConfig:
 
 _DEFAULT_TEXT_FAMILY_ID = "llama"
 _EMPTY_CONFIG_PAYLOAD: Mapping[str, Any] = {}
+_EMPTY_METADATA: Mapping[str, str] = {}
 _TEXT_FAMILY_ADAPTERS: dict[str, TextFamilyDescriptor] = {
     "llama": TextFamilyDescriptor(
         family_id="llama",
@@ -232,7 +233,7 @@ def resolve_text_family_config(
     config_payload: Mapping[str, Any] | None = None,
     default_route_kind: str = "swift_text",
 ) -> ResolvedTextFamilyConfig:
-    metadata = dict(metadata or {})
+    metadata = metadata or _EMPTY_METADATA
     detection = detect_text_family_identity(
         model_path=model_path,
         config_payload=config_payload,


### PR DESCRIPTION
## Summary
- Avoid eager `dict(metadata)` copying in `resolve_text_family_config()`; the resolver only reads metadata and now keeps the incoming mapping directly, falling back to a shared empty mapping for `None`/empty input.
- Extend the registered `text-family-config-copy-elision` probe to measure metadata mapping copy attempts in addition to config copy attempts.
- Add regression coverage and a governing plan for the text-family metadata copy-elision slice.

## Plan or Spec
- `docs/plans/2026-05-11-text-family-metadata-copy-elision.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics
# 17 passed in 3.85s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/text_family_adapters.py services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/text_family_config_probe.py
# 17 passed in 23.42s; changed-scope coverage TOTAL 51 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py
# {"config_copy_calls_mean": 0.0, "elapsed_ms_mean": 555.4802475962788, "iterations": 10000, "metadata_copy_calls_mean": 0.0, "peak_bytes_mean": 1481.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 51 0 100%`.
- Local registered probe (new implementation): `elapsed_ms_mean=555.480`, `metadata_copy_calls_mean=0.0`, `config_copy_calls_mean=0.0`, `peak_bytes_mean=1481.0`.
- Same updated probe against the pre-change resolver implementation: `old_mean=2854.417ms`, `old_metadata_copy_calls_mean=10000.0`, `old_peak_bytes_mean=95718.0`.
- Delta: `new_mean=534.126ms` in the direct old/new comparison run, `speedup=5.34x`, `delta_ms=-2320.291`, `metadata_copy_calls_mean 10000.0 -> 0.0`, `peak_bytes_mean 95718.0 -> 1481.0`.
- Registered PR-scoped CI probe validation is required before merge.

## Known Gaps
- Local validation is Linux/Python focused. No Swift runtime behavior is changed.
- Full repository gates are left to GitHub Actions for this small registered probe slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
