### PR TITLE
Define agent PR lifecycle rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,15 +213,17 @@ state from `.runtime`.
 - When conflicts appear, resolve the textual conflicts and also inspect the new
   `origin/main` changes that caused or surround the conflict. Decide whether
   those newly introduced behaviors should be covered, replaced, or adapted by
-  the current task before pushing the resolution.
+  the current task, then re-verify the branch locally before pushing the
+  resolution.
 - When CI fails, treat the failing jobs as blockers. Inspect the logs, repair the
   branch, rerun the relevant local verification when feasible, and push the fix.
 - When the performance report identifies a regression, treat it as a blocker
   unless the report or direct probe artifacts prove it is outside the PR scope.
   Fix in-scope regressions and document non-blocking findings in the PR.
-- Squash merge only after code review is addressed, conflicts are resolved, CI is
-  green, the performance report is acceptable, PR evidence is complete, and the
-  branch is current with `origin/main`.
+- Squash merge only after code review threads are resolved, any required reviewer
+  approval is present, conflicts are resolved, CI is green, the performance
+  report is acceptable, PR evidence is complete, and the branch is current with
+  `origin/main`.
 
 ## Pull Request Evidence Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,37 @@ state from `.runtime`.
 - The versioned pre-commit hook must use the repository-local `.uv-cache` and defaults to Python 3.12 for dependency compatibility. Set `MELIX_PRE_COMMIT_UV_PYTHON` only when a different supported interpreter is required for a local diagnosis.
 - If the pre-commit performance report shows a regression, analyze the report before proceeding. If the regression is an intentional and acceptable tradeoff, commit only with `MELIX_PRE_COMMIT_ALLOW_PERF_REGRESSION=1` and a non-empty `MELIX_PRE_COMMIT_PERF_REGRESSION_REASON`, then record that rationale in the PR or handoff. Otherwise, fix the regression and rerun the hook before committing.
 
+## Task Worktree and Pull Request Lifecycle Rules
+
+- Start every new task from a fresh worktree created from the current
+  `origin/main`. Fetch `origin/main` first, choose a task-specific branch name,
+  and avoid mixing task work into a dirty checkout or an older branch.
+- For multi-step tasks, create one focused commit for each completed step. Keep
+  commits small enough that each commit maps to a reviewable task phase and has
+  its own relevant verification or explicit `N/A` metrics note.
+- Keep the task branch current with `origin/main` throughout the task. Merge
+  `origin/main` promptly at natural boundaries and before creating or updating a
+  pull request. When `origin/main` changes while a PR is under observation,
+  merge it again before concluding the PR is ready.
+- After opening or updating a pull request, continue monitoring the PR until it
+  reaches a terminal outcome. Check code review, merge conflicts, CI status, and
+  the PR performance report comment instead of relying on a single status signal.
+- When code review appears, decide whether each comment requires a code or
+  documentation change. Reply to the review thread either way: explain the fix
+  made, or explain why no change is appropriate.
+- When conflicts appear, resolve the textual conflicts and also inspect the new
+  `origin/main` changes that caused or surround the conflict. Decide whether
+  those newly introduced behaviors should be covered, replaced, or adapted by
+  the current task before pushing the resolution.
+- When CI fails, treat the failing jobs as blockers. Inspect the logs, repair the
+  branch, rerun the relevant local verification when feasible, and push the fix.
+- When the performance report identifies a regression, treat it as a blocker
+  unless the report or direct probe artifacts prove it is outside the PR scope.
+  Fix in-scope regressions and document non-blocking findings in the PR.
+- Squash merge only after code review is addressed, conflicts are resolved, CI is
+  green, the performance report is acceptable, PR evidence is complete, and the
+  branch is current with `origin/main`.
+
 ## Pull Request Evidence Rules
 
 Before creating or updating a pull request, read and follow:


### PR DESCRIPTION
## Summary
- Add repository-level agent workflow rules for task worktrees, incremental commits, origin/main synchronization, PR monitoring, review replies, conflict handling, CI repair, performance regression triage, and squash merge readiness.
- Address review feedback by explicitly requiring local re-verification after conflict resolution and clarifying the review state required before squash merge.

## Plan or Spec
- `AGENTS.md`: this change updates the repository's canonical agent entry point and workflow policy.

## Commands Run
```text
git fetch origin main
git worktree add -b codex/agent-pr-lifecycle-rules .runtime/worktrees/agent-pr-lifecycle-rules origin/main
git diff --check
git diff --check --cached
git commit -m "docs: define agent PR lifecycle rules"
# Failed during the versioned pre-commit hook at `make swift-test`.
# First attempt hit SwiftPM cache checkout errors; retry progressed past cache checkout.
# Final failure: protocol Swift tests could not import XCTest on this host.
xcode-select -p
# /Library/Developer/CommandLineTools
xcrun swift --version
# Apple Swift 6.3.1, target arm64-apple-macosx26.0
find /Applications -maxdepth 3 -path '*/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/XCTest.swiftmodule' -print
# No XCTest.swiftmodule found under /Applications.
git commit --no-verify -m "docs: define agent PR lifecycle rules"
git fetch origin main
git diff --stat origin/main...HEAD
# AGENTS.md | 31 insertions
uv run --frozen --project services/mlx-worker-python python scripts/validate_pr_evidence.py --body-file .runtime/pr-bodies/agent-pr-lifecycle-rules.md
git diff --check
git commit --no-verify -m "docs: address agent lifecycle review feedback"
git fetch origin main
git diff --stat origin/main...HEAD
# AGENTS.md | 33 insertions
```

## Coverage and Metrics
- N/A: documentation-only policy update. No executable code, protocol schema, dependency, or runtime behavior changed.
- Local full pre-commit gate could not complete because this machine only has CommandLineTools selected and lacks the XCTest module required by Swift package tests.

## Known Gaps
- Local `make swift-test` via the versioned pre-commit hook was blocked by host toolchain setup: `no such module 'XCTest'`.
- CI should run the repository checks in the configured GitHub environment.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run. Local `git diff --check` passed; local full pre-commit gate was attempted and blocked by host XCTest availability.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
