### PR TITLE
perf: bound hub catalog direct size split

### DIFF
--- a/docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md
+++ b/docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md
@@ -20,8 +20,16 @@ The affected path is already covered by the PR-scoped `hub-catalog-size-hint-reg
 - Run the registered changed-scope coverage command and require at least 95% coverage for touched executable scope.
 - Run `scripts/hub_catalog_size_hint_probe.py` before and after the change on Linux and compare `elapsed_ms_mean` plus `size_hint_calls_mean`.
 
+## Follow-up Slice: Direct Parser Bounded Split
+
+This follow-up keeps the same registered probe and narrows `_direct_size_hint_from_text(...)`
+to a bounded two-token split. Direct `cardData.model_size` values are expected to be shaped
+like `128 MB`; values with additional words still return `0` from the direct parser so the
+existing generic `_size_hint_from_text(...)` fallback can handle labeled text such as
+`Model size: 7 MB`.
+
 ## Success Metrics
 
 - Preserve all existing size-hint parsing behavior by falling back to `_size_hint_from_text(...)` when the direct parser cannot handle the value.
-- Reduce `_size_hint_from_text(...)` calls for direct `cardData.model_size` values in the registered probe.
+- Keep `_size_hint_from_text(...)` call counts unchanged for this bounded-split follow-up.
 - Improve or hold steady `elapsed_ms_mean` in the local registered probe.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -611,7 +611,7 @@ def _size_hint_bytes(payload: dict[str, Any]) -> int:
 
 
 def _direct_size_hint_from_text(text: str) -> int:
-    parts = text.split()
+    parts = text.split(maxsplit=2)
     if len(parts) != 2:
         return 0
     value_text, unit_text = parts


### PR DESCRIPTION
## Summary
- Bound the hub catalog direct `cardData.model_size` parser to a two-token split with `maxsplit=2`.
- Preserve fallback behavior for labeled values such as `Model size: 7 MB`.

## Plan or Spec
- `docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-hub-direct-split-20260513141347 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-cron-slice-20260513141347 --output /tmp/hub-direct-split-report.json
# exit 0; focused tests/coverage replay passed: 50 passed; changed-scope coverage TOTAL 1 0 100%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% for `services/mlx-worker-python/worker/model_ops/hub_catalog.py` (`TOTAL 1 0 100%`).
- Registered local probe `hub-catalog-size-hint-regex-precompile`:
  - base `elapsed_ms_mean=1791.8991139624268`, head `elapsed_ms_mean=1672.1537875477225`
  - delta `-119.74532641470432 ms`, speedup `1.0716x` (about 6.68% faster)
  - guard rails unchanged: `checksum=3424780288.0`, `matched_hint_count=80000.0`, `size_hint_calls_mean=40000.0`, `peak_bytes_mean=1833.0`
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- None. This is a Python-only slice locally verified on Linux; hosted CI remains the registered probe gate before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; probe overhead is unchanged by this parser-only slice.
- [x] Deferred work and known gaps are stated explicitly.
