### PR TITLE
perf: shortcut saturated serving diagnostics queue

### DIFF
--- a/docs/plans/2026-05-13-serving-diagnostics-queue-overflow-fast-path.md
+++ b/docs/plans/2026-05-13-serving-diagnostics-queue-overflow-fast-path.md
@@ -1,0 +1,33 @@
+# Serving Diagnostics Queue Overflow Fast Path
+
+## Scope
+
+This Python-only slice optimizes the debug serving diagnostics event queue after
+it reaches its configured bound. The queue is append-only for a request bundle,
+so once the first event has been dropped every later append is also an overflow.
+The implementation can reuse that state instead of rechecking the current deque
+length on each saturated append. The queue object also uses explicit slots so
+this high-frequency debug buffer does not carry a per-instance dictionary.
+
+## Affected Paths
+
+- `services/mlx-worker-python/worker/productization/serving_diagnostics.py`
+- `services/mlx-worker-python/tests/test_serving_diagnostics.py`
+- `scripts/serving_diagnostics_queue_probe.py`
+
+## Registered Probe
+
+The affected path is covered by the existing
+`serving-diagnostics-debug-queue-bounds` PR-scoped performance probe in
+`infra/perf/pr_scoped_probes.json`. The registered entry includes focused
+`test_command`, `coverage_command`, and `probe_command` values and reports:
+
+- `elapsed_ms_mean` (`lower_is_better`)
+- `dropped_count` (`informational`)
+- `retained_count` (`informational`)
+
+## Verification Plan
+
+Run the registered focused pytest command, changed-scope coverage command, and
+local Linux probe before opening the PR. The GitHub PR-scoped performance
+workflow remains the merge gate for the registered probe report.

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -27,19 +27,24 @@ class ServingDiagnosticsQueueSnapshot:
 
 
 class BoundedServingDiagnosticsEventQueue:
+    __slots__ = ("_dropped_count", "_events", "_is_saturated", "_lock", "_max_events")
+
     def __init__(self, *, max_events: int = 256) -> None:
         self._max_events = max(int(max_events), 1)
         self._events: deque[ServingDiagnosticsEvent] = deque(maxlen=self._max_events)
         self._dropped_count = 0
+        self._is_saturated = False
         self._lock = threading.Lock()
 
     def append(self, event: ServingDiagnosticsEvent) -> bool:
         with self._lock:
-            dropped = len(self._events) >= self._max_events
-            if dropped:
+            if self._is_saturated:
                 self._dropped_count += 1
+                self._events.append(event)
+                return False
             self._events.append(event)
-            return not dropped
+            self._is_saturated = len(self._events) >= self._max_events
+            return True
 
     def snapshot(self) -> ServingDiagnosticsQueueSnapshot:
         with self._lock:


### PR DESCRIPTION
## Summary
- Short-circuit saturated `BoundedServingDiagnosticsEventQueue.append()` calls after the first dropped event.
- Keep append ordering, dropped-count accounting, and bounded snapshot semantics unchanged.

## Plan or Spec
- `docs/plans/2026-05-13-serving-diagnostics-queue-overflow-fast-path.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 24 passed in 0.11s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# {"capacity": 64.0, "dropped_count": 4032.0, "elapsed_ms_mean": 7.274084, "event_count": 4096.0, "retained_count": 64.0, "sample_count": 5.0}
# {"capacity": 64.0, "dropped_count": 4032.0, "elapsed_ms_mean": 8.371189, "event_count": 4096.0, "retained_count": 64.0, "sample_count": 5.0}
# {"capacity": 64.0, "dropped_count": 4032.0, "elapsed_ms_mean": 7.188763, "event_count": 4096.0, "retained_count": 64.0, "sample_count": 5.0}

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id serving-diagnostics-debug-queue-bounds --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-serving-diagnostics-queue-20260513172056 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-cron-slice-20260513172056 --output /tmp/serving-diagnostics-queue-fastpath-v2.json
# head verification ok; coverage 100%; base/head probe ok

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Registered local probe: `serving-diagnostics-debug-queue-bounds`.
- Local base/head probe: `elapsed_ms_mean` improved from `7.072335 ms` to `6.922546 ms` (`delta=-0.149789 ms`, `speedup=1.021638x`, `2.118%` lower).
- Informational metrics remained stable: `dropped_count=4032`, `retained_count=64`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- The slice is Python-only and locally verified on Linux; no Swift runtime effect is claimed.
- Local improvement is small, so the registered CI probe is the authoritative merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
