### PR TITLE
perf: cache serving diagnostics queue occupancy

### DIFF
--- a/docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md
+++ b/docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md
@@ -1,0 +1,38 @@
+# Serving Diagnostics Queue Retained Count Slice
+
+## Scope
+
+This slice optimizes only the Python serving diagnostics debug event queue append path.
+`BoundedServingDiagnosticsEventQueue.append(...)` keeps the same bounded-queue semantics:
+append returns `False` once the fixed queue capacity has been reached, the oldest event is
+dropped by the underlying bounded deque, and snapshots still report retained events plus the
+accumulated dropped-event count.
+
+## Linux-only constraint
+
+This slice is Python-only under `services/mlx-worker-python` and is locally verifiable on Linux
+with focused pytest, changed-scope coverage, and the registered PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/productization/serving_diagnostics.py`
+- `docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md`
+
+## Registered probe
+
+The affected path is already covered by `serving-diagnostics-debug-queue-bounds` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`,
+`coverage_command`, and `probe_command` values. The probe repeatedly appends debug events to a
+bounded queue and reports:
+
+- `elapsed_ms_mean` — lower is better
+- `dropped_count` — guard rail for bounded drop semantics
+- `retained_count` — guard rail for fixed retained capacity
+
+## Acceptance
+
+- Focused serving diagnostics tests pass.
+- Changed-scope coverage for `serving_diagnostics.py` is at least 95%.
+- The registered local probe reports lower `elapsed_ms_mean` than the origin/main baseline while
+  preserving `dropped_count` and `retained_count`.
+- `git diff --check` passes.

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -30,16 +30,18 @@ class BoundedServingDiagnosticsEventQueue:
     def __init__(self, *, max_events: int = 256) -> None:
         self._max_events = max(int(max_events), 1)
         self._events: deque[ServingDiagnosticsEvent] = deque(maxlen=self._max_events)
+        self._retained_count = 0
         self._dropped_count = 0
         self._lock = threading.Lock()
 
     def append(self, event: ServingDiagnosticsEvent) -> bool:
         with self._lock:
-            events = self._events
-            dropped = len(events) >= self._max_events
+            dropped = self._retained_count >= self._max_events
             if dropped:
                 self._dropped_count += 1
-            events.append(event)
+            else:
+                self._retained_count += 1
+            self._events.append(event)
             return not dropped
 
     def snapshot(self) -> ServingDiagnosticsQueueSnapshot:


### PR DESCRIPTION
## Summary
- Cache the serving diagnostics bounded queue occupancy so saturated debug-event appends no longer call `len(deque)` on every append.
- Preserve bounded deque semantics: append returns `False` once capacity is reached, dropped events are counted, and snapshots retain the newest events.

## Plan or Spec
- `docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md`
- Registered probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json` already covers the affected path and includes focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
# Baseline on origin/main before the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
{"elapsed_ms_mean": 7.671965, "dropped_count": 4032.0, "retained_count": 64.0, ...}
{"elapsed_ms_mean": 7.179853, "dropped_count": 4032.0, "retained_count": 64.0, ...}
{"elapsed_ms_mean": 7.902002, "dropped_count": 4032.0, "retained_count": 64.0, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
24 passed in 0.66s

# After the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
{"elapsed_ms_mean": 7.263651, "dropped_count": 4032.0, "retained_count": 64.0, ...}
{"elapsed_ms_mean": 7.587893, "dropped_count": 4032.0, "retained_count": 64.0, ...}
{"elapsed_ms_mean": 7.013499, "dropped_count": 4032.0, "retained_count": 64.0, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
24 passed in 0.23s
TOTAL 4 0 100%

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 4 0 100%`).
- Local registered probe, 3-run mean: old_mean=7.584607 ms, new_mean=7.288348 ms, delta=-0.296259 ms, speedup=1.040648x.
- Guard rails unchanged: `dropped_count=4032.0`, `retained_count=64.0`.
- CI must run the PR-scoped registered probe and is the merge gate.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python performance slice.
- The local probe is synthetic Linux evidence for the registered Python path; GitHub Actions PR-scoped performance must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: debug/evidence synthetic queue probe; no production observability surface changed.
- [x] Deferred work and known gaps are stated explicitly.
