### PR TITLE
perf: cache probe policy mode flags

### DIFF
--- a/docs/plans/2026-05-13-probe-policy-mode-check-fast-path.md
+++ b/docs/plans/2026-05-13-probe-policy-mode-check-fast-path.md
@@ -1,0 +1,36 @@
+# Probe Policy Mode Check Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to
+`services/mlx-worker-python/worker/productization/probe_policy.py` and its
+focused tests. It keeps probe mode semantics unchanged while avoiding per-call
+temporary set allocation and repeated enum comparisons in the hot
+`telemetry_enabled` and `evidence_enabled` properties.
+
+## Registered performance probe
+
+The affected path is covered by the registered PR-scoped probe
+`probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`. The probe has
+focused `test_command`, `coverage_command`, and `probe_command` entries and
+reports:
+
+- `no_op_policy_check_call_ms_mean`
+- `no_op_policy_check_overhead_pct`
+- `no_op_recorder_overhead_pct`
+- `threshold_passed`
+
+## Verification plan
+
+1. Run the focused probe policy tests and PR-scoped performance registry tests on
+   Linux.
+2. Run changed-scope coverage for the touched probe policy files and tests.
+3. Run the registered `probe-policy-noop-overhead` probe locally, then use the
+   GitHub PR-scoped performance workflow as the merge gate.
+
+## Success criteria
+
+- Probe policy behavior remains identical for all supported modes.
+- Changed-scope coverage remains at least 95%.
+- The local registered probe and CI registered probe show a clear non-regression
+  or improvement in policy-check overhead with `threshold_passed == 1.0`.

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -38,6 +38,14 @@ def test_probe_policy_telemetry_enabled_only_for_sampling_modes() -> None:
     assert ProbePolicy(mode=ProbeMode.DEBUG).telemetry_enabled is True
 
 
+def test_probe_policy_evidence_enabled_only_for_evidence_modes() -> None:
+    assert ProbePolicy(mode=ProbeMode.OFF).evidence_enabled is False
+    assert ProbePolicy(mode=ProbeMode.MINIMAL).evidence_enabled is False
+    assert ProbePolicy(mode=ProbeMode.SAMPLED).evidence_enabled is False
+    assert ProbePolicy(mode=ProbeMode.EVIDENCE).evidence_enabled is True
+    assert ProbePolicy(mode=ProbeMode.DEBUG).evidence_enabled is True
+
+
 def test_no_op_probe_policy_overhead_metrics_are_thresholded() -> None:
     metrics = measure_no_op_probe_policy_overhead(iterations=16, samples=1, threshold_pct=10_000.0)
     payload = metrics.to_dict()

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Mapping
 
@@ -22,21 +22,26 @@ class ProbePolicy:
     mode: ProbeMode = ProbeMode.MINIMAL
     source_value: str = ""
     fallback_applied: bool = False
+    _telemetry_enabled: bool = field(init=False, repr=False, compare=False)
+    _evidence_enabled: bool = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        mode = self.mode
+        evidence_enabled = mode is ProbeMode.EVIDENCE or mode is ProbeMode.DEBUG
+        object.__setattr__(
+            self,
+            "_telemetry_enabled",
+            mode is ProbeMode.SAMPLED or evidence_enabled,
+        )
+        object.__setattr__(self, "_evidence_enabled", evidence_enabled)
 
     @property
     def telemetry_enabled(self) -> bool:
-        return self.mode in {
-            ProbeMode.SAMPLED,
-            ProbeMode.EVIDENCE,
-            ProbeMode.DEBUG,
-        }
+        return self._telemetry_enabled
 
     @property
     def evidence_enabled(self) -> bool:
-        return self.mode in {
-            ProbeMode.EVIDENCE,
-            ProbeMode.DEBUG,
-        }
+        return self._evidence_enabled
 
     @property
     def no_op_reason(self) -> str:


### PR DESCRIPTION
## Summary
- Cache `ProbePolicy` telemetry/evidence mode flags at construction time.
- Avoid repeated temporary membership checks in hot `telemetry_enabled` and `evidence_enabled` property reads.
- Add focused evidence-mode behavior coverage for the cached flag path.

## Plan or Spec
- `docs/plans/2026-05-13-probe-policy-mode-check-fast-path.md`
- Registered PR-scoped probe: `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json` (includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 9 passed in 0.11s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py
# exit 0; TOTAL 16 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py
# exit 0; latest repeated samples showed threshold_passed=1.0 and no_op_policy_check_call_ms_mean around 0.000073-0.000082 ms

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id probe-policy-noop-overhead --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-probe-policy-20260513115507 --head-repo "$PWD" --output /tmp/probe_policy_noop_overhead_result2.json
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 16 0 100%`).
- Local registered base-vs-head probe (`probe-policy-noop-overhead`):
  - `no_op_policy_check_call_ms_mean`: base `0.000202663` ms, head `0.000076376` ms, delta `-0.000126287` ms (`62.31%` faster).
  - `no_op_policy_check_overhead_pct`: base `414.373096`, head `99.670597`.
  - `threshold_passed` is noisy because it gates no-op recorder overhead rather than the policy check itself; direct repeated head probes after the change reported `threshold_passed=1.0` in 3/3 samples.
- CI PR-scoped performance is still required as the merge gate for the registered probe.

## Known Gaps
- Local verification was Linux-only. No Swift/runtime effect is claimed for this Python-only slice.
- The registered probe's `threshold_passed` metric is sensitive to no-op recorder microbenchmark noise; the targeted policy-check metric is the intended optimization signal.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
