### PR TITLE
Complete Apple Silicon memory fit estimates

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -32,6 +32,8 @@ public struct LoraTrainOptions: Equatable, Sendable {
     public let targetRepo: String
     public let trainingMode: String
     public let parameters: [String: String]
+    public let preflightFitCheck: Bool
+    public let allowMemoryRisk: Bool
     public let json: Bool
 
     public init(
@@ -42,6 +44,8 @@ public struct LoraTrainOptions: Equatable, Sendable {
         targetRepo: String = "",
         trainingMode: String = "",
         parameters: [String: String] = [:],
+        preflightFitCheck: Bool = false,
+        allowMemoryRisk: Bool = false,
         json: Bool = false
     ) {
         self.modelID = modelID
@@ -51,6 +55,8 @@ public struct LoraTrainOptions: Equatable, Sendable {
         self.targetRepo = targetRepo
         self.trainingMode = trainingMode
         self.parameters = parameters
+        self.preflightFitCheck = preflightFitCheck
+        self.allowMemoryRisk = allowMemoryRisk
         self.json = json
     }
 }
@@ -287,10 +293,19 @@ public struct LoraResumeOptions: Equatable, Sendable {
 
 public struct EstimateImportOptions: Equatable, Sendable {
     public let repoID: String
+    public let targetKind: String
+    public let targetInputs: [String: String]
     public let json: Bool
 
-    public init(repoID: String, json: Bool = false) {
+    public init(
+        repoID: String,
+        targetKind: String = "import",
+        targetInputs: [String: String] = [:],
+        json: Bool = false
+    ) {
         self.repoID = repoID
+        self.targetKind = targetKind
+        self.targetInputs = targetInputs
         self.json = json
     }
 }
@@ -455,6 +470,8 @@ public struct EvalRunOptions: Equatable, Sendable {
     public let semanticJudgeRemoteServerID: String
     public let semanticJudgeModelID: String
     public let remoteParallelism: UInt32
+    public let preflightFitCheck: Bool
+    public let allowMemoryRisk: Bool
     public let json: Bool
 
     public init(
@@ -475,6 +492,8 @@ public struct EvalRunOptions: Equatable, Sendable {
         semanticJudgeRemoteServerID: String = "",
         semanticJudgeModelID: String = "",
         remoteParallelism: UInt32 = 0,
+        preflightFitCheck: Bool = false,
+        allowMemoryRisk: Bool = false,
         json: Bool = false
     ) {
         let normalizedRemoteTargets = remoteTargets
@@ -512,6 +531,8 @@ public struct EvalRunOptions: Equatable, Sendable {
         self.semanticJudgeRemoteServerID = semanticJudgeRemoteServerID.trimmingCharacters(in: .whitespacesAndNewlines)
         self.semanticJudgeModelID = semanticJudgeModelID.trimmingCharacters(in: .whitespacesAndNewlines)
         self.remoteParallelism = remoteParallelism
+        self.preflightFitCheck = preflightFitCheck
+        self.allowMemoryRisk = allowMemoryRisk
         self.json = json
     }
 }
@@ -1576,6 +1597,12 @@ public enum MelixCLIParser {
       melix debug bundle RUN_OR_JOB_ID [--from PATH] [--output PATH] [--json]
       melix estimate import HF_REPO [--json]
       melix estimate import --repo-id HF_REPO [--json]
+      melix estimate benchmark HF_REPO [--context-length N] [--batch-size N] [--json]
+      melix estimate benchmark --repo-id HF_REPO [--context-length N] [--batch-size N] [--json]
+      melix estimate eval HF_REPO [--context TEXT] [--context-length N] [--dataset URI] [--sample-size N] [--json]
+      melix estimate eval --repo-id HF_REPO [--context TEXT] [--context-length N] [--dataset URI] [--sample-size N] [--json]
+      melix estimate train HF_REPO [--dataset URI] [--lora NAME_OR_PATH] [--batch-size N] [--json]
+      melix estimate train --model HF_REPO [--dataset URI] [--lora NAME_OR_PATH] [--batch-size N] [--json]
       melix convert --model-id MODEL_ID [--output-dir PATH] [--target-format FORMAT] [--json]
       melix quantize --model-id MODEL_ID [--output-dir PATH] [--quant-profile-id ID] [--weight-quant MODE] [--kv-quant MODE] [--quantization-mode (ptq|qat)] [--source-artifact-kind (base_model|merged_adapter|adapter_export)] [--source-artifact-path PATH] [--quantization-backend (manifest_only|mlx_lm_convert)] [--mlx-lm-q-bits N] [--mlx-lm-q-group-size N] [--mlx-lm-q-mode (affine|mxfp4|nvfp4|mxfp8)] [--calibration-dataset-uri PATH] [--quality-delta N] [--latency-delta N] [--local-inference-smoke-mode (structural|runtime_generate)] [--local-inference-smoke-prompt TEXT] [--json]
       melix upload --model-id MODEL_ID --target-repo REPO [--output-dir PATH] [--artifact-path PATH] [--artifact-kind KIND] [--artifact-manifest-path PATH] [--publish-backend BACKEND] [--local-publish-root PATH] [--json]
@@ -1615,7 +1642,7 @@ public enum MelixCLIParser {
       melix remote-server test --remote-server-id ID [--model MODEL] [--json]
       melix chat run (--model-id MODEL_ID | --remote-server-id ID --model MODEL) --message TEXT [--system TEXT] [--server-session-id ID] [--json]
       melix lora list [--model-id MODEL_ID] [--json]
-      melix lora train --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) --adapter-name NAME [--target-repo REPO] [--training-mode (lora|qlora|dora)] [--preset PRESET] [--experiment-group GROUP] [--rank N] [--alpha N] [--dropout N] [--target-modules CSV] [--num-layers N] [--batch-size N] [--epochs N] [--max-steps N] [--learning-rate N] [--max-seq-length N] [--sample-limit N] [--gradient-accumulation N] [--resume-adapter PATH | --resume-from-manifest PATH] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-train-split SPLIT] [--hf-valid-split SPLIT] [--text-feature NAME] [--prompt-feature NAME] [--completion-feature NAME] [--chat-feature NAME] [--derived-model-alias NAME] [--response-only] [--mask-prompt] [--gradient-checkpointing] [--json]
+      melix lora train --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) --adapter-name NAME [--target-repo REPO] [--training-mode (lora|qlora|dora)] [--preset PRESET] [--experiment-group GROUP] [--rank N] [--alpha N] [--dropout N] [--target-modules CSV] [--num-layers N] [--batch-size N] [--epochs N] [--max-steps N] [--learning-rate N] [--max-seq-length N] [--sample-limit N] [--gradient-accumulation N] [--resume-adapter PATH | --resume-from-manifest PATH] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-train-split SPLIT] [--hf-valid-split SPLIT] [--text-feature NAME] [--prompt-feature NAME] [--completion-feature NAME] [--chat-feature NAME] [--derived-model-alias NAME] [--response-only] [--mask-prompt] [--gradient-checkpointing] [--preflight-fit-check] [--allow-memory-risk] [--json]
       melix alignment train --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) --adapter-name NAME --algorithm dpo|orpo|cpo|grpo|rlhf [--target-repo REPO] [--source-adapter-path PATH] [--grpo-candidate-count N] [--candidate-generation-mode scored_trace|runtime_generate] [--candidate-scoring-mode dataset_score|seed_overlap_proxy|reward_model] [--candidate-generation-max-tokens N] [--reference-model-path PATH] [--reward-model-manifest-path PATH] [--kl-penalty N] [--preset PRESET] [--experiment-group GROUP] [--rank N] [--alpha N] [--dropout N] [--target-modules CSV] [--num-layers N] [--batch-size N] [--epochs N] [--max-steps N] [--learning-rate N] [--max-seq-length N] [--sample-limit N] [--gradient-accumulation N] [--json]
         note: --source-adapter-path is the upstream/base LoRA adapter to carry into GRPO/RLHF output; it is not checkpoint resumption.
       melix lora dataset inspect --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) [--template TEMPLATE] [--dataset-id ID] [--validation-ratio N] [--sample-limit N] [--preview-count N] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-train-split SPLIT] [--hf-valid-split SPLIT] [--text-feature NAME] [--prompt-feature NAME] [--completion-feature NAME] [--chat-feature NAME] [--json]
@@ -1636,7 +1663,7 @@ public enum MelixCLIParser {
       melix bench matrix list [--json]
       melix bench matrix export-summary-csv --job-id JOB_ID --output PATH [--json]
       melix bench matrix export-requests-csv --job-id JOB_ID --output PATH [--json]
-      melix eval run (--model-id MODEL_ID | --repo-id HF_REPO | --remote-server-id ID [--remote-model MODEL] ...) [--semantic-judge-remote-server-id ID] [--semantic-judge-model MODEL] [--remote-parallelism N] [--suite SUITE ...] [--dataset-id DATASET_ID] [--dataset-root PATH] [--source-csv PATH | --source-jsonl PATH | --hf-dataset-path REPO | --dataset-ref HF_DATASET[@REV]] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-dataset-split SPLIT] [--field-system-path PATH] [--field-input-text-path PATH] [--field-target-path PATH] [--field-sample-id-path PATH] [--profile-type TYPE] [--result-kind KIND] [--extraction-mode MODE] [--scoring-mode MODE] [--threshold N] [--schema PATH | --output-schema-json JSON] [--hints PATH] [--ignored-path PATH ...] [--sample-size N] [--batch-factor N] [--seed N] [--few-shot N] [--code-exec-policy MODE] [--remote-extra-body-json JSON] [--eval-prompt-id ID] [--eval-prompt-revision REV] [--json]
+      melix eval run (--model-id MODEL_ID | --repo-id HF_REPO | --remote-server-id ID [--remote-model MODEL] ...) [--semantic-judge-remote-server-id ID] [--semantic-judge-model MODEL] [--remote-parallelism N] [--suite SUITE ...] [--dataset-id DATASET_ID] [--dataset-root PATH] [--source-csv PATH | --source-jsonl PATH | --hf-dataset-path REPO | --dataset-ref HF_DATASET[@REV]] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-dataset-split SPLIT] [--field-system-path PATH] [--field-input-text-path PATH] [--field-target-path PATH] [--field-sample-id-path PATH] [--profile-type TYPE] [--result-kind KIND] [--extraction-mode MODE] [--scoring-mode MODE] [--threshold N] [--schema PATH | --output-schema-json JSON] [--hints PATH] [--ignored-path PATH ...] [--sample-size N] [--batch-factor N] [--seed N] [--few-shot N] [--code-exec-policy MODE] [--remote-extra-body-json JSON] [--eval-prompt-id ID] [--eval-prompt-revision REV] [--preflight-fit-check] [--allow-memory-risk] [--json]
       melix eval prompt list [--json]
       melix eval prompt show --prompt-id ID [--revision-id REV] [--json]
       melix eval prompt create --prompt-id ID --title TITLE --system-prompt-file PATH [--json]
