### PR TITLE
Normalize OpenAI tool-call names

### DIFF
--- a/docs/plans/2026-03-30-m3-7-xml-and-namespaced-tool-parsing.md
+++ b/docs/plans/2026-03-30-m3-7-xml-and-namespaced-tool-parsing.md
@@ -49,6 +49,11 @@ The worker parser should also treat the `<|tool_call>...<tool_call|>` marker as
 a recoverable XML-family fallback when tool parsing is enabled, so raw tool
 markup is not exposed as assistant text.
 
+The pipe-call fallback accepts action-qualified names that extend a declared
+tool name with `.`, `:`, or `/`, normalizing those calls back to the declared
+OpenAI tool name before streaming deltas. Empty argument parentheses may contain
+whitespace and are canonicalized to `{}` for downstream JSON consumers.
+
 ### Probes And Metrics
 
 - `http.openai_chat_tools_request_count`

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -1981,6 +1981,11 @@ public struct OpenAIHandler: Sendable {
            stripCount > 0 {
             await metricsStore.increment("http.reasoning_history_strip_count", by: stripCount)
         }
+        if let rawToolCallStripCount = translated.workerRequest.execution.ext["melix.tool_call_history_strip_count"],
+           let toolCallStripCount = Double(rawToolCallStripCount),
+           toolCallStripCount > 0 {
+            await metricsStore.increment("http.tool_call_history_strip_count", by: toolCallStripCount)
+        }
     }
 
     private func streamResponse(

--- a/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
+++ b/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
@@ -244,6 +244,7 @@ public struct ShapedTextRequest: Sendable, Equatable {
     public let reasoningAutoDetectModelFamily: String?
     public let reasoningContinuityRehydrated: Bool
     public let reasoningHistoryStripCount: Int
+    public let rawToolCallHistoryStripCount: Int
     public let structuredOutput: StructuredOutputConfiguration?
     public let toolParser: ToolParserSelection?
     public let tools: [NormalizedToolDefinition]
@@ -1777,6 +1778,8 @@ public struct ChatRequestTranslator: Sendable {
             shapedRequest.reasoningContinuityRehydrated ? "true" : "false"
         generateRequest.execution.ext["melix.reasoning.history_strip_count"] =
             String(shapedRequest.reasoningHistoryStripCount)
+        generateRequest.execution.ext["melix.tool_call_history_strip_count"] =
+            String(shapedRequest.rawToolCallHistoryStripCount)
         generateRequest.execution.reasoning = Melix_Worker_V1_ReasoningConfig()
         generateRequest.execution.reasoning.mode = shapedRequest.reasoningMode
         generateRequest.execution.reasoning.modeSource = shapedRequest.reasoningSource

--- a/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
+++ b/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
@@ -543,8 +543,7 @@ public struct TextRequestShaper: Sendable {
                 return count == 0 ? (text, 0) : ("", count)
             }
             guard remaining[markerStart...].hasPrefix(openMarker) else {
-                let visibleText = remaining.drop(while: { $0.isWhitespace })
-                return count == 0 ? (text, 0) : (String(visibleText), count)
+                return count == 0 ? (text, 0) : (String(remaining), count)
             }
 
             let bodyStart = remaining.index(markerStart, offsetBy: openMarker.count)

--- a/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
+++ b/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
@@ -123,6 +123,7 @@ public struct TextRequestShaper: Sendable {
     private struct HistorySanitizationResult: Sendable {
         let messages: [NormalizedTextMessage]
         let stripCount: Int
+        let toolCallStripCount: Int
     }
 
     private struct PresetDefaults: Sendable {
@@ -358,6 +359,7 @@ public struct TextRequestShaper: Sendable {
             reasoningAutoDetectModelFamily: resolvedThinking.autoDetectModelFamily,
             reasoningContinuityRehydrated: resolvedThinking.continuityRehydrated,
             reasoningHistoryStripCount: sanitizedHistory.stripCount,
+            rawToolCallHistoryStripCount: sanitizedHistory.toolCallStripCount,
             structuredOutput: request.structuredOutput,
             toolParser: resolvedToolParser,
             tools: request.tools,
@@ -447,6 +449,7 @@ public struct TextRequestShaper: Sendable {
 
     private func sanitizeReasoningHistory(messages: [NormalizedTextMessage]) -> HistorySanitizationResult {
         var stripCount = 0
+        var toolCallStripCount = 0
         let sanitizedMessages = messages.map { message in
             guard message.role == "assistant" else {
                 return message
@@ -459,10 +462,11 @@ public struct TextRequestShaper: Sendable {
                     continue
                 }
 
-                let stripped = Self.stripLeadingHiddenThoughtBlocks(from: originalText)
-                if stripped.count > 0 {
+                let stripped = Self.stripLeadingHistoryArtifacts(from: originalText)
+                if stripped.reasoningCount > 0 || stripped.toolCallCount > 0 {
                     parts[index].text = stripped.text
-                    stripCount += stripped.count
+                    stripCount += stripped.reasoningCount
+                    toolCallStripCount += stripped.toolCallCount
                 }
             }
 
@@ -474,7 +478,37 @@ public struct TextRequestShaper: Sendable {
             )
         }
 
-        return HistorySanitizationResult(messages: sanitizedMessages, stripCount: stripCount)
+        return HistorySanitizationResult(
+            messages: sanitizedMessages,
+            stripCount: stripCount,
+            toolCallStripCount: toolCallStripCount
+        )
+    }
+
+    private static func stripLeadingHistoryArtifacts(
+        from text: String
+    ) -> (text: String, reasoningCount: Int, toolCallCount: Int) {
+        var current = text
+        var reasoningCount = 0
+        var toolCallCount = 0
+
+        while true {
+            let strippedThoughts = stripLeadingHiddenThoughtBlocks(from: current)
+            if strippedThoughts.count > 0 {
+                current = strippedThoughts.text
+                reasoningCount += strippedThoughts.count
+                continue
+            }
+
+            let strippedToolCalls = stripLeadingRawToolCallBlocks(from: current)
+            if strippedToolCalls.count > 0 {
+                current = strippedToolCalls.text
+                toolCallCount += strippedToolCalls.count
+                continue
+            }
+
+            return (current, reasoningCount, toolCallCount)
+        }
     }
 
     private static func stripLeadingHiddenThoughtBlocks(from text: String) -> (text: String, count: Int) {
@@ -489,6 +523,32 @@ public struct TextRequestShaper: Sendable {
 
             let bodyStart = remaining.index(tagStart, offsetBy: "<think>".count)
             guard let closeRange = remaining[bodyStart...].range(of: "</think>") else {
+                return count == 0 ? (text, 0) : (String(remaining), count)
+            }
+
+            count += 1
+            remaining = remaining[closeRange.upperBound...]
+        }
+    }
+
+    private static func stripLeadingRawToolCallBlocks(from text: String) -> (text: String, count: Int) {
+        let openMarker = "<|tool_call>"
+        let closeMarker = "<tool_call|>"
+        var remaining = text[...]
+        var count = 0
+
+        while true {
+            let markerStart = remaining.drop(while: { $0.isWhitespace }).startIndex
+            guard markerStart < remaining.endIndex else {
+                return count == 0 ? (text, 0) : ("", count)
+            }
+            guard remaining[markerStart...].hasPrefix(openMarker) else {
+                let visibleText = remaining.drop(while: { $0.isWhitespace })
+                return count == 0 ? (text, 0) : (String(visibleText), count)
+            }
+
+            let bodyStart = remaining.index(markerStart, offsetBy: openMarker.count)
+            guard let closeRange = remaining[bodyStart...].range(of: closeMarker) else {
                 return count == 0 ? (text, 0) : (String(remaining), count)
             }
 

--- a/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
@@ -377,6 +377,80 @@ struct TextEndpointContractTests {
         #expect(translated.workerRequest.execution.ext["melix.reasoning.history_strip_count"] == "0")
     }
 
+    @Test("prior assistant raw tool-call prefixes are stripped before prompt rebuild")
+    func priorAssistantRawToolCallPrefixesAreStrippedBeforePromptRebuild() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "tool-call-history-strip" })
+        let translated = try translator.translate(
+            OpenAIChatCompletionsRequest(
+                model: "melix-dev-text",
+                messages: [
+                    .init(
+                        role: "assistant",
+                        content: """
+                        <|tool_call>call:github_auth:github_auth_check()<tool_call|>
+                        <think>hidden after tool</think>
+                        <|tool_call>call:terminal:run_command{"command":"gh auth status"}<tool_call|>
+                        Visible follow-up.
+                        """
+                    ),
+                    .init(role: "user", content: "Continue.")
+                ]
+            ),
+            modelHandle: "worker-text"
+        )
+
+        let assistant = try #require(translated.workerRequest.messages.first)
+
+        #expect(assistant.role == "assistant")
+        #expect(assistant.parts.first?.text == "Visible follow-up.")
+        #expect(translated.workerRequest.execution.ext["melix.tool_call_history_strip_count"] == "2")
+        #expect(translated.workerRequest.execution.ext["melix.reasoning.history_strip_count"] == "1")
+        #expect(
+            !translated.workerRequest.messages
+                .map(\.parts)
+                .flatMap { $0 }
+                .map(\.text)
+                .joined(separator: "\n")
+                .contains("github_auth:github_auth_check")
+        )
+        #expect(
+            !translated.workerRequest.messages
+                .map(\.parts)
+                .flatMap { $0 }
+                .map(\.text)
+                .joined(separator: "\n")
+                .contains("hidden after tool")
+        )
+        #expect(
+            !translated.workerRequest.messages
+                .map(\.parts)
+                .flatMap { $0 }
+                .map(\.text)
+                .joined(separator: "\n")
+                .contains("terminal:run_command")
+        )
+    }
+
+    @Test("inline raw tool-call literals in assistant history are preserved")
+    func inlineRawToolCallLiteralsInAssistantHistoryArePreserved() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "tool-call-history-literal" })
+        let translated = try translator.translate(
+            OpenAIChatCompletionsRequest(
+                model: "melix-dev-text",
+                messages: [
+                    .init(role: "assistant", content: "Visible <|tool_call> literal marker"),
+                    .init(role: "user", content: "Continue.")
+                ]
+            ),
+            modelHandle: "worker-text"
+        )
+
+        let assistant = try #require(translated.workerRequest.messages.first)
+
+        #expect(assistant.parts.first?.text == "Visible <|tool_call> literal marker")
+        #expect(translated.workerRequest.execution.ext["melix.tool_call_history_strip_count"] == "0")
+    }
+
     @Test("reasoning policy resolver covers template explicit-disable and family auto-detect precedence")
     func reasoningPolicyResolverCoversTemplateExplicitDisableAndFamilyAutoDetectPrecedence() {
         let resolver = ReasoningPolicyResolver()

--- a/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
@@ -402,7 +402,7 @@ struct TextEndpointContractTests {
         let assistant = try #require(translated.workerRequest.messages.first)
 
         #expect(assistant.role == "assistant")
-        #expect(assistant.parts.first?.text == "Visible follow-up.")
+        #expect(assistant.parts.first?.text == "\nVisible follow-up.")
         #expect(translated.workerRequest.execution.ext["melix.tool_call_history_strip_count"] == "2")
         #expect(translated.workerRequest.execution.ext["melix.reasoning.history_strip_count"] == "1")
         #expect(

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -7579,7 +7579,7 @@ struct OpenAIHandlerTests {
               "workflow_node_id": "node-handler",
               "session_id": "session-handler",
               "messages": [
-                { "role": "assistant", "content": "<think>hidden prior turn</think>Visible prior answer." },
+                { "role": "assistant", "content": "<think>hidden prior turn</think><|tool_call>call:github_auth:github_auth_check()<tool_call|>Visible prior answer." },
                 { "role": "user", "content": "Continue the tool result." }
               ]
             }
@@ -7604,9 +7604,11 @@ struct OpenAIHandlerTests {
         #expect(generated?.execution.ext["melix.preset_id"] == "deep_reasoning")
         #expect(generated?.execution.ext["melix.workflow"] == "tool_followup")
         #expect(generated?.execution.ext["melix.reasoning.history_strip_count"] == "1")
+        #expect(generated?.execution.ext["melix.tool_call_history_strip_count"] == "1")
         #expect(metrics.values["http.preset_shaped_count", default: 0] == 1)
         #expect(metrics.values["http.workflow_shaped_count", default: 0] == 1)
         #expect(metrics.values["http.reasoning_history_strip_count", default: 0] == 1)
+        #expect(metrics.values["http.tool_call_history_strip_count", default: 0] == 1)
         #expect(metrics.values["http.shaping_ms", default: -1] >= 0)
     }
 

--- a/services/mlx-worker-python/tests/test_generate_stream.py
+++ b/services/mlx-worker-python/tests/test_generate_stream.py
@@ -76,6 +76,25 @@ class StructuredStreamingBackend:
         )
 
 
+class ActionQualifiedToolStreamingBackend:
+    runtime_name = "fake-mlx"
+
+    def load_model(self, model_spec):
+        return {"model_id": model_spec.model_id}
+
+    def estimate_resident_bytes(self, model_spec):
+        return 2048
+
+    def generate_tokens(self, loaded_model, prompt, sampling, cancel_event):
+        yield RuntimeTokenEvent(
+            text="",
+            raw_text='<|tool_call>call:terminal:run_command{"command":"gh auth status"}<tool_call|>',
+            prompt_tokens=3,
+            completion_tokens=1,
+            finish_reason="stop",
+        )
+
+
 class ShortPrefixStreamingBackend:
     runtime_name = "fake-mlx"
 
@@ -623,6 +642,54 @@ def test_generate_stream_preserves_explicit_tool_parser_with_structured_json_mod
     assert completed.parser_metrics["stream_parser_request_context_mode"] == "tool_parser"
     assert completed.parser_metrics["tool_call_markup_leak_count"] == "0"
     assert completed.parser_metrics["reasoning_leak_count"] == "0"
+
+
+def test_generate_stream_normalizes_tool_calls_to_declared_openai_tool_names() -> None:
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=ActionQualifiedToolStreamingBackend()),
+        model_catalog=WorkerModelCatalog(),
+    )
+    runtime_service = WorkerRuntimeService(registry)
+    inference_service = WorkerInferenceService(registry)
+    load_response = runtime_service.LoadModel(
+        runtime_pb2.LoadModelRequest(model=WorkerModelCatalog.dev_text_model()),
+        context=None,
+    )
+    request = inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(request_id="req-normalize-openai-tool-name"),
+            model_handle=load_response.model_handle,
+            ext={"melix.tool_parser.mode": "xml"},
+            tool_config=common_pb2.ToolConfig(
+                tools=[
+                    common_pb2.ToolDefinition(
+                        name="terminal",
+                        description="Run commands.",
+                        json_schema='{"type":"object"}',
+                    )
+                ],
+                parser="xml",
+            ),
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(text="Use the terminal.")],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=16),
+        stream=True,
+    )
+
+    events = list(inference_service.Generate(request, context=None))
+    tool_call = next(event.tool_call_delta for event in events if event.HasField("tool_call_delta"))
+    completed = next(event.completed for event in events if event.HasField("completed"))
+
+    assert tool_call.tool_name == "terminal"
+    assert tool_call.arguments_json_fragment == '{"command":"gh auth status"}'
+    assert completed.assistant_text == ""
+    assert completed.parser_metrics["tool_call_name_normalized_count"] == "1"
+    assert completed.parser_metrics["unknown_tool_delta_count"] == "0"
 
 
 def test_generate_stream_flushes_short_visible_prefix_before_marker_hold() -> None:

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -230,6 +230,90 @@ def test_pipe_tool_call_relaxed_object_arguments_are_parsed() -> None:
     assert calls[0].arguments_json_fragment == '{"command":"gh auth status"}'
 
 
