### PR TITLE
perf: specialize validation split streaming loop

### DIFF
--- a/docs/plans/2026-05-07-training-dataset-validation-split-nsmallest.md
+++ b/docs/plans/2026-05-07-training-dataset-validation-split-nsmallest.md
@@ -43,6 +43,13 @@ The registered probe now uses a `0.95` validation ratio so the PR-scoped report
 exercises the complement path. The registry command also uses `python3` for the
 scheduled Linux runner.
 
+## 2026-05-14 follow-up: split streaming branch specialization
+
+Keep the same registered high-ratio probe and specialize the final original-order
+streaming pass into separate high-ratio and low-ratio loops. This removes the
+per-sample `validation_indices is None` branch from the hot loop while preserving
+the same sorted digest selection and output ordering contracts.
+
 ## Success metrics
 
 - Focused pytest passes for the touched training dataset behavior and PR-scoped registry checks.

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1750,24 +1750,27 @@ def _deterministic_validation_split(
         )
         for index, sample in enumerate(samples)
     )
-    if train_count < validation_count:
-        train_indices = {index for _, index in heapq.nlargest(train_count, ranked_samples)}
-        validation_indices: set[int] | None = None
-    else:
-        validation_indices = {index for _, index in heapq.nsmallest(validation_count, ranked_samples)}
-        train_indices = set()
     train_samples: list[dict[str, Any]] = []
     validation_samples: list[dict[str, Any]] = []
-    for index, sample in enumerate(samples):
-        if validation_indices is None:
+    if train_count < validation_count:
+        train_indices = {index for _, index in heapq.nlargest(train_count, ranked_samples)}
+        train_append = train_samples.append
+        validation_append = validation_samples.append
+        for index, sample in enumerate(samples):
             if index in train_indices:
-                train_samples.append(sample)
+                train_append(sample)
             else:
-                validation_samples.append(sample)
-        elif index in validation_indices:
-            validation_samples.append(sample)
+                validation_append(sample)
+        return train_samples, validation_samples
+
+    validation_indices = {index for _, index in heapq.nsmallest(validation_count, ranked_samples)}
+    train_append = train_samples.append
+    validation_append = validation_samples.append
+    for index, sample in enumerate(samples):
+        if index in validation_indices:
+            validation_append(sample)
         else:
-            train_samples.append(sample)
+            train_append(sample)
     return train_samples, validation_samples
 
 


### PR DESCRIPTION
## Summary
- Specialize the automatic validation split streaming pass into separate high-ratio and low-ratio loops.
- Remove the per-sample `validation_indices is None` branch while preserving digest selection and original-order output.

## Plan or Spec
- `docs/plans/2026-05-07-training-dataset-validation-split-nsmallest.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_build_training_dataset_artifact_loads_existing_package_and_helper_branches services/mlx-worker-python/tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_applies_manifest_overrides services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 4 passed in 0.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_build_training_dataset_artifact_loads_existing_package_and_helper_branches services/mlx-worker-python/tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_applies_manifest_overrides services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 4 passed; TOTAL 15 0 100%

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 15 0 100%`.
- Registered probe: `training-dataset-validation-split-nsmallest`.
- Local paired base/head probe, 30,000 samples, validation ratio 0.95, 9 repetitions:
  - origin/main: `elapsed_ms_mean=903.708628`, `peak_bytes_mean=477738.222222`, `validation_count=28500`, `checksum=427535201`.
  - head: `elapsed_ms_mean=898.019522`, `peak_bytes_mean=477882.222222`, `validation_count=28500`, `checksum=427535201`.
  - delta: `elapsed_ms_mean=-5.689106 ms` (~0.63% faster); `peak_bytes_mean=+144 bytes` (~0.03% higher, below the 5% warning threshold); structural metrics unchanged.
- CI PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- Local verification is Linux/Python-only. No Swift or macOS runtime effects are claimed for this slice.
- The local elapsed improvement is intentionally small and scoped to the high validation-ratio streaming pass; CI registered probe remains authoritative before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; probe overhead changes: N/A, no observability code changed.
- [x] Deferred work and known gaps are stated explicitly.
