### PR TITLE
perf: avoid code eval payload strip copy

### DIFF
--- a/docs/plans/2026-05-13-code-eval-payload-bound-scan.md
+++ b/docs/plans/2026-05-13-code-eval-payload-bound-scan.md
@@ -1,0 +1,31 @@
+# Code Eval Payload Boundary Scan
+
+## Goal
+
+Avoid allocating a stripped copy of code-evaluation runner payload bytes before the JSON fast-path field extraction. The fast path only needs to confirm that the payload is an object with optional leading/trailing JSON whitespace, so it can scan the original byte buffer boundaries directly.
+
+## Scope
+
+This slice is Python-only under `services/mlx-worker-python` and can be verified on Linux with focused tests, changed-scope coverage, and the registered PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+
+## Registered performance probe
+
+Use the existing `code-eval-payload-json-bytes` registered PR-scoped probe in `infra/perf/pr_scoped_probes.json`. The probe covers `services/mlx-worker-python/worker/engine/code_eval_runner.py`, has focused `test_command`, `coverage_command`, and `probe_command` entries, and reports:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- `payload_bytes`
+- `sample_count`
+- `iteration_count`
+
+## Success metrics
+
+- Focused pytest passes for the code-eval payload fast path and probe registry smoke tests.
+- Changed-scope coverage for touched Python code is at least 95%.
+- Local registered probe reports a lower mean elapsed time or a neutral result with lower/unchanged peak bytes.
+- `git diff --check` passes.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -872,6 +872,9 @@ def test_load_payload_file_fast_path_falls_back_for_escaped_fields(tmp_path: Pat
 
 
 def test_payload_fast_path_field_extractors_cover_malformed_edges() -> None:
+    assert code_eval_runner._json_object_payload_bounds(b' \n {"runtime_status":"ok"}\t ') == (3, 25)
+    assert code_eval_runner._json_object_payload_bounds(b"   ") is None
+    assert code_eval_runner._json_object_payload_bounds(b' {"runtime_status":"ok"] ') is None
     assert code_eval_runner._json_field_value_start(b'{"runtime_status" : "ok"}', "runtime_status") == 20
     assert code_eval_runner._json_field_value_start(b'{"runtime_status" "ok"}', "runtime_status") is None
     assert code_eval_runner._json_field_value_start(b'{"runtime_status": ', "runtime_status") is None

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -302,9 +302,27 @@ _CODE_EVAL_PAYLOAD_KEY_TOKENS = {
 }
 
 
+_JSON_PAYLOAD_WHITESPACE = b" \t\r\n"
+
+
+def _json_object_payload_bounds(payload_bytes: bytes) -> tuple[int, int] | None:
+    payload_length = len(payload_bytes)
+    start = 0
+    while start < payload_length and payload_bytes[start] in _JSON_PAYLOAD_WHITESPACE:
+        start += 1
+    if start >= payload_length or payload_bytes[start] != ord("{"):
+        return None
+
+    end = payload_length - 1
+    while end > start and payload_bytes[end] in _JSON_PAYLOAD_WHITESPACE:
+        end -= 1
+    if payload_bytes[end] != ord("}"):
+        return None
+    return start, end
+
+
 def _extract_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, object] | None:
-    stripped = payload_bytes.strip()
-    if not stripped.startswith(b"{") or not stripped.endswith(b"}"):
+    if _json_object_payload_bounds(payload_bytes) is None:
         return None
 
     payload: dict[str, object] = {}


### PR DESCRIPTION
## Summary
- Avoid an allocating `bytes.strip()` copy in the code-evaluation payload fast path by scanning JSON object boundaries in the original byte buffer.
- Add regression coverage for whitespace and malformed boundary cases.

## Plan or Spec
- `docs/plans/2026-05-13-code-eval-payload-bound-scan.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
# exit 0; 7 passed in 2.33s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py
# exit 0; TOTAL 18 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
# baseline exit 0; {"elapsed_ms_mean": 218.78031182235904, "iteration_count": 1200.0, "payload_bytes": 55474.0, "peak_bytes_mean": 60425.0, "sample_count": 7.0}
# candidate exit 0; {"elapsed_ms_mean": 208.5386646711933, "iteration_count": 1200.0, "payload_bytes": 55474.0, "peak_bytes_mean": 60425.0, "sample_count": 7.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 18 0 100%`).
- Registered local probe: `code-eval-payload-json-bytes`.
- Probe delta: old_mean=218.7803 ms, new_mean=208.5387 ms, delta=-10.2416 ms, speedup=1.0491x / 4.6812%; peak_bytes_mean unchanged at 60425 bytes.
- CI PR-scoped performance is required to validate the registered probe on GitHub before merge.

## Known Gaps
- None for the Python slice. No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
