### PR TITLE
perf: streamline serving diagnostics queue lock

### DIFF
--- a/docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md
+++ b/docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md
@@ -3,9 +3,9 @@
 ## Scope
 
 This plan now tracks the next small serving diagnostics queue slice: keep the debug queue
-append path on local references while preserving bounded append/drop semantics. The change
-avoids repeated instance attribute reads for the deque and retained count during the per-event
-hot path, including the saturated drop path.
+append path on an explicit lock acquire/release block while preserving bounded append/drop
+semantics. The change avoids the per-event context-manager dispatch on the hottest append path
+while still releasing the lock through a `finally` guard.
 
 ## Linux-only constraint
 

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -48,7 +48,9 @@ class BoundedServingDiagnosticsEventQueue:
         self._lock = threading.Lock()
 
     def append(self, event: ServingDiagnosticsEvent) -> bool:
-        with self._lock:
+        lock = self._lock
+        lock.acquire()
+        try:
             events = self._events
             if self._is_saturated:
                 self._dropped_count += 1
@@ -59,6 +61,8 @@ class BoundedServingDiagnosticsEventQueue:
             self._retained_count = retained_count
             self._is_saturated = retained_count >= self._max_events
             return True
+        finally:
+            lock.release()
 
     def snapshot(self) -> ServingDiagnosticsQueueSnapshot:
         with self._lock:


### PR DESCRIPTION
## Summary
- Streamlines the bounded serving diagnostics queue append path by replacing the per-event lock context manager with explicit acquire/release guarded by `finally`.
- Keeps bounded retention/drop semantics unchanged while reducing overhead in the saturated debug queue hot path.

## Plan or Spec
- `docs/plans/2026-05-13-serving-diagnostics-queue-retained-count.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 26 passed in 0.71s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# 26 passed; changed-line coverage TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# repeated local samples included elapsed_ms_mean values: 10.043163, 6.292395, 6.175676, 7.63, 6.194179; retained_count=64.0 and dropped_count=4032.0 in all runs

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id serving-diagnostics-debug-queue-bounds --base-repo /tmp/melix-base-serving-diagnostics-3713140 --head-repo "$PWD" --output /tmp/serving-diagnostics-queue-report.json
# base elapsed_ms_mean=7.24813, head elapsed_ms_mean=6.143093; retained_count=64.0, dropped_count=4032.0; head verification coverage 100%; exit 0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`services/mlx-worker-python/worker/productization/serving_diagnostics.py` measurable changed lines 4/4 covered).
- Registered probe: `serving-diagnostics-debug-queue-bounds`.
- Local base/head probe: `elapsed_ms_mean` improved from `7.24813 ms` to `6.143093 ms` (`-1.105037 ms`, about `15.25%` faster). Guardrail metrics stayed stable: `retained_count=64.0`, `dropped_count=4032.0`.
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- Local verification is Linux-only for this Python slice; no Swift runtime effect is claimed.
- Probe timing is microbenchmark-sensitive; CI registered probe report is the authoritative PR gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
