### PR TITLE
perf: elide remove tree root exists stat

### DIFF
--- a/docs/plans/2026-05-14-integration-remove-tree-root-stat-elision.md
+++ b/docs/plans/2026-05-14-integration-remove-tree-root-stat-elision.md
@@ -1,0 +1,33 @@
+# Integration Remove Tree Root Stat Elision
+
+## Scope
+
+This performance slice keeps the integration cleanup helper behavior unchanged while removing the initial `Path.exists()` check from `LiveMelixStack._remove_tree()`.
+
+Affected path:
+
+- `tests/integration/helpers.py`
+- `tests/integration/test_helper_remove_tree.py`
+- `scripts/integration_remove_tree_probe.py`
+- `infra/perf/pr_scoped_probes.json` entry `integration-swift-binary-resolution-scandir`
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `integration-swift-binary-resolution-scandir`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries, and the probe command imports `scripts/integration_remove_tree_probe.py` to report the remove-tree cleanup metrics.
+
+## Implementation Plan
+
+1. Preserve the existing explicit-stack `os.scandir()` cleanup path and symlink handling.
+2. Remove the up-front `Path.exists()` stat so missing roots fall through the existing `FileNotFoundError` scan handling.
+3. Add regression coverage proving `_remove_tree()` does not call `Path.exists()` before cleanup.
+4. Run the focused registered tests, changed-scope coverage, and registered probe locally on Linux.
+
+## Success Metrics
+
+- Focused tests pass.
+- Changed-scope coverage for touched Python lines is at least 95%.
+- The registered probe keeps remove-tree elapsed and/or peak memory better than the legacy `Path.rglob()` baseline and records the new-vs-current delta for this slice.
+
+## Verification Boundary
+
+This is a Python integration-helper cleanup slice and is locally verifiable on Linux. The same registered PR-scoped performance workflow remains the CI merge gate.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -356,8 +356,6 @@ class LiveMelixStack:
                 path.unlink(missing_ok=True)
 
     def _remove_tree(self, root: Path) -> None:
-        if not root.exists():
-            return
         root_path = os.fspath(root)
         stack: list[tuple[str, bool]] = [(root_path, False)]
         while stack:

--- a/tests/integration/test_helper_remove_tree.py
+++ b/tests/integration/test_helper_remove_tree.py
@@ -35,6 +35,25 @@ def test_remove_tree_uses_scandir_without_tree_materialization(
     assert not root.exists()
 
 
+def test_remove_tree_skips_initial_path_exists_stat(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "runtime-state"
+    nested = root / "state"
+    nested.mkdir(parents=True)
+    (nested / "session.json").write_text("{}", encoding="utf-8")
+
+    def fail_exists(self: Path):  # pragma: no cover - exercised only on regression
+        raise AssertionError(f"Path.exists should not be used before cleanup scan: {self}")
+
+    monkeypatch.setattr(Path, "exists", fail_exists)
+
+    _stack()._remove_tree(root)
+
+    assert not root.is_dir()
+
+
 def test_remove_tree_removes_directory_symlink_without_following_target(tmp_path: Path) -> None:
     root = tmp_path / "runtime-state"
     target = tmp_path / "shared-target"


### PR DESCRIPTION
## Summary
- Remove the initial `Path.exists()` stat from `LiveMelixStack._remove_tree()` so cleanup goes directly through the existing `os.scandir()`/`FileNotFoundError` path.
- Add regression coverage that fails if `Path.exists()` is reintroduced before the cleanup scan.
- Add a governing plan for the slice.

## Plan or Spec
- `docs/plans/2026-05-14-integration-remove-tree-root-stat-elision.md`
- Registered PR-scoped probe: `integration-swift-binary-resolution-scandir` (covers `tests/integration/helpers.py`, `tests/integration/test_helper_remove_tree.py`, and `scripts/integration_remove_tree_probe.py` with focused test, coverage, and probe commands).

## Commands Run
```text
# Baseline probe on origin/main before the change (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT="$PWD" MELIX_REMOVE_TREE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/integration_swift_binary_resolution_probe.py

# Focused remove-tree regression subset (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics
# 8 passed in 0.73s

# Registered focused test command (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 17 passed in 0.23s

# Registered changed-scope coverage command (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json tests/integration/helpers.py tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/integration_swift_binary_resolution_probe.py scripts/integration_remove_tree_probe.py
# 17 passed in 0.50s; TOTAL 8 0 100%

# Registered probe after the change (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT="$PWD" MELIX_REMOVE_TREE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/integration_swift_binary_resolution_probe.py
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 8 0 100%`.
- Baseline registered probe on `origin/main`:
  - `remove_tree_elapsed_ms_mean=77.719115`
  - `remove_tree_peak_bytes_mean=16217.2`
  - `remove_tree_delta_ms_mean=-180.401925`
- Head registered probe:
  - `remove_tree_elapsed_ms_mean=74.813822`
  - `remove_tree_peak_bytes_mean=17298.8`
  - `remove_tree_delta_ms_mean=-186.712282`
- Head vs baseline current implementation:
  - `remove_tree_elapsed_ms_mean delta=-2.905293 ms` (`-3.738%`, lower is better)
  - `remove_tree_peak_bytes_mean delta=+1081.6 bytes` (`+6.669%`, informational for this slice; still ~3.64 MB below legacy baseline)
  - `remove_tree_delta_ms_mean improved by -6.310357 ms` versus the legacy `Path.rglob()` baseline.
- Observability mode: evidence (`scripts/integration_remove_tree_probe.py` via the registered PR-scoped probe).
- Probe overhead: synthetic cleanup tree with 1200 directories, 2 files per directory, 5 samples; no production runtime instrumentation added.

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally for this small Python integration-helper slice; CI is the broad gate.
- Local Linux validation covers the Python helper/probe path only. No Swift runtime effect is claimed locally.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
