### PR TITLE
Add DataDesigner synthetic dataset adapter

### DIFF
--- a/docs/plans/2026-05-12-datadesigner-synthetic-dataset-function.md
+++ b/docs/plans/2026-05-12-datadesigner-synthetic-dataset-function.md
@@ -333,7 +333,8 @@ is not build-ready for training or evaluation.
 
 ## Execution Steps
 
-1. Validate request fields and reject unsupported output or column types.
+1. Validate request fields and reject unsupported output, duplicate column names,
+   or unsupported column types.
 2. Resolve `job_id` from `request.job_id` or a deterministic dataset id plus
    timestamp fallback, then create an isolated staging root under
    `jobs_root/synthetic-data/<job_id>/`.
@@ -349,17 +350,17 @@ is not build-ready for training or evaluation.
    `DatasetCreationResults.export(..., format="jsonl")`, and capture profiling
    and task-trace summary metadata.
 9. Convert generated rows to the selected Melix package shape.
-10. Write manifest, samples, validation split, previews, token or field stats,
-    quality counters, and DataDesigner provenance.
+10. Write manifest, samples, deterministic hash-based validation split, previews,
+    token or field stats, quality counters, and DataDesigner provenance.
 
 ## Performance Probes And Metrics
 
 First implementation slice should report these timings in the manifest and
-progress events:
+progress events where the step applies:
 
 - `datadesigner_config_build_ms`
 - `datadesigner_generate_ms`
-- `datadesigner_export_ms`
+- `datadesigner_export_ms` for create mode JSONL export
 - `melix_normalize_ms`
 - `melix_package_write_ms`
 