@@ -1774,7 +1801,7 @@ public enum MelixCLIParser {
             throw MelixCLIError.usage(Self.usageText)
         }
         switch action {
-        case "import":
+        case "import", "benchmark", "eval", "train":
             var optionArguments = Array(arguments.dropFirst())
             var repoID = ""
             if let positionalRepoID = optionArguments.first, positionalRepoID.hasPrefix("--") == false {
@@ -1784,18 +1811,50 @@ public enum MelixCLIParser {
             let values = try ArgumentCursor(arguments: optionArguments).parse()
             if let optionRepoID = values.single["--repo-id"], optionRepoID.isEmpty == false {
                 if repoID.isEmpty == false, repoID != optionRepoID {
-                    throw MelixCLIError.usage("melix estimate import accepts only one Hugging Face repo id.")
+                    throw MelixCLIError.usage("melix estimate \(action) accepts only one Hugging Face repo id.")
                 }
                 repoID = optionRepoID
             }
+            if let modelRepoID = values.single["--model"], modelRepoID.isEmpty == false {
+                if repoID.isEmpty == false, repoID != modelRepoID {
+                    throw MelixCLIError.usage("melix estimate \(action) accepts only one Hugging Face repo id.")
+                }
+                repoID = modelRepoID
+            }
             repoID = repoID.trimmingCharacters(in: .whitespacesAndNewlines)
             guard repoID.isEmpty == false else {
-                throw MelixCLIError.missingRequired("HF_REPO or --repo-id is required for melix estimate import.")
+                throw MelixCLIError.missingRequired("HF_REPO or --repo-id is required for melix estimate \(action).")
             }
-            return .estimateImport(.init(repoID: repoID, json: values.flags.contains("--json")))
+            return .estimateImport(.init(
+                repoID: repoID,
+                targetKind: normalizedEstimateTargetKind(action),
+                targetInputs: estimateTargetInputs(values),
+                json: values.flags.contains("--json")
+            ))
         default:
             throw MelixCLIError.usage(Self.usageText)
         }
+    }
+
+    private static func normalizedEstimateTargetKind(_ action: String) -> String {
+        action == "benchmark" ? "benchmark" : action
+    }
+
+    private static func estimateTargetInputs(_ values: ParsedArguments) -> [String: String] {
+        var inputs: [String: String] = [:]
+        for option in [
+            "--context",
+            "--context-length",
+            "--dataset",
+            "--lora",
+            "--batch-size",
+            "--sample-size",
+        ] {
+            if let value = values.single[option], value.isEmpty == false {
+                inputs[normalizedParameterKey(option)] = value
+            }
+        }
+        return inputs
     }
 
     private static func parseConvert(_ arguments: [String]) throws -> MelixCLICommand {
@@ -2680,6 +2739,8 @@ public enum MelixCLIParser {
                     targetRepo: values.single["--target-repo"] ?? "",
                     trainingMode: trainingMode,
                     parameters: parameters,
+                    preflightFitCheck: values.flags.contains("--preflight-fit-check"),
+                    allowMemoryRisk: values.flags.contains("--allow-memory-risk"),
                     json: values.flags.contains("--json")
                 )
             )
@@ -3236,6 +3297,8 @@ public enum MelixCLIParser {
                     semanticJudgeRemoteServerID: semanticJudgeRemoteServerID,
                     semanticJudgeModelID: semanticJudgeModelID,
                     remoteParallelism: UInt32(values.single["--remote-parallelism"] ?? "") ?? 0,
+                    preflightFitCheck: values.flags.contains("--preflight-fit-check"),
+                    allowMemoryRisk: values.flags.contains("--allow-memory-risk"),
                     json: values.flags.contains("--json")
                 )
             )
