### PR TITLE
perf: reuse empty serving diagnostics attributes

### DIFF
--- a/docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md
+++ b/docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md
@@ -2,11 +2,10 @@
 
 ## Scope
 
-This slice optimizes only the Python serving diagnostics debug event queue append path.
-`BoundedServingDiagnosticsEventQueue.append(...)` keeps the same bounded-queue semantics:
-append returns `False` once the fixed queue capacity has been reached, the oldest event is
-dropped by the underlying bounded deque, and snapshots still report retained events plus the
-accumulated dropped-event count.
+This plan now tracks the next small serving diagnostics queue slice: avoid per-event empty
+attribute dictionary allocation when debug queue events are created without attributes. The
+change keeps bounded-queue append/drop semantics unchanged and preserves `to_dict()` output for
+empty attributes.
 
 ## Linux-only constraint
 

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -207,11 +207,32 @@ def test_serving_diagnostics_event_instances_use_slots_for_debug_queue() -> None
         event_index=1,
         status="completed",
         duration_ms=0.25,
-        attributes={"token": "ok"},
+        attributes={"token": "***"},
     )
 
     assert hasattr(event, "__dict__") is False
-    assert event.to_dict()["attributes"] == {"token": "ok"}
+    assert event.to_dict()["attributes"] == {"token": "***"}
+
+
+def test_serving_diagnostics_default_event_attributes_reuse_empty_mapping() -> None:
+    first = ServingDiagnosticsEvent(
+        request_id="req-empty-1",
+        phase="decode",
+        event_index=1,
+        status="completed",
+    )
+    second = ServingDiagnosticsEvent(
+        request_id="req-empty-2",
+        phase="decode",
+        event_index=2,
+        status="completed",
+    )
+
+    assert first.attributes == {}
+    assert first.to_dict()["attributes"] == {}
+    assert first.attributes is second.attributes
+    with pytest.raises(TypeError):
+        first.attributes["late"] = "mutation"  # type: ignore[index]
 
 
 def test_serving_diagnostics_bounded_queue_serializes_append_during_snapshot() -> None:

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -5,8 +5,10 @@ import math
 import threading
 import time
 from collections import deque
-from dataclasses import dataclass, field
+from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
 
@@ -14,6 +16,7 @@ SERVING_DIAGNOSTICS_MANIFEST_SCHEMA_VERSION = "melix.serving_diagnostics.manifes
 SERVING_DIAGNOSTICS_REQUEST_SCHEMA_VERSION = "melix.serving_diagnostics.request_summary.v1"
 SERVING_DIAGNOSTICS_EVENT_SCHEMA_VERSION = "melix.serving_diagnostics.event.v1"
 SERVING_DIAGNOSTICS_COMPARISON_SCHEMA_VERSION = "melix.serving_diagnostics.comparison.v1"
+_EMPTY_EVENT_ATTRIBUTES: Mapping[str, object] = MappingProxyType({})
 
 
 class ServingDiagnosticsComparisonError(ValueError):
@@ -135,7 +138,7 @@ class ServingDiagnosticsEvent:
     event_index: int
     status: str
     duration_ms: float = 0.0
-    attributes: dict[str, object] = field(default_factory=dict)
+    attributes: Mapping[str, object] = _EMPTY_EVENT_ATTRIBUTES
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -404,7 +407,7 @@ def _safe_artifact_id(value: str) -> str:
     return stripped
 
 
-def _stable_json_object(payload: dict[str, object]) -> dict[str, object]:
+def _stable_json_object(payload: Mapping[str, object]) -> dict[str, object]:
     return {
         str(key): _stable_json_value(value)
         for key, value in sorted(payload.items(), key=lambda item: str(item[0]))


### PR DESCRIPTION
## Summary
- Reuse a shared immutable empty attributes mapping for `ServingDiagnosticsEvent` instances that do not carry debug attributes.
- This avoids allocating one empty `dict` per queue event while preserving empty `attributes` serialization and bounded queue behavior.
- Add a regression test for shared immutable default attributes.

## Plan or Spec
- `docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md`
- Registered PR-scoped probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics
# 25 passed in 0.67s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# 25 passed in 0.24s; TOTAL 15 0 100%

for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py; done
# head elapsed_ms_mean samples: 6.726562, 6.614059, 6.736694

# Baseline worktree at origin/main:
for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py; done
# base elapsed_ms_mean samples: 6.964664, 6.898364, 6.934927

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id serving-diagnostics-debug-queue-bounds --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-serving-20260514072304 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-cron-slice-20260514072304 --output /tmp/serving-diagnostics-debug-queue-bounds.json
# head verification: 26 passed, changed-scope coverage 100%; base elapsed_ms_mean=7.346942; head elapsed_ms_mean=6.761641

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 15 0 100%`.
- Manual 3-run local probe mean: base `6.932652 ms`, head `6.692438 ms`, delta `-0.240213 ms`, speedup `1.035893x` (`3.465%` lower elapsed time).
- Registered local probe run: base `7.346942 ms`, head `6.761641 ms`, delta `-0.585301 ms`; guard rails preserved (`dropped_count=4032`, `retained_count=64`).
- CI must run the registered PR-scoped performance workflow before merge.

## Known Gaps
- Local verification is Linux/Python-only. No Swift runtime effects are claimed.
- The probe measures synthetic debug queue append overhead; production impact depends on debug diagnostics event volume.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
