### PR TITLE
perf: cache serving diagnostics retained queue count

### DIFF
--- a/docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md
+++ b/docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md
@@ -16,6 +16,7 @@ with focused pytest, changed-scope coverage, and the registered PR-scoped perfor
 ## Touched files
 
 - `services/mlx-worker-python/worker/productization/serving_diagnostics.py`
+- `services/mlx-worker-python/tests/test_serving_diagnostics.py`
 - `docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md`
 
 ## Registered probe

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -172,6 +172,34 @@ def test_serving_diagnostics_bounded_queue_drops_oldest_without_blocking(
     assert [row["event_index"] for row in event_rows] == [1, 2]
 
 
+def test_serving_diagnostics_queue_append_uses_retained_count_without_len() -> None:
+    event = ServingDiagnosticsEvent(
+        request_id="req-retained-count",
+        phase="decode",
+        event_index=0,
+        status="completed",
+    )
+
+    class NoLenBuffer:
+        def __init__(self) -> None:
+            self.events: list[ServingDiagnosticsEvent] = []
+
+        def __len__(self) -> int:
+            raise AssertionError(
+                "append should use the retained counter, not len(_events)"
+            )  # pragma: no cover
+
+        def append(self, queued_event: ServingDiagnosticsEvent) -> None:
+            self.events.append(queued_event)
+
+    queue = BoundedServingDiagnosticsEventQueue(max_events=2)
+    buffer = NoLenBuffer()
+    queue._events = buffer  # type: ignore[assignment]
+
+    assert queue.append(event) is True
+    assert buffer.events == [event]
+
+
 def test_serving_diagnostics_event_instances_use_slots_for_debug_queue() -> None:
     event = ServingDiagnosticsEvent(
         request_id="req-slots",

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -27,13 +27,21 @@ class ServingDiagnosticsQueueSnapshot:
 
 
 class BoundedServingDiagnosticsEventQueue:
-    __slots__ = ("_dropped_count", "_events", "_is_saturated", "_lock", "_max_events")
+    __slots__ = (
+        "_dropped_count",
+        "_events",
+        "_is_saturated",
+        "_lock",
+        "_max_events",
+        "_retained_count",
+    )
 
     def __init__(self, *, max_events: int = 256) -> None:
         self._max_events = max(int(max_events), 1)
         self._events: deque[ServingDiagnosticsEvent] = deque(maxlen=self._max_events)
         self._dropped_count = 0
         self._is_saturated = False
+        self._retained_count = 0
         self._lock = threading.Lock()
 
     def append(self, event: ServingDiagnosticsEvent) -> bool:
@@ -43,7 +51,8 @@ class BoundedServingDiagnosticsEventQueue:
                 self._events.append(event)
                 return False
             self._events.append(event)
-            self._is_saturated = len(self._events) >= self._max_events
+            self._retained_count += 1
+            self._is_saturated = self._retained_count >= self._max_events
             return True
 
     def snapshot(self) -> ServingDiagnosticsQueueSnapshot:


### PR DESCRIPTION
## Summary
- Cache the retained event count inside `BoundedServingDiagnosticsEventQueue` so the append path no longer calls `len(self._events)` before saturation.
- Add a focused regression test that replaces the underlying buffer with a no-`len()` sentinel to prove append uses the retained counter.

## Plan or Spec
- `docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md`

## Commands Run
```text
# Confirm registered probe coverage
python3 - <<'PY'
import json
from pathlib import Path
probes=json.loads(Path('infra/perf/pr_scoped_probes.json').read_text())
for p in probes:
    if p['id']=='serving-diagnostics-debug-queue-bounds':
        print(p['id'])
        print('test_command', bool(p.get('test_command')))
        print('coverage_command', bool(p.get('coverage_command')))
        print('probe_command', bool(p.get('probe_command')))
        print('\n'.join(p['watch_globs']))
        break
else:
    raise SystemExit('missing')
PY
# exit 0; registered probe has test_command, coverage_command, and probe_command.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 25 passed in 0.13s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 25 passed in 0.23s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# TOTAL 17 0 100%

# origin/main baseline, same registered probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# {"capacity": 64.0, "dropped_count": 4032.0, "elapsed_ms_mean": 10.938258, "event_count": 4096.0, "retained_count": 64.0, "sample_count": 5.0}

# head, same registered probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# {"capacity": 64.0, "dropped_count": 4032.0, "elapsed_ms_mean": 6.859254, "event_count": 4096.0, "retained_count": 64.0, "sample_count": 5.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 17 0 100%`.
- Registered local probe `serving-diagnostics-debug-queue-bounds`: origin/main `elapsed_ms_mean=10.938258`, head `elapsed_ms_mean=6.859254`, delta `-4.079004 ms`, speedup `1.59x`; guard rails unchanged (`dropped_count=4032`, `retained_count=64`).
- GitHub Actions PR-scoped performance report is required before merge.

## Known Gaps
- None for the Python slice. This is Linux-local-verifiable and does not rely on Swift runtime validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; runtime observability unchanged.
- [x] Deferred work and known gaps are stated explicitly.
