### PR TITLE
perf: localize serving diagnostics queue append

### DIFF
--- a/docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md
+++ b/docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md
@@ -2,10 +2,10 @@
 
 ## Scope
 
-This plan now tracks the next small serving diagnostics queue slice: avoid per-event empty
-attribute dictionary allocation when debug queue events are created without attributes. The
-change keeps bounded-queue append/drop semantics unchanged and preserves `to_dict()` output for
-empty attributes.
+This plan now tracks the next small serving diagnostics queue slice: keep the debug queue
+append path on local references while preserving bounded append/drop semantics. The change
+avoids repeated instance attribute reads for the deque and retained count during the per-event
+hot path, including the saturated drop path.
 
 ## Linux-only constraint
 

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -49,13 +49,15 @@ class BoundedServingDiagnosticsEventQueue:
 
     def append(self, event: ServingDiagnosticsEvent) -> bool:
         with self._lock:
+            events = self._events
             if self._is_saturated:
                 self._dropped_count += 1
-                self._events.append(event)
+                events.append(event)
                 return False
-            self._events.append(event)
-            self._retained_count += 1
-            self._is_saturated = self._retained_count >= self._max_events
+            events.append(event)
+            retained_count = self._retained_count + 1
+            self._retained_count = retained_count
+            self._is_saturated = retained_count >= self._max_events
             return True
 
     def snapshot(self) -> ServingDiagnosticsQueueSnapshot:


### PR DESCRIPTION
## Summary
- Localizes the serving diagnostics bounded queue append hot path by caching the deque reference and retained count update in locals.
- Preserves existing bounded retention/drop behavior for debug diagnostics events.

## Plan or Spec
- `docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md`
- Registered PR-scoped probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 26 passed in 0.70s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# 26 passed in 0.22s; TOTAL 6 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# {"capacity": 64.0, "dropped_count": 4032.0, "elapsed_ms_mean": 6.553042, "event_count": 4096.0, "retained_count": 64.0, "sample_count": 5.0}

# Baseline detached worktree at origin/main:
MELIX_SERVING_DIAGNOSTICS_QUEUE_EVENTS=200000 MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=7 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# {"capacity": 64.0, "dropped_count": 199936.0, "elapsed_ms_mean": 343.471004, "event_count": 200000.0, "retained_count": 64.0, "sample_count": 7.0}

# Head worktree:
MELIX_SERVING_DIAGNOSTICS_QUEUE_EVENTS=200000 MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=7 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# {"capacity": 64.0, "dropped_count": 199936.0, "elapsed_ms_mean": 320.096022, "event_count": 200000.0, "retained_count": 64.0, "sample_count": 7.0}

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 6 0 100%`.
- Local registered probe (default): `elapsed_ms_mean=6.553042`, `dropped_count=4032`, `retained_count=64`.
- Local amplified baseline vs head probe: old `343.471004 ms`, new `320.096022 ms`, delta `-23.374982 ms`, improvement `6.8055%`, speedup `7.3025%`.
- The GitHub `pr-scoped-performance` workflow is required for the registered CI probe report before merge.

## Known Gaps
- Linux local validation only; no Swift runtime path is affected.
- The exact registry `probe_command` includes a shell fallback wrapper; locally I ran the same probe script directly because this scheduled environment requested approval for nested shell execution.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