+def test_pipe_tool_call_empty_parentheses_arguments_are_parsed() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-pipe-tool-call-empty-parens",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="xml",
+    )
+
+    deltas = assembler.accept(
+        StreamFragment(
+            raw_text="<|tool_call>call:github_auth:github_auth_check()<tool_call|>"
+        )
+    )
+    completed = assembler.completed()
+    calls = [delta.tool_call for delta in deltas if delta.tool_call]
+
+    assert len(calls) == 1
+    assert calls[0].tool_name == "github_auth:github_auth_check"
+    assert calls[0].arguments_json_fragment == "{}"
+    assert completed.assistant_text == ""
+    assert completed.metrics["tool_call_markup_leak_count"] == 0
+
+
+def test_action_qualified_tool_name_is_normalized_to_declared_openai_tool() -> None:
+    cases = (
+        (
+            "terminal.execute",
+            '<|tool_call>call:terminal.execute{"command":"pwd"}<tool_call|>',
+            "terminal",
+            '{"command":"pwd"}',
+        ),
+        (
+            "terminal:run_command",
+            '<|tool_call>call:terminal:run_command{"command":"gh auth status"}<tool_call|>',
+            "terminal",
+            '{"command":"gh auth status"}',
+        ),
+        (
+            "process/start",
+            '<|tool_call>call:process/start{"command":"npm test"}<tool_call|>',
+            "process",
+            '{"command":"npm test"}',
+        ),
+    )
+
+    for request_id, raw_text, expected_name, expected_arguments in cases:
+        assembler = RequestStreamAssembler(
+            request_id=request_id,
+            reasoning_enabled=False,
+            structured_output_mode="",
+            tool_parser_mode="xml",
+            allowed_tool_names=("terminal", "process"),
+        )
+        deltas = assembler.accept(StreamFragment(raw_text=raw_text))
+        completed = assembler.completed()
+        calls = [delta.tool_call for delta in deltas if delta.tool_call]
+
+        assert len(calls) == 1
+        assert calls[0].tool_name == expected_name
+        assert calls[0].arguments_json_fragment == expected_arguments
+        assert completed.metrics["tool_call_name_normalized_count"] == 1
+        assert completed.metrics["unknown_tool_delta_count"] == 0
+
+
+def test_unknown_tool_name_is_suppressed_when_openai_tools_are_declared() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-unknown-tool",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="xml",
+        allowed_tool_names=("terminal",),
+    )
+
+    deltas = assembler.accept(
+        StreamFragment(raw_text="<|tool_call>call:github_auth:github_auth_check()<tool_call|>")
+    )
+    completed = assembler.completed()
+
+    assert [delta.tool_call for delta in deltas if delta.tool_call] == []
+    assert completed.assistant_text == ""
+    assert completed.metrics["unknown_tool_delta_count"] == 1
+    assert completed.metrics["tool_call_markup_leak_count"] == 0
+
+
 def test_pipe_tool_call_relaxed_object_arguments_preserve_quoted_commas() -> None:
     assembler = RequestStreamAssembler(
         request_id="req-pipe-tool-call-commas",

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -253,6 +253,28 @@ def test_pipe_tool_call_empty_parentheses_arguments_are_parsed() -> None:
     assert completed.metrics["tool_call_markup_leak_count"] == 0
 
 
+def test_pipe_tool_call_whitespace_parentheses_arguments_are_parsed() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-pipe-tool-call-whitespace-parens",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="xml",
+    )
+
+    deltas = assembler.accept(
+        StreamFragment(
+            raw_text="<|tool_call>call:github_auth:github_auth_check( \n )<tool_call|>"
+        )
+    )
+    completed = assembler.completed()
+    calls = [delta.tool_call for delta in deltas if delta.tool_call]
+
+    assert len(calls) == 1
+    assert calls[0].tool_name == "github_auth:github_auth_check"
+    assert calls[0].arguments_json_fragment == "{}"
+    assert completed.metrics["malformed_tool_fragment_count"] == 0
+
+
 def test_action_qualified_tool_name_is_normalized_to_declared_openai_tool() -> None:
     cases = (
         (

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -488,7 +488,10 @@ class EngineCore:
             reasoning_enabled=reasoning_enabled,
             structured_output_mode=ext.get("melix.structured_output.mode", ""),
             tool_parser_mode=ext.get("melix.tool_parser.mode", ""),
-            allowed_tool_names=tuple(tool.name for tool in request.execution.tool_config.tools),
+            allowed_tool_names=(
+                tuple(tool.name for tool in request.execution.tool_config.tools)
+                if request.execution.tool_config.tools else None
+            ),
         )
 
     @staticmethod

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -488,6 +488,7 @@ class EngineCore:
             reasoning_enabled=reasoning_enabled,
             structured_output_mode=ext.get("melix.structured_output.mode", ""),
             tool_parser_mode=ext.get("melix.tool_parser.mode", ""),
+            allowed_tool_names=tuple(tool.name for tool in request.execution.tool_config.tools),
         )
 
     @staticmethod

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -100,7 +100,7 @@ class RequestStreamAssembler:
     _PIPE_TOOL_PREFIXES_REVERSED = tuple(reversed(_PIPE_TOOL_PREFIXES))
     _VISIBLE_TAIL_MARKERS = ("\nFinal answer", "\nFinal:", "\nAnswer:", "\nAssistant:", "\nResult:")
     _PIPE_CALL_RE = re.compile(
-        r"^\s*call:(?P<name>[A-Za-z0-9_.:/-]+)\s*(?P<args>\{.*\}|\(\))\s*$",
+        r"^\s*call:(?P<name>[A-Za-z0-9_.:/-]+)\s*(?P<args>\{.*\}|\(\s*\))\s*$",
         re.DOTALL,
     )
 
