### PR TITLE
Productization: isolate probe telemetry defaults

### DIFF
--- a/docs/plans/2026-05-12-observability-probe-policy.md
+++ b/docs/plans/2026-05-12-observability-probe-policy.md
@@ -1,0 +1,460 @@
+# Observability Probe Policy And Production Isolation
+
+## Goal
+
+Separate Melix observability into explicit runtime modes so production serving
+keeps near-zero probe overhead while benchmark, evaluation, release evidence,
+debug diagnostics, and PR-scoped performance probes keep their required
+evidence.
+
+The canonical contract remains
+`docs/evidence-telemetry-report-contract.md`. This plan refines that contract by
+adding mode boundaries and production defaults; it does not remove required
+benchmark or evaluation evidence.
+
+## Mode Model
+
+Melix observability has five modes:
+
+| Mode | Default Use | Allowed Cost | Required Behavior |
+|---|---|---:|---|
+| `off` | Packaged production serving | Near zero | No telemetry threads, no power sampling, no debug JSONL, no per-row probe expansion |
+| `minimal` | Production health surfaces | O(1) request counters | Reuse counters already produced by request execution |
+| `sampled` | Operator-enabled production diagnostics | Bounded asynchronous work | Sampling rate and queue size must be bounded and non-blocking |
+| `evidence` | Benchmark, evaluation, report gates | Full run-scoped evidence | Preserve valid `run-evidence.json`, `probe_timeline`, and `telemetry_summary` |
+| `debug` | Explicit local diagnostics | Bounded detailed traces | Write detailed bundles only for the opted-in session |
+
+`MELIX_PROBE_MODE` is the common environment override. Invalid values fall back
+to a production-safe default.
+
+## Probe Inventory And Retention Policy
+
+### Swift Debug Probes
+
+Swift debug probes are operator diagnostics, not production performance-claim
+artifacts. They must stay opt-in except for bounded early-failure capture.
+
+Current inventory:
+
+- `Sources/MelixCLICore/MelixDiagnostics.swift` redacts sensitive strings,
+  mappings, and environment values through `MelixDiagnosticsRedaction` before
+  writing diagnostic artifacts.
+- `MelixSystemDiagnostics.payload(...)` records platform state, Melix home
+  layout, directory writability, and whether `MELIX_HOME`, `MELIX_RUNTIME_DIR`,
+  `MELIX_LOGS_DIR`, `MELIX_WORKER_SOCKET_PATH`, and
+  `MELIX_SWIFT_TEXT_WORKER_SOCKET_PATH` are set.
+- `MelixDiagnosticsStore.writeEarlyFailureBundle(...)` writes bounded early CLI
+  failure bundles under `runs/<bundle_id>/debug/` with `command.txt`,
+  `redacted-env.json`, `effective-config.json`, `system.json`,
+  `capability-receipts.json`, `memory-estimate.json`, `logs.txt`,
+  `metrics.json`, `error.json`, and `manifest.json`.
+- `MelixDiagnosticsStore.writeDebugBundle(...)` writes explicit run debug
+  bundles with the same redacted artifact shape and includes run-record
+  artifacts, known gaps, probes, memory-related metrics, logs, metrics, and
+  errors.
+- `Tests/MelixCLITests/MelixCLIParserTests.swift` covers
+  `melix debug bundle RUN_OR_JOB_ID`, `--output`, `--source-path`, and JSON
+  output parsing.
+
+Policy:
+
+- Production hot paths must not emit Swift debug JSONL by default.
+- Debug JSONL, DFlash-style tracing, serving diagnostics bundles, and detailed
+  log snapshots must require `debug` mode, a CLI flag, or a dedicated debug
+  environment variable.
+- Debug artifacts may reference evidence artifacts, but benchmark/evaluation
+  evidence must not depend on debug bundle presence.
+- Debug bundles and `logs.txt` must not be used as public performance evidence
+  unless a separate evidence-mode run generated the claim.
+
+### CI PR-Scoped Probes
+
+CI PR-scoped probes are regression evidence and developer tooling. They must not
+enter packaged production runtime paths.
+
+Current inventory:
+
+- `infra/perf/pr_scoped_probes.json` currently registers 100 scoped probes. Each
+  entry declares `id`, `name`, `runner`, `watch_globs`, `test_command`,
+  `coverage_command`, `probe_command`, `probe_impl`, and `metrics`.
+- `scripts/*probe*.py` contains synthetic and focused probes for dataset
+  registry, hub catalog, multimodal preprocessing, runtime utilities, stream
+  assembly, benchmark/evaluation reporting, event extraction, code evaluation,
+  quantization, worker registry, startup signals, and Swift binary resolution.
+- `scripts/pr_scoped_performance_scope.py` converts PR changed files into a
+  selected-probe scope report.
+- `worker.productization.pr_scoped_performance.build_scope_report(...)` selects
+  probes by `watch_globs` and forces all probes when the workflow, registry,
+  PR-scoped scripts, PR-scoped tests, or PR-scoped implementation changes.
+- `.github/workflows/pr-scoped-performance.yml` checks out isolated base and
+  head worktrees, runs the selected probe matrix, uploads
+  `artifacts/probes/<probe-id>.json`, and posts the scoped report.
+- `scripts/pr_scoped_performance_run.py` runs head tests and coverage before
+  base/head probe commands and writes
+  `melix.pr_scoped_performance_probe_result.v1` JSON.
+
+Policy:
+
+- Keep PR-scoped probes as evidence mode for PR review and merge gates.
+- Do not import CI probe scripts from production serving, benchmark, or
+  evaluation hot paths.
+- Synthetic workloads, repeated loops, `tracemalloc`, monkey-patching, and call
+  counters are allowed only in CI/tooling probes.
+- Keep `test_command`, `coverage_command`, and `probe_command` explicit so each
+  future performance issue has focused tests, coverage, and metrics evidence.
+
+### Benchmark And Evaluation Evidence Probes
+
+Benchmark/evaluation probes are durable operator and release evidence. They
+must remain available when debug probes and CI probes are disabled.
+
+Current inventory:
+
+- `docs/evidence-telemetry-report-contract.md` requires every benchmark,
+  evaluation, event-extraction, and adapter/runtime check to write an evidence
+  envelope with `probe_timeline`, `telemetry_summary`, `model_memory_summary`,
+  linked artifacts, failure state, and fallback state.
+- The evidence contract defines required probe fields: run/span identity,
+  component, phase, monotonic start, duration, status, error attribution, and
+  small structured attributes.
+- Fan-out stages must write aggregate summary probes and may write only bounded
+  representative sample probes for slow, failed, skipped, or fallback samples.
+- `docs/benchmark-evaluation-contract.md` requires `manifest.jsonl`,
+  `effective-config.json`, and optional `preflight-report.json` in both the
+  temporary run directory and operator output directory.
+- Batch-run configuration records isolation and execution variables including
+  `MELIX_HOME`, `MELIX_RUNTIME_DIR`, `MELIX_SERVICE_INSTANCE_NAME`,
+  `MELIX_HTTP_PORT`, `MELIX_CLI`, `MELIX_BATCH_MODEL_LIST`,
+  `MELIX_DOWNLOAD_ROOT`, `MELIX_RUN_TMP_ROOT`,
+  `MELIX_RESTART_STACK_PER_MODEL`, and the benchmark/evaluation `MELIX_*`
+  knobs.
+- `services/mlx-worker-python/worker/productization/benchmark_export.py`
+  collects benchmark jobs, benchmark summaries, matrix rows, evaluation jobs,
+  evaluation summaries, evaluation samples, compare artifacts, and deduplicated
+  `run_evidence`.
+- `Tests/test_phase8_acceptance_bundle.py` preserves
+  `evaluation-samples.jsonl` and an `events.jsonl` diagnostic path in generated
+  acceptance artifacts.
+
+Policy:
+
+- Keep run evidence envelopes, aggregate probe timelines, telemetry summaries,
+  model memory summaries, manifests, and exported JSON/CSV/JSONL artifacts as
+  required `evidence` mode outputs.
+- Do not replace machine-readable evidence with Markdown, terminal summaries,
+  logs, or CSV-only exports.
+- Do not remove evidence probes to optimize production defaults. Instead, bound
+  fan-out probes, keep telemetry off the hot path, and record explicit
+  instrumentation gaps when telemetry is unavailable.
+- Treat `loaded_model_estimated_resident_bytes` and
+  `runtime_stats_model_resident_bytes` as evidence-critical model-residency
+  fields distinct from worker RSS and host memory.
+
+### Production Hot Path Exclusions
+
+The following must not be enabled by default in `off`, `minimal`, or packaged
+production serving paths:
+
+- Per-token, per-row, or full-payload JSONL debug tracing.
+- Full prompt, response, dataset row, credential, or secret capture in probe
+  attributes.
+- Synthetic microbenchmarks, repeated-loop probes, `tracemalloc`, monkey-patched
+  call counters, or CI base/head comparison commands.
+- Request-critical `powermetrics` or heavyweight sampler startup.
+- Blocking debug queues or unbounded in-memory event buffers.
+
+## Milestones
+
+### Milestone 1: Policy Foundation And Production Defaults
+
+Introduce shared policy parsing and default no-op production behavior in the
+Python productization path.
+
+Acceptance:
+
+- Production-safe modes do not start Apple Silicon telemetry sessions.
+- Production-safe modes do not call `powermetrics`, `tracemalloc`, or any heavy
+  sampler by default.
+- Benchmark and evaluation stores can still be constructed with an explicit
+  evidence collector for compatibility.
+- Existing evidence-mode fixtures continue to produce collected telemetry.
+
+### Milestone 2: Evidence Plane Boundary
+
+Make benchmark, evaluation, comparison reports, and release gates explicitly use
+`evidence` mode.
+
+Acceptance:
+
+- `bench` and `eval` produce valid `run-evidence.json` artifacts in evidence
+  mode.
+- Missing evidence remains a verifier failure for evidence-mode runs.
+- Production serving code does not import evidence-only collectors on the hot
+  path.
+- Report and gate tests prove probe timelines remain available for evidence
+  claims.
+
+### Milestone 3: Debug And Diagnostics Plane
+
+Unify detailed diagnostics under explicit `debug` mode.
+
+Acceptance:
+
+- Swift debug probes such as DFlash JSONL tracing remain opt-in.
+- Serving diagnostics bundles are written only when requested.
+- Debug event queues are bounded; queue overflow drops debug events instead of
+  blocking serving.
+- Debug artifacts do not qualify as public performance claims unless generated
+  through evidence mode.
+
+### Milestone 4: CI Performance Probe Isolation
+
+Keep PR-scoped performance probes out of production packages and runtime import
+paths.
+
+Acceptance:
+
+- `scripts/*_probe.py` and `infra/perf/pr_scoped_probes.json` remain CI/tooling
+  entrypoints.
+- Production packaging excludes synthetic probe commands and fixtures unless a
+  developer tooling bundle explicitly requests them.
+- PR-scoped probes can still be selected from changed files and report metrics.
+- Documentation tells contributors when to add CI probes versus runtime metrics.
+
+### Milestone 5: Measurement, Rollout, And Guardrails
+
+Add regression tests, metrics, and release checks that prevent observability
+cost from leaking back into production.
+
+Acceptance:
+
+- No-op policy overhead is measured with a focused microprobe.
+- Evidence artifact validity is covered by focused tests and report gate checks.
+- Production mode has tests that fail if telemetry threads or heavyweight
+  samplers start.
+- The PR template evidence section records mode, probe overhead, and known
+  deferred observability work.
+
+## Plans And Executable Units
+
+### Plan 1.1: Python ProbePolicy Foundation
+
+Executable units:
+
+- Unit 1.1.1: Add `ProbePolicy` and `ProbeMode` parsing for
+  `MELIX_PROBE_MODE`.
+- Unit 1.1.2: Add a no-op telemetry collector/session/collection.
+- Unit 1.1.3: Wire `BenchmarkStore` and `EvaluationStore` through the policy.
+- Unit 1.1.4: Add focused tests for mode parsing and no-op collector behavior.
+
+### Plan 1.2: Production Default Tests
+
+Executable units:
+
+- Unit 1.2.1: Assert production-safe store defaults do not call the sampler.
+- Unit 1.2.2: Assert evidence fixture collectors still produce collected
+  telemetry.
+- Unit 1.2.3: Add a microprobe for no-op policy overhead.
+
+### Plan 2.1: Benchmark And Evaluation Evidence Entry Points
+
+Executable units:
+
+- Unit 2.1.1: Mark CLI and control-plane benchmark entrypoints as `evidence`.
+- Unit 2.1.2: Mark evaluation and event-extraction entrypoints as `evidence`.
+- Unit 2.1.3: Preserve report verifier failures for missing evidence.
+
+### Plan 2.2: Evidence Report Compatibility
+
+Executable units:
+
+- Unit 2.2.1: Prove `probe_timeline` and `telemetry_summary` stay valid in
+  report generation.
+- Unit 2.2.2: Update docs to distinguish model residency, host telemetry, and
+  production counters.
+- Unit 2.2.3: Keep benchmark/evaluation artifacts readable by desktop evidence
+  views.
+
+### Plan 3.1: Swift Debug Probe Policy
+
+Executable units:
+
+- Unit 3.1.1: Inventory Swift debug probe environment variables and callsites.
+- Unit 3.1.2: Route Swift debug probes through the common mode vocabulary.
+- Unit 3.1.3: Add tests that debug JSONL is opt-in and bounded.
+
+### Plan 3.2: Serving Diagnostics Trace Plane
+
+Executable units:
+
+- Unit 3.2.1: Add bounded trace queue semantics for debug diagnostics.
+- Unit 3.2.2: Keep serving diagnostics bundles separate from evidence claims.
+- Unit 3.2.3: Document operational use of debug versus evidence mode.
+
+### Plan 4.1: CI Probe Registry Governance
+
+Executable units:
+
+- Unit 4.1.1: Document PR-scoped probe ownership and naming rules.
+- Unit 4.1.2: Add a registry validation test for probe commands and watch
+  globs.
+- Unit 4.1.3: Ensure production package manifests exclude synthetic probe
+  scripts.
+
+### Plan 4.2: Contributor Workflow
+
+Executable units:
+
+- Unit 4.2.1: Update contributor guidance for runtime metrics versus CI probes.
+- Unit 4.2.2: Add a checklist item for observability mode and overhead.
+- Unit 4.2.3: Add examples for adding a new PR-scoped performance probe.
+
+### Plan 5.1: Overhead Measurement
+
+Executable units:
+
+- Unit 5.1.1: Add no-op recorder overhead microprobe and thresholds.
+- Unit 5.1.2: Add sampled-mode queue saturation microprobe.
+- Unit 5.1.3: Add evidence-mode artifact validity metrics.
+
+### Plan 5.2: Release Guardrails
+
+Executable units:
+
+- Unit 5.2.1: Add release gate checks for production-safe observability mode.
+- Unit 5.2.2: Add changed-scope coverage requirements for probe policy modules.
+- Unit 5.2.3: Add rollback guidance for disabling optional debug probes.
+
+## Performance Probes And Metrics
+
+- Production no-op overhead: mean wall time for a no-op recorder call across a
+  large synthetic loop; target is within 5 percent of a direct empty function
+  call in the same process.
+- Production sampler isolation: count calls to heavy sampler methods while
+  persisting benchmark/evaluation records in `off` and `minimal`; target is `0`.
+- Evidence validity: `assert_valid_run_evidence_payload` passes for benchmark
+  and evaluation evidence mode.
+- Debug opt-in: detailed JSONL event count is `0` unless `debug` mode or the
+  specific debug environment variable is enabled.
+- CI isolation: PR-scoped probe commands run from `infra/perf/pr_scoped_probes.json`
+  and are not imported by serving hot path modules.
+
+## Acceptance Metrics For Follow-Up Issues
+
+Use these metrics when splitting the policy into Milestone, Plan, or Unit
+issues.
+
+| Metric | Required acceptance |
+|---|---|
+| Production no-op overhead | Default execution with debug and CI probes disabled stays at or below 1 percent elapsed-time regression for the touched path, emits no per-token/per-row debug stream, starts no heavyweight sampler, and allocates no unbounded debug buffer. |
+| Evidence artifact validity | Evidence-mode benchmark/evaluation runs emit parseable JSON/JSONL/CSV artifacts with valid schema versions, linked artifact paths, telemetry or explicit telemetry-failure records, model-memory evidence where applicable, and verifier failures for missing required evidence. |
+| Debug JSONL opt-in | Default execution writes no debug JSONL; explicit `debug` mode or a dedicated opt-in writes only valid newline-delimited JSON objects with schema metadata, bounded attributes, redaction metadata, and no full prompts, responses, credentials, or secrets. |
+| PR-scoped probe isolation | Changed-file selection matches registry `watch_globs`, force-all infrastructure changes select all registered probes, base/head worktrees stay separate, each selected probe uploads one scoped JSON result, and production packages do not import synthetic probe scripts. |
+
+## Initial PR Scope
+
+The first PR for this plan implements Milestone 1 foundation:
+
+- `ProbePolicy` and mode parsing.
+- No-op Apple Silicon telemetry collection for production-safe modes.
+- Store-level wiring for benchmark and evaluation persistence.
+- Focused tests proving no heavy telemetry is started by default and evidence
+  fixtures still work.
+
+Later milestones remain tracked as issues so they can land in smaller,
+reviewable slices without weakening the target architecture.
+
+## Issue Tracking Map
+
+Milestone issues:
+
+| Milestone | Issue |
+|---|---|
+| Milestone 1: Policy Foundation And Production Defaults | #882 |
+| Milestone 2: Evidence Plane Boundary | #883 |
+| Milestone 3: Debug And Diagnostics Plane | #884 |
+| Milestone 4: CI Performance Probe Isolation | #885 |
+| Milestone 5: Measurement, Rollout, And Guardrails | #886 |
+
+Plan issues:
+
+| Plan | Parent Milestone | Issue |
+|---|---:|---:|
+| Plan 1.1: Python ProbePolicy Foundation | #882 | #887 |
+| Plan 1.2: Production Default Tests | #882 | #889 |
+| Plan 2.1: Benchmark And Evaluation Evidence Entry Points | #883 | #888 |
+| Plan 2.2: Evidence Report Compatibility | #883 | #891 |
+| Plan 3.1: Swift Debug Probe Policy | #884 | #890 |
+| Plan 3.2: Serving Diagnostics Trace Plane | #884 | #892 |
+| Plan 4.1: CI Probe Registry Governance | #885 | #893 |
+| Plan 4.2: Contributor Workflow | #885 | #894 |
+| Plan 5.1: Overhead Measurement | #886 | #896 |
+| Plan 5.2: Release Guardrails | #886 | #895 |
+
+Executable unit issues:
+
+| Unit | Parent Plan | Issue |
+|---|---:|---:|
+| Unit 1.1.1: Add `ProbePolicy` and `ProbeMode` parsing | #887 | #898 |
+| Unit 1.1.2: Add no-op telemetry collector/session/collection | #887 | #901 |
+| Unit 1.1.3: Wire stores through policy | #887 | #899 |
+| Unit 1.1.4: Add focused ProbePolicy tests | #887 | #900 |
+| Unit 1.2.1: Assert production-safe store defaults do not call sampler | #889 | #897 |
+| Unit 1.2.2: Assert evidence fixture collectors still produce collected telemetry | #889 | #903 |
+| Unit 1.2.3: Add no-op policy overhead microprobe | #889 | #904 |
+| Unit 2.1.1: Mark benchmark entrypoints as evidence mode | #888 | #905 |
+| Unit 2.1.2: Mark evaluation and event-extraction entrypoints as evidence mode | #888 | #902 |
+| Unit 2.1.3: Preserve report verifier failures for missing evidence | #888 | #906 |
+| Unit 2.2.1: Prove report generation compatibility | #891 | #908 |
+| Unit 2.2.2: Update docs for telemetry distinctions | #891 | #909 |
+| Unit 2.2.3: Keep desktop evidence view compatibility | #891 | #907 |
+| Unit 3.1.1: Inventory Swift debug probes | #890 | #910 |
+| Unit 3.1.2: Route Swift debug probes through common mode vocabulary | #890 | #911 |
+| Unit 3.1.3: Add debug JSONL opt-in tests | #890 | #912 |
+| Unit 3.2.1: Add bounded trace queue semantics | #892 | #915 |
+| Unit 3.2.2: Separate serving diagnostics bundles from evidence claims | #892 | #914 |
+| Unit 3.2.3: Document debug versus evidence mode | #892 | #913 |
+| Unit 4.1.1: Document PR-scoped probe ownership | #893 | #916 |
+| Unit 4.1.2: Add registry validation test | #893 | #917 |
+| Unit 4.1.3: Exclude synthetic probe scripts from production packages | #893 | #918 |
+| Unit 4.2.1: Update contributor guidance | #894 | #919 |
+| Unit 4.2.2: Add checklist item for mode and overhead | #894 | #921 |
+| Unit 4.2.3: Add PR-scoped performance probe examples | #894 | #920 |
+| Unit 5.1.1: Add no-op recorder overhead microprobe | #896 | #924 |
+| Unit 5.1.2: Add sampled-mode queue saturation microprobe | #896 | #922 |
+| Unit 5.1.3: Add evidence-mode artifact validity metrics | #896 | #923 |
+| Unit 5.2.1: Add release gate checks | #895 | #926 |
+| Unit 5.2.2: Add changed-scope coverage requirements | #895 | #925 |
+| Unit 5.2.3: Add rollback guidance | #895 | #927 |
+
+## Verification
+
+Focused initial PR commands:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_probe_policy.py \
+  services/mlx-worker-python/tests/test_benchmark_store.py \
+  services/mlx-worker-python/tests/test_evaluation_store.py \
+  services/mlx-worker-python/tests/test_apple_silicon_telemetry.py
+```
+
+Changed-scope coverage command:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_probe_policy.py \
+  services/mlx-worker-python/tests/test_benchmark_store.py \
+  services/mlx-worker-python/tests/test_evaluation_store.py \
+  services/mlx-worker-python/tests/test_apple_silicon_telemetry.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/productization/probe_policy.py \
+  services/mlx-worker-python/worker/productization/apple_silicon_telemetry.py \
+  services/mlx-worker-python/worker/productization/benchmark_store.py \
+  services/mlx-worker-python/worker/productization/evaluation_store.py \
+  services/mlx-worker-python/tests/test_probe_policy.py \
+  services/mlx-worker-python/tests/test_benchmark_store.py \
+  services/mlx-worker-python/tests/test_evaluation_store.py \
+  services/mlx-worker-python/tests/test_apple_silicon_telemetry.py
+```

