### PR TITLE
perf: skip unquote for plain audio file URIs

### DIFF
--- a/docs/plans/2026-05-13-audio-local-uri-unquote-fast-path.md
+++ b/docs/plans/2026-05-13-audio-local-uri-unquote-fast-path.md
@@ -1,0 +1,31 @@
+# Audio local URI unquote fast path
+
+## Scope
+
+This Python-only performance slice is limited to the MLX audio local URI
+preprocessing path in `services/mlx-worker-python/worker/runtime/audio_preprocessing.py`.
+It preserves local `file://` URI behavior while avoiding `urllib.parse.unquote(...)`
+for the common local path case that contains no percent escapes.
+
+## Registered probe
+
+The affected path is covered by the existing `mlx-audio-local-uri-zero-copy-preprocess`
+PR-scoped performance probe in `infra/perf/pr_scoped_probes.json`. The entry includes
+focused `test_command`, `coverage_command`, and `probe_command` values and reports:
+
+- `elapsed_ms_mean` (`lower_is_better`)
+- `peak_bytes_mean` (`lower_is_better`)
+- `local_uri_read_bytes_calls_mean` (`lower_is_better` guard rail)
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage command, and local Linux
+probe before opening the PR. Use the GitHub PR-scoped performance workflow as the
+merge gate for the registered probe report.
+
+## Success criteria
+
+- Local URI decoding behavior remains unchanged, including encoded paths.
+- Changed-scope coverage remains at least 95%.
+- The registered local probe shows a clear non-regression or improvement in
+  `elapsed_ms_mean` while preserving zero local URI file reads.

--- a/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
@@ -143,6 +143,15 @@ def test_mlx_audio_transcription_runtime_uses_local_uri_path_without_reading_byt
     monkeypatch.setattr(audio_preprocessing, "urlparse", fail_urlparse)
     assert audio_preprocessing._path_from_uri(audio_path.as_uri()) == audio_path
 
+    fail_unquote = lambda path: (_ for _ in ()).throw(  # noqa: E731
+        AssertionError(f"unencoded local audio URI should skip unquote: {path}")
+    )
+    monkeypatch.setattr(audio_preprocessing, "unquote", fail_unquote)
+    assert audio_preprocessing._path_from_uri(audio_path.as_uri()) == audio_path
+
+    monkeypatch.setattr(audio_preprocessing, "unquote", lambda path: str(audio_path))
+    assert audio_preprocessing._path_from_uri("file:///tmp/audio%20sample.wav") == audio_path
+
     monkeypatch.setattr(audio_preprocessing, "urlparse", fail_urlparse)
     assert audio_preprocessing._path_from_uri(str(audio_path)) == audio_path
 

--- a/services/mlx-worker-python/worker/runtime/audio_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/audio_preprocessing.py
@@ -91,10 +91,11 @@ def _path_from_uri(uri: str) -> Path:
         elif not path_part.startswith("/"):
             parsed = urlparse(uri)
             path_part = parsed.path
-        return Path(unquote(path_part))
+        return Path(path_part if "%" not in path_part else unquote(path_part))
     if "://" not in uri:
         return Path(uri)
     parsed = urlparse(uri)
     if parsed.scheme != "file":
         raise AudioPreprocessError(f"Unsupported audio URI scheme: {parsed.scheme}")
-    return Path(unquote(parsed.path))
+    parsed_path = parsed.path
+    return Path(parsed_path if "%" not in parsed_path else unquote(parsed_path))


### PR DESCRIPTION
## Summary
- Optimizes the MLX audio local file URI path by skipping `urllib.parse.unquote(...)` when the path has no percent escapes.
- Adds regression coverage for both the unencoded fast path and encoded URI fallback.

## Plan or Spec
- `docs/plans/2026-05-13-audio-local-uri-unquote-fast-path.md`

## Commands Run
```text
# GitHub identity preflight
GH_CONFIG_DIR=/root/.hermes/profiles/coder/gh-config gh auth status
GH_CONFIG_DIR=/root/.hermes/profiles/coder/gh-config gh api user --jq .login
# login=Zigfreidish

# Baseline local probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_audio_local_uri_probe.py
# exit 0; elapsed_ms_mean=0.17925864085555077, local_uri_read_bytes_calls_mean=0.0, peak_bytes_mean=2478.8

# Focused tests after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_audio_runtime.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_local_uri_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_main_covers_checked_in_file
# exit 0; 37 passed in 1.51s

# Changed-scope coverage via registered probe runner
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id mlx-audio-local-uri-zero-copy-preprocess --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-audio-unquote-20260513194510 --head-repo "$PWD" --output /tmp/mlx-audio-unquote-probe2.json
# exit 0; coverage TOTAL 8 0 100%; registered probe completed for base and head

# Diff hygiene
git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 8 0 100%` from the registered probe runner.
- Registered local probe: `mlx-audio-local-uri-zero-copy-preprocess`.
- Probe comparison from `/tmp/mlx-audio-unquote-probe2.json`:
  - base `elapsed_ms_mean=0.23708739317953587`, head `elapsed_ms_mean=0.15964736230671406` (`delta_ms=-0.07744003087282181`, about `32.66%` lower).
  - base/head `local_uri_read_bytes_calls_mean=0.0`.
  - base/head `peak_bytes_mean=2522.0`.

## Known Gaps
- Local verification is Linux/Python-only. Hosted GitHub Actions, including the PR-scoped performance workflow, remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