@@ -124,6 +124,8 @@ class RequestStreamAssembler:
             self._allowed_tool_names_by_casefold = {
                 name.casefold(): name for name in self._allowed_tool_names
             }
+            # Longest-first matching keeps a declared tool such as
+            # "terminal.execute" from being normalized to "terminal".
             self._allowed_tool_names_by_prefix = tuple(
                 sorted(self._allowed_tool_names, key=len, reverse=True)
             )
@@ -610,7 +612,7 @@ class RequestStreamAssembler:
         if match is None:
             self._metrics["malformed_tool_fragment_count"] += 1
             return None
-        if match.group("args") == "()":
+        if match.group("args").startswith("("):
             return {
                 "name": match.group("name"),
                 "arguments": {},
@@ -645,11 +647,13 @@ class RequestStreamAssembler:
 
     @staticmethod
     def _is_action_qualified_tool_name(name: str, declared: str) -> bool:
-        if len(name) <= len(declared):
+        folded_name = name.casefold()
+        folded_declared = declared.casefold()
+        if len(folded_name) <= len(folded_declared):
             return False
-        if not name.casefold().startswith(declared.casefold()):
+        if not folded_name.startswith(folded_declared):
             return False
-        return name[len(declared)] in {".", ":", "/"}
+        return folded_name[len(folded_declared)] in {".", ":", "/"}
 
     def _parse_relaxed_object_arguments(self, text: str) -> dict[str, object] | None:
         stripped = text.strip()

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -110,22 +110,28 @@ class RequestStreamAssembler:
         reasoning_enabled: bool,
         structured_output_mode: str = "",
         tool_parser_mode: str = "",
-        allowed_tool_names: tuple[str, ...] = (),
+        allowed_tool_names: tuple[str, ...] | None = None,
     ) -> None:
         self._request_id = request_id
         self._reasoning_enabled = reasoning_enabled
         self._structured_output_mode = structured_output_mode.strip().lower()
         self._tool_parser_mode = tool_parser_mode.strip().lower()
