### PR TITLE
Add local operator diagnostics commands

### DIFF
--- a/Sources/MelixCLI/main.swift
+++ b/Sources/MelixCLI/main.swift
@@ -12,7 +12,7 @@ struct MelixCLIExecutable {
             let output = try await MelixCLIRunner().run(parsedInvocation)
             FileHandle.standardOutput.write(Data(output.utf8))
         } catch {
-            let traceID = invocation?.traceID.isEmpty == false ? invocation?.traceID ?? "" : UUID().uuidString
+            let traceID = (invocation?.traceID).flatMap { $0.isEmpty ? nil : $0 } ?? UUID().uuidString
             let commandID = invocation.map { MelixCLICommandCodec.commandID(for: $0.command) } ?? "unknown"
             let debugBundlePath = Self.writeEarlyFailureDebugBundle(
                 commandID: commandID,

--- a/Sources/MelixCLI/main.swift
+++ b/Sources/MelixCLI/main.swift
@@ -12,32 +12,81 @@ struct MelixCLIExecutable {
             let output = try await MelixCLIRunner().run(parsedInvocation)
             FileHandle.standardOutput.write(Data(output.utf8))
         } catch {
+            let traceID = invocation?.traceID.isEmpty == false ? invocation?.traceID ?? "" : UUID().uuidString
+            let commandID = invocation.map { MelixCLICommandCodec.commandID(for: $0.command) } ?? "unknown"
+            let debugBundlePath = Self.writeEarlyFailureDebugBundle(
+                commandID: commandID,
+                traceID: traceID,
+                arguments: arguments,
+                error: error
+            )
             if invocation?.outputFormat == .jsonV1 || MelixCLIParser.requestedOutputFormat(arguments) == .jsonV1 {
-                let commandID = invocation.map { MelixCLICommandCodec.commandID(for: $0.command) } ?? "unknown"
-                let traceID = invocation?.traceID.isEmpty == false ? invocation?.traceID ?? "" : UUID().uuidString
-                let envelope = Self.errorEnvelope(commandID: commandID, traceID: traceID, error: error)
+                let envelope = Self.errorEnvelope(
+                    commandID: commandID,
+                    traceID: traceID,
+                    error: error,
+                    debugBundlePath: debugBundlePath
+                )
                 FileHandle.standardOutput.write(Data(envelope.utf8))
                 Foundation.exit(EXIT_FAILURE)
             }
-            FileHandle.standardError.write(Data((Self.message(for: error) + "\n").utf8))
+            var message = Self.message(for: error)
+            if let debugBundlePath {
+                message += "\nDebug bundle: \(debugBundlePath)"
+            }
+            FileHandle.standardError.write(Data((message + "\n").utf8))
             Foundation.exit(EXIT_FAILURE)
         }
     }
 
-    private static func errorEnvelope(commandID: String, traceID: String, error: Error) -> String {
+    private static func errorEnvelope(
+        commandID: String,
+        traceID: String,
+        error: Error,
+        debugBundlePath: String?
+    ) -> String {
+        let artifacts = debugBundlePath.map {
+            [
+                [
+                    "kind": "debug_bundle",
+                    "path": MelixDiagnosticsRedaction.redactString($0),
+                ],
+            ]
+        } ?? []
         if let error = error as? MelixCLIError {
             return (try? MelixCLIJSONEnvelope.errorEnvelopeString(
                 commandID: commandID,
                 traceID: traceID,
-                error: error
+                error: error,
+                artifacts: artifacts
             )) ?? fallbackErrorEnvelope(commandID: commandID)
         }
         return (try? MelixCLIJSONEnvelope.errorEnvelopeString(
             commandID: commandID,
             traceID: traceID,
             code: "runtime",
-            message: "\(error)"
+            message: "\(error)",
+            artifacts: artifacts
         )) ?? fallbackErrorEnvelope(commandID: commandID)
+    }
+
+    private static func writeEarlyFailureDebugBundle(
+        commandID: String,
+        traceID: String,
+        arguments: [String],
+        error: Error
+    ) -> String? {
+        let environment = ProcessInfo.processInfo.environment
+        let store = MelixDiagnosticsStore(
+            melixHome: MelixHome(environment: environment),
+            environment: environment
+        )
+        return try? store.writeEarlyFailureBundle(
+            commandID: commandID,
+            arguments: arguments,
+            errorMessage: message(for: error),
+            traceID: traceID
+        ).path
     }
 
     private static func fallbackErrorEnvelope(commandID: String) -> String {

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -867,6 +867,24 @@ public struct DoctorOptions: Equatable, Sendable {
     }
 }
 
+public struct SystemOptions: Equatable, Sendable {
+    public let json: Bool
+
+    public init(json: Bool = false) {
+        self.json = json
+    }
+}
+
+public struct MonitorOptions: Equatable, Sendable {
+    public let sourcePath: String
+    public let json: Bool
+
+    public init(sourcePath: String = "", json: Bool = false) {
+        self.sourcePath = sourcePath
+        self.json = json
+    }
+}
+
 public struct ConvertOptions: Equatable, Sendable {
     public let modelID: String
     public let outputDir: String
@@ -1356,6 +1374,10 @@ public struct MelixCLIInvocation: Equatable, Sendable {
 
 public enum MelixCLICommand: Equatable, Sendable {
     case doctor(DoctorOptions)
+    case system(SystemOptions)
+    case monitor(MonitorOptions)
+    case logs(LogsOptions)
+    case debugBundle(DebugBundleOptions)
     case estimateImport(EstimateImportOptions)
     case convert(ConvertOptions)
     case quantize(QuantizeOptions)
@@ -1500,6 +1522,14 @@ public enum MelixCLIParser {
         switch group {
         case "doctor":
             return try parseDoctor(tail)
+        case "system":
+            return try parseSystem(tail)
+        case "monitor":
+            return try parseMonitor(tail)
+        case "logs":
+            return try parseLogs(tail)
+        case "debug":
+            return try parseDebug(tail)
         case "estimate":
             return try parseEstimate(tail)
         case "convert":
@@ -1540,6 +1570,10 @@ public enum MelixCLIParser {
     public static let usageText = """
     Usage:
       melix doctor [--json]
+      melix system --json
+      melix monitor [--from PATH] [--json]
+      melix logs JOB_ID [--from PATH] [--follow] [--json]
+      melix debug bundle RUN_OR_JOB_ID [--from PATH] [--output PATH] [--json]
       melix estimate import HF_REPO [--json]
       melix estimate import --repo-id HF_REPO [--json]
       melix convert --model-id MODEL_ID [--output-dir PATH] [--target-format FORMAT] [--json]
@@ -1687,6 +1721,52 @@ public enum MelixCLIParser {
     private static func parseDoctor(_ arguments: [String]) throws -> MelixCLICommand {
         let values = try ArgumentCursor(arguments: arguments).parse()
         return .doctor(.init(json: values.flags.contains("--json")))
+    }
+
+    private static func parseSystem(_ arguments: [String]) throws -> MelixCLICommand {
+        let values = try ArgumentCursor(arguments: arguments).parse()
+        return .system(.init(json: values.flags.contains("--json")))
+    }
+
+    private static func parseMonitor(_ arguments: [String]) throws -> MelixCLICommand {
+        let values = try ArgumentCursor(arguments: arguments).parse()
+        return .monitor(.init(sourcePath: values.single["--from"] ?? "", json: values.flags.contains("--json")))
+    }
+
+    private static func parseLogs(_ arguments: [String]) throws -> MelixCLICommand {
+        var optionArguments = arguments
+        let jobID = try extractRunID(from: &optionArguments, command: "melix logs")
+        let values = try ArgumentCursor(arguments: optionArguments).parse()
+        return .logs(
+            LogsOptions(
+                jobID: jobID,
+                sourcePath: values.single["--from"] ?? "",
+                follow: values.flags.contains("--follow"),
+                json: values.flags.contains("--json")
+            )
+        )
+    }
+
+    private static func parseDebug(_ arguments: [String]) throws -> MelixCLICommand {
+        guard let action = arguments.first else {
+            throw MelixCLIError.usage(usageText)
+        }
+        switch action {
+        case "bundle":
+            var optionArguments = Array(arguments.dropFirst())
+            let runID = try extractRunID(from: &optionArguments, command: "melix debug bundle")
+            let values = try ArgumentCursor(arguments: optionArguments).parse()
+            return .debugBundle(
+                DebugBundleOptions(
+                    runID: runID,
+                    sourcePath: values.single["--from"] ?? "",
+                    outputPath: values.single["--output"] ?? "",
+                    json: values.flags.contains("--json")
+                )
+            )
+        default:
+            throw MelixCLIError.usage(usageText)
+        }
     }
 
     private static func parseEstimate(_ arguments: [String]) throws -> MelixCLICommand {
@@ -3891,6 +3971,7 @@ private struct ArgumentCursor {
             "--allow-memory-risk",
             "--resume",
             "--dry-run",
+            "--follow",
         ]
         while index < arguments.count {
             let token = arguments[index]
@@ -4464,10 +4545,40 @@ public actor MelixCLIRunner {
             return try runBatch(options)
         case .doctor(let options):
             let report = try await client.runDoctor()
+            let systemPayload = makeSystemPayload()
             if options.json {
-                return try prettyJSON(makeDoctorPayload(report))
+                return try prettyJSON(makeDoctorPayload(report, systemPayload: systemPayload))
             }
             return report.markdown.isEmpty ? "# Melix Doctor\n" : report.markdown
+        case .system(let options):
+            let payload = makeSystemPayload()
+            if options.json {
+                return try prettyJSON(payload)
+            }
+            return renderSystemPayload(payload)
+        case .monitor(let options):
+            let records = try runRecordStore().loadRecords(sourcePath: options.sourcePath)
+            let payload = diagnosticsStore().monitorPayload(records: records)
+            if options.json {
+                return try prettyJSON(payload)
+            }
+            return renderMonitorPayload(payload)
+        case .logs(let options):
+            let record = try runRecordStore().findRecord(runID: options.jobID, sourcePath: options.sourcePath)
+            let snapshot = try diagnosticsStore().logSnapshot(record: record, follow: options.follow)
+            if options.json {
+                return try prettyJSON(snapshot.payload)
+            }
+            return snapshot.text.hasSuffix("\n") ? snapshot.text : snapshot.text + "\n"
+        case .debugBundle(let options):
+            let record = try runRecordStore().findRecord(runID: options.runID, sourcePath: options.sourcePath)
+            let result = try diagnosticsStore().writeDebugBundle(record: record, outputPath: options.outputPath)
+            if options.json {
+                var payload = result.manifest
+                payload["bundle_path"] = MelixDiagnosticsRedaction.redactString(result.bundleRoot.path)
+                return try prettyJSON(payload)
+            }
+            return result.bundleRoot.path + "\n"
         case .estimateImport(let options):
             let receipt = try await makeMemoryFitReceipt(repoID: options.repoID, targetKind: "import")
             return options.json ? try prettyJSON(receipt.payload) : renderMemoryFitReceipt(receipt)
@@ -5955,6 +6066,13 @@ public actor MelixCLIRunner {
         MelixRunRecordStore(melixHome: MelixHome(environment: environment))
     }
 
+    private func diagnosticsStore() -> MelixDiagnosticsStore {
+        MelixDiagnosticsStore(
+            melixHome: MelixHome(environment: environment),
+            environment: environment
+        )
+    }
+
     private func renderRunReport(kind: String, options: RunReportOptions) throws -> String {
         let report = try runRecordStore().report(kind: kind, sourcePath: options.sourcePath)
         switch options.format.lowercased() {
@@ -6672,11 +6790,16 @@ public actor MelixCLIRunner {
         ]
     }
 
-    private func makeDoctorPayload(_ report: Melix_Controlplane_V1_DoctorReport) -> [String: Any] {
-        [
+    private func makeDoctorPayload(
+        _ report: Melix_Controlplane_V1_DoctorReport,
+        systemPayload: [String: Any]? = nil
+    ) -> [String: Any] {
+        let melixHome = MelixHome(environment: environment)
+        let resolvedSystemPayload = systemPayload ?? makeSystemPayload()
+        let systemFindings = MelixSystemDiagnostics.missingDependencyFindings(melixHome: melixHome)
+        let redactedReport = MelixDiagnosticsRedaction.redactMapping([
             "markdown": report.markdown,
-            "health_status": doctorHealthStatusLabel(report.healthStatus),
-            "findings": report.findings.map { finding in
+            "findings": report.findings.map { finding -> [String: Any] in
                 [
                     "code": finding.code,
                     "severity": doctorHealthStatusLabel(finding.severity),
@@ -6684,7 +6807,73 @@ public actor MelixCLIRunner {
                     "detail": finding.detail,
                 ]
             },
+        ])
+        var payload: [String: Any] = [
+            "markdown": redactedReport.payload["markdown"] as? String ?? "",
+            "health_status": doctorHealthStatusLabel(report.healthStatus),
+            "diagnostics_consent_state": MelixSystemDiagnostics.diagnosticsConsentState,
+            "redaction_schema_version": MelixDiagnosticsRedaction.schemaVersion,
+            "redacted_field_count": (resolvedSystemPayload["redacted_field_count"] as? Int ?? 0)
+                + redactedReport.redactedFieldCount,
+            "system": resolvedSystemPayload,
+            "findings": (redactedReport.payload["findings"] as? [[String: Any]] ?? []) + systemFindings,
         ]
+        if report.markdown.isEmpty && systemFindings.isEmpty == false {
+            payload["markdown"] = "# Melix Doctor\n"
+        }
+        return payload
+    }
+
+    private func makeSystemPayload() -> [String: Any] {
+        let melixHome = MelixHome(environment: environment)
+        let redactedEnvironment = MelixDiagnosticsRedaction.redactEnvironment(environment)
+        return MelixSystemDiagnostics.payload(
+            melixHome: melixHome,
+            environment: environment,
+            redactedFieldCount: redactedEnvironment.redactedFieldCount
+        )
+    }
+
+    private func renderSystemPayload(_ payload: [String: Any]) -> String {
+        let platform = payload["platform"] as? [String: Any] ?? [:]
+        let melixHome = payload["melix_home"] as? [String: Any] ?? [:]
+        let lines = [
+            "# Melix System",
+            "",
+            "- Diagnostics consent: \(payload["diagnostics_consent_state"] ?? "unknown")",
+            "- Redaction schema: \(payload["redaction_schema_version"] ?? MelixDiagnosticsRedaction.schemaVersion)",
+            "- Redacted fields: \(payload["redacted_field_count"] ?? 0)",
+            "- Operating system: \(platform["operating_system"] ?? "unknown")",
+            "- Physical memory bytes: \(platform["physical_memory_bytes"] ?? 0)",
+            "- MELIX_HOME: \(melixHome["root"] ?? "")",
+            "- Logs: \(melixHome["logs"] ?? "")",
+            "",
+        ]
+        return lines.joined(separator: "\n")
+    }
+
+    private func renderMonitorPayload(_ payload: [String: Any]) -> String {
+        let statusCounts = payload["status_counts"] as? [String: Any] ?? [:]
+        let recentRuns = payload["recent_runs"] as? [[String: Any]] ?? []
+        var lines = [
+            "# Melix Monitor",
+            "",
+            "- Runs: \(payload["run_count"] ?? 0)",
+            "- Status counts: \(statusCounts.map { "\($0.key)=\($0.value)" }.sorted().joined(separator: ", "))",
+            "- Logs: \(payload["logs_directory"] ?? "")",
+            "",
+            "run_id\trun_kind\tstatus\tmodel_id\tstarted_at_unix_ms",
+        ]
+        lines.append(contentsOf: recentRuns.map { run in
+            [
+                stringField(run, "run_id"),
+                stringField(run, "run_kind"),
+                stringField(run, "status"),
+                stringField(run, "model_id"),
+                stringField(run, "started_at_unix_ms"),
+            ].joined(separator: "\t")
+        })
+        return lines.joined(separator: "\n") + "\n"
     }
 
     private func modelStateLabel(_ value: Melix_Controlplane_V1_ModelState) -> String {

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -6849,7 +6849,7 @@ public actor MelixCLIRunner {
             "- Logs: \(melixHome["logs"] ?? "")",
             "",
         ]
-        return lines.joined(separator: "\n")
+        return lines.joined(separator: "\n") + "\n"
     }
 
     private func renderMonitorPayload(_ payload: [String: Any]) -> String {

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -6,6 +6,14 @@ public enum MelixCLICommandCodec {
         switch command {
         case .doctor:
             return "doctor"
+        case .system:
+            return "system"
+        case .monitor:
+            return "monitor"
+        case .logs:
+            return "logs"
+        case .debugBundle:
+            return "debug.bundle"
         case .estimateImport:
             return "estimate.import"
         case .convert:
@@ -188,6 +196,25 @@ public enum MelixCLICommandCodec {
         switch command {
         case .doctor(let options):
             arguments = ["doctor"]
+            json = options.json
+        case .system(let options):
+            arguments = ["system"]
+            json = options.json
+        case .monitor(let options):
+            arguments = ["monitor"]
+            appendOption("--from", value: options.sourcePath, into: &arguments)
+            json = options.json
+        case .logs(let options):
+            arguments = ["logs", options.jobID]
+            appendOption("--from", value: options.sourcePath, into: &arguments)
+            if options.follow {
+                arguments.append("--follow")
+            }
+            json = options.json
+        case .debugBundle(let options):
+            arguments = ["debug", "bundle", options.runID]
+            appendOption("--from", value: options.sourcePath, into: &arguments)
+            appendOption("--output", value: options.outputPath, into: &arguments)
             json = options.json
         case .estimateImport(let options):
             arguments = ["estimate", "import", options.repoID]

--- a/Sources/MelixCLICore/MelixCLIJSON.swift
+++ b/Sources/MelixCLICore/MelixCLIJSON.swift
@@ -188,6 +188,7 @@ public enum MelixCLIJSONEnvelope {
         commandID: String,
         traceID: String,
         error: MelixCLIError,
+        artifacts: [[String: Any]] = [],
         metrics: [String: Double] = [:]
     ) throws -> String {
         try errorEnvelopeString(
@@ -195,6 +196,7 @@ public enum MelixCLIJSONEnvelope {
             traceID: traceID,
             code: code(for: error),
             message: error.errorDescription ?? "\(error)",
+            artifacts: artifacts,
             metrics: metrics
         )
     }
@@ -204,6 +206,7 @@ public enum MelixCLIJSONEnvelope {
         traceID: String,
         code: String,
         message: String,
+        artifacts: [[String: Any]] = [],
         metrics: [String: Double] = [:]
     ) throws -> String {
         let placeholder = MelixCLIJSONMetricPatch.makePlaceholder(metricName: "melix.cli.json_encode_ms")
@@ -222,7 +225,7 @@ public enum MelixCLIJSONEnvelope {
                 "message": message,
             ],
             "warnings": [],
-            "artifacts": [],
+            "artifacts": artifacts,
             "metrics": finalMetrics,
         ]
         let encodeStart = DispatchTime.now()

--- a/Sources/MelixCLICore/MelixDiagnostics.swift
+++ b/Sources/MelixCLICore/MelixDiagnostics.swift
@@ -1,0 +1,616 @@
+import Foundation
+
+public enum MelixDiagnosticsRedaction {
+    public static let schemaVersion = "melix.diagnostics.redaction.v1"
+    private static let sensitiveKeyFragments = [
+        "api_key",
+        "apikey",
+        "authorization",
+        "auth_token",
+        "bearer",
+        "credential",
+        "hf_token",
+        "password",
+        "private_key",
+        "prompt",
+        "secret",
+        "token",
+    ]
+
+    public static func redactMapping(_ payload: [String: Any]) -> (payload: [String: Any], redactedFieldCount: Int) {
+        var count = 0
+        let redacted = payload.mapValues { value in
+            redactValue(value, redactedFieldCount: &count)
+        }
+        return (redacted, count)
+    }
+
+    public static func redactString(_ value: String) -> String {
+        var redacted = value
+        let replacements = [
+            (
+                #"(?i)(^|[\\/])([^\\/\s"']*(?:api[-_]?key|authorization|bearer|credential|hf[_-]?token|password|private[_-]?key|prompt|secret|token)[^\\/\s"']*)"#,
+                "$1<redacted>"
+            ),
+            (
+                #"(?i)(api[-_ ]?key|authorization|bearer|hf[-_ ]?token|password|prompt|secret|token)(["'\s:=]+)([^"'\s,}]+)"#,
+                "$1$2<redacted>"
+            ),
+            (#"(?i)(sk-[A-Za-z0-9_\-]{8,})"#, "<redacted>"),
+            (#"(?i)(hf_[A-Za-z0-9_\-]{8,})"#, "<redacted>"),
+        ]
+        for (pattern, template) in replacements {
+            guard let expression = try? NSRegularExpression(pattern: pattern) else {
+                continue
+            }
+            let range = NSRange(redacted.startIndex..<redacted.endIndex, in: redacted)
+            redacted = expression.stringByReplacingMatches(
+                in: redacted,
+                range: range,
+                withTemplate: template
+            )
+        }
+        return redacted
+    }
+
+    public static func redactEnvironment(_ environment: [String: String]) -> (payload: [String: Any], redactedFieldCount: Int) {
+        var redacted: [String: Any] = [:]
+        var count = 0
+        for key in environment.keys.sorted() {
+            let value = environment[key] ?? ""
+            if isSensitiveKey(key) {
+                redacted[key] = maskedHint(value)
+                count += 1
+            } else if value != redactString(value) {
+                redacted[key] = redactString(value)
+                count += 1
+            } else {
+                redacted[key] = value
+            }
+        }
+        return (redacted, count)
+    }
+
+    public static func isSensitiveKey(_ key: String) -> Bool {
+        let normalized = key
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
+        return sensitiveKeyFragments.contains { normalized.contains($0) }
+    }
+
+    private static func redactValue(_ value: Any, redactedFieldCount: inout Int) -> Any {
+        if let dictionary = value as? [String: Any] {
+            var redacted: [String: Any] = [:]
+            for key in dictionary.keys.sorted() {
+                let child = dictionary[key] ?? NSNull()
+                if isSensitiveKey(key) {
+                    redacted[key] = maskedHint(String(describing: child))
+                    redactedFieldCount += 1
+                } else {
+                    redacted[key] = redactValue(child, redactedFieldCount: &redactedFieldCount)
+                }
+            }
+            return redacted
+        }
+        if let array = value as? [Any] {
+            return array.map { redactValue($0, redactedFieldCount: &redactedFieldCount) }
+        }
+        if let string = value as? String {
+            let redacted = redactString(string)
+            if redacted != string {
+                redactedFieldCount += 1
+            }
+            return redacted
+        }
+        return value
+    }
+
+    private static func maskedHint(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else {
+            return "<redacted:empty>"
+        }
+        let suffix = String(trimmed.suffix(min(4, trimmed.count)))
+        return "<redacted:\(trimmed.count):...\(suffix)>"
+    }
+}
+
+public struct MelixSystemDiagnostics {
+    public static let schemaVersion = "melix.system.v1"
+    public static let diagnosticsConsentState = "local_only"
+
+    public static func payload(
+        melixHome: MelixHome,
+        environment: [String: String],
+        redactedFieldCount: Int
+    ) -> [String: Any] {
+        let redactedHome = MelixDiagnosticsRedaction.redactMapping([
+            "root": melixHome.rootURL.path,
+            "config": melixHome.configDirectoryURL.path,
+            "state": melixHome.stateDirectoryURL.path,
+            "logs": melixHome.logsDirectoryURL.path,
+            "runtime": melixHome.runtimeDirectoryURL.path,
+            "model_ops_jobs": melixHome.modelOpsJobsRootURL.path,
+            "evaluation_jobs": melixHome.evaluationJobsRootURL.path,
+        ])
+        let redactedWritability = MelixDiagnosticsRedaction.redactMapping([
+            "items": writabilityPayload(melixHome: melixHome),
+        ])
+        let totalRedactedFieldCount = redactedFieldCount
+            + redactedHome.redactedFieldCount
+            + redactedWritability.redactedFieldCount
+        return [
+            "schema_version": schemaVersion,
+            "diagnostics_consent_state": diagnosticsConsentState,
+            "redaction_schema_version": MelixDiagnosticsRedaction.schemaVersion,
+            "redacted_field_count": totalRedactedFieldCount,
+            "platform": [
+                "operating_system": ProcessInfo.processInfo.operatingSystemVersionString,
+                "processor_count": ProcessInfo.processInfo.processorCount,
+                "active_processor_count": ProcessInfo.processInfo.activeProcessorCount,
+                "physical_memory_bytes": NSNumber(value: ProcessInfo.processInfo.physicalMemory),
+            ],
+            "melix_home": redactedHome.payload,
+            "writability": redactedWritability.payload["items"] as? [[String: Any]] ?? [],
+            "environment": [
+                "melix_home_set": environment["MELIX_HOME"]?.isEmpty == false,
+                "melix_runtime_dir_set": environment["MELIX_RUNTIME_DIR"]?.isEmpty == false,
+                "melix_logs_dir_set": environment["MELIX_LOGS_DIR"]?.isEmpty == false,
+                "melix_worker_socket_path_set": environment["MELIX_WORKER_SOCKET_PATH"]?.isEmpty == false,
+                "melix_swift_text_worker_socket_path_set": environment["MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH"]?.isEmpty == false,
+            ],
+        ]
+    }
+
+    public static func missingDependencyFindings(melixHome: MelixHome) -> [[String: Any]] {
+        let checks: [(String, URL)] = [
+            ("melix_home_root_missing", melixHome.rootURL),
+            ("melix_config_dir_missing", melixHome.configDirectoryURL),
+            ("melix_state_dir_missing", melixHome.stateDirectoryURL),
+            ("melix_logs_dir_missing", melixHome.logsDirectoryURL),
+            ("melix_runtime_dir_missing", melixHome.runtimeDirectoryURL),
+        ]
+        return checks.compactMap { code, url in
+            guard FileManager.default.fileExists(atPath: url.path) == false else {
+                return nil
+            }
+            return [
+                "code": code,
+                "severity": "warning",
+                "summary": MelixDiagnosticsRedaction.redactString("\(url.path) is not present."),
+                "detail": "Melix can create this path on first use, but early diagnostics record it as missing.",
+            ]
+        }
+    }
+
+    private static func writabilityPayload(melixHome: MelixHome) -> [[String: Any]] {
+        [
+            ("root", melixHome.rootURL),
+            ("config", melixHome.configDirectoryURL),
+            ("state", melixHome.stateDirectoryURL),
+            ("logs", melixHome.logsDirectoryURL),
+            ("runtime", melixHome.runtimeDirectoryURL),
+        ].map { label, url in
+            [
+                "name": label,
+                "path": url.path,
+                "exists": FileManager.default.fileExists(atPath: url.path),
+                "writable": FileManager.default.isWritableFile(atPath: url.path),
+            ]
+        }
+    }
+}
+
+struct MelixLogSnapshot {
+    let runID: String
+    let sourcePath: String
+    let logPath: String
+    let followRequested: Bool
+    let activeFollowSupported: Bool
+    let text: String
+
+    var payload: [String: Any] {
+        let redacted = MelixDiagnosticsRedaction.redactMapping([
+            "source_path": sourcePath,
+            "log_path": logPath,
+            "content": text,
+        ])
+        return [
+            "schema_version": "melix.logs.v1",
+            "run_id": runID,
+            "source_path": redacted.payload["source_path"] ?? sourcePath,
+            "log_path": redacted.payload["log_path"] ?? logPath,
+            "follow_requested": followRequested,
+            "active_follow_supported": activeFollowSupported,
+            "content": redacted.payload["content"] ?? text,
+            "redaction_schema_version": MelixDiagnosticsRedaction.schemaVersion,
+            "redacted_field_count": redacted.redactedFieldCount,
+        ]
+    }
+}
+
+struct MelixDebugBundleResult {
+    let bundleRoot: URL
+    let manifest: [String: Any]
+}
+
+public struct MelixDiagnosticsStore {
+    private let melixHome: MelixHome
+    private let environment: [String: String]
+    private let fileManager: FileManager
+
+    public init(
+        melixHome: MelixHome,
+        environment: [String: String],
+        fileManager: FileManager = .default
+    ) {
+        self.melixHome = melixHome
+        self.environment = environment
+        self.fileManager = fileManager
+    }
+
+    public func writeEarlyFailureBundle(
+        commandID: String,
+        arguments: [String],
+        errorMessage: String,
+        traceID: String = ""
+    ) throws -> URL {
+        let bundleID = traceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? "cli-failure-\(UUID().uuidString)"
+            : traceID
+        let root = melixHome.rootURL
+            .appendingPathComponent("runs", isDirectory: true)
+            .appendingPathComponent(bundleID, isDirectory: true)
+            .appendingPathComponent("debug", isDirectory: true)
+        try fileManager.createDirectory(
+            at: root,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: MelixHome.directoryPermissions]
+        )
+
+        try writeText(
+            MelixDiagnosticsRedaction.redactString((["melix"] + arguments).joined(separator: " ")) + "\n",
+            to: root.appendingPathComponent("command.txt")
+        )
+        let redactedEnvironment = MelixDiagnosticsRedaction.redactEnvironment(environment)
+        try writeJSON(redactedEnvironment.payload, to: root.appendingPathComponent("redacted-env.json"))
+        let effectiveConfig: [String: Any] = [
+            "schema_version": "melix.diagnostics.effective_config.v1",
+            "command_id": commandID,
+            "arguments": arguments,
+            "early_failure": true,
+        ]
+        let redactedEffectiveConfig = MelixDiagnosticsRedaction.redactMapping(effectiveConfig)
+        try writeJSON(redactedEffectiveConfig.payload, to: root.appendingPathComponent("effective-config.json"))
+        var totalRedactedFieldCount = redactedEnvironment.redactedFieldCount
+            + redactedEffectiveConfig.redactedFieldCount
+        let systemPayload = MelixSystemDiagnostics.payload(
+            melixHome: melixHome,
+            environment: environment,
+            redactedFieldCount: totalRedactedFieldCount
+        )
+        totalRedactedFieldCount = systemPayload["redacted_field_count"] as? Int ?? totalRedactedFieldCount
+        try writeJSON(systemPayload, to: root.appendingPathComponent("system.json"))
+        try writeJSON(
+            MelixDiagnosticsRedaction.redactMapping([
+                "schema_version": "melix.diagnostics.capability_receipts.v1",
+                "command_id": commandID,
+                "artifacts": [],
+                "known_gaps": ["Run failed before a persisted run record was available."],
+                "probes": [],
+            ]).payload,
+            to: root.appendingPathComponent("capability-receipts.json")
+        )
+        try writeJSON(
+            MelixDiagnosticsRedaction.redactMapping([
+                "schema_version": "melix.diagnostics.memory_estimate.v1",
+                "command_id": commandID,
+                "resources": [:],
+                "metrics": [],
+            ]).payload,
+            to: root.appendingPathComponent("memory-estimate.json")
+        )
+        try writeText("", to: root.appendingPathComponent("logs.txt"))
+        try writeJSON(
+            MelixDiagnosticsRedaction.redactMapping([
+                "schema_version": "melix.diagnostics.metrics.v1",
+                "command_id": commandID,
+                "metrics": [],
+            ]).payload,
+            to: root.appendingPathComponent("metrics.json")
+        )
+        let redactedError = MelixDiagnosticsRedaction.redactMapping([
+            "schema_version": "melix.diagnostics.error.v1",
+            "command_id": commandID,
+            "error": [
+                "message": errorMessage,
+            ],
+        ])
+        totalRedactedFieldCount += redactedError.redactedFieldCount
+        try writeJSON(
+            redactedError.payload,
+            to: root.appendingPathComponent("error.json")
+        )
+        let manifest: [String: Any] = [
+            "schema_version": "melix.diagnostics.bundle.v1",
+            "bundle_id": bundleID,
+            "created_at_unix_ms": currentUnixMilliseconds(),
+            "diagnostics_consent_state": MelixSystemDiagnostics.diagnosticsConsentState,
+            "redaction_schema_version": MelixDiagnosticsRedaction.schemaVersion,
+            "redacted_field_count": totalRedactedFieldCount,
+            "command_id": commandID,
+            "artifacts": [
+                "command": "command.txt",
+                "redacted_env": "redacted-env.json",
+                "effective_config": "effective-config.json",
+                "system": "system.json",
+                "capability_receipts": "capability-receipts.json",
+                "memory_estimate": "memory-estimate.json",
+                "logs": "logs.txt",
+                "metrics": "metrics.json",
+                "error": "error.json",
+            ],
+        ]
+        try writeJSON(manifest, to: root.appendingPathComponent("manifest.json"))
+        return root
+    }
+
+    func monitorPayload(records: [MelixRunRecord]) -> [String: Any] {
+        let recent = Array(records.prefix(20)).map { $0.summaryPayload() }
+        let statusCounts = Dictionary(grouping: records, by: \.status)
+            .mapValues(\.count)
+        let redacted = MelixDiagnosticsRedaction.redactMapping([
+            "recent_runs": recent,
+            "logs_directory": melixHome.logsDirectoryURL.path,
+        ])
+        return [
+            "schema_version": "melix.monitor.v1",
+            "generated_at_unix_ms": currentUnixMilliseconds(),
+            "diagnostics_consent_state": MelixSystemDiagnostics.diagnosticsConsentState,
+            "redaction_schema_version": MelixDiagnosticsRedaction.schemaVersion,
+            "redacted_field_count": redacted.redactedFieldCount,
+            "run_count": records.count,
+            "status_counts": statusCounts,
+            "recent_runs": redacted.payload["recent_runs"] ?? recent,
+            "logs_directory": redacted.payload["logs_directory"] ?? melixHome.logsDirectoryURL.path,
+        ]
+    }
+
+    func logSnapshot(record: MelixRunRecord, follow: Bool) throws -> MelixLogSnapshot {
+        let logURL = try resolveLogURL(record: record)
+        let activeFollowSupported = follow && isActiveStatus(record.status)
+        let text = try readLogText(from: logURL, follow: activeFollowSupported)
+        return MelixLogSnapshot(
+            runID: record.runID,
+            sourcePath: record.path,
+            logPath: logURL.path,
+            followRequested: follow,
+            activeFollowSupported: activeFollowSupported,
+            text: MelixDiagnosticsRedaction.redactString(text)
+        )
+    }
+
+    func writeDebugBundle(
+        record: MelixRunRecord,
+        outputPath: String = ""
+    ) throws -> MelixDebugBundleResult {
+        let root = bundleRoot(for: record.runID, outputPath: outputPath)
+        try fileManager.createDirectory(
+            at: root,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: MelixHome.directoryPermissions]
+        )
+
+        let redactedCommandText = MelixDiagnosticsRedaction.redactString(record.commandDisplay)
+        try writeText(redactedCommandText + "\n", to: root.appendingPathComponent("command.txt"))
+
+        let redactedEnvironment = MelixDiagnosticsRedaction.redactEnvironment(environment)
+        try writeJSON(redactedEnvironment.payload, to: root.appendingPathComponent("redacted-env.json"))
+
+        let redactedEffectiveConfig = MelixDiagnosticsRedaction.redactMapping([
+            "schema_version": "melix.diagnostics.effective_config.v1",
+            "run_record_path": record.path,
+            "run_record": record.payload,
+        ])
+        try writeJSON(redactedEffectiveConfig.payload, to: root.appendingPathComponent("effective-config.json"))
+
+        var totalRedacted = redactedEnvironment.redactedFieldCount
+            + redactedEffectiveConfig.redactedFieldCount
+            + (redactedCommandText == record.commandDisplay ? 0 : 1)
+        let system = MelixSystemDiagnostics.payload(
+            melixHome: melixHome,
+            environment: environment,
+            redactedFieldCount: totalRedacted
+        )
+        totalRedacted = system["redacted_field_count"] as? Int ?? totalRedacted
+        try writeJSON(system, to: root.appendingPathComponent("system.json"))
+
+        let capabilityReceipts: [String: Any] = [
+            "schema_version": "melix.diagnostics.capability_receipts.v1",
+            "run_id": record.runID,
+            "artifacts": record.artifacts,
+            "known_gaps": record.knownGaps,
+            "probes": record.payload["probes"] as? [[String: Any]] ?? [],
+        ]
+        let redactedCapabilityReceipts = MelixDiagnosticsRedaction.redactMapping(capabilityReceipts)
+        totalRedacted += redactedCapabilityReceipts.redactedFieldCount
+        try writeJSON(
+            redactedCapabilityReceipts.payload,
+            to: root.appendingPathComponent("capability-receipts.json")
+        )
+
+        let memoryEstimate: [String: Any] = [
+            "schema_version": "melix.diagnostics.memory_estimate.v1",
+            "run_id": record.runID,
+            "resources": record.payload["resources"] as? [String: Any] ?? [:],
+            "metrics": record.metrics.filter { stringField($0, "name").lowercased().contains("memory") },
+        ]
+        let redactedMemoryEstimate = MelixDiagnosticsRedaction.redactMapping(memoryEstimate)
+        totalRedacted += redactedMemoryEstimate.redactedFieldCount
+        try writeJSON(redactedMemoryEstimate.payload, to: root.appendingPathComponent("memory-estimate.json"))
+
+        let logsText = (try? logSnapshot(record: record, follow: false).text) ?? ""
+        try writeText(logsText, to: root.appendingPathComponent("logs.txt"))
+
+        let metricsPayload: [String: Any] = [
+            "schema_version": "melix.diagnostics.metrics.v1",
+            "run_id": record.runID,
+            "metrics": record.metrics,
+        ]
+        let redactedMetricsPayload = MelixDiagnosticsRedaction.redactMapping(metricsPayload)
+        totalRedacted += redactedMetricsPayload.redactedFieldCount
+        try writeJSON(redactedMetricsPayload.payload, to: root.appendingPathComponent("metrics.json"))
+
+        let errorPayload: [String: Any] = [
+            "schema_version": "melix.diagnostics.error.v1",
+            "run_id": record.runID,
+            "status": record.status,
+            "error": record.status == "failed" || record.status == "error"
+                ? (record.payload["error"] as? [String: Any] ?? ["message": "Run status was \(record.status)."])
+                : NSNull(),
+        ]
+        let redactedErrorPayload = MelixDiagnosticsRedaction.redactMapping(errorPayload)
+        totalRedacted += redactedErrorPayload.redactedFieldCount
+        try writeJSON(
+            redactedErrorPayload.payload,
+            to: root.appendingPathComponent("error.json")
+        )
+
+        let redactedManifest = MelixDiagnosticsRedaction.redactMapping([
+            "schema_version": "melix.diagnostics.bundle.v1",
+            "bundle_id": record.runID,
+            "created_at_unix_ms": currentUnixMilliseconds(),
+            "diagnostics_consent_state": MelixSystemDiagnostics.diagnosticsConsentState,
+            "redaction_schema_version": MelixDiagnosticsRedaction.schemaVersion,
+            "redacted_field_count": totalRedacted,
+            "source_run_record_path": record.path,
+            "artifacts": [
+                "command": "command.txt",
+                "redacted_env": "redacted-env.json",
+                "effective_config": "effective-config.json",
+                "system": "system.json",
+                "capability_receipts": "capability-receipts.json",
+                "memory_estimate": "memory-estimate.json",
+                "logs": "logs.txt",
+                "metrics": "metrics.json",
+                "error": "error.json",
+            ],
+        ])
+        totalRedacted += redactedManifest.redactedFieldCount
+        var manifest = redactedManifest.payload
+        manifest["redacted_field_count"] = totalRedacted
+        try writeJSON(manifest, to: root.appendingPathComponent("manifest.json"))
+        return MelixDebugBundleResult(bundleRoot: root, manifest: manifest)
+    }
+
+    private func resolveLogURL(record: MelixRunRecord) throws -> URL {
+        let candidates = logCandidates(record: record)
+        for url in candidates where fileManager.fileExists(atPath: url.path) {
+            return url
+        }
+        throw MelixCLIError.runtime("No logs were found for \(record.runID). Checked: \(candidates.map(\.path).joined(separator: ", ")).")
+    }
+
+    private func logCandidates(record: MelixRunRecord) -> [URL] {
+        var candidates: [URL] = []
+        func appendIfPresent(_ path: String) {
+            let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.isEmpty == false else {
+                return
+            }
+            candidates.append(URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath))
+        }
+
+        for artifact in record.artifacts {
+            let kind = stringField(artifact, "kind").lowercased()
+            let path = stringField(artifact, "path")
+            if kind.contains("log") || path.lowercased().hasSuffix(".log") || path.lowercased().hasSuffix("logs.txt") {
+                appendIfPresent(path)
+            }
+        }
+
+        appendIfPresent(URL(fileURLWithPath: record.path).deletingLastPathComponent().appendingPathComponent("logs.txt").path)
+        appendIfPresent(URL(fileURLWithPath: record.path).deletingLastPathComponent().appendingPathComponent("run.log").path)
+        appendIfPresent(URL(fileURLWithPath: record.path).deletingLastPathComponent().appendingPathComponent("\(record.runID).log").path)
+        appendIfPresent(melixHome.logsDirectoryURL.appendingPathComponent("\(record.runID).log").path)
+        appendIfPresent(melixHome.logsDirectoryURL.appendingPathComponent("\(record.runID).txt").path)
+        return uniqueURLs(candidates)
+    }
+
+    private func readLogText(from url: URL, follow: Bool) throws -> String {
+        var data = try Data(contentsOf: url)
+        guard follow else {
+            return String(decoding: data, as: UTF8.self)
+        }
+
+        let deadline = Date().addingTimeInterval(1.0)
+        var stablePolls = 0
+        while Date() < deadline && stablePolls < 2 {
+            Thread.sleep(forTimeInterval: 0.2)
+            let next = try Data(contentsOf: url)
+            if next.count > data.count {
+                data = next
+                stablePolls = 0
+            } else {
+                stablePolls += 1
+            }
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func isActiveStatus(_ status: String) -> Bool {
+        switch status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "active", "in_progress", "in-progress", "pending", "processing", "queued", "running", "started":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func bundleRoot(for runID: String, outputPath: String) -> URL {
+        let trimmed = outputPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty == false {
+            return URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath, isDirectory: true)
+        }
+        return melixHome.rootURL
+            .appendingPathComponent("runs", isDirectory: true)
+            .appendingPathComponent(runID, isDirectory: true)
+            .appendingPathComponent("debug", isDirectory: true)
+    }
+
+    private func writeJSON(_ payload: [String: Any], to url: URL) throws {
+        var data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+        data.append(0x0a)
+        try writeData(data, to: url)
+    }
+
+    private func writeText(_ text: String, to url: URL) throws {
+        try writeData(Data(text.utf8), to: url)
+    }
+
+    private func writeData(_ data: Data, to url: URL) throws {
+        try fileManager.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: MelixHome.directoryPermissions]
+        )
+        try data.write(to: url, options: [.atomic])
+        try? fileManager.setAttributes([.posixPermissions: MelixHome.filePermissions], ofItemAtPath: url.path)
+    }
+}
+
+private func uniqueURLs(_ urls: [URL]) -> [URL] {
+    var seen: Set<String> = []
+    var result: [URL] = []
+    for url in urls {
+        let path = url.standardizedFileURL.path
+        if seen.insert(path).inserted {
+            result.append(url)
+        }
+    }
+    return result
+}
+
+private func currentUnixMilliseconds() -> Int {
+    Int(Date().timeIntervalSince1970 * 1000)
+}

--- a/Sources/MelixCLICore/MelixRunRecords.swift
+++ b/Sources/MelixCLICore/MelixRunRecords.swift
@@ -46,6 +46,34 @@ public struct RunReportOptions: Equatable, Sendable {
     }
 }
 
+public struct LogsOptions: Equatable, Sendable {
+    public let jobID: String
+    public let sourcePath: String
+    public let follow: Bool
+    public let json: Bool
+
+    public init(jobID: String, sourcePath: String = "", follow: Bool = false, json: Bool = false) {
+        self.jobID = jobID
+        self.sourcePath = sourcePath
+        self.follow = follow
+        self.json = json
+    }
+}
+
+public struct DebugBundleOptions: Equatable, Sendable {
+    public let runID: String
+    public let sourcePath: String
+    public let outputPath: String
+    public let json: Bool
+
+    public init(runID: String, sourcePath: String = "", outputPath: String = "", json: Bool = false) {
+        self.runID = runID
+        self.sourcePath = sourcePath
+        self.outputPath = outputPath
+        self.json = json
+    }
+}
+
 struct MelixRunRecord {
     let payload: [String: Any]
     private let envelope: MelixRunRecordEnvelope
@@ -70,6 +98,7 @@ struct MelixRunRecord {
     var metrics: [[String: Any]] { envelope.metrics.map(\.payload) }
     var artifacts: [[String: Any]] { envelope.artifacts.map(\.payload) }
     var knownGaps: [String] { envelope.knownGaps }
+    var artifactRoot: String { envelope.artifactRoot }
 
     func summaryPayload() -> [String: Any] {
         [
@@ -744,7 +773,7 @@ private func suiteLabel(_ value: Any?) -> String {
     return rendered.isEmpty ? "-" : rendered
 }
 
-private func stringField(_ payload: [String: Any], _ key: String, fallback: String = "") -> String {
+func stringField(_ payload: [String: Any], _ key: String, fallback: String = "") -> String {
     guard let value = payload[key] else {
         return fallback
     }

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -339,12 +339,40 @@ struct MelixCLIParserTests {
     @Test("documents and parses public model ops commands")
     func documentsAndParsesPublicModelOpsCommands() throws {
         #expect(MelixCLIParser.usageText.contains("melix doctor [--json]"))
+        #expect(MelixCLIParser.usageText.contains("melix system --json"))
+        #expect(MelixCLIParser.usageText.contains("melix monitor [--from PATH] [--json]"))
+        #expect(MelixCLIParser.usageText.contains("melix logs JOB_ID"))
+        #expect(MelixCLIParser.usageText.contains("melix debug bundle RUN_OR_JOB_ID"))
         #expect(MelixCLIParser.usageText.contains("melix convert --model-id MODEL_ID"))
         #expect(MelixCLIParser.usageText.contains("melix quantize --model-id MODEL_ID"))
         #expect(MelixCLIParser.usageText.contains("melix upload --model-id MODEL_ID"))
 
         let doctorCommand = try MelixCLIParser.parse([
             "doctor",
+            "--json",
+        ])
+        let systemCommand = try MelixCLIParser.parse([
+            "system",
+            "--json",
+        ])
+        let monitorCommand = try MelixCLIParser.parse([
+            "monitor",
+            "--from", "/tmp/melix/jobs",
+            "--json",
+        ])
+        let logsCommand = try MelixCLIParser.parse([
+            "logs",
+            "bench-1",
+            "--from", "/tmp/melix/jobs",
+            "--follow",
+            "--json",
+        ])
+        let debugBundleCommand = try MelixCLIParser.parse([
+            "debug",
+            "bundle",
+            "bench-1",
+            "--from", "/tmp/melix/jobs",
+            "--output", "/tmp/melix-debug/bench-1",
             "--json",
         ])
         let convertCommand = try MelixCLIParser.parse([
@@ -390,6 +418,22 @@ struct MelixCLIParserTests {
             Issue.record("Expected doctor command")
             return
         }
+        guard case .system(let systemOptions) = systemCommand else {
+            Issue.record("Expected system command")
+            return
+        }
+        guard case .monitor(let monitorOptions) = monitorCommand else {
+            Issue.record("Expected monitor command")
+            return
+        }
+        guard case .logs(let logsOptions) = logsCommand else {
+            Issue.record("Expected logs command")
+            return
+        }
+        guard case .debugBundle(let debugBundleOptions) = debugBundleCommand else {
+            Issue.record("Expected debugBundle command")
+            return
+        }
         guard case .convert(let convertOptions) = convertCommand else {
             Issue.record("Expected convert command")
             return
@@ -404,6 +448,17 @@ struct MelixCLIParserTests {
         }
 
         #expect(doctorOptions.json)
+        #expect(systemOptions.json)
+        #expect(monitorOptions.sourcePath == "/tmp/melix/jobs")
+        #expect(monitorOptions.json)
+        #expect(logsOptions.jobID == "bench-1")
+        #expect(logsOptions.sourcePath == "/tmp/melix/jobs")
+        #expect(logsOptions.follow)
+        #expect(logsOptions.json)
+        #expect(debugBundleOptions.runID == "bench-1")
+        #expect(debugBundleOptions.sourcePath == "/tmp/melix/jobs")
+        #expect(debugBundleOptions.outputPath == "/tmp/melix-debug/bench-1")
+        #expect(debugBundleOptions.json)
         #expect(convertOptions.modelID == "melix-dev-text")
         #expect(convertOptions.outputDir == "/tmp/melix-convert")
         #expect(convertOptions.targetFormat == "melix_model_bundle")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -188,6 +188,9 @@ struct MelixCLIRunnerTests {
     @Test("doctor command renders markdown and structured json payloads")
     func doctorCommandRendersMarkdownAndStructuredJSONPayloads() async throws {
         let client = StubControlPlaneXPCClient()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-doctor-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
         await client.setDoctorReport(
             makeDoctorReport(
                 markdown: "# Melix Doctor\n\n- worker_state: idle\n",
@@ -199,14 +202,23 @@ struct MelixCLIRunnerTests {
         )
 
         let textOutput = try await MelixCLIRunner(client: client).run(.doctor(.init()))
-        let jsonOutput = try await MelixCLIRunner(client: client).run(.doctor(.init(json: true)))
+        let jsonOutput = try await MelixCLIRunner(
+            client: client,
+            environment: [
+                "MELIX_HOME": root.path,
+                "MELIX_API_KEY": "sk-secret-doctor",
+            ]
+        ).run(.doctor(.init(json: true)))
         let payload = try #require(parseJSONObject(jsonOutput))
         let findings = try #require(payload["findings"] as? [[String: Any]])
 
         #expect(textOutput.contains("# Melix Doctor"))
         #expect(payload["markdown"] as? String == "# Melix Doctor\n\n- worker_state: idle\n")
         #expect(payload["health_status"] as? String == "healthy")
-        #expect(findings.count == 1)
+        #expect(payload["diagnostics_consent_state"] as? String == "local_only")
+        #expect(payload["redaction_schema_version"] as? String == MelixDiagnosticsRedaction.schemaVersion)
+        #expect((payload["redacted_field_count"] as? Int ?? 0) >= 1)
+        #expect(findings.count >= 1)
         #expect(findings[0]["code"] as? String == "cache_warning")
         #expect(findings[0]["severity"] as? String == "warning")
     }
@@ -7932,7 +7944,14 @@ struct MelixCLIRunnerTests {
                 runID: "bench-1",
                 runKind: "benchmark",
                 runRoot: benchRunRoot,
-                startedAtUnixMS: 200
+                startedAtUnixMS: 200,
+                command: "melix bench run --model-id melix-dev-text --suite smoke --local-inference-smoke-prompt hidden-prompt-token",
+                parameters: [
+                    "sample_size": "2",
+                    "prompt": "hidden-prompt-token",
+                    "authorization_header": "Authorization: Bearer sk-secret-header",
+                    "artifact_path": "/Users/alice/.melix/secrets/sk-secret-path/model",
+                ]
             ),
             to: benchRunRoot.appendingPathComponent("run-record.json")
         )
@@ -7947,10 +7966,18 @@ struct MelixCLIRunnerTests {
             ),
             to: evalRunRoot.appendingPathComponent("run-record.json")
         )
+        try "Authorization: Bearer sk-secret-log\nbenchmark failed after import\n"
+            .write(to: benchRunRoot.appendingPathComponent("logs.txt"), atomically: true, encoding: .utf8)
+        try "active line 1\n"
+            .write(to: evalRunRoot.appendingPathComponent("logs.txt"), atomically: true, encoding: .utf8)
 
         let runner = MelixCLIRunner(
             client: StubControlPlaneXPCClient(),
-            environment: ["MELIX_HOME": root.path]
+            environment: [
+                "MELIX_HOME": root.path,
+                "MELIX_API_KEY": "sk-secret-env",
+                "MELIX_LOGS_DIR": root.appendingPathComponent("logs").path,
+            ]
         )
 
         let listJSON = try await runner.run(.runsList(.init(sourcePath: sourceRoot.path, json: true)))
@@ -8005,6 +8032,95 @@ struct MelixCLIRunnerTests {
         #expect(evalReportPayload["run_count"] as? Int == 1)
         #expect(generation["record_scan_ms"] != nil)
         #expect(generation["markdown_render_ms"] != nil)
+
+        let systemJSON = try await runner.run(.system(.init(json: true)))
+        let systemPayload = try #require(parseJSONObject(systemJSON))
+        #expect(systemPayload["diagnostics_consent_state"] as? String == "local_only")
+        #expect(systemPayload["redaction_schema_version"] as? String == MelixDiagnosticsRedaction.schemaVersion)
+        #expect((systemPayload["redacted_field_count"] as? Int ?? 0) >= 1)
+
+        let monitorJSON = try await runner.run(.monitor(.init(sourcePath: sourceRoot.path, json: true)))
+        let monitorPayload = try #require(parseJSONObject(monitorJSON))
+        let recentRuns = try #require(monitorPayload["recent_runs"] as? [[String: Any]])
+        #expect(monitorPayload["run_count"] as? Int == 2)
+        #expect(recentRuns.first?["run_id"] as? String == "bench-1")
+
+        let logsText = try await runner.run(.logs(.init(jobID: "bench-1", sourcePath: sourceRoot.path, follow: true)))
+        #expect(logsText.contains("benchmark failed after import"))
+        #expect(logsText.contains("sk-secret-log") == false)
+        #expect(logsText.contains("<redacted>"))
+
+        let logsJSON = try await runner.run(.logs(.init(jobID: "bench-1", sourcePath: sourceRoot.path, follow: true, json: true)))
+        let logsPayload = try #require(parseJSONObject(logsJSON))
+        #expect(logsPayload["follow_requested"] as? Bool == true)
+        #expect(logsPayload["active_follow_supported"] as? Bool == false)
+        #expect((logsPayload["content"] as? String)?.contains("sk-secret-log") == false)
+
+        try writeJSONObjectForTest(
+            makeRunRecordPayloadForTest(
+                runID: "eval-1",
+                runKind: "evaluation",
+                runRoot: evalRunRoot,
+                startedAtUnixMS: 100,
+                status: "running",
+                metricName: "eval.mmlu.accuracy",
+                metricUnit: "ratio"
+            ),
+            to: evalRunRoot.appendingPathComponent("run-record.json")
+        )
+        Task.detached {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            if let handle = try? FileHandle(forWritingTo: evalRunRoot.appendingPathComponent("logs.txt")) {
+                try? handle.seekToEnd()
+                try? handle.write(contentsOf: Data("active line 2\n".utf8))
+                try? handle.close()
+            }
+        }
+        let activeLogsJSON = try await runner.run(.logs(.init(jobID: "eval-1", sourcePath: sourceRoot.path, follow: true, json: true)))
+        let activeLogsPayload = try #require(parseJSONObject(activeLogsJSON))
+        #expect(activeLogsPayload["follow_requested"] as? Bool == true)
+        #expect(activeLogsPayload["active_follow_supported"] as? Bool == true)
+        #expect((activeLogsPayload["content"] as? String)?.contains("active line 2") == true)
+
+        let bundleOutputRoot = root.appendingPathComponent("debug-output/bench-1", isDirectory: true)
+        let bundleJSON = try await runner.run(
+            .debugBundle(
+                .init(
+                    runID: "bench-1",
+                    sourcePath: sourceRoot.path,
+                    outputPath: bundleOutputRoot.path,
+                    json: true
+                )
+            )
+        )
+        let bundlePayload = try #require(parseJSONObject(bundleJSON))
+        #expect(bundlePayload["bundle_path"] as? String == bundleOutputRoot.path)
+        #expect(bundlePayload["diagnostics_consent_state"] as? String == "local_only")
+        for filename in [
+            "command.txt",
+            "redacted-env.json",
+            "effective-config.json",
+            "system.json",
+            "capability-receipts.json",
+            "memory-estimate.json",
+            "logs.txt",
+            "metrics.json",
+            "error.json",
+            "manifest.json",
+        ] {
+            #expect(FileManager.default.fileExists(atPath: bundleOutputRoot.appendingPathComponent(filename).path))
+        }
+        let bundleLogs = try String(contentsOf: bundleOutputRoot.appendingPathComponent("logs.txt"), encoding: .utf8)
+        let bundleEnv = try String(contentsOf: bundleOutputRoot.appendingPathComponent("redacted-env.json"), encoding: .utf8)
+        let bundleCommand = try String(contentsOf: bundleOutputRoot.appendingPathComponent("command.txt"), encoding: .utf8)
+        let bundleConfig = try String(contentsOf: bundleOutputRoot.appendingPathComponent("effective-config.json"), encoding: .utf8)
+        #expect(bundleLogs.contains("sk-secret-log") == false)
+        #expect(bundleEnv.contains("sk-secret-env") == false)
+        #expect(bundleCommand.contains("hidden-prompt-token") == false)
+        #expect(bundleConfig.contains("hidden-prompt-token") == false)
+        #expect(bundleConfig.contains("sk-secret-header") == false)
+        #expect(bundleConfig.contains("sk-secret-path") == false)
+        #expect(bundleEnv.contains("<redacted:"))
 
         let emptyList = try await runner.run(.runsList(.init(sourcePath: root.appendingPathComponent("missing").path)))
         #expect(emptyList == "No run records found.\n")
@@ -9239,20 +9355,26 @@ private func makeRunRecordPayloadForTest(
     runKind: String,
     runRoot: URL,
     startedAtUnixMS: Int,
+    status: String = "completed",
+    command: String? = nil,
+    parameters: [String: Any] = [
+        "sample_size": "2",
+    ],
     metricName: String = "bench.smoke.ttft_ms",
     metricUnit: String = "ms"
 ) -> [String: Any] {
     let evaluation = runKind.hasPrefix("evaluation")
     let suiteID = evaluation ? "mmlu" : "smoke"
     let datasetID = evaluation ? "mmlu.dev.v1" : "ultrachat.smoke"
-    let command = evaluation
+    let defaultCommand = evaluation
         ? "melix eval run --model-id melix-dev-text --suite mmlu --dataset-id mmlu.dev.v1 --sample-size 2"
         : "melix bench run --model-id melix-dev-text --suite smoke --sample-size 2"
+    let command = command ?? defaultCommand
     return [
         "schema_version": "melix.run_record.v1",
         "run_id": runID,
         "run_kind": runKind,
-        "status": "completed",
+        "status": status,
         "started_at_unix_ms": startedAtUnixMS,
         "ended_at_unix_ms": startedAtUnixMS + 50,
         "duration_ms": 50,
@@ -9285,9 +9407,7 @@ private func makeRunRecordPayloadForTest(
             "sample_size": 2,
             "scoring_mode": evaluation ? "normalized_exact_match" : "",
         ],
-        "parameters": [
-            "sample_size": "2",
-        ],
+        "parameters": parameters,
         "reproducibility": [
             "schema_sha256": "schema-digest",
         ],


### PR DESCRIPTION
## Summary
- Add local operator diagnostics commands for system, monitor, logs, and debug bundle workflows.
- Extend doctor JSON and JSON-v1 errors with local diagnostics/redaction metadata and debug bundle artifacts.
- Persist local debug bundles for recorded runs and early CLI failures with redacted env, config, system, logs, metrics, memory, and error files.
- Add focused parser/runner coverage for redaction, missing dependency diagnostics, active log follow, and bundle contents.

Closes #642

## Plan or Spec
- Implements GitHub issue #642: operator diagnostics through `melix doctor`, `melix system`, `melix monitor`, `melix logs`, and `melix debug bundle`.
- Keeps diagnostics local-first: generated bundles and machine-readable output are local artifacts only, with shared redaction metadata and no hosted telemetry upload.
- Handles early CLI failures by creating a debug bundle before a persisted run record exists.

## Commands Run
- `git fetch origin main`
- `git rebase origin/main`
- `xcrun swift build --product melix`
- `MELIX_HOME=/private/tmp/melix642-final.WS3S9P/secrets/sk-secret-home MELIX_API_KEY=sk-secret-final .build/debug/melix system --json`
- `MELIX_HOME=/private/tmp/melix642-final.WS3S9P/secrets/sk-secret-home MELIX_API_KEY=sk-secret-final .build/debug/melix logs missing-json --format json-v1`
- `rg -n "sk-secret-final|sk-secret-home|<redacted|diagnostics_consent_state|redacted_field_count" /private/tmp/melix642-final.WS3S9P/secrets/sk-secret-home/runs/00403ECF-667E-4155-99C2-507F86E4B357/debug`
- `xcrun swift test --filter MelixCLIParserTests/documentsAndParsesPublicModelOpsCommands`

## Coverage and Metrics
- Product build passes with `xcrun swift build --product melix`.
- PR scoped performance report is `ok`: selected probes `1`, regressions `0`, verification failures `0`, Swift CLI JSON envelope targeted tests `pass`, coverage `pass`.
- Local CLI smokes verified redacted `system --json`, JSON-v1 failure artifacts, early debug bundle creation, and redaction of secret-looking path/API-key values.
- Focused parser/runner tests were added for command parsing, system/monitor/logs/debug bundle behavior, redaction fixture coverage, active log follow, and missing dependency diagnostics.

## Known Gaps
- Local `xcrun swift test --filter MelixCLIParserTests/documentsAndParsesPublicModelOpsCommands` is blocked before running the target tests because existing test files import Swift's `Testing` module and this local toolchain reports `no such module 'Testing'`.
- Gemini suggested splitting `MelixDiagnostics.swift` into smaller files; this PR keeps the new diagnostics implementation together to limit post-rebase churn, with a follow-up refactor available if maintainers want it.
