### PR TITLE
Add workflow recipes and URI resolver

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -5344,15 +5344,22 @@ public actor MelixCLIRunner {
         case .configMetadata:
             let payload = MelixRuntimeDiscoveryBuilder(environment: environment).configMetadataPayload()
             return try prettyJSON(payload)
-        case .uriInspect,
-             .uriImport,
-             .recipesList,
-             .recipesShow,
-             .recipesValidate,
-             .recipesPlan,
-             .recipesApply,
-             .recipesInit:
-            throw MelixCLIError.runtime("\(MelixCLICommandCodec.commandID(for: command)) is not implemented yet.")
+        case .uriInspect(let options):
+            return try runURIInspect(options)
+        case .uriImport(let options):
+            return try await runURIImport(options)
+        case .recipesList(let options):
+            return try runRecipesList(options)
+        case .recipesShow(let options):
+            return try runRecipesShow(options)
+        case .recipesValidate(let options):
+            return try runRecipesValidate(options)
+        case .recipesPlan(let options):
+            return try runRecipesPlan(options)
+        case .recipesApply(let options):
+            return try await runRecipesApply(options)
+        case .recipesInit(let options):
+            return try runRecipesInit(options)
         case .pipelineRun(let options):
             return try await runPipeline(options)
         case .batchRun(let options):

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1452,6 +1452,139 @@ public struct PipelineRunOptions: Equatable, Sendable {
     }
 }
 
