### PR TITLE
perf: use ASCII scanning for startup version compare

### DIFF
--- a/docs/plans/2026-05-13-startup-version-ascii-digit-fast-path.md
+++ b/docs/plans/2026-05-13-startup-version-ascii-digit-fast-path.md
@@ -1,0 +1,28 @@
+# Startup Version ASCII Digit Fast Path
+
+## Scope
+
+This Python-only performance slice keeps startup version comparison behavior equivalent for Melix semantic-version inputs while avoiding repeated `str.isdigit()` dispatch in the tight normalized-version scanner.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe `startup-signals-version-compare-single-pass` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/startup_signals.py`
+- `services/mlx-worker-python/tests/test_startup_signals.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/startup_signals_version_probe.py`
+
+## Optimization
+
+Use direct ASCII character-code checks inside the normalized version parser for separators (`+`, `-`, `.`) and digit bounds (`0` through `9`). Melix product versions and update-channel versions are ASCII semantic-version strings, and the parser already treats non-prefix suffix text as a zero-valued suffix component.
+
+## Validation Plan
+
+Run the registered focused tests, changed-scope coverage, and the registered probe locally on Linux before pushing. GitHub Actions PR-scoped performance remains the merge gate.
+
+## Success Metric
+
+Accept only if `startup-signals-version-compare-single-pass.elapsed_ms_mean` improves without changing `comparison_total` or increasing measured peak memory.

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -153,17 +153,17 @@ def _next_normalized_version_part(value: str, index: int) -> tuple[int, int, boo
     value_length = len(value)
 
     while index < value_length:
-        character = value[index]
+        character_code = ord(value[index])
         index += 1
-        if character == "+" or character == "-":
+        if character_code == 43 or character_code == 45:
             break
-        if character == ".":
+        if character_code == 46:
             if part_has_chars:
                 return current_value if digit_seen else 0, index, False
             continue
         part_has_chars = True
-        if digit_prefix_active and character.isdigit():
-            current_value = current_value * 10 + (ord(character) - 48)
+        if digit_prefix_active and 48 <= character_code <= 57:
+            current_value = current_value * 10 + (character_code - 48)
             digit_seen = True
         else:
             digit_prefix_active = False
@@ -182,9 +182,10 @@ def _iter_normalized_version_parts(value: str) -> Iterator[int]:
     part_has_chars = False
 
     for character in cleaned[start_index:]:
-        if character == "+" or character == "-":
+        character_code = ord(character)
+        if character_code == 43 or character_code == 45:
             break
-        if character == ".":
+        if character_code == 46:
             if part_has_chars:
                 yield current_value if digit_seen else 0
             current_value = 0
@@ -193,8 +194,8 @@ def _iter_normalized_version_parts(value: str) -> Iterator[int]:
             part_has_chars = False
             continue
         part_has_chars = True
-        if digit_prefix_active and character.isdigit():
-            current_value = current_value * 10 + (ord(character) - 48)
+        if digit_prefix_active and 48 <= character_code <= 57:
+            current_value = current_value * 10 + (character_code - 48)
             digit_seen = True
         else:
             digit_prefix_active = False


### PR DESCRIPTION
## Summary
- Replaces the startup version scanner's hot-loop character/string checks with direct ASCII code checks for `+`, `-`, `.`, and decimal digits.
- Keeps the slice scoped to the registered `startup-signals-version-compare-single-pass` Python path.

## Plan or Spec
- `docs/plans/2026-05-13-startup-version-ascii-digit-fast-path.md`

## Commands Run
```text
# Baseline, origin/main detached worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_version_probe.py
  run1: {"comparison_total": -48.0, "elapsed_ms_mean": 23.772022420806543, "pair_count": 12000.0, "peak_bytes_mean": 112.0, "sample_count": 7.0}
  run2: {"comparison_total": -48.0, "elapsed_ms_mean": 22.208302381581493, "pair_count": 12000.0, "peak_bytes_mean": 112.0, "sample_count": 7.0}
  run3: {"comparison_total": -48.0, "elapsed_ms_mean": 22.793101545955455, "pair_count": 12000.0, "peak_bytes_mean": 112.0, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_does_not_allocate_streaming_part_generators services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics
  exit 0; 6 passed in 1.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_does_not_allocate_streaming_part_generators services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_version_probe.py
  exit 0; TOTAL 10 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_version_probe.py
  run1: {"comparison_total": -48.0, "elapsed_ms_mean": 22.498510145981395, "pair_count": 12000.0, "peak_bytes_mean": 112.0, "sample_count": 7.0}
  run2: {"comparison_total": -48.0, "elapsed_ms_mean": 21.77957901065903, "pair_count": 12000.0, "peak_bytes_mean": 112.0, "sample_count": 7.0}
  run3: {"comparison_total": -48.0, "elapsed_ms_mean": 21.18757224109556, "pair_count": 12000.0, "peak_bytes_mean": 112.0, "sample_count": 7.0}

git diff --check
  exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Registered local probe: `startup-signals-version-compare-single-pass`.
- Baseline mean: `22.924475 ms`; candidate mean: `21.821887 ms`; delta: `-1.102588 ms`; speedup: `4.81%`.
- `comparison_total` remained `-48.0`; `peak_bytes_mean` remained `112.0`.
- CI PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- Linux local verification covers the Python startup-signals path only. CI must validate the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
