### PR TITLE
perf: reuse deterministic image MIME map

### DIFF
--- a/docs/plans/2026-05-13-deterministic-image-mime-map.md
+++ b/docs/plans/2026-05-13-deterministic-image-mime-map.md
@@ -1,0 +1,32 @@
+# Deterministic image MIME map reuse
+
+## Scope
+
+This Python-only performance slice is limited to `services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py`.
+
+The deterministic image runtime resolves MIME types for each generated or edited image job. The previous helper rebuilt the same literal mapping every time `_mime_type_for_format()` was called. This slice hoists that stable mapping to a module-level constant so repeated image generation/edit paths reuse one dictionary while preserving the existing supported format contract.
+
+## Registered probe
+
+The affected runtime path is already covered by the registered PR-scoped probe `deterministic-image-output-byte-accounting` in `infra/perf/pr_scoped_probes.json`. That entry includes focused `test_command`, `coverage_command`, and `probe_command` fields and watches:
+
+- `services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py`
+- `services/mlx-worker-python/tests/test_image_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/deterministic_image_output_bytes_probe.py`
+
+The local Linux probe compares `elapsed_ms_mean` and preserves output byte accounting guard rails. GitHub Actions PR-scoped performance remains the merge gate after push.
+
+## Verification plan
+
+1. Run the focused image runtime pytest selection from the registered probe.
+2. Run changed-scope coverage through the registered coverage command.
+3. Run `scripts/pr_scoped_performance_run.py` for `deterministic-image-output-byte-accounting` against a clean `origin/main` base worktree and this branch.
+4. Accept only if behavior stays equivalent and the registered probe is green with no metric regression beyond noise.
+
+## Success criteria
+
+- Focused image tests pass.
+- Changed-scope coverage for touched executable scope remains at least 95%.
+- The registered probe completes locally and in CI.
+- The PR-scoped performance workflow reports the registered probe successfully before merge.

--- a/services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py
@@ -12,6 +12,13 @@ from packages.protocol.python.worker.v1 import common_pb2, inference_pb2
 from worker.runtime.deterministic_delay import sleep_if_configured
 
 
+_IMAGE_MIME_TYPES = {
+    "png": "image/png",
+    "jpeg": "image/jpeg",
+    "webp": "image/webp",
+}
+
+
 class ImageGenerationCancelled(RuntimeError):
     pass
 
@@ -289,11 +296,7 @@ class DeterministicImageGenerationRuntime:
 
     @staticmethod
     def _mime_type_for_format(image_format: str) -> str:
-        return {
-            "png": "image/png",
-            "jpeg": "image/jpeg",
-            "webp": "image/webp",
-        }[image_format]
+        return _IMAGE_MIME_TYPES[image_format]
 
     @staticmethod
     def _output_dir(images_root: Path, artifact_namespace: str, job_id: str) -> Path:


### PR DESCRIPTION
## Summary
- Hoists deterministic image MIME format lookup into a module-level constant.
- Avoids rebuilding the same literal mapping on each image generate/edit MIME lookup.

## Plan or Spec
- `docs/plans/2026-05-13-deterministic-image-mime-map.md`

## Commands Run
```text
# baseline sanity probe before edits (origin/main vs origin/main worktrees)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-image-output-byte-accounting --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-image-mime-map-20260513050300 --head-repo "$PWD" --output /tmp/image_output_baseline.json
# result: pass; base elapsed_ms_mean=16.8209, head elapsed_ms_mean=17.3879 (pre-change noise sample)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_image_runtime.py::test_image_generation_and_edit_probe_bytes_do_not_rescan_images services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_image_edit_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_image_output_bytes_probe_script_emits_metrics
# result: 4 passed in 0.43s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_image_runtime.py::test_image_generation_and_edit_probe_bytes_do_not_rescan_images services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_image_edit_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_image_output_bytes_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py services/mlx-worker-python/tests/test_image_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_image_output_bytes_probe.py
# result: 4 passed in 0.73s; changed-scope coverage TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-image-output-byte-accounting --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-image-mime-map-20260513050300 --head-repo "$PWD" --output /tmp/image_output_head.json
# result: pass; base elapsed_ms_mean=19.74997278302908, head elapsed_ms_mean=17.107585771009326, delta=-2.6423870120197535 ms, speedup=1.1544570372108007x; output_byte_scan_calls_mean stayed 0.0 -> 0.0

git diff --check
# result: pass
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 2 0 100%`).
- Registered probe: `deterministic-image-output-byte-accounting`.
- Local Linux probe metrics: `elapsed_ms_mean` 19.74997278302908 ms -> 17.107585771009326 ms (`delta=-2.6423870120197535 ms`, `speedup=1.1544570372108007x`).
- Guard metric: `output_byte_scan_calls_mean` remained `0.0` for base and head.
- CI PR-scoped performance is still required as the merge gate for the registered probe report.

## Known Gaps
- Local validation is Linux-only and covers the Python deterministic image runtime; no Swift runtime effect is claimed.
- Micro-benchmark timings are small and can be noisy, so the registered CI probe result is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
