### PR TITLE
perf: tail-scan evaluation text fallback

### DIFF
--- a/docs/plans/2026-05-13-evaluation-text-fallback-tail-scan.md
+++ b/docs/plans/2026-05-13-evaluation-text-fallback-tail-scan.md
@@ -1,0 +1,36 @@
+# Evaluation final-result text fallback tail scan
+
+## Scope
+
+This Python-only performance slice targets heuristic text extraction in
+`services/mlx-worker-python/worker/productization/evaluation_final_result.py`.
+When no answer prefix or fenced block is present, the fallback only needs the
+last nonblank output line. The previous implementation materialized paragraph
+and line lists before returning that value.
+
+## Probe coverage
+
+Register `evaluation-final-result-text-fallback-tail-scan` in
+`infra/perf/pr_scoped_probes.json` for this slice. The registered probe includes:
+
+- focused pytest coverage for text fallback behavior and probe selection,
+- changed-scope coverage for the implementation, tests, registry, and probe
+  script,
+- `scripts/evaluation_text_fallback_probe.py`, which compares the legacy
+  paragraph-list fallback with the optimized tail scan over a synthetic
+  multi-paragraph response.
+
+## Success criteria
+
+- Behavior remains equivalent for answer-prefix, fenced-text, and fallback text
+  extraction cases.
+- Changed-scope coverage remains at or above the repository 95% requirement.
+- The registered local Linux probe reports lower `elapsed_ms_mean` and lower
+  `peak_bytes_mean` versus the legacy fallback, with matching checksum.
+- PR-scoped performance CI selects and completes the registered probe before
+  merge.
+
+## Validation boundary
+
+This slice is Python-only and fully locally verifiable on Linux. GitHub Actions
+remains the merge gate for the PR-scoped registered probe report.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1174,6 +1174,55 @@
     ]
   },
   {
+    "id": "evaluation-final-result-text-fallback-tail-scan",
+    "name": "Evaluation final-result text fallback tail scan",
+    "description": "Avoid paragraph/list materialization when heuristic text extraction falls back to the final nonblank line.",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/evaluation_final_result.py",
+      "services/mlx-worker-python/tests/test_evaluation_final_result.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/evaluation_text_fallback_probe.py",
+      "scripts/changed_scope_coverage.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_text_fallback_scans_tail_without_regex_split services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_accepts_one_answer_prefix services/mlx-worker-python/tests/test_evaluation_final_result.py::test_last_nonblank_text_line_handles_trailing_whitespace_and_empty_input services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_uses_last_text_fence_without_materializing_all_fences services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_text_fallback_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_text_fallback_scans_tail_without_regex_split services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_accepts_one_answer_prefix services/mlx-worker-python/tests/test_evaluation_final_result.py::test_last_nonblank_text_line_handles_trailing_whitespace_and_empty_input services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_uses_last_text_fence_without_materializing_all_fences services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_text_fallback_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_text_fallback_probe.py",
+    "probe_command": "PROBE_SCRIPT=\"scripts/evaluation_text_fallback_probe.py\"; if [ ! -f \"$PROBE_SCRIPT\" ] && [ -f \"../head/scripts/evaluation_text_fallback_probe.py\" ]; then PROBE_SCRIPT=\"../head/scripts/evaluation_text_fallback_probe.py\"; fi; PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 \"$PROBE_SCRIPT\"",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "delta_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_delta_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "paragraph_count",
+        "unit": "count",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "evaluation-final-result-json-typed-score-aggregate",
     "name": "Evaluation final-result JSON typed-score running aggregate",
     "runner": "ubuntu-latest",

--- a/scripts/evaluation_text_fallback_probe.py
+++ b/scripts/evaluation_text_fallback_probe.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path.cwd().resolve()
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.productization.evaluation_final_result import (  # noqa: E402
+    _GENERIC_FENCE_PATTERN,
+    _TEXT_ANSWER_PATTERN,
+    _last_stripped_pattern_match,
+    extract_final_result,
+)
+
+
+def _legacy_extract_text_heuristic(raw_response: str) -> str:
+    answer_prefix_count = 0
+    answer_prefix_candidate = ""
+    for match in _TEXT_ANSWER_PATTERN.finditer(raw_response):
+        candidate = match.group(1).strip()
+        if not candidate:
+            continue
+        answer_prefix_count += 1
+        if answer_prefix_count > 1:
+            return ""
+        answer_prefix_candidate = candidate
+    if answer_prefix_candidate:
+        return answer_prefix_candidate
+
+    candidate = _last_stripped_pattern_match(_GENERIC_FENCE_PATTERN, raw_response)
+    if candidate:
+        return candidate
+
+    paragraphs = [paragraph.strip() for paragraph in re.split(r"\n\s*\n", raw_response) if paragraph.strip()]
+    if not paragraphs:
+        return ""
+    lines = [line.strip() for line in paragraphs[-1].splitlines() if line.strip()]
+    if lines:
+        return lines[-1]
+    return paragraphs[-1]
+
+
+def _payload(*, paragraphs: int, lines_per_paragraph: int, line_width: int) -> str:
+    chunks: list[str] = []
+    body = "x" * max(1, line_width - 20)
+    for paragraph_index in range(paragraphs):
+        lines = [
+            f"p{paragraph_index:05d}-line{line_index:03d}-{body}"
+            for line_index in range(lines_per_paragraph)
+        ]
+        chunks.append("\n".join(lines))
+    chunks.append("Terminal response line")
+    return "\n\n".join(chunks) + "\n\n   \n"
+
+
+def _run_once(raw_response: str, *, legacy: bool, iterations: int) -> tuple[float, int, int]:
+    checksum = 0
+    tracemalloc.start()
+    started = time.perf_counter()
+    for _ in range(iterations):
+        if legacy:
+            extracted = _legacy_extract_text_heuristic(raw_response)
+        else:
+            outcome = extract_final_result(
+                raw_response=raw_response,
+                result_kind="text",
+                extraction_mode="heuristic_final",
+            )
+            extracted = outcome.extracted_result
+        checksum += len(extracted)
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return elapsed_ms, peak, checksum
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--paragraphs", type=int, default=2500)
+    parser.add_argument("--lines-per-paragraph", type=int, default=3)
+    parser.add_argument("--line-width", type=int, default=80)
+    parser.add_argument("--iterations", type=int, default=50)
+    parser.add_argument("--samples", type=int, default=5)
+    args = parser.parse_args()
+
+    raw_response = _payload(
+        paragraphs=args.paragraphs,
+        lines_per_paragraph=args.lines_per_paragraph,
+        line_width=args.line_width,
+    )
+
+    legacy_elapsed: list[float] = []
+    legacy_peaks: list[float] = []
+    new_elapsed: list[float] = []
+    new_peaks: list[float] = []
+    checksum = 0
+    for _ in range(args.samples):
+        elapsed, peak, checksum = _run_once(raw_response, legacy=True, iterations=args.iterations)
+        legacy_elapsed.append(elapsed)
+        legacy_peaks.append(float(peak))
+        elapsed, peak, checksum = _run_once(raw_response, legacy=False, iterations=args.iterations)
+        new_elapsed.append(elapsed)
+        new_peaks.append(float(peak))
+
+    legacy_elapsed_mean = statistics.fmean(legacy_elapsed)
+    elapsed_mean = statistics.fmean(new_elapsed)
+    legacy_peak_mean = statistics.fmean(legacy_peaks)
+    peak_mean = statistics.fmean(new_peaks)
+    print(
+        json.dumps(
+            {
+                "checksum": float(checksum),
+                "elapsed_ms_mean": elapsed_mean,
+                "legacy_elapsed_ms_mean": legacy_elapsed_mean,
+                "delta_ms_mean": elapsed_mean - legacy_elapsed_mean,
+                "peak_bytes_mean": peak_mean,
+                "legacy_peak_bytes_mean": legacy_peak_mean,
+                "peak_bytes_delta_mean": peak_mean - legacy_peak_mean,
+                "paragraph_count": float(args.paragraphs + 1),
+                "iteration_count": float(args.iterations),
+                "samples": float(args.samples),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -15,6 +15,7 @@ from worker.productization.evaluation_final_result import (
     EvaluationMaterializationRequest,
     EvaluationProfileDefinition,
     _local_source_metadata,
+    _last_nonblank_text_line,
     extract_final_result,
     materialize_hf_evaluation_dataset,
     materialize_local_evaluation_dataset,
@@ -175,6 +176,29 @@ def test_extract_final_result_accepts_one_answer_prefix() -> None:
 
     assert outcome.extraction_status == "extracted"
     assert outcome.extracted_result == "Paris"
+
+
+def test_extract_final_result_text_fallback_scans_tail_without_regex_split(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_split(*args: object, **kwargs: object) -> list[str]:
+        raise AssertionError("text fallback should not materialize paragraphs with re.split")
+
+    monkeypatch.setattr(evaluation_final_result_module.re, "split", fail_split)
+
+    outcome = extract_final_result(
+        raw_response="draft paragraph\n\nfinal paragraph\n  Paris  \n\n  ",
+        result_kind="text",
+        extraction_mode="heuristic_final",
+    )
+
+    assert outcome.extraction_status == "extracted"
+    assert outcome.extracted_result == "Paris"
+
+
+def test_last_nonblank_text_line_handles_trailing_whitespace_and_empty_input() -> None:
+    assert _last_nonblank_text_line("draft\n  Paris  \n\t  ") == "Paris"
+    assert _last_nonblank_text_line("  \n\t\n  ") == ""
 
 
 def test_extract_final_result_scans_json_suffix_candidates_from_the_tail(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -583,11 +583,40 @@ def test_scope_report_selects_evaluation_final_result_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/productization/evaluation_final_result.py"],
     )
 
-    assert scope["selected_count"] == 2
+    assert scope["selected_count"] == 3
     assert {probe["id"] for probe in scope["selected_probes"]} == {
         "evaluation-final-result-materialization-streaming",
         "evaluation-final-result-json-typed-score-aggregate",
+        "evaluation-final-result-text-fallback-tail-scan",
     }
+
+
+def test_evaluation_text_fallback_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "evaluation_text_fallback_probe.py",
+            "--paragraphs",
+            "20",
+            "--iterations",
+            "3",
+            "--samples",
+            "2",
+        ],
+    )
+
+    runpy.run_path(str(REPO_ROOT / "scripts/evaluation_text_fallback_probe.py"), run_name="__main__")
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["legacy_elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["checksum"] == 66.0
+    assert metrics["paragraph_count"] == 21.0
 
 
 def test_evaluation_json_typed_score_probe_script_emits_metrics(
@@ -2100,6 +2129,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "evaluation-dialogue-diagnostics-top-k",
         "evaluation-final-result-materialization-streaming",
         "evaluation-final-result-json-typed-score-aggregate",
+        "evaluation-final-result-text-fallback-tail-scan",
         "evaluation-latency-percentile-vector-reuse",
         "evaluation-sample-probe-aggregation",
         "evaluation-compare-target-lookup-short-circuit",

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -291,14 +291,21 @@ def _extract_text_heuristic(raw_response: str) -> ExtractionOutcome:
     if candidate:
         return ExtractionOutcome(candidate, "extracted")
 
-    paragraphs = [paragraph.strip() for paragraph in re.split(r"\n\s*\n", raw_response) if paragraph.strip()]
-    if paragraphs:
-        lines = [line.strip() for line in paragraphs[-1].splitlines() if line.strip()]
-        if lines:
-            return ExtractionOutcome(lines[-1], "extracted")
-        return ExtractionOutcome(paragraphs[-1], "extracted")
+    fallback_line = _last_nonblank_text_line(raw_response)
+    if fallback_line:
+        return ExtractionOutcome(fallback_line, "extracted")
 
     return ExtractionOutcome("", "extraction_failed", "no_text_candidate")
+
+
+def _last_nonblank_text_line(raw_response: str) -> str:
+    end = len(raw_response)
+    while end > 0 and raw_response[end - 1].isspace():
+        end -= 1
+    if end == 0:
+        return ""
+    line_start = raw_response.rfind("\n", 0, end) + 1
+    return raw_response[line_start:end].strip()
 
 
 def _score_json_result(


### PR DESCRIPTION
## Summary
- Optimize Python heuristic final-result text fallback to scan backward for the last nonblank line instead of materializing paragraph and line lists.
- Register a PR-scoped performance probe for this path and add focused behavior/probe tests.
- Make the probe script cwd-rooted so PR-scoped CI can run the head probe script against both base and head checkouts.

## Plan or Spec
- `docs/plans/2026-05-13-evaluation-text-fallback-tail-scan.md`

## Commands Run
```text
# Baseline sync/context
cd /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-cron-slice-20260513012403
git fetch origin
git rev-parse origin/main && git rev-parse HEAD
# origin/main=6883e40c405d511a051269b7e14f2c46b4ec9419, HEAD=6883e40c405d511a051269b7e14f2c46b4ec9419 before the slice commit

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_text_fallback_scans_tail_without_regex_split \
  services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_accepts_one_answer_prefix \
  services/mlx-worker-python/tests/test_evaluation_final_result.py::test_last_nonblank_text_line_handles_trailing_whitespace_and_empty_input \
  services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_uses_last_text_fence_without_materializing_all_fences \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_text_fallback_probe_script_emits_metrics \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 7 passed in 0.11s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same 7 focused tests>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/productization/evaluation_final_result.py \
  services/mlx-worker-python/tests/test_evaluation_final_result.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/evaluation_text_fallback_probe.py
# 7 passed in 0.22s; TOTAL 1 0 100% for post-amend changed lines
# Earlier full pre-amend changed-scope run: 7 passed in 0.23s; TOTAL 31 1 97%

PROBE_SCRIPT="scripts/evaluation_text_fallback_probe.py"; if [ ! -f "$PROBE_SCRIPT" ] && [ -f "../head/scripts/evaluation_text_fallback_probe.py" ]; then PROBE_SCRIPT="../head/scripts/evaluation_text_fallback_probe.py"; fi; PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 "$PROBE_SCRIPT"
# {"checksum": 1100.0, "delta_ms_mean": -124.38682578504086, "elapsed_ms_mean": 265.8575712237507, "iteration_count": 50.0, "legacy_elapsed_ms_mean": 390.24439700879157, "legacy_peak_bytes_mean": 711747.2, "paragraph_count": 2501.0, "peak_bytes_delta_mean": -136311.0, "peak_bytes_mean": 575436.2, "samples": 5.0}

git -C /root/.hermes/profiles/coder/workspace/melix.git worktree add --detach /tmp/melix-base-for-tail-probe origin/main
cd /tmp/melix-base-for-tail-probe
PROBE_SCRIPT=/root/.hermes/profiles/coder/workspace/worktrees/melix-perf-cron-slice-20260513012403/scripts/evaluation_text_fallback_probe.py PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 "$PROBE_SCRIPT" --paragraphs 20 --iterations 3 --samples 2
# {"checksum": 66.0, "delta_ms_mean": -0.07551233284175396, "elapsed_ms_mean": 0.22572302259504795, "iteration_count": 3.0, "legacy_elapsed_ms_mean": 0.3012353554368019, "legacy_peak_bytes_mean": 9430.0, "paragraph_count": 21.0, "peak_bytes_delta_mean": 2536.0, "peak_bytes_mean": 11966.0, "samples": 2.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 31 1 97%` before amend; post-amend delta coverage `TOTAL 1 0 100%`.
- Registered probe: `evaluation-final-result-text-fallback-tail-scan` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command`.
- Local Linux probe result: old mean `390.244 ms`, new mean `265.858 ms`, delta `-124.387 ms`, speedup `1.468x` (`31.87%` lower elapsed mean).
- Local Linux peak allocation result: old mean `711,747.2 bytes`, new mean `575,436.2 bytes`, delta `-136,311.0 bytes` (`19.15%` lower peak bytes).
- Checksum matched (`1100.0`), confirming identical extracted text length across samples.
- GitHub Actions PR-scoped performance CI is still required as the merge gate for the registered probe report.

## Known Gaps
- Full repository `make py-test` was not run locally; this PR is limited to the registered focused Python slice and its changed-scope coverage/probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
