### PR TITLE
Harden multimodal LoRA adapter audits

### DIFF
--- a/docs/runbooks/phase-8-lora-adapter-workflow.md
+++ b/docs/runbooks/phase-8-lora-adapter-workflow.md
@@ -197,6 +197,10 @@ Expected training behavior:
 - quantized LoRA and QLoRA reject embedding, LM head, and output-projection target modules; keep quantized runs on attention or expert projection targets
 - Melix writes a normalized dataset snapshot under `<jobs_root>/train_lora/<job_id>/`
 - Melix emits the stages `resolve_source`, `validate_dataset`, `normalize_config`, `prepare_training_data`, `apply_lora`, `train`, `write_adapter`, and `write_manifest`
+- component-scoped multimodal adapter receipts include `multimodal_lora_nan_guard_triggered`,
+  `unexpected_frozen_param_count`, `adapter_checkpoint_bytes`, and `adapter_freeze_audit`; any
+  serialized vision, audio, embedding, projector, or full base tensor outside the intended
+  LoRA/DoRA target surface fails export before the adapter manifest is written
 - the completed artifact is `train_lora.adapter.json` with schema `melix.lora_adapter_package.v1`
 
 ## Family Support Boundaries

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -182,6 +182,13 @@ def test_multimodal_lora_finite_mask_handles_fully_padded_vision_rows() -> None:
             assert all(value not in {float("inf"), float("-inf")} for value in row)
 
 
+def test_multimodal_lora_finite_mask_handles_empty_visible_rows() -> None:
+    probabilities, mask = finite_masked_softmax([[1.0, 2.0]], [[]], dtype="float32")
+
+    assert mask.additive_mask == [[]]
+    assert probabilities == [[]]
+
+
 def test_multimodal_lora_training_receipt_records_triggered_nan_guard(tmp_path: Path) -> None:
     class NanGuardRunner(DeterministicLoRARunner):
         def train_native(self, request: TrainingRequest) -> TrainingResult:
