### PR TITLE
Harden batch run record identity

### DIFF
--- a/Sources/MelixCLICore/MelixBatchRun.swift
+++ b/Sources/MelixCLICore/MelixBatchRun.swift
@@ -909,7 +909,7 @@ enum BatchRunPlanner {
 }
 
 enum BatchRunArtifacts {
-    static func writeFoundationArtifacts(plan: BatchRunPlan) throws {
+    static func writeFoundationArtifacts(plan: BatchRunPlan, writePlannedManifest: Bool = true) throws {
         let tempRoot = URL(fileURLWithPath: plan.config.tempRoot)
         let outputRoot = URL(fileURLWithPath: plan.config.outputRoot)
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
@@ -918,19 +918,21 @@ enum BatchRunArtifacts {
             to: URL(fileURLWithPath: plan.effectiveConfigPath),
             options: .atomic
         )
-        try manifestText(plan: plan).write(
-            to: URL(fileURLWithPath: plan.manifestPath),
-            atomically: true,
-            encoding: .utf8
-        )
         try FileManager.default.copyItemReplacingExisting(
             at: URL(fileURLWithPath: plan.effectiveConfigPath),
             to: outputRoot.appendingPathComponent("effective-config.json")
         )
-        try FileManager.default.copyItemReplacingExisting(
-            at: URL(fileURLWithPath: plan.manifestPath),
-            to: outputRoot.appendingPathComponent("manifest.jsonl")
-        )
+        if writePlannedManifest {
+            try manifestText(plan: plan).write(
+                to: URL(fileURLWithPath: plan.manifestPath),
+                atomically: true,
+                encoding: .utf8
+            )
+            try FileManager.default.copyItemReplacingExisting(
+                at: URL(fileURLWithPath: plan.manifestPath),
+                to: outputRoot.appendingPathComponent("manifest.jsonl")
+            )
+        }
     }
 
     static func writePreflightReport(_ report: BatchRunPreflightReport, plan: BatchRunPlan) throws {
@@ -998,7 +1000,7 @@ enum BatchRunArtifacts {
     static func manifestText(plan: BatchRunPlan) throws -> String {
         try plan.selectedModels.map { model in
             let modelDir = URL(fileURLWithPath: plan.config.outputRoot)
-                .appendingPathComponent(modelSlug(index: model.index, repoID: model.repoID))
+                .appendingPathComponent(BatchRunSlug.modelSlug(model: model))
                 .path
             let payload: [String: Any] = [
                 "schema_version": "melix.batch.manifest_entry.v1",
@@ -1072,7 +1074,7 @@ enum BatchRunArtifacts {
             "index": model.index,
             "repo_id": model.repoID,
             "source_line": model.sourceLine,
-            "slug": modelSlug(index: model.index, repoID: model.repoID),
+            "slug": BatchRunSlug.modelSlug(model: model),
         ]
     }
 
@@ -1097,25 +1099,6 @@ enum BatchRunArtifacts {
             "force_clean_stack_after_runtime_failure": true,
             "cleanup_failures_preserve_artifacts": true,
         ]
-    }
-
-    private static func modelSlug(index: String, repoID: String) -> String {
-        let raw = "\(index)-\(repoID)"
-        var slug = ""
-        var lastWasDash = false
-        for scalar in raw.lowercased().unicodeScalars {
-            let allowed = CharacterSet.alphanumerics.contains(scalar)
-                || scalar == "."
-                || scalar == "_"
-            if allowed {
-                slug.unicodeScalars.append(scalar)
-                lastWasDash = false
-            } else if lastWasDash == false {
-                slug.append("-")
-                lastWasDash = true
-            }
-        }
-        return slug.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
     }
 
     private static func jsonData(_ payload: [String: Any]) throws -> Data {
@@ -1344,6 +1327,24 @@ struct BatchRunModelRecord: Equatable {
     }
 }
 
+struct BatchRunRecordIdentity: Hashable {
+    let modelIndex: String
+    let repoID: String
+    let sourceLine: Int
+
+    init(model: BatchRunModelEntry) {
+        modelIndex = model.index
+        repoID = model.repoID
+        sourceLine = model.sourceLine
+    }
+
+    init(record: BatchRunModelRecord) {
+        modelIndex = record.modelIndex
+        repoID = record.repoID
+        sourceLine = record.sourceLine
+    }
+}
+
 struct BatchRunSummary {
     let schemaVersion: String
     let runID: String
@@ -1513,6 +1514,58 @@ enum BatchRunManifestStore {
         }
     }
 
+    static func alignedRecords(plan: BatchRunPlan, existingRecords: [BatchRunModelRecord]?) -> [BatchRunModelRecord] {
+        guard let existingRecords, !existingRecords.isEmpty else {
+            return initialRecords(plan: plan)
+        }
+        var recordsByIdentity: [BatchRunRecordIdentity: [BatchRunModelRecord]] = [:]
+        for record in existingRecords {
+            recordsByIdentity[BatchRunRecordIdentity(record: record), default: []].append(record)
+        }
+        var aligned = plan.selectedModels.map { model -> (model: BatchRunModelEntry, record: BatchRunModelRecord) in
+            let identity = BatchRunRecordIdentity(model: model)
+            if var matches = recordsByIdentity[identity], !matches.isEmpty {
+                var record = matches.removeFirst()
+                recordsByIdentity[identity] = matches
+                if record.modelDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    record.modelDir = modelDir(plan: plan, model: model).path
+                }
+                if record.tempDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    record.tempDir = modelTempDir(plan: plan, model: model).path
+                }
+                return (model, record)
+            }
+            return (model, BatchRunModelRecord(
+                runID: plan.config.runID,
+                model: model,
+                modelDir: modelDir(plan: plan, model: model).path,
+                tempDir: modelTempDir(plan: plan, model: model).path
+            ))
+        }
+        let duplicateModelDirs = duplicateValues(aligned.map { $0.record.modelDir })
+        let duplicateTempDirs = duplicateValues(aligned.map { $0.record.tempDir })
+        for index in aligned.indices {
+            if duplicateModelDirs.contains(aligned[index].record.modelDir) {
+                aligned[index].record.modelDir = modelDir(plan: plan, model: aligned[index].model).path
+            }
+            if duplicateTempDirs.contains(aligned[index].record.tempDir) {
+                aligned[index].record.tempDir = modelTempDir(plan: plan, model: aligned[index].model).path
+            }
+        }
+        return aligned.map { $0.record }
+    }
+
+    private static func duplicateValues(_ values: [String]) -> Set<String> {
+        var seen: Set<String> = []
+        var duplicates: Set<String> = []
+        for value in values where !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            if !seen.insert(value).inserted {
+                duplicates.insert(value)
+            }
+        }
+        return duplicates
+    }
+
     static func loadRecords(manifestPath: String) throws -> [BatchRunModelRecord] {
         guard FileManager.default.fileExists(atPath: manifestPath) else {
             throw MelixCLIError.runtime("Batch manifest was not found at \(manifestPath).")
@@ -1595,13 +1648,13 @@ enum BatchRunManifestStore {
 
     static func modelDir(plan: BatchRunPlan, model: BatchRunModelEntry) -> URL {
         URL(fileURLWithPath: plan.config.outputRoot)
-            .appendingPathComponent(BatchRunSlug.modelSlug(index: model.index, repoID: model.repoID), isDirectory: true)
+            .appendingPathComponent(BatchRunSlug.modelSlug(model: model), isDirectory: true)
     }
 
     static func modelTempDir(plan: BatchRunPlan, model: BatchRunModelEntry) -> URL {
         URL(fileURLWithPath: plan.config.tempRoot)
             .appendingPathComponent("models", isDirectory: true)
-            .appendingPathComponent(BatchRunSlug.modelSlug(index: model.index, repoID: model.repoID), isDirectory: true)
+            .appendingPathComponent(BatchRunSlug.modelSlug(model: model), isDirectory: true)
     }
 }
 
@@ -1854,6 +1907,7 @@ enum BatchRunPayloadParser {
 struct BatchRunSubprocessResult {
     let stdout: String
     let stderr: String
+    let exitCode: Int32
 }
 
 typealias BatchRunSubprocessExecutor = @Sendable ([String], [String: String], String) async -> BatchRunSubprocessResult
@@ -1874,12 +1928,9 @@ final class BatchRunExecutor {
     }
 
     func execute(existingRecords: [BatchRunModelRecord]? = nil, resumeMode: BatchRunResumeMode = .none) async throws -> (summary: BatchRunSummary, progressLines: [String]) {
-        try BatchRunArtifacts.writeFoundationArtifacts(plan: plan)
-        var records = existingRecords ?? BatchRunManifestStore.initialRecords(plan: plan)
-        if records.count != plan.selectedModels.count {
-            records = BatchRunManifestStore.initialRecords(plan: plan)
-        }
-        try BatchRunManifestStore.writeRecords(records, plan: plan)
+        try BatchRunArtifacts.writeFoundationArtifacts(plan: plan, writePlannedManifest: false)
+        var records = BatchRunManifestStore.alignedRecords(plan: plan, existingRecords: existingRecords)
+        try persist(records)
         var progress: [String] = [
             "Melix batch run",
             "run_id=\(plan.config.runID)",
@@ -1888,61 +1939,60 @@ final class BatchRunExecutor {
         let runStart = Date()
 
         for (offset, model) in plan.selectedModels.enumerated() {
-            guard let recordIndex = records.firstIndex(where: { $0.modelIndex == model.index && $0.repoID == model.repoID }) else {
-                continue
-            }
-            if resumeMode.shouldSkipModel(records[recordIndex]) {
+            var record = records[offset]
+            if resumeMode.shouldSkipModel(record) {
                 progress.append("[\(offset + 1)/\(plan.selectedModels.count)] SKIP \(model.index) \(model.repoID) already succeeded")
                 continue
             }
             progress.append("[\(offset + 1)/\(plan.selectedModels.count)] START \(model.index) \(model.repoID)")
-            records[recordIndex].status = "running"
-            records[recordIndex].startedAt = isoTimestamp()
-            try BatchRunManifestStore.writeRecords(records, plan: plan)
+            record.status = "running"
+            record.startedAt = isoTimestamp()
+            try persistRecord(record, in: &records)
             let modelStart = Date()
             do {
-                try prepareDirectories(record: records[recordIndex])
+                try prepareDirectories(record: record)
                 if !resumeMode.evalOnly {
-                    try await runSyntheticStep(.preflight, record: &records[recordIndex], message: "Per-model preflight accepted \(model.repoID).")
-                    try await runSyntheticStep(.runtimePrepare, record: &records[recordIndex], message: "Runtime uses \(plan.config.serviceInstanceName) on port \(plan.config.httpPort).")
-                    try await runSyntheticStep(.modelUnload, record: &records[recordIndex], message: "Best-effort previous model unload recorded.")
-                    try await runHubCheck(record: &records[recordIndex])
+                    try await runSyntheticStep(.preflight, record: &record, records: &records, message: "Per-model preflight accepted \(model.repoID).")
+                    try await runSyntheticStep(.runtimePrepare, record: &record, records: &records, message: "Runtime uses \(plan.config.serviceInstanceName) on port \(plan.config.httpPort).")
+                    try await runSyntheticStep(.modelUnload, record: &record, records: &records, message: "Best-effort previous model unload recorded.")
+                    try await runHubCheck(record: &record, records: &records)
                     progress.append("[\(offset + 1)/\(plan.selectedModels.count)] benchmark start \(model.index)")
-                    try await runBenchmark(record: &records[recordIndex])
-                    progress.append("[\(offset + 1)/\(plan.selectedModels.count)] benchmark succeeded \(model.index) job=\(records[recordIndex].benchmarkJobID)")
+                    try await runBenchmark(record: &record, records: &records)
+                    progress.append("[\(offset + 1)/\(plan.selectedModels.count)] benchmark succeeded \(model.index) job=\(record.benchmarkJobID)")
                 } else {
-                    markSkippedBeforeEval(record: &records[recordIndex])
+                    markSkippedBeforeEval(record: &record)
+                    try persistRecord(record, in: &records)
                     progress.append("[\(offset + 1)/\(plan.selectedModels.count)] resume eval-only \(model.index)")
                 }
                 progress.append("[\(offset + 1)/\(plan.selectedModels.count)] semantic judge heartbeat \(plan.config.judgeRemoteServerID)/\(plan.config.judgeModelID)")
-                try await runEvaluation(record: &records[recordIndex])
-                progress.append("[\(offset + 1)/\(plan.selectedModels.count)] evaluation succeeded \(model.index) job=\(records[recordIndex].evaluationJobID)")
-                try await runExports(record: &records[recordIndex])
-                try await copyRawArtifacts(record: &records[recordIndex])
-                records[recordIndex].status = records[recordIndex].benchmarkSucceeded ? "succeeded" : "partial_success"
-                if records[recordIndex].status == "succeeded" {
-                    records[recordIndex].failureCategory = ""
-                    records[recordIndex].recoverability = ""
-                    records[recordIndex].failureMessage = ""
-                } else if records[recordIndex].failureCategory.isEmpty {
-                    records[recordIndex].failureCategory = "unknown_failure"
-                    records[recordIndex].recoverability = BatchRunFailureRecoverability.unknown.rawValue
-                    records[recordIndex].failureMessage = "Evaluation completed, but benchmark did not succeed for this model."
+                try await runEvaluation(record: &record, records: &records)
+                progress.append("[\(offset + 1)/\(plan.selectedModels.count)] evaluation succeeded \(model.index) job=\(record.evaluationJobID)")
+                try await runExports(record: &record, records: &records)
+                try await copyRawArtifacts(record: &record, records: &records)
+                record.status = record.benchmarkSucceeded ? "succeeded" : "partial_success"
+                if record.status == "succeeded" {
+                    record.failureCategory = ""
+                    record.recoverability = ""
+                    record.failureMessage = ""
+                } else if record.failureCategory.isEmpty {
+                    record.failureCategory = "unknown_failure"
+                    record.recoverability = BatchRunFailureRecoverability.unknown.rawValue
+                    record.failureMessage = "Evaluation completed, but benchmark did not succeed for this model."
                 }
             } catch {
-                applyFailure(error, record: &records[recordIndex])
-                progress.append("[\(offset + 1)/\(plan.selectedModels.count)] FAILED \(model.index) \(records[recordIndex].failureCategory): \(records[recordIndex].failureMessage)")
+                applyFailure(error, record: &record)
+                progress.append("[\(offset + 1)/\(plan.selectedModels.count)] FAILED \(model.index) \(record.failureCategory): \(record.failureMessage)")
                 if !plan.config.continueOnFailure {
-                    records[recordIndex].finishedAt = isoTimestamp()
-                    records[recordIndex].durationSeconds = Date().timeIntervalSince(modelStart)
-                    try BatchRunManifestStore.writeRecords(records, plan: plan)
+                    record.finishedAt = isoTimestamp()
+                    record.durationSeconds = Date().timeIntervalSince(modelStart)
+                    try persistRecord(record, in: &records)
                     throw error
                 }
             }
-            records[recordIndex].finishedAt = isoTimestamp()
-            records[recordIndex].durationSeconds = Date().timeIntervalSince(modelStart)
-            try BatchRunManifestStore.writeRecords(records, plan: plan)
-            progress.append("[\(offset + 1)/\(plan.selectedModels.count)] DONE \(model.index) status=\(records[recordIndex].status) elapsed=\(formatDuration(records[recordIndex].durationSeconds))")
+            record.finishedAt = isoTimestamp()
+            record.durationSeconds = Date().timeIntervalSince(modelStart)
+            try persistRecord(record, in: &records)
+            progress.append("[\(offset + 1)/\(plan.selectedModels.count)] DONE \(model.index) status=\(record.status) elapsed=\(formatDuration(record.durationSeconds))")
         }
 
         let summary = BatchRunManifestStore.summarize(
@@ -1957,6 +2007,17 @@ final class BatchRunExecutor {
         return (summary, progress)
     }
 
+    private func persist(_ records: [BatchRunModelRecord]) throws {
+        try BatchRunManifestStore.writeRecords(records, plan: plan)
+    }
+
+    private func persistRecord(_ record: BatchRunModelRecord, in records: inout [BatchRunModelRecord]) throws {
+        if let index = records.firstIndex(where: { BatchRunRecordIdentity(record: $0) == BatchRunRecordIdentity(record: record) }) {
+            records[index] = record
+        }
+        try persist(records)
+    }
+
     private func prepareDirectories(record: BatchRunModelRecord) throws {
         try fileManager.createDirectory(atPath: record.modelDir, withIntermediateDirectories: true)
         try fileManager.createDirectory(atPath: record.tempDir, withIntermediateDirectories: true)
@@ -1965,7 +2026,7 @@ final class BatchRunExecutor {
         try fileManager.createDirectory(atPath: URL(fileURLWithPath: record.modelDir).appendingPathComponent("raw", isDirectory: true).path, withIntermediateDirectories: true)
     }
 
-    private func runSyntheticStep(_ step: BatchRunStepName, record: inout BatchRunModelRecord, message: String) async throws {
+    private func runSyntheticStep(_ step: BatchRunStepName, record: inout BatchRunModelRecord, records: inout [BatchRunModelRecord], message: String) async throws {
         let startedAt = isoTimestamp()
         let started = Date()
         record.steps[step.rawValue] = BatchRunStepRecord(
@@ -1975,10 +2036,10 @@ final class BatchRunExecutor {
             durationSeconds: Date().timeIntervalSince(started),
             message: message
         )
-        try BatchRunManifestStore.writeRecords(currentRecords(updating: record), plan: plan)
+        try persistRecord(record, in: &records)
     }
 
-    private func runHubCheck(record: inout BatchRunModelRecord) async throws {
+    private func runHubCheck(record: inout BatchRunModelRecord, records: inout [BatchRunModelRecord]) async throws {
         let step = BatchRunStepName.hubCheck
         let startedAt = isoTimestamp()
         let started = Date()
@@ -1993,6 +2054,7 @@ final class BatchRunExecutor {
                 recoverability: classification.recoverability.rawValue,
                 message: classification.reason
             )
+            try persistRecord(record, in: &records)
             throw MelixCLIError.runtime(classification.reason)
         }
         record.steps[step.rawValue] = BatchRunStepRecord(
@@ -2002,10 +2064,10 @@ final class BatchRunExecutor {
             durationSeconds: Date().timeIntervalSince(started),
             message: "Repo id \(record.repoID) is owner/name-shaped."
         )
-        try BatchRunManifestStore.writeRecords(currentRecords(updating: record), plan: plan)
+        try persistRecord(record, in: &records)
     }
 
-    private func runBenchmark(record: inout BatchRunModelRecord) async throws {
+    private func runBenchmark(record: inout BatchRunModelRecord, records: inout [BatchRunModelRecord]) async throws {
         let exportsDir = URL(fileURLWithPath: record.modelDir).appendingPathComponent("exports", isDirectory: true)
         let arguments = [
             "bench", "run",
@@ -2019,7 +2081,7 @@ final class BatchRunExecutor {
             "--batch-factor", "\(plan.config.benchBatchFactor)",
             "--json",
         ]
-        let result = try await runCommand(step: .benchmark, arguments: arguments, record: &record)
+        let result = try await runCommand(step: .benchmark, arguments: arguments, record: &record, records: &records)
         let payload = BatchRunPayloadParser.object(from: result.stdout)
         record.benchmarkJobID = BatchRunPayloadParser.jobID(from: payload)
         record.metricFields.merge(BatchRunPayloadParser.metricValues(from: payload), uniquingKeysWith: { _, new in new })
@@ -2032,13 +2094,14 @@ final class BatchRunExecutor {
             step: .exports,
             arguments: ["bench", "export-csv", "--job-id", record.benchmarkJobID, "--output", csvPath, "--json"],
             record: &record,
+            records: &records,
             appendStep: true
         )
         record.benchmarkCSVPath = csvPath
-        try BatchRunManifestStore.writeRecords(currentRecords(updating: record), plan: plan)
+        try persistRecord(record, in: &records)
     }
 
-    private func runEvaluation(record: inout BatchRunModelRecord) async throws {
+    private func runEvaluation(record: inout BatchRunModelRecord, records: inout [BatchRunModelRecord]) async throws {
         let arguments = [
             "eval", "run",
             "--repo-id", record.repoID,
@@ -2051,7 +2114,7 @@ final class BatchRunExecutor {
             "--batch-factor", "\(plan.config.evalBatchFactor)",
             "--json",
         ]
-        let result = try await runCommand(step: .evaluation, arguments: arguments, record: &record)
+        let result = try await runCommand(step: .evaluation, arguments: arguments, record: &record, records: &records)
         let payload = BatchRunPayloadParser.object(from: result.stdout)
         record.evaluationJobID = BatchRunPayloadParser.jobID(from: payload)
         record.metricFields.merge(BatchRunPayloadParser.metricValues(from: payload), uniquingKeysWith: { _, new in new })
@@ -2059,10 +2122,10 @@ final class BatchRunExecutor {
         guard !record.evaluationJobID.isEmpty else {
             throw MelixCLIError.runtime("eval run did not return job_id; cannot export evaluation artifacts.")
         }
-        try BatchRunManifestStore.writeRecords(currentRecords(updating: record), plan: plan)
+        try persistRecord(record, in: &records)
     }
 
-    private func runExports(record: inout BatchRunModelRecord) async throws {
+    private func runExports(record: inout BatchRunModelRecord, records: inout [BatchRunModelRecord]) async throws {
         guard !record.evaluationJobID.isEmpty else {
             return
         }
@@ -2074,27 +2137,30 @@ final class BatchRunExecutor {
             step: .exports,
             arguments: ["eval", "export-summary-csv", "--job-id", record.evaluationJobID, "--output", summaryCSV, "--json"],
             record: &record,
+            records: &records,
             appendStep: true
         )
         _ = try await runCommand(
             step: .exports,
             arguments: ["eval", "export-samples-csv", "--job-id", record.evaluationJobID, "--output", samplesCSV, "--json"],
             record: &record,
+            records: &records,
             appendStep: true
         )
         _ = try await runCommand(
             step: .exports,
             arguments: ["eval", "export-samples-jsonl", "--job-id", record.evaluationJobID, "--output", samplesJSONL, "--json"],
             record: &record,
+            records: &records,
             appendStep: true
         )
         record.evaluationSummaryCSVPath = summaryCSV
         record.evaluationSamplesCSVPath = samplesCSV
         record.evaluationSamplesJSONLPath = samplesJSONL
-        try BatchRunManifestStore.writeRecords(currentRecords(updating: record), plan: plan)
+        try persistRecord(record, in: &records)
     }
 
-    private func copyRawArtifacts(record: inout BatchRunModelRecord) async throws {
+    private func copyRawArtifacts(record: inout BatchRunModelRecord, records: inout [BatchRunModelRecord]) async throws {
         let step = BatchRunStepName.artifactCopy
         let started = Date()
         let rawDir = URL(fileURLWithPath: record.modelDir).appendingPathComponent("raw", isDirectory: true)
@@ -2124,6 +2190,7 @@ final class BatchRunExecutor {
                     recoverability: classification.recoverability.rawValue,
                     message: error.localizedDescription
                 )
+                try persistRecord(record, in: &records)
                 throw error
             }
         }
@@ -2136,13 +2203,14 @@ final class BatchRunExecutor {
             durationSeconds: Date().timeIntervalSince(started),
             message: "Copied \(copied.count) raw artifact path(s)."
         )
-        try BatchRunManifestStore.writeRecords(currentRecords(updating: record), plan: plan)
+        try persistRecord(record, in: &records)
     }
 
     private func runCommand(
         step: BatchRunStepName,
         arguments: [String],
         record: inout BatchRunModelRecord,
+        records: inout [BatchRunModelRecord],
         appendStep: Bool = false
     ) async throws -> BatchRunSubprocessResult {
         let started = Date()
@@ -2161,7 +2229,7 @@ final class BatchRunExecutor {
         runningStep.stderrPath = stderrPath
         runningStep.artifactPath = receiptPath
         record.steps[step.rawValue] = runningStep
-        try BatchRunManifestStore.writeRecords(currentRecords(updating: record), plan: plan)
+        try persistRecord(record, in: &records)
 
         let result = await commandExecutor(arguments, commandEnvironment(record: record), record.tempDir)
         try result.stdout.write(toFile: stdoutPath, atomically: true, encoding: .utf8)
@@ -2171,6 +2239,7 @@ final class BatchRunExecutor {
             "schema_version": "melix.batch.command_receipt.v1",
             "step": step.rawValue,
             "arguments": arguments,
+            "exit_code": NSNumber(value: result.exitCode),
             "stdout_path": stdoutPath,
             "stderr_path": stderrPath,
             "duration_seconds": duration,
@@ -2179,8 +2248,9 @@ final class BatchRunExecutor {
         ]
         try JSONSerialization.data(withJSONObject: receipt, options: [.prettyPrinted, .sortedKeys])
             .write(to: URL(fileURLWithPath: receiptPath), options: .atomic)
-        if !result.stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if result.exitCode != 0 {
             let classification = BatchRunFailureClassifier.classify(stdout: result.stdout, stderr: result.stderr)
+            let failureMessage = MelixCLIProcessFailureMessage.make(stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode)
             record.steps[step.rawValue] = BatchRunStepRecord(
                 status: "failed",
                 stdoutPath: stdoutPath,
@@ -2191,15 +2261,18 @@ final class BatchRunExecutor {
                 durationSeconds: duration,
                 failureCategory: classification.category,
                 recoverability: classification.recoverability.rawValue,
-                message: result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                message: failureMessage
             )
-            try BatchRunManifestStore.writeRecords(currentRecords(updating: record), plan: plan)
-            throw MelixCLIError.runtime(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+            try persistRecord(record, in: &records)
+            throw MelixCLIError.runtime(failureMessage)
         }
         let existingMessage = appendStep ? (record.steps[step.rawValue]?.message ?? "") : ""
-        let message = appendStep && !existingMessage.isEmpty
+        var message = appendStep && !existingMessage.isEmpty
             ? existingMessage + "; completed \(arguments.prefix(2).joined(separator: " "))"
             : "completed \(arguments.prefix(2).joined(separator: " "))"
+        if !result.stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            message += "; stderr captured"
+        }
         var completed = BatchRunStepRecord(
             status: "succeeded",
             stdoutPath: stdoutPath,
@@ -2217,7 +2290,7 @@ final class BatchRunExecutor {
             completed.jobID = BatchRunPayloadParser.jobID(from: BatchRunPayloadParser.object(from: result.stdout))
         }
         record.steps[step.rawValue] = completed
-        try BatchRunManifestStore.writeRecords(currentRecords(updating: record), plan: plan)
+        try persistRecord(record, in: &records)
         return result
     }
 
@@ -2254,14 +2327,6 @@ final class BatchRunExecutor {
         if BatchRunFailureClassifier.runtimeFailureRequiresCleanStack(classification) {
             record.steps[BatchRunStepName.runtimePrepare.rawValue]?.message = "Clean stack required before the next model: \(classification.reason)"
         }
-    }
-
-    private func currentRecords(updating record: BatchRunModelRecord) -> [BatchRunModelRecord] {
-        var records = (try? BatchRunManifestStore.loadRecords(manifestPath: plan.manifestPath)) ?? BatchRunManifestStore.initialRecords(plan: plan)
-        if let index = records.firstIndex(where: { $0.modelIndex == record.modelIndex && $0.repoID == record.repoID }) {
-            records[index] = record
-        }
-        return records
     }
 
     private func commandCount(record: BatchRunModelRecord, step: BatchRunStepName) -> Int {
@@ -2406,7 +2471,17 @@ enum BatchRunResumePlanner {
             : URL(fileURLWithPath: resolution.tempRoot)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         let path = root.appendingPathComponent("resume-models.txt")
-        let text = records.map { "\($0.modelIndex)|\($0.repoID)" }.joined(separator: "\n") + "\n"
+        var lines: [String] = []
+        for record in records {
+            let targetLine = record.sourceLine > 0
+                ? max(record.sourceLine, lines.count + 1)
+                : lines.count + 1
+            while lines.count + 1 < targetLine {
+                lines.append("")
+            }
+            lines.append("\(record.modelIndex)|\(record.repoID)")
+        }
+        let text = lines.joined(separator: "\n") + "\n"
         try text.write(to: path, atomically: true, encoding: .utf8)
         return path.path
     }
@@ -2464,8 +2539,19 @@ enum BatchRunResumePlanner {
 }
 
 enum BatchRunSlug {
+    static func modelSlug(model: BatchRunModelEntry) -> String {
+        modelSlug(index: model.index, repoID: model.repoID, sourceLine: model.sourceLine)
+    }
+
+    static func modelSlug(index: String, repoID: String, sourceLine: Int) -> String {
+        modelSlug(raw: "\(index)-line-\(sourceLine)-\(repoID)")
+    }
+
     static func modelSlug(index: String, repoID: String) -> String {
-        let raw = "\(index)-\(repoID)"
+        modelSlug(raw: "\(index)-\(repoID)")
+    }
+
+    private static func modelSlug(raw: String) -> String {
         var slug = ""
         var lastWasDash = false
         for scalar in raw.lowercased().unicodeScalars {

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -4397,6 +4397,32 @@ private struct ArgumentCursor {
 
 public typealias MelixCLICommandExecutor = @Sendable ([String]) async throws -> String
 
+public struct MelixCLIProcessResult: Equatable, Sendable {
+    public let stdout: String
+    public let stderr: String
+    public let exitCode: Int32
+
+    public init(stdout: String, stderr: String, exitCode: Int32) {
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exitCode = exitCode
+    }
+}
+
+public enum MelixCLIProcessFailureMessage {
+    public static func make(stdout: String, stderr: String, exitCode: Int32) -> String {
+        let stderrMessage = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !stderrMessage.isEmpty {
+            return stderrMessage
+        }
+        let stdoutMessage = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !stdoutMessage.isEmpty {
+            return stdoutMessage
+        }
+        return "Subprocess exited with status \(exitCode)."
+    }
+}
+
 public struct MelixCLIProcessExecutor: Sendable {
     public let baseCommand: [String]
     public let environment: [String: String]
@@ -4413,10 +4439,23 @@ public struct MelixCLIProcessExecutor: Sendable {
     }
 
     public func run(arguments: [String]) async throws -> String {
+        let result = try await runDetailed(arguments: arguments)
+        guard result.exitCode == 0 else {
+            let message = MelixCLIProcessFailureMessage.make(
+                stdout: result.stdout,
+                stderr: result.stderr,
+                exitCode: result.exitCode
+            )
+            throw MelixCLIError.runtime(message)
+        }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public func runDetailed(arguments: [String]) async throws -> MelixCLIProcessResult {
         try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 do {
-                    continuation.resume(returning: try runSync(arguments: arguments))
+                    continuation.resume(returning: try runDetailedSync(arguments: arguments))
                 } catch {
                     continuation.resume(throwing: error)
                 }
@@ -4424,7 +4463,7 @@ public struct MelixCLIProcessExecutor: Sendable {
         }
     }
 
-    private func runSync(arguments: [String]) throws -> String {
+    private func runDetailedSync(arguments: [String]) throws -> MelixCLIProcessResult {
         guard let executable = baseCommand.first else {
             throw MelixCLIError.runtime("The melix subprocess command is not configured.")
         }
@@ -4446,11 +4485,7 @@ public struct MelixCLIProcessExecutor: Sendable {
         let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
         let stdoutText = String(data: stdoutData, encoding: .utf8) ?? ""
         let stderrText = String(data: stderrData, encoding: .utf8) ?? ""
-        guard process.terminationStatus == 0 else {
-            let message = stderrText.isEmpty ? stdoutText : stderrText
-            throw MelixCLIError.runtime(message.trimmingCharacters(in: .whitespacesAndNewlines))
-        }
-        return stdoutText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return MelixCLIProcessResult(stdout: stdoutText, stderr: stderrText, exitCode: process.terminationStatus)
     }
 }
 
@@ -9242,9 +9277,10 @@ public actor MelixCLIRunner {
                 workingDirectory: workingDirectory
             )
             do {
-                return BatchRunSubprocessResult(stdout: try await executor.run(arguments: arguments), stderr: "")
+                let result = try await executor.runDetailed(arguments: arguments)
+                return BatchRunSubprocessResult(stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode)
             } catch {
-                return BatchRunSubprocessResult(stdout: "", stderr: error.localizedDescription)
+                return BatchRunSubprocessResult(stdout: "", stderr: error.localizedDescription, exitCode: -1)
             }
         }
     }

--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -83,6 +83,12 @@ display `index` value. `start_index: 2` starts with the second selected line in
 the normalized model list even when explicit display indexes are non-numeric or
 non-contiguous.
 
+Artifact and manifest identity uses the tuple `index`, `repo_id`, and
+`source_line`. This keeps duplicate explicit entries isolated even when an
+operator intentionally repeats the same display index and repo id. Per-model
+artifact directory slugs must include the source line so repeated rows never
+overwrite each other's command receipts, exports, or raw artifacts.
+
 ### Effective Configuration
 
 Batch-run planning must resolve one effective configuration before any per-model
@@ -253,7 +259,11 @@ the configured semantic judge and then exports summary CSV, samples CSV, and
 samples JSONL under the model exports directory.
 
 The batch runner records subprocess stdout and stderr for every dispatched
-command under `<model>/commands/`. Missing job ids are treated as execution
+command under `<model>/commands/`. Command receipts must also persist the child
+process exit code. Exit code, not stderr text alone, decides subprocess success:
+stderr from an exit-zero command is preserved as evidence and noted in the step
+message, while non-zero exits fail the step using stderr, or stdout when stderr
+is empty, as the diagnostic message. Missing job ids are treated as execution
 failures because downstream export commands would otherwise be ambiguous.
 
 ### Status And Resume
@@ -267,6 +277,13 @@ configuration, rebuild the model list from manifest rows when `--models` is not
 provided, and execute only incomplete work by default. `--eval-only` skips
 benchmark stages and reruns missing or failed evaluation/export work. `--dry-run`
 for resume prints the planned model rows without dispatching commands.
+
+Resume planning must align existing manifest records back to selected models by
+`index`, `repo_id`, and `source_line`, preserving duplicate rows independently
+instead of collapsing them by display index or repo id. When resume rebuilds a
+model list from manifest rows, it must preserve source-line positions by
+inserting blank spacer lines before records whose original source line was
+greater than the current recovered line count.
 
 Resume must preserve the original run id, temporary root, output root, judge,
 benchmark, and evaluation settings when they are available in

--- a/docs/plans/2026-05-11-bench-eval-batch-run-foundation.md
+++ b/docs/plans/2026-05-11-bench-eval-batch-run-foundation.md
@@ -85,7 +85,9 @@ job ids are known, and copies raw artifact paths into the model bundle when the
 child command reports them.
 
 `BatchRunManifestStore` is the crash-safe source of truth for status and resume.
-It loads and rewrites JSONL rows without relying on summary prose.
+It loads and rewrites JSONL rows without relying on summary prose. Manifest
+updates align rows by the stable model identity tuple `model_index`, `repo_id`,
+and `source_line` so duplicate operator-requested rows remain independent.
 
 `BatchRunReporter` writes operator-visible summary artifacts:
 
@@ -96,7 +98,8 @@ It loads and rewrites JSONL rows without relying on summary prose.
 
 `BatchRunResumePlanner` rebuilds a model list from the manifest when necessary
 and preserves run id, artifact roots, judge, benchmark, and evaluation settings
-from `effective-config.json`.
+from `effective-config.json`. The recovered model list preserves original
+source-line positions so resume identity aligns with existing manifest rows.
 
 The temporary run directory remains the working source for future execution.
 The operator output directory receives a copy immediately so an interrupted run
@@ -105,17 +108,23 @@ still leaves inspectable evidence outside transient worker state.
 ## Metrics And Success Targets
 
 - Model-list parsing preserves duplicates and records source line numbers.
+- Per-model artifact slugs include source line numbers to prevent collisions
+  for duplicate explicit indexes and repo ids.
 - Dry-run planning writes one manifest row per selected model.
 - `effective-config.json` records selected and total model counts.
 - Subset selection is deterministic for `--start-index` and `--max-models`.
 - Dry-run command completion does not require a running Melix development
   stack, network access, or local model downloads.
 - Non-dry-run execution updates manifest status after every stage.
-- Each dispatched command records stdout, stderr, duration, and a JSON receipt.
+- Each dispatched command records stdout, stderr, exit code, duration, and a
+  JSON receipt; exit code is the success contract, while exit-zero stderr is
+  retained as warning evidence.
 - Summary artifacts are present in `output_root` after completion or resume.
 - Status inspection reads `manifest.jsonl` directly.
 - Resume eval-only reruns missing evaluation/export work without rerunning
   benchmark stages.
+- Resume-generated model lists preserve source-line identity for rows preceded
+  by comments or blank lines.
 - Failure classification persists both model-level and step-level category and
   recoverability.
 
@@ -124,7 +133,7 @@ Performance probes and success metrics:
 - Manifest write overhead target: one atomic JSONL rewrite per stage, bounded by
   selected model count and acceptable for operator-scale sweeps.
 - Command receipt overhead target: one stdout file, one stderr file, and one
-  JSON receipt per dispatched child command.
+  JSON receipt including exit code per dispatched child command.
 - Progress latency target: terminal progress lines are produced at every
   model/stage boundary instead of only after the full sweep.
 - Recovery target: `melix batch status` and `melix batch resume --dry-run` work
@@ -138,6 +147,8 @@ Performance probes and success metrics:
 - Swift runner tests for non-dry-run benchmark/evaluation/export dispatch,
   manifest updates, summary artifacts, status rendering, partial failure
   attribution, and eval-only resume.
+- Swift runner tests for duplicate explicit model rows and exit-zero stderr
+  warning handling.
 - `git diff --check`.
 - `xcrun swift build --product melix`.
 - Targeted Swift test invocation for the touched CLI tests when the local Swift

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -1211,6 +1211,95 @@ struct MelixCLIRunnerTests {
         #expect(statusJSON?["status"] as? String == "succeeded")
     }
 
+    @Test("batch run isolates duplicate explicit model rows by source line")
+    func batchRunIsolatesDuplicateExplicitModelRowsBySourceLine() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let modelList = root.appendingPathComponent("models.txt")
+        let tempRoot = root.appendingPathComponent("tmp-run")
+        let outputRoot = root.appendingPathComponent("downloads")
+        let fakeCLI = root.appendingPathComponent("fake-melix")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try """
+        A|mlx-community/Duplicate-4bit
+        A|mlx-community/Duplicate-4bit
+        """.write(to: modelList, atomically: true, encoding: .utf8)
+        try writeFakeBatchCLI(fakeCLI)
+
+        let runner = MelixCLIRunner(environment: [
+            "HOME": root.path,
+            "MELIX_CLI": fakeCLI.path,
+            "MELIX_HTTP_PORT": "12444",
+        ])
+        let output = try await runner.run(.batchRun(.init(
+            modelListPath: modelList.path,
+            runID: "batch-duplicates",
+            outputRoot: outputRoot.path,
+            tempRoot: tempRoot.path,
+            judgeRemoteServerID: "judge",
+            judgeModelID: "gpt-test"
+        )))
+
+        #expect(output.contains("[1/2] DONE A status=succeeded"))
+        #expect(output.contains("[2/2] DONE A status=succeeded"))
+        let manifestLines = try String(contentsOf: tempRoot.appendingPathComponent("manifest.jsonl"), encoding: .utf8)
+            .split(separator: "\n")
+        #expect(manifestLines.count == 2)
+        let entries = try manifestLines.map { try #require(parseJSONObject(String($0))) }
+        #expect(entries.map { $0["source_line"] as? Int } == [1, 2])
+        #expect(entries.allSatisfy { $0["status"] as? String == "succeeded" })
+        let modelDirs = entries.compactMap { $0["model_dir"] as? String }
+        #expect(Set(modelDirs).count == 2)
+        #expect(modelDirs.allSatisfy { $0.contains("-line-") })
+        #expect(modelDirs.allSatisfy { FileManager.default.fileExists(atPath: $0) })
+        let commandDirs = modelDirs.map { URL(fileURLWithPath: $0).appendingPathComponent("commands", isDirectory: true) }
+        #expect(commandDirs.allSatisfy { FileManager.default.fileExists(atPath: $0.appendingPathComponent("benchmark-1.json").path) })
+
+        let summary = try #require(try parseJSONFile(outputRoot.appendingPathComponent("run-summary.json").path))
+        #expect(summary["succeeded_models"] as? Int == 2)
+    }
+
+    @Test("batch run treats successful stderr as captured evidence")
+    func batchRunTreatsSuccessfulStderrAsCapturedEvidence() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let modelList = root.appendingPathComponent("models.txt")
+        let tempRoot = root.appendingPathComponent("tmp-run")
+        let outputRoot = root.appendingPathComponent("downloads")
+        let fakeCLI = root.appendingPathComponent("fake-melix")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "mlx-community/Qwen3.5-9B-MLX-4bit\n".write(to: modelList, atomically: true, encoding: .utf8)
+        try writeFakeBatchCLI(fakeCLI, warnBench: true)
+
+        let runner = MelixCLIRunner(environment: [
+            "HOME": root.path,
+            "MELIX_CLI": fakeCLI.path,
+            "MELIX_HTTP_PORT": "12444",
+        ])
+        _ = try await runner.run(.batchRun(.init(
+            modelListPath: modelList.path,
+            runID: "batch-stderr-warning",
+            outputRoot: outputRoot.path,
+            tempRoot: tempRoot.path,
+            judgeRemoteServerID: "judge",
+            judgeModelID: "gpt-test"
+        )))
+
+        let manifestLine = try #require(try String(contentsOf: tempRoot.appendingPathComponent("manifest.jsonl"), encoding: .utf8).split(separator: "\n").first)
+        let entry = try #require(parseJSONObject(String(manifestLine)))
+        #expect(entry["status"] as? String == "succeeded")
+        let steps = try #require(entry["steps"] as? [String: Any])
+        let benchmark = try #require(steps["benchmark"] as? [String: Any])
+        #expect(benchmark["status"] as? String == "succeeded")
+        #expect((benchmark["message"] as? String)?.contains("stderr captured") == true)
+        let receiptPath = try #require(benchmark["artifact_path"] as? String)
+        let receipt = try #require(try parseJSONFile(receiptPath))
+        #expect(receipt["exit_code"] as? Int == 0)
+        let stderrPath = try #require(benchmark["stderr_path"] as? String)
+        let stderr = try String(contentsOfFile: stderrPath, encoding: .utf8)
+        #expect(stderr.contains("bench warning"))
+    }
+
     @Test("batch run records partial success and failure attribution")
     func batchRunRecordsPartialSuccessAndFailureAttribution() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
@@ -1258,7 +1347,10 @@ struct MelixCLIRunnerTests {
         let fakeCLI = root.appendingPathComponent("fake-melix")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
-        try "mlx-community/Qwen3.5-9B-MLX-4bit\n".write(to: modelList, atomically: true, encoding: .utf8)
+        try """
+        # resume keeps this source line stable
+        mlx-community/Qwen3.5-9B-MLX-4bit
+        """.write(to: modelList, atomically: true, encoding: .utf8)
         try writeFakeBatchCLI(fakeCLI, failEval: true)
 
         let failingRunner = MelixCLIRunner(environment: [
@@ -1301,7 +1393,10 @@ struct MelixCLIRunnerTests {
         let manifestLine = try #require(try String(contentsOf: tempRoot.appendingPathComponent("manifest.jsonl"), encoding: .utf8).split(separator: "\n").first)
         let entry = try #require(parseJSONObject(String(manifestLine)))
         #expect(entry["status"] as? String == "succeeded")
+        #expect(entry["source_line"] as? Int == 2)
         #expect(entry["evaluation_job_id"] as? String == "eval-01")
+        let recoveredModelList = try String(contentsOf: tempRoot.appendingPathComponent("resume-models.txt"), encoding: .utf8)
+        #expect(recoveredModelList.split(separator: "\n", omittingEmptySubsequences: false).first?.isEmpty == true)
     }
 
     @Test("json metric patching preserves user artifact strings that look like the old sentinel")
@@ -7140,6 +7235,7 @@ struct MelixCLIRunnerTests {
         )
 
         let output = try await executor.run(arguments: ["runner-arg"])
+        let detailed = try await executor.runDetailed(arguments: ["runner-arg"])
         let components = output.split(separator: ":", maxSplits: 2).map(String.init)
 
         #expect(components.count == 3)
@@ -7149,6 +7245,9 @@ struct MelixCLIRunnerTests {
             root.resolvingSymlinksInPath().path
         )
         #expect(components[2] == "runner-arg")
+        #expect(detailed.exitCode == 0)
+        #expect(detailed.stderr == "")
+        #expect(detailed.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == output)
     }
 
     @Test("process executor surfaces subprocess failures and rejects empty commands")
@@ -7168,6 +7267,9 @@ struct MelixCLIRunnerTests {
         } catch let error as MelixCLIError {
             #expect(error == .runtime("subprocess boom"))
         }
+        let failedDetails = try await failingExecutor.runDetailed(arguments: [])
+        #expect(failedDetails.exitCode == 3)
+        #expect(failedDetails.stderr == "subprocess boom")
 
         let misconfiguredExecutor = MelixCLIProcessExecutor(baseCommand: [])
 
@@ -11297,14 +11399,18 @@ private func makeEvaluationCompareResult(
     return ControlPlaneEvaluationResult(job: job, results: results)
 }
 
-private func writeFakeBatchCLI(_ path: URL, failEval: Bool = false) throws {
+private func writeFakeBatchCLI(_ path: URL, failEval: Bool = false, warnBench: Bool = false) throws {
     let failEvalLiteral = failEval ? "1" : "0"
+    let warnBenchLiteral = warnBench ? "1" : "0"
     let script = """
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p "${MELIX_BATCH_MODEL_DIR}/fake-raw"
     printf '{"raw": true}\\n' > "${MELIX_BATCH_MODEL_DIR}/fake-raw/raw.json"
     if [[ "$1 $2" == "bench run" ]]; then
+      if [[ "\(warnBenchLiteral)" == "1" ]]; then
+        printf 'bench warning for %s\\n' "${MELIX_BATCH_MODEL_INDEX}" >&2
+      fi
       printf '{"job_id":"bench-01","metrics":{"bench.smoke.tokens_per_second":12.5},"output_dir":"%s"}\\n' "${MELIX_BATCH_MODEL_DIR}/fake-raw"
       exit 0
     fi


### PR DESCRIPTION
## Summary
- Harden `melix batch run` manifest identity so duplicate explicit model rows keep independent manifest records and artifact directories.
- Preserve subprocess exit codes in command receipts and treat exit code, not stderr text alone, as the success contract.
- Preserve source-line identity for generated resume model lists and document the updated contract.

## Plan or Spec
- `docs/benchmark-evaluation-contract.md`
- `docs/plans/2026-05-11-bench-eval-batch-run-foundation.md`

## Commands Run
```text
# passed
xcrun swift build --product melix

# passed
batch smoke: duplicate explicit model rows + exit-zero stderr warning using .build/debug/melix batch run

# passed
resume smoke: failed eval followed by melix batch resume --eval-only with original source_line preserved

# passed
git diff --check

# local environment failure, not a code failure
xcrun swift test --filter 'MelixCLIRunnerTests/batchRun|MelixCLIRunnerTests/processExecutor'
failed before filtered tests compiled because this local CommandLineTools Swift environment cannot import the Swift Testing module.

# local environment failure, not a code failure
pre-commit make swift-test
first hit stale SwiftPM cache checkout failures, then after cache refresh failed in protocol package with `no such module 'XCTest'` in this local CommandLineTools Swift environment.
```

## Coverage and Metrics
- Changed-scope automated coverage: targeted Swift tests were added for duplicate explicit rows, exit-zero stderr evidence, resume source-line preservation, and detailed subprocess results, but local coverage is not measurable because this machine's Swift test toolchain lacks `Testing`/`XCTest` modules.
- Metrics: runtime behavior is neutral to improved for operator-scale sweeps. Manifest writes remain one atomic JSONL rewrite per stage, command receipt overhead stays one stdout file, one stderr file, and one JSON receipt per dispatched command, with one additional `exit_code` scalar in the receipt. Duplicate rows now avoid artifact overwrite rather than sharing directories.
- Observability mode: evidence. Probe overhead: N/A, no new probe path; this extends existing command receipts with exit code.

## Known Gaps
- Full Swift test coverage is deferred to GitHub CI because the local CommandLineTools Swift environment cannot import `Testing`/`XCTest`.
- No protocol or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