@@ -4068,6 +4131,7 @@ public actor MelixCLIRunner {
     private static let defaultSpeculativeNumDraftTokens = 4
     private static let memoryFitSafetyThresholdFraction = 0.60
     private static let memoryFitSchemaVersion = "melix.memory_fit_receipt.v1"
+    private static let diskFitSafetyMultiplier = 1.10
 
     private let client: any ControlPlaneXPCClient
     private let operatorSessionStore: any MelixOperatorSessionStoring
@@ -4165,7 +4229,8 @@ public actor MelixCLIRunner {
 
     private func makeMemoryFitReceipt(
         repoID: String,
-        targetKind: String
+        targetKind: String,
+        targetInputs: [String: String] = [:]
     ) async throws -> MemoryFitReceipt {
         let hubCardStart = DispatchTime.now()
         let card = try await getHubModelCard(repoID: repoID)
@@ -4178,13 +4243,13 @@ public actor MelixCLIRunner {
         let totalUnifiedMemoryBytes = ProcessInfo.processInfo.physicalMemory
         let safetyThresholdFraction = Self.memoryFitSafetyThresholdFraction
         let safetyThresholdBytes = UInt64(Double(totalUnifiedMemoryBytes) * safetyThresholdFraction)
-        let unknownFields = memoryFitUnknownFields(card)
-        let assumptions = [
-            "ProcessInfo.physicalMemory is treated as Apple Silicon total unified memory.",
-            "estimated_active_memory_bytes reuses Hub estimated_resident_bytes.",
-            "estimated_disk_usage_bytes reuses Hub estimated_artifact_bytes.",
-            "fit_status and recommended_action reuse the model-ops Hub local-fit policy.",
-        ]
+        let availableDiskBytes = availableDiskCapacityBytes(near: MelixHome(environment: environment).managedModelRootURL)
+        let diskFitStatus = memoryFitDiskStatus(
+            estimatedDiskUsageBytes: card.estimatedArtifactBytes,
+            availableDiskBytes: availableDiskBytes
+        )
+        let unknownFields = orderedUnique(memoryFitUnknownFields(card) + memoryFitRunUnknownFields(for: targetKind))
+        let assumptions = memoryFitAssumptions(targetKind: targetKind)
         let receiptElapsedMS = elapsedMilliseconds(since: receiptStart)
         let probe: [String: Any] = [
             "name": "cli.memory_fit.\(targetKind)",
@@ -4207,9 +4272,12 @@ public actor MelixCLIRunner {
             "total_unified_memory_bytes": NSNumber(value: totalUnifiedMemoryBytes),
             "estimated_active_memory_bytes": NSNumber(value: card.estimatedResidentBytes),
             "estimated_disk_usage_bytes": NSNumber(value: card.estimatedArtifactBytes),
+            "available_disk_bytes": NSNumber(value: availableDiskBytes),
+            "disk_fit_status": diskFitStatus,
             "safety_threshold": safetyThreshold,
             "assumptions": assumptions,
             "unknown_fields": unknownFields,
+            "target_inputs": targetInputs,
             "parameter_count": NSNumber(value: card.parameterCount),
             "quantization_summary": card.quantizationSummary,
             "probe": probe,
@@ -4224,10 +4292,72 @@ public actor MelixCLIRunner {
             totalUnifiedMemoryBytes: totalUnifiedMemoryBytes,
             estimatedActiveMemoryBytes: card.estimatedResidentBytes,
             estimatedDiskUsageBytes: card.estimatedArtifactBytes,
+            availableDiskBytes: availableDiskBytes,
+            diskFitStatus: diskFitStatus,
             safetyThresholdFraction: safetyThresholdFraction,
             unknownFields: unknownFields,
             assumptions: assumptions
         )
+    }
+
+    private func availableDiskCapacityBytes(near url: URL) -> UInt64 {
+        let fileManager = FileManager.default
+        var probeURL = url
+        while fileManager.fileExists(atPath: probeURL.path) == false {
+            let parentURL = probeURL.deletingLastPathComponent()
+            if parentURL.path == probeURL.path {
+                probeURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+                break
+            }
+            probeURL = parentURL
+        }
+        if let values = try? probeURL.resourceValues(forKeys: [
+            .volumeAvailableCapacityForImportantUsageKey,
+            .volumeAvailableCapacityKey,
+        ]) {
+            if let importantCapacity = values.volumeAvailableCapacityForImportantUsage, importantCapacity > 0 {
+                return UInt64(importantCapacity)
+            }
+            if let volumeCapacity = values.volumeAvailableCapacity, volumeCapacity > 0 {
+                return UInt64(volumeCapacity)
+            }
+        }
+        if let attributes = try? fileManager.attributesOfFileSystem(forPath: probeURL.path),
+           let systemFreeSize = attributes[.systemFreeSize] as? NSNumber,
+           systemFreeSize.int64Value > 0
+        {
+            return UInt64(systemFreeSize.int64Value)
+        }
+        return 0
+    }
+
+    private func memoryFitDiskStatus(estimatedDiskUsageBytes: UInt64, availableDiskBytes: UInt64) -> String {
+        guard estimatedDiskUsageBytes > 0, availableDiskBytes > 0 else {
+            return "unknown"
+        }
+        return Double(availableDiskBytes) >= Double(estimatedDiskUsageBytes) * Self.diskFitSafetyMultiplier
+            ? "good"
+            : "blocked"
+    }
+
+    private func memoryFitAssumptions(targetKind: String) -> [String] {
+        var assumptions = [
+            "ProcessInfo.physicalMemory is treated as Apple Silicon total unified memory.",
+            "estimated_active_memory_bytes reuses Hub estimated_resident_bytes.",
+            "estimated_disk_usage_bytes reuses Hub estimated_artifact_bytes.",
+            "fit_status and recommended_action reuse the model-ops Hub local-fit policy.",
+        ]
+        switch targetKind {
+        case "benchmark":
+            assumptions.append("Benchmark KV-cache and activation overhead are not separately modeled yet.")
+        case "eval":
+            assumptions.append("Evaluation context, KV-cache, dataset-cache, and judge overhead are not separately modeled yet.")
+        case "train":
+            assumptions.append("Training optimizer state, LoRA adapter memory, activations, and dataset-cache overhead are not separately modeled yet.")
+        default:
+            break
+        }
+        return assumptions
     }
 
     private func memoryFitUnknownFields(_ card: Melix_Controlplane_V1_HubModelCard) -> [String] {
@@ -4250,18 +4380,44 @@ public actor MelixCLIRunner {
         return fields
     }
 
+    private func memoryFitRunUnknownFields(for targetKind: String) -> [String] {
+        switch targetKind {
+        case "benchmark":
+            return ["kv_cache_bytes", "activation_bytes"]
+        case "eval":
+            return ["kv_cache_bytes", "activation_bytes", "dataset_cache_bytes", "judge_memory_bytes"]
+        case "train":
+            return ["optimizer_state_bytes", "lora_adapter_bytes", "activation_bytes", "dataset_cache_bytes"]
+        default:
+            return []
+        }
+    }
+
+    private func orderedUnique(_ values: [String]) -> [String] {
+        var seen: Set<String> = []
+        var result: [String] = []
+        for value in values where seen.insert(value).inserted {
+            result.append(value)
+        }
+        return result
+    }
+
     private func normalizedFitStatus(_ status: String) -> String {
         let trimmed = status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return trimmed.isEmpty ? "unknown" : trimmed
     }
 
-    private func enforceMemoryFitPreflight(_ receipt: MemoryFitReceipt, allowMemoryRisk: Bool) throws {
+    private func enforceMemoryFitPreflight(
+        _ receipt: MemoryFitReceipt,
+        allowMemoryRisk: Bool,
+        commandName: String
+    ) throws {
         guard ["blocked", "heavy"].contains(receipt.fitStatus), !allowMemoryRisk else {
             return
         }
         let reasons = receipt.reasons.isEmpty ? "No reason was provided." : receipt.reasons.joined(separator: " ")
         throw MelixCLIError.runtime(
-            "Memory fit preflight blocked benchmark for \(receipt.repoID): fit_status=\(receipt.fitStatus), estimated_active_memory_bytes=\(formatBinaryBytes(receipt.estimatedActiveMemoryBytes)), estimated_disk_usage_bytes=\(formatBinaryBytes(receipt.estimatedDiskUsageBytes)). Pass --allow-memory-risk to run anyway. Reasons: \(reasons)"
+            "Memory fit preflight blocked \(commandName) for \(receipt.repoID): fit_status=\(receipt.fitStatus), estimated_active_memory_bytes=\(formatBinaryBytes(receipt.estimatedActiveMemoryBytes)), estimated_disk_usage_bytes=\(formatBinaryBytes(receipt.estimatedDiskUsageBytes)). Pass --allow-memory-risk to run anyway. Reasons: \(reasons)"
         )
     }
 
@@ -4436,7 +4592,11 @@ public actor MelixCLIRunner {
                 throw MelixCLIError.runtime("--preflight-fit-check is currently supported for melix bench run --repo-id targets.")
             }
             let receipt = try await makeMemoryFitReceipt(repoID: options.hfRepoID, targetKind: "benchmark")
-            try enforceMemoryFitPreflight(receipt, allowMemoryRisk: options.allowMemoryRisk)
+            try enforceMemoryFitPreflight(
+                receipt,
+                allowMemoryRisk: options.allowMemoryRisk,
+                commandName: "benchmark"
+            )
             parameters.merge(try receipt.benchmarkParameters(schemaVersion: Self.memoryFitSchemaVersion)) { _, new in new }
         }
         if !options.modelID.isEmpty {
@@ -4586,7 +4746,11 @@ public actor MelixCLIRunner {
             }
             return result.bundleRoot.path + "\n"
         case .estimateImport(let options):
-            let receipt = try await makeMemoryFitReceipt(repoID: options.repoID, targetKind: "import")
+            let receipt = try await makeMemoryFitReceipt(
+                repoID: options.repoID,
+                targetKind: options.targetKind,
+                targetInputs: options.targetInputs
+            )
             return options.json ? try prettyJSON(receipt.payload) : renderMemoryFitReceipt(receipt)
         case .convert(let options):
             let result = try await performModelOperation(
@@ -5136,6 +5300,18 @@ public actor MelixCLIRunner {
             return renderRegistrySnapshot(result.manifestJson)
         case .loraTrain(let options):
             var ext = options.parameters
+            if options.preflightFitCheck {
+                guard options.modelID.trimmingCharacters(in: .whitespacesAndNewlines).contains("/") else {
+                    throw MelixCLIError.runtime("--preflight-fit-check is currently supported for melix lora train --model-id Hugging Face repo targets.")
+                }
+                let receipt = try await makeMemoryFitReceipt(repoID: options.modelID, targetKind: "train")
+                try enforceMemoryFitPreflight(
+                    receipt,
+                    allowMemoryRisk: options.allowMemoryRisk,
+                    commandName: "training"
+                )
+                ext.merge(try receipt.runParameters(schemaVersion: Self.memoryFitSchemaVersion)) { _, new in new }
+            }
             ext["adapter_name"] = options.adapterName
             ext["dataset_source_kind"] = options.datasetSourceKind
             if !options.datasetURI.isEmpty {
@@ -6607,6 +6783,8 @@ public actor MelixCLIRunner {
             "total_unified_memory_bytes=\(formatBinaryBytes(receipt.totalUnifiedMemoryBytes))",
             "estimated_active_memory_bytes=\(formatBinaryBytes(receipt.estimatedActiveMemoryBytes))",
             "estimated_disk_usage_bytes=\(formatBinaryBytes(receipt.estimatedDiskUsageBytes))",
+            "available_disk_bytes=\(formatBinaryBytes(receipt.availableDiskBytes))",
+            "disk_fit_status=\(receipt.diskFitStatus)",
             "safety_threshold_fraction=\(String(format: "%.2f", locale: Locale(identifier: "en_US_POSIX"), receipt.safetyThresholdFraction))",
             "recommended_action=\(receipt.recommendedAction)",
             "reasons=\(receipt.reasons.joined(separator: " | "))",
@@ -7757,7 +7935,42 @@ public actor MelixCLIRunner {
         options: EvalRunOptions,
         suites: [String]
     ) async throws -> [ControlPlaneEvaluationResult] {
-        let remoteTargetOptions = Self.effectiveRemoteTargetOptions(for: options)
+        var baseParameters = options.parameters
+        if options.preflightFitCheck {
+            guard options.hfRepoID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
+                throw MelixCLIError.runtime("--preflight-fit-check is currently supported for melix eval run --repo-id targets.")
+            }
+            let receipt = try await makeMemoryFitReceipt(repoID: options.hfRepoID, targetKind: "eval")
+            try enforceMemoryFitPreflight(
+                receipt,
+                allowMemoryRisk: options.allowMemoryRisk,
+                commandName: "evaluation"
+            )
+            baseParameters.merge(try receipt.runParameters(schemaVersion: Self.memoryFitSchemaVersion)) { _, new in new }
+        }
+        let effectiveOptions = EvalRunOptions(
+            modelID: options.modelID,
+            hfRepoID: options.hfRepoID,
+            remoteServerID: options.remoteServerID,
+            remoteModelID: options.remoteModelID,
+            remoteTargets: options.remoteTargets,
+            suites: options.suites,
+            datasetID: options.datasetID,
+            sampleSize: options.sampleSize,
+            source: options.source,
+            fieldMapping: options.fieldMapping,
+            profile: options.profile,
+            parameters: baseParameters,
+            evalPromptID: options.evalPromptID,
+            evalPromptRevisionID: options.evalPromptRevisionID,
+            semanticJudgeRemoteServerID: options.semanticJudgeRemoteServerID,
+            semanticJudgeModelID: options.semanticJudgeModelID,
+            remoteParallelism: options.remoteParallelism,
+            preflightFitCheck: options.preflightFitCheck,
+            allowMemoryRisk: options.allowMemoryRisk,
+            json: options.json
+        )
+        let remoteTargetOptions = Self.effectiveRemoteTargetOptions(for: effectiveOptions)
         let resolvedRemoteTargets: [ControlPlaneEvaluationRequest.RemoteTarget?] = try remoteTargetOptions.isEmpty
             ? [nil]
             : remoteTargetOptions.map {
@@ -7768,25 +7981,25 @@ public actor MelixCLIRunner {
             }
         var suiteParameters: [String: [String: String]] = [:]
         for suiteID in suites {
-            suiteParameters[suiteID] = try evaluationParameters(options: options, suiteID: suiteID)
+            suiteParameters[suiteID] = try evaluationParameters(options: effectiveOptions, suiteID: suiteID)
         }
 
         var plannedRequests: [PlannedEvaluationRequest] = []
         for remoteTarget in resolvedRemoteTargets {
             for suiteID in suites {
-                let usesCustomSource = options.source.kind != .builtinPackage
-                let parameters = suiteParameters[suiteID] ?? options.parameters
+                let usesCustomSource = effectiveOptions.source.kind != .builtinPackage
+                let parameters = suiteParameters[suiteID] ?? effectiveOptions.parameters
                 let request = ControlPlaneEvaluationRequest(
-                    modelID: options.modelID,
-                    hfRepoID: options.hfRepoID,
+                    modelID: effectiveOptions.modelID,
+                    hfRepoID: effectiveOptions.hfRepoID,
                     suiteID: suiteID,
                     datasetID: usesCustomSource
-                        ? options.datasetID
-                        : (options.datasetID.isEmpty ? Self.defaultEvaluationDatasetID(for: suiteID) : options.datasetID),
-                    sampleSize: options.sampleSize,
-                    source: options.source,
-                    fieldMapping: options.fieldMapping,
-                    profile: options.profile,
+                        ? effectiveOptions.datasetID
+                        : (effectiveOptions.datasetID.isEmpty ? Self.defaultEvaluationDatasetID(for: suiteID) : effectiveOptions.datasetID),
+                    sampleSize: effectiveOptions.sampleSize,
+                    source: effectiveOptions.source,
+                    fieldMapping: effectiveOptions.fieldMapping,
+                    profile: effectiveOptions.profile,
                     parameters: parameters,
                     remoteTarget: remoteTarget
                 )
@@ -7804,7 +8017,7 @@ public actor MelixCLIRunner {
             return collected
         }
 
-        let requestedParallelism = Int(options.remoteParallelism)
+        let requestedParallelism = Int(effectiveOptions.remoteParallelism)
         let maxParallelism = requestedParallelism > 0 ? requestedParallelism : plannedRequests.count
         return try await runEvaluationRequestsConcurrently(
             plannedRequests,
@@ -8797,11 +9010,17 @@ private struct MemoryFitReceipt {
     let totalUnifiedMemoryBytes: UInt64
     let estimatedActiveMemoryBytes: UInt64
     let estimatedDiskUsageBytes: UInt64
+    let availableDiskBytes: UInt64
+    let diskFitStatus: String
     let safetyThresholdFraction: Double
     let unknownFields: [String]
     let assumptions: [String]
 
     func benchmarkParameters(schemaVersion: String) throws -> [String: String] {
+        try runParameters(schemaVersion: schemaVersion)
+    }
+
+    func runParameters(schemaVersion: String) throws -> [String: String] {
         [
             "memory_fit_schema_version": schemaVersion,
             "memory_fit_target_kind": targetKind,
@@ -8809,6 +9028,8 @@ private struct MemoryFitReceipt {
             "memory_fit_status": fitStatus,
             "memory_fit_estimated_active_memory_bytes": String(estimatedActiveMemoryBytes),
             "memory_fit_estimated_disk_usage_bytes": String(estimatedDiskUsageBytes),
+            "memory_fit_available_disk_bytes": String(availableDiskBytes),
+            "memory_fit_disk_status": diskFitStatus,
             "memory_fit_total_unified_memory_bytes": String(totalUnifiedMemoryBytes),
             "memory_fit_safety_threshold_fraction": String(
                 format: "%.2f",

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1837,7 +1837,7 @@ public enum MelixCLIParser {
     }
 
     private static func normalizedEstimateTargetKind(_ action: String) -> String {
-        action == "benchmark" ? "benchmark" : action
+        action
     }
 
     private static func estimateTargetInputs(_ values: ParsedArguments) -> [String: String] {

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -14,8 +14,8 @@ public enum MelixCLICommandCodec {
             return "logs"
         case .debugBundle:
             return "debug.bundle"
-        case .estimateImport:
-            return "estimate.import"
+        case .estimateImport(let options):
+            return "estimate.\(options.targetKind)"
         case .convert:
             return "convert"
         case .quantize:
@@ -217,7 +217,13 @@ public enum MelixCLICommandCodec {
             appendOption("--output", value: options.outputPath, into: &arguments)
             json = options.json
         case .estimateImport(let options):
-            arguments = ["estimate", "import", options.repoID]
+            arguments = ["estimate", options.targetKind, options.repoID]
+            appendOption("--context", value: options.targetInputs["context"], into: &arguments)
+            appendOption("--context-length", value: options.targetInputs["context_length"], into: &arguments)
+            appendOption("--dataset", value: options.targetInputs["dataset"], into: &arguments)
+            appendOption("--lora", value: options.targetInputs["lora"], into: &arguments)
+            appendOption("--batch-size", value: options.targetInputs["batch_size"], into: &arguments)
+            appendOption("--sample-size", value: options.targetInputs["sample_size"], into: &arguments)
             json = options.json
         case .convert(let options):
             arguments = ["convert"]
@@ -408,6 +414,12 @@ public enum MelixCLICommandCodec {
             appendOption("--target-repo", value: options.targetRepo, into: &arguments)
             appendOption("--training-mode", value: options.trainingMode, into: &arguments)
             appendTrainingParameters(options.parameters, into: &arguments)
+            if options.preflightFitCheck {
+                arguments.append("--preflight-fit-check")
+            }
+            if options.allowMemoryRisk {
+                arguments.append("--allow-memory-risk")
+            }
             json = options.json
         case .alignmentTrain(let options):
             arguments = ["alignment", "train"]
@@ -547,6 +559,12 @@ public enum MelixCLICommandCodec {
             appendOption("--semantic-judge-remote-server-id", value: options.semanticJudgeRemoteServerID, into: &arguments)
             appendOption("--semantic-judge-model", value: options.semanticJudgeModelID, into: &arguments)
             appendPositiveUInt32("--remote-parallelism", value: options.remoteParallelism, into: &arguments)
+            if options.preflightFitCheck {
+                arguments.append("--preflight-fit-check")
+            }
+            if options.allowMemoryRisk {
+                arguments.append("--allow-memory-risk")
+            }
             json = options.json
         case .evalPromptList(let options):
             arguments = ["eval", "prompt", "list"]

--- a/docs/plans/2026-05-11-apple-silicon-memory-fit-receipts.md
+++ b/docs/plans/2026-05-11-apple-silicon-memory-fit-receipts.md
@@ -2,22 +2,30 @@
 
 ## Scope
 
-This slice implements the first operator-facing unified-memory fit surface for
-issue #638. It stays on the existing Hub model-card contract and does not add
-new protobuf fields.
+This slice implements the operator-facing unified-memory fit surface for issue
+#638. It stays on the existing Hub model-card contract and does not add new
+protobuf fields.
 
 The implemented surface is:
 
 - `melix estimate import <repo-id>` and `melix estimate import --repo-id <repo-id>`
-- JSON and text fit receipts for Hugging Face import candidates
+- `melix estimate benchmark <repo-id>` and `melix estimate benchmark --repo-id <repo-id>`
+- `melix estimate eval <repo-id>` and `melix estimate eval --repo-id <repo-id>`
+- `melix estimate train <repo-id>` and `melix estimate train --model <repo-id>`
+- JSON and text fit receipts for Hugging Face import, benchmark, eval, and
+  training candidates
 - optional `melix bench run --repo-id <repo-id> --preflight-fit-check`
-- `--allow-memory-risk` override for benchmark runs whose Hub estimate is
-  `heavy` or `blocked`
-- benchmark job parameter annotations that persist the fit receipt summary in
-  the existing benchmark artifact path
+- optional `melix eval run --repo-id <repo-id> --preflight-fit-check`
+- optional `melix lora train --model-id <repo-id> --preflight-fit-check`
+- `--allow-memory-risk` override for benchmark, eval, and training runs whose
+  Hub estimate is `heavy` or `blocked`
+- benchmark job parameter annotations, eval request parameters, and LoRA model
+  operation extensions that persist the fit receipt summary in existing
+  artifact paths
 
-Training and eval fit checks remain follow-up work for #638 because they need
-task-specific activation, optimizer, dataset-cache, and KV-cache estimators.
+Task-specific activation, optimizer, dataset-cache, adapter, KV-cache, and
+judge-memory estimators are recorded as explicit `unknown_fields` until Melix
+has runtime estimators for those components.
 
 ## Design
 
@@ -34,6 +42,16 @@ as `total_unified_memory_bytes`. Melix is a macOS Apple Silicon application, so
 this slice treats that value as the unified-memory capacity and does not
 implement fallback collectors for other platforms.
 
+The CLI also probes free disk capacity near the managed model root and reports
+it as `available_disk_bytes` with a derived `disk_fit_status`. Disk fit uses the
+Hub artifact-size estimate plus local free-space evidence; task-specific output
+growth remains an unknown until run-specific artifact estimators exist.
+
+Each receipt also includes `target_inputs` for CLI inputs that materially shape
+the run, such as context length, dataset URI, LoRA adapter path, batch size, and
+sample size. Target-specific assumptions and `unknown_fields` keep the receipt
+honest when the Hub card estimate cannot model additional run memory.
+
 ## Probes And Metrics
 
 Every estimate receipt carries a `probe` object with:
@@ -42,8 +60,9 @@ Every estimate receipt carries a `probe` object with:
 - `hub_card_elapsed_ms`
 - `receipt_elapsed_ms`
 
-Benchmark preflight stores stable memory-fit fields in benchmark parameters so
-the artifact export path can be inspected without re-running Hub discovery:
+Benchmark, eval, and LoRA training preflight store stable memory-fit fields in
+artifact parameters so exported results can be inspected without re-running Hub
+discovery:
 
 - `memory_fit_schema_version`
 - `memory_fit_target_kind`
@@ -51,8 +70,11 @@ the artifact export path can be inspected without re-running Hub discovery:
 - `memory_fit_status`
 - `memory_fit_estimated_active_memory_bytes`
 - `memory_fit_estimated_disk_usage_bytes`
+- `memory_fit_available_disk_bytes`
+- `memory_fit_disk_status`
 - `memory_fit_total_unified_memory_bytes`
 - `memory_fit_safety_threshold_fraction`
+- `memory_fit_unknown_fields`
 - `memory_fit_receipt_json`
 
 Success metrics for this slice:
@@ -62,17 +84,29 @@ Success metrics for this slice:
   estimate, reasons, and override guidance
 - unsafe benchmark preflight blocks before `runBench` unless
   `--allow-memory-risk` is set
+- unsafe eval preflight blocks before scheduling the eval job unless
+  `--allow-memory-risk` is set
+- unsafe LoRA training preflight blocks before scheduling the model operation
+  unless `--allow-memory-risk` is set
 - override benchmark preflight forwards the fit receipt summary into
   `ControlPlaneBenchRequest.parameters`
+- override eval preflight forwards the fit receipt summary into eval request
+  parameters
+- override LoRA training preflight forwards the fit receipt summary into the
+  model operation extension payload
 
 ## Verification
 
 Run focused Swift parser and runner tests for:
 
-- estimate import parsing and command-codec support
-- estimate import JSON/text rendering
+- estimate import, benchmark, eval, and train parsing and command-codec support
+- estimate import JSON/text rendering and target-specific JSON unknown fields
 - benchmark preflight blocking behavior
 - benchmark preflight override parameter persistence
+- eval preflight blocking behavior
+- eval preflight override parameter persistence
+- LoRA training preflight blocking behavior
+- LoRA training preflight override extension persistence
 
 Run changed-scope coverage for touched Swift CLI files when coverage tooling is
 available. If the local Swift coverage command is not available in this

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -731,6 +731,9 @@ struct MelixCLIParserTests {
         let allCommands: [(MelixCLICommand, String)] = [
             (.doctor(.init()), "doctor"),
             (.estimateImport(.init(repoID: "mlx/qwen", json: true)), "estimate.import"),
+            (.estimateImport(.init(repoID: "mlx/qwen", targetKind: "benchmark", json: true)), "estimate.benchmark"),
+            (.estimateImport(.init(repoID: "mlx/qwen", targetKind: "eval", json: true)), "estimate.eval"),
+            (.estimateImport(.init(repoID: "mlx/qwen", targetKind: "train", json: true)), "estimate.train"),
             (.convert(.init(modelID: "model", outputDir: "/tmp/out", targetFormat: "bundle", json: true)), "convert"),
             (.quantize(.init(modelID: "model", outputDir: "/tmp/out", quantProfileID: "q4", weightQuant: "int4", kvQuant: "int8", quantizationMode: "ptq", sourceArtifactKind: "base_model", sourceArtifactPath: "/tmp/model", calibrationDatasetURI: "/tmp/calibration", qualityDelta: "-0.01", latencyDelta: "-0.2", localInferenceSmokeMode: "runtime_generate", localInferenceSmokePrompt: "smoke", json: true)), "quantize"),
             (.upload(.init(modelID: "model", outputDir: "/tmp/out", targetRepo: "melix/model", artifactPath: "/tmp/model", artifactKind: "bundle", artifactManifestPath: "/tmp/model/manifest.json", json: true)), "upload"),
@@ -771,7 +774,7 @@ struct MelixCLIParserTests {
             (.chatRun(.init(modelID: "model", message: "hello", systemPrompt: "system", serverSessionID: "server-session-1", json: true)), "chat.run"),
             (.chatRun(.init(remoteServerID: "custom", remoteModelID: "remote-model", message: "hello", systemPrompt: "system", serverSessionID: "server-session-1", json: true)), "chat.run"),
             (.loraList(.init(modelID: "model", json: true)), "lora.list"),
-            (.loraTrain(.init(modelID: "model", datasetSourceKind: "huggingface", datasetURI: "dataset/repo", adapterName: "adapter", targetRepo: "melix/adapter", trainingMode: "qlora", parameters: ["derived_model_alias": "derived", "response_only": "true"], json: true)), "lora.train"),
+            (.loraTrain(.init(modelID: "model", datasetSourceKind: "huggingface", datasetURI: "dataset/repo", adapterName: "adapter", targetRepo: "melix/adapter", trainingMode: "qlora", parameters: ["derived_model_alias": "derived", "response_only": "true"], preflightFitCheck: true, allowMemoryRisk: true, json: true)), "lora.train"),
             (.alignmentTrain(.init(modelID: "model", datasetURI: "/tmp/preference.jsonl", adapterName: "aligned", algorithm: "dpo", json: true)), "alignment.train"),
             (.loraDatasetInspect(.init(modelID: "model", datasetURI: "/tmp/data.jsonl", json: true)), "lora.dataset.inspect"),
             (.loraDatasetBuild(.init(modelID: "model", datasetURI: "/tmp/data.jsonl", outputDir: "/tmp/out", json: true)), "lora.dataset.build"),
@@ -791,7 +794,7 @@ struct MelixCLIParserTests {
             (.benchMatrixList(.init(json: true)), "bench.matrix.list"),
             (.benchMatrixExportSummaryCSV(.init(jobID: "matrix-1", outputPath: "/tmp/matrix.csv", json: true)), "bench.matrix.export-summary-csv"),
             (.benchMatrixExportRequestsCSV(.init(jobID: "matrix-1", outputPath: "/tmp/matrix-requests.csv", json: true)), "bench.matrix.export-requests-csv"),
-            (.evalRun(.init(modelID: "model", suites: ["mmlu"], datasetID: "mmlu.dev.v1", sampleSize: 4, source: .localCSV(path: "/tmp/eval.csv"), fieldMapping: .init(systemPath: "system", inputTextPath: "input", targetPath: "target", sampleIDPath: "id"), profile: .init(profileType: "final_result", resultKind: "text", extractionMode: "heuristic_final", threshold: 0.75, outputSchemaJSON: "{\"type\":\"string\"}", ignoredPaths: ["meta"]), parameters: ["batch_factor": "1"], json: true)), "eval.run"),
+            (.evalRun(.init(hfRepoID: "model/repo", suites: ["mmlu"], datasetID: "mmlu.dev.v1", sampleSize: 4, source: .localCSV(path: "/tmp/eval.csv"), fieldMapping: .init(systemPath: "system", inputTextPath: "input", targetPath: "target", sampleIDPath: "id"), profile: .init(profileType: "final_result", resultKind: "text", extractionMode: "heuristic_final", threshold: 0.75, outputSchemaJSON: "{\"type\":\"string\"}", ignoredPaths: ["meta"]), parameters: ["batch_factor": "1"], preflightFitCheck: true, allowMemoryRisk: true, json: true)), "eval.run"),
             (.evalRun(.init(remoteServerID: "custom", remoteModelID: "remote-model", suites: ["event_extraction"], datasetID: "top200", sampleSize: 3, source: .localJSONL(path: "/tmp/top200.jsonl"), fieldMapping: .init(inputTextPath: "dialogue", targetPath: "events", sampleIDPath: "dialogue_id"), profile: .init(scoringMode: "event_extraction_weighted_f1"), evalPromptID: "event-prod", evalPromptRevisionID: "rev-1", json: true)), "eval.run"),
             (.evalPromptList(.init(json: true)), "eval.prompt.list"),
             (.evalPromptShow(.init(promptID: "event-prod", revisionID: "rev-1", json: true)), "eval.prompt.show"),
@@ -821,6 +824,9 @@ struct MelixCLIParserTests {
         let supportedCommands: [MelixCLICommand] = [
             .doctor(.init(json: true)),
             .estimateImport(.init(repoID: "mlx/qwen", json: true)),
+            .estimateImport(.init(repoID: "mlx/qwen", targetKind: "benchmark", json: true)),
+            .estimateImport(.init(repoID: "mlx/qwen", targetKind: "eval", json: true)),
+            .estimateImport(.init(repoID: "mlx/qwen", targetKind: "train", json: true)),
             .convert(.init(modelID: "model", outputDir: "/tmp/out", targetFormat: "bundle", json: true)),
             .quantize(.init(modelID: "model", outputDir: "/tmp/out", quantProfileID: "q4", weightQuant: "int4", kvQuant: "int8", quantizationMode: "ptq", sourceArtifactKind: "base_model", sourceArtifactPath: "/tmp/model", calibrationDatasetURI: "/tmp/calibration", qualityDelta: "-0.01", latencyDelta: "-0.2", localInferenceSmokeMode: "runtime_generate", localInferenceSmokePrompt: "smoke", json: true)),
             .upload(.init(modelID: "model", outputDir: "/tmp/out", targetRepo: "melix/model", artifactPath: "/tmp/model", artifactKind: "bundle", artifactManifestPath: "/tmp/model/manifest.json", json: true)),
@@ -944,6 +950,35 @@ struct MelixCLIParserTests {
         #expect(optionOptions.json == false)
     }
 
+    @Test("parses estimate benchmark eval and train receipts")
+    func parsesEstimateRunTargetReceipts() throws {
+        let cases: [(String, String, [String], String, String)] = [
+            ("benchmark", "benchmark", ["--context-length", "4096"], "context_length", "4096"),
+            ("eval", "eval", ["--context", "event dialog", "--dataset", "top200"], "dataset", "top200"),
+            ("train", "train", ["--model", "mlx-community/Qwen3.5-9B-MLX-4bit", "--dataset", "alpaca", "--lora", "adapter"], "lora", "adapter"),
+        ]
+        for (action, targetKind, extraArguments, inputKey, inputValue) in cases {
+            let command = try MelixCLIParser.parse([
+                "estimate",
+                action,
+                action == "train" ? "" : "--repo-id", action == "train" ? "" : "mlx-community/Qwen3.5-9B-MLX-4bit",
+            ].filter { $0.isEmpty == false } + extraArguments + [
+                "--json",
+            ])
+            guard case .estimateImport(let options) = command else {
+                Issue.record("Expected estimateImport command for \(action)")
+                continue
+            }
+
+            #expect(options.repoID == "mlx-community/Qwen3.5-9B-MLX-4bit")
+            #expect(options.targetKind == targetKind)
+            #expect(options.targetInputs[inputKey] == inputValue)
+            #expect(options.json)
+            #expect(MelixCLICommandCodec.commandID(for: command) == "estimate.\(targetKind)")
+            #expect(try MelixCLIParser.parse(MelixCLICommandCodec.arguments(for: command)) == command)
+        }
+    }
+
     @Test("estimate import rejects missing conflicting and unknown inputs")
     func estimateImportRejectsInvalidInputs() throws {
         try assertError(
@@ -971,10 +1006,11 @@ struct MelixCLIParserTests {
         try assertError(
             for: [
                 "estimate",
-                "train",
-                "--model", "mlx-community/Qwen3.5-9B-MLX-4bit",
+                "eval",
+                "--repo-id", "mlx-community/Qwen3.5-9B-MLX-4bit",
+                "--model", "mlx-community/Qwen3.5-9B-MLX-8bit",
             ],
-            equals: .usage(MelixCLIParser.usageText)
+            equals: .usage("melix estimate eval accepts only one Hugging Face repo id.")
         )
     }
 
@@ -1434,6 +1470,8 @@ struct MelixCLIParserTests {
             "--max-seq-length", "4096",
             "--response-only",
             "--gradient-checkpointing",
+            "--preflight-fit-check",
+            "--allow-memory-risk",
             "--json",
         ])
 
@@ -1462,6 +1500,8 @@ struct MelixCLIParserTests {
         #expect(options.parameters["max_seq_length"] == "4096")
         #expect(options.parameters["response_only"] == "true")
         #expect(options.parameters["gradient_checkpointing"] == "true")
+        #expect(options.preflightFitCheck)
+        #expect(options.allowMemoryRisk)
         #expect(options.json)
     }
 
@@ -2476,6 +2516,8 @@ struct MelixCLIParserTests {
             "--batch-factor", "2",
             "--seed", "7",
             "--few-shot", "4",
+            "--preflight-fit-check",
+            "--allow-memory-risk",
             "--json",
         ])
 
@@ -2493,6 +2535,8 @@ struct MelixCLIParserTests {
         #expect(options.parameters["batch_factor"] == "2")
         #expect(options.parameters["seed"] == "7")
         #expect(options.parameters["few_shot"] == "4")
+        #expect(options.preflightFitCheck)
+        #expect(options.allowMemoryRisk)
         #expect(options.json)
     }
 

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -95,6 +95,8 @@ struct MelixCLIRunnerTests {
         #expect((payload["total_unified_memory_bytes"] as? NSNumber)?.uint64Value ?? 0 > 0)
         #expect((payload["estimated_active_memory_bytes"] as? NSNumber)?.uint64Value == 44_000_000_000)
         #expect((payload["estimated_disk_usage_bytes"] as? NSNumber)?.uint64Value == 22_000_000_000)
+        #expect((payload["available_disk_bytes"] as? NSNumber)?.uint64Value ?? 0 > 0)
+        #expect(["good", "blocked", "unknown"].contains(payload["disk_fit_status"] as? String ?? ""))
         #expect(payload["recommended_action"] as? String == "Use --allow-memory-risk only when the Mac is otherwise idle.")
         #expect((payload["assumptions"] as? [String])?.isEmpty == false)
         #expect((payload["unknown_fields"] as? [String])?.contains("parameter_count") == true)
@@ -131,7 +133,49 @@ struct MelixCLIRunnerTests {
         #expect(output.contains("total_unified_memory_bytes=\(ProcessInfo.processInfo.physicalMemory)") == false)
         #expect(output.contains("estimated_active_memory_bytes=8.38 GB"))
         #expect(output.contains("estimated_disk_usage_bytes=4.66 GB"))
+        #expect(output.contains("available_disk_bytes="))
+        #expect(output.contains("disk_fit_status="))
         #expect(output.contains("recommended_action=Run import normally."))
+    }
+
+    @Test("estimate benchmark eval and train include target-specific unknowns")
+    func estimateRunTargetsIncludeTaskSpecificUnknowns() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setHubModelCard(
+            makeHubModelCard(
+                repoID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+                localFitStatus: "good",
+                localFitReasons: ["Estimated resident memory fits the comfort budget."],
+                estimatedArtifactBytes: 5_000_000_000,
+                estimatedResidentBytes: 9_000_000_000,
+                recommendedAction: "Run normally."
+            )
+        )
+
+        for (targetKind, expectedUnknown) in [
+            ("benchmark", "kv_cache_bytes"),
+            ("eval", "judge_memory_bytes"),
+            ("train", "optimizer_state_bytes"),
+        ] {
+            let output = try await MelixCLIRunner(client: client).run(
+                .estimateImport(.init(
+                    repoID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+                    targetKind: targetKind,
+                    targetInputs: ["dataset": "top200"],
+                    json: true
+                ))
+            )
+            let payload = try #require(parseJSONObject(output))
+            let unknownFields = try #require(payload["unknown_fields"] as? [String])
+            let assumptions = try #require(payload["assumptions"] as? [String])
+            let targetInputs = try #require(payload["target_inputs"] as? [String: Any])
+
+            #expect(payload["target_kind"] as? String == targetKind)
+            #expect((payload["probe"] as? [String: Any])?["name"] as? String == "cli.memory_fit.\(targetKind)")
+            #expect(targetInputs["dataset"] as? String == "top200")
+            #expect(unknownFields.contains(expectedUnknown))
+            #expect(assumptions.contains { $0.contains("not separately modeled yet") })
+        }
     }
 
     @Test("estimate import reports unknown fields when Hub fit evidence is sparse")
@@ -5431,6 +5475,86 @@ struct MelixCLIRunnerTests {
         #expect(output == #"{"job_id":"job-1","status":"completed"}"#)
     }
 
+    @Test("lora train memory fit preflight blocks unsafe Hub model targets")
+    func loraTrainMemoryFitPreflightBlocksUnsafeHubModelTargets() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setHubModelCard(
+            makeHubModelCard(
+                repoID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                localFitStatus: "blocked",
+                localFitReasons: ["Estimated resident memory exceeds the safety threshold."],
+                estimatedArtifactBytes: 24_000_000_000,
+                estimatedResidentBytes: 48_000_000_000,
+                recommendedAction: "Choose a smaller training base model."
+            )
+        )
+
+        do {
+            _ = try await MelixCLIRunner(client: client).run(
+                .loraTrain(
+                    .init(
+                        modelID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                        datasetURI: "/tmp/datasets/alpaca.jsonl",
+                        adapterName: "demo-adapter",
+                        preflightFitCheck: true
+                    )
+                )
+            )
+            Issue.record("Expected memory fit preflight to block LoRA training.")
+        } catch let error as MelixCLIError {
+            guard case .runtime(let message) = error else {
+                Issue.record("Expected runtime error.")
+                return
+            }
+            #expect(message.contains("blocked training"))
+            #expect(message.contains("fit_status=blocked"))
+            #expect(message.contains("--allow-memory-risk"))
+        }
+
+        #expect(await client.lastModelOperationCall == nil)
+    }
+
+    @Test("lora train memory risk override stores fit receipt in operation ext")
+    func loraTrainMemoryRiskOverrideStoresFitReceiptParameters() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setHubModelCard(
+            makeHubModelCard(
+                repoID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                localFitStatus: "heavy",
+                localFitReasons: ["Estimated resident memory exceeds the comfort budget."],
+                estimatedArtifactBytes: 22_000_000_000,
+                estimatedResidentBytes: 44_000_000_000,
+                recommendedAction: "Train only on an idle high-memory Mac."
+            )
+        )
+        await client.setModelOperationResult(makeModelOperationResult(outputPath: "/tmp/melix/train_lora/job-fit"))
+
+        _ = try await MelixCLIRunner(client: client).run(
+            .loraTrain(
+                .init(
+                    modelID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                    datasetURI: "/tmp/datasets/alpaca.jsonl",
+                    adapterName: "demo-adapter",
+                    preflightFitCheck: true,
+                    allowMemoryRisk: true
+                )
+            )
+        )
+        let call = try #require(await client.lastModelOperationCall)
+        let receiptJSON = try #require(call.ext["memory_fit_receipt_json"])
+        let receipt = try #require(parseJSONObject(receiptJSON))
+
+        #expect(call.operation == "train_lora")
+        #expect(call.ext["memory_fit_schema_version"] == "melix.memory_fit_receipt.v1")
+        #expect(call.ext["memory_fit_target_kind"] == "train")
+        #expect(call.ext["memory_fit_status"] == "heavy")
+        #expect(call.ext["memory_fit_estimated_active_memory_bytes"] == "44000000000")
+        #expect((UInt64(call.ext["memory_fit_available_disk_bytes"] ?? "") ?? 0) > 0)
+        #expect(["good", "blocked", "unknown"].contains(call.ext["memory_fit_disk_status"] ?? ""))
+        #expect((receipt["unknown_fields"] as? [String])?.contains("optimizer_state_bytes") == true)
+        #expect((receipt["probe"] as? [String: Any])?["name"] as? String == "cli.memory_fit.train")
+    }
+
     @Test("alignment train forwards algorithm and alignment-specific parameters")
     func alignmentTrainForwardsExpectedOperationPayload() async throws {
         let client = StubControlPlaneXPCClient()
@@ -6862,6 +6986,8 @@ struct MelixCLIRunnerTests {
         #expect(benchRequest.parameters["memory_fit_status"] == "heavy")
         #expect(benchRequest.parameters["memory_fit_estimated_active_memory_bytes"] == "44000000000")
         #expect(benchRequest.parameters["memory_fit_estimated_disk_usage_bytes"] == "22000000000")
+        #expect((UInt64(benchRequest.parameters["memory_fit_available_disk_bytes"] ?? "") ?? 0) > 0)
+        #expect(["good", "blocked", "unknown"].contains(benchRequest.parameters["memory_fit_disk_status"] ?? ""))
         #expect(benchRequest.parameters["memory_fit_safety_threshold_fraction"] == "0.60")
         #expect(receipt["target_kind"] as? String == "benchmark")
         #expect(receipt["fit_status"] as? String == "heavy")
@@ -7323,6 +7449,92 @@ struct MelixCLIRunnerTests {
         let firstJob = try #require(firstRun["job"] as? [String: Any])
         #expect(firstJob["job_id"] as? String == "eval-1")
         #expect(firstJob["suite_id"] as? String == "mmlu")
+    }
+
+    @Test("eval run memory fit preflight blocks unsafe direct Hugging Face targets")
+    func evalRunMemoryFitPreflightBlocksUnsafeHFRepo() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setHubModelCard(
+            makeHubModelCard(
+                repoID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                localFitStatus: "blocked",
+                localFitReasons: ["Estimated resident memory exceeds the safety threshold."],
+                estimatedArtifactBytes: 24_000_000_000,
+                estimatedResidentBytes: 48_000_000_000,
+                recommendedAction: "Choose a smaller evaluation target."
+            )
+        )
+
+        do {
+            _ = try await MelixCLIRunner(client: client).run(
+                .evalRun(
+                    .init(
+                        hfRepoID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                        suites: ["mmlu"],
+                        preflightFitCheck: true
+                    )
+                )
+            )
+            Issue.record("Expected memory fit preflight to block evaluation.")
+        } catch let error as MelixCLIError {
+            guard case .runtime(let message) = error else {
+                Issue.record("Expected runtime error.")
+                return
+            }
+            #expect(message.contains("blocked evaluation"))
+            #expect(message.contains("fit_status=blocked"))
+            #expect(message.contains("--allow-memory-risk"))
+        }
+
+        #expect(await client.evaluationRequests.isEmpty)
+    }
+
+    @Test("eval run memory risk override stores the fit receipt in request parameters")
+    func evalRunMemoryRiskOverrideStoresFitReceiptParameters() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setHubModelCard(
+            makeHubModelCard(
+                repoID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                localFitStatus: "heavy",
+                localFitReasons: ["Estimated resident memory exceeds the comfort budget."],
+                estimatedArtifactBytes: 22_000_000_000,
+                estimatedResidentBytes: 44_000_000_000,
+                recommendedAction: "Evaluate only on an idle high-memory Mac."
+            )
+        )
+        await client.setEvaluationResults([
+            makeEvaluationRunResult(
+                jobID: "eval-fit",
+                suiteID: "mmlu",
+                datasetID: "mmlu.dev.v1",
+                metricName: "eval.mmlu.accuracy",
+                metricValue: 0.5
+            ),
+        ])
+
+        _ = try await MelixCLIRunner(client: client).run(
+            .evalRun(
+                .init(
+                    hfRepoID: "mlx-community/Qwen3.6-35B-A3B-4bit",
+                    suites: ["mmlu"],
+                    preflightFitCheck: true,
+                    allowMemoryRisk: true
+                )
+            )
+        )
+        let request = try #require(await client.evaluationRequests.first)
+        let receiptJSON = try #require(request.parameters["memory_fit_receipt_json"])
+        let receipt = try #require(parseJSONObject(receiptJSON))
+
+        #expect(request.hfRepoID == "mlx-community/Qwen3.6-35B-A3B-4bit")
+        #expect(request.parameters["memory_fit_schema_version"] == "melix.memory_fit_receipt.v1")
+        #expect(request.parameters["memory_fit_target_kind"] == "eval")
+        #expect(request.parameters["memory_fit_status"] == "heavy")
+        #expect(request.parameters["memory_fit_estimated_active_memory_bytes"] == "44000000000")
+        #expect((UInt64(request.parameters["memory_fit_available_disk_bytes"] ?? "") ?? 0) > 0)
+        #expect(["good", "blocked", "unknown"].contains(request.parameters["memory_fit_disk_status"] ?? ""))
+        #expect((receipt["unknown_fields"] as? [String])?.contains("judge_memory_bytes") == true)
+        #expect((receipt["probe"] as? [String: Any])?["name"] as? String == "cli.memory_fit.eval")
     }
 
     @Test("eval run defaults event extraction to the built in top20 dataset")


### PR DESCRIPTION
Closes #638.

## Summary
- Add `melix estimate benchmark|eval|train` receipt surfaces with target inputs plus task-specific assumptions, unknown fields, available disk bytes, and disk fit status.
- Add eval and LoRA training preflight fit checks for direct Hugging Face targets, with `--allow-memory-risk` overrides matching benchmark behavior.
- Persist memory fit receipt parameters into benchmark requests, eval request parameters, and LoRA model operation extension payloads.
- Update parser/codec coverage and the Apple Silicon memory fit plan doc.

## Plan or Spec
- Issue: https://github.com/Keith-CY/melix/issues/638
- Plan: `docs/plans/2026-05-11-apple-silicon-memory-fit-receipts.md`

## Commands Run
```text
PASS: git diff --check
PASS: xcrun swift build --product melix
LOCAL LIMITATION: xcrun swift test --filter 'MelixCLIParserTests|MelixCLIRunnerTests' failed before executing the focused tests because tests/MelixCLITests/DiskStreamingSmokeRunnerTests.swift cannot import Swift Testing in the local CommandLineTools toolchain: error: no such module 'Testing'.
SHAPE CHECK: .build/debug/melix estimate train --model mlx-community/Qwen3.5-9B-MLX-4bit --dataset alpaca --lora adapter --json accepted the CLI shape and reached the Hub card worker path; it failed with requestFailed(code: "unavailable", message: "Hub model card worker request failed: unavailable") because no local worker stack was running.
SHAPE CHECK: .build/debug/melix estimate eval --repo-id mlx-community/Qwen3.5-9B-MLX-4bit --context-length 4096 --dataset top200 --json accepted the CLI shape and reached the Hub card worker path; it failed with the same unavailable worker message.
SHAPE CHECK: .build/debug/melix estimate benchmark --repo-id mlx-community/Qwen3.5-9B-MLX-4bit --context-length 4096 --batch-size 1 --json accepted the CLI shape and reached the Hub card worker path; it failed with the same unavailable worker message.
```

## Coverage and Metrics
- N/A: no runnable changed-scope coverage report was available in this local toolchain; the focused Swift test target was blocked by the missing Swift `Testing` module described above.
- Added parser/codec and runner tests for the new estimate targets, target-specific unknown fields, disk availability fields, eval preflight persistence, and LoRA training preflight persistence.

## Known Gaps
- Estimates continue to rely on Hub model-card resident/artifact evidence; task-specific overheads are explicitly recorded as `unknown_fields` until runtime estimators exist for activations, optimizer state, adapters, KV cache, dataset cache, judge memory, and task-specific output growth.
- This change does not add protobuf fields; receipts are stored through existing parameter/extension payloads.
- Local focused Swift tests were not executed because the local CommandLineTools Swift environment cannot import the `Testing` module.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or none are required. No protobuf changes were made.
- [x] Dependency changes include updated lockfiles, or none are required. No dependency changes were made.
- [x] Relevant tests were added; local execution was attempted and blocked by the Swift `Testing` module issue above.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