+public struct URIInspectOptions: Equatable, Sendable {
+    public let uri: String
+    public let json: Bool
+
+    public init(uri: String, json: Bool = false) {
+        self.uri = uri
+        self.json = json
+    }
+}
+
+public struct URIImportOptions: Equatable, Sendable {
+    public let uri: String
+    public let modelID: String
+    public let revision: String
+    public let dryRun: Bool
+    public let json: Bool
+
+    public init(
+        uri: String,
+        modelID: String = "",
+        revision: String = "main",
+        dryRun: Bool = false,
+        json: Bool = false
+    ) {
+        self.uri = uri
+        self.modelID = modelID
+        self.revision = revision
+        self.dryRun = dryRun
+        self.json = json
+    }
+}
+
+public struct RecipeListOptions: Equatable, Sendable {
+    public let task: String
+    public let json: Bool
+
+    public init(task: String = "", json: Bool = false) {
+        self.task = task
+        self.json = json
+    }
+}
+
+public struct RecipeShowOptions: Equatable, Sendable {
+    public let recipeID: String
+    public let version: String
+    public let json: Bool
+
+    public init(recipeID: String, version: String = "", json: Bool = false) {
+        self.recipeID = recipeID
+        self.version = version
+        self.json = json
+    }
+}
+
+public struct RecipeValidateOptions: Equatable, Sendable {
+    public let target: String
+    public let json: Bool
+
+    public init(target: String, json: Bool = false) {
+        self.target = target
+        self.json = json
+    }
+}
+
+public struct RecipePlanOptions: Equatable, Sendable {
+    public let recipeID: String
+    public let version: String
+    public let values: [String: String]
+    public let outputPath: String
+    public let json: Bool
+
+    public init(
+        recipeID: String,
+        version: String = "",
+        values: [String: String] = [:],
+        outputPath: String = "",
+        json: Bool = false
+    ) {
+        self.recipeID = recipeID
+        self.version = version
+        self.values = values
+        self.outputPath = outputPath
+        self.json = json
+    }
+}
+
+public struct RecipeApplyOptions: Equatable, Sendable {
+    public let recipeID: String
+    public let version: String
+    public let values: [String: String]
+    public let dryRun: Bool
+    public let resume: Bool
+    public let fromStepID: String
+    public let json: Bool
+
+    public init(
+        recipeID: String,
+        version: String = "",
+        values: [String: String] = [:],
+        dryRun: Bool = false,
+        resume: Bool = false,
+        fromStepID: String = "",
+        json: Bool = false
+    ) {
+        self.recipeID = recipeID
+        self.version = version
+        self.values = values
+        self.dryRun = dryRun
+        self.resume = resume
+        self.fromStepID = fromStepID
+        self.json = json
+    }
+}
+
+public struct RecipeInitOptions: Equatable, Sendable {
+    public let sourceURI: String
+    public let task: String
+    public let outputPath: String
+    public let json: Bool
+
+    public init(
+        sourceURI: String,
+        task: String,
+        outputPath: String = "",
+        json: Bool = false
+    ) {
+        self.sourceURI = sourceURI
+        self.task = task
+        self.outputPath = outputPath
+        self.json = json
+    }
+}
+
 public enum MelixCLIOutputFormat: String, Equatable, Sendable {
     case legacy
     case jsonV1 = "json-v1"
@@ -1507,6 +1640,14 @@ public enum MelixCLICommand: Equatable, Sendable {
     case datasetList(DatasetListOptions)
     case datasetHubDownload(DatasetHubDownloadOptions)
     case datasetRemove(DatasetRemoveOptions)
+    case uriInspect(URIInspectOptions)
+    case uriImport(URIImportOptions)
+    case recipesList(RecipeListOptions)
+    case recipesShow(RecipeShowOptions)
+    case recipesValidate(RecipeValidateOptions)
+    case recipesPlan(RecipePlanOptions)
+    case recipesApply(RecipeApplyOptions)
+    case recipesInit(RecipeInitOptions)
     case modelRootsList(ModelRootsListOptions)
     case modelRootsAdd(ModelRootsMutateOptions)
     case modelRootsRemove(ModelRootsMutateOptions)
@@ -1667,6 +1808,10 @@ public enum MelixCLIParser {
             return try parseModel(tail)
         case "dataset":
             return try parseDataset(tail)
+        case "uri":
+            return try parseURI(tail)
+        case "recipes":
+            return try parseRecipes(tail)
         case "server":
             return try parseServer(tail)
         case "remote-server":
@@ -1731,6 +1876,14 @@ public enum MelixCLIParser {
       melix dataset list [--json]
       melix dataset hub download --repo-id HF_DATASET [--revision REV] [--hf-token TOKEN] [--json]
       melix dataset remove --repo-id HF_DATASET [--revision REV | --snapshot-id SHA] [--json]
+      melix uri inspect URI [--json]
+      melix uri import URI [--model-id MODEL_ID] [--revision REV] [--dry-run] [--json]
+      melix recipes list [--task TASK] [--json]
+      melix recipes show RECIPE_ID [--version VERSION] [--json]
+      melix recipes validate PATH_OR_ID [--json]
+      melix recipes plan RECIPE_ID [--version VERSION] [--set KEY=VALUE ...] [--output PATH] [--json]
+      melix recipes apply RECIPE_ID [--version VERSION] [--set KEY=VALUE ...] [--dry-run] [--resume] [--from-step STEP_ID] [--json]
+      melix recipes init --from URI --task TASK [--output PATH] [--json]
       melix model roots list [--json]
       melix model roots add --path PATH [--json]
       melix model roots remove --path PATH [--json]
@@ -2378,6 +2531,160 @@ public enum MelixCLIParser {
         default:
             throw MelixCLIError.usage(usageText)
         }
+    }
+
+    private static func parseURI(_ arguments: [String]) throws -> MelixCLICommand {
+        guard let action = arguments.first else {
+            throw MelixCLIError.usage(usageText)
+        }
+        var optionArguments = Array(arguments.dropFirst())
+        switch action {
+        case "inspect":
+            let uri = try extractPositionalValue(
+                from: &optionArguments,
+                label: "URI",
+                command: "melix uri inspect"
+            )
+            let values = try ArgumentCursor(arguments: optionArguments).parse()
+            return .uriInspect(.init(uri: uri, json: values.flags.contains("--json")))
+        case "import":
+            let uri = try extractPositionalValue(
+                from: &optionArguments,
+                label: "URI",
+                command: "melix uri import"
+            )
+            let values = try ArgumentCursor(arguments: optionArguments).parse()
+            return .uriImport(
+                .init(
+                    uri: uri,
+                    modelID: values.single["--model-id"] ?? "",
+                    revision: values.single["--revision"] ?? "main",
+                    dryRun: values.flags.contains("--dry-run"),
+                    json: values.flags.contains("--json")
+                )
+            )
+        default:
+            throw MelixCLIError.usage(usageText)
+        }
+    }
+
+    private static func parseRecipes(_ arguments: [String]) throws -> MelixCLICommand {
+        guard let action = arguments.first else {
+            throw MelixCLIError.usage(usageText)
+        }
+        var optionArguments = Array(arguments.dropFirst())
+        switch action {
+        case "list":
+            let values = try ArgumentCursor(arguments: optionArguments).parse()
+            return .recipesList(
+                .init(
+                    task: values.single["--task"] ?? "",
+                    json: values.flags.contains("--json")
+                )
+            )
+        case "show":
+            let recipeID = try extractPositionalValue(
+                from: &optionArguments,
+                label: "RECIPE_ID",
+                command: "melix recipes show"
+            )
+            let values = try ArgumentCursor(arguments: optionArguments).parse()
+            return .recipesShow(
+                .init(
+                    recipeID: recipeID,
+                    version: values.single["--version"] ?? "",
+                    json: values.flags.contains("--json")
+                )
+            )
+        case "validate":
+            let target = try extractPositionalValue(
+                from: &optionArguments,
+                label: "PATH_OR_ID",
+                command: "melix recipes validate"
+            )
+            let values = try ArgumentCursor(arguments: optionArguments).parse()
+            return .recipesValidate(.init(target: target, json: values.flags.contains("--json")))
+        case "plan":
+            let recipeID = try extractPositionalValue(
+                from: &optionArguments,
+                label: "RECIPE_ID",
+                command: "melix recipes plan"
+            )
+            let values = try ArgumentCursor(arguments: optionArguments).parse(multiValueOptions: ["--set"])
+            return .recipesPlan(
+                .init(
+                    recipeID: recipeID,
+                    version: values.single["--version"] ?? "",
+                    values: try keyValueMap(from: values.multi["--set"] ?? [], option: "--set"),
+                    outputPath: values.single["--output"] ?? "",
+                    json: values.flags.contains("--json")
+                )
+            )
+        case "apply":
+            let recipeID = try extractPositionalValue(
+                from: &optionArguments,
+                label: "RECIPE_ID",
+                command: "melix recipes apply"
+            )
+            let values = try ArgumentCursor(arguments: optionArguments).parse(multiValueOptions: ["--set"])
+            return .recipesApply(
+                .init(
+                    recipeID: recipeID,
+                    version: values.single["--version"] ?? "",
+                    values: try keyValueMap(from: values.multi["--set"] ?? [], option: "--set"),
+                    dryRun: values.flags.contains("--dry-run"),
+                    resume: values.flags.contains("--resume"),
+                    fromStepID: values.single["--from-step"] ?? "",
+                    json: values.flags.contains("--json")
+                )
+            )
+        case "init":
+            let values = try ArgumentCursor(arguments: optionArguments).parse()
+            guard let sourceURI = values.single["--from"], sourceURI.isEmpty == false else {
+                throw MelixCLIError.missingRequired("--from is required for melix recipes init.")
+            }
+            guard let task = values.single["--task"], task.isEmpty == false else {
+                throw MelixCLIError.missingRequired("--task is required for melix recipes init.")
+            }
+            return .recipesInit(
+                .init(
+                    sourceURI: sourceURI,
+                    task: task,
+                    outputPath: values.single["--output"] ?? "",
+                    json: values.flags.contains("--json")
+                )
+            )
+        default:
+            throw MelixCLIError.usage(usageText)
+        }
+    }
+
+    private static func extractPositionalValue(
+        from arguments: inout [String],
+        label: String,
+        command: String
+    ) throws -> String {
+        guard let first = arguments.first, first.hasPrefix("--") == false else {
+            throw MelixCLIError.missingRequired("\(label) is required for \(command).")
+        }
+        arguments.removeFirst()
+        let value = first.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard value.isEmpty == false else {
+            throw MelixCLIError.missingRequired("\(label) is required for \(command).")
+        }
+        return value
+    }
+
+    private static func keyValueMap(from rawValues: [String], option: String) throws -> [String: String] {
+        var values: [String: String] = [:]
+        for rawValue in rawValues {
+            let parts = rawValue.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2, parts[0].isEmpty == false else {
+                throw MelixCLIError.usage("\(option) must use KEY=VALUE.")
+            }
+            values[String(parts[0])] = String(parts[1])
+        }
+        return values
     }
 
     private static func parseServer(_ arguments: [String]) throws -> MelixCLICommand {
@@ -5037,6 +5344,15 @@ public actor MelixCLIRunner {
         case .configMetadata:
             let payload = MelixRuntimeDiscoveryBuilder(environment: environment).configMetadataPayload()
             return try prettyJSON(payload)
+        case .uriInspect,
+             .uriImport,
+             .recipesList,
+             .recipesShow,
+             .recipesValidate,
+             .recipesPlan,
+             .recipesApply,
+             .recipesInit:
+            throw MelixCLIError.runtime("\(MelixCLICommandCodec.commandID(for: command)) is not implemented yet.")
         case .pipelineRun(let options):
             return try await runPipeline(options)
         case .batchRun(let options):

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1472,7 +1472,7 @@ public struct URIImportOptions: Equatable, Sendable {
     public init(
         uri: String,
         modelID: String = "",
-        revision: String = "main",
+        revision: String = "",
         dryRun: Bool = false,
         json: Bool = false
     ) {
@@ -2558,7 +2558,7 @@ public enum MelixCLIParser {
                 .init(
                     uri: uri,
                     modelID: values.single["--model-id"] ?? "",
-                    revision: values.single["--revision"] ?? "main",
+                    revision: values.single["--revision"] ?? "",
                     dryRun: values.flags.contains("--dry-run"),
                     json: values.flags.contains("--json")
                 )

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -772,7 +772,9 @@ public enum MelixCLICommandCodec {
         case .uriImport(let options):
             arguments = ["uri", "import", options.uri]
             appendOption("--model-id", value: options.modelID, into: &arguments)
-            appendOption("--revision", value: options.revision, into: &arguments)
+            if options.revision.isEmpty == false {
+                appendOption("--revision", value: options.revision, into: &arguments)
+            }
             if options.dryRun {
                 arguments.append("--dry-run")
             }

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -64,6 +64,22 @@ public enum MelixCLICommandCodec {
             return "dataset.hub.download"
         case .datasetRemove:
             return "dataset.remove"
+        case .uriInspect:
+            return "uri.inspect"
+        case .uriImport:
+            return "uri.import"
+        case .recipesList:
+            return "recipes.list"
+        case .recipesShow:
+            return "recipes.show"
+        case .recipesValidate:
+            return "recipes.validate"
+        case .recipesPlan:
+            return "recipes.plan"
+        case .recipesApply:
+            return "recipes.apply"
+        case .recipesInit:
+            return "recipes.init"
         case .modelRootsList:
             return "model.roots.list"
         case .modelRootsAdd:
@@ -729,6 +745,52 @@ public enum MelixCLICommandCodec {
             appendOption("--from", value: options.sourcePath, into: &arguments)
             appendOption("--output", value: options.outputPath, into: &arguments)
             json = false
+        case .uriInspect(let options):
+            arguments = ["uri", "inspect", options.uri]
+            json = options.json
+        case .uriImport(let options):
+            arguments = ["uri", "import", options.uri]
+            appendOption("--model-id", value: options.modelID, into: &arguments)
+            appendOption("--revision", value: options.revision, into: &arguments)
+            if options.dryRun {
+                arguments.append("--dry-run")
+            }
+            json = options.json
+        case .recipesList(let options):
+            arguments = ["recipes", "list"]
+            appendOption("--task", value: options.task, into: &arguments)
+            json = options.json
+        case .recipesShow(let options):
+            arguments = ["recipes", "show", options.recipeID]
+            appendOption("--version", value: options.version, into: &arguments)
+            json = options.json
+        case .recipesValidate(let options):
+            arguments = ["recipes", "validate", options.target]
+            json = options.json
+        case .recipesPlan(let options):
+            arguments = ["recipes", "plan", options.recipeID]
+            appendOption("--version", value: options.version, into: &arguments)
+            appendRecipeValues(options.values, into: &arguments)
+            appendOption("--output", value: options.outputPath, into: &arguments)
+            json = options.json
+        case .recipesApply(let options):
+            arguments = ["recipes", "apply", options.recipeID]
+            appendOption("--version", value: options.version, into: &arguments)
+            appendRecipeValues(options.values, into: &arguments)
+            if options.dryRun {
+                arguments.append("--dry-run")
+            }
+            if options.resume {
+                arguments.append("--resume")
+            }
+            appendOption("--from-step", value: options.fromStepID, into: &arguments)
+            json = options.json
+        case .recipesInit(let options):
+            arguments = ["recipes", "init"]
+            appendOption("--from", value: options.sourceURI, into: &arguments)
+            appendOption("--task", value: options.task, into: &arguments)
+            appendOption("--output", value: options.outputPath, into: &arguments)
+            json = options.json
         case .pipelineRun(let options):
             arguments = ["pipeline", "run"]
             appendOption("--file", value: options.filePath, into: &arguments)
@@ -766,6 +828,12 @@ public enum MelixCLICommandCodec {
         } else if remoteServerID.isEmpty == false {
             arguments.append(contentsOf: ["--remote-server-id", remoteServerID])
             appendOption("--remote-model", value: remoteModelID, into: &arguments)
+        }
+    }
+
+    private static func appendRecipeValues(_ values: [String: String], into arguments: inout [String]) {
+        for key in values.keys.sorted() {
+            appendOption("--set", value: "\(key)=\(values[key] ?? "")", into: &arguments)
         }
     }
 

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -327,6 +327,10 @@ public enum MelixCLICommandCodec {
             appendOption("--publish-backend", value: options.publishBackend, into: &arguments)
             appendOption("--local-publish-root", value: options.localPublishRoot, into: &arguments)
             json = options.json
+        case .modelInspect(let options):
+            arguments = ["model", "inspect"]
+            appendOption("--model-id", value: options.modelID, into: &arguments)
+            json = options.json
         case .modelImport(let options):
             arguments = ["model", "import"]
             appendOption("--path", value: options.path, into: &arguments)
@@ -669,6 +673,23 @@ public enum MelixCLICommandCodec {
         case .evalPromptArchive(let options):
             arguments = ["eval", "prompt", "archive"]
             appendOption("--prompt-id", value: options.promptID, into: &arguments)
+            json = options.json
+        case .evalCompare(let options):
+            arguments = ["eval", "compare"]
+            appendTarget(modelID: options.modelID, hfRepoID: options.hfRepoID, into: &arguments)
+            appendMultiOption("--target-model-id", values: options.targetModelIDs, into: &arguments)
+            appendMultiOption("--target-adapter", values: options.targetAdapterManifestPaths, into: &arguments)
+            appendMultiOption("--suite", values: options.suites, into: &arguments)
+            appendOption("--dataset-id", value: options.datasetID, into: &arguments)
+            appendPositiveUInt32("--sample-size", value: options.sampleSize, into: &arguments)
+            appendEvaluationSourceArguments(
+                source: options.source,
+                fieldMapping: options.fieldMapping,
+                profile: options.profile,
+                schemaPath: options.parameters["schema_path"],
+                into: &arguments
+            )
+            appendEvalParameters(options.parameters, into: &arguments)
             json = options.json
         case .evalExportSummaryCSV(let options):
             arguments = ["eval", "export-summary-csv"]

--- a/Sources/MelixCLICore/MelixPipelineRunner.swift
+++ b/Sources/MelixCLICore/MelixPipelineRunner.swift
@@ -872,6 +872,17 @@ private enum MelixPipelineCommandBuilder {
     static func command(named name: String, args: [String: Any]) throws -> MelixCLICommand {
         try validateSupportedCommand(named: name)
         switch name {
+        case "estimate.import":
+            return .estimateImport(
+                EstimateImportOptions(
+                    repoID: try requiredString("repo_id", args),
+                    targetKind: string("target_kind", args) ?? "import",
+                    targetInputs: parameters(args, excluding: [
+                        "repo_id",
+                        "target_kind",
+                    ])
+                )
+            )
         case "convert":
             return .convert(
                 ConvertOptions(
@@ -932,8 +943,22 @@ private enum MelixPipelineCommandBuilder {
                     hfToken: string("hf_token", args) ?? ""
                 )
             )
+        case "model.inspect":
+            return .modelInspect(
+                ModelInspectOptions(
+                    modelID: try requiredString("model_id", args)
+                )
+            )
         case "model.roots.rescan":
             return .modelRootsRescan(ModelRootsRescanOptions())
+        case "dataset.hub.download":
+            return .datasetHubDownload(
+                DatasetHubDownloadOptions(
+                    repoID: try requiredString("repo_id", args),
+                    revision: string("revision", args) ?? "main",
+                    hfToken: string("hf_token", args) ?? ""
+                )
+            )
         case "server.session.update":
             return .serverSessionUpdate(
                 ServerSessionUpdateOptions(
@@ -1123,6 +1148,33 @@ private enum MelixPipelineCommandBuilder {
                     evalPromptFile: string("eval_prompt_file", args) ?? ""
                 )
             )
+        case "eval.compare":
+            return .evalCompare(
+                EvalCompareOptions(
+                    modelID: string("model_id", args) ?? "",
+                    hfRepoID: string("repo_id", args) ?? "",
+                    targetModelIDs: try firstStringArray(["target_model_ids", "target_model_id"], args),
+                    targetAdapterManifestPaths: try firstStringArray(["target_adapters", "target_adapter"], args),
+                    suites: try firstStringArray(["suites", "suite"], args),
+                    datasetID: string("dataset_id", args) ?? "",
+                    sampleSize: try uint32("sample_size", args) ?? 0,
+                    source: evaluationSource(args),
+                    fieldMapping: evaluationFieldMapping(args),
+                    profile: try evaluationProfile(args),
+                    parameters: parameters(args, excluding: [
+                        "model_id",
+                        "repo_id",
+                        "target_model_ids",
+                        "target_model_id",
+                        "target_adapters",
+                        "target_adapter",
+                        "suites",
+                        "suite",
+                        "dataset_id",
+                        "sample_size",
+                    ])
+                )
+            )
         case "eval.export-summary-csv":
             return .evalExportSummaryCSV(EvalExportOptions(jobID: try requiredString("job_id", args), outputPath: try requiredString("output", args)))
         case "eval.export-samples-csv":
@@ -1135,12 +1187,15 @@ private enum MelixPipelineCommandBuilder {
     }
 
     private static let supportedCommandNames: Set<String> = [
+        "estimate.import",
         "convert",
         "quantize",
         "upload",
         "model.import",
         "model.hub.download",
+        "model.inspect",
         "model.roots.rescan",
+        "dataset.hub.download",
         "server.session.update",
         "server.session.select",
         "server.start",
@@ -1155,6 +1210,7 @@ private enum MelixPipelineCommandBuilder {
         "bench.matrix.export-summary-csv",
         "bench.matrix.export-requests-csv",
         "eval.run",
+        "eval.compare",
         "eval.export-summary-csv",
         "eval.export-samples-csv",
         "eval.export-samples-jsonl",

--- a/Sources/MelixCLICore/MelixWorkflowRecipes.swift
+++ b/Sources/MelixCLICore/MelixWorkflowRecipes.swift
@@ -1,0 +1,1074 @@
+import Dispatch
+import Foundation
+
+private struct MelixURIInspectionResult {
+    let payload: [String: Any]
+    let candidates: [[String: Any]]
+    let metrics: [String: Double]
+}
+
+private struct MelixWorkflowRecipe: @unchecked Sendable {
+    let id: String
+    let version: String
+    let title: String
+    let description: String
+    let tasks: [String]
+    let inputs: [[String: Any]]
+    let outputs: [String: Any]
+    let plan: @Sendable ([String: String]) throws -> [[String: Any]]
+
+    var payload: [String: Any] {
+        let plannedSteps = (try? plan(defaultValues)) ?? []
+        return [
+            "schema_version": "melix.workflow_recipe.v1",
+            "id": id,
+            "version": version,
+            "title": title,
+            "description": description,
+            "tasks": tasks,
+            "inputs": inputs,
+            "preflight": [
+                "uri_inspection": inputs.contains { $0["uri_kind"] != nil },
+                "pipeline_dry_run": true,
+                "memory_fit": "delegated_to_existing_commands",
+            ],
+            "pipeline": [
+                "schema_version": "melix.pipeline.v1",
+                "steps": plannedSteps,
+            ],
+            "outputs": outputs,
+            "provenance": [
+                "source": "built_in",
+                "governing_issue": "https://github.com/Keith-CY/melix/issues/636",
+                "schema_version": "melix.workflow_recipe.v1",
+            ],
+        ]
+    }
+
+    var defaultValues: [String: String] {
+        var values: [String: String] = [:]
+        for input in inputs {
+            guard let name = input["name"] as? String,
+                  let defaultValue = input["default"] as? String
+            else {
+                continue
+            }
+            values[name] = defaultValue
+        }
+        return values
+    }
+
+    var digest: String {
+        do {
+            return try MelixRecipeHash.hash(payload)
+        } catch {
+            return ""
+        }
+    }
+}
+
+private enum MelixRecipeHash {
+    static func hash(_ object: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        return data.reduce(UInt64(0xcbf29ce484222325)) { hash, byte in
+            (hash ^ UInt64(byte)) &* 0x100000001b3
+        }
+        .hexString
+    }
+
+    static func hash(_ value: String) -> String {
+        Data(value.utf8).reduce(UInt64(0xcbf29ce484222325)) { hash, byte in
+            (hash ^ UInt64(byte)) &* 0x100000001b3
+        }
+        .hexString
+    }
+}
+
+private extension UInt64 {
+    var hexString: String {
+        String(format: "%016llx", self)
+    }
+}
+
+private enum MelixWorkflowRecipeCatalog {
+    static let builtInRecipes: [MelixWorkflowRecipe] = [
+        hfModelImportRecipe,
+        localModelImportRecipe,
+        hfEvalDatasetRecipe,
+        loraLocalDatasetRecipe,
+        benchmarkEvalSmokeRecipe,
+        adapterCompareEvidenceRecipe,
+    ]
+
+    static func list(task: String = "") -> [MelixWorkflowRecipe] {
+        let normalizedTask = task.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalizedTask.isEmpty == false else {
+            return builtInRecipes
+        }
+        return builtInRecipes.filter { $0.tasks.contains(normalizedTask) }
+    }
+
+    static func recipe(id: String, version: String = "") throws -> MelixWorkflowRecipe {
+        let normalizedID = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedVersion = version.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let recipe = builtInRecipes.first(where: {
+            $0.id == normalizedID && (normalizedVersion.isEmpty || $0.version == normalizedVersion)
+        }) else {
+            throw MelixCLIError.runtime("Recipe \(id) was not found.")
+        }
+        return recipe
+    }
+
+    static func validate(_ recipe: MelixWorkflowRecipe) throws -> [String: Any] {
+        let start = DispatchTime.now()
+        var seenInputs = Set<String>()
+        for input in recipe.inputs {
+            guard let name = input["name"] as? String,
+                  name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            else {
+                throw MelixCLIError.usage("Recipe \(recipe.id) has an input without a name.")
+            }
+            guard seenInputs.insert(name).inserted else {
+                throw MelixCLIError.usage("Recipe \(recipe.id) has duplicate input \(name).")
+            }
+        }
+        let pipeline = try MelixRecipePlanner.plan(recipe: recipe, values: validationValues(for: recipe))
+        try MelixRecipePlanner.validatePipelineCommands(pipeline)
+        return [
+            "schema_version": "melix.workflow_recipe.validation.v1",
+            "recipe_id": recipe.id,
+            "recipe_version": recipe.version,
+            "valid": true,
+            "recipe_digest": recipe.digest,
+            "metrics": [
+                "recipe.schema_validate_ms": elapsedMilliseconds(since: start),
+            ],
+        ]
+    }
+
+    private static func validationValues(for recipe: MelixWorkflowRecipe) -> [String: String] {
+        var values = recipe.defaultValues
+        for input in recipe.inputs {
+            guard input["required"] as? Bool == true,
+                  let name = input["name"] as? String,
+                  (values[name] ?? "").isEmpty
+            else {
+                continue
+            }
+            values[name] = input["type"] as? String == "path" ? "/tmp/\(name)" : "sample-\(name)"
+        }
+        return values
+    }
+
+    private static let hfModelImportRecipe = MelixWorkflowRecipe(
+        id: "import.hf-mlx-model",
+        version: "1",
+        title: "Import an MLX-compatible Hugging Face model",
+        description: "Inspect fit, download a Hugging Face model, and rescan managed roots.",
+        tasks: ["model_import"],
+        inputs: [
+            requiredInput("repo_id", type: "string", uriKind: "hf_model_repo"),
+            optionalInput("revision", defaultValue: "main"),
+            optionalInput("model_id"),
+        ],
+        outputs: [
+            "managed_model_path": "from download_model step",
+        ],
+        plan: { values in
+            [
+                step(
+                    "estimate_import",
+                    command: "estimate.import",
+                    args: [
+                        "repo_id": try required("repo_id", in: values),
+                        "target_kind": "import",
+                    ]
+                ),
+                step(
+                    "download_model",
+                    command: "model.hub.download",
+                    args: [
+                        "repo_id": try required("repo_id", in: values),
+                        "revision": value("revision", in: values, defaultValue: "main"),
+                    ]
+                ),
+                step("rescan_roots", command: "model.roots.rescan"),
+            ]
+        }
+    )
+
+    private static let localModelImportRecipe = MelixWorkflowRecipe(
+        id: "import.local-mlx-model",
+        version: "1",
+        title: "Import a local MLX model directory",
+        description: "Import a local model directory into Melix managed storage and rescan roots.",
+        tasks: ["model_import"],
+        inputs: [
+            requiredInput("path", type: "path", uriKind: "local_mlx_model_directory"),
+            requiredInput("model_id"),
+            optionalInput("model_kind", defaultValue: "text"),
+            optionalInput("revision", defaultValue: "main"),
+        ],
+        outputs: [
+            "managed_model_path": "from import_model step",
+        ],
+        plan: { values in
+            [
+                step(
+                    "import_model",
+                    command: "model.import",
+                    args: [
+                        "path": try required("path", in: values),
+                        "model_id": try required("model_id", in: values),
+                        "model_kind": value("model_kind", in: values, defaultValue: "text"),
+                        "revision": value("revision", in: values, defaultValue: "main"),
+                    ]
+                ),
+                step("rescan_roots", command: "model.roots.rescan"),
+            ]
+        }
+    )
+
+    private static let hfEvalDatasetRecipe = MelixWorkflowRecipe(
+        id: "dataset.hf-eval",
+        version: "1",
+        title: "Prepare a Hugging Face evaluation dataset",
+        description: "Download a Hugging Face dataset snapshot for evaluation workflows.",
+        tasks: ["dataset_import", "eval"],
+        inputs: [
+            requiredInput("repo_id", type: "string", uriKind: "hf_dataset_repo"),
+            optionalInput("revision", defaultValue: "main"),
+        ],
+        outputs: [
+            "managed_dataset_path": "from download_dataset step",
+        ],
+        plan: { values in
+            [
+                step(
+                    "download_dataset",
+                    command: "dataset.hub.download",
+                    args: [
+                        "repo_id": try required("repo_id", in: values),
+                        "revision": value("revision", in: values, defaultValue: "main"),
+                    ]
+                ),
+            ]
+        }
+    )
+
+    private static let loraLocalDatasetRecipe = MelixWorkflowRecipe(
+        id: "train.lora.local-dataset",
+        version: "1",
+        title: "Train LoRA from a local dataset",
+        description: "Train a LoRA or QLoRA adapter from a local dataset package.",
+        tasks: ["train_lora"],
+        inputs: [
+            requiredInput("model_id"),
+            requiredInput("dataset_uri", type: "path", uriKind: "local_dataset"),
+            requiredInput("adapter_name"),
+            optionalInput("training_mode", defaultValue: "lora"),
+            optionalInput("target_repo"),
+        ],
+        outputs: [
+            "adapter_manifest": "from train_lora step",
+        ],
+        plan: { values in
+            [
+                step(
+                    "train_lora",
+                    command: "lora.train",
+                    args: [
+                        "model_id": try required("model_id", in: values),
+                        "dataset_uri": try required("dataset_uri", in: values),
+                        "adapter_name": try required("adapter_name", in: values),
+                        "training_mode": value("training_mode", in: values, defaultValue: "lora"),
+                        "target_repo": values["target_repo"] ?? "",
+                        "source_recipe_id": "train.lora.local-dataset",
+                    ]
+                ),
+            ]
+        }
+    )
+
+    private static let benchmarkEvalSmokeRecipe = MelixWorkflowRecipe(
+        id: "benchmark.eval.smoke",
+        version: "1",
+        title: "Run benchmark and evaluation smoke evidence",
+        description: "Run one small benchmark and one small evaluation against the same target.",
+        tasks: ["benchmark", "eval"],
+        inputs: [
+            requiredInput("model_id"),
+            optionalInput("bench_suite", defaultValue: "smoke"),
+            optionalInput("eval_suite", defaultValue: "smoke"),
+            optionalInput("dataset_id"),
+            optionalInput("sample_size", defaultValue: "1"),
+        ],
+        outputs: [
+            "benchmark_job": "from benchmark step",
+            "evaluation_job": "from evaluation step",
+        ],
+        plan: { values in
+            [
+                step(
+                    "benchmark",
+                    command: "bench.run",
+                    args: [
+                        "model_id": try required("model_id", in: values),
+                        "suite": [value("bench_suite", in: values, defaultValue: "smoke")],
+                        "context_length": [1024],
+                        "generation_length": 32,
+                        "batch_size": [1],
+                        "repeats": 1,
+                        "sample_size": value("sample_size", in: values, defaultValue: "1"),
+                        "source_recipe_id": "benchmark.eval.smoke",
+                    ]
+                ),
+                step(
+                    "evaluation",
+                    command: "eval.run",
+                    args: [
+                        "model_id": try required("model_id", in: values),
+                        "suite": [value("eval_suite", in: values, defaultValue: "smoke")],
+                        "dataset_id": values["dataset_id"] ?? "",
+                        "sample_size": value("sample_size", in: values, defaultValue: "1"),
+                        "source_recipe_id": "benchmark.eval.smoke",
+                    ]
+                ),
+            ]
+        }
+    )
+
+    private static let adapterCompareEvidenceRecipe = MelixWorkflowRecipe(
+        id: "adapter.compare.evidence",
+        version: "1",
+        title: "Compare base model and adapter evidence",
+        description: "Run base-vs-adapter evaluation comparison without release-gate verdict enforcement.",
+        tasks: ["eval_compare"],
+        inputs: [
+            requiredInput("model_id"),
+            requiredInput("target_adapter"),
+            optionalInput("suite", defaultValue: "smoke"),
+            optionalInput("dataset_id"),
+            optionalInput("sample_size", defaultValue: "1"),
+        ],
+        outputs: [
+            "comparison_job": "from eval_compare step",
+        ],
+        plan: { values in
+            [
+                step(
+                    "eval_compare",
+                    command: "eval.compare",
+                    args: [
+                        "model_id": try required("model_id", in: values),
+                        "target_adapter": [try required("target_adapter", in: values)],
+                        "suite": [value("suite", in: values, defaultValue: "smoke")],
+                        "dataset_id": values["dataset_id"] ?? "",
+                        "sample_size": value("sample_size", in: values, defaultValue: "1"),
+                        "source_recipe_id": "adapter.compare.evidence",
+                    ]
+                ),
+            ]
+        }
+    )
+
+    private static func requiredInput(_ name: String, type: String = "string", uriKind: String? = nil) -> [String: Any] {
+        var input: [String: Any] = [
+            "name": name,
+            "type": type,
+            "required": true,
+        ]
+        if let uriKind {
+            input["uri_kind"] = uriKind
+        }
+        return input
+    }
+
+    private static func optionalInput(_ name: String, defaultValue: String = "") -> [String: Any] {
+        var input: [String: Any] = [
+            "name": name,
+            "type": "string",
+            "required": false,
+        ]
+        if defaultValue.isEmpty == false {
+            input["default"] = defaultValue
+        }
+        return input
+    }
+
+    private static func step(_ id: String, command: String, args: [String: Any] = [:]) -> [String: Any] {
+        [
+            "id": id,
+            "command": command,
+            "args": args,
+        ]
+    }
+
+    private static func required(_ key: String, in values: [String: String]) throws -> String {
+        let value = value(key, in: values)
+        guard value.isEmpty == false else {
+            throw MelixCLIError.missingRequired("Recipe input \(key) is required.")
+        }
+        return value
+    }
+
+    private static func value(_ key: String, in values: [String: String], defaultValue: String = "") -> String {
+        (values[key] ?? defaultValue).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private enum MelixRecipePlanner {
+    static func plan(recipe: MelixWorkflowRecipe, values: [String: String]) throws -> [String: Any] {
+        let inputs = mergedInputs(recipe: recipe, values: values)
+        try validateRequiredInputs(recipe, values: inputs)
+        let steps = try recipe.plan(inputs)
+        let provenance = provenance(recipe: recipe, values: inputs)
+        return [
+            "schema_version": "melix.pipeline.v1",
+            "name": recipe.id,
+            "inputs": inputs.merging(provenance) { current, _ in current },
+            "steps": steps,
+            "metadata": [
+                "source_recipe_id": recipe.id,
+                "source_recipe_version": recipe.version,
+                "source_recipe_digest": recipe.digest,
+                "governing_issue": "https://github.com/Keith-CY/melix/issues/636",
+            ],
+        ]
+    }
+
+    static func validatePipelineCommands(_ pipeline: [String: Any]) throws {
+        guard pipeline["schema_version"] as? String == "melix.pipeline.v1" else {
+            throw MelixCLIError.usage("Recipe plan must emit melix.pipeline.v1.")
+        }
+        guard let steps = pipeline["steps"] as? [[String: Any]],
+              steps.isEmpty == false
+        else {
+            throw MelixCLIError.missingRequired("Recipe plan must emit at least one pipeline step.")
+        }
+        let supportedCommands = Set([
+            "estimate.import",
+            "model.import",
+            "model.hub.download",
+            "model.roots.rescan",
+            "dataset.hub.download",
+            "lora.train",
+            "bench.run",
+            "eval.run",
+            "eval.compare",
+        ])
+        for step in steps {
+            guard let command = step["command"] as? String,
+                  supportedCommands.contains(command)
+            else {
+                throw MelixCLIError.usage("Recipe plan contains an unsupported pipeline command.")
+            }
+        }
+    }
+
+    static func writePipeline(_ pipeline: [String: Any], to outputPath: String) throws -> String {
+        let expandedPath = (outputPath as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: expandedPath)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try MelixCLIJSON.prettyData(pipeline)
+        try data.write(to: url, options: .atomic)
+        return url.path
+    }
+
+    private static func mergedInputs(recipe: MelixWorkflowRecipe, values: [String: String]) -> [String: String] {
+        recipe.defaultValues.merging(values) { _, override in override }
+    }
+
+    private static func validateRequiredInputs(_ recipe: MelixWorkflowRecipe, values: [String: String]) throws {
+        for input in recipe.inputs {
+            guard input["required"] as? Bool == true,
+                  let name = input["name"] as? String
+            else {
+                continue
+            }
+            guard (values[name] ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
+                throw MelixCLIError.missingRequired("Recipe input \(name) is required.")
+            }
+        }
+    }
+
+    private static func provenance(recipe: MelixWorkflowRecipe, values: [String: String]) -> [String: String] {
+        var provenance = [
+            "source_recipe_id": recipe.id,
+            "source_recipe_version": recipe.version,
+            "source_recipe_digest": recipe.digest,
+        ]
+        for key in ["uri", "source_uri", "repo_id", "path", "dataset_uri"] {
+            guard let value = values[key], value.isEmpty == false else {
+                continue
+            }
+            provenance["source_uri_digest"] = MelixRecipeHash.hash(value)
+            break
+        }
+        return provenance
+    }
+}
+
+private enum MelixURIResolver {
+    static func inspect(_ uri: String) -> MelixURIInspectionResult {
+        let start = DispatchTime.now()
+        let normalizedURI = uri.trimmingCharacters(in: .whitespacesAndNewlines)
+        let candidates = candidates(for: normalizedURI)
+        let ambiguityCount = max(candidates.count - 1, 0)
+        let metrics = [
+            "uri.inspect_ms": elapsedMilliseconds(since: start),
+            "uri.candidate_count": Double(candidates.count),
+            "uri.ambiguity_count": Double(ambiguityCount),
+        ]
+        let payload: [String: Any] = [
+            "schema_version": "melix.uri_inspection.v1",
+            "original_uri": uri,
+            "normalized_locator": normalizedURI,
+            "candidate_count": candidates.count,
+            "ambiguity_count": ambiguityCount,
+            "candidates": candidates,
+            "metrics": metrics,
+        ]
+        return MelixURIInspectionResult(payload: payload, candidates: candidates, metrics: metrics)
+    }
+
+    private static func candidates(for uri: String) -> [[String: Any]] {
+        guard uri.isEmpty == false else {
+            return []
+        }
+        if let hf = hfLocator(uri) {
+            return [hfCandidate(hf)]
+        }
+        if isBareHuggingFaceRepo(uri) {
+            return [
+                candidate(
+                    kind: "hf_model_repo",
+                    confidence: 0.62,
+                    taskKind: "model_import",
+                    sourceKind: "huggingface",
+                    revision: "main",
+                    locator: "hf://model/\(uri)",
+                    reasons: ["bare org/repo locator; prefer hf://model or hf://dataset for disambiguation"],
+                    command: ["model", "hub", "download", "--repo-id", uri]
+                ),
+                candidate(
+                    kind: "hf_dataset_repo",
+                    confidence: 0.38,
+                    taskKind: "dataset_import",
+                    sourceKind: "huggingface",
+                    revision: "main",
+                    locator: "hf://dataset/\(uri)",
+                    reasons: ["bare org/repo locator could also identify a Hugging Face dataset"],
+                    command: ["dataset", "hub", "download", "--repo-id", uri]
+                ),
+            ]
+        }
+        return localCandidates(for: uri)
+    }
+
+    private static func hfLocator(_ uri: String) -> (kind: String, repoID: String, revision: String, locator: String)? {
+        if uri.hasPrefix("hf://model/") {
+            let (repoID, revision) = splitRevision(String(uri.dropFirst("hf://model/".count)))
+            return ("hf_model_repo", repoID, revision, "hf://model/\(repoID)@\(revision)")
+        }
+        if uri.hasPrefix("hf://dataset/") {
+            let (repoID, revision) = splitRevision(String(uri.dropFirst("hf://dataset/".count)))
+            return ("hf_dataset_repo", repoID, revision, "hf://dataset/\(repoID)@\(revision)")
+        }
+        if uri.hasPrefix("https://huggingface.co/datasets/") {
+            let (repoID, revision) = splitRevision(String(uri.dropFirst("https://huggingface.co/datasets/".count)))
+            return ("hf_dataset_repo", repoID, revision, "hf://dataset/\(repoID)@\(revision)")
+        }
+        if uri.hasPrefix("https://huggingface.co/") {
+            let (repoID, revision) = splitRevision(String(uri.dropFirst("https://huggingface.co/".count)))
+            return ("hf_model_repo", repoID, revision, "hf://model/\(repoID)@\(revision)")
+        }
+        return nil
+    }
+
+    private static func hfCandidate(_ hf: (kind: String, repoID: String, revision: String, locator: String)) -> [String: Any] {
+        let isDataset = hf.kind == "hf_dataset_repo"
+        return candidate(
+            kind: hf.kind,
+            confidence: 0.96,
+            taskKind: isDataset ? "dataset_import" : "model_import",
+            sourceKind: "huggingface",
+            revision: hf.revision,
+            locator: hf.locator,
+            reasons: ["explicit Hugging Face \(isDataset ? "dataset" : "model") locator"],
+            command: isDataset
+                ? ["dataset", "hub", "download", "--repo-id", hf.repoID, "--revision", hf.revision]
+                : ["model", "hub", "download", "--repo-id", hf.repoID, "--revision", hf.revision],
+            extra: ["repo_id": hf.repoID]
+        )
+    }
+
+    private static func localCandidates(for rawURI: String) -> [[String: Any]] {
+        let path = (rawURI as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: path)
+        let fileManager = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return [
+                candidate(
+                    kind: "unknown",
+                    confidence: 0.0,
+                    taskKind: "inspect",
+                    sourceKind: "local_path",
+                    locator: url.path,
+                    reasons: ["path does not exist"],
+                    command: []
+                ),
+            ]
+        }
+        if isDirectory.boolValue {
+            return localDirectoryCandidates(url)
+        }
+        return localFileCandidates(url)
+    }
+
+    private static func localDirectoryCandidates(_ url: URL) -> [[String: Any]] {
+        var candidates: [[String: Any]] = []
+        let fileManager = FileManager.default
+        let children = (try? fileManager.contentsOfDirectory(atPath: url.path)) ?? []
+        if children.contains("config.json"),
+           children.contains(where: { ["safetensors", "bin", "gguf"].contains(URL(fileURLWithPath: $0).pathExtension.lowercased()) })
+        {
+            candidates.append(candidate(
+                kind: "local_mlx_model_directory",
+                confidence: 0.90,
+                taskKind: "model_import",
+                sourceKind: "local_path",
+                locator: url.path,
+                reasons: ["directory contains config.json and model weight files"],
+                command: ["model", "import", "--path", url.path],
+                extra: ["resolved_path": url.path]
+            ))
+        }
+        if children.contains("samples.jsonl") || children.contains("dataset.json") || children.contains("manifest.json") {
+            candidates.append(candidate(
+                kind: "local_dataset_package",
+                confidence: 0.72,
+                taskKind: "train_lora",
+                sourceKind: "local_path",
+                locator: url.path,
+                reasons: ["directory contains dataset package markers"],
+                command: ["lora", "dataset", "inspect", "--dataset-uri", url.path],
+                extra: ["resolved_path": url.path]
+            ))
+        }
+        if children.contains("train_lora.adapter.json") || children.contains("adapter_config.json") {
+            candidates.append(candidate(
+                kind: "local_lora_adapter",
+                confidence: 0.82,
+                taskKind: "eval_compare",
+                sourceKind: "local_path",
+                locator: url.path,
+                reasons: ["directory contains LoRA adapter metadata"],
+                command: ["eval", "compare", "--target-adapter", url.path],
+                extra: ["resolved_path": url.path]
+            ))
+        }
+        return candidates.isEmpty ? [
+            candidate(
+                kind: "local_directory",
+                confidence: 0.20,
+                taskKind: "inspect",
+                sourceKind: "local_path",
+                locator: url.path,
+                reasons: ["directory does not match a known Melix artifact shape"],
+                command: [],
+                extra: ["resolved_path": url.path]
+            ),
+        ] : candidates
+    }
+
+    private static func localFileCandidates(_ url: URL) -> [[String: Any]] {
+        let ext = url.pathExtension.lowercased()
+        if ["jsonl", "csv", "parquet"].contains(ext) {
+            return [
+                candidate(
+                    kind: "local_dataset_file",
+                    confidence: 0.88,
+                    taskKind: "train_lora",
+                    sourceKind: "local_path",
+                    locator: url.path,
+                    reasons: ["file extension \(ext) is supported by dataset workflows"],
+                    command: ["lora", "dataset", "inspect", "--dataset-uri", url.path],
+                    extra: ["resolved_path": url.path, "dataset_kind": ext]
+                ),
+            ]
+        }
+        if url.lastPathComponent == "train_lora.adapter.json" || url.lastPathComponent.hasSuffix(".adapter.json") {
+            return [
+                candidate(
+                    kind: "local_lora_adapter_manifest",
+                    confidence: 0.92,
+                    taskKind: "eval_compare",
+                    sourceKind: "local_path",
+                    locator: url.path,
+                    reasons: ["file name matches a Melix LoRA adapter manifest"],
+                    command: ["eval", "compare", "--target-adapter", url.path],
+                    extra: ["resolved_path": url.path]
+                ),
+            ]
+        }
+        if ext == "gguf" {
+            return [
+                candidate(
+                    kind: "gguf_model_file",
+                    confidence: 0.70,
+                    taskKind: "inspect",
+                    sourceKind: "local_path",
+                    locator: url.path,
+                    reasons: ["GGUF files are inspectable but are not a supported direct import target in this slice"],
+                    command: [],
+                    extra: ["resolved_path": url.path, "supported_import": false]
+                ),
+            ]
+        }
+        return [
+            candidate(
+                kind: "local_file",
+                confidence: 0.10,
+                taskKind: "inspect",
+                sourceKind: "local_path",
+                locator: url.path,
+                reasons: ["file does not match a known Melix artifact shape"],
+                command: [],
+                extra: ["resolved_path": url.path]
+            ),
+        ]
+    }
+
+    private static func candidate(
+        kind: String,
+        confidence: Double,
+        taskKind: String,
+        sourceKind: String,
+        revision: String = "",
+        locator: String,
+        reasons: [String],
+        command: [String],
+        extra: [String: Any] = [:]
+    ) -> [String: Any] {
+        var payload: [String: Any] = [
+            "kind": kind,
+            "confidence": confidence,
+            "task_kind": taskKind,
+            "source_kind": sourceKind,
+            "normalized_locator": locator,
+            "reasons": reasons,
+            "recommended_next_action": command.isEmpty ? "inspect_only" : command.joined(separator: " "),
+            "generated_command_arguments": command,
+            "warnings": [],
+        ]
+        if revision.isEmpty == false {
+            payload["revision"] = revision
+        }
+        for (key, value) in extra {
+            payload[key] = value
+        }
+        return payload
+    }
+
+    private static func splitRevision(_ value: String) -> (repoID: String, revision: String) {
+        let trimmed = value.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let parts = trimmed.split(separator: "@", maxSplits: 1, omittingEmptySubsequences: false)
+        let repoID = parts.first.map(String.init) ?? ""
+        let revision = parts.count > 1 ? String(parts[1]) : "main"
+        return (repoID, revision.isEmpty ? "main" : revision)
+    }
+
+    private static func isBareHuggingFaceRepo(_ value: String) -> Bool {
+        let parts = value.split(separator: "/", omittingEmptySubsequences: false)
+        return parts.count == 2
+            && parts.allSatisfy { part in
+                part.isEmpty == false && part.allSatisfy { character in
+                    character.isLetter || character.isNumber || ["-", "_", "."].contains(character)
+                }
+            }
+    }
+}
+
+extension MelixCLIRunner {
+    public func runURIInspect(_ options: URIInspectOptions) throws -> String {
+        let inspection = MelixURIResolver.inspect(options.uri)
+        if options.json {
+            return try prettyWorkflowJSON(inspection.payload)
+        }
+        return renderURIInspection(inspection.payload)
+    }
+
+    public func runURIImport(_ options: URIImportOptions) async throws -> String {
+        let inspection = MelixURIResolver.inspect(options.uri)
+        guard let candidate = inspection.candidates.first,
+              inspection.candidates.count == 1
+        else {
+            let payload: [String: Any] = [
+                "schema_version": "melix.uri_import.v1",
+                "status": "ambiguous",
+                "inspection": inspection.payload,
+            ]
+            return options.json ? try prettyWorkflowJSON(payload) : "URI import is ambiguous. Run melix uri inspect first.\n"
+        }
+        guard let kind = candidate["kind"] as? String else {
+            throw MelixCLIError.runtime("URI inspection did not produce a candidate kind.")
+        }
+        let command = try commandForURIImport(kind: kind, candidate: candidate, options: options)
+        let payload: [String: Any] = [
+            "schema_version": "melix.uri_import.v1",
+            "status": options.dryRun ? "planned" : "executed",
+            "candidate": candidate,
+            "command_id": MelixCLICommandCodec.commandID(for: command),
+            "arguments": try MelixCLICommandCodec.arguments(for: command),
+            "metrics": inspection.metrics,
+        ]
+        guard options.dryRun else {
+            let output = try await run(command)
+            if options.json {
+                var executedPayload = payload
+                executedPayload["result"] = MelixCLIJSON.jsonValue(from: output)
+                return try prettyWorkflowJSON(executedPayload)
+            }
+            return output
+        }
+        if options.json {
+            return try prettyWorkflowJSON(payload)
+        }
+        return (payload["arguments"] as? [String] ?? []).joined(separator: " ") + "\n"
+    }
+
+    public func runRecipesList(_ options: RecipeListOptions) throws -> String {
+        let start = DispatchTime.now()
+        let recipes = MelixWorkflowRecipeCatalog.list(task: options.task)
+        let payload: [String: Any] = [
+            "schema_version": "melix.workflow_recipe_catalog.v1",
+            "recipes": recipes.map(summaryPayload),
+            "metrics": [
+                "recipe.lookup_ms": elapsedMilliseconds(since: start),
+            ],
+        ]
+        return options.json ? try prettyWorkflowJSON(payload) : renderRecipeList(recipes)
+    }
+
+    public func runRecipesShow(_ options: RecipeShowOptions) throws -> String {
+        let start = DispatchTime.now()
+        let recipe = try MelixWorkflowRecipeCatalog.recipe(id: options.recipeID, version: options.version)
+        var payload = recipe.payload
+        payload["recipe_digest"] = recipe.digest
+        payload["metrics"] = [
+            "recipe.lookup_ms": elapsedMilliseconds(since: start),
+        ]
+        return options.json ? try prettyWorkflowJSON(payload) : renderRecipeShow(recipe)
+    }
+
+    public func runRecipesValidate(_ options: RecipeValidateOptions) throws -> String {
+        let recipe = try MelixWorkflowRecipeCatalog.recipe(id: options.target)
+        let payload = try MelixWorkflowRecipeCatalog.validate(recipe)
+        return options.json ? try prettyWorkflowJSON(payload) : "Recipe \(recipe.id) is valid.\n"
+    }
+
+    public func runRecipesPlan(_ options: RecipePlanOptions) throws -> String {
+        let startedAt = DispatchTime.now()
+        let lookupStart = DispatchTime.now()
+        let recipe = try MelixWorkflowRecipeCatalog.recipe(id: options.recipeID, version: options.version)
+        let lookupMS = elapsedMilliseconds(since: lookupStart)
+        let plan = try MelixRecipePlanner.plan(recipe: recipe, values: options.values)
+        try MelixRecipePlanner.validatePipelineCommands(plan)
+        var artifacts: [[String: Any]] = []
+        if options.outputPath.isEmpty == false {
+            let writtenPath = try MelixRecipePlanner.writePipeline(plan, to: options.outputPath)
+            artifacts.append(["kind": "pipeline", "path": writtenPath])
+        }
+        let payload: [String: Any] = [
+            "schema_version": "melix.workflow_recipe_plan.v1",
+            "recipe_id": recipe.id,
+            "recipe_version": recipe.version,
+            "recipe_digest": recipe.digest,
+            "pipeline": plan,
+            "artifacts": artifacts,
+            "metrics": [
+                "recipe.lookup_ms": lookupMS,
+                "recipe.schema_validate_ms": 0,
+                "recipe.plan_ms": elapsedMilliseconds(since: startedAt),
+            ],
+        ]
+        return options.json ? try prettyWorkflowJSON(payload) : try MelixCLIJSON.prettyString(plan)
+    }
+
+    public func runRecipesApply(_ options: RecipeApplyOptions) async throws -> String {
+        let startedAt = DispatchTime.now()
+        let recipe = try MelixWorkflowRecipeCatalog.recipe(id: options.recipeID, version: options.version)
+        let plan = try MelixRecipePlanner.plan(recipe: recipe, values: options.values)
+        try MelixRecipePlanner.validatePipelineCommands(plan)
+        let runRoot = MelixHome(environment: environment).rootURL
+            .appendingPathComponent("workflow-recipes", isDirectory: true)
+            .appendingPathComponent(sanitizeRecipePathComponent(recipe.id), isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: runRoot, withIntermediateDirectories: true)
+        let pipelineURL = runRoot.appendingPathComponent("pipeline.json")
+        _ = try MelixRecipePlanner.writePipeline(plan, to: pipelineURL.path)
+        let receiptURL = runRoot.appendingPathComponent("receipts", isDirectory: true)
+        let output = try await runPipeline(
+            PipelineRunOptions(
+                filePath: pipelineURL.path,
+                receiptDir: receiptURL.path,
+                resume: options.resume,
+                fromStepID: options.fromStepID,
+                dryRun: options.dryRun
+            )
+        )
+        if options.json {
+            var payload = MelixCLIJSON.jsonValue(from: output) as? [String: Any] ?? ["pipeline_output": output]
+            payload["recipe"] = [
+                "id": recipe.id,
+                "version": recipe.version,
+                "digest": recipe.digest,
+            ]
+            payload["metrics"] = (payload["metrics"] as? [String: Any] ?? [:]).merging([
+                "recipe.apply_start_ms": elapsedMilliseconds(since: startedAt),
+            ]) { current, _ in current }
+            return try prettyWorkflowJSON(payload)
+        }
+        return output
+    }
+
+    public func runRecipesInit(_ options: RecipeInitOptions) throws -> String {
+        let inspection = MelixURIResolver.inspect(options.sourceURI)
+        let recipeID = recommendedRecipeID(task: options.task, inspection: inspection)
+        let recipe = try MelixWorkflowRecipeCatalog.recipe(id: recipeID)
+        var payload = recipe.payload
+        payload["provenance"] = [
+            "source": "generated_from_uri",
+            "source_uri_digest": MelixRecipeHash.hash(options.sourceURI),
+            "inspection": inspection.payload,
+        ]
+        if options.outputPath.isEmpty == false {
+            _ = try MelixRecipePlanner.writePipeline(payload, to: options.outputPath)
+        }
+        return options.json ? try prettyWorkflowJSON(payload) : renderRecipeShow(recipe)
+    }
+
+    private func commandForURIImport(
+        kind: String,
+        candidate: [String: Any],
+        options: URIImportOptions
+    ) throws -> MelixCLICommand {
+        switch kind {
+        case "hf_model_repo":
+            return .modelHubDownload(
+                .init(
+                    repoID: try requiredCandidateString("repo_id", candidate),
+                    revision: options.revision.isEmpty ? (candidate["revision"] as? String ?? "main") : options.revision,
+                    json: options.json
+                )
+            )
+        case "hf_dataset_repo":
+            return .datasetHubDownload(
+                .init(
+                    repoID: try requiredCandidateString("repo_id", candidate),
+                    revision: options.revision.isEmpty ? (candidate["revision"] as? String ?? "main") : options.revision,
+                    json: options.json
+                )
+            )
+        case "local_mlx_model_directory":
+            guard options.modelID.isEmpty == false else {
+                throw MelixCLIError.missingRequired("--model-id is required to import a local model URI.")
+            }
+            return .modelImport(
+                .init(
+                    path: try requiredCandidateString("resolved_path", candidate),
+                    modelID: options.modelID,
+                    revision: options.revision,
+                    json: options.json
+                )
+            )
+        default:
+            throw MelixCLIError.runtime("URI kind \(kind) is not importable by melix uri import.")
+        }
+    }
+
+    private func requiredCandidateString(_ key: String, _ candidate: [String: Any]) throws -> String {
+        guard let value = candidate[key] as? String,
+              value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        else {
+            throw MelixCLIError.runtime("URI candidate did not include \(key).")
+        }
+        return value
+    }
+
+    private func summaryPayload(_ recipe: MelixWorkflowRecipe) -> [String: Any] {
+        [
+            "id": recipe.id,
+            "version": recipe.version,
+            "title": recipe.title,
+            "tasks": recipe.tasks,
+            "recipe_digest": recipe.digest,
+        ]
+    }
+
+    private func renderURIInspection(_ payload: [String: Any]) -> String {
+        guard let candidates = payload["candidates"] as? [[String: Any]],
+              candidates.isEmpty == false
+        else {
+            return "No candidates found.\n"
+        }
+        var lines = ["kind\ttask_kind\tconfidence\tnormalized_locator"]
+        for candidate in candidates {
+            lines.append([
+                candidate["kind"] as? String ?? "",
+                candidate["task_kind"] as? String ?? "",
+                "\(candidate["confidence"] ?? "")",
+                candidate["normalized_locator"] as? String ?? "",
+            ].joined(separator: "\t"))
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private func renderRecipeList(_ recipes: [MelixWorkflowRecipe]) -> String {
+        guard recipes.isEmpty == false else {
+            return "No recipes found.\n"
+        }
+        var lines = ["id\tversion\ttasks\ttitle"]
+        for recipe in recipes {
+            lines.append([recipe.id, recipe.version, recipe.tasks.joined(separator: ","), recipe.title].joined(separator: "\t"))
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private func renderRecipeShow(_ recipe: MelixWorkflowRecipe) -> String {
+        "id=\(recipe.id)\nversion=\(recipe.version)\ntasks=\(recipe.tasks.joined(separator: ","))\ntitle=\(recipe.title)\n"
+    }
+
+    private func recommendedRecipeID(task: String, inspection: MelixURIInspectionResult) -> String {
+        if task == "import",
+           let firstKind = inspection.candidates.first?["kind"] as? String
+        {
+            if firstKind == "hf_model_repo" {
+                return "import.hf-mlx-model"
+            }
+            if firstKind == "local_mlx_model_directory" {
+                return "import.local-mlx-model"
+            }
+        }
+        if task == "eval" {
+            return "dataset.hf-eval"
+        }
+        return MelixWorkflowRecipeCatalog.list(task: task).first?.id ?? "import.hf-mlx-model"
+    }
+
+    private func prettyWorkflowJSON(_ payload: [String: Any]) throws -> String {
+        try MelixCLIJSON.prettyString(payload)
+    }
+
+    private func sanitizeRecipePathComponent(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+        let sanitized = String(value.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" })
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-."))
+        return sanitized.isEmpty ? "recipe" : sanitized
+    }
+}

--- a/Sources/MelixCLICore/MelixWorkflowRecipes.swift
+++ b/Sources/MelixCLICore/MelixWorkflowRecipes.swift
@@ -1,6 +1,8 @@
 import Dispatch
 import Foundation
 
+private let defaultWorkflowRecipeRunRetentionLimit = 20
+
 private struct MelixURIInspectionResult {
     let payload: [String: Any]
     let candidates: [[String: Any]]
@@ -69,7 +71,11 @@ private struct MelixWorkflowRecipe: @unchecked Sendable {
 
 private enum MelixRecipeHash {
     static func hash(_ object: [String: Any]) throws -> String {
-        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        let compatibleObject = try jsonCompatibleValue(object, context: "recipe payload")
+        guard JSONSerialization.isValidJSONObject(compatibleObject) else {
+            throw MelixCLIError.usage("Recipe payload contains values that cannot be serialized as JSON.")
+        }
+        let data = try JSONSerialization.data(withJSONObject: compatibleObject, options: [.sortedKeys])
         return data.reduce(UInt64(0xcbf29ce484222325)) { hash, byte in
             (hash ^ UInt64(byte)) &* 0x100000001b3
         }
@@ -81,6 +87,27 @@ private enum MelixRecipeHash {
             (hash ^ UInt64(byte)) &* 0x100000001b3
         }
         .hexString
+    }
+
+    private static func jsonCompatibleValue(_ value: Any, context: String) throws -> Any {
+        switch value {
+        case let dictionary as [String: Any]:
+            var compatible: [String: Any] = [:]
+            for (key, nestedValue) in dictionary {
+                compatible[key] = try jsonCompatibleValue(nestedValue, context: "\(context).\(key)")
+            }
+            return compatible
+        case let array as [Any]:
+            return try array.enumerated().map { index, nestedValue in
+                try jsonCompatibleValue(nestedValue, context: "\(context)[\(index)]")
+            }
+        case is NSNull, is String, is Bool, is Int, is Int64, is UInt, is UInt64, is Double, is Float:
+            return value
+        case let number as NSNumber:
+            return number
+        default:
+            throw MelixCLIError.usage("Recipe payload field \(context) is not JSON-compatible.")
+        }
     }
 }
 
@@ -132,6 +159,7 @@ private enum MelixWorkflowRecipeCatalog {
                 throw MelixCLIError.usage("Recipe \(recipe.id) has duplicate input \(name).")
             }
         }
+        _ = try MelixRecipeHash.hash(recipe.payload)
         let pipeline = try MelixRecipePlanner.plan(recipe: recipe, values: validationValues(for: recipe))
         try MelixRecipePlanner.validatePipelineCommands(pipeline)
         return [
@@ -420,8 +448,10 @@ private enum MelixWorkflowRecipeCatalog {
 private enum MelixRecipePlanner {
     static func plan(recipe: MelixWorkflowRecipe, values: [String: String]) throws -> [String: Any] {
         let inputs = mergedInputs(recipe: recipe, values: values)
+        let validationStart = DispatchTime.now()
         try validateRequiredInputs(recipe, values: inputs)
         let steps = try recipe.plan(inputs)
+        let schemaValidateMS = elapsedMilliseconds(since: validationStart)
         let provenance = provenance(recipe: recipe, values: inputs)
         return [
             "schema_version": "melix.pipeline.v1",
@@ -433,6 +463,7 @@ private enum MelixRecipePlanner {
                 "source_recipe_version": recipe.version,
                 "source_recipe_digest": recipe.digest,
                 "governing_issue": "https://github.com/Keith-CY/melix/issues/636",
+                "recipe.schema_validate_ms": schemaValidateMS,
             ],
         ]
     }
@@ -570,23 +601,87 @@ private enum MelixURIResolver {
     }
 
     private static func hfLocator(_ uri: String) -> (kind: String, repoID: String, revision: String, locator: String)? {
-        if uri.hasPrefix("hf://model/") {
-            let (repoID, revision) = splitRevision(String(uri.dropFirst("hf://model/".count)))
-            return ("hf_model_repo", repoID, revision, "hf://model/\(repoID)@\(revision)")
+        guard let components = URLComponents(string: uri) else {
+            return nil
         }
-        if uri.hasPrefix("hf://dataset/") {
-            let (repoID, revision) = splitRevision(String(uri.dropFirst("hf://dataset/".count)))
-            return ("hf_dataset_repo", repoID, revision, "hf://dataset/\(repoID)@\(revision)")
+        if components.scheme == "hf" {
+            let kind: String
+            let locatorPrefix: String
+            switch components.host?.lowercased() {
+            case "model":
+                kind = "hf_model_repo"
+                locatorPrefix = "hf://model"
+            case "dataset":
+                kind = "hf_dataset_repo"
+                locatorPrefix = "hf://dataset"
+            default:
+                return nil
+            }
+            return hfLocator(kind: kind, locatorPrefix: locatorPrefix, pathComponents: hfPathComponents(components.path))
         }
-        if uri.hasPrefix("https://huggingface.co/datasets/") {
-            let (repoID, revision) = splitRevision(String(uri.dropFirst("https://huggingface.co/datasets/".count)))
-            return ("hf_dataset_repo", repoID, revision, "hf://dataset/\(repoID)@\(revision)")
+        guard ["http", "https"].contains(components.scheme?.lowercased() ?? ""),
+              components.host?.lowercased() == "huggingface.co"
+        else {
+            return nil
         }
-        if uri.hasPrefix("https://huggingface.co/") {
-            let (repoID, revision) = splitRevision(String(uri.dropFirst("https://huggingface.co/".count)))
-            return ("hf_model_repo", repoID, revision, "hf://model/\(repoID)@\(revision)")
+        var pathComponents = hfPathComponents(components.path)
+        var kind = "hf_model_repo"
+        var locatorPrefix = "hf://model"
+        if pathComponents.first == "datasets" {
+            pathComponents.removeFirst()
+            kind = "hf_dataset_repo"
+            locatorPrefix = "hf://dataset"
         }
-        return nil
+        return hfLocator(kind: kind, locatorPrefix: locatorPrefix, pathComponents: pathComponents)
+    }
+
+    private static func hfLocator(
+        kind: String,
+        locatorPrefix: String,
+        pathComponents: [String]
+    ) -> (kind: String, repoID: String, revision: String, locator: String)? {
+        guard pathComponents.count >= 2 else {
+            return nil
+        }
+        let second = pathComponents[1].split(separator: "@", maxSplits: 1, omittingEmptySubsequences: false)
+        let repoName = second.first.map(String.init) ?? ""
+        let repoID = "\(pathComponents[0])/\(repoName)"
+        guard isBareHuggingFaceRepo(repoID) else {
+            return nil
+        }
+        let revision: String
+        if second.count > 1 {
+            let explicitRevision = [String(second[1])] + Array(pathComponents.dropFirst(2))
+            revision = explicitRevision.joined(separator: "/")
+        } else {
+            revision = revisionFromPathRemainder(Array(pathComponents.dropFirst(2))) ?? "main"
+        }
+        return (kind, repoID, revision, "\(locatorPrefix)/\(repoID)@\(revision)")
+    }
+
+    private static func hfPathComponents(_ path: String) -> [String] {
+        path.split(separator: "/", omittingEmptySubsequences: true)
+            .map(String.init)
+            .map { $0.removingPercentEncoding ?? $0 }
+    }
+
+    private static func revisionFromPathRemainder(_ pathRemainder: [String]) -> String? {
+        guard let marker = pathRemainder.first,
+              ["tree", "blob", "resolve"].contains(marker),
+              pathRemainder.count >= 2
+        else {
+            return nil
+        }
+        let revisionParts: ArraySlice<String>
+        if pathRemainder.count >= 4,
+           pathRemainder[1] == "refs"
+        {
+            revisionParts = pathRemainder[1...3]
+        } else {
+            revisionParts = pathRemainder[1...1]
+        }
+        let revision = revisionParts.joined(separator: "/")
+        return revision.isEmpty ? nil : revision
     }
 
     private static func hfCandidate(_ hf: (kind: String, repoID: String, revision: String, locator: String)) -> [String: Any] {
@@ -633,10 +728,12 @@ private enum MelixURIResolver {
     private static func localDirectoryCandidates(_ url: URL) -> [[String: Any]] {
         var candidates: [[String: Any]] = []
         let fileManager = FileManager.default
-        let children = (try? fileManager.contentsOfDirectory(atPath: url.path)) ?? []
-        if children.contains("config.json"),
-           children.contains(where: { ["safetensors", "bin", "gguf"].contains(URL(fileURLWithPath: $0).pathExtension.lowercased()) })
-        {
+        let hasConfig = fileManager.fileExists(atPath: url.appendingPathComponent("config.json").path)
+        let hasModelWeights = directoryContainsFile(
+            in: url,
+            withExtensions: ["safetensors", "bin", "gguf"]
+        )
+        if hasConfig && hasModelWeights {
             candidates.append(candidate(
                 kind: "local_mlx_model_directory",
                 confidence: 0.90,
@@ -648,7 +745,9 @@ private enum MelixURIResolver {
                 extra: ["resolved_path": url.path]
             ))
         }
-        if children.contains("samples.jsonl") || children.contains("dataset.json") || children.contains("manifest.json") {
+        if ["samples.jsonl", "dataset.json", "manifest.json"].contains(where: {
+            fileManager.fileExists(atPath: url.appendingPathComponent($0).path)
+        }) {
             candidates.append(candidate(
                 kind: "local_dataset_package",
                 confidence: 0.72,
@@ -660,7 +759,9 @@ private enum MelixURIResolver {
                 extra: ["resolved_path": url.path]
             ))
         }
-        if children.contains("train_lora.adapter.json") || children.contains("adapter_config.json") {
+        if ["train_lora.adapter.json", "adapter_config.json"].contains(where: {
+            fileManager.fileExists(atPath: url.appendingPathComponent($0).path)
+        }) {
             candidates.append(candidate(
                 kind: "local_lora_adapter",
                 confidence: 0.82,
@@ -684,6 +785,26 @@ private enum MelixURIResolver {
                 extra: ["resolved_path": url.path]
             ),
         ] : candidates
+    }
+
+    private static func directoryContainsFile(in url: URL, withExtensions extensions: Set<String>) -> Bool {
+        guard let enumerator = FileManager.default.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+        ) else {
+            return false
+        }
+        for case let childURL as URL in enumerator {
+            guard extensions.contains(childURL.pathExtension.lowercased()) else {
+                continue
+            }
+            let values = try? childURL.resourceValues(forKeys: [.isRegularFileKey])
+            if values?.isRegularFile != false {
+                return true
+            }
+        }
+        return false
     }
 
     private static func localFileCandidates(_ url: URL) -> [[String: Any]] {
@@ -805,15 +926,23 @@ extension MelixCLIRunner {
 
     public func runURIImport(_ options: URIImportOptions) async throws -> String {
         let inspection = MelixURIResolver.inspect(options.uri)
-        guard let candidate = inspection.candidates.first,
-              inspection.candidates.count == 1
+        let importableCandidates = inspection.candidates.filter { candidate in
+            isURIImportableKind(candidate["kind"] as? String ?? "")
+        }
+        guard let candidate = importableCandidates.first,
+              importableCandidates.count == 1
         else {
+            let status = importableCandidates.isEmpty ? "unresolved" : "ambiguous"
             let payload: [String: Any] = [
                 "schema_version": "melix.uri_import.v1",
-                "status": "ambiguous",
+                "status": status,
                 "inspection": inspection.payload,
+                "importable_candidate_count": importableCandidates.count,
             ]
-            return options.json ? try prettyWorkflowJSON(payload) : "URI import is ambiguous. Run melix uri inspect first.\n"
+            let message = importableCandidates.isEmpty
+                ? "URI import did not resolve an importable candidate. Run melix uri inspect first.\n"
+                : "URI import is ambiguous. Run melix uri inspect first.\n"
+            return options.json ? try prettyWorkflowJSON(payload) : message
         }
         guard let kind = candidate["kind"] as? String else {
             throw MelixCLIError.runtime("URI inspection did not produce a candidate kind.")
@@ -893,7 +1022,7 @@ extension MelixCLIRunner {
             "artifacts": artifacts,
             "metrics": [
                 "recipe.lookup_ms": lookupMS,
-                "recipe.schema_validate_ms": 0,
+                "recipe.schema_validate_ms": (plan["metadata"] as? [String: Any])?["recipe.schema_validate_ms"] ?? 0,
                 "recipe.plan_ms": elapsedMilliseconds(since: startedAt),
             ],
         ]
@@ -910,6 +1039,11 @@ extension MelixCLIRunner {
             .appendingPathComponent(sanitizeRecipePathComponent(recipe.id), isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: runRoot, withIntermediateDirectories: true)
+        let retainedRuns = try pruneRecipeRuns(
+            under: runRoot.deletingLastPathComponent(),
+            keeping: runRoot,
+            limit: defaultWorkflowRecipeRunRetentionLimit
+        )
         let pipelineURL = runRoot.appendingPathComponent("pipeline.json")
         _ = try MelixRecipePlanner.writePipeline(plan, to: pipelineURL.path)
         let receiptURL = runRoot.appendingPathComponent("receipts", isDirectory: true)
@@ -928,9 +1062,12 @@ extension MelixCLIRunner {
                 "id": recipe.id,
                 "version": recipe.version,
                 "digest": recipe.digest,
+                "retention_limit": defaultWorkflowRecipeRunRetentionLimit,
+                "run_root": runRoot.path,
             ]
             payload["metrics"] = (payload["metrics"] as? [String: Any] ?? [:]).merging([
                 "recipe.apply_start_ms": elapsedMilliseconds(since: startedAt),
+                "recipe.apply_retained_runs": retainedRuns,
             ]) { current, _ in current }
             return try prettyWorkflowJSON(payload)
         }
@@ -939,7 +1076,7 @@ extension MelixCLIRunner {
 
     public func runRecipesInit(_ options: RecipeInitOptions) throws -> String {
         let inspection = MelixURIResolver.inspect(options.sourceURI)
-        let recipeID = recommendedRecipeID(task: options.task, inspection: inspection)
+        let recipeID = try recommendedRecipeID(task: options.task, inspection: inspection)
         let recipe = try MelixWorkflowRecipeCatalog.recipe(id: recipeID)
         var payload = recipe.payload
         payload["provenance"] = [
@@ -1001,6 +1138,10 @@ extension MelixCLIRunner {
         return value
     }
 
+    private func isURIImportableKind(_ kind: String) -> Bool {
+        ["hf_model_repo", "hf_dataset_repo", "local_mlx_model_directory"].contains(kind)
+    }
+
     private func summaryPayload(_ recipe: MelixWorkflowRecipe) -> [String: Any] {
         [
             "id": recipe.id,
@@ -1044,7 +1185,7 @@ extension MelixCLIRunner {
         "id=\(recipe.id)\nversion=\(recipe.version)\ntasks=\(recipe.tasks.joined(separator: ","))\ntitle=\(recipe.title)\n"
     }
 
-    private func recommendedRecipeID(task: String, inspection: MelixURIInspectionResult) -> String {
+    private func recommendedRecipeID(task: String, inspection: MelixURIInspectionResult) throws -> String {
         if task == "import",
            let firstKind = inspection.candidates.first?["kind"] as? String
         {
@@ -1058,7 +1199,48 @@ extension MelixCLIRunner {
         if task == "eval" {
             return "dataset.hf-eval"
         }
-        return MelixWorkflowRecipeCatalog.list(task: task).first?.id ?? "import.hf-mlx-model"
+        guard let recipeID = MelixWorkflowRecipeCatalog.list(task: task).first?.id else {
+            throw MelixCLIError.runtime("No workflow recipe matches task \(task).")
+        }
+        return recipeID
+    }
+
+    private func pruneRecipeRuns(under recipeRoot: URL, keeping currentRunRoot: URL, limit: Int) throws -> Int {
+        guard limit > 0 else {
+            return 0
+        }
+        let fileManager = FileManager.default
+        guard let children = try? fileManager.contentsOfDirectory(
+            at: recipeRoot,
+            includingPropertiesForKeys: [.creationDateKey, .contentModificationDateKey, .isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return 1
+        }
+        let runDirectories = children.compactMap { url -> (url: URL, date: Date)? in
+            guard url != currentRunRoot,
+                  UUID(uuidString: url.lastPathComponent) != nil
+            else {
+                return nil
+            }
+            let values = try? url.resourceValues(forKeys: [.creationDateKey, .contentModificationDateKey, .isDirectoryKey])
+            guard values?.isDirectory == true else {
+                return nil
+            }
+            return (url, values?.creationDate ?? values?.contentModificationDate ?? .distantPast)
+        }
+        let removable = runDirectories
+            .sorted { left, right in
+                if left.date == right.date {
+                    return left.url.lastPathComponent < right.url.lastPathComponent
+                }
+                return left.date > right.date
+            }
+            .dropFirst(max(limit - 1, 0))
+        for run in removable {
+            try? fileManager.removeItem(at: run.url)
+        }
+        return min(runDirectories.count + 1, limit)
     }
 
     private func prettyWorkflowJSON(_ payload: [String: Any]) throws -> String {

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ Step-by-step operating procedures for specific workflows. Use these when you nee
 | [Agent UI Walkthrough](runbooks/agent-ui-walkthrough.md) | Browser-based walkthrough workflow for substantial UI/UX changes before App implementation |
 | [Local Stack](runbooks/phase-1-local-stack.md) | Runtime layout, environment exports, and alternate startup modes |
 | [Benchmark, Matrix & LoRA](runbooks/benchmark-matrix-evaluation-and-lora.md) | Full operator guide: benchmarking, matrix runs, evaluation, and LoRA fine-tuning |
+| [Workflow Recipes And URI Inspection](runbooks/workflow-recipes.md) | Built-in workflow recipes, URI inspection, planning, and pipeline-backed apply |
 | [LoRA Adapter Workflow](runbooks/phase-8-lora-adapter-workflow.md) | Training, activating, publishing, and removing LoRA adapters |
 | [Local Install](runbooks/phase-8-local-install.md) | Install Melix as a persistent local service via launch agent |
 | [Homebrew Install](runbooks/homebrew-install.md) | Install and manage Melix through Homebrew |

--- a/docs/plans/2026-05-13-issue-636-workflow-recipes-uri-resolver.md
+++ b/docs/plans/2026-05-13-issue-636-workflow-recipes-uri-resolver.md
@@ -30,6 +30,8 @@ inspectable, preflightable, and reproducible by emitting concrete
   document.
 - Route recipe application through the existing pipeline runner and preserve its
   dry-run, resume, from-step, receipt, and JSON v1 behavior.
+- Keep recipe apply artifacts bounded by pruning old UUID run directories under
+  each recipe while preserving the newest 20 runs and non-UUID operator files.
 
 ## Non-Goals
 
@@ -85,6 +87,7 @@ Record deterministic CLI-side metrics in JSON outputs where practical:
 - `recipe.schema_validate_ms`
 - `recipe.plan_ms`
 - `recipe.apply_start_ms`
+- `recipe.apply_retained_runs`
 
 The first implementation does not require a live runtime. Runtime-heavy probes
 such as memory-fit timing are covered by existing command paths and should be
@@ -146,5 +149,7 @@ and validate with `scripts/validate_pr_evidence.py`.
 - Ambiguous URI inspection returns multiple candidates.
 - Recipe application reuses pipeline receipts and dry-run behavior.
 - Sensitive values are redacted in public arguments and outputs.
+- Recipe apply artifacts use a bounded retention policy instead of growing
+  indefinitely.
 - The final PR links issue #636 and reports coverage, metrics, local commands,
   known gaps, CI state, and performance-report state.

--- a/docs/plans/2026-05-13-issue-636-workflow-recipes-uri-resolver.md
+++ b/docs/plans/2026-05-13-issue-636-workflow-recipes-uri-resolver.md
@@ -1,0 +1,150 @@
+# Issue 636 Workflow Recipes And URI Resolver
+
+## Goal
+
+Implement the first Melix-native workflow recipe catalog and URI resolver for
+GitHub issue #636. The feature must compose existing Melix command surfaces
+instead of introducing a second execution engine.
+
+Recipes should make common local Apple Silicon workflows discoverable,
+inspectable, preflightable, and reproducible by emitting concrete
+`melix.pipeline.v1` plans backed by existing command IDs.
+
+## Scope
+
+- Add typed CLI commands for:
+  - `melix uri inspect URI [--json]`
+  - `melix uri import URI [--model-id MODEL_ID] [--revision REV] [--dry-run] [--json]`
+  - `melix recipes list [--task TASK] [--json]`
+  - `melix recipes show RECIPE_ID [--version VERSION] [--json]`
+  - `melix recipes validate PATH_OR_ID [--json]`
+  - `melix recipes plan RECIPE_ID --set KEY=VALUE ... [--output PATH] [--json]`
+  - `melix recipes apply RECIPE_ID --set KEY=VALUE ... [--dry-run] [--resume] [--from-step STEP_ID] [--json]`
+  - `melix recipes init --from URI --task TASK [--output PATH] [--json]`
+- Add a built-in recipe catalog with initial recipes that map to existing
+  `model`, `dataset`, `lora`, `bench`, `eval`, `runs`, and `pipeline` commands.
+- Add no-mutation URI inspection for Hugging Face model and dataset locators,
+  local MLX model directories, LoRA adapter manifests, and local dataset files
+  or directories.
+- Add recipe planning that writes or returns a valid `melix.pipeline.v1`
+  document.
+- Route recipe application through the existing pipeline runner and preserve its
+  dry-run, resume, from-step, receipt, and JSON v1 behavior.
+
+## Non-Goals
+
+- Do not copy external gallery schemas or code.
+- Do not introduce arbitrary shell execution inside recipes.
+- Do not replace existing model, dataset, LoRA, benchmark, evaluation, run, or
+  pipeline commands.
+- Do not implement the full durable job/log/cancel API tracked by #637.
+- Do not build a UI-first marketplace.
+- Do not add new runtime execution paths for unsupported formats such as GGUF.
+
+## Architecture
+
+The Swift CLI remains the user-facing recipe authority for this slice.
+
+Recipe planning is intentionally a command-to-pipeline projection:
+
+1. Load a built-in or file-backed recipe.
+2. Validate schema and required inputs.
+3. Resolve `--set` values into typed recipe inputs.
+4. Run URI inspection for URI-backed inputs when needed.
+5. Render a `melix.pipeline.v1` object containing only existing command IDs.
+6. Optionally write the rendered pipeline to disk.
+7. For `recipes apply`, execute the rendered pipeline through the existing
+   `runPipeline` path.
+
+The first slice keeps provenance in recipe planning output and the pipeline
+inputs. Deeper propagation into every downstream run record or model manifest
+can follow after the command path is stable and after #637 decides the durable
+job envelope.
+
+## Built-In Seed Recipes
+
+- `import.hf-mlx-model`: estimate fit, download a Hugging Face model, rescan
+  registry roots, and inspect the model.
+- `import.local-mlx-model`: import a local MLX directory, rescan roots, and
+  inspect the imported model.
+- `dataset.hf-eval`: download a Hugging Face dataset for later evaluation use.
+- `train.lora.local-dataset`: train LoRA from a local dataset package.
+- `benchmark.eval.smoke`: run one benchmark and one evaluation against the same
+  target.
+- `adapter.compare.evidence`: run adapter comparison and export evidence without
+  claiming #724 release-gate verdict enforcement.
+
+## Performance Probes And Success Metrics
+
+Record deterministic CLI-side metrics in JSON outputs where practical:
+
+- `uri.inspect_ms`
+- `uri.candidate_count`
+- `uri.ambiguity_count`
+- `recipe.lookup_ms`
+- `recipe.schema_validate_ms`
+- `recipe.plan_ms`
+- `recipe.apply_start_ms`
+
+The first implementation does not require a live runtime. Runtime-heavy probes
+such as memory-fit timing are covered by existing command paths and should be
+reported as `N/A` for docs-only or dry-run-only verification.
+
+## Implementation Slices
+
+### Slice 1: Plan
+
+- Add this plan.
+- Commit as documentation-only.
+- Metrics: `N/A` because no runtime or executable path changes.
+- Coverage: `N/A` because this slice is documentation-only.
+
+### Slice 2: CLI Surface And Types
+
+- Add typed command options and enum cases.
+- Extend usage text, parser, command codec, and command-ID tests.
+- Keep command execution stubbed or minimal only where required for compiler
+  completeness.
+- Verify focused parser and codec tests.
+- Merge current `origin/main` after the commit.
+
+### Slice 3: Resolver, Catalog, Planner, And Apply
+
+- Add resolver and recipe-catalog implementation in `MelixCLICore`.
+- Add built-in recipe definitions and validation.
+- Add recipe planning to concrete `melix.pipeline.v1` JSON.
+- Add `recipes apply` execution through the existing pipeline runner.
+- Add focused runner tests for URI inspection, ambiguity, built-in listing,
+  validation errors, planning, output writing, and dry-run apply.
+- Add docs/runbook coverage for recipe authoring and operator workflow.
+- Merge current `origin/main` after the commit.
+
+## Verification Plan
+
+Focused commands:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" \
+swift test --filter MelixCLIParserTests
+
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" \
+swift test --filter MelixCLIRunnerTests
+```
+
+Changed-scope coverage should be measured before the final PR handoff. If local
+Swift coverage is blocked by host toolchain limits, record the exact blocker and
+let CI provide the broader gate.
+
+PR evidence must keep the required headings from `.github/pull_request_template.md`
+and validate with `scripts/validate_pr_evidence.py`.
+
+## Acceptance
+
+- Built-in recipes can be listed, shown as JSON, validated, planned, and dry-run.
+- Planning emits a valid `melix.pipeline.v1` with existing command IDs only.
+- URI inspection returns structured candidates and does not mutate local state.
+- Ambiguous URI inspection returns multiple candidates.
+- Recipe application reuses pipeline receipts and dry-run behavior.
+- Sensitive values are redacted in public arguments and outputs.
+- The final PR links issue #636 and reports coverage, metrics, local commands,
+  known gaps, CI state, and performance-report state.

--- a/docs/runbooks/workflow-recipes.md
+++ b/docs/runbooks/workflow-recipes.md
@@ -1,0 +1,96 @@
+# Workflow Recipes And URI Inspection
+
+Melix workflow recipes are versioned templates for common local runtime tasks.
+They do not introduce a second execution engine. A recipe resolves operator
+inputs, emits a concrete `melix.pipeline.v1` plan, and applies that plan through
+the existing pipeline runner.
+
+## URI Inspection
+
+Use URI inspection when an operator has a source but not yet a full Melix
+command:
+
+```bash
+melix uri inspect hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit --json
+melix uri inspect hf://dataset/Jax-dan/HundredCV-Chat --json
+melix uri inspect /path/to/local-model --json
+```
+
+Inspection is read-only. It returns candidate kinds, confidence, normalized
+locators, warnings, recommended Melix arguments, and ambiguity metrics.
+Ambiguous bare `org/repo` inputs return both model and dataset candidates so
+operators can choose an explicit `hf://model/...` or `hf://dataset/...` URI.
+
+`melix uri import` is the mutating companion. Use `--dry-run` first to inspect
+the command that would run:
+
+```bash
+melix uri import hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit --dry-run --json
+```
+
+## Built-In Recipes
+
+The initial built-in catalog includes:
+
+| Recipe | Tasks |
+|---|---|
+| `import.hf-mlx-model` | `model_import` |
+| `import.local-mlx-model` | `model_import` |
+| `dataset.hf-eval` | `dataset_import`, `eval` |
+| `train.lora.local-dataset` | `train_lora` |
+| `benchmark.eval.smoke` | `benchmark`, `eval` |
+| `adapter.compare.evidence` | `eval_compare` |
+
+List and inspect recipes:
+
+```bash
+melix recipes list --json
+melix recipes list --task model_import --json
+melix recipes show import.hf-mlx-model --json
+melix recipes validate import.hf-mlx-model --json
+```
+
+## Planning
+
+Planning renders a concrete pipeline without executing it:
+
+```bash
+melix recipes plan import.hf-mlx-model \
+  --set repo_id=mlx-community/Qwen3.5-0.8B-OptiQ-4bit \
+  --set revision=main \
+  --output .runtime/import-qwen.pipeline.json \
+  --json
+```
+
+The emitted pipeline uses existing command IDs only, such as
+`estimate.import`, `model.hub.download`, `model.roots.rescan`, `lora.train`,
+`bench.run`, and `eval.run`.
+
+## Applying
+
+Recipe application writes a generated pipeline and routes through
+`melix pipeline run`, preserving dry-run, resume, from-step behavior, and normal
+pipeline receipts:
+
+```bash
+melix recipes apply import.hf-mlx-model \
+  --set repo_id=mlx-community/Qwen3.5-0.8B-OptiQ-4bit \
+  --dry-run \
+  --json
+```
+
+Generated pipeline files and receipts live under `MELIX_HOME/workflow-recipes/`
+unless `MELIX_HOME` points at a worktree-local runtime home.
+
+## Provenance
+
+Planned pipelines include:
+
+- `source_recipe_id`
+- `source_recipe_version`
+- `source_recipe_digest`
+- `source_uri_digest` when a URI-like input is present
+
+Pipeline step receipts also preserve the resolved step metadata already written
+by the pipeline runner. Deeper propagation into every downstream manifest should
+continue to follow the durable job and artifact model as it matures.

--- a/docs/runbooks/workflow-recipes.md
+++ b/docs/runbooks/workflow-recipes.md
@@ -80,7 +80,11 @@ melix recipes apply import.hf-mlx-model \
 ```
 
 Generated pipeline files and receipts live under `MELIX_HOME/workflow-recipes/`
-unless `MELIX_HOME` points at a worktree-local runtime home.
+unless `MELIX_HOME` points at a worktree-local runtime home. Melix stores each
+recipe application in a UUID-named run directory under the recipe ID and keeps
+the newest 20 run directories for that recipe. Older UUID run directories are
+removed before a new apply executes, while non-UUID files or operator-managed
+notes in the recipe directory are left untouched.
 
 ## Provenance
 

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -19,6 +19,8 @@ struct MelixCLIParserTests {
         #expect(MelixCLIParser.usageText.contains("melix info --json"))
         #expect(MelixCLIParser.usageText.contains("melix capabilities --json [--model-query MODEL]"))
         #expect(MelixCLIParser.usageText.contains("melix config metadata --json"))
+        #expect(MelixCLIParser.usageText.contains("melix uri inspect URI [--json]"))
+        #expect(MelixCLIParser.usageText.contains("melix recipes plan RECIPE_ID"))
     }
 
     @Test("parses runtime settings and machine readable discovery commands")
@@ -855,6 +857,14 @@ struct MelixCLIParserTests {
             (.datasetList(.init(json: true)), "dataset.list"),
             (.datasetHubDownload(.init(repoID: "org/dataset", revision: "main", json: true)), "dataset.hub.download"),
             (.datasetRemove(.init(repoID: "org/dataset", revision: "main", snapshotID: "abc123", json: true)), "dataset.remove"),
+            (.uriInspect(.init(uri: "hf://model/org/model", json: true)), "uri.inspect"),
+            (.uriImport(.init(uri: "hf://model/org/model", modelID: "model", revision: "main", dryRun: true, json: true)), "uri.import"),
+            (.recipesList(.init(task: "import", json: true)), "recipes.list"),
+            (.recipesShow(.init(recipeID: "import.hf-mlx-model", version: "1", json: true)), "recipes.show"),
+            (.recipesValidate(.init(target: "import.hf-mlx-model", json: true)), "recipes.validate"),
+            (.recipesPlan(.init(recipeID: "import.hf-mlx-model", version: "1", values: ["repo_id": "org/model", "model_id": "model"], outputPath: "/tmp/plan.json", json: true)), "recipes.plan"),
+            (.recipesApply(.init(recipeID: "benchmark.eval.smoke", version: "1", values: ["model_id": "model"], dryRun: true, resume: true, fromStepID: "benchmark", json: true)), "recipes.apply"),
+            (.recipesInit(.init(sourceURI: "hf://model/org/model", task: "import", outputPath: "/tmp/import.recipe.json", json: true)), "recipes.init"),
             (.modelRootsList(.init(json: true)), "model.roots.list"),
             (.modelRootsAdd(.init(path: "/models", json: true)), "model.roots.add"),
             (.modelRootsRemove(.init(path: "/models", json: true)), "model.roots.remove"),
@@ -942,6 +952,14 @@ struct MelixCLIParserTests {
             .datasetList(.init(json: true)),
             .datasetHubDownload(.init(repoID: "org/dataset", revision: "main", json: true)),
             .datasetRemove(.init(repoID: "org/dataset", revision: "main", snapshotID: "abc123", json: true)),
+            .uriInspect(.init(uri: "hf://model/org/model", json: true)),
+            .uriImport(.init(uri: "hf://model/org/model", modelID: "model", revision: "main", dryRun: true, json: true)),
+            .recipesList(.init(task: "import", json: true)),
+            .recipesShow(.init(recipeID: "import.hf-mlx-model", version: "1", json: true)),
+            .recipesValidate(.init(target: "import.hf-mlx-model", json: true)),
+            .recipesPlan(.init(recipeID: "import.hf-mlx-model", version: "1", values: ["repo_id": "org/model", "model_id": "model"], outputPath: "/tmp/plan.json", json: true)),
+            .recipesApply(.init(recipeID: "benchmark.eval.smoke", version: "1", values: ["model_id": "model"], dryRun: true, resume: true, fromStepID: "benchmark", json: true)),
+            .recipesInit(.init(sourceURI: "hf://model/org/model", task: "import", outputPath: "/tmp/import.recipe.json", json: true)),
             .modelRootsList(.init(json: true)),
             .modelRootsAdd(.init(path: "/models", json: true)),
             .modelRootsRemove(.init(path: "/models", json: true)),
@@ -1264,6 +1282,161 @@ struct MelixCLIParserTests {
         #expect(removeOptions.revision == "main")
         #expect(removeOptions.snapshotID == "abc123")
         #expect(removeOptions.json)
+    }
+
+    @Test("parses uri resolver commands")
+    func parsesURIResolverCommands() throws {
+        let inspect = try MelixCLIParser.parse([
+            "uri",
+            "inspect",
+            "hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+            "--json",
+        ])
+        let importCommand = try MelixCLIParser.parse([
+            "uri",
+            "import",
+            "hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+            "--model-id", "qwen35-08b",
+            "--revision", "refs/pr/1",
+            "--dry-run",
+            "--json",
+        ])
+
+        #expect(
+            inspect ==
+                .uriInspect(
+                    .init(
+                        uri: "hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+                        json: true
+                    )
+                )
+        )
+        #expect(
+            importCommand ==
+                .uriImport(
+                    .init(
+                        uri: "hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+                        modelID: "qwen35-08b",
+                        revision: "refs/pr/1",
+                        dryRun: true,
+                        json: true
+                    )
+                )
+        )
+
+        #expect(throws: MelixCLIError.missingRequired("URI is required for melix uri inspect.")) {
+            try MelixCLIParser.parse(["uri", "inspect", "--json"])
+        }
+        #expect(throws: MelixCLIError.missingRequired("URI is required for melix uri import.")) {
+            try MelixCLIParser.parse(["uri", "import", "--json"])
+        }
+    }
+
+    @Test("parses workflow recipe catalog commands")
+    func parsesWorkflowRecipeCatalogCommands() throws {
+        let list = try MelixCLIParser.parse([
+            "recipes",
+            "list",
+            "--task", "import",
+            "--json",
+        ])
+        let show = try MelixCLIParser.parse([
+            "recipes",
+            "show",
+            "import.hf-mlx-model",
+            "--version", "1",
+            "--json",
+        ])
+        let validate = try MelixCLIParser.parse([
+            "recipes",
+            "validate",
+            "import.hf-mlx-model",
+            "--json",
+        ])
+        let plan = try MelixCLIParser.parse([
+            "recipes",
+            "plan",
+            "import.hf-mlx-model",
+            "--set", "repo_id=mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+            "--set", "model_id=qwen35-08b",
+            "--output", "/tmp/recipe-plan.json",
+            "--json",
+        ])
+        let apply = try MelixCLIParser.parse([
+            "recipes",
+            "apply",
+            "benchmark.eval.smoke",
+            "--version", "1",
+            "--set", "model_id=qwen35-08b",
+            "--dry-run",
+            "--resume",
+            "--from-step", "benchmark",
+            "--json",
+        ])
+        let initCommand = try MelixCLIParser.parse([
+            "recipes",
+            "init",
+            "--from", "hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+            "--task", "import",
+            "--output", "/tmp/import.recipe.json",
+            "--json",
+        ])
+
+        #expect(list == .recipesList(.init(task: "import", json: true)))
+        #expect(show == .recipesShow(.init(recipeID: "import.hf-mlx-model", version: "1", json: true)))
+        #expect(validate == .recipesValidate(.init(target: "import.hf-mlx-model", json: true)))
+        #expect(
+            plan ==
+                .recipesPlan(
+                    .init(
+                        recipeID: "import.hf-mlx-model",
+                        values: [
+                            "repo_id": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+                            "model_id": "qwen35-08b",
+                        ],
+                        outputPath: "/tmp/recipe-plan.json",
+                        json: true
+                    )
+                )
+        )
+        #expect(
+            apply ==
+                .recipesApply(
+                    .init(
+                        recipeID: "benchmark.eval.smoke",
+                        version: "1",
+                        values: ["model_id": "qwen35-08b"],
+                        dryRun: true,
+                        resume: true,
+                        fromStepID: "benchmark",
+                        json: true
+                    )
+                )
+        )
+        #expect(
+            initCommand ==
+                .recipesInit(
+                    .init(
+                        sourceURI: "hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+                        task: "import",
+                        outputPath: "/tmp/import.recipe.json",
+                        json: true
+                    )
+                )
+        )
+
+        #expect(throws: MelixCLIError.missingRequired("RECIPE_ID is required for melix recipes show.")) {
+            try MelixCLIParser.parse(["recipes", "show", "--json"])
+        }
+        #expect(throws: MelixCLIError.usage("--set must use KEY=VALUE.")) {
+            try MelixCLIParser.parse(["recipes", "plan", "import.hf-mlx-model", "--set", "=bad"])
+        }
+        #expect(throws: MelixCLIError.missingRequired("--from is required for melix recipes init.")) {
+            try MelixCLIParser.parse(["recipes", "init", "--task", "import"])
+        }
+        #expect(throws: MelixCLIError.missingRequired("--task is required for melix recipes init.")) {
+            try MelixCLIParser.parse(["recipes", "init", "--from", "hf://model/org/repo"])
+        }
     }
 
     @Test("parses model import command and rejects missing import path")

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -1034,7 +1034,6 @@ struct MelixCLIParserTests {
         let unsupported: [MelixCLICommand] = [
             .modelList(.init()),
             .loraDatasetInspect(.init(modelID: "model", datasetURI: "/tmp/data.jsonl")),
-            .evalCompare(.init(modelID: "base", targetModelIDs: ["target"])),
         ]
         for command in unsupported {
             do {

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -1300,12 +1300,29 @@ struct MelixCLIParserTests {
             "--dry-run",
             "--json",
         ])
+        let importFromRevisionURI = try MelixCLIParser.parse([
+            "uri",
+            "import",
+            "hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit@refs/pr/2",
+            "--dry-run",
+            "--json",
+        ])
 
         #expect(
             inspect ==
                 .uriInspect(
                     .init(
                         uri: "hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+                        json: true
+                    )
+                )
+        )
+        #expect(
+            importFromRevisionURI ==
+                .uriImport(
+                    .init(
+                        uri: "hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit@refs/pr/2",
+                        dryRun: true,
                         json: true
                     )
                 )

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -3816,6 +3816,107 @@ struct MelixCLIRunnerTests {
         #expect(reusedTokenCall.ext["melix.hf_token"] == "hf_secret_token")
     }
 
+    @Test("uri inspect classifies huggingface local and ambiguous sources")
+    func uriInspectClassifiesSources() async throws {
+        let runner = MelixCLIRunner(client: StubControlPlaneXPCClient())
+        let hfOutput = try await runner.run(.uriInspect(.init(uri: "hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit", json: true)))
+        let hfPayload = try #require(parseJSONObject(hfOutput))
+        let hfCandidates = try #require(hfPayload["candidates"] as? [[String: Any]])
+        #expect(hfCandidates.first?["kind"] as? String == "hf_model_repo")
+        #expect(hfCandidates.first?["repo_id"] as? String == "mlx-community/Qwen3.5-0.8B-OptiQ-4bit")
+        #expect((hfPayload["metrics"] as? [String: Any])?["uri.candidate_count"] as? Double == 1)
+
+        let ambiguousOutput = try await runner.run(.uriInspect(.init(uri: "org/repo", json: true)))
+        let ambiguousPayload = try #require(parseJSONObject(ambiguousOutput))
+        #expect(ambiguousPayload["candidate_count"] as? Int == 2)
+        #expect(ambiguousPayload["ambiguity_count"] as? Int == 1)
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-uri-inspect-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "{}".write(to: root.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        try Data([0]).write(to: root.appendingPathComponent("model.safetensors"))
+        try "{}".write(to: root.appendingPathComponent("manifest.json"), atomically: true, encoding: .utf8)
+
+        let localOutput = try await runner.run(.uriInspect(.init(uri: root.path, json: true)))
+        let localPayload = try #require(parseJSONObject(localOutput))
+        let localCandidates = try #require(localPayload["candidates"] as? [[String: Any]])
+        let localKinds = Set(localCandidates.compactMap { $0["kind"] as? String })
+        #expect(localKinds.contains("local_mlx_model_directory"))
+        #expect(localKinds.contains("local_dataset_package"))
+        #expect(localPayload["ambiguity_count"] as? Int == 1)
+    }
+
+    @Test("workflow recipes list show validate and plan")
+    func workflowRecipesListShowValidateAndPlan() async throws {
+        let outputRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-recipe-plan-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: outputRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outputRoot) }
+
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: ["MELIX_HOME": outputRoot.path]
+        )
+        let listPayload = try #require(parseJSONObject(try await runner.run(.recipesList(.init(task: "model_import", json: true)))))
+        let recipes = try #require(listPayload["recipes"] as? [[String: Any]])
+        #expect(recipes.contains { $0["id"] as? String == "import.hf-mlx-model" })
+
+        let showPayload = try #require(parseJSONObject(try await runner.run(.recipesShow(.init(recipeID: "import.hf-mlx-model", json: true)))))
+        #expect(showPayload["schema_version"] as? String == "melix.workflow_recipe.v1")
+        #expect(showPayload["recipe_digest"] as? String != "")
+
+        let validatePayload = try #require(parseJSONObject(try await runner.run(.recipesValidate(.init(target: "import.hf-mlx-model", json: true)))))
+        #expect(validatePayload["valid"] as? Bool == true)
+
+        let pipelineURL = outputRoot.appendingPathComponent("planned.pipeline.json")
+        let planPayload = try #require(parseJSONObject(try await runner.run(.recipesPlan(
+            .init(
+                recipeID: "import.hf-mlx-model",
+                values: ["repo_id": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"],
+                outputPath: pipelineURL.path,
+                json: true
+            )
+        ))))
+        let pipeline = try #require(planPayload["pipeline"] as? [String: Any])
+        let steps = try #require(pipeline["steps"] as? [[String: Any]])
+        #expect(pipeline["schema_version"] as? String == "melix.pipeline.v1")
+        #expect(steps.map { $0["command"] as? String } == ["estimate.import", "model.hub.download", "model.roots.rescan"])
+        #expect(FileManager.default.fileExists(atPath: pipelineURL.path))
+    }
+
+    @Test("workflow recipe apply dry run writes pipeline receipts")
+    func workflowRecipeApplyDryRunWritesPipelineReceipts() async throws {
+        let melixHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-recipe-apply-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: melixHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: melixHome) }
+
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: ["MELIX_HOME": melixHome.path]
+        )
+        let output = try await runner.run(.recipesApply(
+            .init(
+                recipeID: "import.hf-mlx-model",
+                values: ["repo_id": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"],
+                dryRun: true,
+                json: true
+            )
+        ))
+        let payload = try #require(parseJSONObject(output))
+        #expect(payload["schema_version"] as? String == "melix.pipeline.run.v1")
+        #expect(payload["status"] as? String == "planned")
+        let recipe = try #require(payload["recipe"] as? [String: Any])
+        #expect(recipe["id"] as? String == "import.hf-mlx-model")
+        let steps = try #require(payload["steps"] as? [[String: Any]])
+        #expect(steps.count == 3)
+        let receiptDir = try #require(payload["receipt_dir"] as? String)
+        #expect(FileManager.default.fileExists(atPath: receiptDir))
+        #expect((payload["metrics"] as? [String: Any])?["recipe.apply_start_ms"] as? Double != nil)
+    }
+
     @Test("dataset remove forwards safe snapshot selector")
     func datasetRemoveForwardsSafeSnapshotSelector() async throws {
         let client = StubControlPlaneXPCClient()

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -3986,6 +3986,16 @@ struct MelixCLIRunnerTests {
         #expect(ambiguousPayload["candidate_count"] as? Int == 2)
         #expect(ambiguousPayload["ambiguity_count"] as? Int == 1)
 
+        let datasetURLPayload = try #require(parseJSONObject(try await runner.run(.uriInspect(.init(
+            uri: "https://huggingface.co/datasets/org/repo/tree/refs/pr/2?download=1",
+            json: true
+        )))))
+        let datasetURLCandidate = try #require((datasetURLPayload["candidates"] as? [[String: Any]])?.first)
+        #expect(datasetURLCandidate["kind"] as? String == "hf_dataset_repo")
+        #expect(datasetURLCandidate["repo_id"] as? String == "org/repo")
+        #expect(datasetURLCandidate["revision"] as? String == "refs/pr/2")
+        #expect(datasetURLCandidate["normalized_locator"] as? String == "hf://dataset/org/repo@refs/pr/2")
+
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("melix-uri-inspect-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -4001,6 +4011,10 @@ struct MelixCLIRunnerTests {
         #expect(localKinds.contains("local_mlx_model_directory"))
         #expect(localKinds.contains("local_dataset_package"))
         #expect(localPayload["ambiguity_count"] as? Int == 1)
+
+        let unresolvedOutput = try await runner.run(.uriImport(.init(uri: root.appendingPathComponent("missing").path, dryRun: true, json: true)))
+        let unresolvedPayload = try #require(parseJSONObject(unresolvedOutput))
+        #expect(unresolvedPayload["status"] as? String == "unresolved")
     }
 
     @Test("workflow recipes list show validate and plan")
@@ -4070,6 +4084,41 @@ struct MelixCLIRunnerTests {
         let receiptDir = try #require(payload["receipt_dir"] as? String)
         #expect(FileManager.default.fileExists(atPath: receiptDir))
         #expect((payload["metrics"] as? [String: Any])?["recipe.apply_start_ms"] as? Double != nil)
+        #expect((payload["metrics"] as? [String: Any])?["recipe.apply_retained_runs"] as? Int == 1)
+
+        let recipeRoot = melixHome
+            .appendingPathComponent("workflow-recipes", isDirectory: true)
+            .appendingPathComponent("import.hf-mlx-model", isDirectory: true)
+        for _ in 0..<22 {
+            _ = try await runner.run(.recipesApply(
+                .init(
+                    recipeID: "import.hf-mlx-model",
+                    values: ["repo_id": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"],
+                    dryRun: true,
+                    json: true
+                )
+            ))
+        }
+        let runDirectories = try FileManager.default.contentsOfDirectory(
+            at: recipeRoot,
+            includingPropertiesForKeys: [.isDirectoryKey]
+        ).filter { url in
+            UUID(uuidString: url.lastPathComponent) != nil
+        }
+        #expect(runDirectories.count == 20)
+    }
+
+    @Test("workflow recipe init rejects unmatched tasks")
+    func workflowRecipeInitRejectsUnmatchedTasks() async throws {
+        let runner = MelixCLIRunner(client: StubControlPlaneXPCClient())
+
+        await #expect(throws: MelixCLIError.runtime("No workflow recipe matches task missing_task.")) {
+            try await runner.run(.recipesInit(.init(
+                sourceURI: "hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+                task: "missing_task",
+                json: true
+            )))
+        }
     }
 
     @Test("dataset remove forwards safe snapshot selector")


### PR DESCRIPTION
## Summary
- Adds the first Melix workflow recipe catalog and URI resolver for #636.
- Adds typed CLI/parser/codec support for `melix uri ...` and `melix recipes ...`.
- Implements built-in recipe listing/show/validation/planning/apply through existing `melix.pipeline.v1` dry-run receipts, plus docs and focused tests.

## Plan or Spec
- Governing plan: `docs/plans/2026-05-13-issue-636-workflow-recipes-uri-resolver.md`
- Operator runbook: `docs/runbooks/workflow-recipes.md`
- Issue: Closes #636

## Commands Run
```text
# Stage 1
xcrun swift package --help
HOME="$PWD/.swift-home/protocol" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/protocol" xcrun swift test --package-path packages/protocol/swift
  -> failed locally: no such module XCTest with Command Line Tools-only Swift toolchain.

git diff --check
  -> passed

# Stage 2
HOME="$PWD/.swift-home/root" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/root" xcrun swift build --product melix
  -> passed
HOME="$PWD/.swift-home/root" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/root" xcrun swift test --filter MelixCLIParserTests
  -> failed locally: no such module Testing with Command Line Tools-only Swift toolchain.

git diff --check
  -> passed

# Stage 3 / final
HOME="$PWD/.swift-home/root" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/root" xcrun swift build --product melix
  -> passed
.build/debug/melix uri inspect hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit --json
  -> passed; emitted melix.uri_inspection.v1 with one hf_model_repo candidate.
.build/debug/melix recipes list --task model_import --json
  -> passed; listed import.hf-mlx-model and import.local-mlx-model.
.build/debug/melix recipes plan import.hf-mlx-model --set repo_id=mlx-community/Qwen3.5-0.8B-OptiQ-4bit --json
  -> passed; emitted melix.pipeline.v1 using estimate.import, model.hub.download, model.roots.rescan.
MELIX_HOME="$PWD/.runtime/manual-recipe-home" .build/debug/melix recipes apply import.hf-mlx-model --set repo_id=mlx-community/Qwen3.5-0.8B-OptiQ-4bit --dry-run --json
  -> passed; wrote planned pipeline receipts and melix.pipeline.run.v1 summary.
HOME="$PWD/.swift-home/root" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/root" xcrun swift test --filter MelixCLIRunnerTests
  -> failed locally: no such module Testing with Command Line Tools-only Swift toolchain.
python3 scripts/validate_pr_evidence.py --help
  -> failed under system Python 3.9 because datetime.UTC is unavailable.
python3.11 scripts/validate_pr_evidence.py --body-file .runtime/pr/pr-636-body.md
  -> passed

# Review follow-up
HOME="$PWD/.swift-home/root" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/root" xcrun swift build --product melix
  -> passed after review fixes.
.build/debug/melix uri inspect 'https://huggingface.co/datasets/org/repo/tree/refs/pr/2?download=1' --json
  -> passed; normalized to hf://dataset/org/repo@refs/pr/2.
.build/debug/melix uri import /tmp/melix-definitely-missing --dry-run --json
  -> passed; emitted status=unresolved with zero importable candidates.
MELIX_HOME="$PWD/.runtime/manual-review-fix-home" .build/debug/melix recipes apply import.hf-mlx-model --set repo_id=mlx-community/Qwen3.5-0.8B-OptiQ-4bit --dry-run --json
  -> passed; emitted recipe.apply_retained_runs and retention_limit=20.
rm -rf .runtime/manual-review-fix-retention && for i in {1..22}; do MELIX_HOME="$PWD/.runtime/manual-review-fix-retention" .build/debug/melix recipes apply import.hf-mlx-model --set repo_id=mlx-community/Qwen3.5-0.8B-OptiQ-4bit --dry-run --json >/dev/null || exit 1; done; find .runtime/manual-review-fix-retention/workflow-recipes/import.hf-mlx-model -maxdepth 1 -type d -name '????????-????-????-????-????????????' | wc -l
  -> passed; retained 20 UUID run directories.
.build/debug/melix recipes init --from hf://model/mlx-community/Qwen3.5-0.8B-OptiQ-4bit --task missing_task --json
  -> failed as expected with "No workflow recipe matches task missing_task."
```

## Coverage and Metrics
- Changed-scope automated coverage: not locally measurable because this host only exposes the Command Line Tools Swift test environment and cannot import the Swift `Testing` module used by the test target. CI should run the full test matrix.
- Metrics exercised by manual CLI smoke:
  - `uri.inspect_ms`, `uri.candidate_count`, `uri.ambiguity_count`
  - `recipe.lookup_ms`, `recipe.plan_ms`, `recipe.schema_validate_ms`
  - `recipe.apply_start_ms`, `recipe.apply_retained_runs`
  - existing pipeline receipt metrics such as `melix.pipeline.total_ms` and per-step timing
- Observability mode: minimal CLI JSON metrics and existing pipeline evidence receipts. Probe overhead is limited to local JSON timing around URI inspection, recipe lookup/planning/apply start, and existing pipeline receipt writes.

## Known Gaps
- Local Swift tests could not run on this machine due missing `Testing`/`XCTest` modules in the installed Command Line Tools toolchain; executable build and manual CLI smoke passed.
- `recipes apply` records provenance in generated pipeline inputs/metadata and receipt paths; deeper propagation into every downstream model manifest/run record remains aligned with the durable job/artifact model from follow-up work.
- `uri import` supports unambiguous Hugging Face model/dataset locators and local MLX model directories; ambiguous bare `org/repo` inputs intentionally require inspection first.
- `recipes apply` keeps the newest 20 UUID run directories per built-in recipe and leaves non-UUID operator files untouched; changing the retention limit is a future configurability decision.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run. Build and manual CLI smoke passed; Swift test execution is locally blocked as recorded above.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