-        self._allowed_tool_names = tuple(
-            dict.fromkeys(name.strip() for name in allowed_tool_names if name.strip())
-        )
-        self._allowed_tool_name_set = set(self._allowed_tool_names)
-        self._allowed_tool_names_by_casefold = {
-            name.casefold(): name for name in self._allowed_tool_names
-        }
-        self._allowed_tool_names_by_prefix = tuple(
-            sorted(self._allowed_tool_names, key=len, reverse=True)
-        )
+        if allowed_tool_names:
+            self._allowed_tool_names = tuple(
+                dict.fromkeys(name.strip() for name in allowed_tool_names if name.strip())
+            )
+            self._allowed_tool_name_set = set(self._allowed_tool_names)
+            self._allowed_tool_names_by_casefold = {
+                name.casefold(): name for name in self._allowed_tool_names
+            }
+            self._allowed_tool_names_by_prefix = tuple(
+                sorted(self._allowed_tool_names, key=len, reverse=True)
+            )
+        else:
+            self._allowed_tool_names = ()
+            self._allowed_tool_name_set = frozenset()
+            self._allowed_tool_names_by_casefold = {}
+            self._allowed_tool_names_by_prefix = ()
         self._tool_parsing_enabled_value = bool(self._tool_parser_mode)
         self._is_json_structured_output_value = self._structured_output_mode in {
             "json_object",

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -100,7 +100,7 @@ class RequestStreamAssembler:
     _PIPE_TOOL_PREFIXES_REVERSED = tuple(reversed(_PIPE_TOOL_PREFIXES))
     _VISIBLE_TAIL_MARKERS = ("\nFinal answer", "\nFinal:", "\nAnswer:", "\nAssistant:", "\nResult:")
     _PIPE_CALL_RE = re.compile(
-        r"^\s*call:(?P<name>[A-Za-z0-9_.:-]+)\s*(?P<args>\{.*\})\s*$",
+        r"^\s*call:(?P<name>[A-Za-z0-9_.:/-]+)\s*(?P<args>\{.*\}|\(\))\s*$",
         re.DOTALL,
     )
 
@@ -110,11 +110,22 @@ class RequestStreamAssembler:
         reasoning_enabled: bool,
         structured_output_mode: str = "",
         tool_parser_mode: str = "",
+        allowed_tool_names: tuple[str, ...] = (),
     ) -> None:
         self._request_id = request_id
         self._reasoning_enabled = reasoning_enabled
         self._structured_output_mode = structured_output_mode.strip().lower()
         self._tool_parser_mode = tool_parser_mode.strip().lower()
