### PR TITLE
perf: reuse statistical evidence constant scan

### DIFF
--- a/docs/plans/statistical-evidence-constant-bootstrap-short-circuit.md
+++ b/docs/plans/statistical-evidence-constant-bootstrap-short-circuit.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Avoid redundant paired-bootstrap work when every paired outcome has the same value. In that case every bootstrap replicate has the same mean, so the percentile interval can be returned exactly without allocating and sorting the replicate vector. This follow-up slice keeps that short-circuit and removes the preflight tuple-tail slice used to detect constant outcomes.
+Avoid redundant paired-bootstrap and analytical interval work when every paired outcome has the same value. In that case every bootstrap replicate and the analytical margin are exact, so the percentile interval can be returned without allocating and sorting the replicate vector, and the analytical interval can reuse the same constant-outcome scan instead of walking the sample again.
 
 ## Linux-only constraint
 
@@ -18,7 +18,7 @@ This is a Python worker/productization slice and is verifiable on Linux with foc
 
 Run `/tmp/statistical_evidence_constant_probe.py <origin-main-worktree> <head-worktree>` against a synthetic homogeneous `paired_outcomes=(1.0,) * 200000` workload with `bootstrap_iterations=1000` and five samples. Compare mean elapsed time and traced peak allocation while asserting the returned bootstrap bounds stay exactly `1.0`.
 
-The repository already has the `statistical-evidence-bootstrap-single-sort` PR-scoped performance probe watching this production file and test file. This slice relies on that registered probe to validate no regression in the mixed-outcome bootstrap path, and the local homogeneous probe validates the new short-circuit path.
+The repository already has the `statistical-evidence-bootstrap-single-sort` PR-scoped performance probe watching this production file and test file. This slice relies on that registered probe to validate no regression in the mixed-outcome bootstrap path, and the local homogeneous probe validates that the shared mean/constant scan improves the constant-outcome path.
 
 ## Success metrics
 

--- a/services/mlx-worker-python/tests/test_statistical_evidence.py
+++ b/services/mlx-worker-python/tests/test_statistical_evidence.py
@@ -167,7 +167,7 @@ def test_bootstrap_interval_sums_replicates_without_per_replicate_mean_helper_ca
         bootstrap_seed=13,
     )
 
