### PR TITLE
Suppress Harmony internal channel leaks

### DIFF
--- a/docs/plans/2026-03-30-m3-4-harmony-protocol-compatibility.md
+++ b/docs/plans/2026-03-30-m3-4-harmony-protocol-compatibility.md
@@ -21,13 +21,23 @@ Add compatibility for harmony-style request and response semantics without intro
 - compatibility should stay in the translation layer
 - request metadata must preserve enough fidelity for later tool-calling and reasoning integration
 - avoid wire-shape drift between live and non-stream responses
+- worker streaming assembly must suppress Harmony internal channels such as `thought`,
+  `analysis`, and `reasoning` from public assistant content while preserving visible
+  `final` and `commentary` channel text
+- the same suppression applies to the Swift text worker generate/decode path because
+  local serving may route text generation there instead of through the Python worker
 
 ## Verification
 
 - `make swift-test`
 - `make integration-test`
+- Focused worker checks:
+  - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_generate_stream.py`
+  - `xcrun swift build --package-path services/mlx-text-worker-swift --product melix-text-worker-swift`
 
 ## Acceptance
 
 - harmony-compatible inputs can be translated into Melix execution requests
 - streaming and completed outputs are contract-tested
+- internal Harmony channel markers do not leak into streamed content or completed
+  `assistant_text`

--- a/services/mlx-text-worker-swift/Sources/Core/Inference/FilteredTextOutputWriter.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Inference/FilteredTextOutputWriter.swift
@@ -1,0 +1,71 @@
+import Foundation
+import GRPCCore
+import MelixWorkerProtocol
+
+struct FilteredTextOutputState {
+    var assistantText = ""
+    var reasoningText = ""
+    var eventCount = 0
+    var sawFirstToken = false
+}
+
+func writeFilteredTextOutput(
+    _ output: HarmonyChannelOutputFilter.Output,
+    response: GRPCCore.RPCWriter<Melix_Worker_V1_ExecuteEvent>,
+    requestID: String,
+    executionKind: String,
+    seq: inout UInt64,
+    state: inout FilteredTextOutputState,
+    metrics: MetricsStore,
+    ttftMetricName: String,
+    startedAt: Date,
+    decorateEvent: (inout Melix_Worker_V1_ExecuteEvent) -> Void = { _ in }
+) async throws {
+    if !output.reasoningText.isEmpty {
+        state.reasoningText += output.reasoningText
+
+        var event = Melix_Worker_V1_ExecuteEvent()
+        event.requestID = requestID
+        event.executionKind = executionKind
+        event.seq = seq
+        seq += 1
+        decorateEvent(&event)
+
+        var payload = Melix_Worker_V1_ReasoningDelta()
+        payload.text = output.reasoningText
+        event.reasoningDelta = payload
+        try await response.write(event)
+        state.eventCount += 1
+    }
+
+    guard !output.visibleText.isEmpty else {
+        return
+    }
+
+    if !state.sawFirstToken {
+        state.sawFirstToken = true
+        metrics.recordMilliseconds(
+            ttftMetricName,
+            value: filteredOutputElapsedMilliseconds(since: startedAt)
+        )
+    }
+
+    state.assistantText += output.visibleText
+
+    var event = Melix_Worker_V1_ExecuteEvent()
+    event.requestID = requestID
+    event.executionKind = executionKind
+    event.seq = seq
+    seq += 1
+    decorateEvent(&event)
+
+    var payload = Melix_Worker_V1_TokenDelta()
+    payload.text = output.visibleText
+    event.tokenDelta = payload
+    try await response.write(event)
+    state.eventCount += 1
+}
+
+private func filteredOutputElapsedMilliseconds(since startedAt: Date) -> Int {
+    max(0, Int(Date().timeIntervalSince(startedAt) * 1_000.0))
+}

--- a/services/mlx-text-worker-swift/Sources/Core/Inference/HarmonyChannelOutputFilter.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Inference/HarmonyChannelOutputFilter.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+struct HarmonyChannelOutputFilter: Sendable {
+    struct Output: Equatable {
+        var visibleText: String = ""
+        var reasoningText: String = ""
+    }
+
+    enum Mode: Equatable {
+        case visible
+        case hidden
+        case unknown
+    }
+
+    private static let openMarker = "<|channel>"
+    private static let headerCloseMarker = "<channel|>"
+    private static let hiddenChannels: Set<String> = ["analysis", "thought", "reasoning"]
+    private static let visibleChannels: Set<String> = ["commentary", "final"]
+
+    private var mode: Mode = .visible
+    private var buffer = ""
+
+    mutating func accept(_ text: String, final: Bool = false) -> Output {
+        guard !text.isEmpty || final else {
+            return Output()
+        }
+        buffer += text
+        return drain(final: final)
+    }
+
+    mutating func finish() -> Output {
+        drain(final: true)
+    }
+
+    private mutating func drain(final: Bool) -> Output {
+        var output = Output()
+
+        while !buffer.isEmpty {
+            guard let markerRange = buffer.range(of: Self.openMarker) else {
+                let heldSuffix = final ? "" : Self.partialOpenMarkerSuffix(in: buffer)
+                if !heldSuffix.isEmpty {
+                    let prefixEnd = buffer.index(buffer.endIndex, offsetBy: -heldSuffix.count)
+                    let prefix = String(buffer[..<prefixEnd])
+                    append(prefix, to: &output)
+                    buffer = heldSuffix
+                    break
+                }
+                append(buffer, to: &output)
+                buffer.removeAll(keepingCapacity: true)
+                break
+            }
+
+            if markerRange.lowerBound > buffer.startIndex {
+                let prefix = String(buffer[..<markerRange.lowerBound])
+                append(prefix, to: &output)
+                buffer.removeSubrange(..<markerRange.lowerBound)
+                continue
+            }
+
+            guard let headerCloseRange = buffer.range(
+                of: Self.headerCloseMarker,
+                range: buffer.index(buffer.startIndex, offsetBy: Self.openMarker.count)..<buffer.endIndex
+            ) else {
+                if final {
+                    buffer.removeAll(keepingCapacity: true)
+                }
+                break
+            }
+
+            let headerStart = buffer.index(buffer.startIndex, offsetBy: Self.openMarker.count)
+            let header = String(buffer[headerStart..<headerCloseRange.lowerBound])
+            mode = Self.mode(for: header)
+            buffer.removeSubrange(buffer.startIndex..<headerCloseRange.upperBound)
+        }
+
+        return output
+    }
+
+    private mutating func append(_ text: String, to output: inout Output) {
+        switch mode {
+        case .visible:
+            output.visibleText += text
+        case .hidden:
+            output.reasoningText += text
+        case .unknown:
+            break
+        }
+    }
+
+    private static func mode(for header: String) -> Mode {
+        guard let channel = header
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: { $0.isWhitespace })
+            .first?
+            .lowercased()
+        else {
+            return .unknown
+        }
+        if visibleChannels.contains(channel) {
+            return .visible
+        }
+        if hiddenChannels.contains(channel) {
+            return .hidden
+        }
+        return .unknown
+    }
+
+    private static func partialOpenMarkerSuffix(in text: String) -> String {
+        guard !text.isEmpty else {
+            return ""
+        }
+        var candidate = ""
+        for length in 1..<openMarker.count {
+            let start = text.index(text.endIndex, offsetBy: -min(length, text.count))
+            let suffix = String(text[start...])
+            if openMarker.hasPrefix(suffix) {
+                candidate = suffix
+            }
+        }
+        return candidate
+    }
+}

--- a/services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeEngine.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeEngine.swift
@@ -62,9 +62,7 @@ struct TextDecodeEngine: Sendable {
 
             var seq: UInt64 = 1
             var completionTokens = 0
-            var assistantText = ""
-            var eventCount = 0
-            var sawFirstToken = false
+            var outputState = FilteredTextOutputState()
             var tokensPerSecond: Double?
             var speculativeAccepted: Int?
             var speculativeRejected: Int?
@@ -76,6 +74,26 @@ struct TextDecodeEngine: Sendable {
             var dflashRollbackCount: Int?
             var dflashTargetHiddenLayers: Int?
             var activeKVProbe: ActiveKVProbeSummary?
+
+            func writeOutput(_ output: HarmonyChannelOutputFilter.Output) async throws {
+                try await writeFilteredTextOutput(
+                    output,
+                    response: response,
+                    requestID: requestID,
+                    executionKind: "decode",
+                    seq: &seq,
+                    state: &outputState,
+                    metrics: metrics,
+                    ttftMetricName: "swift_text.decode_ttft_ms",
+                    startedAt: startedAt,
+                    decorateEvent: { event in
+                        event.phase = .executionDecoding
+                        event.admissionState = .admissionAdmitted
+                        event.lane = lane
+                        event.accelerationMode = acceleration.mode
+                    }
+                )
+            }
 
             if acceleration.mode != .baseline {
                 var accelerationEvent = Melix_Worker_V1_ExecuteEvent()
@@ -92,7 +110,7 @@ struct TextDecodeEngine: Sendable {
                 accelerationEvent.accelerationApplied = payload
                 try await response.write(accelerationEvent)
                 seq += 1
-                eventCount += 1
+                outputState.eventCount += 1
             }
 
             var startedEvent = Melix_Worker_V1_ExecuteEvent()
@@ -111,7 +129,7 @@ struct TextDecodeEngine: Sendable {
             startedEvent.decodeStarted = payload
             try await response.write(startedEvent)
             seq += 1
-            eventCount += 1
+            outputState.eventCount += 1
 
             if !session.prefill.restoredSnapshotID.isEmpty {
                 var cacheDecisionEvent = Melix_Worker_V1_ExecuteEvent()
@@ -130,41 +148,20 @@ struct TextDecodeEngine: Sendable {
                 cacheDecisionEvent.cacheDecision = cacheDecision
                 try await response.write(cacheDecisionEvent)
                 seq += 1
-                eventCount += 1
+                outputState.eventCount += 1
             }
 
+            var outputFilter = HarmonyChannelOutputFilter()
             for try await runtimeEvent in runtimeStream {
                 switch runtimeEvent {
                 case .prefillStarted:
                     continue
                 case .token(let text):
-                    if !sawFirstToken {
-                        sawFirstToken = true
-                        metrics.recordMilliseconds(
-                            "swift_text.decode_ttft_ms",
-                            value: elapsedMilliseconds(since: startedAt)
-                        )
-                    }
-
-                    assistantText.append(text)
-
-                    var event = Melix_Worker_V1_ExecuteEvent()
-                    event.requestID = requestID
-                    event.executionKind = "decode"
-                    event.seq = seq
-                    event.phase = .executionDecoding
-                    event.admissionState = .admissionAdmitted
-                    event.lane = lane
-                    event.accelerationMode = acceleration.mode
-
-                    var tokenDelta = Melix_Worker_V1_TokenDelta()
-                    tokenDelta.text = text
-                    event.tokenDelta = tokenDelta
-                    try await response.write(event)
-                    seq += 1
-                    eventCount += 1
+                    completionTokens += 1
+                    let filtered = outputFilter.accept(text)
+                    try await writeOutput(filtered)
                 case .summary(let summary):
-                    completionTokens = summary.completionTokens
+                    completionTokens = max(completionTokens, summary.completionTokens)
                     tokensPerSecond = summary.tokensPerSecond
                     speculativeAccepted = summary.speculativeAcceptedTokens
                     speculativeRejected = summary.speculativeRejectedTokens
@@ -178,6 +175,9 @@ struct TextDecodeEngine: Sendable {
                     activeKVProbe = summary.activeKVProbe
                 }
             }
+
+            let finalFiltered = outputFilter.finish()
+            try await writeOutput(finalFiltered)
 
             if request.returnUsage && !(abortHandle?.isAborted ?? false) {
                 var event = Melix_Worker_V1_ExecuteEvent()
@@ -195,7 +195,7 @@ struct TextDecodeEngine: Sendable {
                 event.usageDelta = usage
                 try await response.write(event)
                 seq += 1
-                eventCount += 1
+                outputState.eventCount += 1
             }
 
             if request.execution.cacheHints.saveBoundarySnapshot && !(abortHandle?.isAborted ?? false) {
@@ -222,7 +222,7 @@ struct TextDecodeEngine: Sendable {
                 snapshotEvent.snapshotCreated = snapshotCreated
                 try await response.write(snapshotEvent)
                 seq += 1
-                eventCount += 1
+                outputState.eventCount += 1
 
                 metrics.recordMilliseconds(
                     "swift_text.cache_snapshot_save_ms",
@@ -232,7 +232,8 @@ struct TextDecodeEngine: Sendable {
 
             var completed = Melix_Worker_V1_Completed()
             completed.finishReason = (abortHandle?.isAborted ?? false) ? "cancelled" : "stop"
-            completed.assistantText = assistantText
+            completed.assistantText = outputState.assistantText
+            completed.reasoningText = outputState.reasoningText
 
             var completedEvent = Melix_Worker_V1_ExecuteEvent()
             completedEvent.requestID = requestID
@@ -244,16 +245,16 @@ struct TextDecodeEngine: Sendable {
             completedEvent.accelerationMode = acceleration.mode
             completedEvent.completed = completed
             try await response.write(completedEvent)
-            eventCount += 1
+            outputState.eventCount += 1
 
-            if !sawFirstToken {
+            if !outputState.sawFirstToken {
                 metrics.recordMilliseconds(
                     "swift_text.decode_ttft_ms",
                     value: elapsedMilliseconds(since: startedAt)
                 )
             }
             metrics.recordMilliseconds("swift_text.decode_ms", value: elapsedMilliseconds(since: startedAt))
-            metrics.set("swift_text.decode_stream_event_count", value: eventCount)
+            metrics.set("swift_text.decode_stream_event_count", value: outputState.eventCount)
             metrics.set(
                 "swift_text.decode_tokens_per_second",
                 value: max(0, Int((tokensPerSecond ?? 0).rounded()))

--- a/services/mlx-text-worker-swift/Sources/Core/Inference/TextGenerationEngine.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Inference/TextGenerationEngine.swift
@@ -32,10 +32,23 @@ struct TextGenerationEngine: Sendable {
             var seq: UInt64 = 1
             var promptTokens = 0
             var completionTokens = 0
-            var assistantText = ""
-            var eventCount = 0
-            var sawFirstToken = false
+            var outputState = FilteredTextOutputState()
             var tokensPerSecond: Double?
+            var outputFilter = HarmonyChannelOutputFilter()
+
+            func writeOutput(_ output: HarmonyChannelOutputFilter.Output) async throws {
+                try await writeFilteredTextOutput(
+                    output,
+                    response: response,
+                    requestID: requestID,
+                    executionKind: "generate",
+                    seq: &seq,
+                    state: &outputState,
+                    metrics: metrics,
+                    ttftMetricName: "swift_text.ttft_ms",
+                    startedAt: startedAt
+                )
+            }
 
             for try await runtimeEvent in runtimeStream {
                 switch runtimeEvent {
@@ -51,36 +64,20 @@ struct TextGenerationEngine: Sendable {
                     payload.inputTokens = UInt32(max(0, inputTokens))
                     event.prefillStarted = payload
                     try await response.write(event)
-                    eventCount += 1
+                    outputState.eventCount += 1
                 case .token(let text):
-                    if !sawFirstToken {
-                        sawFirstToken = true
-                        metrics.recordMilliseconds(
-                            "swift_text.ttft_ms",
-                            value: elapsedMilliseconds(since: startedAt)
-                        )
-                    }
-
-                    assistantText.append(text)
                     completionTokens += 1
-
-                    var event = Melix_Worker_V1_ExecuteEvent()
-                    event.requestID = requestID
-                    event.executionKind = "generate"
-                    event.seq = seq
-                    seq += 1
-
-                    var payload = Melix_Worker_V1_TokenDelta()
-                    payload.text = text
-                    event.tokenDelta = payload
-                    try await response.write(event)
-                    eventCount += 1
+                    let filtered = outputFilter.accept(text)
+                    try await writeOutput(filtered)
                 case .summary(let summary):
                     promptTokens = max(promptTokens, summary.promptTokens)
                     completionTokens = max(completionTokens, summary.completionTokens)
                     tokensPerSecond = summary.tokensPerSecond
                 }
             }
+
+            let finalFiltered = outputFilter.finish()
+            try await writeOutput(finalFiltered)
 
             if request.returnUsage && !abortHandle.isAborted {
                 var event = Melix_Worker_V1_ExecuteEvent()
@@ -94,12 +91,13 @@ struct TextGenerationEngine: Sendable {
                 payload.completionTokens = UInt32(max(0, completionTokens))
                 event.usageDelta = payload
                 try await response.write(event)
-                eventCount += 1
+                outputState.eventCount += 1
             }
 
             var completed = Melix_Worker_V1_Completed()
             completed.finishReason = abortHandle.isAborted ? "cancelled" : "stop"
-            completed.assistantText = assistantText
+            completed.assistantText = outputState.assistantText
+            completed.reasoningText = outputState.reasoningText
 
             var completedEvent = Melix_Worker_V1_ExecuteEvent()
             completedEvent.requestID = requestID
@@ -107,16 +105,16 @@ struct TextGenerationEngine: Sendable {
             completedEvent.seq = seq
             completedEvent.completed = completed
             try await response.write(completedEvent)
-            eventCount += 1
+            outputState.eventCount += 1
 
-            if !sawFirstToken {
+            if !outputState.sawFirstToken {
                 metrics.recordMilliseconds(
                     "swift_text.ttft_ms",
                     value: elapsedMilliseconds(since: startedAt)
                 )
             }
             metrics.recordMilliseconds("swift_text.generate_ms", value: elapsedMilliseconds(since: startedAt))
-            metrics.set("swift_text.stream_event_count", value: eventCount)
+            metrics.set("swift_text.stream_event_count", value: outputState.eventCount)
 
             if let tokensPerSecond {
                 metrics.set(

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -21,6 +21,24 @@ import Tokenizers
 
 @available(macOS 15.0, *)
 final class WorkerScaffoldTests: XCTestCase {
+    func testHarmonyChannelOutputFilterSuppressesInternalChannels() {
+        var filter = HarmonyChannelOutputFilter()
+
+        let first = filter.accept("<|chan")
+        let second = filter.accept("nel>thought\n<channel|>\nsecret")
+        let third = filter.accept("<|channel>debug\n<channel|>\ndropped")
+        let fourth = filter.accept("<|channel>final\n<channel|>\nvisible")
+        let finished = filter.finish()
+
+        XCTAssertEqual(first, HarmonyChannelOutputFilter.Output())
+        XCTAssertEqual(second.reasoningText, "\nsecret")
+        XCTAssertEqual(second.visibleText, "")
+        XCTAssertEqual(third, HarmonyChannelOutputFilter.Output())
+        XCTAssertEqual(fourth.visibleText, "\nvisible")
+        XCTAssertEqual(fourth.reasoningText, "")
+        XCTAssertEqual(finished, HarmonyChannelOutputFilter.Output())
+    }
+
     func testConfigurationDefaultsPreferDedicatedWorkerIdentity() {
         let configuration = WorkerConfiguration()
         let matchingConfiguration = WorkerConfiguration(
@@ -3589,6 +3607,79 @@ final class WorkerScaffoldTests: XCTestCase {
         XCTAssertEqual(recorded.last?.completed.finishReason, "stop")
         XCTAssertFalse(recorded.last?.completed.assistantText.isEmpty ?? true)
         XCTAssertEqual(services.metrics.counters["swift_text.stream_event_count"], recorded.count)
+    }
+
+    func testGenerateSuppressesHarmonyThoughtChannelForLoadedModel() async throws {
+        let services = makeServices(
+            environment: ["MELIX_DEV_TEXT_MODEL_PATH": "mlx-community/melix-dev-text-4bit"],
+            backend: FakeRuntimeBackend(generatedChunks: [
+                "<|channel>thought\n<channel|>\n{\"output\":\"pwd\",\"exit_code\":0}",
+                "<|channel>final\n<channel|>\nRepository reviewed.",
+            ])
+        )
+        let loadResponse = try await withTestServerContextRPCCancellationHandle { handle in
+            var request = Melix_Worker_V1_LoadModelRequest()
+            request.model.modelID = "melix-dev-text"
+            return try await services.runtime.loadModel(
+                request: request,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_RuntimeService.Method.LoadModel.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        let writer = RecordingRPCWriter<Melix_Worker_V1_ExecuteEvent>()
+        var request = Melix_Worker_V1_GenerateRequest()
+        request.execution.id.requestID = "req-harmony-generate"
+        request.execution.modelHandle = loadResponse.modelHandle
+        request.execution.ext["melix.harmony"] = "true"
+        request.returnUsage = true
+        var message = Melix_Worker_V1_ChatMessage()
+        message.role = "user"
+        var part = Melix_Worker_V1_MessagePart()
+        part.text = "Review the repo."
+        message.parts = [part]
+        request.messages = [message]
+
+        try await withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.generate(
+                request: request,
+                response: RPCWriter(wrapping: writer),
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Generate.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        let recorded = await writer.snapshot()
+        let tokenText = recorded.compactMap { event -> String? in
+            guard case .tokenDelta(let token) = event.payload else {
+                return nil
+            }
+            return token.text
+        }
+        let reasoningText = recorded.compactMap { event -> String? in
+            guard case .reasoningDelta(let reasoning) = event.payload else {
+                return nil
+            }
+            return reasoning.text
+        }
+        let usage = try XCTUnwrap(recorded.first { event in
+            matches(event.payload, .usageDelta)
+        }?.usageDelta)
+
+        XCTAssertEqual(tokenText, ["\nRepository reviewed."])
+        XCTAssertEqual(reasoningText, ["\n{\"output\":\"pwd\",\"exit_code\":0}"])
+        XCTAssertEqual(usage.completionTokens, 2)
+        XCTAssertEqual(recorded.last?.completed.assistantText, "\nRepository reviewed.")
+        XCTAssertFalse(recorded.last?.completed.assistantText.contains("<|channel>") ?? true)
+        XCTAssertFalse(recorded.last?.completed.assistantText.contains("pwd") ?? true)
     }
 
     func testGenerateReturnsNotFoundErrorEventForUnknownModelHandle() async throws {

--- a/services/mlx-worker-python/tests/test_generate_stream.py
+++ b/services/mlx-worker-python/tests/test_generate_stream.py
@@ -95,6 +95,28 @@ class ActionQualifiedToolStreamingBackend:
         )
 
 
+class HarmonyChannelStreamingBackend:
+    runtime_name = "fake-mlx"
+
+    def load_model(self, model_spec):
+        return {"model_id": model_spec.model_id}
+
+    def estimate_resident_bytes(self, model_spec):
+        return 2048
+
+    def generate_tokens(self, loaded_model, prompt, sampling, cancel_event):
+        yield RuntimeTokenEvent(
+            text="",
+            raw_text=(
+                '<|channel>thought\n<channel|>\n{"output":"pwd","exit_code":0}'
+                "<|channel>final\n<channel|>\nRepository reviewed."
+            ),
+            prompt_tokens=3,
+            completion_tokens=1,
+            finish_reason="stop",
+        )
+
+
 class ShortPrefixStreamingBackend:
     runtime_name = "fake-mlx"
 
@@ -690,6 +712,44 @@ def test_generate_stream_normalizes_tool_calls_to_declared_openai_tool_names() -
     assert completed.assistant_text == ""
     assert completed.parser_metrics["tool_call_name_normalized_count"] == "1"
     assert completed.parser_metrics["unknown_tool_delta_count"] == "0"
+
+
+def test_generate_stream_suppresses_harmony_thought_channel_content() -> None:
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=HarmonyChannelStreamingBackend()),
+        model_catalog=WorkerModelCatalog(),
+    )
+    runtime_service = WorkerRuntimeService(registry)
+    inference_service = WorkerInferenceService(registry)
+    load_response = runtime_service.LoadModel(
+        runtime_pb2.LoadModelRequest(model=WorkerModelCatalog.dev_text_model()),
+        context=None,
+    )
+    request = inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(request_id="req-harmony-channel-output"),
+            model_handle=load_response.model_handle,
+            ext={"melix.harmony": "true"},
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(text="Review the repo.")],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=16),
+        stream=True,
+    )
+
+    events = list(inference_service.Generate(request, context=None))
+    token_text = [event.token_delta.text for event in events if event.HasField("token_delta")]
+    completed = next(event.completed for event in events if event.HasField("completed"))
+
+    assert token_text == ["\nRepository reviewed."]
+    assert completed.assistant_text == "\nRepository reviewed."
+    assert "pwd" not in completed.assistant_text
+    assert completed.parser_metrics["harmony_channel_hidden_count"] == "1"
+    assert completed.parser_metrics["harmony_channel_markup_leak_count"] == "0"
 
 
 def test_generate_stream_flushes_short_visible_prefix_before_marker_hold() -> None:

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -12,10 +12,6 @@ def test_structural_tag_prefixes_are_cached_per_parser_mode() -> None:
         RequestStreamAssembler._THINK_OPEN[:index]
         for index in range(1, len(RequestStreamAssembler._THINK_OPEN))
     )
-    pipe_reasoning_prefixes = tuple(
-        RequestStreamAssembler._PIPE_REASONING_OPEN[:index]
-        for index in range(1, len(RequestStreamAssembler._PIPE_REASONING_OPEN))
-    )
     tool_prefixes = tuple(
         RequestStreamAssembler._TOOL_OPEN[:index]
         for index in range(1, len(RequestStreamAssembler._TOOL_OPEN))
@@ -23,6 +19,10 @@ def test_structural_tag_prefixes_are_cached_per_parser_mode() -> None:
     pipe_tool_prefixes = tuple(
         RequestStreamAssembler._PIPE_TOOL_OPEN[:index]
         for index in range(1, len(RequestStreamAssembler._PIPE_TOOL_OPEN))
+    )
+    pipe_channel_prefixes = tuple(
+        RequestStreamAssembler._PIPE_CHANNEL_OPEN[:index]
+        for index in range(1, len(RequestStreamAssembler._PIPE_CHANNEL_OPEN))
     )
 
     tool_enabled = RequestStreamAssembler(
@@ -39,7 +39,7 @@ def test_structural_tag_prefixes_are_cached_per_parser_mode() -> None:
     )
 
     assert tool_enabled._structural_tag_prefixes == (
-        think_prefixes + pipe_reasoning_prefixes + tool_prefixes + pipe_tool_prefixes
+        think_prefixes + pipe_channel_prefixes + tool_prefixes + pipe_tool_prefixes
     )
     assert (
         tool_enabled._structural_open_tags
@@ -47,16 +47,16 @@ def test_structural_tag_prefixes_are_cached_per_parser_mode() -> None:
     )
     assert tool_enabled._structural_tag_prefixes is tool_enabled._structural_tag_prefixes
     assert tool_enabled._structural_tag_prefixes_reversed == (
-        tuple(reversed(pipe_tool_prefixes))
+        tuple(reversed(pipe_channel_prefixes))
+        + tuple(reversed(pipe_tool_prefixes))
         + tuple(reversed(tool_prefixes))
-        + tuple(reversed(pipe_reasoning_prefixes))
         + tuple(reversed(think_prefixes))
     )
     assert (
         tool_enabled._structural_tag_prefixes_reversed
         is tool_enabled._structural_tag_prefixes_reversed
     )
-    assert tool_disabled._structural_tag_prefixes == think_prefixes + pipe_reasoning_prefixes
+    assert tool_disabled._structural_tag_prefixes == think_prefixes + pipe_channel_prefixes
     assert tool_enabled._structural_tag_prefixes is tool_enabled._structural_tag_prefixes
     assert tool_disabled._structural_tag_prefixes is tool_disabled._structural_tag_prefixes
     assert tool_disabled._structural_tag_prefixes is RequestStreamAssembler._REASONING_PREFIXES
@@ -95,9 +95,9 @@ def test_next_structural_tag_prefers_the_earliest_tool_tag() -> None:
     assert assembler._next_structural_tag() == (RequestStreamAssembler._TOOL_OPEN, 0)
 
 
-def test_next_structural_tag_prefers_earliest_pipe_reasoning_tag() -> None:
+def test_next_structural_tag_prefers_earliest_pipe_channel_tag() -> None:
     assembler = RequestStreamAssembler(
-        request_id="req-pipe-reasoning-first",
+        request_id="req-pipe-channel-first",
         reasoning_enabled=True,
         structured_output_mode="",
         tool_parser_mode="qwen",
@@ -108,7 +108,7 @@ def test_next_structural_tag_prefers_earliest_pipe_reasoning_tag() -> None:
     )
 
     assert assembler._next_structural_tag() == (
-        RequestStreamAssembler._PIPE_REASONING_OPEN,
+        RequestStreamAssembler._PIPE_CHANNEL_OPEN,
         4,
     )
 
@@ -232,6 +232,161 @@ def test_plain_buffer_with_marker_still_holds_partial_structural_prefix() -> Non
     assert [delta.tool_call.tool_name for delta in second if delta.tool_call] == ["search"]
     assert completed.assistant_text == "alpha"
     assert completed.metrics["stream_prefix_hold_chars"] == len("<tool_ca")
+
+
+def test_harmony_thought_channel_is_suppressed_from_public_content() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-harmony-thought",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="",
+    )
+
+    first = assembler.accept(
+        StreamFragment(raw_text='<|channel>thought\n<channel|>\n{"output":"pwd"}')
+    )
+    second = assembler.accept(
+        StreamFragment(
+            raw_text=(
+                '<|channel>thought\n<channel|>\n{"output":"pwd"}'
+                "<|channel>final\n<channel|>\nDone."
+            )
+        )
+    )
+    completed = assembler.completed()
+
+    assert [delta.content_text for delta in first if delta.content_text] == []
+    assert [delta.content_text for delta in second if delta.content_text] == ["\nDone."]
+    assert completed.assistant_text == "\nDone."
+    assert completed.reasoning_text == ""
+    assert completed.metrics["harmony_channel_hidden_count"] == 1
+    assert completed.metrics["suppressed_reasoning_count"] == 1
+    assert completed.metrics["harmony_channel_markup_leak_count"] == 0
+
+
+def test_harmony_analysis_channel_is_reasoning_when_enabled() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-harmony-analysis",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="",
+    )
+
+    deltas = assembler.accept(
+        StreamFragment(
+            raw_text="<|channel>analysis\n<channel|>\nPlan.<|channel>final\n<channel|>\nAnswer."
+        )
+    )
+    completed = assembler.completed()
+
+    assert [delta.reasoning_text for delta in deltas if delta.reasoning_text] == ["\nPlan."]
+    assert [delta.content_text for delta in deltas if delta.content_text] == ["\nAnswer."]
+    assert completed.reasoning_text == "\nPlan."
+    assert completed.assistant_text == "\nAnswer."
+    assert completed.metrics["harmony_channel_hidden_count"] == 1
+
+
+def test_harmony_channel_partial_prefix_is_held() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-harmony-channel-prefix",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="",
+    )
+
+    first = assembler.accept(StreamFragment(raw_text="alpha<|chan"))
+    second = assembler.accept(
+        StreamFragment(raw_text="alpha<|channel>final\n<channel|>\nomega")
+    )
+    completed = assembler.completed()
+
+    assert [delta.content_text for delta in first if delta.content_text] == ["alpha"]
+    assert [delta.content_text for delta in second if delta.content_text] == ["\nomega"]
+    assert completed.assistant_text == "alpha\nomega"
+    assert completed.metrics["stream_prefix_hold_chars"] == len("<|chan")
+
+
+def test_unknown_harmony_channel_is_dropped_without_public_markup_leak() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-harmony-unknown",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="",
+    )
+
+    deltas = assembler.accept(StreamFragment(raw_text="<|channel>debug\n<channel|>\nsecret"))
+    completed = assembler.completed()
+
+    assert [delta.content_text for delta in deltas if delta.content_text] == []
+    assert completed.assistant_text == ""
+    assert completed.metrics["harmony_channel_unknown_count"] == 1
+    assert completed.metrics["harmony_channel_markup_leak_count"] == 0
+
+
+def test_malformed_harmony_channel_header_is_dropped_at_completion() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-harmony-malformed-header",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="",
+    )
+
+    assert assembler.accept(StreamFragment(raw_text="<|channel>thought")) == []
+    completed = assembler.completed()
+
+    assert completed.assistant_text == ""
+    assert completed.metrics["malformed_reasoning_count"] == 1
+    assert completed.metrics["harmony_channel_markup_leak_count"] == 0
+
+
+def test_harmony_hidden_channel_recovers_visible_tail_at_completion() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-harmony-recover-tail",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="",
+    )
+
+    assert assembler.accept(
+        StreamFragment(raw_text="<|channel>analysis\n<channel|>\nplan\n\nFinal answer")
+    ) == []
+    completed = assembler.completed()
+
+    assert completed.reasoning_text == "plan"
+    assert completed.assistant_text == "Final answer"
+    assert completed.metrics["harmony_channel_hidden_count"] == 1
+
+
+def test_harmony_channel_like_public_content_is_counted_as_leak() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-harmony-channel-like-leak",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="",
+    )
+
+    deltas = assembler.accept(StreamFragment(raw_text="visible <|channelx"))
+    completed = assembler.completed()
+
+    assert [delta.content_text for delta in deltas if delta.content_text] == [
+        "visible <|channelx"
+    ]
+    assert completed.metrics["harmony_channel_markup_leak_count"] == 1
+
+
+def test_blank_harmony_channel_header_is_counted_as_unknown() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-harmony-blank-header",
+        reasoning_enabled=False,
+        structured_output_mode="",
+        tool_parser_mode="",
+    )
+
+    deltas = assembler.accept(StreamFragment(raw_text="<|channel> \n<channel|>\nsecret"))
+    completed = assembler.completed()
+
+    assert [delta.content_text for delta in deltas if delta.content_text] == []
+    assert completed.metrics["harmony_channel_unknown_count"] == 1
 
 
 def test_pipe_tool_call_marker_is_parsed_without_public_markup_leak() -> None:
@@ -605,7 +760,7 @@ def test_partial_structural_tag_suffix_ignores_complete_or_unknown_markers() -> 
     assert assembler._partial_structural_tag_suffix() == ""
 
 
-def test_partial_pipe_reasoning_leak_marker_increments_metric() -> None:
+def test_partial_pipe_reasoning_marker_is_suppressed_at_completion() -> None:
     assembler = RequestStreamAssembler(
         request_id="req-partial-pipe-reasoning-leak",
         reasoning_enabled=False,
@@ -617,8 +772,9 @@ def test_partial_pipe_reasoning_leak_marker_increments_metric() -> None:
     completed = assembler.completed()
 
     assert [delta.content_text for delta in deltas] == ["visible "]
-    assert completed.assistant_text == "visible <|channel>tho"
-    assert completed.metrics["reasoning_leak_count"] == 1
+    assert completed.assistant_text == "visible "
+    assert completed.metrics["malformed_reasoning_count"] == 1
+    assert completed.metrics["harmony_channel_markup_leak_count"] == 0
 
 
 def test_json_structured_output_partial_pipe_reasoning_prefix_counts_as_leak() -> None:

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -92,7 +92,9 @@ class RequestStreamAssembler:
     _TOOL_CLOSE = "</tool_call>"
     _PIPE_TOOL_OPEN = "<|tool_call>"
     _PIPE_TOOL_CLOSE = "<tool_call|>"
-    _REASONING_OPEN_TAGS = (_THINK_OPEN, _PIPE_REASONING_OPEN)
+    _PIPE_CHANNEL_OPEN = "<|channel>"
+    _PIPE_CHANNEL_HEADER_CLOSE = "<channel|>"
+    _REASONING_OPEN_TAGS = (_THINK_OPEN, _PIPE_CHANNEL_OPEN)
     _TOOL_OPEN_TAGS = (_TOOL_OPEN, _PIPE_TOOL_OPEN)
     _TOOL_PARSER_STRUCTURAL_OPEN_TAGS = _REASONING_OPEN_TAGS + _TOOL_OPEN_TAGS
     _THINK_PREFIXES = tuple("<think>"[:index] for index in range(1, len("<think>")))
@@ -104,13 +106,19 @@ class RequestStreamAssembler:
         "<|tool_call>"[:index] for index in range(1, len("<|tool_call>"))
     )
     _REASONING_LEAK_PREFIXES = ("<think", "<|channel")
-    _REASONING_PREFIXES = _THINK_PREFIXES + _PIPE_REASONING_PREFIXES
+    _PIPE_CHANNEL_PREFIXES = tuple(
+        "<|channel>"[:index] for index in range(1, len("<|channel>"))
+    )
+    _REASONING_PREFIXES = _THINK_PREFIXES + _PIPE_CHANNEL_PREFIXES
     _THINK_PREFIXES_REVERSED = tuple(reversed(_THINK_PREFIXES))
     _PIPE_REASONING_PREFIXES_REVERSED = tuple(reversed(_PIPE_REASONING_PREFIXES))
     _REASONING_PREFIXES_REVERSED = tuple(reversed(_REASONING_PREFIXES))
     _TOOL_PREFIXES_REVERSED = tuple(reversed(_TOOL_PREFIXES))
     _PIPE_TOOL_PREFIXES_REVERSED = tuple(reversed(_PIPE_TOOL_PREFIXES))
+    _PIPE_CHANNEL_PREFIXES_REVERSED = tuple(reversed(_PIPE_CHANNEL_PREFIXES))
     _VISIBLE_TAIL_MARKERS = ("\nFinal answer", "\nFinal:", "\nAnswer:", "\nAssistant:", "\nResult:")
+    _HIDDEN_PIPE_CHANNELS = frozenset({"analysis", "thought", "reasoning"})
+    _VISIBLE_PIPE_CHANNELS = frozenset({"commentary", "final"})
     _PIPE_CALL_RE = re.compile(
         r"^\s*call:(?P<name>[A-Za-z0-9_.:/-]+)\s*(?P<args>\{.*\}|\(\s*\))\s*$",
         re.DOTALL,
@@ -164,9 +172,10 @@ class RequestStreamAssembler:
                 self._REASONING_PREFIXES + self._TOOL_PREFIXES + self._PIPE_TOOL_PREFIXES
             )
             self._structural_tag_prefixes_reversed_value = (
-                self._PIPE_TOOL_PREFIXES_REVERSED
+                self._PIPE_CHANNEL_PREFIXES_REVERSED
+                + self._PIPE_TOOL_PREFIXES_REVERSED
                 + self._TOOL_PREFIXES_REVERSED
-                + self._REASONING_PREFIXES_REVERSED
+                + self._THINK_PREFIXES_REVERSED
             )
         elif self._is_json_structured_output_value:
             self._request_context_mode_value = "structured_json"
@@ -206,6 +215,9 @@ class RequestStreamAssembler:
             "reasoning_parser_bypassed_count": 0,
             "tool_call_name_normalized_count": 0,
             "unknown_tool_delta_count": 0,
+            "harmony_channel_hidden_count": 0,
+            "harmony_channel_unknown_count": 0,
+            "harmony_channel_markup_leak_count": 0,
         }
 
     def accept(self, fragment: StreamFragment) -> list[AssemblyDelta]:
@@ -517,6 +529,13 @@ class RequestStreamAssembler:
                     deltas.append(AssemblyDelta(raw_text=body, tool_call=tool_delta))
                 continue
 
+            if tag == self._PIPE_CHANNEL_OPEN:
+                channel_deltas = self._drain_pipe_channel(final=final)
+                if channel_deltas is None:
+                    break
+                deltas.extend(channel_deltas)
+                continue
+
             break
         return deltas
 
@@ -546,41 +565,44 @@ class RequestStreamAssembler:
                 return None if think_index < 0 else (self._THINK_OPEN, think_index)
 
             tool_index = buffer.find(self._TOOL_OPEN)
-            if think_index < 0:
-                return None if tool_index < 0 else (self._TOOL_OPEN, tool_index)
-            if tool_index < 0 or think_index <= tool_index:
-                return (self._THINK_OPEN, think_index)
-            return (self._TOOL_OPEN, tool_index)
+            return self._earliest_structural_tag(
+                ((self._THINK_OPEN, think_index), (self._TOOL_OPEN, tool_index))
+            )
 
-        pipe_reasoning_index = (
-            buffer.find(self._PIPE_REASONING_OPEN) if has_pipe_marker else -1
-        )
-        best_tag = ""
-        best_index = -1
-        if think_index >= 0:
-            best_tag = self._THINK_OPEN
-            best_index = think_index
-        if pipe_reasoning_index >= 0 and (
-            best_index < 0 or pipe_reasoning_index < best_index
-        ):
-            best_tag = self._PIPE_REASONING_OPEN
-            best_index = pipe_reasoning_index
-        if not self._tool_parsing_enabled_value:
-            if best_index < 0:
-                return None
-            return (best_tag, best_index)
+        candidates = [
+            (self._THINK_OPEN, think_index),
+            (self._PIPE_CHANNEL_OPEN, buffer.find(self._PIPE_CHANNEL_OPEN)),
+        ]
+        if self._tool_parsing_enabled_value:
+            candidates.extend(
+                (
+                    (self._TOOL_OPEN, buffer.find(self._TOOL_OPEN)),
+                    (self._PIPE_TOOL_OPEN, buffer.find(self._PIPE_TOOL_OPEN)),
+                )
+            )
+        return self._earliest_structural_tag(candidates)
 
-        tool_index = buffer.find(self._TOOL_OPEN)
-        if tool_index >= 0 and (best_index < 0 or tool_index < best_index):
-            best_tag = self._TOOL_OPEN
-            best_index = tool_index
-        pipe_tool_index = buffer.find(self._PIPE_TOOL_OPEN) if has_pipe_marker else -1
-        if pipe_tool_index >= 0 and (best_index < 0 or pipe_tool_index < best_index):
-            best_tag = self._PIPE_TOOL_OPEN
-            best_index = pipe_tool_index
-        if best_index < 0:
-            return None
-        return (best_tag, best_index)
+    @staticmethod
+    def _earliest_structural_tag(
+        candidates: list[tuple[str, int]] | tuple[tuple[str, int], ...],
+    ) -> tuple[str, int] | None:
+        matches = [candidate for candidate in candidates if candidate[1] >= 0]
+        return min(matches, key=lambda item: item[1]) if matches else None
+
+    def _next_structural_tag_after(self, start: int) -> int:
+        candidates = [
+            index
+            for index in (
+                self._buffer.find(self._THINK_OPEN, start),
+                self._buffer.find(self._PIPE_CHANNEL_OPEN, start),
+                self._buffer.find(self._TOOL_OPEN, start)
+                if self._tool_parsing_enabled_value else -1,
+                self._buffer.find(self._PIPE_TOOL_OPEN, start)
+                if self._tool_parsing_enabled_value else -1,
+            )
+            if index >= 0
+        ]
+        return min(candidates) if candidates else -1
 
     def _has_partial_structural_tag_suffix(self) -> bool:
         return bool(self._partial_structural_tag_suffix())
@@ -609,6 +631,11 @@ class RequestStreamAssembler:
         ):
             return suffix
         if (
+            0 < suffix_len < len(self._PIPE_CHANNEL_OPEN)
+            and self._PIPE_CHANNEL_OPEN.startswith(suffix)
+        ):
+            return suffix
+        if (
             0 < suffix_len < len(self._PIPE_REASONING_OPEN)
             and self._PIPE_REASONING_OPEN.startswith(suffix)
         ):
@@ -634,8 +661,118 @@ class RequestStreamAssembler:
                 self._metrics["tool_call_markup_leak_count"] += 1
             if self._contains_reasoning_leak_marker(content):
                 self._metrics["reasoning_leak_count"] += 1
+                self._metrics["harmony_channel_markup_leak_count"] += 1
         self._assistant_parts.append(content)
         return AssemblyDelta(content_text=content, raw_text=content)
+
+    def _drain_pipe_channel(self, final: bool) -> list[AssemblyDelta] | None:
+        header_close_index = self._buffer.find(
+            self._PIPE_CHANNEL_HEADER_CLOSE,
+            len(self._PIPE_CHANNEL_OPEN),
+        )
+        if header_close_index < 0:
+            if final:
+                self._metrics["malformed_reasoning_count"] += 1
+                if self._buffer.startswith(self._PIPE_REASONING_OPEN):
+                    self._metrics["reasoning_channel_recovery_count"] += 1
+                    body = self._buffer[len(self._PIPE_REASONING_OPEN) :]
+                    self._buffer = ""
+                    hidden, visible = self._recover_unclosed_reasoning_body(body)
+                    return self._hidden_pipe_channel_deltas(
+                        hidden=hidden,
+                        visible=visible,
+                    )
+                self._buffer = ""
+                return []
+            return None
+
+        header = self._buffer[len(self._PIPE_CHANNEL_OPEN) : header_close_index]
+        body_start = header_close_index + len(self._PIPE_CHANNEL_HEADER_CLOSE)
+        channel_name = self._pipe_channel_name(header)
+        legacy_hidden = self._legacy_pipe_channel_header_body(header, channel_name)
+        if legacy_hidden is not None or self._tool_parsing_enabled_value:
+            next_index = self._next_structural_tag_after(body_start)
+            has_boundary = next_index >= 0
+            if has_boundary:
+                visible = self._buffer[body_start:next_index]
+                self._buffer = self._buffer[next_index:]
+            else:
+                visible = self._buffer[body_start:]
+                self._buffer = ""
+            return self._hidden_pipe_channel_deltas(
+                hidden=legacy_hidden or "",
+                visible=visible,
+            )
+
+        next_index = self._next_structural_tag_after(body_start)
+        has_boundary = next_index >= 0
+
+        if has_boundary:
+            body = self._buffer[body_start:next_index]
+            self._buffer = self._buffer[next_index:]
+        elif channel_name in self._VISIBLE_PIPE_CHANNELS or final:
+            body = self._buffer[body_start:]
+            self._buffer = ""
+        else:
+            return None
+
+        return self._pipe_channel_deltas(
+            channel_name=channel_name,
+            body=body,
+            recover_visible_tail=final and not has_boundary,
+        )
+
+    @staticmethod
+    def _pipe_channel_name(header: str) -> str:
+        stripped = header.strip().lower()
+        if not stripped:
+            return ""
+        return stripped.split(maxsplit=1)[0]
+
+    @classmethod
+    def _legacy_pipe_channel_header_body(cls, header: str, channel_name: str) -> str | None:
+        if channel_name not in cls._HIDDEN_PIPE_CHANNELS:
+            return None
+        body = header[len(channel_name) :]
+        return body if body.strip() else None
+
+    def _pipe_channel_deltas(
+        self,
+        channel_name: str,
+        body: str,
+        recover_visible_tail: bool,
+    ) -> list[AssemblyDelta]:
+        if channel_name in self._VISIBLE_PIPE_CHANNELS:
+            return [self._content_delta(body)] if body else []
+
+        if channel_name in self._HIDDEN_PIPE_CHANNELS:
+            self._metrics["harmony_channel_hidden_count"] += 1
+            hidden = body
+            visible = ""
+            if recover_visible_tail:
+                recovered_hidden, recovered_visible = self._recover_unclosed_reasoning_body(body)
+                if recovered_hidden or recovered_visible:
+                    hidden = recovered_hidden
+                    visible = recovered_visible
+            return self._hidden_pipe_channel_deltas(hidden=hidden, visible=visible)
+
+        self._metrics["harmony_channel_unknown_count"] += 1
+        return []
+
+    def _hidden_pipe_channel_deltas(self, hidden: str, visible: str = "") -> list[AssemblyDelta]:
+        if not hidden.strip():
+            self._metrics["empty_thinking_sentinel_count"] += 1
+        deltas: list[AssemblyDelta] = []
+        if hidden.strip():
+            if self._reasoning_enabled:
+                self._reasoning_parts.append(hidden)
+                deltas.append(AssemblyDelta(reasoning_text=hidden, raw_text=hidden))
+            else:
+                self._metrics["suppressed_reasoning_count"] += 1
+                self._metrics["reasoning_parser_bypassed_count"] += 1
+        if visible:
+            deltas.append(self._content_delta(visible))
+        return deltas
 
     def _tool_delta(self, body: str) -> AssembledToolCall | None:
         payload = self._parse_tool_body(body)


### PR DESCRIPTION
## Summary
- Suppress Harmony pipe-channel markup from worker streaming outputs so internal `thought`, `analysis`, and `reasoning` channels do not leak into public assistant content.
- Route hidden channel content to reasoning deltas where supported, preserve visible `final` and `commentary` channel text, and apply the same filtering in the Swift text worker generate/decode path.
- Address CI/review follow-up by counting Swift completion usage from runtime token events, draining hidden/unknown channel content immediately, and simplifying Python structural tag selection while preserving the no-pipe fast path.

## Plan or Spec
- `docs/plans/2026-03-30-m3-4-harmony-protocol-compatibility.md`

## Commands Run
```text
# stopped the Hermes Melix service started from the jobs script
MELIX_REPO_ROOT=/Users/chenyu/Documents/github/melix/.runtime/worktrees/gemma4-tool-call-parser-fix /Users/chenyu/Documents/jobs/melix/stop_hermes_session_server.sh && lsof -nP -iTCP:12436 -sTCP:LISTEN || true
Outcome: service stopped; port 12436 is free.