+        self._allowed_tool_names = tuple(
+            dict.fromkeys(name.strip() for name in allowed_tool_names if name.strip())
+        )
+        self._allowed_tool_name_set = set(self._allowed_tool_names)
+        self._allowed_tool_names_by_casefold = {
+            name.casefold(): name for name in self._allowed_tool_names
+        }
+        self._allowed_tool_names_by_prefix = tuple(
+            sorted(self._allowed_tool_names, key=len, reverse=True)
+        )
         self._tool_parsing_enabled_value = bool(self._tool_parser_mode)
         self._is_json_structured_output_value = self._structured_output_mode in {
             "json_object",
@@ -170,6 +181,8 @@ class RequestStreamAssembler:
             "byte_fallback_decode_error_count": 0,
             "empty_thinking_sentinel_count": 0,
             "reasoning_parser_bypassed_count": 0,
+            "tool_call_name_normalized_count": 0,
+            "unknown_tool_delta_count": 0,
         }
 
     def accept(self, fragment: StreamFragment) -> list[AssemblyDelta]:
@@ -542,6 +555,13 @@ class RequestStreamAssembler:
         if not name:
             self._metrics["malformed_tool_fragment_count"] += 1
             return None
+        resolved_name = self._resolve_tool_name(name)
+        if resolved_name is None:
+            self._metrics["unknown_tool_delta_count"] += 1
+            return None
+        if resolved_name != name:
+            self._metrics["tool_call_name_normalized_count"] += 1
+            name = resolved_name
 
         arguments = payload.get("arguments", {})
         call_id = str(payload.get("id") or payload.get("call_id") or "").strip()