--- a/docs/plans/2026-05-12-datadesigner-synthetic-dataset-function.md
+++ b/docs/plans/2026-05-12-datadesigner-synthetic-dataset-function.md
@@ -1,0 +1,438 @@
+# DataDesigner Synthetic Dataset Function
+
+## Goal
+
+Implement the first Melix integration function for NVIDIA NeMo DataDesigner:
+
+```python
+generate_synthetic_dataset_package(request, *, jobs_root, output_dir, progress=None) -> SyntheticDatasetPackageResult
+```
+
+The function converts a Melix-owned synthetic dataset request into a DataDesigner
+configuration, runs preview or create mode, exports the generated rows, and
+normalizes them into Melix dataset packages that can be consumed by training and
+evaluation workflows.
+
+## Non-Goals
+
+- Do not add a public CLI, protobuf RPC, or native UI surface in the first slice.
+- Do not make DataDesigner a required worker dependency for the base worker.
+- Do not bypass Melix dataset package contracts by executing training or
+  evaluation directly against DataDesigner artifacts.
+- Do not upload generated datasets to Hugging Face Hub in the first slice.
+- Do not enable arbitrary user-provided Python callables in Melix requests.
+
+## Context
+
+Relevant specs:
+
+- `AGENTS.md`
+- `docs/benchmark-evaluation-contract.md`
+- `docs/plans/2026-05-05-dataset-management-and-selection.md`
+- `docs/plans/2026-03-30-m7-4-offline-dataset-packaging-and-runners.md`
+
+Relevant code paths:
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset.py`
+- `services/mlx-worker-python/worker/productization/evaluation_final_result.py`
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_training_dataset_builder.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+
+DataDesigner facts checked from `NVIDIA-NeMo/DataDesigner` on May 12, 2026:
+
+- The install package is `data-designer`, Python `>=3.10`, Apache-2.0.
+- The public interface is `data_designer.interface.DataDesigner`.
+- `DataDesigner.create(config_builder, *, num_records, dataset_name, resume)`
+  writes local artifacts under the configured `artifact_path`.
+- `DataDesigner.preview(config_builder, *, num_records)` stores preview results
+  in memory.
+- `DatasetCreationResults.export(path, format="jsonl")` streams generated
+  Parquet batches to JSONL without loading the full dataset.
+- `DataDesignerConfigBuilder` supports `add_model_config`, `add_column`,
+  `with_seed_dataset`, `write_config`, and `build`.
+- Model configuration supports OpenAI-compatible providers through
+  `ModelProvider(name, endpoint, provider_type="openai", api_key=...)` and
+  `ModelConfig(alias, model, provider, inference_parameters=...)`.
+- Core column configs include sampler, LLM text, LLM structured, LLM judge,
+  expression, validation, seed dataset, embedding, image, and custom columns.
+
+Current Melix contracts:
+
+- Training data packages use `manifest.json`, `samples.jsonl`, and optional
+  `valid.jsonl`.
+- Evaluation executes materialized packages and not raw external schemas.
+- Local training conversion already supports `chat_messages`,
+  `prompt_completion`, `text_completion`, `preference_pair`,
+  `prompt_candidate`, `reward_scored`, and `calibration`.
+- Final-result evaluation packages use `system`, `input`, and `target` rows
+  with a profile declared in `manifest.json`.
+
+## Implementation Status
+
+This slice implements the worker/productization adapter and dependency contract:
+
+- `services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py`
+- `services/mlx-worker-python/tests/test_synthetic_dataset_generation.py`
+- optional worker extra `synthetic-data = ["data-designer>=0.5.9,<0.6"]`
+
+Public CLI, protobuf RPC, registry browse UI, and native studio surfaces remain
+separate follow-up slices because they touch operator-facing workflows beyond
+the function boundary.
+
+## Function Boundary
+
+The Python worker/productization module exposes:
+
+```python
+@dataclass(frozen=True)
+class SyntheticDatasetRequest:
+    dataset_id: str
+    dataset_name: str
+    mode: Literal["preview", "create"]
+    num_records: int
+    output_kind: Literal["training", "evaluation_final_result", "raw_jsonl"]
+    output_format: str
+    model_provider: SyntheticModelProvider
+    models: tuple[SyntheticModelConfig, ...]
+    columns: tuple[SyntheticColumnSpec, ...]
+    job_id: str = ""
+    seed_source: SyntheticSeedSource | None = None
+    validation_ratio: float = 0.0
+    preview_count: int = 3
+    random_seed: int | None = None
+    data_designer_resume_mode: Literal["never", "if_possible", "always"] = "never"
+    disable_data_designer_telemetry: bool = True
+
+
+@dataclass(frozen=True)
+class SyntheticDatasetPackageResult:
+    package_path: Path
+    manifest_path: Path
+    output_path: Path
+    generated_jsonl_path: Path
+    data_designer_artifact_path: Path
+    config_path: Path
+    manifest_payload: dict[str, Any]
+    row_count: int
+    validation_row_count: int
+    output_kind: str
+    preview_only: bool
+```
+
+The implementation function:
+
+```python
+def generate_synthetic_dataset_package(
+    request: SyntheticDatasetRequest,
+    *,
+    jobs_root: Path,
+    output_dir: Path,
+    progress: Callable[[str, float], None] | None = None,
+) -> SyntheticDatasetPackageResult:
+    ...
+```
+
+### Placement
+
+The implementation is placed under:
+
+```text
+services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
+```
+
+Keep it separate from `training_dataset.py` and
+`evaluation_final_result.py` so DataDesigner remains an optional generation
+adapter rather than a dependency of existing package readers.
+
+### Dependency Shape
+
+The worker declares DataDesigner as an optional extra:
+
+```toml
+[project.optional-dependencies]
+synthetic-data = [
+  "data-designer>=0.5.9,<0.6",
+]
+```
+
+The function must lazy-import `data_designer` inside the call path and raise a
+Melix `ModelOperationError(code="missing_optional_dependency", ...)` when the
+extra is not installed.
+
+Set `NEMO_TELEMETRY_ENABLED=false` by default for this Melix call path unless
+the request explicitly opts in.
+
+## Request Mapping
+
+### Model Provider
+
+Melix should map its local OpenAI-compatible gateway or remote-server target
+into a DataDesigner model provider:
+
+```python
+dd.ModelProvider(
+    name="melix",
+    endpoint=request.model_provider.endpoint,
+    provider_type="openai",
+    api_key=request.model_provider.api_key,
+    extra_headers=request.model_provider.extra_headers,
+)
+```
+
+Each model alias maps to:
+
+```python
+dd.ModelConfig(
+    alias=model.alias,
+    model=model.model,
+    provider="melix",
+    inference_parameters=dd.ChatCompletionInferenceParams(
+        temperature=model.temperature,
+        top_p=model.top_p,
+        max_tokens=model.max_tokens,
+        timeout=model.timeout_seconds,
+        max_parallel_requests=model.max_parallel_requests,
+        extra_body=model.extra_body,
+    ),
+)
+```
+
+Do not store API keys in manifests, configs, or progress payloads. Persist only
+the provider name, endpoint origin, model aliases, and model identifiers.
+
+### Columns
+
+The first supported Melix column subset should be conservative:
+
+- `sampler`
+- `llm_text`
+- `llm_structured`
+- `llm_judge`
+- `expression`
+
+Defer `validation`, `custom`, `image`, `embedding`, and MCP tool columns until
+their security, asset, and dependency contracts are explicit. DataDesigner
+validators can execute code, call local Python functions, or call remote
+endpoints; Melix needs an explicit sandbox and allowlist contract before
+exposing them.
+
+Melix request fields should be declarative JSON-compatible data. The adapter
+constructs DataDesigner config objects internally and rejects unknown column
+types with `ModelOperationError(code="unsupported_synthetic_column", ...)`.
+
+### Seed Data
+
+The first seed sources should be:
+
+- existing Melix training package
+- existing Melix evaluation package
+- local JSONL or CSV source
+- managed HF dataset snapshot already readable through the dataset registry
+
+The adapter should convert Melix packages to a staging JSONL/Parquet seed file
+inside `jobs_root/synthetic-data/<job_id>/seed/`, then call
+`DataDesignerConfigBuilder.with_seed_dataset(...)`. Avoid passing in-memory
+dataframes across the function boundary because DataDesigner cannot serialize
+DataFrame seed configs to reusable config files.
+
+### Output Format
+
+For `output_kind="training"`, `output_format` is the Melix training sample
+format. Supported values are the formats listed in the training package section.
+
+For `output_kind="evaluation_final_result"`, `output_format` is the
+final-result `result_kind`; supported values are `json` and `text`.
+
+For `output_kind="raw_jsonl"`, `output_format` must be `jsonl`.
+
+## Output Mapping
+
+DataDesigner should produce an intermediate JSONL:
+
+```text
+<output_dir>/data_designer/generated.jsonl
+```
+
+The Melix adapter then transforms that JSONL into one of these package shapes.
+
+### Training Package
+
+For `output_kind="training"`, normalize generated rows through the same sample
+schemas used by `build_training_dataset_artifact`:
+
+- `chat_messages`: requires `messages`
+- `prompt_completion`: requires `prompt` and `completion`
+- `text_completion`: requires `text`
+- `preference_pair`: requires `prompt`, `chosen`, `rejected`
+- `prompt_candidate`: requires `prompt`, `candidates`
+- `reward_scored`: requires `prompt`, `response`, `reward_score`
+- `calibration`: requires `text`
+
+Write:
+
+```text
+<output_dir>/manifest.json
+<output_dir>/samples.jsonl
+<output_dir>/valid.jsonl      # only when validation rows exist
+```
+
+Manifest additions beyond the existing training package fields:
+
+```json
+{
+  "schema_version": "melix.training_dataset_package.v1",
+  "source_kind": "datadesigner",
+  "operation": "generate_synthetic_dataset",
+  "datadesigner": {
+    "package": "data-designer",
+    "config_path": ".../data_designer/config.json",
+    "artifact_path": ".../data_designer/artifacts",
+    "generated_jsonl_path": ".../data_designer/generated.jsonl",
+    "num_records_requested": 100,
+    "num_records_generated": 100,
+    "mode": "create",
+    "columns": ["topic", "prompt", "completion"],
+    "model_aliases": ["generator"]
+  }
+}
+```
+
+### Evaluation Final-Result Package
+
+For `output_kind="evaluation_final_result"`, map generated rows into:
+
+- `system`
+- `input`
+- `target`
+- optional `sample_id`
+
+The function should reuse the final-result materialization semantics from
+`evaluation_final_result.py` and write a package whose manifest declares:
+
+```json
+{
+  "schema_version": "melix.evaluation_dataset_package.v2",
+  "source_kind": "datadesigner",
+  "profile_type": "final_result",
+  "result_kind": "json",
+  "extraction_mode": "strict_full_response",
+  "scoring_mode": "normalized_exact_match",
+  "threshold": 1.0
+}
+```
+
+The generated `target` field must be valid for the requested `result_kind`
+before the package is accepted.
+
+### Raw JSONL
+
+For `output_kind="raw_jsonl"`, only export the DataDesigner JSONL and write a
+Melix inspection manifest. This is useful for preview and schema iteration, but
+is not build-ready for training or evaluation.
+
+## Execution Steps
+
+1. Validate request fields and reject unsupported output or column types.
+2. Resolve `job_id` from `request.job_id` or a deterministic dataset id plus
+   timestamp fallback, then create an isolated staging root under
+   `jobs_root/synthetic-data/<job_id>/`.
+3. Lazy-import DataDesigner and verify the installed version if available.
+4. Disable DataDesigner telemetry by default with a scoped environment override
+   around the DataDesigner call and restore the prior environment afterward.
+5. Build DataDesigner model providers, model configs, columns, and seed config.
+6. Write the DataDesigner builder config to
+   `<output_dir>/data_designer/config.json` for reproducibility.
+7. In preview mode, call `DataDesigner.preview(...)`, convert the in-memory
+   dataframe to JSONL, write an inspection manifest, and stop.
+8. In create mode, call `DataDesigner.create(...)`, export JSONL with
+   `DatasetCreationResults.export(..., format="jsonl")`, and capture profiling
+   and task-trace summary metadata.
+9. Convert generated rows to the selected Melix package shape.
+10. Write manifest, samples, validation split, previews, token or field stats,
+    quality counters, and DataDesigner provenance.
+
+## Performance Probes And Metrics
+
+First implementation slice should report these timings in the manifest and
+progress events:
+
+- `datadesigner_config_build_ms`
+- `datadesigner_generate_ms`
+- `datadesigner_export_ms`
+- `melix_normalize_ms`
+- `melix_package_write_ms`
+
+Success metrics:
+
+- `num_records_generated == num_records_requested` for create mode unless
+  DataDesigner reports early shutdown or filtered rows.
+- JSONL export uses DataDesigner streaming export, not `load_dataset()`, for
+  create mode.
+- Peak memory in a local synthetic probe is proportional to one DataDesigner
+  output batch plus Melix normalization buffers, not the full generated dataset.
+- Manifest contains no secrets.
+
+## Verification
+
+Focused implementation verification:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run \
+  --data-file /tmp/synthetic_dataset_generation.coverage \
+  --source=worker.productization.synthetic_dataset_generation \
+  -m pytest -q \
+  services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report \
+  --data-file /tmp/synthetic_dataset_generation.coverage \
+  --include='*/worker/productization/synthetic_dataset_generation.py'
+```
+
+Optional live smoke after the dependency extra is locked:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra synthetic-data \
+  python scripts/synthetic_dataset_generation_smoke.py \
+  --endpoint http://127.0.0.1:12434/v1 \
+  --model melix-dev-text \
+  --output-dir .runtime/synthetic-data-smoke
+```
+
+## Acceptance Criteria
+
+- A focused adapter function can generate a Melix training package from a
+  DataDesigner config without changing existing training package readers.
+- The same function can generate a final-result evaluation package from
+  DataDesigner rows without changing evaluation execution semantics.
+- Preview mode produces inspection artifacts but does not claim build-ready
+  package status.
+- DataDesigner artifacts, generated JSONL, and Melix manifests are linked by
+  stable paths and provenance fields.
+- Secrets are redacted from all persisted artifacts.
+- DataDesigner remains an optional dependency.
+
+## Risks And Open Questions
+
+- DataDesigner stays behind the `synthetic-data` extra so pandas, pyarrow, MCP,
+  and related generation dependencies stay out of the base worker install path.
+- Preview results are in memory; large generation must use create mode plus
+  streaming export.
+- Local Melix gateway compatibility with DataDesigner OpenAI provider should be
+  validated against `/v1/chat/completions` before enabling a public command.
+- DataDesigner custom columns and validators can execute user logic or call
+  remote endpoints; the first Melix surface should expose only declarative,
+  allowlisted column specs.
+- Final-result evaluation scoring requires target validity. The adapter should
+  fail package creation early when generated targets do not match the requested
+  `result_kind`.
+
+## Rollback Or Safe Exit
+
+Remove `synthetic_dataset_generation.py`, its focused tests, and the
+`synthetic-data` optional extra if the integration direction changes. Generated
+runtime artifacts belong under `.runtime/` or the operator-specified output
+directory, never under tracked repository paths.

--- a/services/mlx-worker-python/pyproject.toml
+++ b/services/mlx-worker-python/pyproject.toml
@@ -31,6 +31,9 @@ audio-tts = [
 audio = [
   "mlx-audio==0.4.3",
 ]
+synthetic-data = [
+  "data-designer>=0.5.9,<0.6",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
+++ b/services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
@@ -21,6 +21,19 @@ from worker.productization.synthetic_dataset_generation import (
 )
 
 
+@dataclass
+class _FakeDesignerState:
+    rows: list[dict[str, Any]]
+    instances: list["_FakeDataDesigner"] | None = None
+
+    def __post_init__(self) -> None:
+        if self.instances is None:
+            self.instances = []
+
+
+_fake_state = _FakeDesignerState(rows=[])
+
+
 @dataclass(frozen=True)
 class _FakeModelProvider:
     name: str
@@ -143,19 +156,19 @@ def _fake_get_column_config_from_kwargs(
 
 
 class _FakeDataDesigner:
-    instances: list[_FakeDataDesigner] = []
-    rows: list[dict[str, Any]] = []
+    state = _fake_state
 
     def __init__(self, *, model_providers: list[_FakeModelProvider], artifact_path: str) -> None:
         self.model_providers = model_providers
         self.artifact_path = artifact_path
+        self.rows = list(type(self).state.rows)
         self.preview_calls: list[tuple[_FakeBuilder, int]] = []
         self.create_calls: list[tuple[_FakeBuilder, int, str, bool]] = []
-        _FakeDataDesigner.instances.append(self)
+        type(self).state.instances.append(self)
 
     def preview(self, builder: _FakeBuilder, *, num_records: int) -> list[dict[str, Any]]:
         self.preview_calls.append((builder, num_records))
-        return _FakeDataDesigner.rows[:num_records]
+        return self.rows[:num_records]
 
     def create(
         self,
@@ -166,13 +179,13 @@ class _FakeDataDesigner:
         resume: bool,
     ) -> _FakeCreationResult:
         self.create_calls.append((builder, num_records, dataset_name, resume))
-        return _FakeCreationResult(_FakeDataDesigner.rows[:num_records])
+        return _FakeCreationResult(self.rows[:num_records])
 
 
 @pytest.fixture(autouse=True)
 def _fake_datadesigner_modules(monkeypatch: pytest.MonkeyPatch) -> None:
-    _FakeDataDesigner.instances = []
-    _FakeDataDesigner.rows = [
+    _fake_state.instances = []
+    _fake_state.rows = [
         {"prompt": "p1", "completion": "c1"},
         {"prompt": "p2", "completion": "c2"},
         {"prompt": "p3", "completion": "c3"},
@@ -264,12 +277,12 @@ def test_create_training_package_writes_melix_contract_and_redacts_secrets(
     assert result.validation_row_count == 1
     assert result.preview_only is False
     assert (tmp_path / "out" / "samples.jsonl").read_text(encoding="utf-8") == (
-        '{"prompt": "p1", "completion": "c1"}\n'
         '{"prompt": "p2", "completion": "c2"}\n'
         '{"prompt": "p3", "completion": "c3"}\n'
+        '{"prompt": "p4", "completion": "c4"}\n'
     )
     assert (tmp_path / "out" / "valid.jsonl").read_text(encoding="utf-8") == (
-        '{"prompt": "p4", "completion": "c4"}\n'
+        '{"prompt": "p1", "completion": "c1"}\n'
     )
 
     manifest = json.loads((tmp_path / "out" / "manifest.json").read_text(encoding="utf-8"))
@@ -279,6 +292,7 @@ def test_create_training_package_writes_melix_contract_and_redacts_secrets(
     assert manifest["format"] == "prompt_completion"
     assert manifest["sample_count"] == 3
     assert manifest["validation_sample_count"] == 1
+    assert manifest["validation_strategy"] == "deterministic_hash_ratio"
     assert manifest["build_ready"] is True
     assert manifest["datadesigner"]["provider"]["api_key"] == "[REDACTED]"
     assert manifest["datadesigner"]["provider"]["extra_headers"]["Authorization"] == "[REDACTED]"
@@ -298,8 +312,8 @@ def test_create_training_package_writes_melix_contract_and_redacts_secrets(
     config = json.loads((tmp_path / "out" / "data_designer" / "config.json").read_text(encoding="utf-8"))
     assert config["api_key"] == "[REDACTED]"
     assert config["Authorization"] == "[REDACTED]"
-    assert _FakeDataDesigner.instances[0].model_providers[0].api_key == "secret-key"
-    assert _FakeDataDesigner.instances[0].create_calls[0][3] is False
+    assert _fake_state.instances[0].model_providers[0].api_key == "secret-key"
+    assert _fake_state.instances[0].create_calls[0][3] is False
     assert progress_events[0][0] == "load_datadesigner"
     assert progress_events[-1] == ("complete", 1.0)
     assert synthetic_module.os.environ["NEMO_TELEMETRY_ENABLED"] == "true"
@@ -316,6 +330,23 @@ def test_create_training_package_removes_stale_valid_jsonl_without_validation(tm
     )
 
     assert not (tmp_path / "out" / "valid.jsonl").exists()
+
+
+def test_training_validation_split_uses_stable_hash_instead_of_tail_rows(tmp_path: Path) -> None:
+    generate_synthetic_dataset_package(
+        _request(validation_ratio=0.5),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "out",
+    )
+
+    assert (tmp_path / "out" / "samples.jsonl").read_text(encoding="utf-8") == (
+        '{"prompt": "p3", "completion": "c3"}\n'
+        '{"prompt": "p4", "completion": "c4"}\n'
+    )
+    assert (tmp_path / "out" / "valid.jsonl").read_text(encoding="utf-8") == (
+        '{"prompt": "p1", "completion": "c1"}\n'
+        '{"prompt": "p2", "completion": "c2"}\n'
+    )
 
 
 def test_preview_raw_jsonl_writes_inspection_manifest_without_build_ready_package(tmp_path: Path) -> None:
@@ -340,14 +371,16 @@ def test_preview_raw_jsonl_writes_inspection_manifest_without_build_ready_packag
     assert manifest["build_ready"] is False
     assert manifest["preview_only"] is True
     assert manifest["sample_count"] == 2
-    assert _FakeDataDesigner.instances[0].preview_calls[0][1] == 2
+    assert "datadesigner_export_ms" not in manifest["timing"]
+    assert _fake_state.instances[0].preview_calls[0][1] == 2
 
 
 def test_create_evaluation_final_result_package_validates_json_targets(tmp_path: Path) -> None:
-    _FakeDataDesigner.rows = [
+    source_rows = [
         {"sample_id": "one", "system": "sys", "input": "extract", "target": {"label": "a"}},
         {"sample_id": "two", "system": "", "input": "extract b", "target": '{"label":"b"}'},
     ]
+    _fake_state.rows = source_rows
 
     result = generate_synthetic_dataset_package(
         _request(
@@ -369,10 +402,11 @@ def test_create_evaluation_final_result_package_validates_json_targets(tmp_path:
         '{"id": "one", "system": "sys", "input": {"text": "extract"}, "target": {"label": "a"}}\n'
         '{"id": "two", "system": "", "input": {"text": "extract b"}, "target": {"label": "b"}}\n'
     )
+    assert source_rows[1]["target"] == '{"label":"b"}'
 
 
 def test_create_evaluation_text_package_and_resume_mode(tmp_path: Path) -> None:
-    _FakeDataDesigner.rows = [
+    _fake_state.rows = [
         {"sample_id": "one", "system": "", "input": "classify", "target": "positive"},
     ]
 
@@ -392,7 +426,7 @@ def test_create_evaluation_text_package_and_resume_mode(tmp_path: Path) -> None:
     manifest = json.loads((tmp_path / "eval" / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["result_kind"] == "text"
     assert manifest["datadesigner"]["telemetry_disabled"] is False
-    assert _FakeDataDesigner.instances[0].create_calls[0][3] is True
+    assert _fake_state.instances[0].create_calls[0][3] is True
 
 
 def test_create_raw_jsonl_inspection_from_create_mode(tmp_path: Path) -> None:
@@ -410,7 +444,7 @@ def test_create_raw_jsonl_inspection_from_create_mode(tmp_path: Path) -> None:
 
 
 def test_invalid_evaluation_json_target_fails_before_package_write(tmp_path: Path) -> None:
-    _FakeDataDesigner.rows = [
+    _fake_state.rows = [
         {"sample_id": "one", "system": "", "input": "extract", "target": "not json"},
     ]
 
@@ -430,7 +464,7 @@ def test_invalid_evaluation_json_target_fails_before_package_write(tmp_path: Pat
 
 
 def test_invalid_evaluation_json_target_type_fails_before_package_write(tmp_path: Path) -> None:
-    _FakeDataDesigner.rows = [
+    _fake_state.rows = [
         {"sample_id": "one", "system": "", "input": "extract", "target": 42},
     ]
 
@@ -449,7 +483,7 @@ def test_invalid_evaluation_json_target_type_fails_before_package_write(tmp_path
 
 
 def test_invalid_evaluation_text_target_is_rejected(tmp_path: Path) -> None:
-    _FakeDataDesigner.rows = [
+    _fake_state.rows = [
         {"sample_id": "one", "system": "", "input": "classify", "target": ""},
     ]
 
@@ -468,7 +502,7 @@ def test_invalid_evaluation_text_target_is_rejected(tmp_path: Path) -> None:
 
 
 def test_invalid_training_row_is_reported_as_synthetic_output_error(tmp_path: Path) -> None:
-    _FakeDataDesigner.rows = [{"prompt": "", "completion": "answer"}]
+    _fake_state.rows = [{"prompt": "", "completion": "answer"}]
 
     with pytest.raises(ModelOperationError) as error:
         generate_synthetic_dataset_package(
@@ -546,7 +580,7 @@ def test_stages_training_package_seed_rows(tmp_path: Path) -> None:
         '{"prompt": "seed-p", "completion": "seed-c"}\n'
         '{"prompt": "seed-v", "completion": "seed-vc"}\n'
     )
-    assert str(_FakeDataDesigner.instances[0].create_calls[0][0].seed_source) == str(staged)
+    assert str(_fake_state.instances[0].create_calls[0][0].seed_source) == str(staged)
 
 
 def test_stages_evaluation_package_seed_rows(tmp_path: Path) -> None:
@@ -617,6 +651,78 @@ def test_stages_local_seed_file_and_directory(tmp_path: Path) -> None:
         output_dir=tmp_path / "out-dir-second",
     )
     assert (tmp_path / "jobs-dir" / "synthetic-data" / "job-1" / "seed" / "snapshot" / "extra.jsonl").is_file()
+
+
+def test_replaces_stale_seed_file_when_source_changes_to_directory(tmp_path: Path) -> None:
+    source_file = tmp_path / "seed"
+    source_file.write_text('{"topic": "file"}\n', encoding="utf-8")
+    jobs_root = tmp_path / "jobs"
+
+    generate_synthetic_dataset_package(
+        _request(
+            seed_source=SyntheticSeedSource(
+                source_kind="local_jsonl",
+                source_path=source_file,
+            )
+        ),
+        jobs_root=jobs_root,
+        output_dir=tmp_path / "out-file",
+    )
+    staged_path = jobs_root / "synthetic-data" / "job-1" / "seed" / "seed"
+    assert staged_path.is_file()
+
+    source_file.unlink()
+    source_file.mkdir()
+    (source_file / "rows.jsonl").write_text('{"topic": "dir"}\n', encoding="utf-8")
+    generate_synthetic_dataset_package(
+        _request(
+            seed_source=SyntheticSeedSource(
+                source_kind="managed_hf_snapshot",
+                source_path=source_file,
+            )
+        ),
+        jobs_root=jobs_root,
+        output_dir=tmp_path / "out-dir",
+    )
+
+    assert (staged_path / "rows.jsonl").is_file()
+
+
+def test_replaces_stale_seed_directory_when_source_changes_to_file(tmp_path: Path) -> None:
+    source_dir = tmp_path / "seed"
+    source_dir.mkdir()
+    (source_dir / "rows.jsonl").write_text('{"topic": "dir"}\n', encoding="utf-8")
+    jobs_root = tmp_path / "jobs"
+
+    generate_synthetic_dataset_package(
+        _request(
+            seed_source=SyntheticSeedSource(
+                source_kind="managed_hf_snapshot",
+                source_path=source_dir,
+            )
+        ),
+        jobs_root=jobs_root,
+        output_dir=tmp_path / "out-dir",
+    )
+    staged_path = jobs_root / "synthetic-data" / "job-1" / "seed" / "seed"
+    assert (staged_path / "rows.jsonl").is_file()
+
+    source_dir.rename(tmp_path / "old-seed")
+    source_file = tmp_path / "seed"
+    source_file.write_text('{"topic": "file"}\n', encoding="utf-8")
+    generate_synthetic_dataset_package(
+        _request(
+            seed_source=SyntheticSeedSource(
+                source_kind="local_jsonl",
+                source_path=source_file,
+            )
+        ),
+        jobs_root=jobs_root,
+        output_dir=tmp_path / "out-file",
+    )
+
+    assert staged_path.is_file()
+    assert staged_path.read_text(encoding="utf-8") == '{"topic": "file"}\n'
 
 
 def test_missing_seed_source_fails(tmp_path: Path) -> None:
@@ -701,6 +807,14 @@ def test_missing_seed_package_samples_are_rejected(tmp_path: Path) -> None:
             (SyntheticColumnSpec(name="", column_type="llm_text"),),
             "invalid_synthetic_dataset_request",
         ),
+        (
+            "columns",
+            (
+                SyntheticColumnSpec(name="prompt", column_type="llm_text"),
+                SyntheticColumnSpec(name=" prompt ", column_type="expression"),
+            ),
+            "invalid_synthetic_dataset_request",
+        ),
         ("validation_ratio", 1.0, "invalid_synthetic_dataset_request"),
         ("preview_count", 0, "invalid_synthetic_dataset_request"),
     ],
@@ -719,6 +833,23 @@ def test_request_validation_errors(
         )
 
     assert error.value.code == expected_code
+
+
+def test_duplicate_column_validation_reports_column_name(tmp_path: Path) -> None:
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(
+                columns=(
+                    SyntheticColumnSpec(name="prompt", column_type="llm_text"),
+                    SyntheticColumnSpec(name="prompt", column_type="expression"),
+                )
+            ),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "invalid_synthetic_dataset_request"
+    assert error.value.details["column_name"] == "prompt"
 
 
 def test_raw_jsonl_requires_jsonl_output_format(tmp_path: Path) -> None:
@@ -761,7 +892,7 @@ def test_uses_fallback_column_api_when_config_factory_is_unavailable(
         output_dir=tmp_path / "out",
     )
 
-    builder = _FakeDataDesigner.instances[0].create_calls[0][0]
+    builder = _fake_state.instances[0].create_calls[0][0]
     assert builder.columns[0].name == "prompt"
 
 
@@ -830,6 +961,16 @@ def test_invalid_preview_shape_is_reported(tmp_path: Path) -> None:
         )
 
     assert error.value.code == "invalid_datadesigner_preview"
+    assert error.value.details["preview_result_type"] == "object"
+
+
+def test_empty_jsonl_writer_creates_empty_file(tmp_path: Path) -> None:
+    output = tmp_path / "empty.jsonl"
+
+    synthetic_module._write_jsonl_rows(output, [])
+
+    assert output.is_file()
+    assert output.read_text(encoding="utf-8") == ""
 
 
 def test_config_write_failure_is_reported(tmp_path: Path) -> None:
@@ -942,7 +1083,7 @@ def test_column_type_falls_back_to_string_when_enum_name_is_unavailable(
         output_dir=tmp_path / "out",
     )
 
-    builder = _FakeDataDesigner.instances[0].create_calls[0][0]
+    builder = _fake_state.instances[0].create_calls[0][0]
     assert builder.columns[0].column_type == "llm_text"
 
 
@@ -965,4 +1106,4 @@ def test_local_seed_source_can_fallback_to_plain_path_when_local_seed_class_miss
         output_dir=tmp_path / "out",
     )
 
-    assert isinstance(_FakeDataDesigner.instances[0].create_calls[0][0].seed_source, str)
+    assert isinstance(_fake_state.instances[0].create_calls[0][0].seed_source, str)

--- a/services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
+++ b/services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
@@ -1,0 +1,968 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from worker.model_ops.errors import ModelOperationError
+from worker.productization import synthetic_dataset_generation as synthetic_module
+from worker.productization.synthetic_dataset_generation import (
+    SyntheticColumnSpec,
+    SyntheticDatasetRequest,
+    SyntheticModelConfig,
+    SyntheticModelProvider,
+    SyntheticSeedSource,
+    generate_synthetic_dataset_package,
+)
+
+
+@dataclass(frozen=True)
+class _FakeModelProvider:
+    name: str
+    endpoint: str
+    provider_type: str
+    api_key: str
+    extra_headers: dict[str, str]
+
+
+@dataclass(frozen=True)
+class _FakeInferenceParams:
+    kwargs: dict[str, Any]
+
+    def __init__(self, **kwargs: Any) -> None:
+        object.__setattr__(self, "kwargs", kwargs)
+
+
+@dataclass(frozen=True)
+class _FakeModelConfig:
+    alias: str
+    model: str
+    provider: str
+    inference_parameters: _FakeInferenceParams
+
+
+@dataclass(frozen=True)
+class _FakeColumnConfig:
+    name: str
+    column_type: str
+    params: dict[str, Any]
+
+
+class _FakeColumnType:
+    SAMPLER = "sampler"
+    LLM_TEXT = "llm_text"
+    LLM_STRUCTURED = "llm_structured"
+    LLM_JUDGE = "llm_judge"
+    EXPRESSION = "expression"
+
+
+class _FakeBuilder:
+    def __init__(self, *, model_configs: list[_FakeModelConfig]) -> None:
+        self.model_configs = model_configs
+        self.columns: list[_FakeColumnConfig] = []
+        self.seed_source: Any = None
+        self.artifact_path = Path()
+
+    def add_column(self, column_config: _FakeColumnConfig) -> None:
+        self.columns.append(column_config)
+
+    def with_seed_dataset(self, seed_source: Any) -> None:
+        self.seed_source = seed_source
+
+    def write_config(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "models": [
+                        {
+                            "alias": model.alias,
+                            "model": model.model,
+                            "provider": model.provider,
+                            "inference_parameters": model.inference_parameters.kwargs,
+                        }
+                        for model in self.model_configs
+                    ],
+                    "columns": [
+                        {
+                            "name": column.name,
+                            "column_type": column.column_type,
+                            **column.params,
+                        }
+                        for column in self.columns
+                    ],
+                    "column_names": [column.name for column in self.columns],
+                    "seed_source": str(self.seed_source or ""),
+                    "api_key": "should-not-persist",
+                    "Authorization": "Bearer should-not-persist",
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+
+class _FakeCreationResult:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def export(self, path: Path, *, format: str) -> None:
+        assert format == "jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "".join(json.dumps(row) + "\n" for row in self.rows),
+            encoding="utf-8",
+        )
+
+
+class _FakeLocalFileSeedSource:
+    def __init__(self, *, path: str) -> None:
+        self.path = path
+
+    @classmethod
+    def from_path(cls, path: Path) -> _FakeLocalFileSeedSource:
+        return cls(path=str(path))
+
+    def __str__(self) -> str:
+        return self.path
+
+
+def _fake_get_column_config_from_kwargs(
+    *,
+    name: str,
+    column_type: str,
+    **params: Any,
+) -> _FakeColumnConfig:
+    return _FakeColumnConfig(name=name, column_type=column_type, params=params)
+
+
+class _FakeDataDesigner:
+    instances: list[_FakeDataDesigner] = []
+    rows: list[dict[str, Any]] = []
+
+    def __init__(self, *, model_providers: list[_FakeModelProvider], artifact_path: str) -> None:
+        self.model_providers = model_providers
+        self.artifact_path = artifact_path
+        self.preview_calls: list[tuple[_FakeBuilder, int]] = []
+        self.create_calls: list[tuple[_FakeBuilder, int, str, bool]] = []
+        _FakeDataDesigner.instances.append(self)
+
+    def preview(self, builder: _FakeBuilder, *, num_records: int) -> list[dict[str, Any]]:
+        self.preview_calls.append((builder, num_records))
+        return _FakeDataDesigner.rows[:num_records]
+
+    def create(
+        self,
+        builder: _FakeBuilder,
+        *,
+        num_records: int,
+        dataset_name: str,
+        resume: bool,
+    ) -> _FakeCreationResult:
+        self.create_calls.append((builder, num_records, dataset_name, resume))
+        return _FakeCreationResult(_FakeDataDesigner.rows[:num_records])
+
+
+@pytest.fixture(autouse=True)
+def _fake_datadesigner_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeDataDesigner.instances = []
+    _FakeDataDesigner.rows = [
+        {"prompt": "p1", "completion": "c1"},
+        {"prompt": "p2", "completion": "c2"},
+        {"prompt": "p3", "completion": "c3"},
+        {"prompt": "p4", "completion": "c4"},
+    ]
+
+    package = types.ModuleType("data_designer")
+    interface = types.ModuleType("data_designer.interface")
+    config = types.ModuleType("data_designer.config")
+    builder = types.ModuleType("data_designer.config.config_builder")
+    models = types.ModuleType("data_designer.config.models")
+    column_types = types.ModuleType("data_designer.config.column_types")
+    seed_source = types.ModuleType("data_designer.config.seed_source")
+
+    interface.DataDesigner = _FakeDataDesigner
+    builder.DataDesignerConfigBuilder = _FakeBuilder
+    models.ModelProvider = _FakeModelProvider
+    models.ModelConfig = _FakeModelConfig
+    models.ChatCompletionInferenceParams = _FakeInferenceParams
+    column_types.DataDesignerColumnType = _FakeColumnType
+    column_types.get_column_config_from_kwargs = _fake_get_column_config_from_kwargs
+    seed_source.LocalFileSeedSource = _FakeLocalFileSeedSource
+
+    monkeypatch.setitem(sys.modules, "data_designer", package)
+    monkeypatch.setitem(sys.modules, "data_designer.interface", interface)
+    monkeypatch.setitem(sys.modules, "data_designer.config", config)
+    monkeypatch.setitem(sys.modules, "data_designer.config.config_builder", builder)
+    monkeypatch.setitem(sys.modules, "data_designer.config.models", models)
+    monkeypatch.setitem(sys.modules, "data_designer.config.column_types", column_types)
+    monkeypatch.setitem(sys.modules, "data_designer.config.seed_source", seed_source)
+
+
+def _request(**overrides: Any) -> SyntheticDatasetRequest:
+    defaults: dict[str, Any] = {
+        "dataset_id": "support.sft.v1",
+        "dataset_name": "support-sft",
+        "mode": "create",
+        "num_records": 4,
+        "output_kind": "training",
+        "output_format": "prompt_completion",
+        "model_provider": SyntheticModelProvider(
+            endpoint="http://127.0.0.1:12434/v1",
+            api_key="secret-key",
+            extra_headers={"Authorization": "Bearer secret-token", "X-Trace": "ok"},
+        ),
+        "models": (
+            SyntheticModelConfig(
+                alias="generator",
+                model="melix-dev-text",
+                temperature=0.2,
+                max_tokens=128,
+                extra_body={"api_key": "nested-secret", "safe": True},
+            ),
+        ),
+        "columns": (
+            SyntheticColumnSpec(
+                name="prompt",
+                column_type="llm_text",
+                params={"prompt": "write prompt"},
+            ),
+            SyntheticColumnSpec(
+                name="completion",
+                column_type="llm_text",
+                params={"prompt": "write completion"},
+            ),
+        ),
+        "job_id": "job-1",
+        "preview_count": 2,
+    }
+    defaults.update(overrides)
+    return SyntheticDatasetRequest(**defaults)
+
+
+def test_create_training_package_writes_melix_contract_and_redacts_secrets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+    progress_events: list[tuple[str, float]] = []
+
+    result = generate_synthetic_dataset_package(
+        _request(validation_ratio=0.25),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "out",
+        progress=lambda stage, fraction: progress_events.append((stage, fraction)),
+    )
+
+    assert result.row_count == 3
+    assert result.validation_row_count == 1
+    assert result.preview_only is False
+    assert (tmp_path / "out" / "samples.jsonl").read_text(encoding="utf-8") == (
+        '{"prompt": "p1", "completion": "c1"}\n'
+        '{"prompt": "p2", "completion": "c2"}\n'
+        '{"prompt": "p3", "completion": "c3"}\n'
+    )
+    assert (tmp_path / "out" / "valid.jsonl").read_text(encoding="utf-8") == (
+        '{"prompt": "p4", "completion": "c4"}\n'
+    )
+
+    manifest = json.loads((tmp_path / "out" / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "melix.training_dataset_package.v1"
+    assert manifest["source_kind"] == "datadesigner"
+    assert manifest["operation"] == "generate_synthetic_dataset"
+    assert manifest["format"] == "prompt_completion"
+    assert manifest["sample_count"] == 3
+    assert manifest["validation_sample_count"] == 1
+    assert manifest["build_ready"] is True
+    assert manifest["datadesigner"]["provider"]["api_key"] == "[REDACTED]"
+    assert manifest["datadesigner"]["provider"]["extra_headers"]["Authorization"] == "[REDACTED]"
+    assert manifest["datadesigner"]["models"][0]["extra_body"]["api_key"] == "[REDACTED]"
+    assert "secret-key" not in json.dumps(manifest)
+    assert "secret-token" not in json.dumps(manifest)
+    assert "nested-secret" not in json.dumps(manifest)
+    assert set(manifest["timing"]) >= {
+        "datadesigner_config_build_ms",
+        "datadesigner_generate_ms",
+        "datadesigner_export_ms",
+        "melix_normalize_ms",
+        "melix_package_write_ms",
+        "total_elapsed_ms",
+    }
+
+    config = json.loads((tmp_path / "out" / "data_designer" / "config.json").read_text(encoding="utf-8"))
+    assert config["api_key"] == "[REDACTED]"
+    assert config["Authorization"] == "[REDACTED]"
+    assert _FakeDataDesigner.instances[0].model_providers[0].api_key == "secret-key"
+    assert _FakeDataDesigner.instances[0].create_calls[0][3] is False
+    assert progress_events[0][0] == "load_datadesigner"
+    assert progress_events[-1] == ("complete", 1.0)
+    assert synthetic_module.os.environ["NEMO_TELEMETRY_ENABLED"] == "true"
+
+
+def test_create_training_package_removes_stale_valid_jsonl_without_validation(tmp_path: Path) -> None:
+    (tmp_path / "out").mkdir()
+    (tmp_path / "out" / "valid.jsonl").write_text("stale\n", encoding="utf-8")
+
+    generate_synthetic_dataset_package(
+        _request(num_records=1),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "out",
+    )
+
+    assert not (tmp_path / "out" / "valid.jsonl").exists()
+
+
+def test_preview_raw_jsonl_writes_inspection_manifest_without_build_ready_package(tmp_path: Path) -> None:
+    (tmp_path / "out").mkdir()
+    (tmp_path / "out" / "manifest.json").write_text("stale\n", encoding="utf-8")
+    (tmp_path / "out" / "samples.jsonl").write_text("stale\n", encoding="utf-8")
+    (tmp_path / "out" / "valid.jsonl").write_text("stale\n", encoding="utf-8")
+
+    result = generate_synthetic_dataset_package(
+        _request(mode="preview", output_kind="raw_jsonl", output_format="jsonl", num_records=2),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "out",
+    )
+
+    assert result.preview_only is True
+    assert result.output_path == tmp_path / "out" / "data_designer" / "generated.jsonl"
+    assert not (tmp_path / "out" / "manifest.json").exists()
+    assert not (tmp_path / "out" / "samples.jsonl").exists()
+    assert not (tmp_path / "out" / "valid.jsonl").exists()
+    manifest = json.loads((tmp_path / "out" / "synthetic_dataset.preview.json").read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "melix.synthetic_dataset_preview.v1"
+    assert manifest["build_ready"] is False
+    assert manifest["preview_only"] is True
+    assert manifest["sample_count"] == 2
+    assert _FakeDataDesigner.instances[0].preview_calls[0][1] == 2
+
+
+def test_create_evaluation_final_result_package_validates_json_targets(tmp_path: Path) -> None:
+    _FakeDataDesigner.rows = [
+        {"sample_id": "one", "system": "sys", "input": "extract", "target": {"label": "a"}},
+        {"sample_id": "two", "system": "", "input": "extract b", "target": '{"label":"b"}'},
+    ]
+
+    result = generate_synthetic_dataset_package(
+        _request(
+            output_kind="evaluation_final_result",
+            output_format="json",
+            num_records=2,
+        ),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "eval",
+    )
+
+    assert result.row_count == 2
+    manifest = json.loads((tmp_path / "eval" / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "melix.evaluation_dataset_package.v2"
+    assert manifest["profile_type"] == "final_result"
+    assert manifest["result_kind"] == "json"
+    assert manifest["field_mapping"]["input_text_path"] == "input"
+    assert (tmp_path / "eval" / "samples.jsonl").read_text(encoding="utf-8") == (
+        '{"id": "one", "system": "sys", "input": {"text": "extract"}, "target": {"label": "a"}}\n'
+        '{"id": "two", "system": "", "input": {"text": "extract b"}, "target": {"label": "b"}}\n'
+    )
+
+
+def test_create_evaluation_text_package_and_resume_mode(tmp_path: Path) -> None:
+    _FakeDataDesigner.rows = [
+        {"sample_id": "one", "system": "", "input": "classify", "target": "positive"},
+    ]
+
+    result = generate_synthetic_dataset_package(
+        _request(
+            output_kind="evaluation_final_result",
+            output_format="text",
+            num_records=1,
+            data_designer_resume_mode="always",
+            disable_data_designer_telemetry=False,
+        ),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "eval",
+    )
+
+    assert result.row_count == 1
+    manifest = json.loads((tmp_path / "eval" / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["result_kind"] == "text"
+    assert manifest["datadesigner"]["telemetry_disabled"] is False
+    assert _FakeDataDesigner.instances[0].create_calls[0][3] is True
+
+
+def test_create_raw_jsonl_inspection_from_create_mode(tmp_path: Path) -> None:
+    result = generate_synthetic_dataset_package(
+        _request(output_kind="raw_jsonl", output_format="jsonl", num_records=2),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "out",
+    )
+
+    assert result.preview_only is True
+    manifest = json.loads((tmp_path / "out" / "synthetic_dataset.inspect.json").read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "melix.synthetic_dataset_inspection.v1"
+    assert manifest["sample_count"] == 2
+    assert manifest["build_ready"] is False
+
+
+def test_invalid_evaluation_json_target_fails_before_package_write(tmp_path: Path) -> None:
+    _FakeDataDesigner.rows = [
+        {"sample_id": "one", "system": "", "input": "extract", "target": "not json"},
+    ]
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(
+                output_kind="evaluation_final_result",
+                output_format="json",
+                num_records=1,
+            ),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "eval",
+        )
+
+    assert error.value.code == "invalid_synthetic_output_row"
+    assert not (tmp_path / "eval" / "manifest.json").exists()
+
+
+def test_invalid_evaluation_json_target_type_fails_before_package_write(tmp_path: Path) -> None:
+    _FakeDataDesigner.rows = [
+        {"sample_id": "one", "system": "", "input": "extract", "target": 42},
+    ]
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(
+                output_kind="evaluation_final_result",
+                output_format="json",
+                num_records=1,
+            ),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "eval",
+        )
+
+    assert error.value.code == "invalid_synthetic_output_row"
+
+
+def test_invalid_evaluation_text_target_is_rejected(tmp_path: Path) -> None:
+    _FakeDataDesigner.rows = [
+        {"sample_id": "one", "system": "", "input": "classify", "target": ""},
+    ]
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(
+                output_kind="evaluation_final_result",
+                output_format="text",
+                num_records=1,
+            ),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "eval",
+        )
+
+    assert error.value.code == "invalid_synthetic_output_row"
+
+
+def test_invalid_training_row_is_reported_as_synthetic_output_error(tmp_path: Path) -> None:
+    _FakeDataDesigner.rows = [{"prompt": "", "completion": "answer"}]
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(num_records=1),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "invalid_synthetic_output_row"
+
+
+def test_missing_datadesigner_dependency_reports_optional_extra(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for module_name in list(sys.modules):
+        if module_name == "data_designer" or module_name.startswith("data_designer."):
+            monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "missing_optional_dependency"
+    assert error.value.details["extra"] == "synthetic-data"
+
+
+def test_unsupported_column_is_rejected_before_import(tmp_path: Path) -> None:
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(
+                columns=(
+                    SyntheticColumnSpec(
+                        name="unsafe",
+                        column_type="validation",  # type: ignore[arg-type]
+                    ),
+                )
+            ),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "unsupported_synthetic_column"
+    assert error.value.details["column_type"] == "validation"
+
+
+def test_stages_training_package_seed_rows(tmp_path: Path) -> None:
+    seed_package = tmp_path / "seed-package"
+    seed_package.mkdir()
+    (seed_package / "samples.jsonl").write_text(
+        '{"prompt": "seed-p", "completion": "seed-c"}\n',
+        encoding="utf-8",
+    )
+    (seed_package / "valid.jsonl").write_text(
+        '{"prompt": "seed-v", "completion": "seed-vc"}\n',
+        encoding="utf-8",
+    )
+
+    generate_synthetic_dataset_package(
+        _request(
+            seed_source=SyntheticSeedSource(
+                source_kind="training_package",
+                source_path=seed_package,
+            )
+        ),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "out",
+    )
+
+    staged = tmp_path / "jobs" / "synthetic-data" / "job-1" / "seed" / "training-package-seed.jsonl"
+    assert staged.read_text(encoding="utf-8") == (
+        '{"prompt": "seed-p", "completion": "seed-c"}\n'
+        '{"prompt": "seed-v", "completion": "seed-vc"}\n'
+    )
+    assert str(_FakeDataDesigner.instances[0].create_calls[0][0].seed_source) == str(staged)
+
+
+def test_stages_evaluation_package_seed_rows(tmp_path: Path) -> None:
+    seed_package = tmp_path / "eval-seed"
+    seed_package.mkdir()
+    (seed_package / "samples.jsonl").write_text(
+        '{"id": "e1", "system": "sys", "input": {"text": "q"}, "target": {"a": 1}}\n',
+        encoding="utf-8",
+    )
+
+    generate_synthetic_dataset_package(
+        _request(
+            seed_source=SyntheticSeedSource(
+                source_kind="evaluation_package",
+                source_path=seed_package,
+            )
+        ),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "out",
+    )
+
+    staged = tmp_path / "jobs" / "synthetic-data" / "job-1" / "seed" / "evaluation-package-seed.jsonl"
+    assert staged.read_text(encoding="utf-8") == (
+        '{"system": "sys", "input": "q", "target": {"a": 1}, "sample_id": "e1"}\n'
+    )
+
+
+def test_stages_local_seed_file_and_directory(tmp_path: Path) -> None:
+    local_jsonl = tmp_path / "source.jsonl"
+    local_jsonl.write_text('{"topic": "a"}\n', encoding="utf-8")
+
+    generate_synthetic_dataset_package(
+        _request(
+            seed_source=SyntheticSeedSource(
+                source_kind="local_jsonl",
+                source_path=local_jsonl,
+            )
+        ),
+        jobs_root=tmp_path / "jobs-file",
+        output_dir=tmp_path / "out-file",
+    )
+    assert (tmp_path / "jobs-file" / "synthetic-data" / "job-1" / "seed" / "source.jsonl").is_file()
+
+    local_dir = tmp_path / "snapshot"
+    local_dir.mkdir()
+    (local_dir / "rows.jsonl").write_text('{"topic": "b"}\n', encoding="utf-8")
+    generate_synthetic_dataset_package(
+        _request(
+            seed_source=SyntheticSeedSource(
+                source_kind="managed_hf_snapshot",
+                source_path=local_dir,
+            )
+        ),
+        jobs_root=tmp_path / "jobs-dir",
+        output_dir=tmp_path / "out-dir",
+    )
+    assert (tmp_path / "jobs-dir" / "synthetic-data" / "job-1" / "seed" / "snapshot" / "rows.jsonl").is_file()
+
+    (local_dir / "extra.jsonl").write_text('{"topic": "c"}\n', encoding="utf-8")
+    generate_synthetic_dataset_package(
+        _request(
+            seed_source=SyntheticSeedSource(
+                source_kind="managed_hf_snapshot",
+                source_path=local_dir,
+            )
+        ),
+        jobs_root=tmp_path / "jobs-dir",
+        output_dir=tmp_path / "out-dir-second",
+    )
+    assert (tmp_path / "jobs-dir" / "synthetic-data" / "job-1" / "seed" / "snapshot" / "extra.jsonl").is_file()
+
+
+def test_missing_seed_source_fails(tmp_path: Path) -> None:
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(
+                seed_source=SyntheticSeedSource(
+                    source_kind="local_jsonl",
+                    source_path=tmp_path / "missing.jsonl",
+                )
+            ),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "invalid_synthetic_seed_source"
+
+
+def test_missing_seed_package_samples_are_rejected(tmp_path: Path) -> None:
+    training_seed = tmp_path / "training-seed"
+    training_seed.mkdir()
+    with pytest.raises(ModelOperationError) as training_error:
+        generate_synthetic_dataset_package(
+            _request(
+                seed_source=SyntheticSeedSource(
+                    source_kind="training_package",
+                    source_path=training_seed,
+                )
+            ),
+            jobs_root=tmp_path / "jobs-training",
+            output_dir=tmp_path / "out-training",
+        )
+
+    assert training_error.value.code == "invalid_synthetic_seed_source"
+
+    evaluation_seed = tmp_path / "evaluation-seed"
+    evaluation_seed.mkdir()
+    with pytest.raises(ModelOperationError) as evaluation_error:
+        generate_synthetic_dataset_package(
+            _request(
+                seed_source=SyntheticSeedSource(
+                    source_kind="evaluation_package",
+                    source_path=evaluation_seed,
+                )
+            ),
+            jobs_root=tmp_path / "jobs-evaluation",
+            output_dir=tmp_path / "out-evaluation",
+        )
+
+    assert evaluation_error.value.code == "invalid_synthetic_seed_source"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_code"),
+    [
+        ("dataset_id", "", "invalid_synthetic_dataset_request"),
+        ("dataset_name", "", "invalid_synthetic_dataset_request"),
+        ("mode", "bad", "invalid_synthetic_dataset_request"),
+        ("num_records", 0, "invalid_synthetic_dataset_request"),
+        ("output_kind", "bad", "unsupported_synthetic_output"),
+        ("output_format", "bad", "unsupported_synthetic_output"),
+        ("model_provider", SyntheticModelProvider(endpoint=""), "invalid_synthetic_dataset_request"),
+        ("models", (), "invalid_synthetic_dataset_request"),
+        (
+            "models",
+            (
+                SyntheticModelConfig(alias="", model="a"),
+            ),
+            "invalid_synthetic_dataset_request",
+        ),
+        (
+            "models",
+            (
+                SyntheticModelConfig(alias="same", model="a"),
+                SyntheticModelConfig(alias="same", model="b"),
+            ),
+            "invalid_synthetic_dataset_request",
+        ),
+        ("columns", (), "invalid_synthetic_dataset_request"),
+        (
+            "columns",
+            (SyntheticColumnSpec(name="", column_type="llm_text"),),
+            "invalid_synthetic_dataset_request",
+        ),
+        ("validation_ratio", 1.0, "invalid_synthetic_dataset_request"),
+        ("preview_count", 0, "invalid_synthetic_dataset_request"),
+    ],
+)
+def test_request_validation_errors(
+    tmp_path: Path,
+    field: str,
+    value: Any,
+    expected_code: str,
+) -> None:
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(**{field: value}),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == expected_code
+
+
+def test_raw_jsonl_requires_jsonl_output_format(tmp_path: Path) -> None:
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(output_kind="raw_jsonl", output_format="text"),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "unsupported_synthetic_output"
+
+
+def test_uses_fallback_column_api_when_config_factory_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    column_types = sys.modules["data_designer.config.column_types"]
+    monkeypatch.delattr(column_types, "get_column_config_from_kwargs", raising=False)
+
+    class FallbackBuilder(_FakeBuilder):
+        def add_column(
+            self,
+            column_config: _FakeColumnConfig | None = None,
+            *,
+            name: str | None = None,
+            column_type: str | None = None,
+            **params: Any,
+        ) -> None:
+            assert column_config is None
+            assert name is not None
+            assert column_type is not None
+            self.columns.append(_FakeColumnConfig(name=name, column_type=column_type, params=params))
+
+    sys.modules["data_designer.config.config_builder"].DataDesignerConfigBuilder = FallbackBuilder
+
+    generate_synthetic_dataset_package(
+        _request(),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "out",
+    )
+
+    builder = _FakeDataDesigner.instances[0].create_calls[0][0]
+    assert builder.columns[0].name == "prompt"
+
+
+def test_preview_result_accepts_tuple_dataframe_like_and_wrappers(tmp_path: Path) -> None:
+    class TuplePreviewDesigner(_FakeDataDesigner):
+        def preview(self, builder: _FakeBuilder, *, num_records: int) -> tuple[dict[str, str], ...]:
+            return ({"prompt": "tuple", "completion": "row"},)
+
+    sys.modules["data_designer.interface"].DataDesigner = TuplePreviewDesigner
+    result = generate_synthetic_dataset_package(
+        _request(mode="preview", num_records=1),
+        jobs_root=tmp_path / "jobs-tuple",
+        output_dir=tmp_path / "out-tuple",
+    )
+    assert result.row_count == 1
+    assert not (tmp_path / "out-tuple" / "samples.jsonl").exists()
+
+    class FrameLike:
+        def to_dict(self, *, orient: str) -> list[dict[str, str]]:
+            assert orient == "records"
+            return [{"prompt": "frame", "completion": "row"}]
+
+    class DataWrapper:
+        data = FrameLike()
+
+    class FramePreviewDesigner(_FakeDataDesigner):
+        def preview(self, builder: _FakeBuilder, *, num_records: int) -> DataWrapper:
+            return DataWrapper()
+
+    sys.modules["data_designer.interface"].DataDesigner = FramePreviewDesigner
+    result = generate_synthetic_dataset_package(
+        _request(mode="preview", num_records=1),
+        jobs_root=tmp_path / "jobs-frame",
+        output_dir=tmp_path / "out-frame",
+    )
+    assert result.row_count == 1
+
+    class ResultsWrapper:
+        preview_results = [{"prompt": "wrapped", "completion": "row"}]
+
+    class ResultsPreviewDesigner(_FakeDataDesigner):
+        def preview(self, builder: _FakeBuilder, *, num_records: int) -> ResultsWrapper:
+            return ResultsWrapper()
+
+    sys.modules["data_designer.interface"].DataDesigner = ResultsPreviewDesigner
+    result = generate_synthetic_dataset_package(
+        _request(mode="preview", num_records=1),
+        jobs_root=tmp_path / "jobs-results",
+        output_dir=tmp_path / "out-results",
+    )
+    assert result.row_count == 1
+
+
+def test_invalid_preview_shape_is_reported(tmp_path: Path) -> None:
+    class BadPreviewDesigner(_FakeDataDesigner):
+        def preview(self, builder: _FakeBuilder, *, num_records: int) -> object:
+            return object()
+
+    sys.modules["data_designer.interface"].DataDesigner = BadPreviewDesigner
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(mode="preview", num_records=1),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "invalid_datadesigner_preview"
+
+
+def test_config_write_failure_is_reported(tmp_path: Path) -> None:
+    class BadBuilder(_FakeBuilder):
+        def write_config(self, path: Path) -> None:
+            raise RuntimeError("boom")
+
+    sys.modules["data_designer.config.config_builder"].DataDesignerConfigBuilder = BadBuilder
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "synthetic_config_write_failed"
+
+
+def test_create_rejects_invalid_export_jsonl(tmp_path: Path) -> None:
+    class BadCreationResult:
+        def export(self, path: Path, *, format: str) -> None:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text('{"ok": true}\n[]\n', encoding="utf-8")
+
+    class BadExportDesigner(_FakeDataDesigner):
+        def create(
+            self,
+            builder: _FakeBuilder,
+            *,
+            num_records: int,
+            dataset_name: str,
+            resume: bool,
+        ) -> BadCreationResult:
+            return BadCreationResult()
+
+    sys.modules["data_designer.interface"].DataDesigner = BadExportDesigner
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "invalid_datadesigner_export"
+
+
+def test_default_job_id_is_sanitized_and_invalid_config_redaction_is_ignored(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(synthetic_module.time, "time", lambda: 10.0)
+
+    class InvalidJSONBuilder(_FakeBuilder):
+        def write_config(self, path: Path) -> None:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("{not-json\n", encoding="utf-8")
+
+    sys.modules["data_designer.config.config_builder"].DataDesignerConfigBuilder = InvalidJSONBuilder
+    result = generate_synthetic_dataset_package(
+        _request(dataset_id="bad id/../x", job_id=""),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "out",
+    )
+
+    assert result.row_count == 4
+    assert (tmp_path / "jobs" / "synthetic-data" / "bad-id-..-x-10000").is_dir()
+    assert (tmp_path / "out" / "data_designer" / "config.json").read_text(encoding="utf-8") == "{not-json\n"
+
+
+def test_redaction_handles_lists_and_scalar_values(tmp_path: Path) -> None:
+    result = generate_synthetic_dataset_package(
+        _request(
+            models=(
+                SyntheticModelConfig(
+                    alias="generator",
+                    model="melix-dev-text",
+                    extra_body={
+                        "items": [
+                            {"token": "list-secret"},
+                            "literal",
+                        ],
+                    },
+                ),
+            )
+        ),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "out",
+    )
+
+    assert result.manifest_payload["datadesigner"]["models"][0]["extra_body"]["items"] == [
+        {"token": "[REDACTED]"},
+        "literal",
+    ]
+
+
+def test_column_type_falls_back_to_string_when_enum_name_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class EmptyColumnType:
+        pass
+
+    sys.modules["data_designer.config.column_types"].DataDesignerColumnType = EmptyColumnType
+
+    generate_synthetic_dataset_package(
+        _request(),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "out",
+    )
+
+    builder = _FakeDataDesigner.instances[0].create_calls[0][0]
+    assert builder.columns[0].column_type == "llm_text"
+
+
+def test_local_seed_source_can_fallback_to_plain_path_when_local_seed_class_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delitem(sys.modules, "data_designer.config.seed_source", raising=False)
+    local_jsonl = tmp_path / "source.jsonl"
+    local_jsonl.write_text('{"topic": "a"}\n', encoding="utf-8")
+
+    generate_synthetic_dataset_package(
+        _request(
+            seed_source=SyntheticSeedSource(
+                source_kind="local_jsonl",
+                source_path=local_jsonl,
+            )
+        ),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "out",
+    )
+
+    assert isinstance(_FakeDataDesigner.instances[0].create_calls[0][0].seed_source, str)

--- a/services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
+++ b/services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+import hashlib
 import importlib
 import json
 import os
@@ -310,12 +311,21 @@ def _validate_request(request: SyntheticDatasetRequest) -> None:
             code="invalid_synthetic_dataset_request",
             message="At least one synthetic column is required.",
         )
+    column_names: set[str] = set()
     for column in request.columns:
-        if not column.name.strip():
+        column_name = column.name.strip()
+        if not column_name:
             raise ModelOperationError(
                 code="invalid_synthetic_dataset_request",
                 message="Synthetic column name is required.",
             )
+        if column_name in column_names:
+            raise ModelOperationError(
+                code="invalid_synthetic_dataset_request",
+                message="Synthetic column names must be unique.",
+                details={"column_name": column_name},
+            )
+        column_names.add(column_name)
         if column.column_type not in _SUPPORTED_COLUMN_TYPES:
             raise ModelOperationError(
                 code="unsupported_synthetic_column",
@@ -402,8 +412,6 @@ def _build_datadesigner_config(
     if request.seed_source is not None:
         seed_source = _stage_seed_source(request.seed_source, seed_root=seed_root, api=api)
         builder.with_seed_dataset(seed_source)
-    if hasattr(builder, "artifact_path"):
-        setattr(builder, "artifact_path", artifact_path)
     return builder
 
 
@@ -424,7 +432,6 @@ def _run_preview(
         )
         preview_result = designer.preview(builder, num_records=request.num_records)
     timing["datadesigner_generate_ms"] = _elapsed_ms(generate_started)
-    timing["datadesigner_export_ms"] = 0.0
     return _rows_from_preview_result(preview_result, limit=request.num_records)
 
 
@@ -519,7 +526,7 @@ def _write_training_package(
             "version": "synthetic",
             "build_ready": request.mode == "create",
             "preview_only": request.mode == "preview",
-            "validation_strategy": "deterministic_ratio" if validation_rows else "none",
+            "validation_strategy": "deterministic_hash_ratio" if validation_rows else "none",
             "validation_ratio": request.validation_ratio,
             "preview_count": request.preview_count,
             "preview_samples": train_rows[: request.preview_count],
@@ -555,7 +562,7 @@ def _write_evaluation_package(
     config_path: Path,
     timing: dict[str, float],
 ) -> SyntheticDatasetPackageResult:
-    _validate_evaluation_targets(rows, result_kind=request.output_format)
+    serialized_rows = _parse_and_validate_evaluation_targets(rows, result_kind=request.output_format)
     package_write_started = time.perf_counter()
     manifest_path = package_path / "manifest.json"
     samples_path = package_path / "samples.jsonl"
@@ -572,10 +579,10 @@ def _write_evaluation_package(
         target_path="target",
         sample_id_path="sample_id",
     )
-    _write_jsonl_rows(samples_path, _iter_serialized_samples(rows, field_mapping))
+    _write_jsonl_rows(samples_path, _iter_serialized_samples(serialized_rows, field_mapping))
     manifest_payload = _base_manifest(
         request,
-        rows=rows,
+        rows=serialized_rows,
         generated_jsonl_path=generated_jsonl_path,
         artifact_path=artifact_path,
         config_path=config_path,
@@ -587,7 +594,7 @@ def _write_evaluation_package(
             "dataset_id": request.dataset_id,
             "suite_id": request.dataset_id,
             "version": "synthetic",
-            "sample_count": len(rows),
+            "sample_count": len(serialized_rows),
             "split": "validation",
             "task_kind": "text-generation",
             "input_modalities": ["text"],
@@ -619,7 +626,7 @@ def _write_evaluation_package(
         data_designer_artifact_path=artifact_path,
         config_path=config_path,
         manifest_payload=manifest_payload,
-        row_count=len(rows),
+        row_count=len(serialized_rows),
         validation_row_count=0,
         output_kind=request.output_kind,
         preview_only=request.mode == "preview",
@@ -790,8 +797,14 @@ def _normalize_synthetic_training_row(row: dict[str, Any], output_format: str) -
         ) from exc
 
 
-def _validate_evaluation_targets(rows: list[dict[str, Any]], *, result_kind: str) -> None:
+def _parse_and_validate_evaluation_targets(
+    rows: list[dict[str, Any]],
+    *,
+    result_kind: str,
+) -> list[dict[str, Any]]:
+    parsed_rows: list[dict[str, Any]] = []
     for index, row in enumerate(rows, start=1):
+        parsed_row = dict(row)
         target = row.get("target")
         if result_kind == "json":
             if isinstance(target, str):
@@ -809,7 +822,7 @@ def _validate_evaluation_targets(rows: list[dict[str, Any]], *, result_kind: str
                     message="Synthetic final-result JSON target must be an object or array.",
                     details={"row": str(index)},
                 )
-            row["target"] = target
+            parsed_row["target"] = target
         elif result_kind == "text":
             if str(target or "").strip() == "":
                 raise ModelOperationError(
@@ -817,6 +830,8 @@ def _validate_evaluation_targets(rows: list[dict[str, Any]], *, result_kind: str
                     message="Synthetic final-result text target must be non-empty.",
                     details={"row": str(index)},
                 )
+        parsed_rows.append(parsed_row)
+    return parsed_rows
 
 
 def _split_validation(
@@ -827,8 +842,25 @@ def _split_validation(
         return rows, []
     validation_count = int(round(len(rows) * validation_ratio))
     validation_count = min(max(validation_count, 1), len(rows) - 1)
-    split_at = len(rows) - validation_count
-    return rows[:split_at], rows[split_at:]
+    validation_indices = {
+        index
+        for _, index in sorted(
+            (_canonical_row_hash(row), index) for index, row in enumerate(rows)
+        )[:validation_count]
+    }
+    train_rows: list[dict[str, Any]] = []
+    validation_rows: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        if index in validation_indices:
+            validation_rows.append(row)
+        else:
+            train_rows.append(row)
+    return train_rows, validation_rows
+
+
+def _canonical_row_hash(row: dict[str, Any]) -> str:
+    encoded = json.dumps(row, sort_keys=True, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _stage_seed_source(seed_source: SyntheticSeedSource, *, seed_root: Path, api: _DataDesignerAPI) -> Any:
@@ -844,9 +876,14 @@ def _stage_seed_source(seed_source: SyntheticSeedSource, *, seed_root: Path, api
         staged_path = seed_root / source_path.name
         if source_path.is_dir():
             if staged_path.exists():
-                shutil.rmtree(staged_path)
+                if staged_path.is_dir():
+                    shutil.rmtree(staged_path)
+                else:
+                    staged_path.unlink()
             shutil.copytree(source_path, staged_path)
         else:
+            if staged_path.is_dir():
+                shutil.rmtree(staged_path)
             shutil.copy2(source_path, staged_path)
     elif seed_source.source_kind == "training_package":
         staged_path = seed_root / "training-package-seed.jsonl"
@@ -954,6 +991,7 @@ def _rows_from_preview_result(preview_result: Any, *, limit: int) -> list[dict[s
     raise ModelOperationError(
         code="invalid_datadesigner_preview",
         message="DataDesigner preview did not return JSON-object rows.",
+        details={"preview_result_type": type(preview_result).__name__},
     )
 
 
@@ -983,12 +1021,8 @@ def _iter_jsonl_rows(path: Path, *, error_code: str) -> Iterable[dict[str, Any]]
 def _write_jsonl_rows(path: Path, rows: Iterable[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as handle:
-        wrote_any = False
         for row in rows:
-            wrote_any = True
             handle.write(json.dumps(row))
-            handle.write("\n")
-        if not wrote_any:
             handle.write("\n")
 
 
@@ -1074,7 +1108,7 @@ def _datadesigner_column_type(data_designer_column_type: Any, column_type: str) 
 
 
 @contextmanager
-def _data_designer_telemetry(disable: bool) -> Iterable[None]:
+def _data_designer_telemetry(disable: bool) -> Iterator[None]:
     previous = os.environ.get(_TELEMETRY_ENV_VAR)
     if disable:
         os.environ[_TELEMETRY_ENV_VAR] = "false"

--- a/services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
+++ b/services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
@@ -1,0 +1,1087 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+import importlib
+import json
+import os
+from pathlib import Path
+import shutil
+import time
+from typing import Any, Literal
+
+from worker.model_ops.errors import ModelOperationError
+from worker.model_ops.training_dataset import _normalize_sample
+from worker.productization.evaluation_final_result import (
+    EvaluationFieldMapping,
+    EvaluationProfileDefinition,
+    _iter_serialized_samples,
+)
+
+_SUPPORTED_COLUMN_TYPES = {
+    "sampler",
+    "llm_text",
+    "llm_structured",
+    "llm_judge",
+    "expression",
+}
+_SUPPORTED_OUTPUT_KINDS = {"training", "evaluation_final_result", "raw_jsonl"}
+_SUPPORTED_TRAINING_FORMATS = {
+    "chat_messages",
+    "prompt_completion",
+    "text_completion",
+    "preference_pair",
+    "prompt_candidate",
+    "reward_scored",
+    "calibration",
+}
+_SUPPORTED_EVALUATION_RESULT_KINDS = {"json", "text"}
+_SECRET_FIELD_MARKERS = ("api_key", "authorization", "token", "secret", "password")
+_TELEMETRY_ENV_VAR = "NEMO_TELEMETRY_ENABLED"
+
+
+@dataclass(frozen=True)
+class SyntheticModelProvider:
+    endpoint: str
+    name: str = "melix"
+    provider_type: str = "openai"
+    api_key: str = ""
+    extra_headers: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SyntheticModelConfig:
+    alias: str
+    model: str
+    temperature: float | None = None
+    top_p: float | None = None
+    max_tokens: int | None = None
+    timeout_seconds: float | None = None
+    max_parallel_requests: int | None = None
+    extra_body: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SyntheticColumnSpec:
+    name: str
+    column_type: Literal["sampler", "llm_text", "llm_structured", "llm_judge", "expression"]
+    params: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SyntheticSeedSource:
+    source_kind: Literal[
+        "local_jsonl",
+        "local_csv",
+        "training_package",
+        "evaluation_package",
+        "managed_hf_snapshot",
+    ]
+    source_path: Path
+
+
+@dataclass(frozen=True)
+class SyntheticDatasetRequest:
+    dataset_id: str
+    dataset_name: str
+    mode: Literal["preview", "create"]
+    num_records: int
+    output_kind: Literal["training", "evaluation_final_result", "raw_jsonl"]
+    output_format: str
+    model_provider: SyntheticModelProvider
+    models: tuple[SyntheticModelConfig, ...]
+    columns: tuple[SyntheticColumnSpec, ...]
+    job_id: str = ""
+    seed_source: SyntheticSeedSource | None = None
+    validation_ratio: float = 0.0
+    preview_count: int = 3
+    random_seed: int | None = None
+    data_designer_resume_mode: Literal["never", "if_possible", "always"] = "never"
+    disable_data_designer_telemetry: bool = True
+
+
+@dataclass(frozen=True)
+class SyntheticDatasetPackageResult:
+    package_path: Path
+    manifest_path: Path
+    output_path: Path
+    generated_jsonl_path: Path
+    data_designer_artifact_path: Path
+    config_path: Path
+    manifest_payload: dict[str, Any]
+    row_count: int
+    validation_row_count: int
+    output_kind: str
+    preview_only: bool
+
+
+@dataclass(frozen=True)
+class _DataDesignerAPI:
+    DataDesigner: type[Any]
+    DataDesignerConfigBuilder: type[Any]
+    ModelProvider: type[Any]
+    ModelConfig: type[Any]
+    ChatCompletionInferenceParams: type[Any]
+    DataDesignerColumnType: Any
+    get_column_config_from_kwargs: Callable[..., Any] | None
+    LocalFileSeedSource: type[Any] | None
+
+
+def generate_synthetic_dataset_package(
+    request: SyntheticDatasetRequest,
+    *,
+    jobs_root: Path,
+    output_dir: Path,
+    progress: Callable[[str, float], None] | None = None,
+) -> SyntheticDatasetPackageResult:
+    """Generate DataDesigner rows and normalize them into Melix dataset packages."""
+
+    _validate_request(request)
+    started = time.perf_counter()
+    timing: dict[str, float] = {}
+    job_id = _resolve_job_id(request)
+    package_path = output_dir.expanduser().resolve()
+    data_designer_dir = package_path / "data_designer"
+    artifact_path = data_designer_dir / "artifacts"
+    generated_jsonl_path = data_designer_dir / "generated.jsonl"
+    config_path = data_designer_dir / "config.json"
+    job_root = jobs_root.expanduser().resolve() / "synthetic-data" / job_id
+    seed_root = job_root / "seed"
+
+    package_path.mkdir(parents=True, exist_ok=True)
+    data_designer_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path.mkdir(parents=True, exist_ok=True)
+    job_root.mkdir(parents=True, exist_ok=True)
+
+    _emit(progress, "load_datadesigner", 0.05)
+    api = _load_data_designer_api()
+
+    _emit(progress, "build_datadesigner_config", 0.15)
+    config_started = time.perf_counter()
+    builder = _build_datadesigner_config(
+        request,
+        api=api,
+        artifact_path=artifact_path,
+        seed_root=seed_root,
+    )
+    _write_datadesigner_config(builder, config_path)
+    timing["datadesigner_config_build_ms"] = _elapsed_ms(config_started)
+
+    _emit(progress, "generate_rows", 0.35)
+    if request.mode == "preview":
+        rows = _run_preview(
+            request,
+            api=api,
+            builder=builder,
+            artifact_path=artifact_path,
+            timing=timing,
+        )
+        _write_jsonl_rows(generated_jsonl_path, rows)
+    else:
+        rows = _run_create(
+            request,
+            api=api,
+            builder=builder,
+            artifact_path=artifact_path,
+            generated_jsonl_path=generated_jsonl_path,
+            timing=timing,
+        )
+
+    _emit(progress, "normalize_rows", 0.7)
+    normalize_started = time.perf_counter()
+    if request.mode == "preview":
+        result = _write_preview_inspection(
+            request,
+            rows=rows,
+            package_path=package_path,
+            generated_jsonl_path=generated_jsonl_path,
+            artifact_path=artifact_path,
+            config_path=config_path,
+            timing=timing,
+        )
+    elif request.output_kind == "training":
+        result = _write_training_package(
+            request,
+            rows=rows,
+            package_path=package_path,
+            generated_jsonl_path=generated_jsonl_path,
+            artifact_path=artifact_path,
+            config_path=config_path,
+            timing=timing,
+        )
+    elif request.output_kind == "evaluation_final_result":
+        result = _write_evaluation_package(
+            request,
+            rows=rows,
+            package_path=package_path,
+            generated_jsonl_path=generated_jsonl_path,
+            artifact_path=artifact_path,
+            config_path=config_path,
+            timing=timing,
+        )
+    else:
+        result = _write_raw_jsonl_inspection(
+            request,
+            rows=rows,
+            package_path=package_path,
+            generated_jsonl_path=generated_jsonl_path,
+            artifact_path=artifact_path,
+            config_path=config_path,
+            timing=timing,
+        )
+    result.manifest_payload.setdefault("timing", {})["melix_normalize_ms"] = _elapsed_ms(normalize_started)
+    result.manifest_payload["timing"]["total_elapsed_ms"] = _elapsed_ms(started)
+    _rewrite_manifest(result.manifest_path, result.manifest_payload)
+    _emit(progress, "complete", 1.0)
+    return result
+
+
+def _validate_request(request: SyntheticDatasetRequest) -> None:
+    if not request.dataset_id.strip():
+        raise ModelOperationError(code="invalid_synthetic_dataset_request", message="dataset_id is required.")
+    if not request.dataset_name.strip():
+        raise ModelOperationError(code="invalid_synthetic_dataset_request", message="dataset_name is required.")
+    if request.mode not in {"preview", "create"}:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message=f"Unsupported synthetic dataset mode: {request.mode}",
+            details={"mode": request.mode},
+        )
+    if request.num_records <= 0:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message="num_records must be greater than zero.",
+            details={"num_records": str(request.num_records)},
+        )
+    if request.output_kind not in _SUPPORTED_OUTPUT_KINDS:
+        raise ModelOperationError(
+            code="unsupported_synthetic_output",
+            message=f"Unsupported synthetic output kind: {request.output_kind}",
+            details={"output_kind": request.output_kind},
+        )
+    if request.output_kind == "training" and request.output_format not in _SUPPORTED_TRAINING_FORMATS:
+        raise ModelOperationError(
+            code="unsupported_synthetic_output",
+            message=f"Unsupported synthetic training format: {request.output_format}",
+            details={"output_format": request.output_format},
+        )
+    if (
+        request.output_kind == "evaluation_final_result"
+        and request.output_format not in _SUPPORTED_EVALUATION_RESULT_KINDS
+    ):
+        raise ModelOperationError(
+            code="unsupported_synthetic_output",
+            message=f"Unsupported final-result kind: {request.output_format}",
+            details={"output_format": request.output_format},
+        )
+    if request.output_kind == "raw_jsonl" and request.output_format != "jsonl":
+        raise ModelOperationError(
+            code="unsupported_synthetic_output",
+            message='raw_jsonl output requires output_format="jsonl".',
+            details={"output_format": request.output_format},
+        )
+    if not request.model_provider.endpoint.strip():
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message="model_provider.endpoint is required.",
+        )
+    if not request.models:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message="At least one synthetic model config is required.",
+        )
+    aliases: set[str] = set()
+    for model in request.models:
+        if not model.alias.strip() or not model.model.strip():
+            raise ModelOperationError(
+                code="invalid_synthetic_dataset_request",
+                message="Synthetic model alias and model id are required.",
+            )
+        if model.alias in aliases:
+            raise ModelOperationError(
+                code="invalid_synthetic_dataset_request",
+                message="Synthetic model aliases must be unique.",
+                details={"alias": model.alias},
+            )
+        aliases.add(model.alias)
+    if not request.columns:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message="At least one synthetic column is required.",
+        )
+    for column in request.columns:
+        if not column.name.strip():
+            raise ModelOperationError(
+                code="invalid_synthetic_dataset_request",
+                message="Synthetic column name is required.",
+            )
+        if column.column_type not in _SUPPORTED_COLUMN_TYPES:
+            raise ModelOperationError(
+                code="unsupported_synthetic_column",
+                message=f"Unsupported synthetic column type: {column.column_type}",
+                details={"column_type": column.column_type, "column": column.name},
+            )
+    if not 0.0 <= request.validation_ratio < 1.0:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message="validation_ratio must be in the range [0.0, 1.0).",
+            details={"validation_ratio": str(request.validation_ratio)},
+        )
+    if request.preview_count <= 0:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message="preview_count must be greater than zero.",
+            details={"preview_count": str(request.preview_count)},
+        )
+
+
+def _load_data_designer_api() -> _DataDesignerAPI:
+    try:
+        interface_module = importlib.import_module("data_designer.interface")
+        builder_module = importlib.import_module("data_designer.config.config_builder")
+        models_module = importlib.import_module("data_designer.config.models")
+        column_types_module = importlib.import_module("data_designer.config.column_types")
+    except ImportError as exc:
+        raise ModelOperationError(
+            code="missing_optional_dependency",
+            message="Synthetic dataset generation requires the data-designer optional dependency.",
+            details={"extra": "synthetic-data", "package": "data-designer"},
+        ) from exc
+
+    try:
+        seed_source_module = importlib.import_module("data_designer.config.seed_source")
+        local_file_seed_source = getattr(seed_source_module, "LocalFileSeedSource", None)
+    except ImportError:
+        local_file_seed_source = None
+
+    return _DataDesignerAPI(
+        DataDesigner=getattr(interface_module, "DataDesigner"),
+        DataDesignerConfigBuilder=getattr(builder_module, "DataDesignerConfigBuilder"),
+        ModelProvider=getattr(models_module, "ModelProvider"),
+        ModelConfig=getattr(models_module, "ModelConfig"),
+        ChatCompletionInferenceParams=getattr(models_module, "ChatCompletionInferenceParams"),
+        DataDesignerColumnType=getattr(column_types_module, "DataDesignerColumnType"),
+        get_column_config_from_kwargs=getattr(column_types_module, "get_column_config_from_kwargs", None),
+        LocalFileSeedSource=local_file_seed_source,
+    )
+
+
+def _build_datadesigner_config(
+    request: SyntheticDatasetRequest,
+    *,
+    api: _DataDesignerAPI,
+    artifact_path: Path,
+    seed_root: Path,
+) -> Any:
+    model_configs = []
+    for model in request.models:
+        inference_kwargs = _compact_dict(
+            {
+                "temperature": model.temperature,
+                "top_p": model.top_p,
+                "max_tokens": model.max_tokens,
+                "timeout": model.timeout_seconds,
+                "max_parallel_requests": model.max_parallel_requests,
+                "extra_body": dict(model.extra_body),
+            }
+        )
+        inference_parameters = api.ChatCompletionInferenceParams(**inference_kwargs)
+        model_configs.append(
+            api.ModelConfig(
+                alias=model.alias,
+                model=model.model,
+                provider=request.model_provider.name,
+                inference_parameters=inference_parameters,
+            )
+        )
+
+    builder = api.DataDesignerConfigBuilder(model_configs=model_configs)
+    for column in request.columns:
+        _add_datadesigner_column(builder, api=api, column=column)
+    if request.seed_source is not None:
+        seed_source = _stage_seed_source(request.seed_source, seed_root=seed_root, api=api)
+        builder.with_seed_dataset(seed_source)
+    if hasattr(builder, "artifact_path"):
+        setattr(builder, "artifact_path", artifact_path)
+    return builder
+
+
+def _run_preview(
+    request: SyntheticDatasetRequest,
+    *,
+    api: _DataDesignerAPI,
+    builder: Any,
+    artifact_path: Path,
+    timing: dict[str, float],
+) -> list[dict[str, Any]]:
+    generate_started = time.perf_counter()
+    with _data_designer_telemetry(request.disable_data_designer_telemetry):
+        designer = _create_data_designer(
+            api,
+            request,
+            artifact_path=artifact_path,
+        )
+        preview_result = designer.preview(builder, num_records=request.num_records)
+    timing["datadesigner_generate_ms"] = _elapsed_ms(generate_started)
+    timing["datadesigner_export_ms"] = 0.0
+    return _rows_from_preview_result(preview_result, limit=request.num_records)
+
+
+def _run_create(
+    request: SyntheticDatasetRequest,
+    *,
+    api: _DataDesignerAPI,
+    builder: Any,
+    artifact_path: Path,
+    generated_jsonl_path: Path,
+    timing: dict[str, float],
+) -> list[dict[str, Any]]:
+    resume = request.data_designer_resume_mode in {"if_possible", "always"}
+    generate_started = time.perf_counter()
+    with _data_designer_telemetry(request.disable_data_designer_telemetry):
+        designer = _create_data_designer(
+            api,
+            request,
+            artifact_path=artifact_path,
+        )
+        creation_result = designer.create(
+            builder,
+            num_records=request.num_records,
+            dataset_name=request.dataset_name,
+            resume=resume,
+        )
+    timing["datadesigner_generate_ms"] = _elapsed_ms(generate_started)
+
+    export_started = time.perf_counter()
+    generated_jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+    creation_result.export(generated_jsonl_path, format="jsonl")
+    timing["datadesigner_export_ms"] = _elapsed_ms(export_started)
+    return list(_iter_jsonl_rows(generated_jsonl_path, error_code="invalid_datadesigner_export"))
+
+
+def _create_data_designer(
+    api: _DataDesignerAPI,
+    request: SyntheticDatasetRequest,
+    *,
+    artifact_path: Path,
+) -> Any:
+    provider = api.ModelProvider(
+        name=request.model_provider.name,
+        endpoint=request.model_provider.endpoint,
+        provider_type=request.model_provider.provider_type,
+        api_key=request.model_provider.api_key,
+        extra_headers=dict(request.model_provider.extra_headers),
+    )
+    return api.DataDesigner(
+        model_providers=[provider],
+        artifact_path=str(artifact_path),
+    )
+
+
+def _write_training_package(
+    request: SyntheticDatasetRequest,
+    *,
+    rows: list[dict[str, Any]],
+    package_path: Path,
+    generated_jsonl_path: Path,
+    artifact_path: Path,
+    config_path: Path,
+    timing: dict[str, float],
+) -> SyntheticDatasetPackageResult:
+    normalized = [_normalize_synthetic_training_row(row, request.output_format) for row in rows]
+    train_rows, validation_rows = _split_validation(normalized, request.validation_ratio)
+    package_write_started = time.perf_counter()
+    samples_path = package_path / "samples.jsonl"
+    valid_path = package_path / "valid.jsonl"
+    manifest_path = package_path / "manifest.json"
+    _write_jsonl_rows(samples_path, train_rows)
+    if validation_rows:
+        _write_jsonl_rows(valid_path, validation_rows)
+    elif valid_path.exists():
+        valid_path.unlink()
+
+    manifest_payload = _base_manifest(
+        request,
+        rows=rows,
+        generated_jsonl_path=generated_jsonl_path,
+        artifact_path=artifact_path,
+        config_path=config_path,
+        timing=timing,
+    )
+    manifest_payload.update(
+        {
+            "schema_version": "melix.training_dataset_package.v1",
+            "dataset_id": request.dataset_id,
+            "format": request.output_format,
+            "sample_count": len(train_rows),
+            "validation_sample_count": len(validation_rows),
+            "version": "synthetic",
+            "build_ready": request.mode == "create",
+            "preview_only": request.mode == "preview",
+            "validation_strategy": "deterministic_ratio" if validation_rows else "none",
+            "validation_ratio": request.validation_ratio,
+            "preview_count": request.preview_count,
+            "preview_samples": train_rows[: request.preview_count],
+            "validation_preview_samples": validation_rows[: request.preview_count],
+            "response_only_supported": request.output_format in {"chat_messages", "prompt_completion"},
+        }
+    )
+    timing["melix_package_write_ms"] = _elapsed_ms(package_write_started)
+    manifest_payload["timing"] = dict(timing)
+    _rewrite_manifest(manifest_path, manifest_payload)
+    return SyntheticDatasetPackageResult(
+        package_path=package_path,
+        manifest_path=manifest_path,
+        output_path=package_path,
+        generated_jsonl_path=generated_jsonl_path,
+        data_designer_artifact_path=artifact_path,
+        config_path=config_path,
+        manifest_payload=manifest_payload,
+        row_count=len(train_rows),
+        validation_row_count=len(validation_rows),
+        output_kind=request.output_kind,
+        preview_only=request.mode == "preview",
+    )
+
+
+def _write_evaluation_package(
+    request: SyntheticDatasetRequest,
+    *,
+    rows: list[dict[str, Any]],
+    package_path: Path,
+    generated_jsonl_path: Path,
+    artifact_path: Path,
+    config_path: Path,
+    timing: dict[str, float],
+) -> SyntheticDatasetPackageResult:
+    _validate_evaluation_targets(rows, result_kind=request.output_format)
+    package_write_started = time.perf_counter()
+    manifest_path = package_path / "manifest.json"
+    samples_path = package_path / "samples.jsonl"
+    profile = EvaluationProfileDefinition(
+        profile_type="final_result",
+        result_kind=request.output_format,
+        extraction_mode="strict_full_response",
+        scoring_mode="normalized_exact_match",
+        threshold=1.0,
+    )
+    field_mapping = EvaluationFieldMapping(
+        system_path="system",
+        input_text_path="input",
+        target_path="target",
+        sample_id_path="sample_id",
+    )
+    _write_jsonl_rows(samples_path, _iter_serialized_samples(rows, field_mapping))
+    manifest_payload = _base_manifest(
+        request,
+        rows=rows,
+        generated_jsonl_path=generated_jsonl_path,
+        artifact_path=artifact_path,
+        config_path=config_path,
+        timing=timing,
+    )
+    manifest_payload.update(
+        {
+            "schema_version": "melix.evaluation_dataset_package.v2",
+            "dataset_id": request.dataset_id,
+            "suite_id": request.dataset_id,
+            "version": "synthetic",
+            "sample_count": len(rows),
+            "split": "validation",
+            "task_kind": "text-generation",
+            "input_modalities": ["text"],
+            "profile_type": profile.profile_type,
+            "result_kind": profile.result_kind,
+            "extraction_mode": profile.extraction_mode,
+            "scoring_mode": profile.scoring_mode,
+            "threshold": profile.threshold,
+            "output_schema": {},
+            "ignored_paths": [],
+            "build_ready": request.mode == "create",
+            "preview_only": request.mode == "preview",
+            "field_mapping": {
+                "system_path": field_mapping.system_path,
+                "input_text_path": field_mapping.input_text_path,
+                "target_path": field_mapping.target_path,
+                "sample_id_path": field_mapping.sample_id_path,
+            },
+        }
+    )
+    timing["melix_package_write_ms"] = _elapsed_ms(package_write_started)
+    manifest_payload["timing"] = dict(timing)
+    _rewrite_manifest(manifest_path, manifest_payload)
+    return SyntheticDatasetPackageResult(
+        package_path=package_path,
+        manifest_path=manifest_path,
+        output_path=package_path,
+        generated_jsonl_path=generated_jsonl_path,
+        data_designer_artifact_path=artifact_path,
+        config_path=config_path,
+        manifest_payload=manifest_payload,
+        row_count=len(rows),
+        validation_row_count=0,
+        output_kind=request.output_kind,
+        preview_only=request.mode == "preview",
+    )
+
+
+def _write_preview_inspection(
+    request: SyntheticDatasetRequest,
+    *,
+    rows: list[dict[str, Any]],
+    package_path: Path,
+    generated_jsonl_path: Path,
+    artifact_path: Path,
+    config_path: Path,
+    timing: dict[str, float],
+) -> SyntheticDatasetPackageResult:
+    package_write_started = time.perf_counter()
+    manifest_path = package_path / "synthetic_dataset.preview.json"
+    manifest_payload = _base_manifest(
+        request,
+        rows=rows,
+        generated_jsonl_path=generated_jsonl_path,
+        artifact_path=artifact_path,
+        config_path=config_path,
+        timing=timing,
+    )
+    manifest_payload.update(
+        {
+            "schema_version": "melix.synthetic_dataset_preview.v1",
+            "dataset_id": request.dataset_id,
+            "sample_count": len(rows),
+            "build_ready": False,
+            "preview_only": True,
+            "preview_count": request.preview_count,
+            "preview_samples": rows[: request.preview_count],
+        }
+    )
+    timing["melix_package_write_ms"] = _elapsed_ms(package_write_started)
+    manifest_payload["timing"] = dict(timing)
+    _rewrite_manifest(manifest_path, manifest_payload)
+    _cleanup_build_ready_package_files(package_path)
+    return SyntheticDatasetPackageResult(
+        package_path=package_path,
+        manifest_path=manifest_path,
+        output_path=generated_jsonl_path,
+        generated_jsonl_path=generated_jsonl_path,
+        data_designer_artifact_path=artifact_path,
+        config_path=config_path,
+        manifest_payload=manifest_payload,
+        row_count=len(rows),
+        validation_row_count=0,
+        output_kind=request.output_kind,
+        preview_only=True,
+    )
+
+
+def _write_raw_jsonl_inspection(
+    request: SyntheticDatasetRequest,
+    *,
+    rows: list[dict[str, Any]],
+    package_path: Path,
+    generated_jsonl_path: Path,
+    artifact_path: Path,
+    config_path: Path,
+    timing: dict[str, float],
+) -> SyntheticDatasetPackageResult:
+    package_write_started = time.perf_counter()
+    manifest_path = package_path / "synthetic_dataset.inspect.json"
+    manifest_payload = _base_manifest(
+        request,
+        rows=rows,
+        generated_jsonl_path=generated_jsonl_path,
+        artifact_path=artifact_path,
+        config_path=config_path,
+        timing=timing,
+    )
+    manifest_payload.update(
+        {
+            "schema_version": "melix.synthetic_dataset_inspection.v1",
+            "dataset_id": request.dataset_id,
+            "sample_count": len(rows),
+            "build_ready": False,
+            "preview_only": True,
+            "preview_count": request.preview_count,
+            "preview_samples": rows[: request.preview_count],
+        }
+    )
+    timing["melix_package_write_ms"] = _elapsed_ms(package_write_started)
+    manifest_payload["timing"] = dict(timing)
+    _rewrite_manifest(manifest_path, manifest_payload)
+    return SyntheticDatasetPackageResult(
+        package_path=package_path,
+        manifest_path=manifest_path,
+        output_path=generated_jsonl_path,
+        generated_jsonl_path=generated_jsonl_path,
+        data_designer_artifact_path=artifact_path,
+        config_path=config_path,
+        manifest_payload=manifest_payload,
+        row_count=len(rows),
+        validation_row_count=0,
+        output_kind=request.output_kind,
+        preview_only=True,
+    )
+
+
+def _cleanup_build_ready_package_files(package_path: Path) -> None:
+    for filename in ("manifest.json", "samples.jsonl", "valid.jsonl"):
+        path = package_path / filename
+        if path.exists():
+            path.unlink()
+
+
+def _base_manifest(
+    request: SyntheticDatasetRequest,
+    *,
+    rows: list[dict[str, Any]],
+    generated_jsonl_path: Path,
+    artifact_path: Path,
+    config_path: Path,
+    timing: dict[str, float],
+) -> dict[str, Any]:
+    return {
+        "source_kind": "datadesigner",
+        "operation": "generate_synthetic_dataset",
+        "dataset_name": request.dataset_name,
+        "output_kind": request.output_kind,
+        "output_format": request.output_format,
+        "row_count": len(rows),
+        "timing": dict(timing),
+        "datadesigner": {
+            "package": "data-designer",
+            "config_path": str(config_path),
+            "artifact_path": str(artifact_path),
+            "generated_jsonl_path": str(generated_jsonl_path),
+            "num_records_requested": request.num_records,
+            "num_records_generated": len(rows),
+            "mode": request.mode,
+            "columns": [column.name for column in request.columns],
+            "model_aliases": [model.alias for model in request.models],
+            "provider": _redacted_provider_manifest(request.model_provider),
+            "models": [
+                {
+                    "alias": model.alias,
+                    "model": model.model,
+                    "temperature": model.temperature,
+                    "top_p": model.top_p,
+                    "max_tokens": model.max_tokens,
+                    "timeout_seconds": model.timeout_seconds,
+                    "max_parallel_requests": model.max_parallel_requests,
+                    "extra_body": _redact_mapping(model.extra_body),
+                }
+                for model in request.models
+            ],
+            "secret_redaction": "applied",
+            "telemetry_disabled": request.disable_data_designer_telemetry,
+        },
+    }
+
+
+def _normalize_synthetic_training_row(row: dict[str, Any], output_format: str) -> dict[str, Any]:
+    try:
+        return _normalize_sample(row, format_name=output_format, max_characters_per_sample=0)
+    except ModelOperationError as exc:
+        raise ModelOperationError(
+            code="invalid_synthetic_output_row",
+            message=f"Synthetic DataDesigner row is invalid for {output_format} training output.",
+            details={"format": output_format, **exc.details},
+        ) from exc
+
+
+def _validate_evaluation_targets(rows: list[dict[str, Any]], *, result_kind: str) -> None:
+    for index, row in enumerate(rows, start=1):
+        target = row.get("target")
+        if result_kind == "json":
+            if isinstance(target, str):
+                try:
+                    target = json.loads(target)
+                except json.JSONDecodeError as exc:
+                    raise ModelOperationError(
+                        code="invalid_synthetic_output_row",
+                        message="Synthetic final-result JSON target must parse as JSON.",
+                        details={"row": str(index)},
+                    ) from exc
+            if not isinstance(target, (dict, list)):
+                raise ModelOperationError(
+                    code="invalid_synthetic_output_row",
+                    message="Synthetic final-result JSON target must be an object or array.",
+                    details={"row": str(index)},
+                )
+            row["target"] = target
+        elif result_kind == "text":
+            if str(target or "").strip() == "":
+                raise ModelOperationError(
+                    code="invalid_synthetic_output_row",
+                    message="Synthetic final-result text target must be non-empty.",
+                    details={"row": str(index)},
+                )
+
+
+def _split_validation(
+    rows: list[dict[str, Any]],
+    validation_ratio: float,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if validation_ratio <= 0 or len(rows) < 2:
+        return rows, []
+    validation_count = int(round(len(rows) * validation_ratio))
+    validation_count = min(max(validation_count, 1), len(rows) - 1)
+    split_at = len(rows) - validation_count
+    return rows[:split_at], rows[split_at:]
+
+
+def _stage_seed_source(seed_source: SyntheticSeedSource, *, seed_root: Path, api: _DataDesignerAPI) -> Any:
+    source_path = seed_source.source_path.expanduser().resolve()
+    if not source_path.exists():
+        raise ModelOperationError(
+            code="invalid_synthetic_seed_source",
+            message="Synthetic seed source does not exist.",
+            details={"source_path": str(source_path)},
+        )
+    seed_root.mkdir(parents=True, exist_ok=True)
+    if seed_source.source_kind in {"local_jsonl", "local_csv", "managed_hf_snapshot"}:
+        staged_path = seed_root / source_path.name
+        if source_path.is_dir():
+            if staged_path.exists():
+                shutil.rmtree(staged_path)
+            shutil.copytree(source_path, staged_path)
+        else:
+            shutil.copy2(source_path, staged_path)
+    elif seed_source.source_kind == "training_package":
+        staged_path = seed_root / "training-package-seed.jsonl"
+        _write_jsonl_rows(staged_path, _iter_training_package_seed_rows(source_path))
+    elif seed_source.source_kind == "evaluation_package":
+        staged_path = seed_root / "evaluation-package-seed.jsonl"
+        _write_jsonl_rows(staged_path, _iter_evaluation_package_seed_rows(source_path))
+    else:
+        raise ModelOperationError(
+            code="invalid_synthetic_seed_source",
+            message=f"Unsupported synthetic seed source kind: {seed_source.source_kind}",
+            details={"source_kind": seed_source.source_kind},
+        )
+    if api.LocalFileSeedSource is None:
+        return str(staged_path)
+    if hasattr(api.LocalFileSeedSource, "from_path"):
+        return api.LocalFileSeedSource.from_path(staged_path)
+    return api.LocalFileSeedSource(path=str(staged_path))
+
+
+def _add_datadesigner_column(
+    builder: Any,
+    *,
+    api: _DataDesignerAPI,
+    column: SyntheticColumnSpec,
+) -> None:
+    column_type = _datadesigner_column_type(api.DataDesignerColumnType, column.column_type)
+    params = dict(column.params)
+    if api.get_column_config_from_kwargs is not None:
+        column_config = api.get_column_config_from_kwargs(
+            name=column.name,
+            column_type=column_type,
+            **params,
+        )
+        builder.add_column(column_config)
+        return
+    builder.add_column(
+        name=column.name,
+        column_type=column_type,
+        **params,
+    )
+
+
+def _iter_training_package_seed_rows(package_path: Path) -> Iterable[dict[str, Any]]:
+    samples_path = package_path / "samples.jsonl"
+    if not samples_path.is_file():
+        raise ModelOperationError(
+            code="invalid_synthetic_seed_source",
+            message="Training seed package must contain samples.jsonl.",
+            details={"package_path": str(package_path)},
+        )
+    yield from _iter_jsonl_rows(samples_path, error_code="invalid_synthetic_seed_source")
+    valid_path = package_path / "valid.jsonl"
+    if valid_path.is_file():
+        yield from _iter_jsonl_rows(valid_path, error_code="invalid_synthetic_seed_source")
+
+
+def _iter_evaluation_package_seed_rows(package_path: Path) -> Iterable[dict[str, Any]]:
+    samples_path = package_path / "samples.jsonl"
+    if not samples_path.is_file():
+        raise ModelOperationError(
+            code="invalid_synthetic_seed_source",
+            message="Evaluation seed package must contain samples.jsonl.",
+            details={"package_path": str(package_path)},
+        )
+    for row in _iter_jsonl_rows(samples_path, error_code="invalid_synthetic_seed_source"):
+        input_payload = row.get("input")
+        input_text = input_payload.get("text", "") if isinstance(input_payload, dict) else ""
+        yield {
+            "system": row.get("system", ""),
+            "input": input_text,
+            "target": row.get("target"),
+            "sample_id": row.get("id", ""),
+        }
+
+
+def _write_datadesigner_config(builder: Any, config_path: Path) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        builder.write_config(config_path)
+    except Exception as exc:
+        raise ModelOperationError(
+            code="synthetic_config_write_failed",
+            message="Unable to write DataDesigner configuration.",
+            details={"config_path": str(config_path)},
+        ) from exc
+    _redact_json_file(config_path)
+
+
+def _rows_from_preview_result(preview_result: Any, *, limit: int) -> list[dict[str, Any]]:
+    if preview_result is None:
+        return []
+    if isinstance(preview_result, list):
+        return [dict(row) for row in preview_result if isinstance(row, dict)][:limit]
+    if isinstance(preview_result, tuple):
+        return [dict(row) for row in preview_result if isinstance(row, dict)][:limit]
+    if hasattr(preview_result, "to_dict"):
+        payload = preview_result.to_dict(orient="records")
+        if isinstance(payload, list):
+            return [dict(row) for row in payload if isinstance(row, dict)][:limit]
+    if hasattr(preview_result, "data"):
+        return _rows_from_preview_result(preview_result.data, limit=limit)
+    if hasattr(preview_result, "preview_results"):
+        return _rows_from_preview_result(preview_result.preview_results, limit=limit)
+    raise ModelOperationError(
+        code="invalid_datadesigner_preview",
+        message="DataDesigner preview did not return JSON-object rows.",
+    )
+
+
+def _iter_jsonl_rows(path: Path, *, error_code: str) -> Iterable[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ModelOperationError(
+                    code=error_code,
+                    message="JSONL row is not valid JSON.",
+                    details={"path": str(path), "line": str(line_number)},
+                ) from exc
+            if not isinstance(payload, dict):
+                raise ModelOperationError(
+                    code=error_code,
+                    message="JSONL row must be a JSON object.",
+                    details={"path": str(path), "line": str(line_number)},
+                )
+            yield payload
+
+
+def _write_jsonl_rows(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        wrote_any = False
+        for row in rows:
+            wrote_any = True
+            handle.write(json.dumps(row))
+            handle.write("\n")
+        if not wrote_any:
+            handle.write("\n")
+
+
+def _rewrite_manifest(manifest_path: Path, manifest_payload: dict[str, Any]) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _resolve_job_id(request: SyntheticDatasetRequest) -> str:
+    if request.job_id.strip():
+        return _safe_path_component(request.job_id)
+    return f"{_safe_path_component(request.dataset_id)}-{int(time.time() * 1000)}"
+
+
+def _safe_path_component(value: str) -> str:
+    cleaned = "".join(char if char.isalnum() or char in {"-", "_", "."} else "-" for char in value.strip())
+    return cleaned.strip(".-") or "synthetic-dataset"
+
+
+def _emit(progress: Callable[[str, float], None] | None, stage: str, fraction: float) -> None:
+    if progress is not None:
+        progress(stage, fraction)
+
+
+def _elapsed_ms(started: float) -> float:
+    return round((time.perf_counter() - started) * 1000.0, 3)
+
+
+def _compact_dict(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if value not in (None, {}, [])}
+
+
+def _redacted_provider_manifest(provider: SyntheticModelProvider) -> dict[str, Any]:
+    return {
+        "name": provider.name,
+        "endpoint": provider.endpoint,
+        "provider_type": provider.provider_type,
+        "api_key": "[REDACTED]" if provider.api_key else "",
+        "extra_headers": _redact_mapping(provider.extra_headers),
+    }
+
+
+def _redact_mapping(payload: Mapping[str, Any]) -> dict[str, Any]:
+    redacted: dict[str, Any] = {}
+    for key, value in payload.items():
+        lowered = str(key).lower()
+        if any(marker in lowered for marker in _SECRET_FIELD_MARKERS):
+            redacted[str(key)] = "[REDACTED]"
+        elif isinstance(value, Mapping):
+            redacted[str(key)] = _redact_mapping(value)
+        elif isinstance(value, list):
+            redacted[str(key)] = [
+                _redact_mapping(item) if isinstance(item, Mapping) else item
+                for item in value
+            ]
+        else:
+            redacted[str(key)] = value
+    return redacted
+
+
+def _redact_json_file(path: Path) -> None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return
+    redacted = _redact_value(payload)
+    path.write_text(json.dumps(redacted, indent=2) + "\n", encoding="utf-8")
+
+
+def _redact_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _redact_mapping(value)
+    if isinstance(value, list):
+        return [_redact_value(item) for item in value]
+    return value
+
+
+def _datadesigner_column_type(data_designer_column_type: Any, column_type: str) -> Any:
+    enum_name = column_type.upper()
+    if hasattr(data_designer_column_type, enum_name):
+        return getattr(data_designer_column_type, enum_name)
+    return column_type
+
+
+@contextmanager
+def _data_designer_telemetry(disable: bool) -> Iterable[None]:
+    previous = os.environ.get(_TELEMETRY_ENV_VAR)
+    if disable:
+        os.environ[_TELEMETRY_ENV_VAR] = "false"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(_TELEMETRY_ENV_VAR, None)
+        else:
+            os.environ[_TELEMETRY_ENV_VAR] = previous

--- a/uv.lock
+++ b/uv.lock
@@ -149,12 +149,21 @@ wheels = [
 ]
 
 [[package]]
+name = "anyascii"
+version = "0.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/ba/edebda727008390936da4a9bf677c19cd63b32d51e864656d2cbd1028e25/anyascii-0.3.3.tar.gz", hash = "sha256:c94e9dd9d47b3d9494eca305fef9447d00b4bf1a32aff85aa746fa3ec7fb95c3", size = 264680, upload-time = "2025-06-29T03:33:30.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/76/783b75a21ce3563b8709050de030ae253853b147bd52e141edc1025aa268/anyascii-0.3.3-py3-none-any.whl", hash = "sha256:f5ab5e53c8781a36b5a40e1296a0eeda2f48c649ef10c3921c1381b1d00dee7a", size = 345090, upload-time = "2025-06-29T03:33:28.356Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
@@ -184,7 +193,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -234,6 +243,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "chardet"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
 ]
 
 [[package]]
@@ -311,14 +329,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
 ]
 
 [[package]]
@@ -415,14 +433,135 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
+name = "data-designer"
+version = "0.5.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "data-designer-config" },
+    { name = "data-designer-engine" },
+    { name = "prompt-toolkit" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/a5/ee29d0f858e8b36e348fc4b99929384865a31cbce81c4e303bf96d6a39c7/data_designer-0.5.9.tar.gz", hash = "sha256:2b50e075bf4f58532fb22dea5aa777fe5679050b57e540ab7f51de33e8d74299", size = 120115, upload-time = "2026-04-28T23:23:04.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/2b/b6adf669d53d04d2c5c78608974f8e68d32cb22334e1bbbb0c4998ac34db/data_designer-0.5.9-py3-none-any.whl", hash = "sha256:5c583d635fc26e5effe63f96001d1d11cdb8a5e23df96d1855780a7224559b8e", size = 99164, upload-time = "2026-04-28T23:23:03.397Z" },
+]
+
+[[package]]
+name = "data-designer-config"
+version = "0.5.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "pyarrow" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pygments" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/a4/304374c08ede51262aaeb59848adb6a3cf8b18811847111e6152821ecebd/data_designer_config-0.5.9.tar.gz", hash = "sha256:401cad60ac68f15f05d694c4a053f8ee9001609838f96f6022394884eab10bba", size = 128778, upload-time = "2026-04-28T23:22:57.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/ea/e46d62abe4eeb2180bf1c512930501dcee85b606974fb4eebb0be5180c23/data_designer_config-0.5.9-py3-none-any.whl", hash = "sha256:13f0b3232db3f565c8eb759b08763bf66ed0da9f712efe451d242cb81ec396ee", size = 114597, upload-time = "2026-04-28T23:22:56.406Z" },
+]
+
+[[package]]
+name = "data-designer-engine"
+version = "0.5.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyascii" },
+    { name = "chardet" },
+    { name = "data-designer-config" },
+    { name = "duckdb" },
+    { name = "faker" },
+    { name = "fsspec" },
+    { name = "httpx" },
+    { name = "httpx-retries" },
+    { name = "huggingface-hub" },
+    { name = "json-repair" },
+    { name = "jsonpath-rust-bindings" },
+    { name = "jsonschema" },
+    { name = "lxml" },
+    { name = "marko" },
+    { name = "mcp" },
+    { name = "networkx" },
+    { name = "ruff" },
+    { name = "scipy" },
+    { name = "sqlfluff" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/c9/16a5d199fcb30f045cfc83e26a3a69dcf06c6e0387b13f98f43d8ed345e7/data_designer_engine-0.5.9.tar.gz", hash = "sha256:3adf2185404b156fe7ebc03d022eef2398c96f033a31cf96434b1eaa81f51cea", size = 799004, upload-time = "2026-04-28T23:23:01.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9a/48816e9e83854c00b26c165a8fbb53701a5b845c8f403d19dad52418fe84/data_designer_engine-0.5.9-py3-none-any.whl", hash = "sha256:09b4db93304d7a1fc1500f562684cc9199e9b9d986fbb18f21609e152390b01a", size = 632446, upload-time = "2026-04-28T23:22:59.734Z" },
+]
+
+[[package]]
 name = "datasets"
-version = "4.8.4"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dill" },
     { name = "filelock" },
     { name = "fsspec", extra = ["http"], marker = "extra == 'extra-16-melix-mlx-worker-mlx'" },
-    { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "multiprocess" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
@@ -435,18 +574,96 @@ dependencies = [
     { name = "tqdm" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/22/73e46ac7a8c25e7ef0b3bd6f10da3465021d90219a32eb0b4d2afea4c56e/datasets-4.8.4.tar.gz", hash = "sha256:a1429ed853275ce7943a01c6d2e25475b4501eb758934362106a280470df3a52", size = 604382, upload-time = "2026-03-23T14:21:17.987Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/9d/348ed92110ba5f9b70b51ca1078d4809767a835aa2b7ce7e74ad2b98323d/datasets-4.0.0.tar.gz", hash = "sha256:9657e7140a9050db13443ba21cb5de185af8af944479b00e7ff1e00a61c8dbf1", size = 569566, upload-time = "2025-07-09T14:35:52.431Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/e5/247d094108e42ac26363ab8dc57f168840cf7c05774b40ffeb0d78868fcc/datasets-4.8.4-py3-none-any.whl", hash = "sha256:cdc8bee4698e549d78bf1fed6aea2eebc760b22b084f07e6fc020c6577a6ce6d", size = 526991, upload-time = "2026-03-23T14:21:15.89Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/eb8157afb21bd229c864521c1ab4fa8e9b4f1b06bafdd8c4668a7a31b5dd/datasets-4.0.0-py3-none-any.whl", hash = "sha256:7ef95e62025fd122882dbce6cb904c8cd3fbc829de6669a5eb939c77d50e203d", size = 494825, upload-time = "2025-07-09T14:35:50.658Z" },
+]
+
+[[package]]
+name = "diff-cover"
+version = "10.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "jinja2" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/b4/eee71d1e338bc1f9bd3539b46b70e303dac061324b759c9a80fa3c96d90d/diff_cover-10.2.0.tar.gz", hash = "sha256:61bf83025f10510c76ef6a5820680cf61b9b974e8f81de70c57ac926fa63872a", size = 102473, upload-time = "2026-01-09T01:59:07.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/2c/61eeb887055a37150db824b6bf830e821a736580769ac2fea4eadb0d613f/diff_cover-10.2.0-py3-none-any.whl", hash = "sha256:59c328595e0b8948617cc5269af9e484c86462e2844bfcafa3fb37f8fca0af87", size = 56748, upload-time = "2026-01-09T01:59:06.028Z" },
 ]
 
 [[package]]
 name = "dill"
-version = "0.4.1"
+version = "0.3.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/4d/ac7ffa80c69ea1df30a8aa11b3578692a5118e7cd1aa157e3ef73b092d15/dill-0.3.8.tar.gz", hash = "sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca", size = 184847, upload-time = "2024-01-27T23:42:16.145Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7a/cef76fd8438a42f96db64ddaa85280485a9c395e7df3db8158cfec1eee34/dill-0.3.8-py3-none-any.whl", hash = "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7", size = 116252, upload-time = "2024-01-27T23:42:14.239Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "duckdb"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/66/744b4931b799a42f8cb9bc7a6f169e7b8e51195b62b246db407fd90bf15f/duckdb-1.5.2.tar.gz", hash = "sha256:638da0d5102b6cb6f7d47f83d0600708ac1d3cb46c5e9aaabc845f9ba4d69246", size = 18017166, upload-time = "2026-04-13T11:30:09.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/de/ebe66bbe78125fc610f4fd415447a65349d94245950f3b3dfb31d028af02/duckdb-1.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e6495b00cad16888384119842797c49316a96ae1cb132bb03856d980d95afee1", size = 30064950, upload-time = "2026-04-13T11:29:11.468Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/8a/3e25b5d03bcf1fb99d189912f8ce92b1db4f9c8778e1b1f55745973a855a/duckdb-1.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d72b8856b1839d35648f38301b058f6232f4d36b463fe4dc8f4d3fdff2df1a2e", size = 15969113, upload-time = "2026-04-13T11:29:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/58001f0815002b1a93431bf907f77854085c7d049b83d521814a07b9db0b/duckdb-1.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2a1de4f4d454b8c97aec546c82003fc834d3422ce4bc6a19902f3462ef293bed", size = 14224774, upload-time = "2026-04-13T11:29:16.758Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2f/a7f0de9509d1cef35608aeb382919041cdd70f58c173865c3da6a0d87979/duckdb-1.5.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce0b8141a10d37ecef729c45bc41d334854013f4389f1488bd6035c5579aaac1", size = 19313510, upload-time = "2026-04-13T11:29:19.574Z" },
+    { url = "https://files.pythonhosted.org/packages/26/78/eb1e064ea8b9df3b87b167bfd7a407b2f615a4291e06cba756727adfa06c/duckdb-1.5.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99ef73a277c8921bc0a1f16dee38d924484251d9cfd20951748c20fcd5ed855", size = 21429692, upload-time = "2026-04-13T11:29:22.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/12/05b0c47d14839925c5e35b79081d918ca82e3f236bb724a6f58409dd5291/duckdb-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:8d599758b4e48bf12e18c9b960cf491d219f0c4972d19a45489c05cc5ab36f83", size = 13107594, upload-time = "2026-04-13T11:29:25.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2c/80558a82b236e044330e84a154b96aacddb343316b479f3d49be03ea11cb/duckdb-1.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:fc85a5dbcbe6eccac1113c72370d1d3aacfdd49198d63950bdf7d8638a307f00", size = 13927537, upload-time = "2026-04-13T11:29:27.842Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f2/e3d742808f138d374be4bb516fade3d1f33749b813650810ab7885cdc363/duckdb-1.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4420b3f47027a7849d0e1815532007f377fa95ee5810b47ea717d35525c12f79", size = 30064879, upload-time = "2026-04-13T11:29:30.763Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/f3dc1cf97e1267ca15e4307d456f96ce583961f0703fd75e62b2ad8d64fa/duckdb-1.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bb42e6ed543902e14eae647850da24103a89f0bc2587dec5601b1c1f213bd2ed", size = 15969327, upload-time = "2026-04-13T11:29:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e0/d5418def53ae4e05a63075705ff44ed5af5a1a5932627eb2b600c5df1c93/duckdb-1.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98c0535cd6d901f61a5ea3c2e26a1fd28482953d794deb183daf568e3aa5dda6", size = 14225107, upload-time = "2026-04-13T11:29:35.882Z" },
+    { url = "https://files.pythonhosted.org/packages/16/a7/15aaa59dbecc35e9711980fcdbf525b32a52470b32d18ef678193a146213/duckdb-1.5.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:486c862bf7f163c0110b6d85b3e5c031d224a671cca468f12ebb1d3a348f6b39", size = 19313433, upload-time = "2026-04-13T11:29:38.367Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/21/d903cc63a5140c822b7b62b373a87dc557e60c29b321dfb435061c5e67cf/duckdb-1.5.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70631c847ca918ee710ec874241b00cf9d2e5be90762cbb2a0389f17823c08f7", size = 21429837, upload-time = "2026-04-13T11:29:41.135Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/0a/b770d1f60c70597302130d6247f418549b7094251a02348fbaf1c7e147ae/duckdb-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:52a21823f3fbb52f0f0e5425e20b07391ad882464b955879499b5ff0b45a376b", size = 13107699, upload-time = "2026-04-13T11:29:43.905Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cf/e200fe431d700962d1a908d2ce89f53ccee1cc8db260174ae663ba09686b/duckdb-1.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:411ad438bd4140f189a10e7f515781335962c5d18bd07837dc6d202e3985253d", size = 13927646, upload-time = "2026-04-13T11:29:46.598Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a1/f6286c67726cc1ea60a6e3c0d9fbc66527dde24ae089a51bbe298b13ca78/duckdb-1.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6b0fe75c148000f060aa1a27b293cacc0ea08cc1cad724fbf2143d56070a3785", size = 30078598, upload-time = "2026-04-13T11:29:49.828Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/59febb02f21a4a5c6b0b0099ef7c965fdd5e61e4904cf813809bb792e35f/duckdb-1.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:35579b8e3a064b5eaf15b0eafc558056a13f79a0a62e34cc4baf57119daecfec", size = 15975120, upload-time = "2026-04-13T11:29:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/09/70/ce750854d37bb5a45cccbb2c3cb04df4af56aea8fc30a2499bb643b4a9c0/duckdb-1.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea58ff5b0880593a280cf5511734b17711b32ee1f58b47d726e8600848358160", size = 14227762, upload-time = "2026-04-13T11:29:55.564Z" },
+    { url = "https://files.pythonhosted.org/packages/28/dc/ad45ac3c0b6c4687dc649e8f6cf01af1c8b0443932a39b2abb4ebcb3babd/duckdb-1.5.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef461bca07313412dc09961c4a4757a851f56b95ac01c58fac6007632b7b94f2", size = 19315668, upload-time = "2026-04-13T11:29:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b1/1464f468d2e5813f5808de95df9d3113a645a5bfa2ffcaecbc542ddae272/duckdb-1.5.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be37680ddb380015cb37318e378c53511c45c4f0d8fac5599d22b7d092b9217a", size = 21434056, upload-time = "2026-04-13T11:30:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/32/6673607e024722473fa7aafdd29c0e3dd231dd528f6cd8b5797fbeeb229d/duckdb-1.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:0b291786014df1133f8f18b9df4d004484613146e858d71a21791e0fcca16cf4", size = 13633667, upload-time = "2026-04-13T11:30:04.05Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e3/9d34173ec068631faea3ea6e73050700729363e7e33306a9a3218e5cdc61/duckdb-1.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:c9f3e0b71b8a50fccfb42794899285d9d318ce2503782b9dd54868e5ecd0ad31", size = 14402513, upload-time = "2026-04-13T11:30:06.609Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "faker"
+version = "20.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/24/54413530c8924a6a1bf75c3670f0911707fc7435017b57b4f57be098e469/Faker-20.1.0.tar.gz", hash = "sha256:562a3a09c3ed3a1a7b20e13d79f904dfdfc5e740f72813ecf95e4cf71e5a2f52", size = 1701717, upload-time = "2023-11-20T18:09:20.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/9a/74db0cf3115df2f71edcaf8d86ed556195ac31575212c20425820f81bfd0/Faker-20.1.0-py3-none-any.whl", hash = "sha256:aeb3e26742863d1e387f9d156f1c36e14af63bf5e6f36fb39b8c27f6a903be38", size = 1739139, upload-time = "2023-11-20T18:09:14.773Z" },
 ]
 
 [[package]]
@@ -565,11 +782,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2026.2.0"
+version = "2025.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/f4/5721faf47b8c499e776bc34c6a8fc17efdf7fdef0b00f398128bc5dcb4ac/fsspec-2025.3.0.tar.gz", hash = "sha256:a935fd1ea872591f2b5148907d103488fc523295e6c64b835cfad8c3eca44972", size = 298491, upload-time = "2025-03-07T21:47:56.461Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
+    { url = "https://files.pythonhosted.org/packages/56/53/eb690efa8513166adef3e0669afd31e95ffde69fb3c52ec2ac7223ed6018/fsspec-2025.3.0-py3-none-any.whl", hash = "sha256:efb87af3efa9103f94ca91a7f8cb7a4df91af9f74fc106c9c7ea0efd7277c1b3", size = 193615, upload-time = "2025-03-07T21:47:54.809Z" },
 ]
 
 [package.optional-dependencies]
@@ -731,13 +948,34 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-retries"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/f5/046cac13877ce9b55aebdbb3999e0e45b19b989a95c5fd1040fa04bd1f92/httpx_retries-0.5.0.tar.gz", hash = "sha256:d8c8e1e0852d84be3837aba0bcf78aeb89a4b77db95e8cc988c8c058830b3044", size = 15647, upload-time = "2026-04-20T01:21:47.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/a8/aadeaa9a28510727d538636ee8688f0782a98523147852b29404ce696f1b/httpx_retries-0.5.0-py3-none-any.whl", hash = "sha256:d3124592979a9dc6197e666d1f02e9ab996a0c58fce59fad8db6201a6a87304e", size = 8908, upload-time = "2026-04-20T01:21:46.157Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -781,6 +1019,175 @@ wheels = [
 ]
 
 [[package]]
+name = "json-repair"
+version = "0.59.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/f4/bf2e3fb48517a74c75bc08a85f781f3229cfe09fb1292d6969228be378b7/json_repair-0.59.9.tar.gz", hash = "sha256:761f495a9c0d4ff7d56aa8859b470b072f9470a8280797ea5da246736c294324", size = 49000, upload-time = "2026-05-12T12:28:49.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/6b/8c42827dc2a7ac4d28340da81f816ee89f9e0b1588497b5ada2de3aefca1/json_repair-0.59.9-py3-none-any.whl", hash = "sha256:5264909878c4214e16342485559998d9735befd6ad44a802f3768eb7b95d0a55", size = 47660, upload-time = "2026-05-12T12:28:47.937Z" },
+]
+
+[[package]]
+name = "jsonpath-rust-bindings"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/1d/68607c574dd78f0305018071dd132c28ae919137089e86edcf29918952ed/jsonpath_rust_bindings-1.1.1.tar.gz", hash = "sha256:b06b24668085b2791acbfefdfe2f2824d36be539c7647c00aee33242b4d3385d", size = 11996, upload-time = "2025-11-16T19:03:35.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7b/6e5c06f55b697576ac8378c3c64d0d980d27ec83f15eb5e2617d3e5a37b8/jsonpath_rust_bindings-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8e8315e8dc196cd370b8f6742e992e82da6a849bd1087f6f5d4ad7332c09d2ba", size = 898535, upload-time = "2025-11-16T19:02:15.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f6/02301a17826e0f5d253146918e52436831f43fdf018031819ab4dc2af8e4/jsonpath_rust_bindings-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:44de7464ad227028c36e8d713653b4bfe5eb7524ac1a4b0a71e8bcb3bd4f4f3a", size = 814583, upload-time = "2025-11-16T19:01:55.251Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/63/8860fc926e25ef3dfbc61d6366932f3e106a089308e3ad6a36987fac3efe/jsonpath_rust_bindings-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c220c2d27ab6a0791e3af10e2a7c53ccd1dc2dfc8681999fed4458392aa0372", size = 831964, upload-time = "2025-11-16T19:00:17.016Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2d/5f16683333b298969c24b6a09b5cb071fe4d603e4e8788e5db6b82231618/jsonpath_rust_bindings-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e423363b47080830bbb4d8257c0f26bda8ee655a18c4f934952bfe4c46e8d510", size = 836196, upload-time = "2025-11-16T19:00:33.647Z" },
+    { url = "https://files.pythonhosted.org/packages/da/c9/5c75bad74f27eca1853d9d58fabc4ed838e94997d65177d9f29cc9bb3229/jsonpath_rust_bindings-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:366cba544c080c08530cef0cc19922f0380f0caab6e7e5a0ddfb70de288d5abc", size = 931327, upload-time = "2025-11-16T19:00:50.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/5f/8e3a65a8053945d0c63ea8e5c11832b051e0919b342f29e1365108165472/jsonpath_rust_bindings-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7bf30e27a81d07c79cc58c86600687e5adfe0f7b1aaf8069a737085bebfaea71", size = 959445, upload-time = "2025-11-16T19:01:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5a/f44c4b55cecc6eb1a4b22dc2aacb9cf9f434b600706527ab619f6076ced0/jsonpath_rust_bindings-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c390c33582cd268d35b86eb0f550229e0cf26f03bb06c470db4712d6fa4dc0f", size = 947132, upload-time = "2025-11-16T19:01:38.408Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3e/406a044f96f7d5401d9715f22fc537f7f247fb261c22ab3f7781672fb200/jsonpath_rust_bindings-1.1.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b44214579dcfee42ac30f9d2c815de643269dab0a25f53f139636a74d44f0448", size = 943157, upload-time = "2025-11-16T19:01:23.224Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9d/e35fdaea0a065584d4864af8711a9be501015d4354d3eb9f61de0fedccc6/jsonpath_rust_bindings-1.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0017af7054fb6bce55863a7065ae465a9c47fd93fb94f002ca98bb8adf15101a", size = 1066860, upload-time = "2025-11-16T19:02:31.654Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/25/8ca3c1b67435f3a29d121c86867afdb86e02ec932c7a5343af61554c5788/jsonpath_rust_bindings-1.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:9212d3746a57015fc3722488f61c4afc465d993f68371d864be8fa5b0c58d635", size = 1148553, upload-time = "2025-11-16T19:02:47.91Z" },
+    { url = "https://files.pythonhosted.org/packages/84/98/65ceefc7f60b9abb9ffa6352b53eb19cca5ba586145e738d86c152d90e3a/jsonpath_rust_bindings-1.1.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2e2fbca1e2c710451a0339eccbdd007c1d22b035900aa732deb73b83dee027f8", size = 1105914, upload-time = "2025-11-16T19:03:04.546Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/be/708f5c15718e796d3d3fb3d139fe5dfa8aa6b0eff44adadc0bf66822d388/jsonpath_rust_bindings-1.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d21101114514d34b21ab216eef1d7bb41155311fa61284e8f2dbdb93bde41c78", size = 1133969, upload-time = "2025-11-16T19:03:21.839Z" },
+    { url = "https://files.pythonhosted.org/packages/df/79/c83cde39770f34ddcc8b12457481a1cefdd450fe7b05d2ffb33ab3e966be/jsonpath_rust_bindings-1.1.1-cp312-cp312-win32.whl", hash = "sha256:4f86912a05b4d85e76b4b3473fb4fbdc4e7fcb240d70617e8459645c68bd4197", size = 749424, upload-time = "2025-11-16T19:04:04.149Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8d/7f32c0cbf6c504082bbef24818a6eadad8b444f42af42ff186859bd0d438/jsonpath_rust_bindings-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:bacd75a58bfb97b1a18c016db44245ec6147f946c84c2ff268c7e72c8733e4c7", size = 808571, upload-time = "2025-11-16T19:03:47.151Z" },
+    { url = "https://files.pythonhosted.org/packages/97/74/7a144ef1f7e773d60b221fed185440828a3213d1e64161928aa05ae36f6c/jsonpath_rust_bindings-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:5b1ff715fcf0e0a87cc549267d52d5227e60374aea59c58b66c585bcf6631212", size = 748088, upload-time = "2025-11-16T19:03:38.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d9/076045fe57fe5d706f9faa55d33e1e0ab4b20dfe43700daadad9e9e2cfc3/jsonpath_rust_bindings-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:38ed917b928c33f484c14848c982eea81741c0441fb87b2de6db69ec8dc3b563", size = 898798, upload-time = "2025-11-16T19:02:16.976Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/4c/2a7995761e247610551cb218b5fcfa9c95a542d8a38915a91579178eba73/jsonpath_rust_bindings-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f55ee1e7fdb6bb2363c40a6d6ce0285e53bd52b4ecae7bef3909eeb11a9b4cd2", size = 815031, upload-time = "2025-11-16T19:01:56.972Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/f1375e4f254fdf088ebbb397cfb42f3bdd5c7fed3349ad140f09d052ae09/jsonpath_rust_bindings-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:734eee89754c829a0fb55a30467c8a33081976375b763c907f71f7018682c26c", size = 832342, upload-time = "2025-11-16T19:00:18.79Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5f/bccd6178fc9655e03b01917531c08a25951b55455189a98faa13f7125d4a/jsonpath_rust_bindings-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6716caa0855dbf9d021509a3caa00a9fa7cc241930f40830c24e85d0e17a6246", size = 836616, upload-time = "2025-11-16T19:00:35.477Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e6/e809c31962c161230ef136646e7a6bc1783ab9299255f043923af1d55a90/jsonpath_rust_bindings-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:02373d581a093d0640e60858884d67ec93259e7b6d6bd8e5874400ad99558e00", size = 931852, upload-time = "2025-11-16T19:00:52.271Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/51/9d29b9f642012d545233416138c96562aefdab78d3602b61e19267fc4098/jsonpath_rust_bindings-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:146b69ce20cb9869e05a6d369f4a10b52f98e1f8575f1ac5b49e285fa2032380", size = 959626, upload-time = "2025-11-16T19:01:08.348Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/95/696e02d5af89b95da829b79473cde3e7a1c0d73c571d1dc7c32e886e04e0/jsonpath_rust_bindings-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe44737c6c72079ef30c85f975c19fa0114c13039fe538d8c5b259007a35a0ff", size = 947152, upload-time = "2025-11-16T19:01:41.146Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/99/a070c38d108936239a7cbc1c0da5c0996728c194c08b0d0a3f7827d919ff/jsonpath_rust_bindings-1.1.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b810ed42981e587e39b26e320a15741c0580c2d11e2bce92bb2cea19ef078d49", size = 943609, upload-time = "2025-11-16T19:01:24.719Z" },
+    { url = "https://files.pythonhosted.org/packages/66/5c/b7eb6647de1721b632cccbfe3de777f1030fa0525a89b119ed70ebafc2c6/jsonpath_rust_bindings-1.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:40c23781d28a8b126c8a2b337e4fe275cc8f35a149bda769e3ec2760dfb58b91", size = 1067196, upload-time = "2025-11-16T19:02:33.289Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/1c56c148c92f43aca6799716f549ff2463ee328c377b9c1e630d4057a607/jsonpath_rust_bindings-1.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:4eacb98f80fff7d43956503ca7b42e491f7084c7b9bd8b5b6bad3f50d08480df", size = 1148940, upload-time = "2025-11-16T19:02:49.647Z" },
+    { url = "https://files.pythonhosted.org/packages/89/2f/97f8c52a88104014e273317b407d06d679e0ec2e7142cb8c09944f62880c/jsonpath_rust_bindings-1.1.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:fdeff7e888d4410a8538ed930e9be053cf5afc476366dd34ffc17ef2ed5dd285", size = 1106486, upload-time = "2025-11-16T19:03:06.233Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/df/b0c2fd033c5f5714a7ea4c03dabe8ab66dbaabab4fa7d9385344ab7a16e7/jsonpath_rust_bindings-1.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f2a526c87a245f708dc1d8d4988c471384c369a5909b8b730e63b6a7f0c2d60", size = 1134078, upload-time = "2025-11-16T19:03:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/26b3c59d5a18ac6cfb1b59f4eac4d5e1b8fd0f4b0f376b2ec6f1a9f6f56c/jsonpath_rust_bindings-1.1.1-cp313-cp313-win32.whl", hash = "sha256:528038bf902e9f831ab9dff4b0f777aa6dc3e17454ee07a21fa84277d4cae768", size = 750011, upload-time = "2025-11-16T19:04:05.99Z" },
+    { url = "https://files.pythonhosted.org/packages/66/18/d427cc16e1974503720106abe190b882d27b101f3ba83aa49deb04022ecb/jsonpath_rust_bindings-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:e364eb3234ee5f36bbf40d2409979ac6f4dd6a04f89438137649174d0ac8a0a3", size = 808602, upload-time = "2025-11-16T19:03:48.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c5/5e4edf2a76d1d07a1ea343ca9cf859a23b0819867291814be05c7afeedff/jsonpath_rust_bindings-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:924d993c08c807e54fcfcf2ad21a51c663f9af329d14d1bc3d8b21902a0c9741", size = 747523, upload-time = "2025-11-16T19:03:40.416Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6d/86076c2eb1aa886fa2e22a86ef88c4eac83360ac94f77ac7eeafc80ffc3d/jsonpath_rust_bindings-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1ae390842ed00983b5b2b648f5e87f4dce6c8435fc3b5d54987fe55197bbd08f", size = 899275, upload-time = "2025-11-16T19:02:18.403Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/22/24f8aaa63ff342b441ce1f32e206e533f8d0ece19e89955313fc7243d884/jsonpath_rust_bindings-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:62d2d07129e49b5e8306c492ba88890fffeaa7d5dcf483ceef05f1ea371d0656", size = 814873, upload-time = "2025-11-16T19:02:01.488Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/6a/099c1ee9c1eb5e717d0eb70236dae34c665e1ad29cc742f86711b142a243/jsonpath_rust_bindings-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2baad20da8f4800599e9294834cfc38acadd59ababb31e1b67dce01377ee30ff", size = 832311, upload-time = "2025-11-16T19:00:20.244Z" },
+    { url = "https://files.pythonhosted.org/packages/20/75/3acfd6f1b158f6455c8795d2752282cb3de73eebcc6fb1ee95c536abc9ab/jsonpath_rust_bindings-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:082a6638ba126bdfa2be38b1126c954d8fb7f87358d8abfc1d993ec9ebb0894c", size = 836867, upload-time = "2025-11-16T19:00:36.872Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0d/ab8bc58dbefc1b4ea8b44506c8ab9ac2bf84629b9f8f6e2dd064eb19d4c5/jsonpath_rust_bindings-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9e72af8d566b4e08e212f67d49061dd82df0db9a6a295d1a3d5b78d0566a4ef4", size = 931945, upload-time = "2025-11-16T19:00:53.827Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/fe917a76245d3effcf89c3d70b854a5fbdf5c23624a8114c13f45626efe3/jsonpath_rust_bindings-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96fb734bae80a098b5876a9b44677c023cd7b93346a4d28a18bdef086cc21c71", size = 959706, upload-time = "2025-11-16T19:01:10.181Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/dc/8364a55d3103c6ce38e61b80f3a3775302a049f5e16e5d741ead5037c505/jsonpath_rust_bindings-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b4fc4106d74d3cb5cb57a6c35b682db50662b9bb501dffecd5cdcdeee9a8367", size = 947323, upload-time = "2025-11-16T19:01:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/00/ff1d7dc2ff75e91a9f0835df53b8fa9eef1aa805e105999149d8ebfb3211/jsonpath_rust_bindings-1.1.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a95feebca3a7ff2aab3429a18ddea5247c0c2ed5370cefd78d412c5f78191e2a", size = 943743, upload-time = "2025-11-16T19:01:26.22Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f5/cc58c47854132565b6e36aef5aa48b4c35521a1230d3fbf9e4468be708ee/jsonpath_rust_bindings-1.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ca94d86cdeb623a711a20780fbf947d60d0fffcf2fb1276239ca89590cfdf03d", size = 1067125, upload-time = "2025-11-16T19:02:34.809Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9f/a1256090c3f65db067e96ed528c40806917783091587a81f2063df18ea4f/jsonpath_rust_bindings-1.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:eb54794b19ad60a6d0a778fac8588e54db8985da894548a25457edd702ec40e9", size = 1149151, upload-time = "2025-11-16T19:02:51.238Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/50/3fb9e66e60fe569587c824e7d2c147931e33704b7a990794974386afd047/jsonpath_rust_bindings-1.1.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ccccf83576a332d916a1dc053735e64aa4adfb40f14cefc1600df7b35d06f3c9", size = 1106555, upload-time = "2025-11-16T19:03:07.811Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/55/be1bd6a6250761387a76b032de18f01bf0e6e2a5704766ae107013970669/jsonpath_rust_bindings-1.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e242a58b5d2aacdc2346e2a6cdfa8f1d90f92e3d9e76518b63b3402e91551a10", size = 1134317, upload-time = "2025-11-16T19:03:25.423Z" },
+    { url = "https://files.pythonhosted.org/packages/25/23/25afbb1938708d1a546483dca7c24b8277547da2c30527ceed44bd73171c/jsonpath_rust_bindings-1.1.1-cp314-cp314-win32.whl", hash = "sha256:085e3d33ded7a1f838bd4374fd2bf1eb418076efe02b4740f4066b09b5b61a88", size = 750319, upload-time = "2025-11-16T19:04:07.546Z" },
+    { url = "https://files.pythonhosted.org/packages/29/06/ff2042c07e7f7dab0decd2b2cd0a1022a5d01510e85496a1a736f1d40b22/jsonpath_rust_bindings-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:edd8b32f2aa82f33205f460035c28641a856834662df0dfb6323cb330f16690c", size = 808653, upload-time = "2025-11-16T19:03:50.491Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/0f/bdf99abf8b08eebcb5f96e6da06dcc06017cb527fc5f199bf7ce033ab13d/jsonpath_rust_bindings-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:6ba310703af5b437a5e4e041a2f36d1fcd744152ea6e1e83bfcf78bca032bfe3", size = 747614, upload-time = "2025-11-16T19:03:41.965Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/d4/9326838b59dc36dfae42eec9656b97520f9997eee1de47b8316aaeed169c/lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d", size = 8570663, upload-time = "2026-04-18T04:27:48.253Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a4/053745ce1f8303ccbb788b86c0db3a91b973675cefc42566a188637b7c40/lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93", size = 4624024, upload-time = "2026-04-18T04:27:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/90/97/a517944b20f8fd0932ad2109482bee4e29fe721416387a363306667941f6/lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d", size = 4930895, upload-time = "2026-04-18T04:32:56.29Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/e08a970727d556caa040a44773c7b7e3ad0f0d73dedc863543e9a8b931f2/lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a", size = 5093820, upload-time = "2026-04-18T04:32:58.94Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ee/2a5c2aa2c32016a226ca25d3e1056a8102ea6e1fe308bf50213586635400/lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105", size = 5005790, upload-time = "2026-04-18T04:33:01.272Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/a0db9be8f38ad6043ab9429487c128dd1d30f07956ef43040402f8da49e8/lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485", size = 5630827, upload-time = "2026-04-18T04:33:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ba/3c13d3fc24b7cacf675f808a3a1baabf43a30d0cd24c98f94548e9aa58eb/lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814", size = 5240445, upload-time = "2026-04-18T04:33:06.87Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eeef4ccba09b2212fe239f46c1692a98db1878e0872ae320756488878a94/lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32", size = 5350121, upload-time = "2026-04-18T04:33:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/01/1da87c7b587c38d0cbe77a01aae3b9c1c49ed47d76918ef3db8fc151b1ca/lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad", size = 4694949, upload-time = "2026-04-18T04:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/88/7db0fe66d5aaf128443ee1623dec3db1576f3e4c17751ec0ef5866468590/lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54", size = 5243901, upload-time = "2026-04-18T04:33:13.95Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a8/1346726af7d1f6fca1f11223ba34001462b0a3660416986d37641708d57c/lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d", size = 5048054, upload-time = "2026-04-18T04:33:16.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b7/85057012f035d1a0c87e02f8c723ca3c3e6e0728bcf4cb62080b21b1c1e3/lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69", size = 4777324, upload-time = "2026-04-18T04:33:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6c/ad2f94a91073ef570f33718040e8e160d5fb93331cf1ab3ca1323f939e2d/lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d", size = 5645702, upload-time = "2026-04-18T04:33:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/89/0bb6c0bd549c19004c60eea9dc554dd78fd647b72314ef25d460e0d208c6/lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5", size = 5232901, upload-time = "2026-04-18T04:33:26.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/d609a11fb567da9399f525193e2b49847b5a409cdebe737f06a8b7126bdc/lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d", size = 5261333, upload-time = "2026-04-18T04:33:28.984Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3a/ac3f99ec8ac93089e7dd556f279e0d14c24de0a74a507e143a2e4b496e7c/lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f", size = 3596289, upload-time = "2026-04-18T04:27:42.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a7/0a915557538593cb1bbeedcd40e13c7a261822c26fecbbdb71dad0c2f540/lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366", size = 3997059, upload-time = "2026-04-18T04:27:46.764Z" },
+    { url = "https://files.pythonhosted.org/packages/92/96/a5dc078cf0126fbfbc35611d77ecd5da80054b5893e28fb213a5613b9e1d/lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819", size = 3659552, upload-time = "2026-04-18T04:27:51.133Z" },
+    { url = "https://files.pythonhosted.org/packages/08/03/69347590f1cf4a6d5a4944bb6099e6d37f334784f16062234e1f892fdb1d/lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45", size = 8559689, upload-time = "2026-04-18T04:31:57.785Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/25e00bb40b185c974cfe156c110474d9a8a8390d5f7c92a4e328189bb60e/lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d", size = 4617892, upload-time = "2026-04-18T04:32:01.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/54/92ad98a94ac318dc4f97aaac22ff8d1b94212b2ae8af5b6e9b354bf825f7/lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2", size = 4923489, upload-time = "2026-04-18T04:33:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3b/a20aecfab42bdf4f9b390590d345857ad3ffd7c51988d1c89c53a0c73faf/lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491", size = 5082162, upload-time = "2026-04-18T04:33:34.262Z" },
+    { url = "https://files.pythonhosted.org/packages/45/26/2cdb3d281ac1bd175603e290cbe4bad6eff127c0f8de90bafd6f8548f0fd/lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc", size = 4993247, upload-time = "2026-04-18T04:33:36.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/05/d735aef963740022a08185c84821f689fc903acb3d50326e6b1e9886cc22/lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e", size = 5613042, upload-time = "2026-04-18T04:33:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/ead7c10efff731738c72e59ed6eb5791854879fbed7ae98781a12006263a/lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2", size = 5228304, upload-time = "2026-04-18T04:33:41.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/10/e9842d2ec322ea65f0a7270aa0315a53abed06058b88ef1b027f620e7a5f/lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9", size = 5341578, upload-time = "2026-04-18T04:33:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/89/54/40d9403d7c2775fa7301d3ddd3464689bfe9ba71acc17dfff777071b4fdc/lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe", size = 4700209, upload-time = "2026-04-18T04:33:47.552Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/bbdcc2cf45dfc7dfffef4fd97e5c47b15919b6a365247d95d6f684ef5e82/lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88", size = 5232365, upload-time = "2026-04-18T04:33:50.249Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/b06875665e53aaba7127611a7bed3b7b9658e20b22bc2dd217a0b7ab0091/lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181", size = 5043654, upload-time = "2026-04-18T04:33:52.71Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/e71a069d09641c1a7abeb30e693f828c7c90a41cbe3d650b2d734d876f85/lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24", size = 4769326, upload-time = "2026-04-18T04:33:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/06/7a9cd84b3d4ed79adf35f874750abb697dec0b4a81a836037b36e47c091a/lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e", size = 5635879, upload-time = "2026-04-18T04:33:58.509Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f0/9d57916befc1e54c451712c7ee48e9e74e80ae4d03bdce49914e0aee42cd/lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495", size = 5224048, upload-time = "2026-04-18T04:34:00.943Z" },
+    { url = "https://files.pythonhosted.org/packages/99/75/90c4eefda0c08c92221fe0753db2d6699a4c628f76ff4465ec20dea84cc1/lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33", size = 5250241, upload-time = "2026-04-18T04:34:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938, upload-time = "2026-04-18T04:31:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728, upload-time = "2026-04-18T04:31:58.763Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372, upload-time = "2026-04-18T04:32:03.629Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/cee4cf203ef0bab5c52afc118da61d6b460c928f2893d40023cfa27e0b80/lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8", size = 8576713, upload-time = "2026-04-18T04:32:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/eda05babeb7e046839204eaf254cd4d7c9130ce2bbf0d9e90ea41af5654d/lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9", size = 4623874, upload-time = "2026-04-18T04:32:10.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e9/db5846de9b436b91890a62f29d80cd849ea17948a49bf532d5278ee69a9e/lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03", size = 4949535, upload-time = "2026-04-18T04:34:06.657Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/0d3593373dcae1d68f40dc3c41a5a92f2544e68115eb2f62319a4c2a6500/lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb", size = 5086881, upload-time = "2026-04-18T04:34:09.556Z" },
+    { url = "https://files.pythonhosted.org/packages/43/76/759a7484539ad1af0d125a9afe9c3fb5f82a8779fd1f5f56319d9e4ea2fd/lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c", size = 5031305, upload-time = "2026-04-18T04:34:12.336Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/c1f0daf981a11e47636126901fd4ab82429e18c57aeb0fc3ad2940b42d8b/lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28", size = 5647522, upload-time = "2026-04-18T04:34:14.89Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/1f533dcd205275363d9ba3511bcec52fa2df86abf8abe6a5f2c599f0dc31/lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086", size = 5239310, upload-time = "2026-04-18T04:34:17.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8c/4175fb709c78a6e315ed814ed33be3defd8b8721067e70419a6cf6f971da/lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f", size = 5350799, upload-time = "2026-04-18T04:34:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/6ffdebc5994975f0dde4acb59761902bd9d9bb84422b9a0bd239a7da9ca8/lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292", size = 4697693, upload-time = "2026-04-18T04:34:23.541Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f1/565f36bd5c73294602d48e04d23f81ff4c8736be6ba5e1d1ec670ac9be80/lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb", size = 5250708, upload-time = "2026-04-18T04:34:26.001Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/11/a68ab9dd18c5c499404deb4005f4bc4e0e88e5b72cd755ad96efec81d18d/lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad", size = 5084737, upload-time = "2026-04-18T04:34:28.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/e8f41e2c74f4af564e6a0348aea69fb6daaefa64bc071ef469823d22cc18/lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb", size = 4737817, upload-time = "2026-04-18T04:34:30.784Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2d/aa4e117aa2ce2f3b35d9ff246be74a2f8e853baba5d2a92c64744474603a/lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f", size = 5670753, upload-time = "2026-04-18T04:34:33.675Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/dd745d50c0409031dbfcc4881740542a01e54d6f0110bd420fa7782110b8/lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43", size = 5238071, upload-time = "2026-04-18T04:34:36.12Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/74/ad424f36d0340a904665867dab310a3f1f4c96ff4039698de83b77f44c1f/lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585", size = 5264319, upload-time = "2026-04-18T04:34:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/53/36/a15d8b3514ec889bfd6aa3609107fcb6c9189f8dc347f1c0b81eded8d87c/lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f", size = 3657139, upload-time = "2026-04-18T04:32:20.006Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/263ebb0710851a3c6c937180a9a86df1206fdfe53cc43005aa2237fd7736/lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120", size = 4064195, upload-time = "2026-04-18T04:32:23.876Z" },
+    { url = "https://files.pythonhosted.org/packages/80/68/2000f29d323b6c286de077ad20b429fc52272e44eae6d295467043e56012/lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946", size = 3741870, upload-time = "2026-04-18T04:32:27.922Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e9/21383c7c8d43799f0da90224c0d7c921870d476ec9b3e01e1b2c0b8237c5/lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c", size = 8827548, upload-time = "2026-04-18T04:32:15.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/01/c6bc11cd587030dd4f719f65c5657960649fe3e19196c844c75bf32cd0d6/lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d", size = 4735866, upload-time = "2026-04-18T04:32:18.924Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/757132fff5f4acf25463b5298f1a46099f3a94480b806547b29ce5e385de/lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9", size = 4969476, upload-time = "2026-04-18T04:34:41.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/fb/1bc8b9d27ed64be7c8903db6c89e74dc8c2cd9ec630a7462e4654316dc5b/lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9", size = 5103719, upload-time = "2026-04-18T04:34:44.797Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/5bf82fa28133536a54601aae633b14988e89ed61d4c1eb6b899b023233aa/lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7", size = 5027890, upload-time = "2026-04-18T04:34:47.634Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/20/e048db5d4b4ea0366648aa595f26bb764b2670903fc585b87436d0a5032c/lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86", size = 5596008, upload-time = "2026-04-18T04:34:51.503Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c2/d10807bc8da4824b39e5bd01b5d05c077b6fd01bd91584167edf6b269d22/lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb", size = 5224451, upload-time = "2026-04-18T04:34:54.263Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/15/2ebea45bea427e7f0057e9ce7b2d62c5aba20c6b001cca89ed0aadb3ad41/lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c", size = 5312135, upload-time = "2026-04-18T04:34:56.818Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e2/87eeae151b0be2a308d49a7ec444ff3eb192b14251e62addb29d0bf3778f/lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f", size = 4639126, upload-time = "2026-04-18T04:34:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/51/8a3f6a20902ad604dd746ec7b4000311b240d389dac5e9d95adefd349e0c/lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773", size = 5232579, upload-time = "2026-04-18T04:35:02.658Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d2/650d619bdbe048d2c3f2c31edb00e35670a5e2d65b4fe3b61bce37b19121/lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b", size = 5084206, upload-time = "2026-04-18T04:35:05.175Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8a/672ca1a3cbeabd1f511ca275a916c0514b747f4b85bdaae103b8fa92f307/lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405", size = 4758906, upload-time = "2026-04-18T04:35:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f1/ef4b691da85c916cb2feb1eec7414f678162798ac85e042fa164419ac05c/lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690", size = 5620553, upload-time = "2026-04-18T04:35:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/59/17/94e81def74107809755ac2782fdad4404420f1c92ca83433d117a6d5acf0/lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd", size = 5229458, upload-time = "2026-04-18T04:35:14.254Z" },
+    { url = "https://files.pythonhosted.org/packages/21/55/c4be91b0f830a871fc1b0d730943d56013b683d4671d5198260e2eae722b/lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180", size = 5247861, upload-time = "2026-04-18T04:35:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ca/77123e4d77df3cb1e968ade7b1f808f5d3a5c1c96b18a33895397de292c1/lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2", size = 3897377, upload-time = "2026-04-18T04:32:07.656Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ce/3554833989d074267c063209bae8b09815e5656456a2d332b947806b05ff/lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5", size = 4392701, upload-time = "2026-04-18T04:32:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/9b916c68c0e57752c07f8f64b30138d9d4059dbeb27b90274dedbea128ff/lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac", size = 3817120, upload-time = "2026-04-18T04:32:15.803Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -790,6 +1197,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "marko"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/2f/050b6d485f052ddf17d76a41f9334d6fb2a8a85df35347a12d97ed3bc5c1/marko-2.2.2.tar.gz", hash = "sha256:6940308e655f63733ca518c47a68ec9510279dbb916c83616e4c4b5829f052e8", size = 143641, upload-time = "2026-01-05T11:04:41.935Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/f8/36d79bac5701e6786f9880c61bbe57574760a13c1af84ab71e5ed21faecc/marko-2.2.2-py3-none-any.whl", hash = "sha256:f064ae8c10416285ad1d96048dc11e98ef04e662d3342ae416f662b70aa7959e", size = 42701, upload-time = "2026-01-05T11:04:40.75Z" },
 ]
 
 [[package]]
@@ -856,6 +1272,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -888,6 +1329,9 @@ mlx = [
     { name = "mlx-lm" },
     { name = "mlx-vlm" },
 ]
+synthetic-data = [
+    { name = "data-designer" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -898,16 +1342,17 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "data-designer", marker = "extra == 'synthetic-data'", specifier = ">=0.5.9,<0.6" },
     { name = "grpcio", specifier = ">=1.71.0" },
     { name = "mlx", marker = "extra == 'mlx'", specifier = ">=0.31.2,<0.32" },
     { name = "mlx-audio", marker = "extra == 'audio'", specifier = "==0.4.3" },
     { name = "mlx-audio", marker = "extra == 'audio-stt'", specifier = "==0.4.3" },
     { name = "mlx-audio", marker = "extra == 'audio-tts'", specifier = "==0.4.3" },
     { name = "mlx-lm", marker = "extra == 'mlx'", specifier = ">=0.31.3,<0.32" },
-    { name = "mlx-vlm", marker = "extra == 'mlx'", specifier = ">=0.4.4,<0.5" },
+    { name = "mlx-vlm", marker = "extra == 'mlx'", specifier = ">=0.4.4,<0.6" },
     { name = "protobuf", specifier = ">=5.29.0" },
 ]
-provides-extras = ["mlx", "audio-stt", "audio-tts", "audio"]
+provides-extras = ["mlx", "audio-stt", "audio-tts", "audio", "synthetic-data"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -974,12 +1419,12 @@ dependencies = [
     { name = "miniaudio" },
     { name = "mlx" },
     { name = "mlx-lm" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (python_full_version < '3.13' and extra != 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (python_full_version >= '3.13' and extra != 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
     { name = "scipy" },
     { name = "sounddevice" },
     { name = "tqdm" },
-    { name = "transformers", version = "5.8.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/db/a9f95e3794eca373d681220c8b9f8f84451a0d14959f85cc341ca592394c/mlx_audio-0.4.3.tar.gz", hash = "sha256:8e87badf56a0f73bf91e3797b1195c01440a181cf0b64a2a08dc1bda4b037f54", size = 1144947, upload-time = "2026-04-28T20:18:12.09Z" }
 wheels = [
@@ -993,13 +1438,12 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
     { name = "protobuf" },
     { name = "pyyaml" },
     { name = "sentencepiece" },
-    { name = "transformers", version = "5.3.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-16-melix-mlx-worker-mlx'" },
-    { name = "transformers", version = "5.8.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-16-melix-mlx-worker-audio' or extra == 'extra-16-melix-mlx-worker-audio-stt' or extra == 'extra-16-melix-mlx-worker-audio-tts'" },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
 wheels = [
@@ -1032,7 +1476,7 @@ dependencies = [
     { name = "pillow" },
     { name = "requests" },
     { name = "tqdm" },
-    { name = "transformers", version = "5.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "transformers" },
     { name = "uvicorn" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/ec/108aec30efb159940ea29d133d5d8ec14840edbec914869b46eaafac5552/mlx_vlm-0.4.4.tar.gz", hash = "sha256:3197e277c1be9ed1712ea04624df029e486f7747ad93e40e7bd1c9c771f8b179", size = 836370, upload-time = "2026-04-04T15:19:01.087Z" }
@@ -1141,19 +1585,27 @@ wheels = [
 
 [[package]]
 name = "multiprocess"
-version = "0.70.19"
+version = "0.70.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dill" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/ae/04f39c5d0d0def03247c2893d6f2b83c136bf3320a2154d7b8858f2ba72d/multiprocess-0.70.16.tar.gz", hash = "sha256:161af703d4652a0e1410be6abccecde4a7ddffd19341be0a7011b94aeb171ac1", size = 1772603, upload-time = "2024-01-28T18:52:34.85Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/45/8004d1e6b9185c1a444d6b55ac5682acf9d98035e54386d967366035a03a/multiprocess-0.70.19-py310-none-any.whl", hash = "sha256:97404393419dcb2a8385910864eedf47a3cadf82c66345b44f036420eb0b5d87", size = 134948, upload-time = "2026-01-19T06:47:32.325Z" },
-    { url = "https://files.pythonhosted.org/packages/86/c2/dec9722dc3474c164a0b6bcd9a7ed7da542c98af8cabce05374abab35edd/multiprocess-0.70.19-py311-none-any.whl", hash = "sha256:928851ae7973aea4ce0eaf330bbdafb2e01398a91518d5c8818802845564f45c", size = 144457, upload-time = "2026-01-19T06:47:33.711Z" },
-    { url = "https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl", hash = "sha256:3a56c0e85dd5025161bac5ce138dcac1e49174c7d8e74596537e729fd5c53c28", size = 150281, upload-time = "2026-01-19T06:47:35.037Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/74/d2c27e03cb84251dfe7249b8e82923643c6d48fa4883b9476b025e7dc7eb/multiprocess-0.70.19-py313-none-any.whl", hash = "sha256:8d5eb4ec5017ba2fab4e34a747c6d2c2b6fecfe9e7236e77988db91580ada952", size = 156414, upload-time = "2026-01-19T06:47:35.915Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/61/af9115673a5870fd885247e2f1b68c4f1197737da315b520a91c757a861a/multiprocess-0.70.19-py314-none-any.whl", hash = "sha256:e8cc7fbdff15c0613f0a1f1f8744bef961b0a164c0ca29bdff53e9d2d93c5e5f", size = 160318, upload-time = "2026-01-19T06:47:37.497Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/82/69e539c4c2027f1e1697e09aaa2449243085a0edf81ae2c6341e84d769b6/multiprocess-0.70.19-py39-none-any.whl", hash = "sha256:0d4b4397ed669d371c81dcd1ef33fd384a44d6c3de1bd0ca7ac06d837720d3c5", size = 133477, upload-time = "2026-01-19T06:47:38.619Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f7/7ec7fddc92e50714ea3745631f79bd9c96424cb2702632521028e57d3a36/multiprocess-0.70.16-py310-none-any.whl", hash = "sha256:c4a9944c67bd49f823687463660a2d6daae94c289adff97e0f9d696ba6371d02", size = 134824, upload-time = "2024-01-28T18:52:26.062Z" },
+    { url = "https://files.pythonhosted.org/packages/50/15/b56e50e8debaf439f44befec5b2af11db85f6e0f344c3113ae0be0593a91/multiprocess-0.70.16-py311-none-any.whl", hash = "sha256:af4cabb0dac72abfb1e794fa7855c325fd2b55a10a44628a3c1ad3311c04127a", size = 143519, upload-time = "2024-01-28T18:52:28.115Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7d/a988f258104dcd2ccf1ed40fdc97e26c4ac351eeaf81d76e266c52d84e2f/multiprocess-0.70.16-py312-none-any.whl", hash = "sha256:fc0544c531920dde3b00c29863377f87e1632601092ea2daca74e4beb40faa2e", size = 146741, upload-time = "2024-01-28T18:52:29.395Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/89/38df130f2c799090c978b366cfdf5b96d08de5b29a4a293df7f7429fa50b/multiprocess-0.70.16-py38-none-any.whl", hash = "sha256:a71d82033454891091a226dfc319d0cfa8019a4e888ef9ca910372a446de4435", size = 132628, upload-time = "2024-01-28T18:52:30.853Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d9/f7f9379981e39b8c2511c9e0326d212accacb82f12fbfdc1aa2ce2a7b2b6/multiprocess-0.70.16-py39-none-any.whl", hash = "sha256:a0bafd3ae1b732eac64be2e72038231c1ba97724b60b09400d68f229fcc2fbf3", size = 133351, upload-time = "2024-01-28T18:52:31.981Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -1320,8 +1772,8 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -1364,69 +1816,90 @@ wheels = [
 ]
 
 [[package]]
-name = "pillow"
-version = "11.3.0"
+name = "pathspec"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523", size = 47113069, upload-time = "2025-07-01T09:16:30.666Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/fe/1bc9b3ee13f68487a99ac9529968035cca2f0a51ec36892060edcc51d06a/pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4", size = 5278800, upload-time = "2025-07-01T09:14:17.648Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/32/7e2ac19b5713657384cec55f89065fb306b06af008cfd87e572035b27119/pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69", size = 4686296, upload-time = "2025-07-01T09:14:19.828Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/1e/b9e12bbe6e4c2220effebc09ea0923a07a6da1e1f1bfbc8d7d29a01ce32b/pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d", size = 5871726, upload-time = "2025-07-03T13:10:04.448Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/33/e9200d2bd7ba00dc3ddb78df1198a6e80d7669cce6c2bdbeb2530a74ec58/pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6", size = 7644652, upload-time = "2025-07-03T13:10:10.391Z" },
-    { url = "https://files.pythonhosted.org/packages/41/f1/6f2427a26fc683e00d985bc391bdd76d8dd4e92fac33d841127eb8fb2313/pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7", size = 5977787, upload-time = "2025-07-01T09:14:21.63Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/c9/06dd4a38974e24f932ff5f98ea3c546ce3f8c995d3f0985f8e5ba48bba19/pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024", size = 6645236, upload-time = "2025-07-01T09:14:23.321Z" },
-    { url = "https://files.pythonhosted.org/packages/40/e7/848f69fb79843b3d91241bad658e9c14f39a32f71a301bcd1d139416d1be/pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809", size = 6086950, upload-time = "2025-07-01T09:14:25.237Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/1a/7cff92e695a2a29ac1958c2a0fe4c0b2393b60aac13b04a4fe2735cad52d/pillow-11.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6be31e3fc9a621e071bc17bb7de63b85cbe0bfae91bb0363c893cbe67247780d", size = 6723358, upload-time = "2025-07-01T09:14:27.053Z" },
-    { url = "https://files.pythonhosted.org/packages/26/7d/73699ad77895f69edff76b0f332acc3d497f22f5d75e5360f78cbcaff248/pillow-11.3.0-cp312-cp312-win32.whl", hash = "sha256:7b161756381f0918e05e7cb8a371fff367e807770f8fe92ecb20d905d0e1c149", size = 6275079, upload-time = "2025-07-01T09:14:30.104Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ce/e7dfc873bdd9828f3b6e5c2bbb74e47a98ec23cc5c74fc4e54462f0d9204/pillow-11.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a6444696fce635783440b7f7a9fc24b3ad10a9ea3f0ab66c5905be1c19ccf17d", size = 6986324, upload-time = "2025-07-01T09:14:31.899Z" },
-    { url = "https://files.pythonhosted.org/packages/16/8f/b13447d1bf0b1f7467ce7d86f6e6edf66c0ad7cf44cf5c87a37f9bed9936/pillow-11.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:2aceea54f957dd4448264f9bf40875da0415c83eb85f55069d89c0ed436e3542", size = 2423067, upload-time = "2025-07-01T09:14:33.709Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/93/0952f2ed8db3a5a4c7a11f91965d6184ebc8cd7cbb7941a260d5f018cd2d/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:1c627742b539bba4309df89171356fcb3cc5a9178355b2727d1b74a6cf155fbd", size = 2128328, upload-time = "2025-07-01T09:14:35.276Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/e8/100c3d114b1a0bf4042f27e0f87d2f25e857e838034e98ca98fe7b8c0a9c/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:30b7c02f3899d10f13d7a48163c8969e4e653f8b43416d23d13d1bbfdc93b9f8", size = 2170652, upload-time = "2025-07-01T09:14:37.203Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/86/3f758a28a6e381758545f7cdb4942e1cb79abd271bea932998fc0db93cb6/pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f", size = 2227443, upload-time = "2025-07-01T09:14:39.344Z" },
-    { url = "https://files.pythonhosted.org/packages/01/f4/91d5b3ffa718df2f53b0dc109877993e511f4fd055d7e9508682e8aba092/pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c", size = 5278474, upload-time = "2025-07-01T09:14:41.843Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/0e/37d7d3eca6c879fbd9dba21268427dffda1ab00d4eb05b32923d4fbe3b12/pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd", size = 4686038, upload-time = "2025-07-01T09:14:44.008Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/b0/3426e5c7f6565e752d81221af9d3676fdbb4f352317ceafd42899aaf5d8a/pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e", size = 5864407, upload-time = "2025-07-03T13:10:15.628Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/c1/c6c423134229f2a221ee53f838d4be9d82bab86f7e2f8e75e47b6bf6cd77/pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1", size = 7639094, upload-time = "2025-07-03T13:10:21.857Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/c9/09e6746630fe6372c67c648ff9deae52a2bc20897d51fa293571977ceb5d/pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805", size = 5973503, upload-time = "2025-07-01T09:14:45.698Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/1c/a2a29649c0b1983d3ef57ee87a66487fdeb45132df66ab30dd37f7dbe162/pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8", size = 6642574, upload-time = "2025-07-01T09:14:47.415Z" },
-    { url = "https://files.pythonhosted.org/packages/36/de/d5cc31cc4b055b6c6fd990e3e7f0f8aaf36229a2698501bcb0cdf67c7146/pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2", size = 6084060, upload-time = "2025-07-01T09:14:49.636Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ea/502d938cbaeec836ac28a9b730193716f0114c41325db428e6b280513f09/pillow-11.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:45dfc51ac5975b938e9809451c51734124e73b04d0f0ac621649821a63852e7b", size = 6721407, upload-time = "2025-07-01T09:14:51.962Z" },
-    { url = "https://files.pythonhosted.org/packages/45/9c/9c5e2a73f125f6cbc59cc7087c8f2d649a7ae453f83bd0362ff7c9e2aee2/pillow-11.3.0-cp313-cp313-win32.whl", hash = "sha256:a4d336baed65d50d37b88ca5b60c0fa9d81e3a87d4a7930d3880d1624d5b31f3", size = 6273841, upload-time = "2025-07-01T09:14:54.142Z" },
-    { url = "https://files.pythonhosted.org/packages/23/85/397c73524e0cd212067e0c969aa245b01d50183439550d24d9f55781b776/pillow-11.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bce5c4fd0921f99d2e858dc4d4d64193407e1b99478bc5cacecba2311abde51", size = 6978450, upload-time = "2025-07-01T09:14:56.436Z" },
-    { url = "https://files.pythonhosted.org/packages/17/d2/622f4547f69cd173955194b78e4d19ca4935a1b0f03a302d655c9f6aae65/pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580", size = 2423055, upload-time = "2025-07-01T09:14:58.072Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/80/a8a2ac21dda2e82480852978416cfacd439a4b490a501a288ecf4fe2532d/pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e", size = 5281110, upload-time = "2025-07-01T09:14:59.79Z" },
-    { url = "https://files.pythonhosted.org/packages/44/d6/b79754ca790f315918732e18f82a8146d33bcd7f4494380457ea89eb883d/pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d", size = 4689547, upload-time = "2025-07-01T09:15:01.648Z" },
-    { url = "https://files.pythonhosted.org/packages/49/20/716b8717d331150cb00f7fdd78169c01e8e0c219732a78b0e59b6bdb2fd6/pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced", size = 5901554, upload-time = "2025-07-03T13:10:27.018Z" },
-    { url = "https://files.pythonhosted.org/packages/74/cf/a9f3a2514a65bb071075063a96f0a5cf949c2f2fce683c15ccc83b1c1cab/pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c", size = 7669132, upload-time = "2025-07-03T13:10:33.01Z" },
-    { url = "https://files.pythonhosted.org/packages/98/3c/da78805cbdbee9cb43efe8261dd7cc0b4b93f2ac79b676c03159e9db2187/pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8", size = 6005001, upload-time = "2025-07-01T09:15:03.365Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/fa/ce044b91faecf30e635321351bba32bab5a7e034c60187fe9698191aef4f/pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59", size = 6668814, upload-time = "2025-07-01T09:15:05.655Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/51/90f9291406d09bf93686434f9183aba27b831c10c87746ff49f127ee80cb/pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe", size = 6113124, upload-time = "2025-07-01T09:15:07.358Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/5a/6fec59b1dfb619234f7636d4157d11fb4e196caeee220232a8d2ec48488d/pillow-11.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83e1b0161c9d148125083a35c1c5a89db5b7054834fd4387499e06552035236c", size = 6747186, upload-time = "2025-07-01T09:15:09.317Z" },
-    { url = "https://files.pythonhosted.org/packages/49/6b/00187a044f98255225f172de653941e61da37104a9ea60e4f6887717e2b5/pillow-11.3.0-cp313-cp313t-win32.whl", hash = "sha256:2a3117c06b8fb646639dce83694f2f9eac405472713fcb1ae887469c0d4f6788", size = 6277546, upload-time = "2025-07-01T09:15:11.311Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/5c/6caaba7e261c0d75bab23be79f1d06b5ad2a2ae49f028ccec801b0e853d6/pillow-11.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:857844335c95bea93fb39e0fa2726b4d9d758850b34075a7e3ff4f4fa3aa3b31", size = 6985102, upload-time = "2025-07-01T09:15:13.164Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/7e/b623008460c09a0cb38263c93b828c666493caee2eb34ff67f778b87e58c/pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e", size = 2424803, upload-time = "2025-07-01T09:15:15.695Z" },
-    { url = "https://files.pythonhosted.org/packages/73/f4/04905af42837292ed86cb1b1dabe03dce1edc008ef14c473c5c7e1443c5d/pillow-11.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d9da3df5f9ea2a89b81bb6087177fb1f4d1c7146d583a3fe5c672c0d94e55e12", size = 5278520, upload-time = "2025-07-01T09:15:17.429Z" },
-    { url = "https://files.pythonhosted.org/packages/41/b0/33d79e377a336247df6348a54e6d2a2b85d644ca202555e3faa0cf811ecc/pillow-11.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b275ff9b04df7b640c59ec5a3cb113eefd3795a8df80bac69646ef699c6981a", size = 4686116, upload-time = "2025-07-01T09:15:19.423Z" },
-    { url = "https://files.pythonhosted.org/packages/49/2d/ed8bc0ab219ae8768f529597d9509d184fe8a6c4741a6864fea334d25f3f/pillow-11.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0743841cabd3dba6a83f38a92672cccbd69af56e3e91777b0ee7f4dba4385632", size = 5864597, upload-time = "2025-07-03T13:10:38.404Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/3d/b932bb4225c80b58dfadaca9d42d08d0b7064d2d1791b6a237f87f661834/pillow-11.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2465a69cf967b8b49ee1b96d76718cd98c4e925414ead59fdf75cf0fd07df673", size = 7638246, upload-time = "2025-07-03T13:10:44.987Z" },
-    { url = "https://files.pythonhosted.org/packages/09/b5/0487044b7c096f1b48f0d7ad416472c02e0e4bf6919541b111efd3cae690/pillow-11.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41742638139424703b4d01665b807c6468e23e699e8e90cffefe291c5832b027", size = 5973336, upload-time = "2025-07-01T09:15:21.237Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/2d/524f9318f6cbfcc79fbc004801ea6b607ec3f843977652fdee4857a7568b/pillow-11.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93efb0b4de7e340d99057415c749175e24c8864302369e05914682ba642e5d77", size = 6642699, upload-time = "2025-07-01T09:15:23.186Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/d2/a9a4f280c6aefedce1e8f615baaa5474e0701d86dd6f1dede66726462bbd/pillow-11.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7966e38dcd0fa11ca390aed7c6f20454443581d758242023cf36fcb319b1a874", size = 6083789, upload-time = "2025-07-01T09:15:25.1Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/54/86b0cd9dbb683a9d5e960b66c7379e821a19be4ac5810e2e5a715c09a0c0/pillow-11.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:98a9afa7b9007c67ed84c57c9e0ad86a6000da96eaa638e4f8abe5b65ff83f0a", size = 6720386, upload-time = "2025-07-01T09:15:27.378Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/95/88efcaf384c3588e24259c4203b909cbe3e3c2d887af9e938c2022c9dd48/pillow-11.3.0-cp314-cp314-win32.whl", hash = "sha256:02a723e6bf909e7cea0dac1b0e0310be9d7650cd66222a5f1c571455c0a45214", size = 6370911, upload-time = "2025-07-01T09:15:29.294Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/cc/934e5820850ec5eb107e7b1a72dd278140731c669f396110ebc326f2a503/pillow-11.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:a418486160228f64dd9e9efcd132679b7a02a5f22c982c78b6fc7dab3fefb635", size = 7117383, upload-time = "2025-07-01T09:15:31.128Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/e9/9c0a616a71da2a5d163aa37405e8aced9a906d574b4a214bede134e731bc/pillow-11.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:155658efb5e044669c08896c0c44231c5e9abcaadbc5cd3648df2f7c0b96b9a6", size = 2511385, upload-time = "2025-07-01T09:15:33.328Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/33/c88376898aff369658b225262cd4f2659b13e8178e7534df9e6e1fa289f6/pillow-11.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:59a03cdf019efbfeeed910bf79c7c93255c3d54bc45898ac2a4140071b02b4ae", size = 5281129, upload-time = "2025-07-01T09:15:35.194Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/70/d376247fb36f1844b42910911c83a02d5544ebd2a8bad9efcc0f707ea774/pillow-11.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f8a5827f84d973d8636e9dc5764af4f0cf2318d26744b3d902931701b0d46653", size = 4689580, upload-time = "2025-07-01T09:15:37.114Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/1c/537e930496149fbac69efd2fc4329035bbe2e5475b4165439e3be9cb183b/pillow-11.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee92f2fd10f4adc4b43d07ec5e779932b4eb3dbfbc34790ada5a6669bc095aa6", size = 5902860, upload-time = "2025-07-03T13:10:50.248Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/57/80f53264954dcefeebcf9dae6e3eb1daea1b488f0be8b8fef12f79a3eb10/pillow-11.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96d333dcf42d01f47b37e0979b6bd73ec91eae18614864622d9b87bbd5bbf36", size = 7670694, upload-time = "2025-07-03T13:10:56.432Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ff/4727d3b71a8578b4587d9c276e90efad2d6fe0335fd76742a6da08132e8c/pillow-11.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c96f993ab8c98460cd0c001447bff6194403e8b1d7e149ade5f00594918128b", size = 6005888, upload-time = "2025-07-01T09:15:39.436Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ae/716592277934f85d3be51d7256f3636672d7b1abfafdc42cf3f8cbd4b4c8/pillow-11.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41342b64afeba938edb034d122b2dda5db2139b9a4af999729ba8818e0056477", size = 6670330, upload-time = "2025-07-01T09:15:41.269Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/bb/7fe6cddcc8827b01b1a9766f5fdeb7418680744f9082035bdbabecf1d57f/pillow-11.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:068d9c39a2d1b358eb9f245ce7ab1b5c3246c7c8c7d9ba58cfa5b43146c06e50", size = 6114089, upload-time = "2025-07-01T09:15:43.13Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f5/06bfaa444c8e80f1a8e4bff98da9c83b37b5be3b1deaa43d27a0db37ef84/pillow-11.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a1bc6ba083b145187f648b667e05a2534ecc4b9f2784c2cbe3089e44868f2b9b", size = 6748206, upload-time = "2025-07-01T09:15:44.937Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/77/bc6f92a3e8e6e46c0ca78abfffec0037845800ea38c73483760362804c41/pillow-11.3.0-cp314-cp314t-win32.whl", hash = "sha256:118ca10c0d60b06d006be10a501fd6bbdfef559251ed31b794668ed569c87e12", size = 6377370, upload-time = "2025-07-01T09:15:46.673Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/82/3a721f7d69dca802befb8af08b7c79ebcab461007ce1c18bd91a5d5896f9/pillow-11.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8924748b688aa210d79883357d102cd64690e56b923a186f35a82cbc10f997db", size = 7121500, upload-time = "2025-07-01T09:15:48.512Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c7/5572fa4a3f45740eaab6ae86fcdf7195b55beac1371ac8c619d880cfe948/pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa", size = 2512835, upload-time = "2025-07-01T09:15:50.399Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -1436,6 +1909,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -1539,45 +2024,30 @@ wheels = [
 
 [[package]]
 name = "pyarrow"
-version = "23.0.1"
+version = "19.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/09/a9046344212690f0632b9c709f9bf18506522feb333c894d0de81d62341a/pyarrow-19.0.1.tar.gz", hash = "sha256:3bf266b485df66a400f282ac0b6d1b500b9d2ae73314a153dbe97d6d5cc8a99e", size = 1129437, upload-time = "2025-02-18T18:55:57.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/4b/4166bb5abbfe6f750fc60ad337c43ecf61340fa52ab386da6e8dbf9e63c4/pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f4b0dbfa124c0bb161f8b5ebb40f1a680b70279aa0c9901d44a2b5a20806039f", size = 34214575, upload-time = "2026-02-16T10:09:56.225Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/da/3f941e3734ac8088ea588b53e860baeddac8323ea40ce22e3d0baa865cc9/pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:7707d2b6673f7de054e2e83d59f9e805939038eebe1763fe811ee8fa5c0cd1a7", size = 35832540, upload-time = "2026-02-16T10:10:03.428Z" },
-    { url = "https://files.pythonhosted.org/packages/88/7c/3d841c366620e906d54430817531b877ba646310296df42ef697308c2705/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86ff03fb9f1a320266e0de855dee4b17da6794c595d207f89bba40d16b5c78b9", size = 44470940, upload-time = "2026-02-16T10:10:10.704Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:813d99f31275919c383aab17f0f455a04f5a429c261cc411b1e9a8f5e4aaaa05", size = 47586063, upload-time = "2026-02-16T10:10:17.95Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/3c/b7d2ebcff47a514f47f9da1e74b7949138c58cfeb108cdd4ee62f43f0cf3/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bf5842f960cddd2ef757d486041d57c96483efc295a8c4a0e20e704cbbf39c67", size = 48173045, upload-time = "2026-02-16T10:10:25.363Z" },
-    { url = "https://files.pythonhosted.org/packages/43/b2/b40961262213beaba6acfc88698eb773dfce32ecdf34d19291db94c2bd73/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564baf97c858ecc03ec01a41062e8f4698abc3e6e2acd79c01c2e97880a19730", size = 50621741, upload-time = "2026-02-16T10:10:33.477Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/70/1fdda42d65b28b078e93d75d371b2185a61da89dda4def8ba6ba41ebdeb4/pyarrow-23.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:07deae7783782ac7250989a7b2ecde9b3c343a643f82e8a4df03d93b633006f0", size = 27620678, upload-time = "2026-02-16T10:10:39.31Z" },
-    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
-    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
-    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca", size = 34238755, upload-time = "2026-02-16T10:12:32.819Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/b5/d58a241fbe324dbaeb8df07be6af8752c846192d78d2272e551098f74e88/pyarrow-23.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1", size = 35847826, upload-time = "2026-02-16T10:12:38.949Z" },
-    { url = "https://files.pythonhosted.org/packages/54/a5/8cbc83f04aba433ca7b331b38f39e000efd9f0c7ce47128670e737542996/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb", size = 44536859, upload-time = "2026-02-16T10:12:45.467Z" },
-    { url = "https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1", size = 47614443, upload-time = "2026-02-16T10:12:55.525Z" },
-    { url = "https://files.pythonhosted.org/packages/af/6b/2314a78057912f5627afa13ba43809d9d653e6630859618b0fd81a4e0759/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c250248f1fe266db627921c89b47b7c06fee0489ad95b04d50353537d74d6886", size = 48232991, upload-time = "2026-02-16T10:13:04.729Z" },
-    { url = "https://files.pythonhosted.org/packages/40/f2/1bcb1d3be3460832ef3370d621142216e15a2c7c62602a4ea19ec240dd64/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f4763b83c11c16e5f4c15601ba6dfa849e20723b46aa2617cb4bffe8768479f", size = 50645077, upload-time = "2026-02-16T10:13:14.147Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/3f/b1da7b61cd66566a4d4c8383d376c606d1c34a906c3f1cb35c479f59d1aa/pyarrow-23.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:3a4c85ef66c134161987c17b147d6bffdca4566f9a4c1d81a0a01cdf08414ea5", size = 28234271, upload-time = "2026-02-16T10:14:09.397Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/78/07f67434e910a0f7323269be7bfbf58699bd0c1d080b18a1ab49ba943fe8/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:17cd28e906c18af486a499422740298c52d7c6795344ea5002a7720b4eadf16d", size = 34488692, upload-time = "2026-02-16T10:13:21.541Z" },
-    { url = "https://files.pythonhosted.org/packages/50/76/34cf7ae93ece1f740a04910d9f7e80ba166b9b4ab9596a953e9e62b90fe1/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:76e823d0e86b4fb5e1cf4a58d293036e678b5a4b03539be933d3b31f9406859f", size = 35964383, upload-time = "2026-02-16T10:13:28.63Z" },
-    { url = "https://files.pythonhosted.org/packages/46/90/459b827238936d4244214be7c684e1b366a63f8c78c380807ae25ed92199/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a62e1899e3078bf65943078b3ad2a6ddcacf2373bc06379aac61b1e548a75814", size = 44538119, upload-time = "2026-02-16T10:13:35.506Z" },
-    { url = "https://files.pythonhosted.org/packages/28/a1/93a71ae5881e99d1f9de1d4554a87be37da11cd6b152239fb5bd924fdc64/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:df088e8f640c9fae3b1f495b3c64755c4e719091caf250f3a74d095ddf3c836d", size = 47571199, upload-time = "2026-02-16T10:13:42.504Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
-    { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b4/94e828704b050e723f67d67c3535cf7076c7432cd4cf046e4bb3b96a9c9d/pyarrow-19.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:80b2ad2b193e7d19e81008a96e313fbd53157945c7be9ac65f44f8937a55427b", size = 30670749, upload-time = "2025-02-18T18:53:00.062Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3b/4692965e04bb1df55e2c314c4296f1eb12b4f3052d4cf43d29e076aedf66/pyarrow-19.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:ee8dec072569f43835932a3b10c55973593abc00936c202707a4ad06af7cb294", size = 32128007, upload-time = "2025-02-18T18:53:06.581Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f7/2239af706252c6582a5635c35caa17cb4d401cd74a87821ef702e3888957/pyarrow-19.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d5d1ec7ec5324b98887bdc006f4d2ce534e10e60f7ad995e7875ffa0ff9cb14", size = 41144566, upload-time = "2025-02-18T18:53:11.958Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e3/c9661b2b2849cfefddd9fd65b64e093594b231b472de08ff658f76c732b2/pyarrow-19.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3ad4c0eb4e2a9aeb990af6c09e6fa0b195c8c0e7b272ecc8d4d2b6574809d34", size = 42202991, upload-time = "2025-02-18T18:53:17.678Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/4f/a2c0ed309167ef436674782dfee4a124570ba64299c551e38d3fdaf0a17b/pyarrow-19.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d383591f3dcbe545f6cc62daaef9c7cdfe0dff0fb9e1c8121101cabe9098cfa6", size = 40507986, upload-time = "2025-02-18T18:53:26.263Z" },
+    { url = "https://files.pythonhosted.org/packages/27/2e/29bb28a7102a6f71026a9d70d1d61df926887e36ec797f2e6acfd2dd3867/pyarrow-19.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b4c4156a625f1e35d6c0b2132635a237708944eb41df5fbe7d50f20d20c17832", size = 42087026, upload-time = "2025-02-18T18:53:33.063Z" },
+    { url = "https://files.pythonhosted.org/packages/16/33/2a67c0f783251106aeeee516f4806161e7b481f7d744d0d643d2f30230a5/pyarrow-19.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:5bd1618ae5e5476b7654c7b55a6364ae87686d4724538c24185bbb2952679960", size = 25250108, upload-time = "2025-02-18T18:53:38.462Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/8d/275c58d4b00781bd36579501a259eacc5c6dfb369be4ddeb672ceb551d2d/pyarrow-19.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e45274b20e524ae5c39d7fc1ca2aa923aab494776d2d4b316b49ec7572ca324c", size = 30653552, upload-time = "2025-02-18T18:53:44.357Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/9e/e6aca5cc4ef0c7aec5f8db93feb0bde08dbad8c56b9014216205d271101b/pyarrow-19.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:d9dedeaf19097a143ed6da37f04f4051aba353c95ef507764d344229b2b740ae", size = 32103413, upload-time = "2025-02-18T18:53:52.971Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fa/a7033f66e5d4f1308c7eb0dfcd2ccd70f881724eb6fd1776657fdf65458f/pyarrow-19.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ebfb5171bb5f4a52319344ebbbecc731af3f021e49318c74f33d520d31ae0c4", size = 41134869, upload-time = "2025-02-18T18:53:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/92/34d2569be8e7abdc9d145c98dc410db0071ac579b92ebc30da35f500d630/pyarrow-19.0.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2a21d39fbdb948857f67eacb5bbaaf36802de044ec36fbef7a1c8f0dd3a4ab2", size = 42192626, upload-time = "2025-02-18T18:54:06.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1f/80c617b1084fc833804dc3309aa9d8daacd46f9ec8d736df733f15aebe2c/pyarrow-19.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:99bc1bec6d234359743b01e70d4310d0ab240c3d6b0da7e2a93663b0158616f6", size = 40496708, upload-time = "2025-02-18T18:54:12.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/90/83698fcecf939a611c8d9a78e38e7fed7792dcc4317e29e72cf8135526fb/pyarrow-19.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1b93ef2c93e77c442c979b0d596af45e4665d8b96da598db145b0fec014b9136", size = 42075728, upload-time = "2025-02-18T18:54:19.364Z" },
+    { url = "https://files.pythonhosted.org/packages/40/49/2325f5c9e7a1c125c01ba0c509d400b152c972a47958768e4e35e04d13d8/pyarrow-19.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:d9d46e06846a41ba906ab25302cf0fd522f81aa2a85a71021826f34639ad31ef", size = 25242568, upload-time = "2025-02-18T18:54:25.846Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/72/135088d995a759d4d916ec4824cb19e066585b4909ebad4ab196177aa825/pyarrow-19.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:c0fe3dbbf054a00d1f162fda94ce236a899ca01123a798c561ba307ca38af5f0", size = 30702371, upload-time = "2025-02-18T18:54:30.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/01/00beeebd33d6bac701f20816a29d2018eba463616bbc07397fdf99ac4ce3/pyarrow-19.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:96606c3ba57944d128e8a8399da4812f56c7f61de8c647e3470b417f795d0ef9", size = 32116046, upload-time = "2025-02-18T18:54:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/c9/23b1ea718dfe967cbd986d16cf2a31fe59d015874258baae16d7ea0ccabc/pyarrow-19.0.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f04d49a6b64cf24719c080b3c2029a3a5b16417fd5fd7c4041f94233af732f3", size = 41091183, upload-time = "2025-02-18T18:54:42.662Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/d4/b4a3aa781a2c715520aa8ab4fe2e7fa49d33a1d4e71c8fc6ab7b5de7a3f8/pyarrow-19.0.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a9137cf7e1640dce4c190551ee69d478f7121b5c6f323553b319cac936395f6", size = 42171896, upload-time = "2025-02-18T18:54:49.808Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1b/716d4cd5a3cbc387c6e6745d2704c4b46654ba2668260d25c402626c5ddb/pyarrow-19.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7c1bca1897c28013db5e4c83944a2ab53231f541b9e0c3f4791206d0c0de389a", size = 40464851, upload-time = "2025-02-18T18:54:57.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bd/54907846383dcc7ee28772d7e646f6c34276a17da740002a5cefe90f04f7/pyarrow-19.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:58d9397b2e273ef76264b45531e9d552d8ec8a6688b7390b5be44c02a37aade8", size = 42085744, upload-time = "2025-02-18T18:55:08.562Z" },
 ]
 
 [[package]]
@@ -1602,6 +2072,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/1e/4f0a3233767010308f2fd6bd0814597e3f63f1dc98304a9112b8759df4ff/pydantic-2.12.3.tar.gz", hash = "sha256:1da1c82b0fc140bb0103bc1441ffe062154c8d38491189751ee00fd8ca65ce74", size = 819383, upload-time = "2025-10-17T15:04:21.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/6b/83661fa77dcefa195ad5f8cd9af3d1a7450fd57cc883ad04d65446ac2029/pydantic-2.12.3-py3-none-any.whl", hash = "sha256:6986454a854bc3bc6e5443e1369e06a3a456af9d339eda45510f517d9ea5c6bf", size = 462431, upload-time = "2025-10-17T15:04:19.346Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -1672,12 +2147,40 @@ wheels = [
 ]
 
 [[package]]
-name = "pygments"
-version = "2.19.2"
+name = "pydantic-settings"
+version = "2.14.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1709,12 +2212,55 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/d3144a0bceede957f961e975f3752760fbe390d57fbe194baf709d8f1f7b/python_json_logger-3.3.0.tar.gz", hash = "sha256:12b7e74b17775e7d565129296105bbe3910842d9d0eb083fc83a6a617aa8df84", size = 16642, upload-time = "2025-03-07T07:08:27.301Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/20/0f2523b9e50a8052bc6a8b732dfc8568abbdc42010aef03a2d750bdab3b2/python_json_logger-3.3.0-py3-none-any.whl", hash = "sha256:dd980fae8cffb24c13caf6e158d3d61c0d6d22342f932cb6e9deedab3d35eec7", size = 15163, upload-time = "2025-03-07T07:08:25.627Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.28"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.1.post1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -1761,6 +2307,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
 ]
 
 [[package]]
@@ -1880,6 +2440,112 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1906,8 +2572,8 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2054,16 +2720,108 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlfluff"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "click" },
+    { name = "colorama" },
+    { name = "diff-cover" },
+    { name = "jinja2" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytest" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "tblib" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/a8/d3dc6c510cc3bba9abbf7a3052a96d5ce6771b71dda141846003fa37277a/sqlfluff-3.5.0.tar.gz", hash = "sha256:2d0a546078ffb021de7021b9a6c2a50e5eef590daa820d5f1b082d24a1d5e1d4", size = 921199, upload-time = "2025-10-18T19:33:07.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d5/83c3eacdd6c3249fb5f8a0b5612ab10b661862e0df869951f45fd837448d/sqlfluff-3.5.0-py3-none-any.whl", hash = "sha256:6e5fb7a0c491676ded68912245fc0627e88f8b0e6290bd4b54a65ce735f69716", size = 921597, upload-time = "2025-10-18T19:33:05.839Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/13/3cafb96bceb02949f265bbdf1cbcea2810271ae709e4aa35e980f90c07fd/sse_starlette-3.4.3.tar.gz", hash = "sha256:a7f6d87cf482cf38b911c31075811c7f8b4efbada8ac9d5199a8e239fed513c9", size = 35247, upload-time = "2026-05-11T17:23:41.987Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/a4/c888212b19dd432110d4a78dbc5e6c1bc7476e5fff2f2df2ea9f298b0003/sse_starlette-3.4.3-py3-none-any.whl", hash = "sha256:bf8a90d76192062f01b55095593606bfc7edd0e3ad481339a6e16e7890bc9367", size = 16514, upload-time = "2026-05-11T17:23:40.352Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
+name = "tblib"
+version = "3.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8a/14c15ae154895cc131174f858c707790d416c444fc69f93918adfd8c4c0b/tblib-3.2.2.tar.gz", hash = "sha256:e9a652692d91bf4f743d4a15bc174c0b76afc750fe8c7b6d195cc1c1d6d2ccec", size = 35046, upload-time = "2025-11-12T12:21:16.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl", hash = "sha256:26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76", size = 12893, upload-time = "2025-11-12T12:21:14.407Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/85/be65d39d6b647c79800fd9d29241d081d4eeb06271f383bb87200d74cf76/tiktoken-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b97f74aca0d78a1ff21b8cd9e9925714c15a9236d6ceacf5c7327c117e6e21e8", size = 1050728, upload-time = "2025-10-06T20:21:52.756Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/42/6573e9129bc55c9bf7300b3a35bef2c6b9117018acca0dc760ac2d93dffe/tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b", size = 994049, upload-time = "2025-10-06T20:21:53.782Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c5/ed88504d2f4a5fd6856990b230b56d85a777feab84e6129af0822f5d0f70/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65b26c7a780e2139e73acc193e5c63ac754021f160df919add909c1492c0fb37", size = 1129008, upload-time = "2025-10-06T20:21:54.832Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/90/3dae6cc5436137ebd38944d396b5849e167896fc2073da643a49f372dc4f/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:edde1ec917dfd21c1f2f8046b86348b0f54a2c0547f68149d8600859598769ad", size = 1152665, upload-time = "2025-10-06T20:21:56.129Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/fe/26df24ce53ffde419a42f5f53d755b995c9318908288c17ec3f3448313a3/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:35a2f8ddd3824608b3d650a000c1ef71f730d0c56486845705a8248da00f9fe5", size = 1194230, upload-time = "2025-10-06T20:21:57.546Z" },
+    { url = "https://files.pythonhosted.org/packages/20/cc/b064cae1a0e9fac84b0d2c46b89f4e57051a5f41324e385d10225a984c24/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3", size = 1254688, upload-time = "2025-10-06T20:21:58.619Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/b8523105c590c5b8349f2587e2fdfe51a69544bd5a76295fc20f2374f470/tiktoken-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc5288f34a8bc02e1ea7047b8d041104791d2ddbf42d1e5fa07822cbffe16bd", size = 878694, upload-time = "2025-10-06T20:21:59.876Z" },
+    { url = "https://files.pythonhosted.org/packages/00/61/441588ee21e6b5cdf59d6870f86beb9789e532ee9718c251b391b70c68d6/tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3", size = 1050802, upload-time = "2025-10-06T20:22:00.96Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/05/dcf94486d5c5c8d34496abe271ac76c5b785507c8eae71b3708f1ad9b45a/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160", size = 993995, upload-time = "2025-10-06T20:22:02.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/70/5163fe5359b943f8db9946b62f19be2305de8c3d78a16f629d4165e2f40e/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa", size = 1128948, upload-time = "2025-10-06T20:22:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/da/c028aa0babf77315e1cef357d4d768800c5f8a6de04d0eac0f377cb619fa/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be", size = 1151986, upload-time = "2025-10-06T20:22:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5a/886b108b766aa53e295f7216b509be95eb7d60b166049ce2c58416b25f2a/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a", size = 1194222, upload-time = "2025-10-06T20:22:06.265Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f8/4db272048397636ac7a078d22773dd2795b1becee7bc4922fe6207288d57/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3", size = 1255097, upload-time = "2025-10-06T20:22:07.403Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/32/45d02e2e0ea2be3a9ed22afc47d93741247e75018aac967b713b2941f8ea/tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697", size = 879117, upload-time = "2025-10-06T20:22:08.418Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/76/994fc868f88e016e6d05b0da5ac24582a14c47893f4474c3e9744283f1d5/tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16", size = 1050309, upload-time = "2025-10-06T20:22:10.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b8/57ef1456504c43a849821920d582a738a461b76a047f352f18c0b26c6516/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a", size = 993712, upload-time = "2025-10-06T20:22:12.115Z" },
+    { url = "https://files.pythonhosted.org/packages/72/90/13da56f664286ffbae9dbcfadcc625439142675845baa62715e49b87b68b/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27", size = 1128725, upload-time = "2025-10-06T20:22:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/05/df/4f80030d44682235bdaecd7346c90f67ae87ec8f3df4a3442cb53834f7e4/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb", size = 1151875, upload-time = "2025-10-06T20:22:14.559Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1f/ae535223a8c4ef4c0c1192e3f9b82da660be9eb66b9279e95c99288e9dab/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e", size = 1194451, upload-time = "2025-10-06T20:22:15.545Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a7/f8ead382fce0243cb625c4f266e66c27f65ae65ee9e77f59ea1653b6d730/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25", size = 1253794, upload-time = "2025-10-06T20:22:16.624Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e0/6cc82a562bc6365785a3ff0af27a2a092d57c47d7a81d9e2295d8c36f011/tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f", size = 878777, upload-time = "2025-10-06T20:22:18.036Z" },
+    { url = "https://files.pythonhosted.org/packages/72/05/3abc1db5d2c9aadc4d2c76fa5640134e475e58d9fbb82b5c535dc0de9b01/tiktoken-0.12.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a90388128df3b3abeb2bfd1895b0681412a8d7dc644142519e6f0a97c2111646", size = 1050188, upload-time = "2025-10-06T20:22:19.563Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7b/50c2f060412202d6c95f32b20755c7a6273543b125c0985d6fa9465105af/tiktoken-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:da900aa0ad52247d8794e307d6446bd3cdea8e192769b56276695d34d2c9aa88", size = 993978, upload-time = "2025-10-06T20:22:20.702Z" },
+    { url = "https://files.pythonhosted.org/packages/14/27/bf795595a2b897e271771cd31cb847d479073497344c637966bdf2853da1/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:285ba9d73ea0d6171e7f9407039a290ca77efcdb026be7769dccc01d2c8d7fff", size = 1129271, upload-time = "2025-10-06T20:22:22.06Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/9341a6d7a8f1b448573bbf3425fa57669ac58258a667eb48a25dfe916d70/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d186a5c60c6a0213f04a7a802264083dea1bbde92a2d4c7069e1a56630aef830", size = 1151216, upload-time = "2025-10-06T20:22:23.085Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0d/881866647b8d1be4d67cb24e50d0c26f9f807f994aa1510cb9ba2fe5f612/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:604831189bd05480f2b885ecd2d1986dc7686f609de48208ebbbddeea071fc0b", size = 1194860, upload-time = "2025-10-06T20:22:24.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1e/b651ec3059474dab649b8d5b69f5c65cd8fcd8918568c1935bd4136c9392/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8f317e8530bb3a222547b85a58583238c8f74fd7a7408305f9f63246d1a0958b", size = 1254567, upload-time = "2025-10-06T20:22:25.671Z" },
+    { url = "https://files.pythonhosted.org/packages/80/57/ce64fd16ac390fafde001268c364d559447ba09b509181b2808622420eec/tiktoken-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:399c3dd672a6406719d84442299a490420b458c44d3ae65516302a99675888f3", size = 921067, upload-time = "2025-10-06T20:22:26.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a4/72eed53e8976a099539cdd5eb36f241987212c29629d0a52c305173e0a68/tiktoken-0.12.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2c714c72bc00a38ca969dae79e8266ddec999c7ceccd603cc4f0d04ccd76365", size = 1050473, upload-time = "2025-10-06T20:22:27.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d7/0110b8f54c008466b19672c615f2168896b83706a6611ba6e47313dbc6e9/tiktoken-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cbb9a3ba275165a2cb0f9a83f5d7025afe6b9d0ab01a22b50f0e74fee2ad253e", size = 993855, upload-time = "2025-10-06T20:22:28.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/77/4f268c41a3957c418b084dd576ea2fad2e95da0d8e1ab705372892c2ca22/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:dfdfaa5ffff8993a3af94d1125870b1d27aed7cb97aa7eb8c1cefdbc87dbee63", size = 1129022, upload-time = "2025-10-06T20:22:29.981Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2b/fc46c90fe5028bd094cd6ee25a7db321cb91d45dc87531e2bdbb26b4867a/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:584c3ad3d0c74f5269906eb8a659c8bfc6144a52895d9261cdaf90a0ae5f4de0", size = 1150736, upload-time = "2025-10-06T20:22:30.996Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c0/3c7a39ff68022ddfd7d93f3337ad90389a342f761c4d71de99a3ccc57857/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a", size = 1194908, upload-time = "2025-10-06T20:22:32.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/0d/c1ad6f4016a3968c048545f5d9b8ffebf577774b2ede3e2e352553b685fe/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0", size = 1253706, upload-time = "2025-10-06T20:22:33.385Z" },
+    { url = "https://files.pythonhosted.org/packages/af/df/c7891ef9d2712ad774777271d39fdef63941ffba0a9d59b7ad1fd2765e57/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71", size = 920667, upload-time = "2025-10-06T20:22:34.444Z" },
 ]
 
 [[package]]
@@ -2097,7 +2855,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
@@ -2106,50 +2864,19 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.3.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version < '3.13'",
-]
-dependencies = [
-    { name = "huggingface-hub", marker = "extra == 'extra-16-melix-mlx-worker-mlx'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
-    { name = "packaging", marker = "extra == 'extra-16-melix-mlx-worker-mlx'" },
-    { name = "pyyaml", marker = "extra == 'extra-16-melix-mlx-worker-mlx'" },
-    { name = "regex", marker = "extra == 'extra-16-melix-mlx-worker-mlx'" },
-    { name = "safetensors", marker = "extra == 'extra-16-melix-mlx-worker-mlx'" },
-    { name = "tokenizers", marker = "extra == 'extra-16-melix-mlx-worker-mlx'" },
-    { name = "tqdm", marker = "extra == 'extra-16-melix-mlx-worker-mlx'" },
-    { name = "typer", marker = "extra == 'extra-16-melix-mlx-worker-mlx'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/1a/70e830d53ecc96ce69cfa8de38f163712d2b43ac52fbd743f39f56025c31/transformers-5.3.0.tar.gz", hash = "sha256:009555b364029da9e2946d41f1c5de9f15e6b1df46b189b7293f33a161b9c557", size = 8830831, upload-time = "2026-03-04T17:41:46.119Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/88/ae8320064e32679a5429a2c9ebbc05c2bf32cefb6e076f9b07f6d685a9b4/transformers-5.3.0-py3-none-any.whl", hash = "sha256:50ac8c89c3c7033444fb3f9f53138096b997ebb70d4b5e50a2e810bf12d3d29a", size = 10661827, upload-time = "2026-03-04T17:41:42.722Z" },
-]
-
-[[package]]
-name = "transformers"
 version = "5.8.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version < '3.13'",
-]
 dependencies = [
-    { name = "huggingface-hub", marker = "extra == 'extra-16-melix-mlx-worker-audio' or extra == 'extra-16-melix-mlx-worker-audio-stt' or extra == 'extra-16-melix-mlx-worker-audio-tts'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version < '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-stt') or (python_full_version >= '3.13' and extra == 'extra-16-melix-mlx-worker-audio-tts') or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
-    { name = "packaging", marker = "extra == 'extra-16-melix-mlx-worker-audio' or extra == 'extra-16-melix-mlx-worker-audio-stt' or extra == 'extra-16-melix-mlx-worker-audio-tts'" },
-    { name = "pyyaml", marker = "extra == 'extra-16-melix-mlx-worker-audio' or extra == 'extra-16-melix-mlx-worker-audio-stt' or extra == 'extra-16-melix-mlx-worker-audio-tts'" },
-    { name = "regex", marker = "extra == 'extra-16-melix-mlx-worker-audio' or extra == 'extra-16-melix-mlx-worker-audio-stt' or extra == 'extra-16-melix-mlx-worker-audio-tts'" },
-    { name = "safetensors", marker = "extra == 'extra-16-melix-mlx-worker-audio' or extra == 'extra-16-melix-mlx-worker-audio-stt' or extra == 'extra-16-melix-mlx-worker-audio-tts'" },
-    { name = "tokenizers", marker = "extra == 'extra-16-melix-mlx-worker-audio' or extra == 'extra-16-melix-mlx-worker-audio-stt' or extra == 'extra-16-melix-mlx-worker-audio-tts'" },
-    { name = "tqdm", marker = "extra == 'extra-16-melix-mlx-worker-audio' or extra == 'extra-16-melix-mlx-worker-audio-stt' or extra == 'extra-16-melix-mlx-worker-audio-tts'" },
-    { name = "typer", marker = "extra == 'extra-16-melix-mlx-worker-audio' or extra == 'extra-16-melix-mlx-worker-audio-stt' or extra == 'extra-16-melix-mlx-worker-audio-tts'" },
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or (extra == 'extra-16-melix-mlx-worker-audio' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-stt' and extra == 'extra-16-melix-mlx-worker-mlx') or (extra == 'extra-16-melix-mlx-worker-audio-tts' and extra == 'extra-16-melix-mlx-worker-mlx')" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/36/390075693b76d4fb4a2bea360fb6080347763bd1f1147c49ed0ed938778c/transformers-5.8.0.tar.gz", hash = "sha256:6cc9a1f0291d16b1c1b735bad775e78ebefff7722701d4e28f98aaaa2bd6fb91", size = 8528141, upload-time = "2026-05-05T16:50:04.778Z" }
 wheels = [
@@ -2221,6 +2948,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add a worker/productization adapter that converts DataDesigner synthetic rows into Melix training, final-result evaluation, or raw JSONL inspection artifacts.
- Keep DataDesigner behind a `synthetic-data` optional extra with lazy import, telemetry opt-out, seed staging, and secret redaction.
- Address review feedback with duplicate column validation, deterministic hash validation splits, safer seed staging, cleaner preview timing, and more explicit preview/evaluation handling.

## Plan or Spec
- `docs/plans/2026-05-12-datadesigner-synthetic-dataset-function.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
Result: 47 passed in 0.10s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 -m compileall -q services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
Result: passed

