### PR TITLE
perf: skip empty embedding projection tail extend

### DIFF
--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -60,7 +60,8 @@ class DeterministicEmbeddingBackend:
             return [0.0] * dimensions
         normalized_base = [round(value / l2_norm, 6) for value in base_values]
         result = normalized_base * full_repeats
-        result.extend(normalized_base[:remainder])
+        if remainder:
+            result.extend(normalized_base[:remainder])
         return result
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Skip the empty tail slice/extend in deterministic embedding digest projection when dimensions are an exact multiple of the digest base vector.
- Keeps deterministic embedding output unchanged while reducing allocation work in the registered project-digest probe.

## Plan or Spec
- N/A: no behavior or workflow contract changes; this is a scoped Python hot-path micro-optimization covered by the registered PR-scoped probe `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline sync / worktree
GH_CONFIG_DIR=/root/.hermes/profiles/coder/gh-config gh auth status && GH_CONFIG_DIR=/root/.hermes/profiles/coder/gh-config gh api user --jq .login && git fetch origin

git worktree add -b perf/cron-registered-python-slice-20260512205251 /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-cron-slice-20260512205251 origin/main

git status --short && git branch --show-current && git rev-parse HEAD && git rev-parse origin/main
# exit 0; clean worktree; branch perf/cron-registered-python-slice-20260512205251; HEAD == origin/main (7283224714c2584e5e0edbd1d0aa3c58d730fa2a)

# Registered focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
# exit 0; 17 passed in 14.79s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
# exit 0; 17 passed in 44.33s; TOTAL 2 0 100%

# Registered probe, baseline origin/main worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
# exit 0; elapsed_ms_mean samples: 17.408246, 18.676203, 18.546269; peak_bytes_mean 66938.333333 each run

# Registered probe, this branch
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
# exit 0; elapsed_ms_mean samples: 17.011475, 17.593237, 17.147393; peak_bytes_mean 66882.333333 each run

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%` for `services/mlx-worker-python/worker/runtime/embedding_backends.py` and registered probe/test scope.
- Registered local probe: `deterministic-embedding-project-digest-allocation`.
- Baseline elapsed mean across three probe runs: `18.210239 ms`.
- Branch elapsed mean across three probe runs: `17.250702 ms`.
- Delta: `-0.959538 ms` (`5.27%` faster; lower is better).
- Baseline peak bytes mean: `66938.333333`; branch peak bytes mean: `66882.333333`; delta `-56 bytes`.
- CI PR-scoped performance validation is still required as the repository merge gate.

## Known Gaps
- Full repository `make` suite was not run locally; this PR used the registered focused test, changed-scope coverage, and registered probe for this Python slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
