### PR TITLE
perf: elide hub catalog size hint joins

### DIFF
--- a/docs/plans/2026-05-14-hub-catalog-size-hint-join-elision.md
+++ b/docs/plans/2026-05-14-hub-catalog-size-hint-join-elision.md
@@ -1,0 +1,33 @@
+# Hub Catalog Size Hint Join Elision
+
+## Scope
+
+This Python-only performance slice narrows `worker.model_ops.hub_catalog._size_hint_bytes` for payloads that provide multiple descriptive text fields but no model-size marker.
+
+## Optimization
+
+Before this slice, the multi-field fallback always built a newline-joined string before checking whether any field could contain a `model size` marker. The slice checks each source field for the marker first, and only builds the combined string when at least one field can require the explicit size parser.
+
+The combined-string parser path remains intact when a marker is present so cross-field inputs such as `description="Model size:"` plus `readme="5 MB"` preserve existing behavior.
+
+## Registered Probe
+
+Affected paths are already covered by PR-scoped probe `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.
+
+The probe provides:
+
+- focused tests through `test_command`
+- changed-scope coverage through `coverage_command`
+- repeated command JSON metrics through `probe_command`
+
+## Verification Plan
+
+Run locally on Linux before PR:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo <baseline-worktree> --head-repo "$PWD" --output <probe-output.json>
+```
+
+CI PR-scoped performance remains the final registered-probe merge gate.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -633,6 +633,30 @@ def test_size_hint_bytes_skips_direct_hint_parser_when_card_model_size_missing(
     assert calls == [("Model size: 7 MB", False)]
 
 
+def test_size_hint_bytes_preserves_combined_marker_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, bool]] = []
+
+    def tracked(text: str, *, allow_bare: bool) -> int:
+        calls.append((text, allow_bare))
+        return 5 * MB
+
+    monkeypatch.setattr(hub_catalog_module, "_size_hint_from_text", tracked)
+
+    assert (
+        hub_catalog_module._size_hint_bytes(
+            {
+                "description": "Model size:",
+                "readme": "5 MB",
+                "cardData": {"description": "operator note"},
+            }
+        )
+        == 5 * MB
+    )
+    assert calls == [("Model size:\n5 MB\noperator note", False)]
+
+
 def test_size_hint_bytes_uses_direct_card_model_size_without_regex(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -600,13 +600,17 @@ def _size_hint_bytes(payload: dict[str, Any]) -> int:
             else 0
         )
 
+    if not (
+        _may_contain_model_marker(description_text)
+        or _may_contain_model_marker(readme_text)
+        or _may_contain_model_marker(card_description_text)
+    ):
+        return 0
     text = "\n".join(
         text
         for text in (description_text, readme_text, card_description_text)
         if text
     )
-    if not _may_contain_model_marker(text):
-        return 0
     return _size_hint_from_text(text, allow_bare=False)
 
 


### PR DESCRIPTION
## Summary
- Elides newline-joined size-hint text construction in the Hub catalog multi-field fallback when no source field can contain a `model size` marker.
- Adds a regression test that preserves the existing combined-string parser behavior when a marker is present across fields.

## Plan or Spec
- `docs/plans/2026-05-14-hub-catalog-size-hint-join-elision.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# Baseline direct probe before implementation (Linux)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
exit 0; elapsed_ms_mean=1761.343333; size_hint_calls_mean=40000.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
exit 0; 51 passed in 0.97s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
exit 0; 51 passed in 0.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
exit 0

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
exit 0; TOTAL 10 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-hub-catalog-size-hint-join-elision-20260514101409 --head-repo "$PWD" --output /tmp/hub_catalog_size_hint_probe.json
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 10 0 100%`).
- Local registered probe `hub-catalog-size-hint-regex-precompile`:
  - base `elapsed_ms_mean=1696.033452`, head `elapsed_ms_mean=1469.087590`, delta `-226.945862 ms`, speedup `1.154x`.
  - base/head `size_hint_calls_mean=40000.0` (unchanged; this slice reduces no-marker join allocation, not parser invocation count).
  - checksum unchanged: `3424780288.0`; matched hint count unchanged: `80000.0`.
- CI PR-scoped performance is still required as the merge gate for the registered probe report.

## Known Gaps
- Linux-only local validation for this Python slice; no Swift runtime effect is involved.
- Full repository `make` gates were not run locally; this PR uses the registered focused test/coverage/probe commands for the touched path and relies on CI for the full merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; probe overhead is the probe workload itself and unchanged by this slice.
- [x] Deferred work and known gaps are stated explicitly.