--- a/services/mlx-worker-python/tests/test_apple_silicon_telemetry.py
+++ b/services/mlx-worker-python/tests/test_apple_silicon_telemetry.py
@@ -17,6 +17,7 @@ from worker.productization.apple_silicon_telemetry import (
     AppleSiliconTelemetrySample,
     AppleSiliconTelemetryUnsupportedError,
     MacOSAppleSiliconSampler,
+    NoOpAppleSiliconTelemetryCollector,
     summarize_process_attribution,
     summarize_samples,
 )
@@ -121,6 +122,51 @@ def test_collector_writes_apple_silicon_summary_and_time_series(tmp_path: Path) 
         "power_sample",
     ]
     assert {probe.status for probe in collection.probes} == {"completed"}
+
+
+def test_no_op_collector_writes_disabled_summary_without_sampling(tmp_path: Path) -> None:
+    collector = NoOpAppleSiliconTelemetryCollector(reason="probe_mode_minimal")
+
+    collection = collector.collect_completed_run(artifact_root=tmp_path, run_id="bench-1")
+    rows = [
+        json.loads(line)
+        for line in collection.artifact_path.read_text(encoding="utf-8").splitlines()
+    ]
+    summary = collection.summary.to_dict()
+
+    assert collection.artifact_path == tmp_path / "telemetry-samples.jsonl"
+    assert rows == [
+        {
+            "schema_version": "melix.apple_silicon_telemetry_sample.v1",
+            "collector_status": "disabled",
+            "reason": "probe_mode_minimal",
+            "sample_kind": "telemetry_disabled",
+            "timestamp_unix_ms": rows[0]["timestamp_unix_ms"],
+        }
+    ]
+    assert summary["collector_status"] == "disabled"
+    assert summary["time_series_path"] == "telemetry-samples.jsonl"
+    assert summary["sample_count"] == 0
+    assert summary["telemetry_failures"] == ["probe_mode_minimal"]
+    assert [probe.phase for probe in collection.probes] == [
+        "hardware_sample",
+        "process_sample",
+        "power_sample",
+    ]
+    assert {probe.status for probe in collection.probes} == {"skipped"}
+    assert {probe.attributes["reason"] for probe in collection.probes} == {"probe_mode_minimal"}
+
+
+def test_no_op_session_finish_writes_disabled_summary(tmp_path: Path) -> None:
+    session = NoOpAppleSiliconTelemetryCollector(reason="probe_mode_off").start_session(
+        run_id="eval-1"
+    )
+
+    collection = session.finish(artifact_root=tmp_path)
+
+    assert collection.summary.collector_status == "disabled"
+    assert collection.summary.time_series_path == "telemetry-samples.jsonl"
+    assert collection.samples == ()
 
 
 def test_collector_records_failures_without_synthesizing_zero_telemetry(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_benchmark_store.py
+++ b/services/mlx-worker-python/tests/test_benchmark_store.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
+
+import pytest
 
 from worker.productization.benchmark_schemas import (
     build_benchmark_matrix_job,
@@ -11,6 +14,7 @@ from worker.productization.benchmark_schemas import (
     build_serving_benchmark_results,
 )
 from worker.productization.benchmark_store import BenchmarkStore
+from worker.productization.probe_policy import ProbeMode, ProbePolicy
 from telemetry_fixtures import fixture_telemetry_collector
 
 
@@ -128,6 +132,54 @@ def test_persist_serving_benchmark_writes_expected_artifact_names_and_payloads(
         "telemetry_jsonl",
     }
     assert run_record["probes"][0]["phase"] == "run_record_write"
+
+
+def test_persist_serving_benchmark_defaults_to_no_op_telemetry(tmp_path: Path) -> None:
+    store = BenchmarkStore(probe_policy=ProbePolicy(mode=ProbeMode.MINIMAL))
+    jobs_root = tmp_path / "bench"
+    job = build_serving_benchmark_job(
+        job_id="bench-no-op",
+        model_id="melix-dev-text",
+        suites=("smoke",),
+        parameters={},
+        status="completed",
+        output_dir=str(jobs_root),
+    )
+    results = build_serving_benchmark_results(
+        job_id="bench-no-op",
+        metrics={},
+        units={},
+        report_path=str(jobs_root / "bench-report.md"),
+        report_markdown="# Melix Bench\n",
+    )
+
+    persisted = store.persist_serving_benchmark(
+        jobs_root=jobs_root,
+        job=job,
+        results=results,
+    )
+
+    evidence = json.loads(persisted["evidence"].read_text(encoding="utf-8"))
+    assert persisted["telemetry_jsonl"] == jobs_root / "telemetry-samples.jsonl"
+    assert evidence["telemetry_summary"]["collector_status"] == "disabled"
+    assert evidence["telemetry_summary"]["sample_count"] == 0
+    assert evidence["telemetry_summary"]["time_series_path"] == "telemetry-samples.jsonl"
+    telemetry_rows = [
+        json.loads(line)
+        for line in persisted["telemetry_jsonl"].read_text(encoding="utf-8").splitlines()
+    ]
+    assert telemetry_rows[0]["sample_kind"] == "telemetry_disabled"
+    assert telemetry_rows[0]["reason"] == "probe_mode_minimal"
+    telemetry_probes = [
+        probe for probe in evidence["probe_timeline"] if probe["component"] == "telemetry"
+    ]
+    assert {probe["status"] for probe in telemetry_probes} == {"skipped"}
+
+
+def test_benchmark_store_evidence_policy_uses_full_collector() -> None:
+    store = BenchmarkStore(probe_policy=ProbePolicy(mode=ProbeMode.EVIDENCE))
+
+    assert type(store._telemetry_collector).__name__ == "AppleSiliconTelemetryCollector"
 
 
 def test_persist_benchmark_matrix_writes_job_summary_request_and_csv_artifacts(
@@ -348,3 +400,67 @@ def test_persist_benchmark_matrix_preserves_empty_jsonl_artifacts(tmp_path: Path
 
     assert persisted["summary_jsonl"].read_text(encoding="utf-8") == ""
     assert persisted["requests_jsonl"].read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.parametrize("probe_mode", ("off", "minimal", "definitely-not-a-mode", ""))
+def test_persist_serving_benchmark_default_policy_skips_heavy_telemetry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    probe_mode: str,
+) -> None:
+    pytest.importorskip(
+        "worker.productization.probe_policy",
+        reason="probe policy foundation is expected from the main implementation",
+    )
+    monkeypatch.setenv("MELIX_PROBE_MODE", probe_mode)
+
+    def fail_heavy_sample(*args: object, **kwargs: object) -> None:
+        raise AssertionError("production-safe probe policy must not call the heavy telemetry sampler")
+
+    def fail_sleep(*args: object, **kwargs: object) -> None:
+        raise AssertionError("production-safe probe policy must not sleep during persist")
+
+    def fail_thread_start(self: threading.Thread) -> None:
+        raise AssertionError("production-safe probe policy must not start a telemetry thread")
+
+    monkeypatch.setattr(
+        "worker.productization.apple_silicon_telemetry.MacOSAppleSiliconSampler.sample",
+        fail_heavy_sample,
+    )
+    monkeypatch.setattr("worker.productization.apple_silicon_telemetry.time.sleep", fail_sleep)
+    monkeypatch.setattr(threading.Thread, "start", fail_thread_start)
+
+    jobs_root = tmp_path / "bench"
+    job = build_serving_benchmark_job(
+        job_id=f"bench-policy-{probe_mode or 'empty'}",
+        model_id="melix-dev-text",
+        suites=("smoke",),
+        parameters={},
+        status="completed",
+        output_dir=str(jobs_root),
+    )
+    results = build_serving_benchmark_results(
+        job_id=job.job_id,
+        metrics={"bench.smoke.ttft_ms": 24.45},
+        units={"bench.smoke.ttft_ms": "ms"},
+        report_path=str(jobs_root / "bench-report.md"),
+        report_markdown="# Melix Bench\n",
+    )
+
+    persisted = BenchmarkStore().persist_serving_benchmark(
+        jobs_root=jobs_root,
+        job=job,
+        results=results,
+    )
+
+    evidence = json.loads(persisted["evidence"].read_text(encoding="utf-8"))
+    assert evidence["schema_version"] == "melix.run_evidence.v1"
+    assert evidence["run_id"] == job.job_id
+    assert evidence["telemetry_summary"]["collector_status"] == "disabled"
+    assert evidence["telemetry_summary"]["sample_count"] == 0
+    assert persisted["telemetry_jsonl"] == jobs_root / "telemetry-samples.jsonl"
+    telemetry_rows = [
+        json.loads(line)
+        for line in persisted["telemetry_jsonl"].read_text(encoding="utf-8").splitlines()
+    ]
+    assert telemetry_rows[0]["sample_kind"] == "telemetry_disabled"

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -85,6 +85,12 @@ def test_evaluation_failure_stage_disables_score_threshold_when_zero() -> None:
     )
 
 
+def test_evaluation_core_defaults_to_evidence_probe_policy(tmp_path: Path) -> None:
+    runner = EvaluationCore(jobs_root=tmp_path / "runs")
+
+    assert type(runner._store._telemetry_collector).__name__ == "AppleSiliconTelemetryCollector"
+
+
 def test_evaluation_failure_stage_reports_validation_and_positive_threshold_scoring() -> None:
     assert (
         EvaluationCore._evaluation_failure_stage(

--- a/services/mlx-worker-python/tests/test_evaluation_store.py
+++ b/services/mlx-worker-python/tests/test_evaluation_store.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import csv
 import io
 import json
+import threading
 from pathlib import Path
+
+import pytest
 
 from worker.productization.evaluation_schemas import (
     EvaluationCompareTargetLineage,
@@ -20,6 +23,7 @@ from worker.productization.benchmark_export import (
     collect_evaluation_artifacts,
 )
 from worker.productization.evaluation_store import EvaluationStore
+from worker.productization.probe_policy import ProbeMode, ProbePolicy
 from telemetry_fixtures import fixture_telemetry_collector
 
 
@@ -253,6 +257,60 @@ def test_persist_result_writes_expected_artifact_names_and_payloads(tmp_path: Pa
         "sample_render_ms,inference_ms,extraction_ms,validation_ms,scoring_ms,raw_response_chars,extracted_result_chars,failure_stage"
         in export_samples_header
     )
+
+
+def test_persist_result_defaults_to_no_op_telemetry(tmp_path: Path) -> None:
+    store = EvaluationStore(probe_policy=ProbePolicy(mode=ProbeMode.MINIMAL))
+    jobs_root = tmp_path / "evaluation"
+    run_root = jobs_root / "runs" / "eval-no-op"
+    job = build_evaluation_job_record(
+        job_id="eval-no-op",
+        model_id="melix-dev-text",
+        task_kind="text-generation",
+        source_repo="HuggingFaceH4/ultrachat_200k",
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_size=0,
+        scoring_mode="deterministic_accuracy",
+        parameters={},
+        status="completed",
+        output_dir=str(run_root),
+        created_at_unix_ms=101,
+        updated_at_unix_ms=202,
+    )
+    result = build_evaluation_result_record(
+        job_id="eval-no-op",
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_size=0,
+        primary_score_name="normalized_exact_match",
+        primary_score_value=0.0,
+        extraction_success_count=0,
+        validation_success_count=0,
+        scored_sample_count=0,
+        failure_count=0,
+        duration_seconds=0.0,
+        metrics={},
+        report_path=str(run_root / "evaluation-result.json"),
+        units={},
+    )
+
+    persisted = store.persist_result(jobs_root=jobs_root, job=job, result=result)
+
+    evidence = json.loads(persisted["evidence"].read_text(encoding="utf-8"))
+    assert persisted["telemetry_jsonl"] == run_root / "telemetry-samples.jsonl"
+    assert evidence["telemetry_summary"]["collector_status"] == "disabled"
+    assert evidence["telemetry_summary"]["sample_count"] == 0
+    telemetry_probes = [
+        probe for probe in evidence["probe_timeline"] if probe["component"] == "telemetry"
+    ]
+    assert {probe["status"] for probe in telemetry_probes} == {"skipped"}
+
+
+def test_evaluation_store_evidence_policy_uses_full_collector() -> None:
+    store = EvaluationStore(probe_policy=ProbePolicy(mode=ProbeMode.EVIDENCE))
+
+    assert type(store._telemetry_collector).__name__ == "AppleSiliconTelemetryCollector"
 
 
 def test_persist_result_streams_samples_csv_without_calling_samples_csv_builder(
@@ -1174,3 +1232,87 @@ def test_compare_summary_csv_carries_adapter_columns_per_target(tmp_path: Path) 
     assert header.endswith("target_adapter_manifest_path,target_adapter_set_hash")
     assert registered_row.endswith(",,")  # both adapter columns empty
     assert adapter_row.endswith(",/tmp/melix-adapters/bee.adapter.json,beefface12345678")
+
+
+@pytest.mark.parametrize("probe_mode", ("off", "minimal", "definitely-not-a-mode", ""))
+def test_persist_result_default_policy_skips_heavy_telemetry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    probe_mode: str,
+) -> None:
+    pytest.importorskip(
+        "worker.productization.probe_policy",
+        reason="probe policy foundation is expected from the main implementation",
+    )
+    monkeypatch.setenv("MELIX_PROBE_MODE", probe_mode)
+
+    def fail_heavy_sample(*args: object, **kwargs: object) -> None:
+        raise AssertionError("production-safe probe policy must not call the heavy telemetry sampler")
+
+    def fail_sleep(*args: object, **kwargs: object) -> None:
+        raise AssertionError("production-safe probe policy must not sleep during persist")
+
+    def fail_thread_start(self: threading.Thread) -> None:
+        raise AssertionError("production-safe probe policy must not start a telemetry thread")
+
+    monkeypatch.setattr(
+        "worker.productization.apple_silicon_telemetry.MacOSAppleSiliconSampler.sample",
+        fail_heavy_sample,
+    )
+    monkeypatch.setattr("worker.productization.apple_silicon_telemetry.time.sleep", fail_sleep)
+    monkeypatch.setattr(threading.Thread, "start", fail_thread_start)
+
+    jobs_root = tmp_path / "evaluation"
+    run_root = jobs_root / "runs" / f"eval-policy-{probe_mode or 'empty'}"
+    job = build_evaluation_job_record(
+        job_id=f"eval-policy-{probe_mode or 'empty'}",
+        model_id="melix-dev-text",
+        task_kind="text-generation",
+        source_repo="HuggingFaceH4/ultrachat_200k",
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_size=1,
+        scoring_mode="deterministic_accuracy",
+        few_shot=0,
+        seed=7,
+        code_exec_policy="sandboxed",
+        parameters={"dataset_root": str(tmp_path / "datasets" / "mmlu-dev")},
+        status="completed",
+        output_dir=str(run_root),
+        created_at_unix_ms=101,
+        updated_at_unix_ms=202,
+    )
+    result = build_evaluation_result_record(
+        job_id=job.job_id,
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_size=1,
+        primary_score_name="normalized_exact_match",
+        primary_score_value=1.0,
+        extraction_success_count=1,
+        validation_success_count=1,
+        scored_sample_count=1,
+        failure_count=0,
+        duration_seconds=0.25,
+        metrics={"eval.mmlu.accuracy": 1.0},
+        report_path=str(run_root / "evaluation-result.json"),
+        units={"eval.mmlu.accuracy": "ratio"},
+    )
+
+    persisted = EvaluationStore().persist_result(
+        jobs_root=jobs_root,
+        job=job,
+        result=result,
+    )
+
+    evidence = json.loads(persisted["evidence"].read_text(encoding="utf-8"))
+    assert evidence["schema_version"] == "melix.run_evidence.v1"
+    assert evidence["run_id"] == job.job_id
+    assert evidence["telemetry_summary"]["collector_status"] == "disabled"
+    assert evidence["telemetry_summary"]["sample_count"] == 0
+    assert persisted["telemetry_jsonl"] == run_root / "telemetry-samples.jsonl"
+    telemetry_rows = [
+        json.loads(line)
+        for line in persisted["telemetry_jsonl"].read_text(encoding="utf-8").splitlines()
+    ]
+    assert telemetry_rows[0]["sample_kind"] == "telemetry_disabled"

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -4633,6 +4633,33 @@ def test_run_bench_measures_runtime_behavior_from_loaded_backend(tmp_path: Path)
     assert "runtime_stats_model_resident_bytes: 1024" in report
 
 
+def test_bench_events_defaults_to_evidence_probe_policy(tmp_path: Path) -> None:
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=FastBenchmarkBackend()),
+        model_catalog=WorkerModelCatalog(),
+    )
+    loaded = registry.load_model(WorkerModelCatalog.dev_text_model())
+    core = MaintenanceCore(
+        registry,
+        jobs_root=tmp_path / "model-ops",
+        benchmark_suite_catalog=BenchmarkSuiteCatalog(
+            hf_dataset_fetcher=FakeBenchmarkHFDatasetFetcher()
+        ),
+    )
+
+    list(
+        core.bench_events(
+            maintenance_pb2.RunBenchRequest(
+                model_handle=loaded.handle,
+                suites=["smoke"],
+                parameters={"require_live_model": "true"},
+            )
+        )
+    )
+
+    assert type(core._benchmark_store._telemetry_collector).__name__ == "AppleSiliconTelemetryCollector"
+
+
 def test_run_bench_persists_report_without_reading_report_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     registry = WorkerRegistry(
         runtime=MLXTextRuntime(backend=FastBenchmarkBackend()),

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from worker.productization.probe_policy import ProbeMode, ProbePolicy, probe_policy_from_env
+
+
+def test_probe_policy_parses_supported_modes() -> None:
+    assert ProbePolicy.from_value("off").mode == ProbeMode.OFF
+    assert ProbePolicy.from_value("minimal").mode == ProbeMode.MINIMAL
+    assert ProbePolicy.from_value("sampled").mode == ProbeMode.SAMPLED
+    assert ProbePolicy.from_value("evidence").mode == ProbeMode.EVIDENCE
+    assert ProbePolicy.from_value("debug").mode == ProbeMode.DEBUG
+
+
+def test_probe_policy_invalid_env_falls_back_to_production_default() -> None:
+    policy = probe_policy_from_env({"MELIX_PROBE_MODE": "definitely-not-valid"})
+
+    assert policy.mode == ProbeMode.MINIMAL
+    assert policy.source_value == "definitely-not-valid"
+    assert policy.fallback_applied is True
+    assert policy.telemetry_enabled is False
+
+
+def test_probe_policy_empty_env_uses_production_default() -> None:
+    policy = probe_policy_from_env({"MELIX_PROBE_MODE": ""})
+
+    assert policy.mode == ProbeMode.MINIMAL
+    assert policy.source_value == ""
+    assert policy.fallback_applied is False
+    assert policy.telemetry_enabled is False
+
+
+def test_probe_policy_telemetry_enabled_only_for_sampling_modes() -> None:
+    assert ProbePolicy(mode=ProbeMode.OFF).telemetry_enabled is False
+    assert ProbePolicy(mode=ProbeMode.MINIMAL).telemetry_enabled is False
+    assert ProbePolicy(mode=ProbeMode.SAMPLED).telemetry_enabled is True
+    assert ProbePolicy(mode=ProbeMode.EVIDENCE).telemetry_enabled is True
+    assert ProbePolicy(mode=ProbeMode.DEBUG).telemetry_enabled is True

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -2108,17 +2108,19 @@ class EvaluationCore:
     def _sample_probe_means(samples: Any, field_names: tuple[str, ...]) -> dict[str, float]:
         if not field_names:
             return {}
-        totals = {field_name: 0.0 for field_name in field_names}
+        totals = [0.0] * len(field_names)
         sample_count = 0
         for sample in samples:
             sample_count += 1
-            for field_name in field_names:
-                totals[field_name] += float(getattr(sample, field_name, 0.0) or 0.0)
+            for index, field_name in enumerate(field_names):
+                value = getattr(sample, field_name, 0.0)
+                if value:
+                    totals[index] += float(value)
         if sample_count == 0:
             return {field_name: 0.0 for field_name in field_names}
         return {
-            field_name: round(total / sample_count, 4)
-            for field_name, total in totals.items()
+            field_name: round(totals[index] / sample_count, 4)
+            for index, field_name in enumerate(field_names)
         }
 
     @staticmethod

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -75,6 +75,7 @@ from worker.productization.evaluation_schemas import (
     build_evaluation_sample_record,
 )
 from worker.productization.evaluation_store import EvaluationStore
+from worker.productization.probe_policy import ProbePolicy
 
 
 _SUITE_SCORE_MODES = {
@@ -246,7 +247,7 @@ class EvaluationCore:
         registry: Any | None = None,
     ) -> None:
         self._jobs_root = Path(jobs_root).resolve() if jobs_root is not None else None
-        self._store = store or EvaluationStore()
+        self._store = store or EvaluationStore(probe_policy=ProbePolicy.evidence())
         self._queue_store = queue_store or BenchmarkQueueStore()
         self._registry = registry
         self._job_id_lock = threading.Lock()

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -1189,6 +1189,7 @@ class MaintenanceCore:
             build_serving_benchmark_results,
         )
         from worker.productization.benchmark_store import BenchmarkStore
+        from worker.productization.probe_policy import ProbePolicy
 
         suites = list(request.suites) or ["smoke"]
         raw_parameters = getattr(request, "parameters", None)
@@ -1230,7 +1231,7 @@ class MaintenanceCore:
         lazy_model_handle = ""
         loaded_model = None
         if self._benchmark_store is None:
-            self._benchmark_store = BenchmarkStore()
+            self._benchmark_store = BenchmarkStore(probe_policy=ProbePolicy.evidence())
         telemetry_session = self._benchmark_store.start_telemetry_session(run_id=job.job_id)
         try:
             resolved_model = self._resolve_benchmark_loaded_model(request.model_handle)

--- a/services/mlx-worker-python/worker/productization/apple_silicon_telemetry.py
+++ b/services/mlx-worker-python/worker/productization/apple_silicon_telemetry.py
@@ -108,6 +108,48 @@ class AppleSiliconTelemetryCollection:
     artifact_path: Path
 
 
+class NoOpAppleSiliconTelemetryCollector:
+    def __init__(self, *, reason: str = "probe_mode_minimal") -> None:
+        self._reason = reason or "probe_mode_minimal"
+
+    def start_session(self, *, run_id: str) -> NoOpAppleSiliconTelemetrySession:
+        return NoOpAppleSiliconTelemetrySession(run_id=run_id, reason=self._reason)
+
+    def collect_completed_run(
+        self,
+        *,
+        artifact_root: Path,
+        run_id: str,
+        output_token_count: int = 0,
+    ) -> AppleSiliconTelemetryCollection:
+        return _finalize_no_op_collection(
+            artifact_root=artifact_root,
+            run_id=run_id,
+            reason=self._reason,
+        )
+
+
+class NoOpAppleSiliconTelemetrySession:
+    def __init__(self, *, run_id: str, reason: str) -> None:
+        self._run_id = run_id
+        self._reason = reason
+
+    def finish(
+        self,
+        *,
+        artifact_root: Path,
+        output_token_count: int = 0,
+    ) -> AppleSiliconTelemetryCollection:
+        return _finalize_no_op_collection(
+            artifact_root=artifact_root,
+            run_id=self._run_id,
+            reason=self._reason,
+        )
+
+    def cancel(self) -> None:
+        return None
+
+
 class AppleSiliconTelemetryCollector:
     def __init__(
         self,
@@ -509,6 +551,79 @@ def _finalize_collection(
         samples=samples,
         probes=probes,
         artifact_path=artifact_path,
+    )
+
+
+def _finalize_no_op_collection(
+    *,
+    artifact_root: Path,
+    run_id: str,
+    reason: str,
+) -> AppleSiliconTelemetryCollection:
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    artifact_path = artifact_root / "telemetry-samples.jsonl"
+    _write_no_op_jsonl(artifact_path, reason=reason)
+    summary = RunEvidenceTelemetrySummary(
+        collector_status="disabled",
+        telemetry_failures=(reason,),
+        time_series_path=artifact_path.name,
+        sample_count=0,
+        process_attribution=summarize_process_attribution(()),
+    )
+    probes = telemetry_probes_for_disabled(
+        run_id=run_id,
+        summary=summary,
+        reason=reason,
+    )
+    return AppleSiliconTelemetryCollection(
+        summary=summary,
+        samples=(),
+        probes=probes,
+        artifact_path=artifact_path,
+    )
+
+
+def _write_no_op_jsonl(path: Path, *, reason: str) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": APPLE_SILICON_TELEMETRY_SAMPLE_SCHEMA_VERSION,
+                "timestamp_unix_ms": int(time.time() * 1000),
+                "sample_kind": "telemetry_disabled",
+                "collector_status": "disabled",
+                "reason": reason,
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def telemetry_probes_for_disabled(
+    *,
+    run_id: str,
+    summary: RunEvidenceTelemetrySummary,
+    reason: str,
+) -> tuple[RunEvidenceProbe, ...]:
+    started_at = int(time.monotonic() * 1000)
+    attributes = {
+        "collector_status": summary.collector_status,
+        "sample_count": 0,
+        "time_series_path": summary.time_series_path,
+        "reason": reason,
+    }
+    return tuple(
+        _telemetry_probe(
+            run_id=run_id,
+            phase=phase,
+            started_at_monotonic_ms=started_at,
+            duration_ms=0.001,
+            status="skipped",
+            error_code="",
+            attributes=attributes,
+        )
+        for phase in ("hardware_sample", "process_sample", "power_sample")
     )
 
 

--- a/services/mlx-worker-python/worker/productization/benchmark_store.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_store.py
@@ -6,7 +6,10 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
-from worker.productization.apple_silicon_telemetry import AppleSiliconTelemetryCollector
+from worker.productization.apple_silicon_telemetry import (
+    AppleSiliconTelemetryCollector,
+    NoOpAppleSiliconTelemetryCollector,
+)
 from worker.productization.benchmark_export import (
     _canonical_benchmark_matrix_request_columns,
     _canonical_benchmark_matrix_summary_columns,
@@ -19,6 +22,7 @@ from worker.productization.benchmark_schemas import (
     ServingBenchmarkJob,
     ServingBenchmarkResult,
 )
+from worker.productization.probe_policy import ProbePolicy
 from worker.productization.run_evidence import (
     assert_valid_run_evidence_payload,
     build_serving_benchmark_run_evidence,
@@ -33,11 +37,25 @@ from worker.productization.run_records import (
 
 
 class BenchmarkStore:
-    def __init__(self, *, telemetry_collector: Any | None = None) -> None:
-        self._telemetry_collector = telemetry_collector or AppleSiliconTelemetryCollector()
+    def __init__(
+        self,
+        *,
+        telemetry_collector: Any | None = None,
+        probe_policy: ProbePolicy | None = None,
+    ) -> None:
+        self._probe_policy = probe_policy or ProbePolicy.from_env()
+        self._telemetry_collector = telemetry_collector or self._default_telemetry_collector(
+            self._probe_policy
+        )
 
     def start_telemetry_session(self, *, run_id: str):
         return self._telemetry_collector.start_session(run_id=run_id)
+
+    @staticmethod
+    def _default_telemetry_collector(policy: ProbePolicy) -> Any:
+        if policy.telemetry_enabled:
+            return AppleSiliconTelemetryCollector()
+        return NoOpAppleSiliconTelemetryCollector(reason=policy.no_op_reason)
 
     def persist_serving_benchmark(
         self,

--- a/services/mlx-worker-python/worker/productization/evaluation_store.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_store.py
@@ -5,7 +5,10 @@ import json
 from pathlib import Path
 from typing import Any
 
-from worker.productization.apple_silicon_telemetry import AppleSiliconTelemetryCollector
+from worker.productization.apple_silicon_telemetry import (
+    AppleSiliconTelemetryCollector,
+    NoOpAppleSiliconTelemetryCollector,
+)
 from worker.productization.evaluation_reports import build_evaluation_compare_report_markdown
 from worker.productization.evaluation_schemas import (
     EvaluationCompareJob,
@@ -15,6 +18,7 @@ from worker.productization.evaluation_schemas import (
     EvaluationResult,
     EvaluationSample,
 )
+from worker.productization.probe_policy import ProbePolicy
 from worker.productization.run_evidence import (
     assert_valid_run_evidence_payload,
     build_evaluation_run_evidence,
@@ -29,11 +33,25 @@ from worker.productization.run_records import (
 
 
 class EvaluationStore:
-    def __init__(self, *, telemetry_collector: Any | None = None) -> None:
-        self._telemetry_collector = telemetry_collector or AppleSiliconTelemetryCollector()
+    def __init__(
+        self,
+        *,
+        telemetry_collector: Any | None = None,
+        probe_policy: ProbePolicy | None = None,
+    ) -> None:
+        self._probe_policy = probe_policy or ProbePolicy.from_env()
+        self._telemetry_collector = telemetry_collector or self._default_telemetry_collector(
+            self._probe_policy
+        )
 
     def start_telemetry_session(self, *, run_id: str):
         return self._telemetry_collector.start_session(run_id=run_id)
+
+    @staticmethod
+    def _default_telemetry_collector(policy: ProbePolicy) -> Any:
+        if policy.telemetry_enabled:
+            return AppleSiliconTelemetryCollector()
+        return NoOpAppleSiliconTelemetryCollector(reason=policy.no_op_reason)
 
     def persist_result(
         self,

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Mapping
+
+
+MELIX_PROBE_MODE_ENV = "MELIX_PROBE_MODE"
+
+
+class ProbeMode(StrEnum):
+    OFF = "off"
+    MINIMAL = "minimal"
+    SAMPLED = "sampled"
+    EVIDENCE = "evidence"
+    DEBUG = "debug"
+
+
+@dataclass(frozen=True)
+class ProbePolicy:
+    mode: ProbeMode = ProbeMode.MINIMAL
+    source_value: str = ""
+    fallback_applied: bool = False
+
+    @property
+    def telemetry_enabled(self) -> bool:
+        return self.mode in {
+            ProbeMode.SAMPLED,
+            ProbeMode.EVIDENCE,
+            ProbeMode.DEBUG,
+        }
+
+    @property
+    def evidence_enabled(self) -> bool:
+        return self.mode in {
+            ProbeMode.EVIDENCE,
+            ProbeMode.DEBUG,
+        }
+
+    @property
+    def no_op_reason(self) -> str:
+        if self.telemetry_enabled:
+            return ""
+        return f"probe_mode_{self.mode.value}"
+
+    @classmethod
+    def from_env(
+        cls,
+        env: Mapping[str, str] | None = None,
+        *,
+        default_mode: ProbeMode = ProbeMode.MINIMAL,
+    ) -> ProbePolicy:
+        values = os.environ if env is None else env
+        raw_value = values.get(MELIX_PROBE_MODE_ENV, "")
+        return cls.from_value(raw_value, default_mode=default_mode)
+
+    @classmethod
+    def from_value(
+        cls,
+        value: str | ProbeMode | None,
+        *,
+        default_mode: ProbeMode = ProbeMode.MINIMAL,
+    ) -> ProbePolicy:
+        if isinstance(value, ProbeMode):
+            return cls(mode=value, source_value=value.value)
+        raw_value = str(value or "").strip().lower()
+        if not raw_value:
+            return cls(mode=default_mode)
+        try:
+            return cls(mode=ProbeMode(raw_value), source_value=raw_value)
+        except ValueError:
+            return cls(
+                mode=default_mode,
+                source_value=raw_value,
+                fallback_applied=True,
+            )
+
+    @classmethod
+    def evidence(cls) -> ProbePolicy:
+        return cls(mode=ProbeMode.EVIDENCE, source_value=ProbeMode.EVIDENCE.value)
+
+    @classmethod
+    def debug(cls) -> ProbePolicy:
+        return cls(mode=ProbeMode.DEBUG, source_value=ProbeMode.DEBUG.value)
+
+
+def probe_policy_from_env(env: Mapping[str, str] | None = None) -> ProbePolicy:
+    return ProbePolicy.from_env(env)


### PR DESCRIPTION
## Summary
- Add an observability probe policy plan with 5 milestone issues (#882-#886), 10 plan issues (#887-#896), and 30 executable unit issues (#897-#927).
- Add `ProbePolicy` / `ProbeMode` parsing for `MELIX_PROBE_MODE` and default production-safe no-op telemetry for productization stores.
- Keep benchmark and evaluation entrypoints explicitly on evidence mode so `run-evidence.json`, `probe_timeline`, and `telemetry_summary` remain valid for evidence claims.
- Tighten evaluation sample probe aggregation after the PR-scoped performance report flagged it; the rerun now reports `Status: ok` with zero regressions.

## Plan or Spec
- Governing plan: `docs/plans/2026-05-12-observability-probe-policy.md`
- Governing spec: `docs/evidence-telemetry-report-contract.md`
- Issue tree: milestones #882-#886, plan issues #887-#896, unit issues #897-#927.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_apple_silicon_telemetry.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_evaluation_core.py::test_sample_probe_means_aggregate_multiple_fields_in_one_pass services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_core_defaults_to_evidence_probe_policy services/mlx-worker-python/tests/test_maintenance_service.py::test_bench_events_defaults_to_evidence_probe_policy
# 50 passed in 0.91s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_apple_silicon_telemetry.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_evaluation_core.py::test_sample_probe_means_aggregate_multiple_fields_in_one_pass services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_core_defaults_to_evidence_probe_policy services/mlx-worker-python/tests/test_maintenance_service.py::test_bench_events_defaults_to_evidence_probe_policy
# 50 passed in 0.91s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json -o coverage.json
# Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/apple_silicon_telemetry.py services/mlx-worker-python/worker/productization/benchmark_store.py services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_apple_silicon_telemetry.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_maintenance_service.py
# TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_evaluation_sample_probe_aggregation as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
# {"elapsed_ms_mean": 9.782, "metric_count": 7.0, "per_call_ms_mean": 0.000489, "sample_count": 20000.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python -c "import json, statistics, time; from worker.engine.maintenance_core import MaintenanceCore; prompt='alpha beta gamma delta epsilon'; contexts=(2048,8192,32768); elapsed=[]; counts=[]; MaintenanceCore._shape_benchmark_prompt.cache_clear();
for _sample in range(5):
    total=0; start=time.perf_counter()
    for _ in range(120):
        for context_length in contexts:
            shaped=MaintenanceCore._shape_benchmark_prompt(prompt, context_length=context_length); token_count=len(shaped.split());
            assert token_count == context_length; total += token_count
    elapsed.append((time.perf_counter()-start)*1000.0); counts.append(float(total))
print(json.dumps({'elapsed_ms_mean': round(statistics.fmean(elapsed), 6), 'token_count_mean': round(statistics.fmean(counts), 3)}, sort_keys=True))"
# {"elapsed_ms_mean": 74.17345, "token_count_mean": 5160960.0}

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/apple_silicon_telemetry.py services/mlx-worker-python/worker/productization/benchmark_store.py services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_apple_silicon_telemetry.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_maintenance_service.py
# TOTAL 5 0 100%

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% aggregate changed-line coverage for the latest touched Python helper lines; earlier focused productization coverage was 96% before the performance hot-loop patch.
- Production sampler isolation: tests monkeypatch the heavy sampler, sleep, and telemetry thread start to fail if production-safe defaults invoke them; `off`, `minimal`, empty, and invalid `MELIX_PROBE_MODE` all persist valid evidence without heavy telemetry.
- Evidence validity: focused tests verify benchmark/evaluation evidence-mode entrypoints still select the full Apple Silicon collector.
- PR-scoped performance: updated report is `Status: ok`, `Regressions: 0`; evaluation sample aggregation is now an improvement (`22.816 ms` base, `21.407 ms` head, `-6.18%`), and maintenance prompt shape is neutral (`+1.23%`).

## Known Gaps
- This PR implements Milestone 1 foundation only. Follow-up issues #883-#927 track the evidence boundary, Swift debug probe policy, serving diagnostics trace plane, CI probe isolation, measurement probes, and release guardrails.
- Full `make py-test` / integration gates were not run locally for this PR; focused tests, changed-scope coverage, and the PR-scoped performance workflow were run.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
