### PR TITLE
perf: bind pr-scoped registry parser helpers

### DIFF
--- a/docs/plans/2026-05-12-pr-scoped-registry-parse-bindings.md
+++ b/docs/plans/2026-05-12-pr-scoped-registry-parse-bindings.md
@@ -1,0 +1,23 @@
+# PR-scoped registry parse binding slice
+
+## Scope
+
+This slice is a Python-only performance optimization for the PR-scoped performance registry parser in `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`.
+
+The parser is on the registered PR-scoped performance path because CI reloads `infra/perf/pr_scoped_probes.json` while selecting and running probe jobs. The change must keep registry semantics unchanged and only reduce repeated global lookups during registry materialization.
+
+## Registered probe
+
+The affected path is covered by `infra/perf/pr_scoped_probes.json` probe `pr-scoped-performance-registry-cache`, which defines focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Verification plan
+
+Run the focused registry-cache tests, changed-scope coverage for the touched files, and the registered local probe on Linux before pushing. The GitHub PR-scoped performance workflow remains the merge gate for the registered probe report.
+
+## Success metric
+
+Accept the slice only if the registered probe shows directionally lower `cold_load_probe_registry_ms_mean` or `build_scope_report_ms_mean` without regressing correctness tests or changed-scope coverage.

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -120,6 +120,12 @@ def _parse_probe_registry_payload(payload: object) -> tuple[ProbeDefinition, ...
     if not isinstance(payload, list):
         raise ValueError("probe registry must be a JSON list")
     probes: list[ProbeDefinition] = []
+    append_probe = probes.append
+    metric_definition = MetricDefinition
+    probe_definition = ProbeDefinition
+    str_value = str
+    float_value = float
+    bool_value = bool
     for raw_probe in payload:
         if not isinstance(raw_probe, dict):
             raise ValueError("probe registry entries must be JSON objects")
@@ -127,27 +133,27 @@ def _parse_probe_registry_payload(payload: object) -> tuple[ProbeDefinition, ...
         if not isinstance(raw_metrics, list) or not raw_metrics:
             raise ValueError("probe registry metrics must be a non-empty list")
         metrics = tuple(
-            MetricDefinition(
-                key=str(raw_metric["key"]),
-                unit=str(raw_metric.get("unit", "value")),
-                direction=str(raw_metric["direction"]),
-                warn_pct=float(raw_metric.get("warn_pct", 5.0)),
+            metric_definition(
+                key=str_value(raw_metric["key"]),
+                unit=str_value(raw_metric.get("unit", "value")),
+                direction=str_value(raw_metric["direction"]),
+                warn_pct=float_value(raw_metric.get("warn_pct", 5.0)),
             )
             for raw_metric in raw_metrics
             if isinstance(raw_metric, dict)
         )
-        probes.append(
-            ProbeDefinition(
-                probe_id=str(raw_probe["id"]),
-                name=str(raw_probe["name"]),
-                runner=str(raw_probe.get("runner", "ubuntu-latest")),
-                watch_globs=tuple(str(glob) for glob in raw_probe.get("watch_globs", [])),
-                test_command=str(raw_probe.get("test_command", "")).strip(),
-                coverage_command=str(raw_probe.get("coverage_command", "")).strip(),
-                probe_impl=str(raw_probe["probe_impl"]),
-                probe_command=str(raw_probe.get("probe_command", "")).strip(),
+        append_probe(
+            probe_definition(
+                probe_id=str_value(raw_probe["id"]),
+                name=str_value(raw_probe["name"]),
+                runner=str_value(raw_probe.get("runner", "ubuntu-latest")),
+                watch_globs=tuple(str_value(glob) for glob in raw_probe.get("watch_globs", [])),
+                test_command=str_value(raw_probe.get("test_command", "")).strip(),
+                coverage_command=str_value(raw_probe.get("coverage_command", "")).strip(),
+                probe_impl=str_value(raw_probe["probe_impl"]),
+                probe_command=str_value(raw_probe.get("probe_command", "")).strip(),
                 metrics=metrics,
-                coverage_replays_tests=bool(raw_probe.get("coverage_replays_tests", False)),
+                coverage_replays_tests=bool_value(raw_probe.get("coverage_replays_tests", False)),
             )
         )
     return tuple(probes)


### PR DESCRIPTION
## Summary
- Bind the PR-scoped performance registry parser's hot helpers (`append`, dataclass constructors, and primitive coercions) once per registry parse.
- Keep registry semantics unchanged while reducing repeated global lookups during cold registry materialization.

## Plan or Spec
- `docs/plans/2026-05-12-pr-scoped-registry-parse-bindings.md`

## Commands Run
```text
# Baseline local registered probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
import json
from pathlib import Path
from worker.productization.pr_scoped_performance import _probe_pr_scoped_performance_registry_cache as probe
print(json.dumps(probe(Path.cwd()), sort_keys=True))
PY
# exit 0; baseline sample: load=7.257990 ms, cold_load=162.772133 ms, build_scope=8.899001 ms

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_uses_absolute_cache_key_without_resolving services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_build_scope_report_reuses_scope_cached_registry_without_double_stat services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_refreshes_cache_when_file_changes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_registry_cache_probe
# exit 0; 7 passed in 1.19s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_uses_absolute_cache_key_without_resolving services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_build_scope_report_reuses_scope_cached_registry_without_double_stat services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_refreshes_cache_when_file_changes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_registry_cache_probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; TOTAL 7 0 100%

# Local registered probe, base origin/main vs head
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id pr-scoped-performance-registry-cache --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-pr-scope-registry-20260512115055 --head-repo "$PWD" --output /tmp/pr_scope_registry_probe.json
# exit 0; head verification ok; base/head probes ok

# Diff hygiene
git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%` for `services/mlx-worker-python/worker/productization/pr_scoped_performance.py` and `services/mlx-worker-python/tests/test_pr_scoped_performance.py`.
- Registered local probe `pr-scoped-performance-registry-cache` (base `origin/main` at `c986211f`, head `8319a244`):
  - `load_probe_registry_ms_mean`: 6.801222 -> 6.717338 ms (delta -0.083884 ms, -1.23%, 1.012x)
  - `cold_load_probe_registry_ms_mean`: 165.745896 -> 143.784787 ms (delta -21.961109 ms, -13.25%, 1.153x)
  - `build_scope_report_ms_mean`: 8.814103 -> 8.752615 ms (delta -0.061488 ms, -0.70%, 1.007x)
- CI PR-scoped performance workflow is still required as the merge gate for the registered probe report.

## Known Gaps
- Local verification was Linux-only. This slice is Python tooling only and has no Swift runtime effect.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