@@ -327,6 +334,45 @@ def test_adapter_freeze_audit_rejects_serialized_vision_tower_weights(tmp_path: 
     assert "vision_tower.encoder.layers.0.weight" in exc.value.details["unexpected_serialized_parameters"]
 
 
+def test_adapter_freeze_audit_deduplicates_live_and_serialized_leaks(tmp_path: Path) -> None:
+    weights_path = tmp_path / "duplicate-leak.safetensors"
+    leaked_name = "vision_tower.encoder.layers.0.weight"
+    _write_safetensors_header(
+        weights_path,
+        {
+            "model.layers.0.self_attn.q_proj.lora_a.weight": {
+                "dtype": "F16",
+                "shape": [2, 4],
+                "data_offsets": [0, 16],
+            },
+            leaked_name: {
+                "dtype": "F16",
+                "shape": [8, 8],
+                "data_offsets": [16, 144],
+            },
+        },
+    )
+
+    audit = audit_adapter_checkpoint(
+        weights_path=weights_path,
+        allowed_target_modules=["model.layers.0.self_attn.q_proj"],
+        source_model_kind="vlm",
+        source_model_ext={},
+        live_audit={
+            "unexpected_trainable_param_count": 64,
+            "unexpected_trainable_parameters": [leaked_name],
+            "unexpected_trainable_param_counts": {leaked_name: 64},
+            "trainable_param_count_by_component": {"vision_encoder": 64},
+        },
+    )
+
+    assert audit.unexpected_serialized_param_count == 64
+    assert audit.unexpected_trainable_param_count == 64
+    assert audit.unexpected_frozen_param_count == 64
+    assert audit.unexpected_serialized_param_counts == {leaked_name: 64}
+    assert audit.unexpected_trainable_param_counts == {leaked_name: 64}
+
+
 def test_adapter_freeze_audit_rejects_full_base_weights_under_allowed_target(tmp_path: Path) -> None:
     weights_path = tmp_path / "base-weight-leak.safetensors"
     _write_safetensors_header(
@@ -355,6 +401,23 @@ def test_adapter_freeze_audit_rejects_full_base_weights_under_allowed_target(tmp
     assert audit.unexpected_serialized_param_count == 16
     assert audit.unexpected_serialized_parameters == ("model.layers.0.self_attn.q_proj.weight",)
     assert audit.serialized_param_count_by_component["text_backbone"] == 24
+
+
+def test_adapter_freeze_audit_ignores_invalid_large_safetensors_header(tmp_path: Path) -> None:
+    weights_path = tmp_path / "oversized-header.safetensors"
+    weights_path.write_bytes((9 * 1024 * 1024).to_bytes(8, "little"))
+
+    audit = audit_adapter_checkpoint(
+        weights_path=weights_path,
+        allowed_target_modules=["model.layers.0.self_attn.q_proj"],
+        source_model_kind="vlm",
+        source_model_ext={},
+    )
+
+    assert audit.adapter_checkpoint_bytes == 8
+    assert audit.unexpected_frozen_param_count == 0
+    assert audit.unexpected_serialized_param_count == 0
+    assert audit.serialized_param_count_by_component == {}
 
 
 def _write_safetensors_header(path: Path, tensors: dict[str, dict[str, object]]) -> None:

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -29,7 +29,12 @@ from worker.model_ops.lora_training_pipeline import (
     _resolve_adapter_scope_metadata,
     _validated_resume_path,
 )
+from worker.model_ops.multimodal_lora_contracts import (
+    audit_adapter_checkpoint,
+    finite_masked_softmax,
+)
 from worker.model_ops.mlx_lm_runner import MLXLMRunner
+from worker.model_ops.mlx_lm_runner import TrainingMetrics, TrainingRequest, TrainingResult
 from worker.model_ops.training_dataset import HFDatasetReference, load_training_dataset_package, materialize_hf_training_dataset_package
 from worker.runtime.mlx_text_runtime import MLXTextRuntime, RuntimeTokenEvent, RuntimeUnavailableError
 
@@ -142,6 +147,227 @@ def test_lora_training_pipeline_uses_component_scope_metadata_for_gemma4_vlm(tmp
     assert result.manifest["component_model_type"] == "gemma4_text"
     assert result.manifest["component_family"] == "gemma"
     assert result.manifest["component_model_path"] == str(component_model_dir)
+    assert result.manifest["multimodal_lora_nan_guard_triggered"] is False
+    assert result.manifest["unexpected_frozen_param_count"] == 0
+    assert result.manifest["adapter_checkpoint_bytes"] == result.manifest["adapter_artifact_bytes"]
+    assert result.manifest["training.multimodal_lora_nan_guard_triggered"] is False
+    assert result.manifest["training.unexpected_frozen_param_count"] == 0
+    assert result.manifest["training.adapter_checkpoint_bytes"] == result.manifest["adapter_checkpoint_bytes"]
+    freeze_audit = result.manifest["adapter_freeze_audit"]
+    assert freeze_audit["unexpected_serialized_param_count"] == 0
+    assert freeze_audit["unexpected_trainable_param_count"] == 0
+    assert freeze_audit["adapter_checkpoint_size_within_target"] is True
+
+
+def test_multimodal_lora_finite_mask_handles_fully_padded_vision_rows() -> None:
+    scores = [
+        [[0.2, 0.1, -0.4], [1.0, -1.0, 0.0]],
+        [[0.0, 0.0, 0.0], [0.5, 0.25, -0.5]],
+    ]
+    visible_mask = [
+        [[True, True, False], [False, False, False]],
+        [[True, False, False], [False, True, False]],
+    ]
+
+    probabilities, mask = finite_masked_softmax(scores, visible_mask, dtype="float16")
+
+    assert mask.nan_guard_triggered is True
+    assert mask.all_masked_row_count == 1
+    assert mask.finite_floor == -1.0e4
+    assert all(value != float("-inf") for batch in mask.additive_mask for row in batch for value in row)
+    assert probabilities[0][1] == [0.0, 0.0, 0.0]
+    for batch in probabilities:
+        for row in batch:
+            assert all(value == value for value in row)
+            assert all(value not in {float("inf"), float("-inf")} for value in row)
+
+
+def test_multimodal_lora_training_receipt_records_triggered_nan_guard(tmp_path: Path) -> None:
+    class NanGuardRunner(DeterministicLoRARunner):
+        def train_native(self, request: TrainingRequest) -> TrainingResult:
+            result = super().train_native(request)
+            return TrainingResult(
+                weights_path=result.weights_path,
+                adapter_config_path=result.adapter_config_path,
+                execution_backend=result.execution_backend,
+                metrics=TrainingMetrics(
+                    **{
+                        **result.metrics.__dict__,
+                        "multimodal_lora_nan_guard_triggered": True,
+                    }
+                ),
+            )
+
+    component_model_dir = tmp_path / "gemma4-vlm-mixed"
+    component_model_dir.mkdir()
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset-mixed-modality",
+        manifest_payload={
+            "schema_version": "melix.training_dataset_package.v1",
+            "dataset_id": "mixed-modality-padded-images",
+            "format": "chat_messages",
+            "sample_count": 2,
+            "version": "1",
+            "modalities": ["text", "image"],
+            "image_shapes": [[256, 384], [384, 256]],
+        },
+        sample_lines=[
+            json.dumps(
+                {
+                    "messages": [
+                        {"role": "user", "content": "Describe the non-square image."},
+                        {"role": "assistant", "content": "The image is non-square."},
+                    ],
+                    "media_refs": [{"id": "image-a", "uri": "images/a.png", "width": 256, "height": 384}],
+                }
+            ),
+            json.dumps(
+                {
+                    "messages": [
+                        {"role": "user", "content": "Describe the padded image."},
+                        {"role": "assistant", "content": "The image includes padded regions."},
+                    ],
+                    "media_refs": [{"id": "image-b", "uri": "images/b.png", "width": 384, "height": 256}],
+                }
+            ),
+        ],
+    )
+
+    result = LoRATrainingPipeline(runner=NanGuardRunner()).run(
+        job_id="train-gemma4-vlm-nan-guard",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "gemma4-padded-image-adapter",
+            "dataset_uri": str(dataset_dir),
+        },
+        source_model=_gemma4_vlm_model(model_path=str(component_model_dir)),
+        output_dir=tmp_path / "output-nan-guard",
+        jobs_root=tmp_path / "jobs-nan-guard",
+    )
+
+    assert result.manifest["dataset_id"] == "mixed-modality-padded-images"
+    assert result.manifest["multimodal_lora_nan_guard_triggered"] is True
+    assert result.manifest["training.multimodal_lora_nan_guard_triggered"] is True
+    assert result.manifest["unexpected_frozen_param_count"] == 0
+    assert result.manifest["adapter_checkpoint_bytes"] > 0
+
+
+def test_adapter_freeze_audit_rejects_serialized_vision_tower_weights(tmp_path: Path) -> None:
+    weights_path = tmp_path / "adapters.safetensors"
+    _write_safetensors_header(
+        weights_path,
+        {
+            "model.layers.0.self_attn.q_proj.lora_a.weight": {
+                "dtype": "F16",
+                "shape": [2, 4],
+                "data_offsets": [0, 16],
+            },
+            "vision_tower.encoder.layers.0.weight": {
+                "dtype": "F16",
+                "shape": [8, 8],
+                "data_offsets": [16, 144],
+            },
+        },
+    )
+
+    audit = audit_adapter_checkpoint(
+        weights_path=weights_path,
+        allowed_target_modules=["model.layers.0.self_attn.q_proj"],
+        source_model_kind="vlm",
+        source_model_ext={},
+    )
+
+    assert audit.adapter_checkpoint_bytes == weights_path.stat().st_size
+    assert audit.unexpected_frozen_param_count == 64
+    assert audit.unexpected_serialized_param_count == 64
+    assert audit.serialized_param_count_by_component["vision_encoder"] == 64
+    assert audit.unexpected_serialized_parameters == ("vision_tower.encoder.layers.0.weight",)
+
+    class LeakyRunner(DeterministicLoRARunner):
+        def train_native(self, request):  # noqa: ANN001
+            result = super().train_native(request)
+            _write_safetensors_header(
+                result.weights_path,
+                {
+                    "model.layers.1.self_attn.q_proj.lora_a.weight": {
+                        "dtype": "F16",
+                        "shape": [2, 4],
+                        "data_offsets": [0, 16],
+                    },
+                    "vision_tower.encoder.layers.0.weight": {
+                        "dtype": "F16",
+                        "shape": [8, 8],
+                        "data_offsets": [16, 144],
+                    },
+                },
+            )
+            return result
+
+    component_model_dir = tmp_path / "gemma4-vlm"
+    component_model_dir.mkdir()
+    dataset_dir = _write_dataset_package(tmp_path / "dataset-leaky")
+
+    with pytest.raises(ModelOperationError) as exc:
+        LoRATrainingPipeline(runner=LeakyRunner()).run(
+            job_id="train-gemma4-vlm-leaky",
+            request_ext={
+                "operation": "train_lora",
+                "adapter_name": "gemma4-leaky-adapter",
+                "dataset_uri": str(dataset_dir),
+                "target_modules": "q_proj",
+                "num_layers": "1",
+            },
+            source_model=_gemma4_vlm_model(model_path=str(component_model_dir)),
+            output_dir=tmp_path / "output-leaky",
+            jobs_root=tmp_path / "jobs-leaky",
+        )
+
+    assert exc.value.code == "adapter_freeze_audit_failed"
+    assert exc.value.details["unexpected_serialized_param_count"] == "64"
+    assert "vision_tower.encoder.layers.0.weight" in exc.value.details["unexpected_serialized_parameters"]
+
+
+def test_adapter_freeze_audit_rejects_full_base_weights_under_allowed_target(tmp_path: Path) -> None:
+    weights_path = tmp_path / "base-weight-leak.safetensors"
+    _write_safetensors_header(
+        weights_path,
+        {
+            "model.layers.0.self_attn.q_proj.lora_a.weight": {
+                "dtype": "F16",
+                "shape": [2, 4],
+                "data_offsets": [0, 16],
+            },
+            "model.layers.0.self_attn.q_proj.weight": {
+                "dtype": "F16",
+                "shape": [4, 4],
+                "data_offsets": [16, 48],
+            },
+        },
+    )
+
+    audit = audit_adapter_checkpoint(
+        weights_path=weights_path,
+        allowed_target_modules=["model.layers.0.self_attn.q_proj"],
+        source_model_kind="vlm",
+        source_model_ext={},
+    )
+
+    assert audit.unexpected_serialized_param_count == 16
+    assert audit.unexpected_serialized_parameters == ("model.layers.0.self_attn.q_proj.weight",)
+    assert audit.serialized_param_count_by_component["text_backbone"] == 24
+
+
+def _write_safetensors_header(path: Path, tensors: dict[str, dict[str, object]]) -> None:
+    header = json.dumps(tensors, separators=(",", ":")).encode("utf-8")
+    tensor_bytes = max(
+        (
+            int(metadata["data_offsets"][1])
+            for metadata in tensors.values()
+            if isinstance(metadata.get("data_offsets"), list)
+        ),
+        default=0,
+    )
+    path.write_bytes(len(header).to_bytes(8, "little") + header + (b"\0" * tensor_bytes))
 
 
 def test_checkpoint_summary_uses_scandir_stack_without_os_walk(

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -12,6 +12,11 @@ from typing import Any, Callable
 from packages.protocol.python.worker.v1 import common_pb2
 
 from worker.model_ops.errors import ModelOperationError
+from worker.model_ops.multimodal_lora_contracts import (
+    audit_adapter_checkpoint,
+    audit_manifest_fields,
+    raise_for_adapter_freeze_audit,
+)
 from worker.model_ops.response_only_boundary import ResponseOnlyBoundaryAggregate
 from worker.model_ops.mlx_lm_runner import MLXLMRunner, TrainingRequest, TrainingResult
 from worker.model_ops.training_config import LoRATrainingConfig, normalize_training_config
@@ -119,7 +124,19 @@ class LoRATrainingPipeline:
         )
 
         emit("write_adapter", 0.9)
-        adapter_artifact_bytes = training_result.weights_path.stat().st_size
+        adapter_audit = audit_adapter_checkpoint(
+            weights_path=training_result.weights_path,
+            allowed_target_modules=config.expanded_target_modules,
+            source_model_kind=source_model.model_kind,
+            source_model_ext=dict(source_model.ext),
+            live_audit=training_result.metrics.adapter_freeze_audit,
+            multimodal_lora_nan_guard_triggered=(
+                training_result.metrics.multimodal_lora_nan_guard_triggered
+            ),
+        )
+        raise_for_adapter_freeze_audit(adapter_audit)
+        adapter_audit_fields = audit_manifest_fields(adapter_audit)
+        adapter_artifact_bytes = adapter_audit.adapter_checkpoint_bytes
         adapter_set_hash = _content_hash(training_result.weights_path, training_result.adapter_config_path)
         checkpoint_count = training_result.metrics.checkpoint_count
         resume_ready = training_result.metrics.resume_ready
@@ -231,6 +248,7 @@ class LoRATrainingPipeline:
             "created_at_unix_ms": persisted_at_unix_ms,
             "updated_at_unix_ms": persisted_at_unix_ms,
         }
+        manifest.update(adapter_audit_fields)
         if resume_context["resume_manifest_path"] is not None:
             manifest["resume_source_manifest_path"] = str(resume_context["resume_manifest_path"])
         if resume_context["resume_source_job_id"]:

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -13,6 +13,10 @@ import time
 from typing import Any
 
 from worker.model_ops.errors import ModelOperationError
+from worker.model_ops.multimodal_lora_contracts import (
+    audit_manifest_fields,
+    audit_trainable_module_tree,
+)
 from worker.model_ops.response_only_boundary import (
     ResponseOnlyBoundary,
     ResponseOnlyBoundaryAggregate,
@@ -77,6 +81,10 @@ class TrainingMetrics:
     candidate_scoring_mode: str = ""
     reward_scoring_backend: str = ""
     generated_candidate_count: int = 0
+    multimodal_lora_nan_guard_triggered: bool = False
+    unexpected_frozen_param_count: int = 0
+    adapter_checkpoint_bytes: int = 0
+    adapter_freeze_audit: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -269,8 +277,16 @@ class MLXLMRunner:
         if duration_ms > 0.0 and collector.tokens_seen > 0:
             tokens_per_second = collector.tokens_seen / (duration_ms / 1000.0)
         checkpoint_count, latest_checkpoint_path = _checkpoint_summary(request.adapter_output_dir)
+        weights_path = request.adapter_output_dir / "adapters.safetensors"
+        live_audit = audit_trainable_module_tree(
+            model,
+            allowed_target_modules=request.config.expanded_target_modules,
+            source_model_kind=request.source_model_kind,
+            source_model_ext=request.source_model_ext or {},
+        )
+        live_audit_fields = audit_manifest_fields(live_audit)
         return TrainingResult(
-            weights_path=request.adapter_output_dir / "adapters.safetensors",
+            weights_path=weights_path,
             adapter_config_path=request.adapter_output_dir / "adapter_config.json",
             metrics=TrainingMetrics(
                 job_duration_ms=duration_ms,
@@ -292,6 +308,9 @@ class MLXLMRunner:
                 chunked_enabled=chunk_stats.enabled,
                 chunk_count=chunk_stats.chunk_count,
                 source_sample_count=chunk_stats.source_sample_count,
+                unexpected_frozen_param_count=int(live_audit_fields["unexpected_frozen_param_count"]),
+                adapter_checkpoint_bytes=weights_path.stat().st_size if weights_path.is_file() else 0,
+                adapter_freeze_audit=live_audit_fields["adapter_freeze_audit"],
             ),
             execution_backend="native",
         )

--- a/services/mlx-worker-python/worker/model_ops/multimodal_lora_contracts.py
+++ b/services/mlx-worker-python/worker/model_ops/multimodal_lora_contracts.py
@@ -61,7 +61,8 @@ _TRAINABLE_ADAPTER_TOKENS = (
     "lora_b",
     "magnitude",
 )
-_MAX_SAFETENSORS_HEADER_BYTES = 64 * 1024 * 1024
+_MAX_SAFETENSORS_HEADER_BYTES = 8 * 1024 * 1024
+_SAFETENSORS_HEADER_READ_CHUNK_BYTES = 64 * 1024
 
 
 @dataclass(frozen=True)
@@ -89,6 +90,8 @@ class AdapterFreezeAudit:
     unexpected_serialized_parameters: tuple[str, ...]
     unexpected_trainable_parameters: tuple[str, ...]
     multimodal_lora_nan_guard_triggered: bool = False
+    unexpected_serialized_param_counts: dict[str, int] | None = None
+    unexpected_trainable_param_counts: dict[str, int] | None = None
 
 
 def dtype_safe_finite_mask_floor(dtype: object = None) -> float:
@@ -149,7 +152,7 @@ def finite_masked_softmax(
             visible_row = [bool(item) for item in visible_node]
             if not any(visible_row):
                 return [0.0 for _ in scored_row]
-            row_max = max(scored_row)
+            row_max = max(scored_row) if scored_row else 0.0
             exps = [
                 math.exp(value - row_max) if visible else 0.0
                 for value, visible in zip(scored_row, visible_row)
@@ -182,6 +185,7 @@ def audit_trainable_module_tree(
     allowed_fragments = _normalized_target_fragments(allowed_target_modules)
     trainable_counts: dict[str, int] = {}
     unexpected_names: list[str] = []
+    unexpected_counts: dict[str, int] = {}
     unexpected_count = 0
     for name, parameter in _iter_trainable_parameters(model):
         count = _parameter_count(parameter)
@@ -189,6 +193,7 @@ def audit_trainable_module_tree(
         trainable_counts[component] = trainable_counts.get(component, 0) + count
         if _is_unexpected_adapter_parameter(name, allowed_fragments):
             unexpected_names.append(name)
+            unexpected_counts[name] = unexpected_counts.get(name, 0) + count
             unexpected_count += count
 
     return AdapterFreezeAudit(
@@ -203,6 +208,7 @@ def audit_trainable_module_tree(
         trainable_param_count_by_component=trainable_counts,
         unexpected_serialized_parameters=(),
         unexpected_trainable_parameters=tuple(unexpected_names),
+        unexpected_trainable_param_counts=unexpected_counts,
     )
 
 
@@ -222,6 +228,7 @@ def audit_adapter_checkpoint(
     tensors = _read_safetensors_header(weights_path)
     serialized_counts: dict[str, int] = {}
     unexpected_serialized_names: list[str] = []
+    unexpected_serialized_counts: dict[str, int] = {}
     unexpected_serialized_count = 0
     unexpected_serialized_bytes = 0
     total_tensor_bytes = 0
@@ -233,21 +240,25 @@ def audit_adapter_checkpoint(
         serialized_counts[component] = serialized_counts.get(component, 0) + count
         if _is_unexpected_adapter_parameter(name, allowed_fragments):
             unexpected_serialized_names.append(name)
+            unexpected_serialized_counts[name] = unexpected_serialized_counts.get(name, 0) + count
             unexpected_serialized_count += count
             unexpected_serialized_bytes += tensor_bytes
 
     unexpected_trainable_count = 0
     unexpected_trainable_names: tuple[str, ...] = ()
+    unexpected_trainable_counts: dict[str, int] = {}
     trainable_counts: Mapping[str, int] = {}
     if isinstance(live_audit, AdapterFreezeAudit):
         unexpected_trainable_count = live_audit.unexpected_trainable_param_count
         unexpected_trainable_names = live_audit.unexpected_trainable_parameters
+        unexpected_trainable_counts = dict(live_audit.unexpected_trainable_param_counts or {})
         trainable_counts = live_audit.trainable_param_count_by_component
     elif isinstance(live_audit, Mapping):
         unexpected_trainable_count = _int_mapping_value(live_audit, "unexpected_trainable_param_count")
         unexpected_names = live_audit.get("unexpected_trainable_parameters", ())
         if isinstance(unexpected_names, Sequence) and not isinstance(unexpected_names, (str, bytes, bytearray)):
             unexpected_trainable_names = tuple(str(item) for item in unexpected_names)
+        unexpected_trainable_counts = _int_dict(live_audit.get("unexpected_trainable_param_counts", {}))
         raw_counts = live_audit.get("trainable_param_count_by_component", {})
         if isinstance(raw_counts, Mapping):
             trainable_counts = {str(key): int(value) for key, value in raw_counts.items()}
@@ -257,7 +268,12 @@ def audit_adapter_checkpoint(
     elif total_tensor_bytes > 0:
         expected_checkpoint_bytes = checkpoint_bytes
     size_ratio = 1.0 if expected_checkpoint_bytes <= 0 else checkpoint_bytes / expected_checkpoint_bytes
-    unexpected_total_count = unexpected_serialized_count + unexpected_trainable_count
+    unexpected_total_count = _combined_unexpected_param_count(
+        serialized_counts=unexpected_serialized_counts,
+        trainable_counts=unexpected_trainable_counts,
+        serialized_total=unexpected_serialized_count,
+        trainable_total=unexpected_trainable_count,
+    )
     return AdapterFreezeAudit(
         adapter_checkpoint_bytes=checkpoint_bytes,
         expected_lora_checkpoint_bytes=expected_checkpoint_bytes,
@@ -271,6 +287,8 @@ def audit_adapter_checkpoint(
         unexpected_serialized_parameters=tuple(unexpected_serialized_names),
         unexpected_trainable_parameters=unexpected_trainable_names,
         multimodal_lora_nan_guard_triggered=multimodal_lora_nan_guard_triggered,
+        unexpected_serialized_param_counts=unexpected_serialized_counts,
+        unexpected_trainable_param_counts=unexpected_trainable_counts,
     )
 
 
@@ -305,6 +323,8 @@ def audit_manifest_fields(audit: AdapterFreezeAudit) -> dict[str, Any]:
             "serialized_param_count_by_component": audit.serialized_param_count_by_component,
             "unexpected_trainable_parameters": list(audit.unexpected_trainable_parameters),
             "unexpected_serialized_parameters": list(audit.unexpected_serialized_parameters),
+            "unexpected_trainable_param_counts": dict(audit.unexpected_trainable_param_counts or {}),
+            "unexpected_serialized_param_counts": dict(audit.unexpected_serialized_param_counts or {}),
             "expected_lora_checkpoint_bytes": audit.expected_lora_checkpoint_bytes,
             "adapter_checkpoint_size_ratio": audit.adapter_checkpoint_size_ratio,
             "adapter_checkpoint_size_within_target": audit.adapter_checkpoint_size_within_target,
@@ -416,18 +436,52 @@ def _parameter_count(parameter: Any) -> int:
         return 1
 
 
+def _combined_unexpected_param_count(
+    *,
+    serialized_counts: Mapping[str, int],
+    trainable_counts: Mapping[str, int],
+    serialized_total: int,
+    trainable_total: int,
+) -> int:
+    if serialized_counts or trainable_counts:
+        names = set(serialized_counts) | set(trainable_counts)
+        return sum(
+            max(
+                int(serialized_counts.get(name, 0)),
+                int(trainable_counts.get(name, 0)),
+            )
+            for name in names
+        )
+    if serialized_total > 0 and trainable_total > 0:
+        return max(serialized_total, trainable_total)
+    return serialized_total + trainable_total
+
+
 def _read_safetensors_header(path: Path) -> dict[str, dict[str, Any]]:
     if not path.is_file():
         return {}
     try:
+        file_size = path.stat().st_size
         with path.open("rb") as handle:
             raw_size = handle.read(8)
             if len(raw_size) != 8:
                 return {}
             header_size = struct.unpack("<Q", raw_size)[0]
-            if header_size <= 0 or header_size > _MAX_SAFETENSORS_HEADER_BYTES:
+            if (
+                header_size <= 0
+                or header_size > _MAX_SAFETENSORS_HEADER_BYTES
+                or header_size > max(0, file_size - 8)
+            ):
                 return {}
-            header = json.loads(handle.read(header_size).decode("utf-8"))
+            remaining = header_size
+            chunks = bytearray()
+            while remaining > 0:
+                chunk = handle.read(min(_SAFETENSORS_HEADER_READ_CHUNK_BYTES, remaining))
+                if not chunk:
+                    return {}
+                chunks.extend(chunk)
+                remaining -= len(chunk)
+            header = json.loads(chunks.decode("utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError, struct.error):
         return {}
     if not isinstance(header, dict):
@@ -469,3 +523,17 @@ def _int_mapping_value(payload: Mapping[str, Any], key: str) -> int:
         return int(payload.get(key, 0) or 0)
     except (TypeError, ValueError):
         return 0
+
+
+def _int_dict(value: Any) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        return {}
+    converted: dict[str, int] = {}
+    for key, raw_count in value.items():
+        try:
+            count = int(raw_count)
+        except (TypeError, ValueError):
+            continue
+        if count >= 0:
+            converted[str(key)] = count
+    return converted

--- a/services/mlx-worker-python/worker/model_ops/multimodal_lora_contracts.py
+++ b/services/mlx-worker-python/worker/model_ops/multimodal_lora_contracts.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import math
+from pathlib import Path
+import struct
+from typing import Any, Iterable, Mapping, Sequence
+
+from worker.model_ops.errors import ModelOperationError
+
+
+_FINITE_MASK_FLOORS = {
+    "float16": -1.0e4,
+    "bfloat16": -1.0e4,
+    "float32": -1.0e9,
+    "float64": -1.0e30,
+}
+_TENSOR_DTYPE_BYTES = {
+    "BOOL": 1,
+    "U8": 1,
+    "I8": 1,
+    "F8_E4M3": 1,
+    "F8_E5M2": 1,
+    "I16": 2,
+    "U16": 2,
+    "F16": 2,
+    "BF16": 2,
+    "I32": 4,
+    "U32": 4,
+    "F32": 4,
+    "I64": 8,
+    "U64": 8,
+    "F64": 8,
+}
+_DISALLOWED_COMPONENT_PREFIXES = {
+    "vision_tower": "vision_encoder",
+    "vision_model": "vision_encoder",
+    "visual": "vision_encoder",
+    "embed_vision": "vision_encoder",
+    "multi_modal_projector": "multimodal_projector",
+    "multimodal_projector": "multimodal_projector",
+    "mm_projector": "multimodal_projector",
+    "audio_tower": "audio_encoder",
+    "audio_model": "audio_encoder",
+    "embed_audio": "audio_encoder",
+    "model.embed_tokens": "embedding",
+    "language_model.model.embed_tokens": "embedding",
+    "text_model.embed_tokens": "embedding",
+    "embed_tokens": "embedding",
+    "lm_head": "embedding",
+    "output_head": "embedding",
+    "output_projection": "embedding",
+}
+_TRAINABLE_ADAPTER_TOKENS = (
+    ".lora_a",
+    ".lora_b",
+    ".m",
+    ".magnitude",
+    "lora_a",
+    "lora_b",
+    "magnitude",
+)
+_MAX_SAFETENSORS_HEADER_BYTES = 64 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class FiniteAttentionMask:
+    additive_mask: list[Any]
+    finite_floor: float
+    all_masked_row_count: int
+
+    @property
+    def nan_guard_triggered(self) -> bool:
+        return self.all_masked_row_count > 0
+
+
+@dataclass(frozen=True)
+class AdapterFreezeAudit:
+    adapter_checkpoint_bytes: int
+    expected_lora_checkpoint_bytes: int
+    adapter_checkpoint_size_ratio: float
+    adapter_checkpoint_size_within_target: bool
+    unexpected_frozen_param_count: int
+    unexpected_trainable_param_count: int
+    unexpected_serialized_param_count: int
+    serialized_param_count_by_component: dict[str, int]
+    trainable_param_count_by_component: dict[str, int]
+    unexpected_serialized_parameters: tuple[str, ...]
+    unexpected_trainable_parameters: tuple[str, ...]
+    multimodal_lora_nan_guard_triggered: bool = False
+
+
+def dtype_safe_finite_mask_floor(dtype: object = None) -> float:
+    dtype_name = str(dtype or "float32").lower()
+    for key, value in _FINITE_MASK_FLOORS.items():
+        if key in dtype_name:
+            return value
+    return _FINITE_MASK_FLOORS["float32"]
+
+
+def finite_attention_mask(
+    visible_mask: Sequence[Any],
+    *,
+    dtype: object = None,
+) -> FiniteAttentionMask:
+    """Convert a bool attention mask to a finite additive mask.
+
+    The returned mask uses ``0`` for visible positions and a dtype-safe finite
+    negative floor for masked positions. Fully masked rows are counted so the
+    training receipt can prove the NaN guard was exercised.
+    """
+
+    floor = dtype_safe_finite_mask_floor(dtype)
+    all_masked_rows = 0
+
+    def convert(node: Any) -> Any:
+        nonlocal all_masked_rows
+        if _is_sequence(node) and node and all(not _is_sequence(item) for item in node):
+            row = [bool(item) for item in node]
+            if not any(row):
+                all_masked_rows += 1
+            return [0.0 if item else floor for item in row]
+        if _is_sequence(node):
+            return [convert(item) for item in node]
+        keep = bool(node)
+        if not keep:
+            all_masked_rows += 1
+        return 0.0 if keep else floor
+
+    return FiniteAttentionMask(
+        additive_mask=convert(visible_mask),
+        finite_floor=floor,
+        all_masked_row_count=all_masked_rows,
+    )
+
+
+def finite_masked_softmax(
+    scores: Sequence[Any],
+    visible_mask: Sequence[Any],
+    *,
+    dtype: object = None,
+) -> tuple[list[Any], FiniteAttentionMask]:
+    mask = finite_attention_mask(visible_mask, dtype=dtype)
+
+    def apply(score_node: Any, mask_node: Any, visible_node: Any) -> Any:
+        if _is_sequence(score_node) and score_node and all(not _is_sequence(item) for item in score_node):
+            scored_row = [float(score) + float(mask_value) for score, mask_value in zip(score_node, mask_node)]
+            visible_row = [bool(item) for item in visible_node]
+            if not any(visible_row):
+                return [0.0 for _ in scored_row]
+            row_max = max(scored_row)
+            exps = [
+                math.exp(value - row_max) if visible else 0.0
+                for value, visible in zip(scored_row, visible_row)
+            ]
+            total = sum(exps)
+            if total <= 0.0:
+                return [0.0 for _ in scored_row]
+            return [value / total for value in exps]
+        if _is_sequence(score_node):
+            return [
+                apply(child_score, child_mask, child_visible)
+                for child_score, child_mask, child_visible in zip(score_node, mask_node, visible_node)
+            ]
+        if not bool(visible_node):
+            return 0.0
+        return 1.0
+
+    return apply(scores, mask.additive_mask, visible_mask), mask
+
+
+def audit_trainable_module_tree(
+    model: Any,
+    *,
+    allowed_target_modules: Iterable[str],
+    source_model_kind: str,
+    source_model_ext: Mapping[str, str] | None = None,
+) -> AdapterFreezeAudit:
+    del source_model_kind
+    del source_model_ext
+    allowed_fragments = _normalized_target_fragments(allowed_target_modules)
+    trainable_counts: dict[str, int] = {}
+    unexpected_names: list[str] = []
+    unexpected_count = 0
+    for name, parameter in _iter_trainable_parameters(model):
+        count = _parameter_count(parameter)
+        component = _component_for_parameter_name(name)
+        trainable_counts[component] = trainable_counts.get(component, 0) + count
+        if _is_unexpected_adapter_parameter(name, allowed_fragments):
+            unexpected_names.append(name)
+            unexpected_count += count
+
+    return AdapterFreezeAudit(
+        adapter_checkpoint_bytes=0,
+        expected_lora_checkpoint_bytes=0,
+        adapter_checkpoint_size_ratio=1.0,
+        adapter_checkpoint_size_within_target=True,
+        unexpected_frozen_param_count=unexpected_count,
+        unexpected_trainable_param_count=unexpected_count,
+        unexpected_serialized_param_count=0,
+        serialized_param_count_by_component={},
+        trainable_param_count_by_component=trainable_counts,
+        unexpected_serialized_parameters=(),
+        unexpected_trainable_parameters=tuple(unexpected_names),
+    )
+
+
+def audit_adapter_checkpoint(
+    *,
+    weights_path: Path,
+    allowed_target_modules: Iterable[str],
+    source_model_kind: str,
+    source_model_ext: Mapping[str, str] | None = None,
+    live_audit: AdapterFreezeAudit | Mapping[str, Any] | None = None,
+    multimodal_lora_nan_guard_triggered: bool = False,
+) -> AdapterFreezeAudit:
+    del source_model_kind
+    del source_model_ext
+    checkpoint_bytes = weights_path.stat().st_size if weights_path.is_file() else 0
+    allowed_fragments = _normalized_target_fragments(allowed_target_modules)
+    tensors = _read_safetensors_header(weights_path)
+    serialized_counts: dict[str, int] = {}
+    unexpected_serialized_names: list[str] = []
+    unexpected_serialized_count = 0
+    unexpected_serialized_bytes = 0
+    total_tensor_bytes = 0
+    for name, metadata in tensors.items():
+        count = _safetensors_parameter_count(metadata)
+        tensor_bytes = _safetensors_tensor_bytes(metadata)
+        total_tensor_bytes += tensor_bytes
+        component = _component_for_parameter_name(name)
+        serialized_counts[component] = serialized_counts.get(component, 0) + count
+        if _is_unexpected_adapter_parameter(name, allowed_fragments):
+            unexpected_serialized_names.append(name)
+            unexpected_serialized_count += count
+            unexpected_serialized_bytes += tensor_bytes
+
+    unexpected_trainable_count = 0
+    unexpected_trainable_names: tuple[str, ...] = ()
+    trainable_counts: Mapping[str, int] = {}
+    if isinstance(live_audit, AdapterFreezeAudit):
+        unexpected_trainable_count = live_audit.unexpected_trainable_param_count
+        unexpected_trainable_names = live_audit.unexpected_trainable_parameters
+        trainable_counts = live_audit.trainable_param_count_by_component
+    elif isinstance(live_audit, Mapping):
+        unexpected_trainable_count = _int_mapping_value(live_audit, "unexpected_trainable_param_count")
+        unexpected_names = live_audit.get("unexpected_trainable_parameters", ())
+        if isinstance(unexpected_names, Sequence) and not isinstance(unexpected_names, (str, bytes, bytearray)):
+            unexpected_trainable_names = tuple(str(item) for item in unexpected_names)
+        raw_counts = live_audit.get("trainable_param_count_by_component", {})
+        if isinstance(raw_counts, Mapping):
+            trainable_counts = {str(key): int(value) for key, value in raw_counts.items()}
+    expected_checkpoint_bytes = checkpoint_bytes
+    if unexpected_serialized_bytes > 0:
+        expected_checkpoint_bytes = max(1, checkpoint_bytes - unexpected_serialized_bytes)
+    elif total_tensor_bytes > 0:
+        expected_checkpoint_bytes = checkpoint_bytes
+    size_ratio = 1.0 if expected_checkpoint_bytes <= 0 else checkpoint_bytes / expected_checkpoint_bytes
+    unexpected_total_count = unexpected_serialized_count + unexpected_trainable_count
+    return AdapterFreezeAudit(
+        adapter_checkpoint_bytes=checkpoint_bytes,
+        expected_lora_checkpoint_bytes=expected_checkpoint_bytes,
+        adapter_checkpoint_size_ratio=size_ratio,
+        adapter_checkpoint_size_within_target=size_ratio <= 1.2,
+        unexpected_frozen_param_count=unexpected_total_count,
+        unexpected_trainable_param_count=unexpected_trainable_count,
+        unexpected_serialized_param_count=unexpected_serialized_count,
+        serialized_param_count_by_component=serialized_counts,
+        trainable_param_count_by_component=dict(trainable_counts),
+        unexpected_serialized_parameters=tuple(unexpected_serialized_names),
+        unexpected_trainable_parameters=unexpected_trainable_names,
+        multimodal_lora_nan_guard_triggered=multimodal_lora_nan_guard_triggered,
+    )
+
+
+def raise_for_adapter_freeze_audit(audit: AdapterFreezeAudit) -> None:
+    if audit.unexpected_frozen_param_count <= 0 and audit.adapter_checkpoint_size_within_target:
+        return
+    raise ModelOperationError(
+        code="adapter_freeze_audit_failed",
+        message="LoRA adapter export contains parameters outside the intended trainable surface.",
+        details={
+            "unexpected_frozen_param_count": str(audit.unexpected_frozen_param_count),
+            "unexpected_trainable_param_count": str(audit.unexpected_trainable_param_count),
+            "unexpected_serialized_param_count": str(audit.unexpected_serialized_param_count),
+            "adapter_checkpoint_bytes": str(audit.adapter_checkpoint_bytes),
+            "expected_lora_checkpoint_bytes": str(audit.expected_lora_checkpoint_bytes),
+            "adapter_checkpoint_size_ratio": f"{audit.adapter_checkpoint_size_ratio:.6f}",
+            "unexpected_serialized_parameters": ",".join(audit.unexpected_serialized_parameters),
+            "unexpected_trainable_parameters": ",".join(audit.unexpected_trainable_parameters),
+        },
+    )
+
+
+def audit_manifest_fields(audit: AdapterFreezeAudit) -> dict[str, Any]:
+    return {
+        "multimodal_lora_nan_guard_triggered": audit.multimodal_lora_nan_guard_triggered,
+        "unexpected_frozen_param_count": audit.unexpected_frozen_param_count,
+        "adapter_checkpoint_bytes": audit.adapter_checkpoint_bytes,
+        "adapter_freeze_audit": {
+            "unexpected_trainable_param_count": audit.unexpected_trainable_param_count,
+            "unexpected_serialized_param_count": audit.unexpected_serialized_param_count,
+            "trainable_param_count_by_component": audit.trainable_param_count_by_component,
+            "serialized_param_count_by_component": audit.serialized_param_count_by_component,
+            "unexpected_trainable_parameters": list(audit.unexpected_trainable_parameters),
+            "unexpected_serialized_parameters": list(audit.unexpected_serialized_parameters),
+            "expected_lora_checkpoint_bytes": audit.expected_lora_checkpoint_bytes,
+            "adapter_checkpoint_size_ratio": audit.adapter_checkpoint_size_ratio,
+            "adapter_checkpoint_size_within_target": audit.adapter_checkpoint_size_within_target,
+        },
+        "training.multimodal_lora_nan_guard_triggered": audit.multimodal_lora_nan_guard_triggered,
+        "training.unexpected_frozen_param_count": audit.unexpected_frozen_param_count,
+        "training.adapter_checkpoint_bytes": audit.adapter_checkpoint_bytes,
+    }
+
+
+def _is_sequence(value: Any) -> bool:
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
+
+
+def _normalized_target_fragments(target_modules: Iterable[str]) -> tuple[str, ...]:
+    fragments: list[str] = []
+    for target in target_modules:
+        normalized = _normalize_parameter_name(str(target))
+        if not normalized:
+            continue
+        fragments.append(normalized)
+        fragments.append(normalized.removeprefix("model."))
+        fragments.append(normalized.removeprefix("language_model."))
+    return tuple(dict.fromkeys(fragment for fragment in fragments if fragment))
+
+
+def _is_unexpected_adapter_parameter(name: str, allowed_fragments: tuple[str, ...]) -> bool:
+    normalized = _normalize_parameter_name(name)
+    if _component_for_parameter_name(normalized) in {
+        "vision_encoder",
+        "multimodal_projector",
+        "audio_encoder",
+        "embedding",
+    }:
+        return True
+    adapter_owned = any(token in normalized for token in _TRAINABLE_ADAPTER_TOKENS)
+    if not allowed_fragments:
+        return not adapter_owned
+    if not adapter_owned:
+        return True
+    return not any(fragment in normalized for fragment in allowed_fragments)
+
+
+def _component_for_parameter_name(name: str) -> str:
+    normalized = _normalize_parameter_name(name)
+    for prefix, component in _DISALLOWED_COMPONENT_PREFIXES.items():
+        if normalized == prefix or normalized.startswith(f"{prefix}."):
+            return component
+    if normalized.startswith("language_model.") or normalized.startswith("model.layers."):
+        return "text_backbone"
+    first = normalized.split(".", 1)[0]
+    return first or "unknown"
+
+
+def _normalize_parameter_name(name: str) -> str:
+    normalized = name.replace("/", ".").replace("..", ".").strip(".").lower()
+    for prefix in ("base_model.", "model.model."):
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix):]
+    return normalized
+
+
+def _iter_trainable_parameters(model: Any) -> Iterable[tuple[str, Any]]:
+    trainable_parameters = getattr(model, "trainable_parameters", None)
+    if callable(trainable_parameters):
+        yield from _flatten_parameter_tree(trainable_parameters())
+        return
+    named_parameters = getattr(model, "named_parameters", None)
+    if callable(named_parameters):
+        for item in named_parameters():
+            try:
+                name, parameter = item
+            except (TypeError, ValueError):
+                continue
+            requires_grad = getattr(parameter, "requires_grad", None)
+            if requires_grad is False:
+                continue
+            yield str(name), parameter
+
+
+def _flatten_parameter_tree(node: Any, prefix: str = "") -> Iterable[tuple[str, Any]]:
+    if isinstance(node, Mapping):
+        for key, value in node.items():
+            child_prefix = f"{prefix}.{key}" if prefix else str(key)
+            yield from _flatten_parameter_tree(value, child_prefix)
+        return
+    if isinstance(node, (list, tuple)):
+        for index, value in enumerate(node):
+            child_prefix = f"{prefix}.{index}" if prefix else str(index)
+            yield from _flatten_parameter_tree(value, child_prefix)
+        return
+    if prefix:
+        yield prefix, node
+
+
+def _parameter_count(parameter: Any) -> int:
+    size = getattr(parameter, "size", None)
+    if isinstance(size, int) and size >= 0:
+        return size
+    shape = getattr(parameter, "shape", None)
+    if isinstance(shape, Sequence):
+        count = 1
+        for dimension in shape:
+            count *= max(0, int(dimension))
+        return count
+    try:
+        return len(parameter)
+    except TypeError:
+        return 1
+
+
+def _read_safetensors_header(path: Path) -> dict[str, dict[str, Any]]:
+    if not path.is_file():
+        return {}
+    try:
+        with path.open("rb") as handle:
+            raw_size = handle.read(8)
+            if len(raw_size) != 8:
+                return {}
+            header_size = struct.unpack("<Q", raw_size)[0]
+            if header_size <= 0 or header_size > _MAX_SAFETENSORS_HEADER_BYTES:
+                return {}
+            header = json.loads(handle.read(header_size).decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, struct.error):
+        return {}
+    if not isinstance(header, dict):
+        return {}
+    tensors: dict[str, dict[str, Any]] = {}
+    for key, value in header.items():
+        if key == "__metadata__" or not isinstance(value, dict):
+            continue
+        tensors[str(key)] = value
+    return tensors
+
+
+def _safetensors_parameter_count(metadata: Mapping[str, Any]) -> int:
+    shape = metadata.get("shape", [])
+    if not isinstance(shape, Sequence):
+        return 0
+    count = 1
+    for dimension in shape:
+        count *= max(0, int(dimension))
+    return count
+
+
+def _safetensors_tensor_bytes(metadata: Mapping[str, Any]) -> int:
+    offsets = metadata.get("data_offsets")
+    if isinstance(offsets, Sequence) and len(offsets) == 2:
+        try:
+            start = int(offsets[0])
+            end = int(offsets[1])
+        except (TypeError, ValueError):
+            start = end = 0
+        if end >= start:
+            return end - start
+    dtype = str(metadata.get("dtype", "")).upper()
+    return _safetensors_parameter_count(metadata) * _TENSOR_DTYPE_BYTES.get(dtype, 0)
+
+
+def _int_mapping_value(payload: Mapping[str, Any], key: str) -> int:
+    try:
+        return int(payload.get(key, 0) or 0)
+    except (TypeError, ValueError):
+        return 0


### PR DESCRIPTION
Closes #70.

## Plan or Spec

- Implement the issue #70 slice for multimodal LoRA stability and export correctness.
- Add a repo-owned finite attention-mask contract for padded multimodal inputs so fully masked vision rows use a dtype-safe finite floor and do not produce NaN/Inf softmax output.
- Add full-tree trainable and serialized-adapter freeze audits so unrelated vision/audio/projector/embedding towers, and full base tensors under target paths, fail adapter export.
- Export the requested evidence fields in adapter receipts: `multimodal_lora_nan_guard_triggered`, `unexpected_frozen_param_count`, `adapter_checkpoint_bytes`, and nested `adapter_freeze_audit`.

## Commands Run

```sh
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_multimodal_lora_training_receipt_records_triggered_nan_guard services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_lora_training_pipeline_uses_component_scope_metadata_for_gemma4_vlm services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_multimodal_lora_finite_mask_handles_fully_padded_vision_rows services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_adapter_freeze_audit_rejects_serialized_vision_tower_weights services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_adapter_freeze_audit_rejects_full_base_weights_under_allowed_target
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_multimodal_lora_finite_mask_handles_empty_visible_rows services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_adapter_freeze_audit_deduplicates_live_and_serialized_leaks services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_adapter_freeze_audit_ignores_invalid_large_safetensors_header
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py
PYTHONPYCACHEPREFIX="$PWD/.runtime/pycache" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python -m py_compile services/mlx-worker-python/worker/model_ops/multimodal_lora_contracts.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py
git diff --check
```

## Coverage and Metrics

- Focused issue #70 regressions: `5 passed in 0.13s`.
- Focused review regressions: `3 passed in 0.13s`.
- Full LoRA unit suite: `105 passed, 9 skipped in 0.11s`.
- Service-level LoRA tests: `71 passed in 2.64s`.
- Adapter audit enforces `adapter_checkpoint_size_ratio <= 1.2` against the expected LoRA-only footprint and fails export when unexpected serialized params are present.
- `unexpected_frozen_param_count` now deduplicates live and serialized leaks by parameter name while retaining separate live and serialized counts in `adapter_freeze_audit`.

## Known Gaps

- The repo-owned Python VLM paths did not contain a direct `-inf` attention-mask fill to patch, so this PR adds the finite-mask contract utility and regression coverage used by the multimodal LoRA path rather than changing vendored attention code.
- I used `uv run --frozen` because `uv run --locked` tried to refresh a stale lockfile under the selected local Python, and this PR should not update dependency lock state.
