### PR TITLE
perf: skip code eval fence count on parsed block

### DIFF
--- a/docs/plans/2026-05-12-code-eval-fence-count-fast-path.md
+++ b/docs/plans/2026-05-12-code-eval-fence-count-fast-path.md
@@ -1,0 +1,22 @@
+# Code Evaluation Fence Count Fast Path
+
+## Context
+
+`worker.engine.code_eval_runner.extract_candidate_code` selects the last complete fenced code block from model responses before running executable-code evaluation. The registered PR-scoped performance probe `code-eval-code-block-last-match-streaming` covers this path with focused tests, changed-scope coverage, and a command-json probe.
+
+The common probe shape includes many complete code blocks followed by natural-language commentary. Before this slice, that path counted every fence in the full response whenever there was trailing text after the selected closing fence, even when the selected block already had non-empty candidate code.
+
+## Slice
+
+This Python-only slice keeps the existing parsing contract and defers the full-response fence count unless the candidate block is empty or a trailing fenced segment makes the final fence ambiguous. The intended effect is to reduce repeated full-string scans for large responses with non-empty final code blocks and trailing commentary.
+
+## Verification Plan
+
+- Run the focused code-evaluation parser test and registered PR-scoped performance probe tests on Linux.
+- Run changed-scope coverage for `code_eval_runner.py`, the focused tests, and the probe script.
+- Run the registered `code-eval-code-block-last-match-streaming` probe locally and compare metrics against the `origin/main` baseline.
+- Use GitHub Actions PR-scoped performance as the merge gate after the PR is opened.
+
+## Expected Metrics
+
+The probe should report lower `elapsed_ms_mean` for the synthetic multi-block response while preserving `parsed_code_block` output and extracted code length. Peak memory is expected to stay similar because the slice removes a scan rather than changing materialization behavior.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -47,19 +47,12 @@ def extract_candidate_code(raw_response: str) -> tuple[str, str]:
     if closing >= 0:
         opening = normalized.rfind("```", 0, closing)
         if opening >= 0:
-            trailing_start = closing + 3
-            fence_count: int | None = None
-            if trailing_start < len(normalized):
-                fence_count = normalized.count("```")
-                if fence_count % 2:
-                    closing = opening
-                    opening = normalized.rfind("```", 0, closing)
             if opening >= 0:
                 content_start = _code_block_content_start(normalized, opening + 3)
                 candidate = normalized[content_start:closing].strip()
-                if candidate or (
-                    fence_count if fence_count is not None else normalized.count("```")
-                ) % 2 == 0:
+                if candidate:
+                    return candidate, "parsed_code_block"
+                if normalized.count("```") % 2 == 0:
                     return candidate, "parsed_code_block"
                 closing = opening
                 opening = normalized.rfind("```", 0, closing)


### PR DESCRIPTION
## Summary
- Optimize `extract_candidate_code` for non-empty final fenced code blocks by returning before a full-response fence count.
- Keep the existing fallback count only for empty/ambiguous fenced candidates.

## Plan or Spec
- `docs/plans/2026-05-12-code-eval-fence-count-fast-path.md`
- Registered PR-scoped probe: `code-eval-code-block-last-match-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# exit 0: 4 passed in 0.64s (also rerun under coverage: 4 passed in 0.18s)

# changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py
# exit 0: TOTAL 3 0 100%

# registered local probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py
# exit 0: {"block_count": 2500.0, "elapsed_ms_mean": 0.0319971503423793, "extracted_chars_mean": 37.0, "peak_bytes_mean": 245.0, "sample_count": 7.0}

# old/new comparison against origin/main code loaded from git show
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 <inline comparison script>
# exit 0: old elapsed_ms_mean=0.09319959208369255, new elapsed_ms_mean=0.025705015286803246, delta_ms=-0.0674945767968893, speedup=3.6257357190345845, peak bytes 305.0 -> 245.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for the touched code path and focused probe/test scope.
- Local registered probe: `elapsed_ms_mean=0.0319971503423793`, `peak_bytes_mean=245.0`, `block_count=2500`, `sample_count=7`.
- Local old/new comparison: `old_mean=0.09319959208369255 ms`, `new_mean=0.025705015286803246 ms`, `delta_ms=-0.0674945767968893`, `speedup=3.6257357190345845x`, `peak_bytes_mean 305.0 -> 245.0`.
- CI PR-scoped performance must still run as the merge gate for the registered probe report.

## Known Gaps
- Full repository `make` gates were not run locally; this is a focused Python performance slice.
- GitHub Actions PR-scoped performance is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
