### PR TITLE
Harden production probe policy defaults

### DIFF
--- a/services/mlx-worker-python/tests/telemetry_fixtures.py
+++ b/services/mlx-worker-python/tests/telemetry_fixtures.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import subprocess
+import threading
+import tracemalloc
+
+import pytest
+
 from worker.productization.apple_silicon_telemetry import (
     AppleSiliconProcessSample,
     AppleSiliconTelemetryCollector,
@@ -59,3 +65,37 @@ def fixture_telemetry_collector(*, sample_count: int = 1) -> AppleSiliconTelemet
         sample_count=sample_count,
         join_timeout_s=1.0,
     )
+
+
+def guard_production_safe_probe_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_heavy_sample(*args: object, **kwargs: object) -> None:
+        raise AssertionError("production-safe probe policy must not call the heavy telemetry sampler")
+
+    def fail_sleep(*args: object, **kwargs: object) -> None:
+        raise AssertionError("production-safe probe policy must not sleep during persist")
+
+    def fail_thread_start(self: threading.Thread) -> None:
+        raise AssertionError("production-safe probe policy must not start a telemetry thread")
+
+    original_subprocess_run = subprocess.run
+
+    def fail_powermetrics(*args: object, **kwargs: object) -> subprocess.CompletedProcess[object]:
+        command = args[0] if args else kwargs.get("args")
+        if "powermetrics" in str(command):
+            raise AssertionError("production-safe probe policy must not call powermetrics")
+        return original_subprocess_run(*args, **kwargs)
+
+    def fail_tracemalloc_start(*args: object, **kwargs: object) -> None:
+        raise AssertionError("production-safe probe policy must not start tracemalloc")
+
+    monkeypatch.setattr(
+        "worker.productization.apple_silicon_telemetry.MacOSAppleSiliconSampler.sample",
+        fail_heavy_sample,
+    )
+    monkeypatch.setattr(
+        "worker.productization.apple_silicon_telemetry.subprocess.run",
+        fail_powermetrics,
+    )
+    monkeypatch.setattr("worker.productization.apple_silicon_telemetry.time.sleep", fail_sleep)
+    monkeypatch.setattr(threading.Thread, "start", fail_thread_start)
+    monkeypatch.setattr(tracemalloc, "start", fail_tracemalloc_start)

--- a/services/mlx-worker-python/tests/test_benchmark_store.py
+++ b/services/mlx-worker-python/tests/test_benchmark_store.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import threading
 from pathlib import Path
 
 import pytest
@@ -15,7 +14,7 @@ from worker.productization.benchmark_schemas import (
 )
 from worker.productization.benchmark_store import BenchmarkStore
 from worker.productization.probe_policy import ProbeMode, ProbePolicy
-from telemetry_fixtures import fixture_telemetry_collector
+from telemetry_fixtures import fixture_telemetry_collector, guard_production_safe_probe_paths
 
 
 class _CountingRow:
@@ -413,22 +412,7 @@ def test_persist_serving_benchmark_default_policy_skips_heavy_telemetry(
         reason="probe policy foundation is expected from the main implementation",
     )
     monkeypatch.setenv("MELIX_PROBE_MODE", probe_mode)