# rebase conflict repair
git fetch origin main --prune
git rebase origin/main
Outcome: conflicts in stream_assembler.py and test_stream_assembler.py were resolved, preserving main's stream parser fast path/cached-prefix changes while keeping Harmony channel filtering behavior.

# focused Python worker tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_generate_stream.py
Outcome: 101 passed.

# changed-scope Python coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_generate_stream.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report --include='services/mlx-worker-python/worker/runtime/stream_assembler.py'
Outcome: 101 passed; stream_assembler.py coverage 96%.

# Swift product builds
xcrun swift build --product melix
xcrun swift build --package-path services/mlx-text-worker-swift --product melix-text-worker-swift
xcrun swift build --package-path services/control-plane-swift --product melix-control-plane
Outcome: products built successfully. The Swift text worker build emitted existing third-party/dependency warnings unrelated to this change.

# Swift filter behavior smoke
xcrun swiftc services/mlx-text-worker-swift/Sources/Core/Inference/HarmonyChannelOutputFilter.swift "$tmpfile" -o /tmp/melix-harmony-filter-smoke && /tmp/melix-harmony-filter-smoke
Outcome: swift harmony filter smoke passed.

# CI failure reproduction: health/cache endpoint integration test
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest tests/integration/test_non_text_endpoints.py::test_health_and_cache_endpoints_return_operator_state -q -s
Outcome: 1 passed.

