### PR TITLE
Clarify agent design evaluation rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,8 +180,8 @@ state from `.runtime`.
 - During design and solution evaluation, start from the best end-state architecture
   for Melix as if time and implementation cost were not constraints. Do not
   optimize the recommended direction for the shortest path, smallest diff, or
-  lowest-effort patch. After the best solution is identified, separate delivery
-  planning may slice it into small, verifiable implementation steps.
+  lowest-effort patch. After the best solution is identified, slice the delivery
+  into small, verifiable implementation steps.
 - During design, define the performance probes, measurement points, and success metrics for the code path being changed.
 - For material UI/UX changes, use the interactive walkthrough workflow in `docs/runbooks/agent-ui-walkthrough.md` before broad App implementation when feasible: create or update a `.runtime/walkthrough/` HTML artifact, review it with the operator in the in-app browser, record decisions in a paired runtime note, then implement after the direction is confirmed.
 - Prefer small, verifiable slices over broad speculative rewrites.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,11 @@ state from `.runtime`.
 - Before each work transaction, read the relevant docs and standards before changing code.
 - Confirm the implementation approach in plan mode before editing code. If plan mode is unavailable, create or update an explicit written plan before broad implementation.
 - For non-trivial work, start from an explicit plan under `docs/plans/` or update the active plan before broad implementation.
-- During design, do not anchor on minimal change or implementation cost. Optimize for the best end-state architecture, best practices, and the most reasonable long-term choice for Melix.
+- During design and solution evaluation, start from the best end-state architecture
+  for Melix as if time and implementation cost were not constraints. Do not
+  optimize the recommended direction for the shortest path, smallest diff, or
+  lowest-effort patch. After the best solution is identified, separate delivery
+  planning may slice it into small, verifiable implementation steps.
 - During design, define the performance probes, measurement points, and success metrics for the code path being changed.
 - For material UI/UX changes, use the interactive walkthrough workflow in `docs/runbooks/agent-ui-walkthrough.md` before broad App implementation when feasible: create or update a `.runtime/walkthrough/` HTML artifact, review it with the operator in the in-app browser, record decisions in a paired runtime note, then implement after the direction is confirmed.
 - Prefer small, verifiable slices over broad speculative rewrites.


### PR DESCRIPTION
## Summary
- Clarify the Melix agent planning rule for design and solution evaluation.
- Require agents to identify the best end-state architecture as if time and implementation cost were not constraints before slicing delivery into smaller implementation steps.

## Plan or Spec
- N/A: documentation-only update to the repository agent entry-point instructions.

## Commands Run
```text
git diff --check
Result: pass.

python3 - <<'PY'
from pathlib import Path
text = Path('AGENTS.md').read_text()
needle = 'During design and solution evaluation, start from the best end-state architecture'
assert needle in text
print('AGENTS.md design-evaluation rule present')
PY
Result: pass.

uv run --frozen --project services/mlx-worker-python python scripts/validate_pr_evidence.py --body-file .runtime/pr-agent-design-best-solution.md
Result: pass.

bash .githooks/pre-commit
Result: blocked in make swift-test because this host is using Command Line Tools only and SwiftPM cannot import XCTest. xcode-select -p returned /Library/Developer/CommandLineTools; xcodebuild -version reported that full Xcode is required.
```

## Coverage and Metrics
- N/A: documentation-only change to `AGENTS.md`; no executable code path changed and no runtime metrics apply.

## Known Gaps
- Full pre-commit verification was attempted but could not complete on this host because the active developer directory is Command Line Tools only, so SwiftPM tests fail with `no such module 'XCTest'`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
