### PR TITLE
perf: trim serving diagnostics queue event overhead

### DIFF
--- a/docs/plans/2026-05-12-observability-probe-policy.md
+++ b/docs/plans/2026-05-12-observability-probe-policy.md
@@ -342,6 +342,9 @@ Executable units:
   specific debug environment variable is enabled.
 - CI isolation: PR-scoped probe commands run from `infra/perf/pr_scoped_probes.json`
   and are not imported by serving hot path modules.
+- Debug queue event overhead: high-volume debug diagnostics should keep bounded
+  queue event objects slot-backed so saturation probes measure append/drop
+  semantics without per-event instance dictionaries.
 
 ## Acceptance Metrics For Follow-Up Issues
 

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -172,6 +172,20 @@ def test_serving_diagnostics_bounded_queue_drops_oldest_without_blocking(
     assert [row["event_index"] for row in event_rows] == [1, 2]
 
 
+def test_serving_diagnostics_event_instances_use_slots_for_debug_queue() -> None:
+    event = ServingDiagnosticsEvent(
+        request_id="req-slots",
+        phase="decode",
+        event_index=1,
+        status="completed",
+        duration_ms=0.25,
+        attributes={"token": "ok"},
+    )
+
+    assert hasattr(event, "__dict__") is False
+    assert event.to_dict()["attributes"] == {"token": "ok"}
+
+
 def test_serving_diagnostics_bounded_queue_serializes_append_during_snapshot() -> None:
     first_event = ServingDiagnosticsEvent(
         request_id="req-concurrent",

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -35,10 +35,11 @@ class BoundedServingDiagnosticsEventQueue:
 
     def append(self, event: ServingDiagnosticsEvent) -> bool:
         with self._lock:
-            dropped = len(self._events) >= self._max_events
+            events = self._events
+            dropped = len(events) >= self._max_events
             if dropped:
                 self._dropped_count += 1
-            self._events.append(event)
+            events.append(event)
             return not dropped
 
     def snapshot(self) -> ServingDiagnosticsQueueSnapshot:
@@ -114,7 +115,7 @@ class ServingDiagnosticsRequestSummary:
         }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ServingDiagnosticsEvent:
     request_id: str
     phase: str


### PR DESCRIPTION
## Summary
- Trim serving diagnostics debug queue overhead by reusing the deque lookup inside `append` and making `ServingDiagnosticsEvent` slot-backed.
- Add regression coverage that debug queue events do not carry per-instance dictionaries while preserving serialized output.
- Update the observability probe-policy plan with the debug queue event-overhead metric.

## Plan or Spec
- `docs/plans/2026-05-12-observability-probe-policy.md` — Plan 3.2 / Plan 5.1 debug diagnostics queue overhead.

## Commands Run
```text
# Baseline on origin/main, before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 23 passed in 0.65s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# exit 0; elapsed_ms_mean=8.457565, dropped_count=4032, retained_count=64

# Head verification
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 24 passed in 0.10s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 24 passed in 0.25s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# exit 0; TOTAL 8 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# exit 0; elapsed_ms_mean=6.93814, dropped_count=4032, retained_count=64

git diff --check
# exit 0
```

## Coverage and Metrics
- Registered PR-scoped probe: `serving-diagnostics-debug-queue-bounds` is already present in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command`.
- Changed-scope coverage: `TOTAL 8 0 100%` for `serving_diagnostics.py`, `test_serving_diagnostics.py`, `test_pr_scoped_performance.py`, and `serving_diagnostics_queue_probe.py`.
- Local Linux probe comparison on 30-sample paired runs:
  - old_mean_ms=(7.295531 + 8.443751) / 2 = 7.869641
  - new_mean_ms=(7.566299 + 7.154664) / 2 = 7.360482
  - delta_ms=-0.509160
  - speedup=1.069x (~6.47% lower mean elapsed time)
- Registered head probe smoke: `elapsed_ms_mean=6.93814`, `dropped_count=4032`, `retained_count=64`.

## Known Gaps
- Local evidence is Linux/Python-only. CI must complete the registered PR-scoped performance workflow before merge.
- No protocol or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
