### PR TITLE
perf: fast path ascii token byte decode

### DIFF
--- a/docs/plans/2026-05-11-stream-assembler-token-byte-fast-decode.md
+++ b/docs/plans/2026-05-11-stream-assembler-token-byte-fast-decode.md
@@ -1,8 +1,11 @@
-# Stream assembler token-byte fast decode
+# Stream assembler ASCII token-byte fast decode
 
 ## Scope
 
-Optimize exactly one Python hot path in `RequestStreamAssembler`: complete UTF-8 token-byte fragments that arrive without pending partial bytes.
+Optimize exactly one Python hot path in `RequestStreamAssembler`: complete ASCII
+`token_bytes` fragments that arrive without pending partial bytes. This is a
+follow-on to the existing direct UTF-8 decode path and keeps split multibyte and
+invalid-byte fallback behavior unchanged.
 
 Affected files:
 
@@ -24,7 +27,11 @@ The probe feeds many ASCII `token_bytes` fragments through a plain stream assemb
 
 ## Optimization
 
-When there are no pending partial token bytes, decode the incoming byte fragment directly with `bytes.decode("utf-8")`. Fall back to the existing incremental decoder path for split multibyte sequences or invalid bytes so behavior remains unchanged.
+When there are no pending partial token bytes and the incoming byte fragment is
+ASCII, decode with `bytes.decode("ascii")` before the generic UTF-8 attempt. The
+existing direct UTF-8 decode remains the non-ASCII complete-fragment path, and
+the incremental decoder still handles split multibyte sequences or invalid
+bytes.
 
 ## Verification
 

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -375,6 +375,8 @@ class RequestStreamAssembler:
             return None
         had_pending = bool(self._pending_token_bytes)
         if not had_pending:
+            if token_bytes.isascii():
+                return token_bytes.decode("ascii")
             try:
                 return token_bytes.decode("utf-8")
             except UnicodeDecodeError:


### PR DESCRIPTION
## Summary
- Adds an ASCII-only fast path for `RequestStreamAssembler._token_byte_delta()` when token bytes are complete and no partial UTF-8 bytes are pending.
- Keeps the existing direct UTF-8 path for non-ASCII complete fragments and the incremental decoder fallback for split multibyte or invalid byte sequences.
- Updates the stream assembler token-byte fast decode plan to record this narrower follow-up slice.

## Plan or Spec
- `docs/plans/2026-05-11-stream-assembler-token-byte-fast-decode.md`
- Registered PR-scoped probe: `stream-assembler-token-byte-fast-decode` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_ascii_without_incremental_decoder services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_preserves_split_multibyte_sequence services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics
# 5 passed in 0.86s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_ascii_without_incremental_decoder services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_preserves_split_multibyte_sequence services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_token_bytes_probe.py
# 5 passed; changed-line coverage TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id stream-assembler-token-byte-fast-decode --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-stream-ascii-byte-decode-20260514030713 --head-repo "$PWD" --output /tmp/stream_ascii_probe.json
# test_ok=true coverage_ok=true base_probe_ok=true head_probe_ok=true

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`services/mlx-worker-python/worker/runtime/stream_assembler.py` changed lines 378-379 covered; aggregate TOTAL 2 0 100%).
- Local registered probe `stream-assembler-token-byte-fast-decode`:
  - `elapsed_ms_mean`: base `771.6303122229874` ms → head `760.6825683731586` ms (`-10.947743849828763` ms, about `1.42%` faster).
  - `peak_bytes_mean`: base `6128389.0` bytes → head `6128389.0` bytes (unchanged).
  - `generated_token_count_mean`: base/head `80000.0` tokens (parity).
- Linux local validation only; GitHub PR-scoped performance CI is still required as merge evidence.

## Known Gaps
- No Swift runtime effect is claimed; this is Python-only and locally verified on Linux.
- The local metric improvement is modest and specific to ASCII `token_bytes`; non-ASCII and split-byte behavior intentionally stays on the existing UTF-8/incremental paths.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead is limited to the synthetic probe command.
- [x] Deferred work and known gaps are stated explicitly.
