### PR TITLE
Add CLI server start shortcut

### DIFF
--- a/Sources/MelixCLICore/MelixBatchRun.swift
+++ b/Sources/MelixCLICore/MelixBatchRun.swift
@@ -127,8 +127,8 @@ public struct BatchRunOptions: Equatable, Sendable {
         if benchBatchFactor != 0 { options.insert("--bench-batch-factor") }
         if evalSampleSize != 0 { options.insert("--eval-sample-size") }
         if evalBatchFactor != 0 { options.insert("--eval-batch-factor") }
-        if continueOnFailure != true { options.insert("--continue-on-failure") }
-        if restartStackPerModel != true { options.insert("--restart-stack-per-model") }
+        if continueOnFailure { options.insert("--continue-on-failure") }
+        if restartStackPerModel { options.insert("--restart-stack-per-model") }
         if preflight { options.insert("--preflight") }
         return options
     }

--- a/Sources/MelixCLICore/MelixBatchRun.swift
+++ b/Sources/MelixCLICore/MelixBatchRun.swift
@@ -84,7 +84,53 @@ public struct BatchRunOptions: Equatable, Sendable {
         self.preflight = preflight
         self.dryRun = dryRun
         self.json = json
-        self.explicitOptions = explicitOptions
+        self.explicitOptions = explicitOptions.union(Self.inferredExplicitOptions(
+            startIndex: startIndex,
+            maxModels: maxModels,
+            benchContextLength: benchContextLength,
+            benchGenerationLength: benchGenerationLength,
+            benchBatchSize: benchBatchSize,
+            benchRepeats: benchRepeats,
+            benchSampleSize: benchSampleSize,
+            benchBatchFactor: benchBatchFactor,
+            evalSampleSize: evalSampleSize,
+            evalBatchFactor: evalBatchFactor,
+            continueOnFailure: continueOnFailure,
+            restartStackPerModel: restartStackPerModel,
+            preflight: preflight
+        ))
+    }
+
+    private static func inferredExplicitOptions(
+        startIndex: Int,
+        maxModels: Int,
+        benchContextLength: UInt32,
+        benchGenerationLength: UInt32,
+        benchBatchSize: UInt32,
+        benchRepeats: UInt32,
+        benchSampleSize: UInt32,
+        benchBatchFactor: UInt32,
+        evalSampleSize: UInt32,
+        evalBatchFactor: UInt32,
+        continueOnFailure: Bool,
+        restartStackPerModel: Bool,
+        preflight: Bool
+    ) -> Set<String> {
+        var options: Set<String> = []
+        if startIndex != 1 { options.insert("--start-index") }
+        if maxModels != 0 { options.insert("--max-models") }
+        if benchContextLength != 0 { options.insert("--bench-context-length") }
+        if benchGenerationLength != 0 { options.insert("--bench-generation-length") }
+        if benchBatchSize != 0 { options.insert("--bench-batch-size") }
+        if benchRepeats != 0 { options.insert("--bench-repeats") }
+        if benchSampleSize != 0 { options.insert("--bench-sample-size") }
+        if benchBatchFactor != 0 { options.insert("--bench-batch-factor") }
+        if evalSampleSize != 0 { options.insert("--eval-sample-size") }
+        if evalBatchFactor != 0 { options.insert("--eval-batch-factor") }
+        if continueOnFailure != true { options.insert("--continue-on-failure") }
+        if restartStackPerModel != true { options.insert("--restart-stack-per-model") }
+        if preflight { options.insert("--preflight") }
+        return options
     }
 }
 

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -666,15 +666,33 @@ public struct ServerSnapshotOptions: Equatable, Sendable {
 
 public struct ServerControlOptions: Equatable, Sendable {
     public let serverSessionID: String
+    public let serverTitle: String
+    public let modelID: String
+    public let host: String
+    public let port: Int
+    public let rateLimitPerMinute: Int
+    public let timeoutSeconds: Int
     public let json: Bool
 
     public init(
         serverSessionID: String = ServerSessionRuntimeStore.defaultServerSessionID,
+        serverTitle: String = "",
+        modelID: String = "",
+        host: String = "",
+        port: Int = 0,
+        rateLimitPerMinute: Int = 0,
+        timeoutSeconds: Int = 0,
         json: Bool = false
     ) {
         self.serverSessionID = serverSessionID.isEmpty
             ? ServerSessionRuntimeStore.defaultServerSessionID
             : serverSessionID
+        self.serverTitle = serverTitle
+        self.modelID = modelID
+        self.host = host
+        self.port = port
+        self.rateLimitPerMinute = rateLimitPerMinute
+        self.timeoutSeconds = timeoutSeconds
         self.json = json
     }
 }
@@ -1602,7 +1620,7 @@ public enum MelixCLIParser {
       melix server session update --server-session-id ID [--title TITLE] [--model-id MODEL_ID] [--host HOST] [--port PORT] [--rate-limit-per-minute N] [--timeout-seconds N] [--acceleration-mode MODE] [--draft-model-id MODEL_ID] [--num-draft-tokens N] [--json]
       melix server session remove --server-session-id ID [--json]
       melix server session select --server-session-id ID [--json]
-      melix server start [--server-session-id ID] [--json]
+      melix server start [TITLE] [--model MODEL_ID] [--host HOST] [--port PORT] [--rate-limit-per-minute N] [--timeout-seconds N] [--server-session-id ID] [--json]
       melix server pause [--server-session-id ID] [--json]
       melix server resume [--server-session-id ID] [--json]
       melix server wake [--server-session-id ID] [--json]
@@ -2110,14 +2128,15 @@ public enum MelixCLIParser {
         if action == "session" {
             return try parseServerSession(Array(arguments.dropFirst()))
         }
+        if action == "start" {
+            return try parseServerStart(Array(arguments.dropFirst()))
+        }
         let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse()
         let serverSessionID = values.single["--server-session-id"] ?? ServerSessionRuntimeStore.defaultServerSessionID
         let json = values.flags.contains("--json")
         switch action {
         case "snapshot":
             return .serverSnapshot(.init(json: json))
-        case "start":
-            return .serverStart(.init(serverSessionID: serverSessionID, json: json))
         case "pause":
             return .serverPause(.init(serverSessionID: serverSessionID, json: json))
         case "resume":
@@ -2157,6 +2176,39 @@ public enum MelixCLIParser {
         default:
             throw MelixCLIError.usage(usageText)
         }
+    }
+
+    private static func parseServerStart(_ arguments: [String]) throws -> MelixCLICommand {
+        let serverTitle: String
+        let optionArguments: [String]
+        if let first = arguments.first, first.hasPrefix("--") == false {
+            serverTitle = first
+            optionArguments = Array(arguments.dropFirst())
+        } else {
+            serverTitle = ""
+            optionArguments = arguments
+        }
+        let values = try ArgumentCursor(arguments: optionArguments).parse()
+        let serverSessionID = values.single["--server-session-id"] ?? ServerSessionRuntimeStore.defaultServerSessionID
+        let json = values.flags.contains("--json")
+        return .serverStart(.init(
+            serverSessionID: serverSessionID,
+            serverTitle: serverTitle,
+            modelID: values.single["--model"] ?? values.single["--model-id"] ?? "",
+            host: values.single["--host"] ?? "",
+            port: try parseIntValue(values.single["--port"], option: "--port", defaultValue: 0) ?? 0,
+            rateLimitPerMinute: try parseIntValue(
+                values.single["--rate-limit-per-minute"],
+                option: "--rate-limit-per-minute",
+                defaultValue: 0
+            ) ?? 0,
+            timeoutSeconds: try parseIntValue(
+                values.single["--timeout-seconds"],
+                option: "--timeout-seconds",
+                defaultValue: 0
+            ) ?? 0,
+            json: json
+        ))
     }
 
     private static func parseServerSession(_ arguments: [String]) throws -> MelixCLICommand {
@@ -4839,9 +4891,8 @@ public actor MelixCLIRunner {
         case .serverSessionCreate(let options):
             var createdID = ""
             let state = try mutateOperatorState { current in
-                let nextIndex = current.serverSessions.count + 1
                 let created = MelixOperatorServerSessionState(
-                    id: "server-session-\(nextIndex)",
+                    id: nextGeneratedServerSessionID(in: current.serverSessions),
                     title: options.title,
                     modelID: options.modelID,
                     host: options.host,
@@ -4924,8 +4975,9 @@ public actor MelixCLIRunner {
             }
             return renderServerSessions(state)
         case .serverStart(let options):
-            guard let configuredSession = try configuredServerSessionIfAvailable(id: options.serverSessionID) else {
-                let snapshot = try await client.startServerSession(serverSessionID: options.serverSessionID)
+            let targetServerSessionID = try upsertServerSessionForStartIfNeeded(options)
+            guard let configuredSession = try configuredServerSessionIfAvailable(id: targetServerSessionID) else {
+                let snapshot = try await client.startServerSession(serverSessionID: targetServerSessionID)
                 return try renderServerSnapshot(snapshot, json: options.json)
             }
             let serverSnapshot = try await client.serverSnapshot()
@@ -6262,6 +6314,80 @@ public actor MelixCLIRunner {
         } catch {
             throw error
         }
+    }
+
+    private func upsertServerSessionForStartIfNeeded(_ options: ServerControlOptions) throws -> String {
+        let title = options.serverTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let modelID = options.modelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let host = options.host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasShortcutConfiguration = title.isEmpty == false
+            || modelID.isEmpty == false
+            || host.isEmpty == false
+            || options.port > 0
+            || options.rateLimitPerMinute > 0
+            || options.timeoutSeconds > 0
+        guard hasShortcutConfiguration else {
+            return options.serverSessionID
+        }
+        guard title.isEmpty == false else {
+            throw MelixCLIError.missingRequired("TITLE is required when passing --model, --host, --port, --rate-limit-per-minute, or --timeout-seconds to melix server start.")
+        }
+        guard modelID.isEmpty == false else {
+            throw MelixCLIError.missingRequired("--model is required when starting a titled server session.")
+        }
+
+        var resolvedID = ""
+        let state = try mutateOperatorState { current in
+            if let index = current.serverSessions.firstIndex(where: { $0.id == title || $0.title == title }) {
+                var session = current.serverSessions[index]
+                session.title = title
+                session.modelID = modelID
+                if host.isEmpty == false {
+                    session.host = host
+                }
+                if options.port > 0 {
+                    session.port = options.port
+                }
+                if options.rateLimitPerMinute > 0 {
+                    session.rateLimitPerMinute = options.rateLimitPerMinute
+                }
+                if options.timeoutSeconds > 0 {
+                    session.timeoutSeconds = options.timeoutSeconds
+                }
+                session.updatedAt = Date()
+                current.serverSessions[index] = session
+                current.selectedServerSessionID = session.id
+                resolvedID = session.id
+            } else {
+                let created = MelixOperatorServerSessionState(
+                    id: nextGeneratedServerSessionID(in: current.serverSessions),
+                    title: title,
+                    modelID: modelID,
+                    host: host.isEmpty ? "127.0.0.1" : host,
+                    port: options.port > 0 ? options.port : 8080,
+                    rateLimitPerMinute: options.rateLimitPerMinute > 0 ? options.rateLimitPerMinute : 120,
+                    timeoutSeconds: options.timeoutSeconds > 0 ? options.timeoutSeconds : 120,
+                    lifecycle: .draft
+                )
+                current.serverSessions.append(created)
+                current.selectedServerSessionID = created.id
+                resolvedID = created.id
+            }
+        }
+        guard resolvedID.isEmpty == false,
+              state.serverSessions.contains(where: { $0.id == resolvedID }) else {
+            throw MelixCLIError.runtime("Server session titled \(title) could not be created.")
+        }
+        return resolvedID
+    }
+
+    private func nextGeneratedServerSessionID(in sessions: [MelixOperatorServerSessionState]) -> String {
+        let existingIDs = Set(sessions.map(\.id))
+        var index = 1
+        while existingIDs.contains("server-session-\(index)") {
+            index += 1
+        }
+        return "server-session-\(index)"
     }
 
     private func markServerSessionUnavailable(

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -338,7 +338,16 @@ public enum MelixCLICommandCodec {
             json = options.json
         case .serverStart(let options):
             arguments = ["server", "start"]
-            appendOption("--server-session-id", value: options.serverSessionID, into: &arguments)
+            if options.serverTitle.isEmpty == false {
+                arguments.append(options.serverTitle)
+            } else {
+                appendOption("--server-session-id", value: options.serverSessionID, into: &arguments)
+            }
+            appendOption("--model", value: options.modelID, into: &arguments)
+            appendOption("--host", value: options.host, into: &arguments)
+            appendPositiveInt("--port", value: options.port, into: &arguments)
+            appendPositiveInt("--rate-limit-per-minute", value: options.rateLimitPerMinute, into: &arguments)
+            appendPositiveInt("--timeout-seconds", value: options.timeoutSeconds, into: &arguments)
             json = options.json
         case .serverPause(let options):
             arguments = ["server", "pause"]

--- a/docs/plans/2026-05-12-cli-server-start-shortcut.md
+++ b/docs/plans/2026-05-12-cli-server-start-shortcut.md
@@ -1,0 +1,40 @@
+# CLI Server Start Shortcut
+
+## Goal
+
+Add a one-command local server start path:
+
+```bash
+melix server start "Session Title" --model MODEL_ID --port PORT
+```
+
+The positional value is a human-readable server session title. Newly created
+sessions continue to receive generated identifiers such as `server-session-1`.
+
+## Behavior
+
+- `melix server start` without shortcut arguments keeps the existing runtime
+  start behavior.
+- `melix server start TITLE --model MODEL_ID` creates a titled local server
+  session when no existing session has the same identifier or title.
+- Later shortcut starts reuse an existing session when its identifier or title
+  matches the supplied positional value.
+- Shortcut starts update the bound model and any supplied listener limits before
+  applying gateway configuration and starting the resolved generated session ID.
+- Generated server session IDs use the first available `server-session-N`
+  identifier rather than relying on the current session count.
+
+## Verification
+
+- Parser coverage for the titled positional argument and shortcut flags.
+- Runner coverage for create, reuse, validation errors, and generated ID
+  allocation.
+- Changed-line Swift coverage for the touched CLI scope must remain at or above
+  95 percent.
+
+## Metrics
+
+No runtime performance probe is required. The shortcut composes existing local
+state persistence and server start paths; success metrics are parser stability,
+correct persisted session state, correct target server session ID, and changed
+line coverage.

--- a/docs/runbooks/session-lifecycle.md
+++ b/docs/runbooks/session-lifecycle.md
@@ -107,6 +107,20 @@ swift run melix server wake --json
 swift run melix server start --json
 ```
 
+- To create or rebind a titled local server session and start it in one command, pass the session
+  title plus the model and listener options:
+
+```bash
+swift run melix server start "Gemma 31B" \
+  --model mlx-community/gemma-4-31b-it-4bit \
+  --port 12434 \
+  --json
+```
+
+- The positional value is the session title. New sessions still receive generated identifiers such as
+  `server-session-1`; later shortcut starts reuse an existing session when its identifier or title
+  matches the supplied value.
+
 - If the restart path fails with a `conflict`, wait for in-flight requests to finish and retry.
   The lifecycle smoke harness already applies a short quiescence retry before recording
   `lifecycle.restart_recovery_ms`.

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -679,6 +679,31 @@ struct MelixCLIParserTests {
         #expect(preflightBenchArguments.contains("--allow-memory-risk"))
         #expect(try MelixCLIParser.parse(preflightBenchArguments) == preflightBenchCommand)
 
+        let titledServerStartCommand = MelixCLICommand.serverStart(
+            .init(
+                serverTitle: "Gemma 31B",
+                modelID: "mlx-community/gemma-4-31b-it-4bit",
+                host: "127.0.0.1",
+                port: 12434,
+                rateLimitPerMinute: 60,
+                timeoutSeconds: 240,
+                json: true
+            )
+        )
+        let titledServerStartArguments = try MelixCLICommandCodec.arguments(for: titledServerStartCommand)
+        #expect(titledServerStartArguments == [
+            "server",
+            "start",
+            "Gemma 31B",
+            "--model", "mlx-community/gemma-4-31b-it-4bit",
+            "--host", "127.0.0.1",
+            "--port", "12434",
+            "--rate-limit-per-minute", "60",
+            "--timeout-seconds", "240",
+            "--json",
+        ])
+        #expect(try MelixCLIParser.parse(titledServerStartArguments) == titledServerStartCommand)
+
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -758,6 +783,7 @@ struct MelixCLIParserTests {
             (.serverSessionRemove(.init(serverSessionID: "server-session-1", json: true)), "server.session.remove"),
             (.serverSessionSelect(.init(serverSessionID: "server-session-1", json: true)), "server.session.select"),
             (.serverStart(.init(serverSessionID: "server-session-1", json: true)), "server.start"),
+            (.serverStart(.init(serverTitle: "Gemma 31B", modelID: "mlx-community/gemma-4-31b-it-4bit", host: "127.0.0.1", port: 12434, json: true)), "server.start"),
             (.serverPause(.init(serverSessionID: "server-session-1", json: true)), "server.pause"),
             (.serverResume(.init(serverSessionID: "server-session-1", json: true)), "server.resume"),
             (.serverWake(.init(serverSessionID: "server-session-1", json: true)), "server.wake"),
@@ -1306,6 +1332,17 @@ struct MelixCLIParserTests {
             "--server-session-id", "server-session-2",
             "--json",
         ])
+        let titledStartCommand = try MelixCLIParser.parse([
+            "server",
+            "start",
+            "Gemma 31B",
+            "--model", "mlx-community/gemma-4-31b-it-4bit",
+            "--host", "127.0.0.1",
+            "--port", "12434",
+            "--rate-limit-per-minute", "60",
+            "--timeout-seconds", "240",
+            "--json",
+        ])
         let resumeCommand = try MelixCLIParser.parse([
             "server",
             "resume",
@@ -1326,6 +1363,10 @@ struct MelixCLIParserTests {
             Issue.record("Expected serverStart command")
             return
         }
+        guard case .serverStart(let titledStartOptions) = titledStartCommand else {
+            Issue.record("Expected titled serverStart command")
+            return
+        }
         guard case .serverResume(let resumeOptions) = resumeCommand else {
             Issue.record("Expected serverResume command")
             return
@@ -1341,6 +1382,14 @@ struct MelixCLIParserTests {
 
         #expect(startOptions.serverSessionID == "server-session-2")
         #expect(startOptions.json)
+        #expect(titledStartOptions.serverSessionID == "server-session-1")
+        #expect(titledStartOptions.serverTitle == "Gemma 31B")
+        #expect(titledStartOptions.modelID == "mlx-community/gemma-4-31b-it-4bit")
+        #expect(titledStartOptions.host == "127.0.0.1")
+        #expect(titledStartOptions.port == 12434)
+        #expect(titledStartOptions.rateLimitPerMinute == 60)
+        #expect(titledStartOptions.timeoutSeconds == 240)
+        #expect(titledStartOptions.json)
         #expect(resumeOptions.serverSessionID == "server-session-3")
         #expect(!resumeOptions.json)
         #expect(wakeOptions.serverSessionID == "server-session-4")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -4686,6 +4686,208 @@ struct MelixCLIRunnerTests {
         #expect(servingDefaultsCall.numDraftTokens == 4)
     }
 
+    @Test("server start shortcut creates a titled session and starts the generated id")
+    func serverStartShortcutCreatesTitledSessionAndStartsGeneratedID() async throws {
+        let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: temporaryRoot)
+        }
+
+        let modelID = "mlx-community/gemma-4-31b-it-4bit"
+        let client = StubControlPlaneXPCClient()
+        await client.setServerSnapshot(makeServerSnapshot(models: [
+            makeModelSummary(id: modelID, kind: "text"),
+        ]))
+        let store = MelixOperatorSessionStore(
+            melixHome: MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
+        )
+        let runner = MelixCLIRunner(client: client, operatorSessionStore: store)
+
+        _ = try await runner.run(
+            .serverStart(
+                .init(
+                    serverTitle: "Gemma 31B",
+                    modelID: modelID,
+                    host: "127.0.0.1",
+                    port: 12434,
+                    rateLimitPerMinute: 60,
+                    timeoutSeconds: 240
+                )
+            )
+        )
+
+        let state = try #require(try store.load())
+        let session = try #require(state.serverSessions.first)
+        let gatewayConfigCall = try #require(await client.lastGatewayConfigApplyRequest)
+        let servingDefaultsCall = try #require(await client.lastServingDefaultsApplyRequest)
+        let startedAction = try #require(await client.lastServerAction)
+
+        #expect(state.selectedServerSessionID == "server-session-1")
+        #expect(session.id == "server-session-1")
+        #expect(session.title == "Gemma 31B")
+        #expect(session.modelID == modelID)
+        #expect(session.host == "127.0.0.1")
+        #expect(session.port == 12434)
+        #expect(session.rateLimitPerMinute == 60)
+        #expect(session.timeoutSeconds == 240)
+        #expect(gatewayConfigCall.serverSessionID == "server-session-1")
+        #expect(gatewayConfigCall.servedModelID == modelID)
+        #expect(gatewayConfigCall.port == 12434)
+        #expect(servingDefaultsCall.serverSessionID == "server-session-1")
+        #expect(startedAction == .start("server-session-1"))
+    }
+
+    @Test("server start shortcut reuses an existing titled session")
+    func serverStartShortcutReusesExistingTitledSession() async throws {
+        let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: temporaryRoot)
+        }
+
+        let originalModelID = "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"
+        let updatedModelID = "mlx-community/gemma-4-31b-it-4bit"
+        let client = StubControlPlaneXPCClient()
+        await client.setServerSnapshot(makeServerSnapshot(models: [
+            makeModelSummary(id: originalModelID, kind: "text"),
+            makeModelSummary(id: updatedModelID, kind: "text"),
+        ]))
+        let store = MelixOperatorSessionStore(
+            melixHome: MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
+        )
+        try store.save(
+            MelixOperatorSessionState(
+                selectedSurfaceID: "server",
+                selectedToolSectionID: "modelsLibrary",
+                selectedServerSessionID: "server-session-1",
+                serverSessions: [
+                    .init(
+                        id: "server-session-1",
+                        title: "Qwen Dev",
+                        modelID: originalModelID,
+                        host: "127.0.0.1",
+                        port: 8080
+                    ),
+                ]
+            )
+        )
+
+        _ = try await MelixCLIRunner(client: client, operatorSessionStore: store).run(
+            .serverStart(
+                .init(
+                    serverTitle: "Qwen Dev",
+                    modelID: updatedModelID,
+                    host: "0.0.0.0",
+                    port: 12435,
+                    rateLimitPerMinute: 90,
+                    timeoutSeconds: 300
+                )
+            )
+        )
+
+        let state = try #require(try store.load())
+        let session = try #require(state.serverSessions.first)
+        let gatewayConfigCall = try #require(await client.lastGatewayConfigApplyRequest)
+        let startedAction = try #require(await client.lastServerAction)
+
+        #expect(state.serverSessions.count == 1)
+        #expect(state.selectedServerSessionID == "server-session-1")
+        #expect(session.id == "server-session-1")
+        #expect(session.title == "Qwen Dev")
+        #expect(session.modelID == updatedModelID)
+        #expect(session.host == "0.0.0.0")
+        #expect(session.port == 12435)
+        #expect(session.rateLimitPerMinute == 90)
+        #expect(session.timeoutSeconds == 300)
+        #expect(gatewayConfigCall.serverSessionID == "server-session-1")
+        #expect(gatewayConfigCall.servedModelID == updatedModelID)
+        #expect(gatewayConfigCall.port == 12435)
+        #expect(startedAction == .start("server-session-1"))
+    }
+
+    @Test("server start shortcut allocates the first available generated id")
+    func serverStartShortcutAllocatesFirstAvailableGeneratedID() async throws {
+        let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: temporaryRoot)
+        }
+
+        let modelID = "mlx-community/gemma-4-31b-it-4bit"
+        let client = StubControlPlaneXPCClient()
+        await client.setServerSnapshot(makeServerSnapshot(models: [
+            makeModelSummary(id: modelID, kind: "text"),
+        ]))
+        let store = MelixOperatorSessionStore(
+            melixHome: MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
+        )
+        try store.save(
+            MelixOperatorSessionState(
+                selectedSurfaceID: "server",
+                selectedToolSectionID: "modelsLibrary",
+                selectedServerSessionID: "server-session-3",
+                serverSessions: [
+                    .init(
+                        id: "server-session-1",
+                        title: "Existing One",
+                        modelID: modelID
+                    ),
+                    .init(
+                        id: "server-session-3",
+                        title: "Existing Three",
+                        modelID: modelID
+                    ),
+                ]
+            )
+        )
+
+        _ = try await MelixCLIRunner(client: client, operatorSessionStore: store).run(
+            .serverStart(
+                .init(
+                    serverTitle: "Gemma 31B",
+                    modelID: modelID,
+                    port: 12434
+                )
+            )
+        )
+
+        let state = try #require(try store.load())
+        let created = try #require(state.serverSessions.first(where: { $0.title == "Gemma 31B" }))
+        let startedAction = try #require(await client.lastServerAction)
+
+        #expect(created.id == "server-session-2")
+        #expect(state.selectedServerSessionID == "server-session-2")
+        #expect(startedAction == .start("server-session-2"))
+    }
+
+    @Test("server start shortcut requires title and model arguments")
+    func serverStartShortcutRequiresTitleAndModelArguments() async throws {
+        let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: temporaryRoot)
+        }
+
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            operatorSessionStore: MelixOperatorSessionStore(
+                melixHome: MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
+            )
+        )
+
+        await #expect(throws: MelixCLIError.missingRequired("TITLE is required when passing --model, --host, --port, --rate-limit-per-minute, or --timeout-seconds to melix server start.")) {
+            _ = try await runner.run(.serverStart(.init(modelID: "mlx-community/gemma-4-31b-it-4bit")))
+        }
+        await #expect(throws: MelixCLIError.missingRequired("--model is required when starting a titled server session.")) {
+            _ = try await runner.run(.serverStart(.init(serverTitle: "Gemma 31B")))
+        }
+    }
+
     @Test("server start falls back to model info when the snapshot omits an imported model")
     func serverStartFallsBackToModelInfoWhenSnapshotOmitsImportedModel() async throws {
         let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())


### PR DESCRIPTION
## Summary
- Add `melix server start TITLE --model MODEL_ID` as a one-command shortcut for creating or rebinding a titled local server session and starting the resolved generated session ID.
- Reuse matching sessions by ID or title, update supplied gateway settings, and allocate the first available `server-session-N` ID for new sessions.
- Document the shortcut semantics and preserve batch dry-run direct-construction precedence with focused tests.

## Plan or Spec
- `docs/plans/2026-05-12-cli-server-start-shortcut.md`
- `docs/runbooks/session-lifecycle.md`

## Commands Run
```text
git diff --check origin/main...HEAD: pass
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" xcrun swift test --skip-update --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests' -Xswiftc -F -Xswiftc /Library/Developer/CommandLineTools/Library/Developer/Frameworks -Xswiftc -I -Xswiftc /Library/Developer/CommandLineTools/Library/Developer/Frameworks/Testing.framework/Versions/A/Modules -Xlinker -F -Xlinker /Library/Developer/CommandLineTools/Library/Developer/Frameworks -Xlinker -framework -Xlinker Testing -Xlinker -rpath -Xlinker /Library/Developer/CommandLineTools/Library/Developer/Frameworks -Xlinker -rpath -Xlinker /Library/Developer/CommandLineTools/Library/Developer/usr/lib: pass, 261 tests
/Users/chenyu/.local/bin/python3.11 scripts/swift_changed_line_coverage.py --diff-from origin/main --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata Sources/MelixCLICore/MelixBatchRun.swift Sources/MelixCLICore/MelixCLI.swift Sources/MelixCLICore/MelixCLICommandCodec.swift tests/MelixCLITests/MelixCLIParserTests.swift tests/MelixCLITests/MelixCLIRunnerTests.swift: pass, TOTAL 99.25% (399/402)
```

## Coverage and Metrics
- Changed-line Swift coverage: 99.25% (399/402) across the touched CLI source and test scope.
- Runtime metrics: N/A. This is a CLI ergonomics shortcut that composes existing local state persistence and server start paths; success metrics are parser stability, persisted session state, target session ID correctness, and changed-line coverage.

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally; this PR was verified with the focused Swift CLI parser/runner suite because the touched behavior is confined to CLI state parsing/running and docs.
- Protocol and dependency artifacts are unchanged.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
