### PR TITLE
Raise default text generation token limit

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -1846,7 +1846,10 @@ public final class RuntimeViewModel {
     public private(set) var lastModelOperation: RuntimeModelOperationState?
     public private(set) var loraWorkflowStatus: RuntimeLoraWorkflowStatusState?
     public private(set) var downloadQueue: [RuntimeDownloadQueueEntryState] = [] {
-        didSet { refreshModelRegistryEntries() }
+        didSet {
+            refreshModelRegistryEntries()
+            persistOperatorSessionState()
+        }
     }
     public private(set) var modelRegistryEntries: [RuntimeRegistryEntryState] = []
     public private(set) var lastDoctorReport: RuntimeDoctorReportState?

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -7845,6 +7845,7 @@ public final class RuntimeViewModel {
                 .sorted { $0.modelID < $1.modelID }
             refreshModelRegistryEntries()
         }
+        persistOperatorSessionState(force: true)
         refreshLoraSelectionState()
     }
 
@@ -8457,13 +8458,13 @@ public final class RuntimeViewModel {
         )
     }
 
-    private func persistOperatorSessionState() {
+    private func persistOperatorSessionState(force: Bool = false) {
         guard operatorStateRestored else {
             return
         }
 
         let state = currentOperatorSessionState()
-        guard state != lastPersistedOperatorSessionState else {
+        guard force || state != lastPersistedOperatorSessionState else {
             return
         }
 
@@ -9584,11 +9585,25 @@ public final class RuntimeViewModel {
                 ? selectedEvaluationHistoryEntry?.jobID
                 : selectedEvaluationHistoryJobID
             let bundle: ControlPlaneBenchmarkExportBundle
-            if let operatorCommandRunner {
-                bundle = try await operatorCommandRunner.fetchBenchmarkExportBundle(outputDir: exportDirectory.path)
-            } else {
-                let export = try await client.exportResults(outputDir: exportDirectory.path)
-                bundle = try ControlPlaneBenchmarkExportBundle.decode(json: export.exportBundleJSON)
+            do {
+                if let operatorCommandRunner {
+                    bundle = try await operatorCommandRunner.fetchBenchmarkExportBundle(outputDir: exportDirectory.path)
+                } else {
+                    let export = try await client.exportResults(outputDir: exportDirectory.path)
+                    bundle = try ControlPlaneBenchmarkExportBundle.decode(json: export.exportBundleJSON)
+                }
+            } catch {
+                if try await exportPendingEvaluationSummaryIfAvailable(
+                    selectedJobID: selectedJobIDBeforeRefresh,
+                    formatTitle: formatTitle,
+                    fileName: fileName,
+                    exportDirectory: exportDirectory,
+                    startedAt: startedAt
+                ) {
+                    notifyStateChanged()
+                    return
+                }
+                throw error
             }
             applyBenchmarkExportBundle(bundle)
             let pendingSelectedJobID = selectedJobIDBeforeRefresh.flatMap { jobID -> String? in
@@ -9606,22 +9621,13 @@ public final class RuntimeViewModel {
             let selectedJobID = selectedEvaluationHistoryJobID.isEmpty ? nil : selectedEvaluationHistoryJobID
             let (rowCount, payload) = builder(bundle, selectedJobID)
             guard rowCount > 0 else {
-                if formatTitle == "summary.csv",
-                   let selectedJobID,
-                   let rows = pendingEvaluationSummaryRows[selectedJobID],
-                   rows.isEmpty == false {
-                    let outputURL = exportDirectory.appendingPathComponent(fileName)
-                    try Self.evaluationSummaryCSV(rows: rows)
-                        .write(to: outputURL, atomically: true, encoding: .utf8)
-                    lastEvaluationExport = RuntimeEvaluationExportState(
-                        outputPath: outputURL.path,
-                        rowCount: rows.count,
-                        formatTitle: formatTitle
-                    )
-                    await metrics.record(
-                        name: "menu.eval_export_csv_ms",
-                        valueMs: Date().timeIntervalSince(startedAt) * 1_000
-                    )
+                if try await exportPendingEvaluationSummaryIfAvailable(
+                    selectedJobID: selectedJobID,
+                    formatTitle: formatTitle,
+                    fileName: fileName,
+                    exportDirectory: exportDirectory,
+                    startedAt: startedAt
+                ) {
                     notifyStateChanged()
                     return
                 }
@@ -9644,6 +9650,37 @@ public final class RuntimeViewModel {
             recordLocalError(String(describing: error))
         }
         notifyStateChanged()
+    }
+
+    private func exportPendingEvaluationSummaryIfAvailable(
+        selectedJobID: String?,
+        formatTitle: String,
+        fileName: String,
+        exportDirectory: URL,
+        startedAt: Date
+    ) async throws -> Bool {
+        guard formatTitle == "summary.csv",
+              let selectedJobID,
+              let rows = pendingEvaluationSummaryRows[selectedJobID],
+              rows.isEmpty == false
+        else {
+            return false
+        }
+
+        let outputURL = exportDirectory.appendingPathComponent(fileName)
+        try Self.evaluationSummaryCSV(rows: rows)
+            .write(to: outputURL, atomically: true, encoding: .utf8)
+        selectedEvaluationHistoryJobID = selectedJobID
+        lastEvaluationExport = RuntimeEvaluationExportState(
+            outputPath: outputURL.path,
+            rowCount: rows.count,
+            formatTitle: formatTitle
+        )
+        await metrics.record(
+            name: "menu.eval_export_csv_ms",
+            valueMs: Date().timeIntervalSince(startedAt) * 1_000
+        )
+        return true
     }
 
     private func upsert(model: Melix_Controlplane_V1_ModelSummary) {

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -8943,17 +8943,9 @@ public final class RuntimeViewModel {
     }
 
     private func rebuildEvaluationDerivedState() {
-        guard let benchmarkExportBundle else {
-            evaluationHistory = []
-            evaluationMetricCards = []
-            evaluationSamplePreview = []
-            if selectedEvaluationHistoryJobID.isEmpty == false {
-                selectedEvaluationHistoryJobID = ""
-            }
-            return
-        }
-
-        let exportedHistory = benchmarkExportBundle.evaluationHistoryEntries().map(Self.makeEvaluationHistoryEntryState)
+        let exportedHistory = benchmarkExportBundle?
+            .evaluationHistoryEntries()
+            .map(Self.makeEvaluationHistoryEntryState) ?? []
         let exportedJobIDs = Set(exportedHistory.map(\.jobID))
         let pendingHistory = pendingEvaluationSummaryRows.values
             .compactMap { rows -> RuntimeEvaluationHistoryEntryState? in
@@ -8976,12 +8968,14 @@ public final class RuntimeViewModel {
             selectedEvaluationHistoryJobID = selectedHistoryJobID
         }
 
-        let exportedRows = benchmarkExportBundle.evaluationSummaryCSVRows(jobID: selectedHistoryJobID.isEmpty ? nil : selectedHistoryJobID)
+        let exportedRows = benchmarkExportBundle?
+            .evaluationSummaryCSVRows(jobID: selectedHistoryJobID.isEmpty ? nil : selectedHistoryJobID) ?? []
         let selectedRows = exportedRows.isEmpty
             ? (pendingEvaluationSummaryRows[selectedHistoryJobID] ?? [])
             : exportedRows
         evaluationMetricCards = selectedRows.map(Self.makeEvaluationMetricCardState)
-        evaluationSamplePreview = benchmarkExportBundle.evaluationSampleRows(jobID: selectedHistoryJobID.isEmpty ? nil : selectedHistoryJobID)
+        evaluationSamplePreview = (benchmarkExportBundle?
+            .evaluationSampleRows(jobID: selectedHistoryJobID.isEmpty ? nil : selectedHistoryJobID) ?? [])
             .prefix(6)
             .map(Self.makeEvaluationSamplePreviewState)
     }

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -9583,6 +9583,9 @@ public final class RuntimeViewModel {
         }
         do {
             let exportDirectory = try Self.ensureEvaluationExportDirectory()
+            let selectedJobIDBeforeRefresh = selectedEvaluationHistoryJobID.isEmpty
+                ? selectedEvaluationHistoryEntry?.jobID
+                : selectedEvaluationHistoryJobID
             let bundle: ControlPlaneBenchmarkExportBundle
             if let operatorCommandRunner {
                 bundle = try await operatorCommandRunner.fetchBenchmarkExportBundle(outputDir: exportDirectory.path)
@@ -9591,6 +9594,18 @@ public final class RuntimeViewModel {
                 bundle = try ControlPlaneBenchmarkExportBundle.decode(json: export.exportBundleJSON)
             }
             applyBenchmarkExportBundle(bundle)
+            let pendingSelectedJobID = selectedJobIDBeforeRefresh.flatMap { jobID -> String? in
+                let trimmedJobID = jobID.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard pendingEvaluationSummaryRows[trimmedJobID]?.isEmpty == false else {
+                    return nil
+                }
+                return trimmedJobID
+            }
+            if let pendingSelectedJobID,
+               bundle.evaluationSummaryCSVRows(jobID: pendingSelectedJobID).isEmpty {
+                selectedEvaluationHistoryJobID = pendingSelectedJobID
+                rebuildEvaluationDerivedState()
+            }
             let selectedJobID = selectedEvaluationHistoryJobID.isEmpty ? nil : selectedEvaluationHistoryJobID
             let (rowCount, payload) = builder(bundle, selectedJobID)
             guard rowCount > 0 else {

--- a/apps/macos-menubar/Tests/MenuBarTests/Phase8LoRAWindowSmokeTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/Phase8LoRAWindowSmokeTests.swift
@@ -142,13 +142,15 @@ struct Phase8LoRAWindowSmokeTests {
             foundation: viewModel.desktopFoundationState
         )
         await diagnosticsSection.runEvaluationCompare()
-        viewModel.selectEvaluationHistory(jobID: evaluationJobID)
+        let runnerEvaluationRequests = await runnerClient.recordedEvaluationRequests
+        #expect(runnerEvaluationRequests.isEmpty == false)
+        #expect(runnerEvaluationRequests.last?.parameters["compare_target_model_ids"] == derivedModelID)
+        #expect(viewModel.selectedEvaluationHistoryJobID == evaluationJobID)
         await viewModel.exportSelectedEvaluationSummaryCSV()
         let lastEvaluationExport = try #require(viewModel.lastEvaluationExport)
+        let runnerExports = await runnerClient.recordedExportOutputDirs
         await trainingSection.removeDerivedModel()
         let runnerModelOps = await runnerClient.recordedModelOperationRequests
-        let runnerEvaluationRequests = await runnerClient.recordedEvaluationRequests
-        let runnerExports = await runnerClient.recordedExportOutputDirs
 
         let negativeTrainClient = FakeControlPlaneXPCClient()
         await negativeTrainClient.configureSnapshot(

--- a/apps/macos-menubar/Tests/MenuBarTests/Phase8LoRAWindowSmokeTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/Phase8LoRAWindowSmokeTests.swift
@@ -31,7 +31,8 @@ struct Phase8LoRAWindowSmokeTests {
         )
         let snapshot = phase8LoRAWindowSnapshot(
             models: [baseModel, derivedModel],
-            runtimeSessions: [phase8LoRAWindowRuntimeSession()]
+            runtimeSessions: [phase8LoRAWindowRuntimeSession()],
+            servedModelID: baseModelID
         )
 
         let directClient = FakeControlPlaneXPCClient()
@@ -181,14 +182,16 @@ struct Phase8LoRAWindowSmokeTests {
         await negativeActionClient.configureSnapshot(
             phase8LoRAWindowSnapshot(
                 models: [baseModel],
-                runtimeSessions: [phase8LoRAWindowRuntimeSession()]
+                runtimeSessions: [phase8LoRAWindowRuntimeSession()],
+                servedModelID: baseModelID
             )
         )
         let negativeActionRunnerClient = FakeControlPlaneXPCClient()
         await negativeActionRunnerClient.configureSnapshot(
             phase8LoRAWindowSnapshot(
                 models: [baseModel],
-                runtimeSessions: [phase8LoRAWindowRuntimeSession()]
+                runtimeSessions: [phase8LoRAWindowRuntimeSession()],
+                servedModelID: baseModelID
             )
         )
         await negativeActionRunnerClient.configureExportResult(
@@ -279,12 +282,48 @@ struct Phase8LoRAWindowSmokeTests {
 
 private func phase8LoRAWindowSnapshot(
     models: [Melix_Controlplane_V1_ModelSummary],
-    runtimeSessions: [Melix_Controlplane_V1_ServerSessionRuntimeState] = []
+    runtimeSessions: [Melix_Controlplane_V1_ServerSessionRuntimeState] = [],
+    servedModelID: String = ""
 ) -> Melix_Controlplane_V1_ServerSnapshot {
     var snapshot = Melix_Controlplane_V1_ServerSnapshot()
     snapshot.serverState = .serverReady
     snapshot.models = models
     snapshot.runtimeSessions = runtimeSessions
+    let normalizedServedModelID = servedModelID.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let runtimeSession = runtimeSessions.first, normalizedServedModelID.isEmpty == false {
+        var listener = Melix_Controlplane_V1_GatewayListenerConfigSummary()
+        listener.serverSessionID = runtimeSession.serverSessionID
+        listener.requestedHost = "127.0.0.1"
+        listener.requestedPort = 8080
+        listener.effectiveHost = "127.0.0.1"
+        listener.effectivePort = 8080
+        listener.servedModelID = normalizedServedModelID
+        listener.rateLimitPerMinute = 60
+        listener.timeoutSeconds = 120
+        listener.source = .operatorOverride
+        listener.activeBinding = true
+        snapshot.gatewayConfig.listeners = [listener]
+
+        var servingDefaults = Melix_Controlplane_V1_ServingDefaultsSessionSummary()
+        servingDefaults.serverSessionID = runtimeSession.serverSessionID
+        servingDefaults.servedModelID = normalizedServedModelID
+        servingDefaults.requestedTemperature = 0.7
+        servingDefaults.requestedTopP = 0.9
+        servingDefaults.requestedMaxTokens = 512
+        servingDefaults.requestedStreamIntervalTokens = 16
+        servingDefaults.requestedMaxConcurrentRequests = 1
+        servingDefaults.requestedPrefillBatchSize = 1
+        servingDefaults.requestedCompletionBatchSize = 1
+        servingDefaults.effectiveTemperature = 0.7
+        servingDefaults.effectiveTopP = 0.9
+        servingDefaults.effectiveMaxTokens = 512
+        servingDefaults.effectiveStreamIntervalTokens = 16
+        servingDefaults.effectiveMaxConcurrentRequests = 1
+        servingDefaults.effectivePrefillBatchSize = 1
+        servingDefaults.effectiveCompletionBatchSize = 1
+        servingDefaults.source = .operatorOverride
+        snapshot.servingDefaults.sessions = [servingDefaults]
+    }
     return snapshot
 }
 

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -6829,6 +6829,73 @@ struct RuntimeViewModelTests {
         #expect(summaryCSV.contains("eval.compare.win_rate"))
     }
 
+    @Test("evaluation pending history survives selection before export bundle loads")
+    @MainActor
+    func evaluationPendingHistorySurvivesSelectionBeforeExportBundleLoads() async throws {
+        let client = FakeControlPlaneXPCClient()
+        await client.configureSnapshot(
+            makeSnapshot(
+                serverState: .serverReady,
+                models: [
+                    makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
+                    makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm),
+                ],
+                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+            )
+        )
+        await client.configureExportResult(
+            ControlPlaneExportResult(exportBundleJSON: makeBenchmarkExportBundleJSONWithoutResults())
+        )
+
+        var evaluationJob = Melix_Controlplane_V1_EvaluationJobSummary()
+        evaluationJob.jobID = "eval-pending-no-bundle"
+        evaluationJob.modelID = "melix-dev-text"
+        evaluationJob.taskKind = "text-generation"
+        evaluationJob.sourceRepo = "cais/mmlu"
+        evaluationJob.suiteID = "mmlu"
+        evaluationJob.datasetID = "mmlu.dev.v1"
+        evaluationJob.sampleSize = 8
+        evaluationJob.scoringMode = "multiple_choice_accuracy"
+        evaluationJob.status = "completed"
+        evaluationJob.outputDir = "/tmp/melix/evaluation/runs/eval-pending-no-bundle"
+        evaluationJob.createdAtUnixMs = 1_712_500_000_000
+        evaluationJob.updatedAtUnixMs = 1_712_500_001_000
+
+        var metric = Melix_Controlplane_V1_BenchmarkMetricValue()
+        metric.name = "eval.compare.win_rate"
+        metric.value = 0.625
+        metric.unit = "ratio"
+
+        var evaluationSummary = Melix_Controlplane_V1_EvaluationResultSummary()
+        evaluationSummary.jobID = "eval-pending-no-bundle"
+        evaluationSummary.suiteID = "mmlu"
+        evaluationSummary.datasetID = "mmlu.dev.v1"
+        evaluationSummary.sampleSize = 8
+        evaluationSummary.metrics = [metric]
+        evaluationSummary.reportPath = "/tmp/melix/evaluation/runs/eval-pending-no-bundle/evaluation-report.md"
+        await client.configureEvaluationResponse(
+            ControlPlaneEvaluationResult(job: evaluationJob, results: [evaluationSummary])
+        )
+
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+        viewModel.selectedEvaluationMode = .compare
+        viewModel.selectedEvaluationCompareTargetModelIDs = ["melix-dev-text-lora"]
+        viewModel.selectedEvaluationSuiteIDs = ["mmlu"]
+
+        await viewModel.runEvaluation()
+        viewModel.selectEvaluationHistory(jobID: "eval-pending-no-bundle")
+        await viewModel.exportSelectedEvaluationSummaryCSV()
+
+        let summaryExport = try #require(viewModel.lastEvaluationExport)
+        let summaryCSV = try String(contentsOfFile: summaryExport.outputPath, encoding: .utf8)
+        #expect(viewModel.selectedEvaluationHistoryJobID == "eval-pending-no-bundle")
+        #expect(summaryExport.formatTitle == "summary.csv")
+        #expect(summaryExport.rowCount == 1)
+        #expect(summaryCSV.contains("eval-pending-no-bundle"))
+        #expect(summaryCSV.contains("eval.compare.win_rate"))
+    }
+
     @Test("benchmark matrix evaluation and exports use the shared operator command runner when available")
     @MainActor
     func benchmarkMatrixEvaluationAndExportsUseSharedOperatorCommandRunnerWhenAvailable() async throws {

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -6762,6 +6762,73 @@ struct RuntimeViewModelTests {
         #expect(await runnerClient.recordedExportOutputDirs.isEmpty == false)
     }
 
+    @Test("evaluation export preserves pending job selection after stale bundle refresh")
+    @MainActor
+    func evaluationExportPreservesPendingJobSelectionAfterStaleBundleRefresh() async throws {
+        let client = FakeControlPlaneXPCClient()
+        await client.configureSnapshot(
+            makeSnapshot(
+                serverState: .serverReady,
+                models: [
+                    makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
+                    makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm),
+                ],
+                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+            )
+        )
+        await client.configureExportResult(
+            ControlPlaneExportResult(exportBundleJSON: makeBenchmarkExportBundleJSON())
+        )
+
+        var evaluationJob = Melix_Controlplane_V1_EvaluationJobSummary()
+        evaluationJob.jobID = "eval-pending-selection"
+        evaluationJob.modelID = "melix-dev-text"
+        evaluationJob.taskKind = "text-generation"
+        evaluationJob.sourceRepo = "cais/mmlu"
+        evaluationJob.suiteID = "mmlu"
+        evaluationJob.datasetID = "mmlu.dev.v1"
+        evaluationJob.sampleSize = 8
+        evaluationJob.scoringMode = "multiple_choice_accuracy"
+        evaluationJob.status = "completed"
+        evaluationJob.outputDir = "/tmp/melix/evaluation/runs/eval-pending-selection"
+        evaluationJob.createdAtUnixMs = 1_712_500_000_000
+        evaluationJob.updatedAtUnixMs = 1_712_500_001_000
+
+        var metric = Melix_Controlplane_V1_BenchmarkMetricValue()
+        metric.name = "eval.compare.win_rate"
+        metric.value = 0.625
+        metric.unit = "ratio"
+
+        var evaluationSummary = Melix_Controlplane_V1_EvaluationResultSummary()
+        evaluationSummary.jobID = "eval-pending-selection"
+        evaluationSummary.suiteID = "mmlu"
+        evaluationSummary.datasetID = "mmlu.dev.v1"
+        evaluationSummary.sampleSize = 8
+        evaluationSummary.metrics = [metric]
+        evaluationSummary.reportPath = "/tmp/melix/evaluation/runs/eval-pending-selection/evaluation-report.md"
+        await client.configureEvaluationResponse(
+            ControlPlaneEvaluationResult(job: evaluationJob, results: [evaluationSummary])
+        )
+
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+        viewModel.selectedEvaluationModelID = "melix-dev-text"
+        viewModel.selectedEvaluationMode = .compare
+        viewModel.selectedEvaluationCompareTargetModelIDs = ["melix-dev-text-lora"]
+        viewModel.selectedEvaluationSuiteIDs = ["mmlu"]
+
+        await viewModel.runEvaluation()
+        await viewModel.exportSelectedEvaluationSummaryCSV()
+
+        let summaryExport = try #require(viewModel.lastEvaluationExport)
+        let summaryCSV = try String(contentsOfFile: summaryExport.outputPath, encoding: .utf8)
+        #expect(viewModel.selectedEvaluationHistoryJobID == "eval-pending-selection")
+        #expect(summaryExport.formatTitle == "summary.csv")
+        #expect(summaryExport.rowCount == 1)
+        #expect(summaryCSV.contains("eval-pending-selection"))
+        #expect(summaryCSV.contains("eval.compare.win_rate"))
+    }
+
     @Test("benchmark matrix evaluation and exports use the shared operator command runner when available")
     @MainActor
     func benchmarkMatrixEvaluationAndExportsUseSharedOperatorCommandRunnerWhenAvailable() async throws {

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/GatewayServingDefaultsStore.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/GatewayServingDefaultsStore.swift
@@ -192,6 +192,8 @@ private struct GatewayServingDefaultsDocument: Codable, Equatable, Sendable {
 }
 
 public actor GatewayServingDefaultsStore {
+    private static let builtInMaxTokens: UInt32 = 32_768
+
     private let storeURL: URL
     private let fileManager: FileManager
     private let nowUnixMS: @Sendable () -> Int64
@@ -427,7 +429,7 @@ public actor GatewayServingDefaultsStore {
         )
         let maxTokens = parseUInt32(
             environment["MELIX_GATEWAY_DEFAULT_MAX_TOKENS"],
-            fallback: 256
+            fallback: builtInMaxTokens
         )
         let streamIntervalTokens = parseUInt32(
             environment["MELIX_GATEWAY_STREAM_INTERVAL_TOKENS"],

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/GatewayServingDefaultsStore.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/GatewayServingDefaultsStore.swift
@@ -192,7 +192,7 @@ private struct GatewayServingDefaultsDocument: Codable, Equatable, Sendable {
 }
 
 public actor GatewayServingDefaultsStore {
-    private static let builtInMaxTokens: UInt32 = 32_768
+    internal static let defaultMaxTokens: UInt32 = 32_768
 
     private let storeURL: URL
     private let fileManager: FileManager
@@ -429,7 +429,7 @@ public actor GatewayServingDefaultsStore {
         )
         let maxTokens = parseUInt32(
             environment["MELIX_GATEWAY_DEFAULT_MAX_TOKENS"],
-            fallback: builtInMaxTokens
+            fallback: Self.defaultMaxTokens
         )
         let streamIntervalTokens = parseUInt32(
             environment["MELIX_GATEWAY_STREAM_INTERVAL_TOKENS"],

--- a/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
+++ b/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
@@ -109,6 +109,8 @@ public struct ModelSamplingPolicy: Sendable, Equatable {
     }
 }
 
+private let defaultTextGenerationMaxTokens: UInt32 = 32_768
+
 public struct ResolvedOCRExecutionPolicy: Sendable, Equatable {
     public let promptProfileID: String
     public let promptTemplate: String
@@ -265,7 +267,7 @@ public struct TextRequestShaper: Sendable {
             ?? gatewayServingDefaults?.maxTokens
         let temperature = request.temperature ?? preset?.temperature ?? fallbackTemperature ?? 0.7
         let topP = request.topP ?? preset?.topP ?? fallbackTopP ?? 1.0
-        let maxTokens = request.maxTokens ?? preset?.maxTokens ?? fallbackMaxTokens ?? 256
+        let maxTokens = request.maxTokens ?? preset?.maxTokens ?? fallbackMaxTokens ?? defaultTextGenerationMaxTokens
         let streamIntervalTokens = gatewayServingDefaults?.streamIntervalTokens ?? 1
         let maxConcurrentRequests = gatewayServingDefaults?.maxConcurrentRequests ?? 4
         let concurrentProcessingEnabled = gatewayServingDefaults?.concurrentProcessingEnabled ?? true

--- a/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
+++ b/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
@@ -2,6 +2,8 @@ import Foundation
 import MelixControlPlaneProtocol
 
 public struct OCRExecutionPolicy: Sendable, Equatable {
+    private static let defaultMaxTokens: UInt32 = 256
+
     public let promptProfileID: String
     public let promptTemplate: String
     public let autoPrompt: String
@@ -45,7 +47,7 @@ public struct OCRExecutionPolicy: Sendable, Equatable {
         self.samplingProfileID = samplingProfileID ?? "ocr-default"
         self.temperature = temperature
         self.topP = topP
-        self.maxTokens = maxTokens
+        self.maxTokens = maxTokens ?? Self.defaultMaxTokens
     }
 
     private static func parseList(_ rawValue: String?) -> [String] {
@@ -108,8 +110,6 @@ public struct ModelSamplingPolicy: Sendable, Equatable {
         return UInt32(rawValue)
     }
 }
-
-private let defaultTextGenerationMaxTokens: UInt32 = 32_768
 
 public struct ResolvedOCRExecutionPolicy: Sendable, Equatable {
     public let promptProfileID: String
@@ -267,7 +267,10 @@ public struct TextRequestShaper: Sendable {
             ?? gatewayServingDefaults?.maxTokens
         let temperature = request.temperature ?? preset?.temperature ?? fallbackTemperature ?? 0.7
         let topP = request.topP ?? preset?.topP ?? fallbackTopP ?? 1.0
-        let maxTokens = request.maxTokens ?? preset?.maxTokens ?? fallbackMaxTokens ?? defaultTextGenerationMaxTokens
+        let maxTokens = request.maxTokens
+            ?? preset?.maxTokens
+            ?? fallbackMaxTokens
+            ?? GatewayServingDefaultsStore.defaultMaxTokens
         let streamIntervalTokens = gatewayServingDefaults?.streamIntervalTokens ?? 1
         let maxConcurrentRequests = gatewayServingDefaults?.maxConcurrentRequests ?? 4
         let concurrentProcessingEnabled = gatewayServingDefaults?.concurrentProcessingEnabled ?? true

--- a/services/control-plane-swift/Tests/ControlPlaneTests/GatewayServingDefaultsStoreTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/GatewayServingDefaultsStoreTests.swift
@@ -50,7 +50,7 @@ struct GatewayServingDefaultsStoreTests {
         #expect(session.serverSessionID == ServerSessionRuntimeStore.defaultServerSessionID)
         #expect(session.requestedTemperature == 0.7)
         #expect(session.requestedTopP == 1.0)
-        #expect(session.requestedMaxTokens == 256)
+        #expect(session.requestedMaxTokens == 32_768)
         #expect(session.requestedStreamIntervalTokens == 1)
         #expect(session.requestedMaxConcurrentRequests == 4)
         #expect(session.requestedConcurrentProcessingEnabled)

--- a/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
@@ -1866,7 +1866,7 @@ struct TextEndpointContractTests {
         #expect(!translated.workerRequest.stream)
         #expect(translated.workerRequest.sampling.temperature == 0.7)
         #expect(translated.workerRequest.sampling.topP == 1.0)
-        #expect(translated.workerRequest.sampling.maxOutputTokens == 256)
+        #expect(translated.workerRequest.sampling.maxOutputTokens == 32_768)
         #expect(translated.workerRequest.execution.id.branchID == "branch-main")
         #expect(translated.workerRequest.execution.cacheHints.saveBoundarySnapshot)
         #expect(translated.workerRequest.execution.cacheHints.allowL1)

--- a/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
@@ -1430,6 +1430,34 @@ struct TextEndpointContractTests {
         #expect(translated.workerRequest.execution.ext["melix.ocr.sampling_source"] == "model")
     }
 
+    @Test("ocr token fallback stays short when gateway text defaults increase")
+    func ocrTokenFallbackStaysShortWhenGatewayTextDefaultsIncrease() throws {
+        let translator = ChatRequestTranslator()
+        var modelSettings = Melix_Controlplane_V1_ModelSettings()
+        modelSettings.ext["ocr_prompt_profile_id"] = "ocr-default-v1"
+
+        let normalized = try translator.normalize(
+            OpenAIChatCompletionsRequest(
+                model: "melix-dev-ocr",
+                messages: [.init(role: "user", content: "Read the image.")]
+            )
+        )
+        let translated = try translator.translate(
+            normalized,
+            modelHandle: "melix-dev-ocr::python",
+            modelOCRPolicy: OCRExecutionPolicy(modelSettings: modelSettings),
+            gatewayServingDefaults: GatewayServingDefaultsPolicy(
+                temperature: 0.35,
+                topP: 0.92,
+                maxTokens: 32_768,
+                streamIntervalTokens: 3,
+                maxConcurrentRequests: 5
+            )
+        )
+
+        #expect(translated.workerRequest.sampling.maxOutputTokens == 256)
+    }
+
     @Test("chat request contracts accept image-only multimodal content")
     func chatRequestContractsDecodeImageOnlyMultimodalContent() throws {
         let decoder = JSONDecoder()


### PR DESCRIPTION
## Plan or Spec
- Align Melix's built-in text-generation default `max_tokens` with OMLX's effective `/v1/chat/completions` default of 32768.
- Keep request-provided, preset, model policy, OCR policy, and gateway serving defaults precedence intact.
- Leave OCR model defaults at 256 tokens; this change targets general text generation/provider defaults.

## Commands Run
- `git diff --check`
- `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" xcrun swift build --package-path services/control-plane-swift --target MelixControlPlaneCore`
- `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" xcrun swift test --package-path services/control-plane-swift --filter 'GatewayServingDefaultsStoreTests|TextEndpointContractTests'` *(blocked locally: SwiftPM cannot import the `Testing` module from this CLT-only environment)*
- `HERMES_DUMP_REQUESTS=1 hermes chat -q '请用三段话说明 Melix 作为 LLM Provider 接入 Agent 时应该怎么做回归测试。'`
- Direct `POST http://127.0.0.1:12436/v1/chat/completions` with `max_tokens=256000`

## Coverage and Metrics
- `MelixControlPlaneCore` builds successfully.
- Hermes local config now sends `max_tokens: 256000` to the Melix provider; request dump confirmed the outgoing body contains that field.
- Direct Melix provider request with `max_tokens=256000` returned a complete answer with `completion_tokens=1137` and `finish_reason=stop`.
- Tests updated to assert the new general text default of 32768 while preserving OCR's 256-token model policy.

## Known Gaps
- Full Swift test execution is blocked on this machine by `error: no such module 'Testing'` during test target compilation, despite the CLT framework being present. The library target compile passed.
- The live Hermes fix also requires the local Hermes config change `model.max_tokens: 256000`, which is outside this Melix repository.
