### PR TITLE
test: verify PR 950 probe checksum parity

### DIFF
--- a/scripts/evaluation_text_fallback_probe.py
+++ b/scripts/evaluation_text_fallback_probe.py
@@ -96,7 +96,6 @@ def main() -> None:
         lines_per_paragraph=args.lines_per_paragraph,
         line_width=args.line_width,
     )
-
     legacy_elapsed: list[float] = []
     legacy_peaks: list[float] = []
     new_elapsed: list[float] = []
@@ -109,6 +108,15 @@ def main() -> None:
         elapsed, peak, checksum = _run_once(raw_response, legacy=False, iterations=args.iterations)
         new_elapsed.append(elapsed)
         new_peaks.append(float(peak))
+
+    legacy_candidate = _legacy_extract_text_heuristic(raw_response)
+    new_candidate = extract_final_result(
+        raw_response=raw_response,
+        result_kind="text",
+        extraction_mode="heuristic_final",
+    ).extracted_result
+    if legacy_candidate != new_candidate:
+        raise ValueError("Legacy and optimized extraction results differ")
 
     legacy_elapsed_mean = statistics.fmean(legacy_elapsed)
     elapsed_mean = statistics.fmean(new_elapsed)


### PR DESCRIPTION
## Plan or Spec

Follow up on the unresolved review thread from #950: https://github.com/Keith-CY/melix/pull/950#discussion_r3230969379

The original PR was already merged before this fix could be pushed to its head branch, so this PR lands the narrow review fix on top of current main.

## Commands Run

- `PYTHONPATH="/Users/chenyu/Documents/jobs/melix/pr-950-review-perf:/Users/chenyu/Documents/jobs/melix/pr-950-review-perf/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_text_fallback_scans_tail_without_regex_split services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_accepts_one_answer_prefix services/mlx-worker-python/tests/test_evaluation_final_result.py::test_last_nonblank_text_line_handles_trailing_whitespace_and_empty_input services/mlx-worker-python/tests/test_evaluation_final_result.py::test_extract_final_result_uses_last_text_fence_without_materializing_all_fences services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_text_fallback_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="/Users/chenyu/Documents/jobs/melix/pr-950-review-perf:/Users/chenyu/Documents/jobs/melix/pr-950-review-perf/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python3 scripts/evaluation_text_fallback_probe.py`
- `git diff --check`

## Coverage and Metrics

- Focused pytest: 7 passed.
- Default text fallback probe: checksum 1100.0; elapsed_ms_mean 110.48275020439178; legacy_elapsed_ms_mean 205.57018340332434; peak_bytes_mean 574262.8; legacy_peak_bytes_mean 711943.4.
- PR #950 performance report was already Status ok with Regressions 0 and direct/gated probes 3/3 ok. Its 10 context regressions were reported under force-all context probes, while the direct evaluation-final-result probes remained ok/improved.

## Known Gaps

- The original PR #950 is already merged, so this PR cannot update that merged head commit directly.
- Full PR-scoped performance will run in CI for this follow-up branch.