### PR TITLE
perf: avoid dataset split candidate list

### DIFF
--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -93,6 +93,8 @@ def test_dataset_catalog_inferred_split_and_config_preserves_legacy_helpers() ->
     assert catalog._inferred_config("custom/validation-00000.parquet") == "custom"
     assert catalog._inferred_split_and_config("data/train-00000-of-00001.jsonl") == ("train", "default")
     assert catalog._inferred_split_and_config("custom\\test.json") == ("test", "custom")
+    assert catalog._inferred_split_and_config("validation/shard-00000.jsonl") == ("validation", "default")
+    assert catalog._inferred_split_and_config("data/shard-00000.jsonl") == ("", "default")
     assert catalog._inferred_split_and_config("README.md") == ("", "default")
     assert catalog._inferred_split_and_config("") == ("", "default")
 

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -864,20 +864,25 @@ def _inferred_split_and_config(relative_path: str) -> tuple[str, str]:
         return "", "default"
     filename = parts[-1]
     stem = filename.rsplit(".", 1)[0]
-    candidates = [stem]
-    candidates.extend(part for part in parts[:-1] if part not in {"data", "default"})
-    split = ""
-    for candidate in candidates:
-        prefix = candidate.split("-", 1)[0].split("_", 1)[0].lower()
-        if prefix in _SPLIT_ALIASES:
-            split = _SPLIT_ALIASES[prefix]
-            break
+    split = _split_alias_from_candidate(stem)
+    if not split:
+        for candidate in parts[:-1]:
+            if candidate in {"data", "default"}:
+                continue
+            split = _split_alias_from_candidate(candidate)
+            if split:
+                break
     if len(parts) < 2:
         return split, "default"
     first = parts[0]
     if first in {"data", "train", "test", "validation", "valid", "dev"}:
         return split, "default"
     return split, first
+
+
+def _split_alias_from_candidate(candidate: str) -> str:
+    prefix = candidate.split("-", 1)[0].split("_", 1)[0].lower()
+    return _SPLIT_ALIASES.get(prefix, "")
 
 
 def _path_matches_split(relative_path: Path, split: str) -> bool:


### PR DESCRIPTION
## Summary
- Avoids materializing a temporary candidate list while inferring dataset snapshot split/config metadata.
- Keeps the same split precedence by checking the filename stem first, then parent path components lazily.
- Adds regression coverage for parent-directory split inference and ignored `data` path components.

## Plan or Spec
- N/A: behavior-preserving Python performance slice for the existing dataset registry snapshot inference path; no workflow or product behavior changes.

## Commands Run
```text
# Baseline registered probe on origin/main-equivalent worktree before changes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py
# exit 0; elapsed_ms_mean=725.0136932358146, file_count_mean=2401.0, legacy_inference_helper_calls_mean=0.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics
# exit 0; 39 passed in 0.27s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics
# exit 0; 39 passed in 0.30s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# exit 0; Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py
# exit 0; TOTAL 13 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py
# exit 0; elapsed_ms_mean=688.5709127876908, file_count_mean=2401.0, legacy_inference_helper_calls_mean=0.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Registered probe: `dataset-registry-snapshot-inference-single-pass`.
- Local Linux probe delta: old_mean=725.013693ms, new_mean=688.570913ms, delta=-36.442780ms, speedup=1.052925x (-5.026%).
- Probe counters preserved: `file_count_mean=2401.0`, `legacy_inference_helper_calls_mean=0.0`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Full repository `make py-test` / `make integration-test` not run locally; this slice used the registered focused test, coverage, and probe commands.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is explained.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
