### PR TITLE
perf: skip dataset split stems on prefix hits

### DIFF
--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -659,6 +659,22 @@ def test_dataset_catalog_path_split_matching_avoids_temporary_path_construction(
     assert catalog._path_matches_split(Path("custom/test.arrow"), "test") is True
     assert catalog._path_matches_split(Path("train_dir/part-00000.parquet"), "train") is True
     assert catalog._path_matches_split(Path("custom/eval.jsonl"), "train") is False
+    assert catalog._path_matches_split(Path("custom/train."), "train") is False
+
+
+def test_dataset_catalog_split_matching_skips_stem_for_direct_prefix_hits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stem_calls: list[str] = []
+    monkeypatch.setattr(
+        catalog,
+        "_string_stem",
+        lambda name: stem_calls.append(name) or name,
+    )
+
+    assert catalog._path_matches_split(Path("data/validation-00000.jsonl"), "validation") is True
+    assert catalog._path_matches_split(Path("train_dir/part-00000.parquet"), "train") is True
+    assert stem_calls == []
 
 
 def test_dataset_catalog_string_stem_matches_pathlib_for_split_names() -> None:

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -891,12 +891,18 @@ def _path_matches_split(relative_path: Path, split: str) -> bool:
     split_underscore_prefix = f"{normalized_split}_"
     for part in relative_path.parts:
         lowered = part.lower()
-        stem = _string_stem(part).lower()
         if (
             lowered == normalized_split
             or lowered.startswith(split_dash_prefix)
             or lowered.startswith(split_underscore_prefix)
-            or stem == normalized_split
+        ):
+            return True
+        dot_index = lowered.rfind(".")
+        if dot_index <= 0 or dot_index == len(lowered) - 1:
+            continue
+        stem = lowered[:dot_index]
+        if (
+            stem == normalized_split
             or stem.startswith(split_dash_prefix)
             or stem.startswith(split_underscore_prefix)
         ):


### PR DESCRIPTION
## Summary
- Optimizes dataset split matching by checking direct lowercase part/prefix matches before deriving a file stem.
- Keeps the existing dotted-filename fallback semantics, including the trailing-dot edge case.
- Adds regression coverage proving direct prefix hits avoid the stem helper.

## Plan or Spec
- Governing guidance: `docs/engineering-standards.md` and the registered PR-scoped probe `dataset-registry-limited-read-streaming` in `infra/perf/pr_scoped_probes.json`.
- Documentation update: N/A; this is an internal equivalent performance optimization with no behavior or workflow change.

## Commands Run
```text
# Baseline before the implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_path_split_matching_avoids_temporary_path_construction services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_string_stem_matches_pathlib_for_split_names services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_selected_split_filters_during_iteration services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_split_match_probe_script_emits_metrics
# exit 0; 6 passed in 0.76s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_split_match_probe.py
# exit 0; elapsed_ms_mean=120.18824117258191, path_constructor_calls_mean=0.0, peak_bytes_mean=42353.4

# Focused post-change tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_path_split_matching_avoids_temporary_path_construction services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_split_matching_skips_stem_for_direct_prefix_hits services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_string_stem_matches_pathlib_for_split_names services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_selected_split_filters_during_iteration services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_split_match_probe_script_emits_metrics
# exit 0; 7 passed in 0.20s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_split_match_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_split_match_probe.py
# exit 0; aggregate changed-line coverage 100.00% (13/13)

# Registered local probe after the implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_split_match_probe.py
# exit 0; elapsed_ms_mean=89.5113863516599, path_constructor_calls_mean=0.0, peak_bytes_mean=42227.4

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (13/13 measurable changed lines).
- Registered local probe: `dataset-registry-limited-read-streaming` via `scripts/dataset_registry_split_match_probe.py`.
- Local probe delta: old_mean=120.188 ms, new_mean=89.511 ms, delta=-30.677 ms, speedup=1.34x / -25.52% elapsed mean.
- Peak bytes: 42353.4 -> 42227.4 bytes.
- CI PR-scoped performance workflow is required for the authoritative base-vs-head registered probe report before merge.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this Python slice used focused tests, changed-scope coverage, and the registered local probe.
- Swift runtime effects are N/A for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated because behavior is unchanged.
- [x] Protocol changes include regenerated generated artifacts, or N/A (no protocol changes).
- [x] Dependency changes include updated lockfiles, or N/A (no dependency changes).
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
