### PR TITLE
perf: use scandir for integration runtime cleanup

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -379,7 +379,7 @@ class LiveMelixStack:
                                 os.unlink(entry.path)
                         except FileNotFoundError:
                             pass
-            except FileNotFoundError:
+            except (FileNotFoundError, NotADirectoryError):
                 pass
 
     def _control_plane_hit_port_conflict(self) -> bool:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -359,22 +359,28 @@ class LiveMelixStack:
         if not root.exists():
             return
         root_path = os.fspath(root)
-        for directory, dirnames, filenames in os.walk(root_path, topdown=False, followlinks=False):
-            for filename in filenames:
+        stack: list[tuple[str, bool]] = [(root_path, False)]
+        while stack:
+            path, visited = stack.pop()
+            if visited:
                 try:
-                    os.unlink(os.path.join(directory, filename))
+                    os.rmdir(path)
                 except FileNotFoundError:
                     pass
-            for dirname in dirnames:
-                child_dir = os.path.join(directory, dirname)
-                if os.path.islink(child_dir):
-                    try:
-                        os.unlink(child_dir)
-                    except FileNotFoundError:
-                        pass
-                else:
-                    os.rmdir(child_dir)
-        os.rmdir(root_path)
+                continue
+            try:
+                with os.scandir(path) as entries:
+                    stack.append((path, True))
+                    for entry in entries:
+                        try:
+                            if entry.is_dir(follow_symlinks=False):
+                                stack.append((entry.path, False))
+                            else:
+                                os.unlink(entry.path)
+                        except FileNotFoundError:
+                            pass
+            except FileNotFoundError:
+                pass
 
     def _control_plane_hit_port_conflict(self) -> bool:
         stderr = (

--- a/tests/integration/test_helper_remove_tree.py
+++ b/tests/integration/test_helper_remove_tree.py
@@ -11,7 +11,7 @@ def _stack() -> helpers.LiveMelixStack:
     return helpers.LiveMelixStack.__new__(helpers.LiveMelixStack)
 
 
-def test_remove_tree_uses_os_walk_without_rglob(
+def test_remove_tree_uses_scandir_without_tree_materialization(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -24,7 +24,11 @@ def test_remove_tree_uses_os_walk_without_rglob(
     def fail_rglob(self: Path, pattern: str):
         raise AssertionError(f"Path.rglob should not be used for runtime cleanup: {pattern}")
 
+    def fail_os_walk(*args: object, **kwargs: object):  # pragma: no cover - must never be called
+        raise AssertionError(f"os.walk should not be used for runtime cleanup: {args!r} {kwargs!r}")
+
     monkeypatch.setattr(Path, "rglob", fail_rglob)
+    monkeypatch.setattr(helpers.os, "walk", fail_os_walk)
 
     _stack()._remove_tree(root)
 
@@ -47,6 +51,32 @@ def test_remove_tree_removes_directory_symlink_without_following_target(tmp_path
 
 def test_remove_tree_tolerates_missing_root(tmp_path: Path) -> None:
     _stack()._remove_tree(tmp_path / "missing")
+
+
+def test_remove_tree_ignores_disappearing_directory_before_scan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "runtime-state"
+    nested = root / "state"
+    nested.mkdir(parents=True)
+    (nested / "session.json").write_text("{}", encoding="utf-8")
+    original_scandir = helpers.os.scandir
+    original_rmdir = helpers.os.rmdir
+
+    def tracked_scandir(path: str):
+        if Path(path).name == "state":
+            for child in Path(path).iterdir():
+                child.unlink()
+            original_rmdir(path)
+            raise FileNotFoundError(path)
+        return original_scandir(path)
+
+    monkeypatch.setattr(helpers.os, "scandir", tracked_scandir)
+
+    _stack()._remove_tree(root)
+
+    assert not root.exists()
 
 
 def test_remove_tree_ignores_disappearing_file_entries(


### PR DESCRIPTION
## Summary
- Replace integration runtime cleanup's `os.walk` removal pass with an explicit `os.scandir` stack.
- Keep directory symlink handling non-following and tolerate disappearing file/directory entries during cleanup.
- Extend focused cleanup coverage to assert `os.walk` is not used and the new disappearing-directory path is safe.

## Plan or Spec
- Governing standards: `docs/engineering-standards.md` small-slice performance guidance and registered PR-scoped probe `integration-swift-binary-resolution-scandir` in `infra/perf/pr_scoped_probes.json`.
- Behavior is intended to remain equivalent for runtime cleanup; no canonical product behavior change required.

## Commands Run
```text
# Baseline from origin/main in /root/.hermes/profiles/coder/workspace/worktrees/melix-base-integration-remove-tree-20260513160848
PYTHONPATH="$base:$base/services/mlx-worker-python" MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT="$base" MELIX_REMOVE_TREE_REPO_ROOT="$base" uv run --project "$base/services/mlx-worker-python" python3 "$base/scripts/integration_swift_binary_resolution_probe.py"
exit 0; remove_tree_elapsed_ms_mean=116.32030983455479; remove_tree_peak_bytes_mean=28797.6

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
exit 0; 16 passed in 0.21s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json tests/integration/helpers.py tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/integration_swift_binary_resolution_probe.py scripts/integration_remove_tree_probe.py
exit 0; TOTAL 37 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT="$PWD" MELIX_REMOVE_TREE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/integration_swift_binary_resolution_probe.py
exit 0; remove_tree_elapsed_ms_mean=71.49487757124007; remove_tree_peak_bytes_mean=17348.4

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 37 0 100%` via `scripts/changed_scope_coverage.py`.
- Registered local probe: `integration-swift-binary-resolution-scandir` / `scripts/integration_swift_binary_resolution_probe.py`.
- Base remove-tree probe: `remove_tree_elapsed_ms_mean=116.32030983455479`, `remove_tree_peak_bytes_mean=28797.6`.
- Head remove-tree probe: `remove_tree_elapsed_ms_mean=71.49487757124007`, `remove_tree_peak_bytes_mean=17348.4`.
- Delta: `-44.82543226331472 ms` vs origin/main for remove-tree elapsed mean, `-11449.2 bytes` peak allocation mean.
- Registered probe CI is required as the merge gate for repository-owned PR-scoped validation.

## Known Gaps
- Local Linux validation covers the Python integration helper path only; no Swift runtime effect is claimed locally.
- Full repository gates were not run locally for this small registered-scope slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or no product behavior change is required.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or N/A: this uses an existing PR-scoped evidence probe and does not add runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