-
-    def fail_heavy_sample(*args: object, **kwargs: object) -> None:
-        raise AssertionError("production-safe probe policy must not call the heavy telemetry sampler")
-
-    def fail_sleep(*args: object, **kwargs: object) -> None:
-        raise AssertionError("production-safe probe policy must not sleep during persist")
-
-    def fail_thread_start(self: threading.Thread) -> None:
-        raise AssertionError("production-safe probe policy must not start a telemetry thread")
-
-    monkeypatch.setattr(
-        "worker.productization.apple_silicon_telemetry.MacOSAppleSiliconSampler.sample",
-        fail_heavy_sample,
-    )
-    monkeypatch.setattr("worker.productization.apple_silicon_telemetry.time.sleep", fail_sleep)
-    monkeypatch.setattr(threading.Thread, "start", fail_thread_start)
+    guard_production_safe_probe_paths(monkeypatch)
 
     jobs_root = tmp_path / "bench"
     job = build_serving_benchmark_job(

--- a/services/mlx-worker-python/tests/test_evaluation_store.py
+++ b/services/mlx-worker-python/tests/test_evaluation_store.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import csv
 import io
 import json
-import threading
 from pathlib import Path
 
 import pytest
@@ -24,7 +23,7 @@ from worker.productization.benchmark_export import (
 )
 from worker.productization.evaluation_store import EvaluationStore
 from worker.productization.probe_policy import ProbeMode, ProbePolicy
-from telemetry_fixtures import fixture_telemetry_collector
+from telemetry_fixtures import fixture_telemetry_collector, guard_production_safe_probe_paths
 
 
 def test_write_jsonl_streams_rows_without_building_one_giant_payload(monkeypatch) -> None:
@@ -1245,22 +1244,7 @@ def test_persist_result_default_policy_skips_heavy_telemetry(
         reason="probe policy foundation is expected from the main implementation",
     )
     monkeypatch.setenv("MELIX_PROBE_MODE", probe_mode)
-
-    def fail_heavy_sample(*args: object, **kwargs: object) -> None:
-        raise AssertionError("production-safe probe policy must not call the heavy telemetry sampler")
-
-    def fail_sleep(*args: object, **kwargs: object) -> None:
-        raise AssertionError("production-safe probe policy must not sleep during persist")
-
-    def fail_thread_start(self: threading.Thread) -> None:
-        raise AssertionError("production-safe probe policy must not start a telemetry thread")
-
-    monkeypatch.setattr(
-        "worker.productization.apple_silicon_telemetry.MacOSAppleSiliconSampler.sample",
-        fail_heavy_sample,
-    )
-    monkeypatch.setattr("worker.productization.apple_silicon_telemetry.time.sleep", fail_sleep)
-    monkeypatch.setattr(threading.Thread, "start", fail_thread_start)
+    guard_production_safe_probe_paths(monkeypatch)
 
     jobs_root = tmp_path / "evaluation"
     run_root = jobs_root / "runs" / f"eval-policy-{probe_mode or 'empty'}"


### PR DESCRIPTION
## Summary
- Hardened the production-safe probe policy regression tests for `BenchmarkStore` and `EvaluationStore`.
- The tests now fail if production-safe defaults invoke Apple Silicon sampler paths, start telemetry threads, call `/usr/bin/powermetrics`, sleep in the telemetry sampler, or start `tracemalloc`.

## Plan or Spec
- Governing plan: `docs/plans/2026-05-12-observability-probe-policy.md`
- Implements the remaining evidence for issue #882 / Plan 1.2 production default tests.
- Closes #882.
- Closes #889.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" /Users/chenyu/Documents/github/melix/.venv/bin/python -m pytest services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_benchmark_store.py::test_persist_serving_benchmark_default_policy_skips_heavy_telemetry services/mlx-worker-python/tests/test_evaluation_store.py::test_persist_result_default_policy_skips_heavy_telemetry
# 13 passed in 1.00s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" /Users/chenyu/Documents/github/melix/.venv/bin/python -m pytest services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_evaluation_store.py
# 34 passed in 1.54s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" .venv/bin/python -m coverage run --source=worker.productization -m pytest services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_evaluation_store.py
# 34 passed in 0.67s

.venv/bin/python -m coverage report --include='services/mlx-worker-python/worker/productization/probe_policy.py,services/mlx-worker-python/worker/productization/benchmark_store.py,services/mlx-worker-python/worker/productization/evaluation_store.py'
# TOTAL 314 statements, 13 missed, 96% coverage

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=20000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=3 /Users/chenyu/Documents/github/melix/.venv/bin/python scripts/probe_policy_noop_overhead_probe.py
# threshold_passed=1.0, no_op_recorder_overhead_pct=-1.787813, no_op_policy_check_overhead_pct=563.454759

UV_PYTHON=3.12 make py-test
# 2497 passed, 14 skipped, 2 warnings in 121.35s

make swift-test-protocol
# Initial run failed resolving grpc-swift-protobuf from stale cache; authorized network refresh resolved dependencies, then failed locally with "no such module 'XCTest'" because this host only has Command Line Tools at /Library/Developer/CommandLineTools and no /Applications/Xcode.app.

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" .venv/bin/python scripts/validate_pr_evidence.py --body-file .runtime/pr-issue-882-body.md
# PR evidence looks valid.
```

## Coverage and Metrics
- Changed productization scope coverage: 96% across `probe_policy.py`, `benchmark_store.py`, and `evaluation_store.py`.
- Observability mode covered: production-safe `off`, `minimal`, invalid fallback to `minimal`, and empty fallback to `minimal`.
- Probe overhead metric: no-op recorder overhead passed the 5% threshold with `threshold_passed=1.0`; the policy-check property cost is recorded as informational.

## Known Gaps
- `make py-test` initially failed when uv selected Python 3.14 because `pyarrow==19.0.1` attempted a source build and `cmake` was unavailable; rerun with the supported `UV_PYTHON=3.12` passed.
- `make swift-test-protocol` was attempted. After refreshing SwiftPM dependencies, it failed locally with `no such module 'XCTest'` because this host has Command Line Tools only and no full Xcode installation.
- `make bootstrap`, `make proto`, full `make swift-test`, and `make integration-test` were not rerun for this Python test-only change.
- No protocol, dependency, generated artifact, or formal doc changes were required; the governing plan already describes the production default behavior.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
