### PR TITLE
perf: streamline statistical evidence category totals

### DIFF
--- a/docs/plans/2026-05-14-statistical-evidence-category-defaultdict.md
+++ b/docs/plans/2026-05-14-statistical-evidence-category-defaultdict.md
@@ -1,0 +1,38 @@
+# Statistical Evidence Category Defaultdict Accumulator
+
+## Scope
+
+This performance slice is limited to `build_category_breakdown` in
+`services/mlx-worker-python/worker/productization/statistical_evidence.py`.
+It preserves the existing statistical-evidence category breakdown behavior while
+reducing per-row accumulator work for repeated categories.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`statistical-evidence-category-breakdown-single-pass` in
+`infra/perf/pr_scoped_probes.json`. The probe includes focused
+`test_command`, `coverage_command`, and `probe_command` entries and reports:
+
+- `elapsed_ms_mean` (`lower_is_better`)
+- `peak_bytes_mean` (`lower_is_better`)
+
+## Implementation plan
+
+Use a `defaultdict` accumulator for category totals so the hot loop can update
+the category counter directly after label normalization instead of performing an
+explicit `dict.get` branch for every row. The slice does not change ordering,
+rounding, missing-label handling, or category-label normalization.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage command, and the
+registered probe locally on Linux with `origin/main` as the baseline before
+pushing. CI PR-scoped performance remains the merge validation source.
+
+## Success criteria
+
+- Focused statistical-evidence tests pass.
+- Changed-scope coverage for touched files is at least 95%.
+- The registered probe reports no regression and preferably lower
+  `elapsed_ms_mean` and/or `peak_bytes_mean`.

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import random
+from collections import defaultdict
 from functools import lru_cache
 from statistics import NormalDist
 
@@ -82,7 +83,7 @@ def build_category_breakdown(
     *,
     rows: tuple[dict[str, object], ...],
 ) -> dict[str, dict[str, object]]:
-    category_totals: dict[str, list[int]] = {}
+    category_totals: defaultdict[str, list[int]] = defaultdict(lambda: [0, 0, 0])
     for row in rows:
         try:
             raw_category_label = row["category_label"]
@@ -91,15 +92,10 @@ def build_category_breakdown(
         category_label = str(raw_category_label).strip()
         if not category_label:
             continue
-        base_correct = 1 if row.get("base_correct", False) else 0
-        target_correct = 1 if row.get("target_correct", False) else 0
-        totals = category_totals.get(category_label)
-        if totals is None:
-            category_totals[category_label] = [1, base_correct, target_correct]
-            continue
+        totals = category_totals[category_label]
         totals[0] += 1
-        totals[1] += base_correct
-        totals[2] += target_correct
+        totals[1] += 1 if row.get("base_correct", False) else 0
+        totals[2] += 1 if row.get("target_correct", False) else 0
 
     breakdown: dict[str, dict[str, object]] = {}
     for category_label, totals in sorted(category_totals.items()):


### PR DESCRIPTION
## Summary
- Streamlines `build_category_breakdown` by using a defaultdict accumulator for repeated category totals.
- Keeps category normalization, missing-label handling, sorted output, and rounded accuracy payloads unchanged.

## Plan or Spec
- `docs/plans/2026-05-14-statistical-evidence-category-defaultdict.md`

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_statistical_evidence.py::test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics
6 passed in 0.63s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_statistical_evidence.py::test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_category_breakdown_probe.py
6 passed in 0.18s
TOTAL 5 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id statistical-evidence-category-breakdown-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-statistical-evidence-category-defaultdict-20260514121500 --head-repo "$PWD" --output /tmp/stat_category_defaultdict_probe.json
head verification: test_ok=True coverage_ok=True
base elapsed_ms_mean=13.627776363864541 peak_bytes_mean=16456.0
head elapsed_ms_mean=12.681634537875652 peak_bytes_mean=17200.0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (5/5 measurable changed lines).
- Registered probe: `statistical-evidence-category-breakdown-single-pass`.
- Local Linux probe delta: elapsed improved by 0.946142 ms (6.94% lower); peak traced allocation increased by 744 bytes (4.52%, within the 5% probe warning threshold).
- CI PR-scoped performance must validate the registered probe before merge.

## Known Gaps
- Full repository test matrix was not run locally; this PR relies on GitHub Actions for the full CI matrix.
- The peak allocation metric is slightly higher locally while still inside the registered 5% threshold; CI report is the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability overhead.
- [x] Deferred work and known gaps are stated explicitly.
