### PR TITLE
perf: fast-path diff control marker parsing

### DIFF
--- a/docs/plans/2026-05-13-changed-scope-diff-marker-fast-path.md
+++ b/docs/plans/2026-05-13-changed-scope-diff-marker-fast-path.md
@@ -1,0 +1,33 @@
+# Changed-scope coverage diff marker fast path
+
+## Context
+
+The changed-scope coverage helper parses `git diff --unified=0` output in PR
+and local evidence flows. Its parser already dispatches on the first character of
+each diff line to avoid repeated prefix checks on hot context/addition/deletion
+lines.
+
+## Slice
+
+Treat any diff control line whose first character is `\` as the synthetic
+"No newline at end of file" marker after the parser has entered a hunk. This
+removes an extra `startswith("\\ ")` call from the hot parser loop while keeping
+normal source lines safe: context lines that contain a literal leading backslash
+still arrive from git with a leading space, and added/deleted source lines still
+arrive with `+` or `-`.
+
+## Probe and success metric
+
+Registered PR-scoped probe: `changed-scope-coverage-diff-parser` in
+`infra/perf/pr_scoped_probes.json`.
+
+Success metric: `elapsed_ms_mean` from `scripts/changed_scope_coverage_parse_probe.py`
+should decrease or remain within the probe tolerance while parser behavior tests
+continue to pass.
+
+## Verification plan
+
+- Run focused changed-scope parser tests.
+- Run the registered coverage command for the changed scope.
+- Run the registered `changed-scope-coverage-diff-parser` probe locally on Linux
+  before opening the PR.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -63,7 +63,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
             continue
         if current_changed_lines is None or new_line is None:
             continue
-        if first_char == "\\" and line.startswith("\\ "):
+        if first_char == "\\":
             continue
         if first_char == "+":
             current_changed_lines.add(new_line)


### PR DESCRIPTION
## Summary
- Fast-path changed-scope coverage diff control marker handling by dispatching directly on the leading backslash.
- Add a focused plan for the registered diff parser performance slice.

## Plan or Spec
- `docs/plans/2026-05-13-changed-scope-diff-marker-fast-path.md`

## Commands Run
```text
# Baseline probe before the change, 5 separate runs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage_parse_probe.py
old elapsed_ms_mean samples: 3.127659709813694, 4.361567882976185, 3.2213528368932507, 3.260733268689364, 3.220960459051033
old_mean=3.438454831484705 ms

# Candidate probe after the change, 5 separate runs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage_parse_probe.py
new elapsed_ms_mean samples: 3.5782723571173847, 3.326522244606167, 3.2661313695522645, 3.079401950041453, 3.081567857104043
new_mean=3.2663791556842625 ms; delta_ms=-0.1720756758004427; speedup=5.004447760220873%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
23 passed in 0.78s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
23 passed in 0.44s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
Wrote JSON report to coverage.json

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
TOTAL 1 0 100%

python3 scripts/changed_scope_coverage_parse_probe.py
{"changed_line_count": 7680.0, "elapsed_ms_mean": 3.1497780000790954, "elapsed_ms_min": 2.973756054416299, "file_count": 240.0, "line_count": 16080.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Registered local probe: `changed-scope-coverage-diff-parser` via `scripts/changed_scope_coverage_parse_probe.py`.
- Local Linux metric comparison: `old_mean=3.438454831484705 ms`, `new_mean=3.2663791556842625 ms`, `delta_ms=-0.1720756758004427`, `speedup=5.004447760220873%`.
- CI PR-scoped performance is required for the registered probe validation before merge.

## Known Gaps
- Local validation is Linux-only; this slice is Python tooling and does not claim Swift runtime effects.
- The repository root worktree had an unrelated dirty `uv.lock`; this PR was created from an isolated worktree based on `origin/main` and did not touch that file.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