-    assert mean_lengths == [8, 8]
+    assert mean_lengths == [8]
     assert evidence["bootstrap"] == {
         "method": "paired_bootstrap_percentile",
         "confidence_level": 0.9,
@@ -203,6 +203,32 @@ def test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling(
         "iterations": 1000,
         "seed": 17,
     }
+    assert evidence["analytical"]["lower_bound"] == 1.0
+    assert evidence["analytical"]["upper_bound"] == 1.0
+
+
+def test_build_paired_statistical_evidence_reuses_constant_scan_between_intervals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    equality_scan_lengths: list[int] = []
+    original_all_values_equal = statistical_evidence_module._all_values_equal
+
+    def tracking_all_values_equal(values: tuple[float, ...]) -> bool:
+        equality_scan_lengths.append(len(values))
+        return original_all_values_equal(values)
+
+    monkeypatch.setattr(statistical_evidence_module, "_all_values_equal", tracking_all_values_equal)
+
+    evidence = build_paired_statistical_evidence(
+        paired_outcomes=(1, 1, 1, 1, 1),
+        confidence_level=0.95,
+        bootstrap_iterations=1000,
+        bootstrap_seed=17,
+    )
+
+    assert equality_scan_lengths == [5]
+    assert evidence["bootstrap"]["lower_bound"] == 1.0
+    assert evidence["bootstrap"]["upper_bound"] == 1.0
     assert evidence["analytical"]["lower_bound"] == 1.0
     assert evidence["analytical"]["upper_bound"] == 1.0
 

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -17,16 +17,21 @@ def build_paired_statistical_evidence(
 ) -> dict[str, object]:
     outcomes = tuple(float(value) for value in paired_outcomes)
     sample_size = len(outcomes)
-    delta_accuracy = _rounded(_mean(outcomes))
+    mean_value = _mean(outcomes)
+    all_values_equal = bool(outcomes) and _all_values_equal(outcomes)
+    delta_accuracy = _rounded(mean_value)
     bootstrap_interval = _paired_bootstrap_interval(
         outcomes=outcomes,
         confidence_level=confidence_level,
         bootstrap_iterations=bootstrap_iterations,
         bootstrap_seed=bootstrap_seed,
+        all_values_equal=all_values_equal,
     )
     analytical_interval = _paired_analytical_interval(
         outcomes=outcomes,
         confidence_level=confidence_level,
+        mean_value=mean_value,
+        all_values_equal=all_values_equal,
     )
     return {
         "sample_size": sample_size,
@@ -113,6 +118,7 @@ def _paired_bootstrap_interval(
     confidence_level: float,
     bootstrap_iterations: int,
     bootstrap_seed: int,
+    all_values_equal: bool | None = None,
 ) -> dict[str, object]:
     if not outcomes or bootstrap_iterations <= 0:
         return _interval_payload(
@@ -124,7 +130,8 @@ def _paired_bootstrap_interval(
             seed=int(bootstrap_seed),
         )
 
-    if _all_values_equal(outcomes):
+    values_equal = all_values_equal if all_values_equal is not None else _all_values_equal(outcomes)
+    if values_equal:
         return _interval_payload(
             method="paired_bootstrap_percentile",
             confidence_level=confidence_level,
@@ -165,6 +172,8 @@ def _paired_analytical_interval(
     *,
     outcomes: tuple[float, ...],
     confidence_level: float,
+    mean_value: float | None = None,
+    all_values_equal: bool | None = None,
 ) -> dict[str, object]:
     if not outcomes:
         return _interval_payload(
@@ -174,11 +183,12 @@ def _paired_analytical_interval(
             upper_bound=0.0,
         )
 
-    mean_value = _mean(outcomes)
-    if len(outcomes) == 1:
+    resolved_mean = _mean(outcomes) if mean_value is None else mean_value
+    values_equal = all_values_equal if all_values_equal is not None else _all_values_equal(outcomes)
+    if len(outcomes) == 1 or values_equal:
         margin = 0.0
     else:
-        variance = sum((value - mean_value) ** 2 for value in outcomes) / (len(outcomes) - 1)
+        variance = sum((value - resolved_mean) ** 2 for value in outcomes) / (len(outcomes) - 1)
         standard_error = math.sqrt(variance) / math.sqrt(len(outcomes))
         z_value = _two_sided_normal_z_value(confidence_level)
         margin = z_value * standard_error
@@ -186,8 +196,8 @@ def _paired_analytical_interval(
     return _interval_payload(
         method="paired_difference_normal_approximation",
         confidence_level=confidence_level,
-        lower_bound=mean_value - margin,
-        upper_bound=mean_value + margin,
+        lower_bound=resolved_mean - margin,
+        upper_bound=resolved_mean + margin,
     )
 
 


### PR DESCRIPTION
## Summary
- Reuses the statistical evidence mean and constant-outcome scan across bootstrap and analytical interval construction.
- Keeps constant bootstrap behavior exact while avoiding the second analytical variance walk for homogeneous paired outcomes.
- Updates the governing plan to describe the shared constant-scan slice.

## Plan or Spec
- `docs/plans/statistical-evidence-constant-bootstrap-short-circuit.md`

## Commands Run
```text
# synced isolated worktree from origin/main
cd /root/.hermes/profiles/coder/workspace && git --git-dir=melix.git fetch origin --prune && git --git-dir=melix.git worktree add -b perf/cron-slice-20260513042907-b /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-cron-slice-20260513042907-b origin/main

# focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics
# 17 passed in 0.60s

# changed-scope coverage
rm -f coverage.json .coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_bootstrap_probe.py
# TOTAL 23 0 100%

# local constant-path probe comparing origin/main baseline worktree to head
python3 /tmp/statistical_evidence_constant_probe.py /root/.hermes/profiles/coder/workspace/worktrees/melix-base-stat-evidence-constant-20260513042907 "$PWD"
# {"base": {"elapsed_ms_mean": 47.28048301434943, "peak_bytes_mean": 1814416.0}, "head": {"elapsed_ms_mean": 15.990356149684105, "peak_bytes_mean": 1814416.0}, "delta_ms": -31.290126864665325, "speedup": 2.956812379396782, "peak_delta_bytes": 0.0, ...}

# registered mixed-outcome probe, baseline then head rerun
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_bootstrap_probe.py
# baseline: {"elapsed_ms_mean": 136.80594274774194, "peak_bytes_mean": 47216.0, ...}
# head:     {"elapsed_ms_mean": 134.47749158367515, "peak_bytes_mean": 47235.2, ...}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 23 0 100%`.
- Local constant-path probe: `old_mean=47.280483 ms`, `new_mean=15.990356 ms`, `speedup=2.9568x`, `delta_ms=-31.290127`, `peak_delta_bytes=0.0`.
- Registered local mixed-outcome probe rerun: baseline `elapsed_ms_mean=136.805943`, head `elapsed_ms_mean=134.477492`, delta `-2.328451 ms`; baseline `peak_bytes_mean=47216.0`, head `peak_bytes_mean=47235.2`.
- PR-scoped performance CI is required for the registered probe validation before merge.

## Known Gaps
- None for the Python/Linux slice. Swift runtime effects are not involved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
