### PR TITLE
perf: stream integration helper tree cleanup

### DIFF
--- a/docs/plans/2026-05-13-integration-helper-remove-tree-oswalk.md
+++ b/docs/plans/2026-05-13-integration-helper-remove-tree-oswalk.md
@@ -1,0 +1,36 @@
+# Integration Helper Remove-Tree Streaming Cleanup Slice
+
+## Context
+
+`tests/integration/helpers.py` owns cleanup for temporary Melix runtime state used by
+integration fixtures. The prior cleanup path materialized every descendant with
+`Path.rglob("*")` and sorted the full list before deletion. Large runtime-state
+trees can therefore pay an avoidable allocation and sort cost during teardown.
+
+## Scope
+
+This slice only changes `LiveMelixStack._remove_tree` to delete fixture-owned
+runtime trees with `os.walk(..., topdown=False, followlinks=False)`. The helper
+keeps the same externally visible behavior: files and symlinks are unlinked,
+directories are removed after their children, missing roots are tolerated, and
+directory symlink targets are not followed.
+
+## Probe and Metrics
+
+The existing PR-scoped integration-helper probe
+`integration-swift-binary-resolution-scandir` is extended so changes to
+`tests/integration/helpers.py` run focused tests, changed-scope coverage, and a
+registered command-json probe for cleanup performance.
+
+The cleanup probe reports:
+
+- `remove_tree_elapsed_ms_mean`
+- `remove_tree_legacy_elapsed_ms_mean`
+- `remove_tree_delta_ms_mean`
+- `remove_tree_peak_bytes_mean`
+- `remove_tree_legacy_peak_bytes_mean`
+- `remove_tree_peak_bytes_delta_mean`
+- fixture dimensions (`remove_tree_directories`, `remove_tree_files_per_directory`)
+
+Success means behavior parity tests pass and the registered probe shows lower
+mean elapsed time or lower peak memory for the os.walk cleanup path.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3582,18 +3582,20 @@
   },
   {
     "id": "integration-swift-binary-resolution-scandir",
-    "name": "Integration Swift binary resolution scandir fallback",
+    "name": "Integration helper cleanup and Swift binary resolution scandir fallbacks",
     "runner": "ubuntu-latest",
     "watch_globs": [
       "tests/integration/helpers.py",
       "tests/integration/test_helper_binary_resolution.py",
       "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
       "scripts/integration_swift_binary_resolution_probe.py",
+      "tests/integration/test_helper_remove_tree.py",
+      "scripts/integration_remove_tree_probe.py",
       "scripts/changed_scope_coverage.py"
     ],
-    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
-    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json tests/integration/helpers.py tests/integration/test_helper_binary_resolution.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/integration_swift_binary_resolution_probe.py",
-    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/integration_swift_binary_resolution_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for PREFIX in \"${MELIX_SWIFT_BINARY_RESOLUTION_HEAD_REPO:-}\" \"${GITHUB_WORKSPACE:-}/head\" \"../head\"; do CANDIDATE=\"$PREFIX/$SCRIPT\"; if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json tests/integration/helpers.py tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/integration_swift_binary_resolution_probe.py scripts/integration_remove_tree_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT=\"$PWD\" MELIX_REMOVE_TREE_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python python3 scripts/integration_swift_binary_resolution_probe.py",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
     "metrics": [
@@ -3617,6 +3619,23 @@
       {
         "key": "candidate_count",
         "unit": "candidates",
+        "direction": "informational"
+      },
+      {
+        "key": "remove_tree_peak_bytes_delta_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "remove_tree_delta_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "remove_tree_directories",
+        "unit": "directories",
         "direction": "informational"
       }
     ]

--- a/scripts/integration_remove_tree_probe.py
+++ b/scripts/integration_remove_tree_probe.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(os.environ.get("MELIX_REMOVE_TREE_REPO_ROOT", Path.cwd())).resolve()
+sys.path.insert(0, str(REPO_ROOT))
+
+from tests.integration import helpers  # noqa: E402
+
+
+def _populate_tree(root: Path, *, directory_count: int, files_per_directory: int) -> None:
+    for index in range(directory_count):
+        nested = root / f"group-{index // 100:04d}" / f"leaf-{index:05d}"
+        nested.mkdir(parents=True, exist_ok=True)
+        for file_index in range(files_per_directory):
+            (nested / f"state-{file_index:02d}.json").write_text("{}\n", encoding="utf-8")
+
+
+def _legacy_remove_tree(root: Path) -> None:
+    if not root.exists():
+        return
+    for child in sorted(root.rglob("*"), reverse=True):
+        if child.is_file() or child.is_symlink():
+            child.unlink(missing_ok=True)
+        else:
+            child.rmdir()
+    root.rmdir()
+
+
+def _new_remove_tree(root: Path) -> None:
+    stack = helpers.LiveMelixStack.__new__(helpers.LiveMelixStack)
+    stack._remove_tree(root)
+
+
+def _run_once(base: Path, *, directory_count: int, files_per_directory: int, legacy: bool) -> tuple[float, int]:
+    root = base / ("legacy" if legacy else "new")
+    _populate_tree(root, directory_count=directory_count, files_per_directory=files_per_directory)
+    tracemalloc.start()
+    started = time.perf_counter()
+    if legacy:
+        _legacy_remove_tree(root)
+    else:
+        _new_remove_tree(root)
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    if root.exists():
+        raise RuntimeError(f"cleanup root still exists: {root}")
+    return elapsed_ms, peak
+
+
+def collect_metrics() -> dict[str, float | int]:
+    directory_count = int(os.environ.get("MELIX_REMOVE_TREE_DIRECTORIES", "1200"))
+    files_per_directory = int(os.environ.get("MELIX_REMOVE_TREE_FILES_PER_DIRECTORY", "2"))
+    samples = int(os.environ.get("MELIX_REMOVE_TREE_SAMPLES", "5"))
+    base = Path(tempfile.mkdtemp(prefix="melix-remove-tree-probe-"))
+    try:
+        old_elapsed: list[float] = []
+        old_peaks: list[float] = []
+        new_elapsed: list[float] = []
+        new_peaks: list[float] = []
+        for sample_index in range(samples):
+            sample_base = base / f"sample-{sample_index:02d}"
+            sample_base.mkdir()
+            elapsed, peak = _run_once(
+                sample_base,
+                directory_count=directory_count,
+                files_per_directory=files_per_directory,
+                legacy=True,
+            )
+            old_elapsed.append(elapsed)
+            old_peaks.append(float(peak))
+            elapsed, peak = _run_once(
+                sample_base,
+                directory_count=directory_count,
+                files_per_directory=files_per_directory,
+                legacy=False,
+            )
+            new_elapsed.append(elapsed)
+            new_peaks.append(float(peak))
+
+        old_mean = statistics.fmean(old_elapsed)
+        new_mean = statistics.fmean(new_elapsed)
+        return {
+            "remove_tree_directories": directory_count,
+            "remove_tree_files_per_directory": files_per_directory,
+            "remove_tree_samples": samples,
+            "remove_tree_legacy_elapsed_ms_mean": old_mean,
+            "remove_tree_elapsed_ms_mean": new_mean,
+            "remove_tree_delta_ms_mean": new_mean - old_mean,
+            "remove_tree_legacy_peak_bytes_mean": statistics.fmean(old_peaks),
+            "remove_tree_peak_bytes_mean": statistics.fmean(new_peaks),
+            "remove_tree_peak_bytes_delta_mean": statistics.fmean(new_peaks) - statistics.fmean(old_peaks),
+        }
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+def main() -> None:
+    print(json.dumps(collect_metrics(), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/integration_swift_binary_resolution_probe.py
+++ b/scripts/integration_swift_binary_resolution_probe.py
@@ -57,7 +57,7 @@ def _run_once(root: Path, build_root: Path, product_name: str, *, legacy: bool) 
     return elapsed_ms, peak, len(resolved.parts)
 
 
-def main() -> None:
+def collect_metrics() -> dict[str, float | int]:
     triples = int(os.environ.get("MELIX_SWIFT_BINARY_RESOLUTION_TRIPLES", "1500"))
     samples = int(os.environ.get("MELIX_SWIFT_BINARY_RESOLUTION_SAMPLES", "5"))
     product_name = "melix-probe"
@@ -81,23 +81,28 @@ def main() -> None:
             new_elapsed.append(elapsed)
             new_peaks.append(float(peak))
 
-        print(
-            json.dumps(
-                {
-                    "candidate_count": triples + 1,
-                    "samples": samples,
-                    "legacy_elapsed_ms_mean": statistics.fmean(old_elapsed),
-                    "elapsed_ms_mean": statistics.fmean(new_elapsed),
-                    "delta_ms_mean": statistics.fmean(new_elapsed) - statistics.fmean(old_elapsed),
-                    "legacy_peak_bytes_mean": statistics.fmean(old_peaks),
-                    "peak_bytes_mean": statistics.fmean(new_peaks),
-                    "peak_bytes_delta_mean": statistics.fmean(new_peaks) - statistics.fmean(old_peaks),
-                },
-                sort_keys=True,
-            )
-        )
+        old_mean = statistics.fmean(old_elapsed)
+        new_mean = statistics.fmean(new_elapsed)
+        return {
+            "candidate_count": triples + 1,
+            "samples": samples,
+            "legacy_elapsed_ms_mean": old_mean,
+            "elapsed_ms_mean": new_mean,
+            "delta_ms_mean": new_mean - old_mean,
+            "legacy_peak_bytes_mean": statistics.fmean(old_peaks),
+            "peak_bytes_mean": statistics.fmean(new_peaks),
+            "peak_bytes_delta_mean": statistics.fmean(new_peaks) - statistics.fmean(old_peaks),
+        }
     finally:
         shutil.rmtree(root, ignore_errors=True)
+
+
+def main() -> None:
+    from scripts.integration_remove_tree_probe import collect_metrics as collect_remove_tree_metrics
+
+    metrics = collect_metrics()
+    metrics.update(collect_remove_tree_metrics())
+    print(json.dumps(metrics, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -188,6 +188,9 @@ def test_integration_swift_binary_resolution_probe_script_emits_metrics(
 ) -> None:
     monkeypatch.setenv("MELIX_SWIFT_BINARY_RESOLUTION_TRIPLES", "8")
     monkeypatch.setenv("MELIX_SWIFT_BINARY_RESOLUTION_SAMPLES", "1")
+    monkeypatch.setenv("MELIX_REMOVE_TREE_DIRECTORIES", "4")
+    monkeypatch.setenv("MELIX_REMOVE_TREE_FILES_PER_DIRECTORY", "1")
+    monkeypatch.setenv("MELIX_REMOVE_TREE_SAMPLES", "1")
 
     runpy.run_path(
         str(REPO_ROOT / "scripts/integration_swift_binary_resolution_probe.py"),
@@ -200,6 +203,31 @@ def test_integration_swift_binary_resolution_probe_script_emits_metrics(
     assert metrics["legacy_elapsed_ms_mean"] >= 0
     assert "delta_ms_mean" in metrics
     assert metrics["peak_bytes_mean"] > 0
+    assert metrics["remove_tree_directories"] == 4
+    assert metrics["remove_tree_elapsed_ms_mean"] >= 0
+    assert metrics["remove_tree_legacy_elapsed_ms_mean"] >= 0
+    assert "remove_tree_delta_ms_mean" in metrics
+
+
+def test_integration_remove_tree_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_REMOVE_TREE_DIRECTORIES", "4")
+    monkeypatch.setenv("MELIX_REMOVE_TREE_FILES_PER_DIRECTORY", "1")
+    monkeypatch.setenv("MELIX_REMOVE_TREE_SAMPLES", "1")
+
+    runpy.run_path(
+        str(REPO_ROOT / "scripts/integration_remove_tree_probe.py"),
+        run_name="__main__",
+    )
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["remove_tree_directories"] == 4
+    assert metrics["remove_tree_files_per_directory"] == 1
+    assert metrics["remove_tree_elapsed_ms_mean"] >= 0
+    assert metrics["remove_tree_legacy_elapsed_ms_mean"] >= 0
+    assert "remove_tree_peak_bytes_delta_mean" in metrics
 
 
 def test_scope_report_selects_mlx_text_stop_kwarg_probe() -> None:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -358,12 +358,23 @@ class LiveMelixStack:
     def _remove_tree(self, root: Path) -> None:
         if not root.exists():
             return
-        for child in sorted(root.rglob("*"), reverse=True):
-            if child.is_file() or child.is_symlink():
-                child.unlink(missing_ok=True)
-            else:
-                child.rmdir()
-        root.rmdir()
+        root_path = os.fspath(root)
+        for directory, dirnames, filenames in os.walk(root_path, topdown=False, followlinks=False):
+            for filename in filenames:
+                try:
+                    os.unlink(os.path.join(directory, filename))
+                except FileNotFoundError:
+                    pass
+            for dirname in dirnames:
+                child_dir = os.path.join(directory, dirname)
+                if os.path.islink(child_dir):
+                    try:
+                        os.unlink(child_dir)
+                    except FileNotFoundError:
+                        pass
+                else:
+                    os.rmdir(child_dir)
+        os.rmdir(root_path)
 
     def _control_plane_hit_port_conflict(self) -> bool:
         stderr = (

--- a/tests/integration/test_helper_remove_tree.py
+++ b/tests/integration/test_helper_remove_tree.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import tests.integration.helpers as helpers
+
+
+def _stack() -> helpers.LiveMelixStack:
+    return helpers.LiveMelixStack.__new__(helpers.LiveMelixStack)
+
+
+def test_remove_tree_uses_os_walk_without_rglob(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "runtime-state"
+    nested = root / "state" / "sessions"
+    nested.mkdir(parents=True)
+    (root / "gateway.json").write_text("{}", encoding="utf-8")
+    (nested / "session.json").write_text("{}", encoding="utf-8")
+
+    def fail_rglob(self: Path, pattern: str):
+        raise AssertionError(f"Path.rglob should not be used for runtime cleanup: {pattern}")
+
+    monkeypatch.setattr(Path, "rglob", fail_rglob)
+
+    _stack()._remove_tree(root)
+
+    assert not root.exists()
+
+
+def test_remove_tree_removes_directory_symlink_without_following_target(tmp_path: Path) -> None:
+    root = tmp_path / "runtime-state"
+    target = tmp_path / "shared-target"
+    target.mkdir()
+    (target / "preserved.txt").write_text("preserve", encoding="utf-8")
+    root.mkdir()
+    (root / "linked-dir").symlink_to(target, target_is_directory=True)
+
+    _stack()._remove_tree(root)
+
+    assert not root.exists()
+    assert (target / "preserved.txt").read_text(encoding="utf-8") == "preserve"
+
+
+def test_remove_tree_tolerates_missing_root(tmp_path: Path) -> None:
+    _stack()._remove_tree(tmp_path / "missing")
+
+
+def test_remove_tree_ignores_disappearing_file_entries(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "runtime-state"
+    root.mkdir()
+    disappearing = root / "stale.json"
+    disappearing.write_text("{}", encoding="utf-8")
+    original_unlink = helpers.os.unlink
+
+    def tracked_unlink(path: str) -> None:
+        if Path(path).name == "stale.json":
+            original_unlink(path)
+            raise FileNotFoundError(path)
+        original_unlink(path)
+
+    monkeypatch.setattr(helpers.os, "unlink", tracked_unlink)
+
+    _stack()._remove_tree(root)
+
+    assert not root.exists()
+
+
+def test_remove_tree_ignores_disappearing_directory_symlink(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "runtime-state"
+    target = tmp_path / "shared-target"
+    target.mkdir()
+    root.mkdir()
+    link = root / "linked-dir"
+    link.symlink_to(target, target_is_directory=True)
+    original_unlink = helpers.os.unlink
+
+    def tracked_unlink(path: str) -> None:
+        if Path(path).name == "linked-dir":
+            original_unlink(path)
+            raise FileNotFoundError(path)
+        original_unlink(path)
+
+    monkeypatch.setattr(helpers.os, "unlink", tracked_unlink)
+
+    _stack()._remove_tree(root)
+
+    assert not root.exists()
+    assert target.exists()


### PR DESCRIPTION
## Summary
- Replace integration fixture runtime-tree cleanup from sorted `Path.rglob("*")` materialization with bottom-up `os.walk` deletion.
- Preserve cleanup behavior for files, nested directories, directory symlinks, missing roots, and disappearing entries.
- Extend the registered integration-helper PR-scoped probe so helper changes include cleanup metrics alongside the existing Swift binary resolution metrics.

## Plan or Spec
- `docs/plans/2026-05-13-integration-helper-remove-tree-oswalk.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics
# 5 passed in 0.86s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 13 passed in 0.19s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json tests/integration/helpers.py tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/integration_swift_binary_resolution_probe.py scripts/integration_remove_tree_probe.py
# 15 passed in 0.50s; TOTAL 43 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT="$PWD" MELIX_REMOVE_TREE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/integration_swift_binary_resolution_probe.py
# {"candidate_count": 1501, "delta_ms_mean": -73.10706381686032, "elapsed_ms_mean": 80.28587657026947, "legacy_elapsed_ms_mean": 153.39294038712978, "legacy_peak_bytes_mean": 1679192.4, "peak_bytes_delta_mean": -1675518.2, "peak_bytes_mean": 3674.2, "remove_tree_delta_ms_mean": -133.47908318974078, "remove_tree_directories": 1200, "remove_tree_elapsed_ms_mean": 115.90280579403043, "remove_tree_files_per_directory": 2, "remove_tree_legacy_elapsed_ms_mean": 249.3818889837712, "remove_tree_legacy_peak_bytes_mean": 3657145.4, "remove_tree_peak_bytes_delta_mean": -3628347.8, "remove_tree_peak_bytes_mean": 28797.6, "remove_tree_samples": 5, "samples": 5}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 43 0 100%` from `scripts/changed_scope_coverage.py`.
- Registered probe: `integration-swift-binary-resolution-scandir` now covers integration helper cleanup and Swift binary resolution.
- Cleanup probe local Linux metrics: `remove_tree_legacy_elapsed_ms_mean=249.3819 ms`, `remove_tree_elapsed_ms_mean=115.9028 ms`, `remove_tree_delta_ms_mean=-133.4791 ms`; `remove_tree_legacy_peak_bytes_mean=3,657,145.4`, `remove_tree_peak_bytes_mean=28,797.6`, `remove_tree_peak_bytes_delta_mean=-3,628,347.8`.
- Existing binary-resolution metrics still improved locally: `legacy_elapsed_ms_mean=153.3929 ms`, `elapsed_ms_mean=80.2859 ms`, `delta_ms_mean=-73.1071 ms`.

## Known Gaps
- This is a Linux-local Python/helper slice. No Swift runtime effect is claimed locally; the registered PR-scoped performance workflow is still required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
