### PR TITLE
perf: bind event actor alias expansion helpers

### DIFF
--- a/docs/plans/2026-05-13-event-actor-alias-local-bindings.md
+++ b/docs/plans/2026-05-13-event-actor-alias-local-bindings.md
@@ -1,0 +1,57 @@
+# Event actor alias local bindings slice
+
+## Scope
+
+Optimize the Python event-extraction semantic actor expansion hot path covered by
+the registered `event-extraction-group-actor-alias-cache` PR-scoped performance
+probe.
+
+Affected code:
+
+- `services/mlx-worker-python/worker/productization/event_extraction.py`
+- focused behavior/probe coverage in `services/mlx-worker-python/tests/test_event_extraction.py`
+  and `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- registered probe script `scripts/event_extraction_actor_alias_probe.py`
+
+## Current behavior
+
+`_semantic_field_values("actor", ...)` normalizes and deduplicates actor field
+values, then expands group actor aliases such as `我们`, `双方`, and normalized
+variants into the two speaker slots. `_expanded_semantic_actor_values()` is cached
+by the normalized tuple, but cache misses still perform repeated global method
+lookups while populating the expanded list.
+
+## Optimization
+
+Bind the group-alias predicate and collection mutator methods once per
+`_expanded_semantic_actor_values()` cache miss, and inline the two speaker-slot
+expansion instead of allocating a short `expansion` tuple for every input value.
+This keeps actor expansion semantics unchanged while reducing repeated global,
+attribute lookup, and tiny tuple allocation overhead inside the value-expansion
+loop.
+
+## Probe and success metric
+
+Registered probe: `event-extraction-group-actor-alias-cache` in
+`infra/perf/pr_scoped_probes.json`.
+
+Success metric:
+
+- `elapsed_ms_mean` lower is better.
+- `normalize_calls_mean`, `output_length_per_sample`, and `value_count` must stay
+  semantically stable for the compared workload.
+
+## Verification plan
+
+1. Run focused event-extraction and PR-scoped probe tests.
+2. Run changed-scope coverage with `scripts/changed_scope_coverage.py`; changed
+   scope must remain at least 95% covered.
+3. Run the registered local probe on Linux.
+4. Compare baseline and optimized probe runs on the same synthetic workload.
+5. Let GitHub Actions run the registered PR-scoped performance workflow before
+   merging.
+
+## Validation boundary
+
+This slice is Python-only and locally validated on Linux. It claims no Swift
+runtime effect.

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -1745,16 +1745,20 @@ def _normalize_unique_event_field(value: object) -> list[str]:
 def _expanded_semantic_actor_values(values: tuple[str, ...]) -> tuple[str, ...]:
     expanded: list[str] = []
     seen_expanded: set[str] = set()
+    is_group_actor_alias = _is_group_actor_alias
+    seen_add = seen_expanded.add
+    expanded_append = expanded.append
     for value in values:
-        if _is_group_actor_alias(value):
-            expansion = ("speaker_1", "speaker_2")
-        else:
-            expansion = (value,)
-        for expanded_value in expansion:
-            if expanded_value in seen_expanded:
-                continue
-            seen_expanded.add(expanded_value)
-            expanded.append(expanded_value)
+        if is_group_actor_alias(value):
+            if "speaker_1" not in seen_expanded:
+                seen_add("speaker_1")
+                expanded_append("speaker_1")
+            if "speaker_2" not in seen_expanded:
+                seen_add("speaker_2")
+                expanded_append("speaker_2")
+        elif value not in seen_expanded:
+            seen_add(value)
+            expanded_append(value)
     return tuple(expanded)
 
 


### PR DESCRIPTION
## Summary
- Bind the event actor alias expansion helper and collection mutators locally on `_expanded_semantic_actor_values()` cache misses.
- Inline the two speaker-slot expansion to avoid allocating a tiny tuple for every actor value while preserving semantic actor expansion behavior.

## Plan or Spec
- `docs/plans/2026-05-13-event-actor-alias-local-bindings.md`

## Commands Run
```text
# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_reuses_cached_group_actor_aliases services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_caches_repeated_group_actor_expansion services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_normalizes_and_deduplicates_in_one_pass services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_expands_group_actor_aliases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_actor_alias_probe_script_emits_metrics
# 7 passed in 0.19s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_reuses_cached_group_actor_aliases services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_caches_repeated_group_actor_expansion services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_normalizes_and_deduplicates_in_one_pass services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_expands_group_actor_aliases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_actor_alias_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_actor_alias_probe.py
# TOTAL 9 0 100%

# Registered local probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EVENT_ACTOR_ALIAS_PROBE_VALUE_COUNT=200 MELIX_EVENT_ACTOR_ALIAS_PROBE_ITERATIONS=200 MELIX_EVENT_ACTOR_ALIAS_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/event_extraction_actor_alias_probe.py
# {"elapsed_ms_mean": 4.624936077743769, "elapsed_ms_min": 4.437258001416922, "iterations_per_sample": 200.0, "normalize_calls_mean": 0.6, "output_length_per_sample": 13600.0, "peak_bytes_mean": 5333.2, "sample_count": 5.0, "value_count": 200.0}

# Baseline/head comparison on the registered default workload; three runs each
old_mean_ms=5.013734397167961
new_mean_ms=4.829478977868955
delta_ms=-0.18425541929900646
speedup=1.038152235498561

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 9 0 100%`.
- Registered probe: `event-extraction-group-actor-alias-cache`.
- Local baseline/head probe comparison on the registered default workload: `old_mean_ms=5.013734397167961`, `new_mean_ms=4.829478977868955`, `delta_ms=-0.18425541929900646`, `speedup=1.038152235498561`.
- Semantic stability metrics unchanged for the compared workload: `normalize_calls_mean=0.6`, `output_length_per_sample=13600.0`, `value_count=200.0`.
- CI PR-scoped performance must run the registered probe for merge validation.

## Known Gaps
- Linux-local validation only; this is a Python-only slice and claims no Swift runtime effect.
- Full repository test gate was not run locally; focused registered probe/test/coverage commands were run.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