git diff --check
Result: passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --data-file /tmp/synthetic_dataset_generation_pr_review.coverage --source=worker.productization.synthetic_dataset_generation -m pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report --data-file /tmp/synthetic_dataset_generation_pr_review.coverage --include='*/worker/productization/synthetic_dataset_generation.py'
Result: 47 passed; synthetic_dataset_generation.py coverage 98%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/validate_pr_evidence.py --body-file .runtime/pr-bodies/datadesigner-synthetic-worker.md
Result: PR evidence looks valid.

uv lock --project services/mlx-worker-python
Result: resolved 120 packages
```

## Coverage and Metrics
- Changed-scope coverage for `services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py`: 98% line coverage, 474 statements, 10 missing.
- Metrics captured in generated manifests where the step applies: `datadesigner_config_build_ms`, `datadesigner_generate_ms`, `datadesigner_export_ms` for create/export mode, `melix_normalize_ms`, `melix_package_write_ms`, and `total_elapsed_ms`.
- Live DataDesigner smoke not run because this PR adds the isolated worker adapter and optional dependency contract; public CLI/runtime smoke remains a follow-up after the user-facing command surface lands.

## Known Gaps
- No public `melix synthetic preview/create` CLI, protobuf RPC, or native UI surface in this PR.
- DataDesigner validation/custom/image/embedding/MCP columns remain blocked pending explicit sandbox and asset contracts.
- Live gateway compatibility smoke against `/v1/chat/completions` is deferred to the CLI/operation integration slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
