### PR TITLE
perf: bind M9 release gate evidence loop helpers

### DIFF
--- a/services/mlx-worker-python/worker/productization/release_gates.py
+++ b/services/mlx-worker-python/worker/productization/release_gates.py
@@ -1565,26 +1565,29 @@ def evaluate_m9_release_evidence(
     required_probe_count = 0.0
     missing_probe_count = 0.0
     failed_threshold_count = 0.0
+    report_get = report.get
+    failures_extend = failures.extend
+    evaluate_section = _evaluate_section_metrics_with_counts
 
     for section_name, section_rules in policy.items():
         if not isinstance(section_rules, dict):
             continue
-        required_probe_count += float(len(section_rules))
-        section = report.get(section_name, {})
+        required_probe_count += len(section_rules)
+        section = report_get(section_name)
         metrics = section.get("metrics", {}) if isinstance(section, dict) else {}
-        section_failures, missing_for_section, failed_for_section = _evaluate_section_metrics_with_counts(
+        section_failures, missing_for_section, failed_for_section = evaluate_section(
             metrics,
             section_rules,
             prefix=f"m9.{section_name}.",
         )
-        failures.extend(section_failures)
-        missing_probe_count += float(missing_for_section)
-        failed_threshold_count += float(failed_for_section)
+        failures_extend(section_failures)
+        missing_probe_count += missing_for_section
+        failed_threshold_count += failed_for_section
 
     return failures, {
-        "required_probe_count": required_probe_count,
-        "missing_probe_count": missing_probe_count,
-        "failed_threshold_count": failed_threshold_count,
+        "required_probe_count": float(required_probe_count),
+        "missing_probe_count": float(missing_probe_count),
+        "failed_threshold_count": float(failed_threshold_count),
     }
 
 


### PR DESCRIPTION
## Summary
- Optimizes the M9 release-gate evidence loop by binding hot helpers once before iterating sections.
- Keeps the existing single-pass failure-counting behavior and output schema unchanged.

## Plan or Spec
- Governing spec: `docs/templates/pr-evidence-checklist.md` and the registered PR-scoped probe `release-gates-m9-failure-count-single-pass` in `infra/perf/pr_scoped_probes.json`.
- No behavior or workflow changes; docs/spec updates are not required for this helper-binding-only performance slice.

## Commands Run
```text
# Baseline registered probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/release_gates_m9_failure_count_probe.py
# exit 0; elapsed_ms_mean=6.867836136370897, endswith_checks_mean=0.0, failure_count_mean=12800.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_m9_release_evidence_ignores_non_dict_policy_entries services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_m9_release_evidence_reuses_section_failure_counts services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_section_metrics_counts_failure_types_without_suffix_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_release_gates_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_release_gates_m9_failure_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 6 passed in 0.93s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_m9_release_evidence_ignores_non_dict_policy_entries services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_m9_release_evidence_reuses_section_failure_counts services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_section_metrics_counts_failure_types_without_suffix_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_release_gates_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_release_gates_m9_failure_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/release_gates.py services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/release_gates_m9_failure_count_probe.py
# exit 0; 6 passed in 0.57s; TOTAL 9 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/release_gates_m9_failure_count_probe.py
# exit 0; elapsed_ms_mean=6.248891586437821, endswith_checks_mean=0.0, failure_count_mean=12800.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 9 0 100%` from `scripts/changed_scope_coverage.py`.
- Registered local probe: `release-gates-m9-failure-count-single-pass`.
- Probe delta: old_mean=6.867836 ms, new_mean=6.248892 ms, delta_ms=-0.618945 ms, speedup=1.099x (~9.01% faster).
- Probe counters stayed stable: `endswith_checks_mean=0.0`, `failure_count_mean=12800.0`.
- GitHub Actions PR-scoped performance validation is still required before merge.

## Known Gaps
- None for the Python slice. CI must run the registered PR-scoped probe in the GitHub environment before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
