### PR TITLE
perf: bind release gate metric helpers locally

### DIFF
--- a/docs/plans/2026-05-13-release-gates-metric-value-local-binding.md
+++ b/docs/plans/2026-05-13-release-gates-metric-value-local-binding.md
@@ -1,0 +1,19 @@
+# Release gates metric value local binding optimization
+
+This Python-only performance slice is limited to `services/mlx-worker-python/worker/productization/release_gates.py`.
+
+## Scope
+
+The M9 release-gate evaluator resolves many policy metric names inside `_evaluate_section_metrics_with_counts(...)`. This slice keeps the release-gate policy semantics unchanged and only binds `_metric_value` and the missing sentinel to local variables before the hot rules loop so each metric check avoids repeated global-name resolution.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `release-gates-m9-failure-count-single-pass` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for the M9 release-gate evaluator and probe script.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage, and the registered local probe on Linux before pushing. Accept the slice only if behavior remains identical and the registered probe shows a stable elapsed-time improvement without changing `failure_count_mean` or `endswith_checks_mean`.
+
+## Linux validation boundary
+
+This is a Python-only worker/productization path and is locally verifiable on Linux. No Swift runtime effect is claimed for this slice.

--- a/services/mlx-worker-python/worker/productization/release_gates.py
+++ b/services/mlx-worker-python/worker/productization/release_gates.py
@@ -1693,9 +1693,11 @@ def _evaluate_section_metrics_with_counts(
     failed_threshold_count = 0
     failures_append = failures.append
     numeric_types = _NUMERIC_METRIC_TYPES
+    missing = _MISSING
+    metric_value = _metric_value
     for name, rule in rules.items():
-        value = _metric_value(values, str(name))
-        if value is _MISSING:
+        value = metric_value(values, str(name))
+        if value is missing:
             failures_append(f"{prefix}{name} is missing")
             missing_count += 1
             continue


### PR DESCRIPTION
## Summary
- Bind the release-gate metric helper and missing sentinel locally inside the M9 section-metric loop.
- Keep M9 release-gate behavior unchanged while reducing repeated global-name resolution in the registered hot path.

## Plan or Spec
- `docs/plans/2026-05-13-release-gates-metric-value-local-binding.md`

## Commands Run
```text
# Baseline vs head probe, 3 interleaved runs with 20 samples each:
old_mean_ms=9.659574130394807
new_mean_ms=8.95940182187284
delta_ms=-0.7001723085219673
speedup=1.0781494481933622

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_m9_release_evidence_ignores_non_dict_policy_entries services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_m9_release_evidence_reuses_section_failure_counts services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_section_metrics_counts_failure_types_without_suffix_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_release_gates_m9_failure_count_probe_script_emits_metrics
# 4 passed in 0.33s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_m9_release_evidence_ignores_non_dict_policy_entries services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_m9_release_evidence_reuses_section_failure_counts services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_section_metrics_counts_failure_types_without_suffix_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_release_gates_m9_failure_count_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/release_gates.py services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/release_gates_m9_failure_count_probe.py
# TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RELEASE_GATES_M9_PROBE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/release_gates_m9_failure_count_probe.py
# {"elapsed_ms_mean": 9.342622209805995, "endswith_checks_mean": 0.0, "failure_count_mean": 12800.0, "failures_per_section": 80.0, "sample_count": 20.0, "section_count": 160.0}

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%` for `services/mlx-worker-python/worker/productization/release_gates.py` and related focused tests/probe.
- Registered local probe: `release-gates-m9-failure-count-single-pass`.
- Probe comparison: `old_mean_ms=9.659574130394807`, `new_mean_ms=8.95940182187284`, `delta_ms=-0.7001723085219673`, `speedup=1.0781494481933622`.
- Structural metrics unchanged: `endswith_checks_mean=0.0`, `failure_count_mean=12800.0`.
- CI PR-scoped performance must run the registered probe for merge validation.

## Known Gaps
- Linux-local validation only; this slice touches Python productization code and claims no Swift runtime effect.
- Full repository test gate was not run locally; focused registered probe/test/coverage commands were run.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
