### PR TITLE
perf: streamline hub catalog quantization tag checks

### DIFF
--- a/docs/plans/2026-05-13-hub-catalog-bytes-per-parameter-single-pass.md
+++ b/docs/plans/2026-05-13-hub-catalog-bytes-per-parameter-single-pass.md
@@ -1,0 +1,20 @@
+# Hub Catalog Quantization Tag Fast Paths
+
+## Scope
+
+This Python-only performance slice is limited to Hub catalog local-fit quantization tag classification in `services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped performance probe `hub-catalog-tag-normalization-single-pass` in `infra/perf/pr_scoped_probes.json`. The registered probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for Hub catalog behavior tests, changed-scope coverage, and the synthetic Hub catalog tag/local-fit workload.
+
+## Optimization
+
+Replace `_bytes_per_parameter(...)` temporary joined lowered-tag string allocation with a single scan over the lowered tag set, and replace `_quantization_summary(...)` alias-set intersections with direct membership checks. Both changes preserve the existing quantization priority and summary order while reducing per-record temporary allocations in local-fit estimates.
+
+## Verification Plan
+
+- Run focused Hub catalog tests from the registered probe.
+- Run changed-scope coverage from the registered probe.
+- Run the registered local probe on Linux with an `origin/main` baseline comparison.
+- Let GitHub Actions run the PR-scoped performance workflow before merge.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -11,6 +11,7 @@ import worker.model_ops.hub_catalog as hub_catalog_module
 from worker.model_ops.hub_catalog import (
     HubCatalog,
     HubCatalogError,
+    _bytes_per_parameter,
     _is_mlx_compatible,
     _local_fit_evidence,
     _quantization_summary,
@@ -40,6 +41,14 @@ def test_quantization_summary_preserves_alias_order_from_lowered_tags() -> None:
         _quantization_summary(["2-bit", "3bit", "8-bit", "float32", "bf16"])
         == "2-bit, 3-bit, 8-bit, fp32, bf16"
     )
+
+
+def test_bytes_per_parameter_preserves_quantization_priority_without_joining_tags() -> None:
+    assert _bytes_per_parameter([], lowered_tags={"family", "float32", "4-bit"}) == 0.5
+    assert _bytes_per_parameter([], lowered_tags={"family", "8bit"}) == 1.0
+    assert _bytes_per_parameter([], lowered_tags={"family", "3-bit", "8bit"}) == 0.375
+    assert _bytes_per_parameter([], lowered_tags={"family", "foo4", "bitbar"}) == 2.0
+    assert _bytes_per_parameter(["adapter", "2bit-mlx"], lowered_tags=None) == 0.25
 
 
 class FakeHTTPResponse:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -21,19 +21,6 @@ _SIZE_HINT_GB = _SIZE_HINT_MB * 1024
 
 _BARE_SIZE_HINT_RE = re.compile(r"(?:model\s+size\s*[:|]?\s*)?(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
 _EXPLICIT_SIZE_HINT_RE = re.compile(r"\bmodel\s+size\s*[:|]?\s*(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
-_QUANTIZATION_ALIASES = (
-    ("2-bit", frozenset(("2bit", "2-bit"))),
-    ("3-bit", frozenset(("3bit", "3-bit"))),
-    ("4-bit", frozenset(("4bit", "4-bit"))),
-    ("8-bit", frozenset(("8bit", "8-bit"))),
-    ("mixed-precision", frozenset(("mixed-precision", "mixed_precision"))),
-    ("optiq", frozenset(("optiq",))),
-    ("fp32", frozenset(("fp32", "float32", "f32"))),
-    ("bf16", frozenset(("bf16",))),
-    ("fp16", frozenset(("fp16", "float16"))),
-)
-
-
 @dataclass(frozen=True)
 class HubModelSummaryRecord:
     repo_id: str
@@ -697,25 +684,53 @@ def _estimated_resident_bytes(
 
 def _bytes_per_parameter(tags: list[str], *, lowered_tags: set[str] | None = None) -> float:
     lowered = _normalized_lowered_tags(tags, lowered_tags)
-    joined = " ".join(lowered)
-    if "2bit" in joined or "2-bit" in joined:
-        return 0.25
-    if "3bit" in joined or "3-bit" in joined:
+    has_3bit = False
+    has_4bit = False
+    has_8bit = False
+    has_fp32 = False
+    for tag in lowered:
+        if "2bit" in tag or "2-bit" in tag:
+            return 0.25
+        if not has_3bit and ("3bit" in tag or "3-bit" in tag):
+            has_3bit = True
+        if not has_4bit and ("4bit" in tag or "4-bit" in tag):
+            has_4bit = True
+        if not has_8bit and ("8bit" in tag or "8-bit" in tag):
+            has_8bit = True
+        if not has_fp32 and ("fp32" in tag or "float32" in tag or "f32" in tag):
+            has_fp32 = True
+    if has_3bit:
         return 0.375
-    if "4bit" in joined or "4-bit" in joined:
+    if has_4bit:
         return 0.5
-    if "8bit" in joined or "8-bit" in joined:
+    if has_8bit:
         return 1.0
-    if "fp32" in joined or "float32" in joined or "f32" in joined:
+    if has_fp32:
         return 4.0
-    if "bf16" in joined or "fp16" in joined or "float16" in joined:
-        return 2.0
     return 2.0
 
 
 def _quantization_summary(tags: list[str], *, lowered_tags: set[str] | None = None) -> str:
     lowered = _normalized_lowered_tags(tags, lowered_tags)
-    values = [label for label, aliases in _QUANTIZATION_ALIASES if lowered.intersection(aliases)]
+    values: list[str] = []
+    if "2bit" in lowered or "2-bit" in lowered:
+        values.append("2-bit")
+    if "3bit" in lowered or "3-bit" in lowered:
+        values.append("3-bit")
+    if "4bit" in lowered or "4-bit" in lowered:
+        values.append("4-bit")
+    if "8bit" in lowered or "8-bit" in lowered:
+        values.append("8-bit")
+    if "mixed-precision" in lowered or "mixed_precision" in lowered:
+        values.append("mixed-precision")
+    if "optiq" in lowered:
+        values.append("optiq")
+    if "fp32" in lowered or "float32" in lowered or "f32" in lowered:
+        values.append("fp32")
+    if "bf16" in lowered:
+        values.append("bf16")
+    if "fp16" in lowered or "float16" in lowered:
+        values.append("fp16")
     return ", ".join(values)
 
 


### PR DESCRIPTION
## Summary
- Streamline Hub catalog quantization tag checks used by local-fit sizing.
- Replace temporary joined lowered-tag allocation and alias-set intersections with direct membership checks while preserving quantization priority and summary order.
- Add a focused regression for bytes-per-parameter priority and non-cross-tag matching.

## Plan or Spec
- `docs/plans/2026-05-13-hub-catalog-bytes-per-parameter-single-pass.md`

## Commands Run
```text
# Baseline local probe before edit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_TAG_PROBE_RECORDS=5000 MELIX_HUB_CATALOG_TAG_PROBE_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py
-> exit 0; {"elapsed_ms_mean": 271.50844045293826, "peak_bytes_mean": 10129035.333333334, "record_count": 5000.0, "sample_count": 3.0, "tag_normalization_calls_mean": 5000.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
-> exit 0; 50 passed in 0.88s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py
-> exit 0; 50 passed; TOTAL 44 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_TAG_PROBE_RECORDS=5000 MELIX_HUB_CATALOG_TAG_PROBE_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-tag-normalization-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-hub-tag-20260513025017 --head-repo "$PWD" --output /tmp/hub_catalog_tag_probe.json
-> exit 0; base elapsed_ms_mean=284.470207, head elapsed_ms_mean=245.577590

git diff --check
-> exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 44 0 100%`.
- Registered local probe: `hub-catalog-tag-normalization-single-pass`.
- Metrics: base `elapsed_ms_mean=284.470207`, head `elapsed_ms_mean=245.577590`, delta `-38.892617 ms`, speedup `1.1584x` / `13.67%` improvement.
- `tag_normalization_calls_mean` stayed `5000.0` on both base and head.

## Known Gaps
- Linux local validation completed for this Python-only slice. Hosted PR-scoped performance CI is still required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