@@ -584,6 +604,11 @@ class RequestStreamAssembler:
         if match is None:
             self._metrics["malformed_tool_fragment_count"] += 1
             return None
+        if match.group("args") == "()":
+            return {
+                "name": match.group("name"),
+                "arguments": {},
+            }
         try:
             arguments = json.loads(match.group("args"))
         except json.JSONDecodeError:
@@ -598,6 +623,27 @@ class RequestStreamAssembler:
             "name": match.group("name"),
             "arguments": arguments,
         }
+
+    def _resolve_tool_name(self, name: str) -> str | None:
+        if not self._allowed_tool_names:
+            return name
+        if name in self._allowed_tool_name_set:
+            return name
+        declared = self._allowed_tool_names_by_casefold.get(name.casefold())
+        if declared is not None:
+            return declared
+        for declared in self._allowed_tool_names_by_prefix:
+            if self._is_action_qualified_tool_name(name, declared):
+                return declared
+        return None
+
+    @staticmethod
+    def _is_action_qualified_tool_name(name: str, declared: str) -> bool:
+        if len(name) <= len(declared):
+            return False
+        if not name.casefold().startswith(declared.casefold()):
+            return False
+        return name[len(declared)] in {".", ":", "/"}
 
     def _parse_relaxed_object_arguments(self, text: str) -> dict[str, object] | None:
         stripped = text.strip()


