### PR TITLE
perf: simplify serving diagnostics queue drop accounting

### DIFF
--- a/docs/plans/2026-05-13-serving-diagnostics-queue-len-drop.md
+++ b/docs/plans/2026-05-13-serving-diagnostics-queue-len-drop.md
@@ -1,0 +1,40 @@
+# Serving diagnostics queue length-based drop accounting
+
+## Goal
+
+Reduce append-path overhead in `BoundedServingDiagnosticsEventQueue` by deriving drop decisions from the bounded deque length instead of maintaining a separate retained-event counter.
+
+## Scope
+
+- `services/mlx-worker-python/worker/productization/serving_diagnostics.py`
+- `services/mlx-worker-python/tests/test_serving_diagnostics.py`
+- Registered PR-scoped probe: `serving-diagnostics-debug-queue-bounds`
+
+## Current behavior
+
+The diagnostics queue keeps a bounded `deque(maxlen=...)`, a retained counter, and a dropped counter. The retained counter increments until capacity, then append increments dropped count while the bounded deque evicts the oldest event. This is correct, but the retained counter duplicates state already available through `len(self._events)`.
+
+## Planned change
+
+Use `len(self._events) >= self._max_events` while holding the queue lock to determine whether the incoming event will drop an existing retained event. Remove the redundant retained counter from the append path. Public behavior remains unchanged:
+
+- `append()` returns `True` for retained-without-drop events and `False` when capacity was already full.
+- `snapshot().events` retains the newest bounded events in order.
+- `snapshot().dropped_count` reports the number of over-capacity appends.
+
+## Verification
+
+Use the existing registered PR-scoped performance probe in `infra/perf/pr_scoped_probes.json`:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
+```
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage remains at or above 95%.
+- Local Linux probe shows a stable lower `elapsed_ms_mean` versus the `origin/main` baseline for the same workload, or the slice is rejected.
+- Hosted PR-scoped performance CI runs the registered probe successfully before merge.

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -30,17 +30,14 @@ class BoundedServingDiagnosticsEventQueue:
     def __init__(self, *, max_events: int = 256) -> None:
         self._max_events = max(int(max_events), 1)
         self._events: deque[ServingDiagnosticsEvent] = deque(maxlen=self._max_events)
-        self._retained_count = 0
         self._dropped_count = 0
         self._lock = threading.Lock()
 
     def append(self, event: ServingDiagnosticsEvent) -> bool:
         with self._lock:
-            dropped = self._retained_count >= self._max_events
+            dropped = len(self._events) >= self._max_events
             if dropped:
                 self._dropped_count += 1
-            else:
-                self._retained_count += 1
             self._events.append(event)
             return not dropped
 


### PR DESCRIPTION
## Summary
- Simplifies `BoundedServingDiagnosticsEventQueue.append()` drop accounting by using the bounded deque length instead of maintaining a duplicate retained-event counter.
- Keeps queue semantics unchanged: over-capacity appends still return `False`, retain the newest events, and increment `dropped_count`.

## Plan or Spec
- `docs/plans/2026-05-13-serving-diagnostics-queue-len-drop.md`
- Registered PR-scoped probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline from origin/main (ae2955b7771fbf53382832a641cd560865d49a2a)
MELIX_SERVING_DIAGNOSTICS_QUEUE_EVENTS=20000 MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=7 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# exit 0; {"capacity": 64.0, "dropped_count": 19936.0, "elapsed_ms_mean": 43.14633, "event_count": 20000.0, "retained_count": 64.0, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 24 passed in 0.68s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# exit 0; {"capacity": 64.0, "dropped_count": 4032.0, "elapsed_ms_mean": 7.933243, "event_count": 4096.0, "retained_count": 64.0, "sample_count": 5.0}

MELIX_SERVING_DIAGNOSTICS_QUEUE_EVENTS=20000 MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=7 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# exit 0; {"capacity": 64.0, "dropped_count": 19936.0, "elapsed_ms_mean": 36.073398, "event_count": 20000.0, "retained_count": 64.0, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# exit 0; aggregate changed-line coverage 100.00% (TOTAL 1 0 100%)

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 1 0 100%`).
- Local Linux registered-probe workload comparison (`MELIX_SERVING_DIAGNOSTICS_QUEUE_EVENTS=20000`, `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=7`):
  - baseline `elapsed_ms_mean=43.14633 ms`
  - head `elapsed_ms_mean=36.073398 ms`
  - delta `-7.072932 ms` (`~16.39%` faster)
- Default registered probe on head: `elapsed_ms_mean=7.933243 ms`, `dropped_count=4032`, `retained_count=64`.
- CI must run the registered PR-scoped performance workflow before merge.

## Known Gaps
- Full repository gates were not run locally; this slice used the registered focused test, coverage, and probe commands for the changed Python path.
- Hosted PR-scoped performance CI is required for final registered-probe validation before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: debug diagnostics queue; probe overhead measured by the registered PR-scoped probe.
- [x] Deferred work and known gaps are stated explicitly.
