### PR TITLE
perf: fast-path statistical category labels

### DIFF
--- a/docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md
+++ b/docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md
@@ -19,7 +19,9 @@ Keep the Phase 8 evaluation-compare category breakdown path behaviorally identic
 
 ## Implementation Note
 
-The accepted slice removes the per-row `row_get = row.get` bound-method allocation and lets CPython dispatch the three `dict.get(...)` calls directly. A trial that added extra category-label sentinel/type-dispatch bindings increased mean time and peak traced bytes, so it was rejected and reverted before this smaller implementation.
+The first accepted slice removed the per-row `row_get = row.get` bound-method allocation and lets CPython dispatch the three `dict.get(...)` calls directly. A trial that added extra category-label sentinel/type-dispatch bindings increased mean time and peak traced bytes, so it was rejected and reverted before that smaller implementation.
+
+This follow-up slice keeps the same category semantics but moves the common non-empty category-label path from `row.get("category_label", "")` to direct key access with a `KeyError` skip for missing labels. The registered probe workload always carries category labels, so the hot path avoids the default-argument dictionary lookup while existing tests continue to cover missing and blank labels.
 
 ## Acceptance Metric
 

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -84,7 +84,11 @@ def build_category_breakdown(
 ) -> dict[str, dict[str, object]]:
     category_totals: dict[str, list[int]] = {}
     for row in rows:
-        category_label = str(row.get("category_label", "")).strip()
+        try:
+            raw_category_label = row["category_label"]
+        except KeyError:
+            continue
+        category_label = str(raw_category_label).strip()
         if not category_label:
             continue
         base_correct = 1 if row.get("base_correct", False) else 0


### PR DESCRIPTION
## Summary
- Fast-path statistical evidence category labels with direct key access in `build_category_breakdown`.
- Preserve missing-label skipping, blank-label skipping, truthiness handling, sorted output, and rounded payload semantics.
- Update the governing statistical category breakdown plan with the follow-up slice details.

## Plan or Spec
- `docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md`

## Commands Run
```text
# Focused tests (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_statistical_evidence.py::test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics
=> 6 passed in 0.61s

# Changed-scope coverage (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_statistical_evidence.py::test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_category_breakdown_probe.py
=> TOTAL 5 0 100%

# Local registered probe, 3 repeated runs each (exit 0)
base elapsed_ms_mean: 12.879109708592296, 15.089107817038894, 12.787408381700516
head elapsed_ms_mean: 13.547420827671885, 13.193237548694015, 12.762086186558008
aggregate base_mean=13.585208635777235, head_mean=13.167581520974636, delta_ms=-0.41762711480259895, improvement=3.0741310347105%

# PR-scoped performance runner (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id statistical-evidence-category-breakdown-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-stat-cat-keyaccess-20260513074142 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-cron-slice-20260513074142 --output /tmp/stat-cat-keyaccess-pr-probe.json
=> base elapsed_ms_mean=13.963447185233235, head elapsed_ms_mean=13.896345440298319, delta_ms=-0.0671017449349165; coverage TOTAL 5 0 100%

# Whitespace check (exit 0)
git diff --check
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%` for the touched executable lines.
- Registered probe: `statistical-evidence-category-breakdown-single-pass`.
- Local repeated probe aggregate: base_mean `13.585208635777235 ms`, head_mean `13.167581520974636 ms`, delta `-0.41762711480259895 ms` (`3.0741310347105%` lower is better), checksum unchanged at `250365.72`.
- Local PR-scoped runner probe: base `13.963447185233235 ms`, head `13.896345440298319 ms`, delta `-0.0671017449349165 ms`; peak bytes unchanged at `16456.0`.
- CI PR-scoped performance report is still required as the merge gate.

## Known Gaps
- The local Linux probe improvement is small and noisy; CI registered probe validation remains the required merge signal.
- Full repository `make` gates were not run locally for this focused Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