### PR DESCRIPTION
## Summary
- Normalize action-qualified streamed tool-call names to declared OpenAI tool names before emitting tool deltas.
- Suppress undeclared tool-call deltas when OpenAI tools are declared, and report parser metrics for normalization/suppression.
- Strip stale raw assistant tool-call prefixes from rebuilt chat history, including interleaved leading reasoning/tool-call artifacts, and surface gateway metrics.
- Address review follow-up by accepting whitespace-only empty parentheses in pipe tool calls, documenting longest-prefix normalization, and making separator checks use casefolded lengths.

## Plan or Spec
- `docs/plans/2026-03-30-m3-7-xml-and-namespaced-tool-parsing.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" .venv/bin/python -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_generate_stream.py::test_generate_stream_normalizes_tool_calls_to_declared_openai_tool_names
# 58 passed in 0.14s

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/control-plane-swift" xcrun swift build --package-path services/control-plane-swift
# Build complete! (4.76s)

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_generate_stream.py
# 85 passed in 0.67s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run -m pytest services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_generate_stream.py
# 85 passed in 0.67s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json -o /private/tmp/pr942-coverage.json
# Wrote JSON report to /private/tmp/pr942-coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json /private/tmp/pr942-coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py
# TOTAL 15 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /private/tmp/pr942-coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py
# TOTAL 100.00% 15/15
```

## Coverage and Metrics
- Python changed-line coverage: `100.00% (15/15)` for `services/mlx-worker-python/worker/runtime/stream_assembler.py` and `services/mlx-worker-python/tests/test_stream_assembler.py` using `/private/tmp/pr942-coverage.json`.
- PR-scoped performance on the prior head reported `Status: ok`, `Regressions: 0`, `Context regressions: 0`, and `Verification failures: 0` across the selected stream assembler and engine probes. A new run will be triggered by the review follow-up commit.

## Known Gaps
- Full repository `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not rerun locally for this review follow-up; focused Python tests, coverage, and diff checks were run, and GitHub Actions covers the full PR gate.
- Swift test target was not rerun locally because the earlier environment failed before execution with `no such module 'Testing'`; the Swift package build was run before this follow-up, and CI covered Swift tests on the previous head.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