# Swift test environment probe
make swift-test-protocol
Outcome: failed before running tests with `no such module 'XCTest'` in this local CommandLineTools-only environment; Swift product builds and CI macOS runners are the executable Swift validation path for this PR.

# repository hygiene
git diff --check
Outcome: passed.
```

## Coverage and Metrics
- Python changed-scope coverage: `services/mlx-worker-python/worker/runtime/stream_assembler.py` at 96% statement coverage from the focused coverage command above.
- Swift changed-scope metrics: product builds succeeded for `melix`, `melix-text-worker-swift`, and `melix-control-plane`; focused filter behavior smoke passed. Swift package test coverage is not currently measurable in this local environment because Swift tests fail before running with `no such module 'XCTest'`.
- Integration evidence: the CI-failing health/cache endpoint test passes locally after building the Swift integration prerequisites.
- PR scoped performance report: status `ok`, direct/gated probes `4`, regressions `0`, context regressions `0`, verification failures `0`.
- Live-stack acceptance evidence from the implementation worktree before PR cleanup: jobs-script restart on `127.0.0.1:12436/v1` returned a clean streamed `assistant_text: "OK"` with no Harmony channel markup.

## Known Gaps
- Full baseline `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run; this PR used focused worker coverage/build checks plus the CI-failing integration test for the touched paths.
- Local Swift tests could not run because this environment cannot import `XCTest`; Swift products compile, the standalone filter smoke passed, and CI is expected to run Swift tests on a runner with XCTest available.
- No protocol or dependency changes were made, so generated protocol artifacts and lockfiles were not updated.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
