### PR TITLE
perf: reuse release gate numeric type tuple

### DIFF
--- a/services/mlx-worker-python/worker/productization/release_gates.py
+++ b/services/mlx-worker-python/worker/productization/release_gates.py
@@ -53,6 +53,7 @@ _AUDIO_MODEL_ID = "melix-whisper-mlx"
 _AUDIO_MODEL_REVISION = "mlx-audio"
 _AUDIO_SOURCE_MODEL_PATH = "hf/mlx-community/whisper-large-v3-turbo-asr-fp16"
 _ARITHMETIC_PROMPT_PATTERN = re.compile(r"(\d+)\s*\+\s*(\d+)\s*\?")
+_NUMERIC_METRIC_TYPES = (int, float)
 DEFAULT_M9_RELEASE_GATE_POLICY: dict[str, Any] = {
     "mcp": {
         "mcp.tool_injection_count": {"min": 1.0},
@@ -1636,7 +1637,7 @@ def _evaluate_section_metrics_with_counts(
     failed_threshold_count = 0
     values_get = values.get
     failures_append = failures.append
-    numeric_types = (int, float)
+    numeric_types = _NUMERIC_METRIC_TYPES
     for name, rule in rules.items():
         value = values_get(name)
         if value is None:


### PR DESCRIPTION
## Summary
- Reuse a module-level numeric type tuple in the M9 release-gate metric evaluator instead of recreating `(int, float)` for each section evaluation.
- Keep M9 failure messages, missing/threshold counters, and policy semantics unchanged.
- Use the registered `release-gates-m9-failure-count-single-pass` probe as the focused performance gate for this Python-only slice.

## Plan or Spec
- `docs/plans/2026-05-10-release-gates-section-threshold-bindings.md`

## Commands Run
```text
# Baseline registered local probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/release_gates_m9_failure_count_probe.py
exit 0; elapsed_ms_mean=7.29106655344367; endswith_checks_mean=0.0; failure_count_mean=12800.0

# Focused tests after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_m9_release_evidence_ignores_non_dict_policy_entries services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_m9_release_evidence_reuses_section_failure_counts services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_section_metrics_counts_failure_types_without_suffix_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_release_gates_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_release_gates_m9_failure_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
exit 0; 6 passed in 0.34s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_m9_release_evidence_ignores_non_dict_policy_entries services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_m9_release_evidence_reuses_section_failure_counts services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_section_metrics_counts_failure_types_without_suffix_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_release_gates_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_release_gates_m9_failure_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
exit 0; 6 passed in 0.56s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
exit 0
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/release_gates.py services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/release_gates_m9_failure_count_probe.py
exit 0; TOTAL 2 0 100%

# Registered local probe after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/release_gates_m9_failure_count_probe.py
exit 0; elapsed_ms_mean=7.039574394002557; endswith_checks_mean=0.0; failure_count_mean=12800.0

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Registered probe: `release-gates-m9-failure-count-single-pass`.
- Local probe delta: old_mean=7.29106655344367 ms, new_mean=7.039574394002557 ms, delta_ms=-0.251492159441113, speedup=1.035725x, elapsed improvement=3.449%.
- Correctness guards: `endswith_checks_mean=0.0` unchanged; `failure_count_mean=12800.0` unchanged.
- CI PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- Full repository `make py-test` was not run locally; this slice used the registered focused test, coverage, and probe commands.
- No Swift/macOS runtime effect is claimed; this is a Python-only release-gate evaluator slice validated locally on Linux and by CI.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs (existing plan already describes this numeric type tuple reuse).
- [x] Protocol changes include regenerated generated artifacts (N/A: no protocol changes).
- [x] Dependency changes include updated lockfiles (N/A: no dependency changes).
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
