### PR TITLE
perf: reuse hub size hint multipliers

### DIFF
--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -18,6 +18,11 @@ RESIDENT_MEMORY_OVERHEAD_FACTOR = 1.35
 _SIZE_HINT_KB = 1024
 _SIZE_HINT_MB = _SIZE_HINT_KB * 1024
 _SIZE_HINT_GB = _SIZE_HINT_MB * 1024
+_SIZE_HINT_MULTIPLIERS = {
+    "kb": _SIZE_HINT_KB,
+    "mb": _SIZE_HINT_MB,
+    "gb": _SIZE_HINT_GB,
+}
 
 _BARE_SIZE_HINT_RE = re.compile(r"(?:model\s+size\s*[:|]?\s*)?(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
 _EXPLICIT_SIZE_HINT_RE = re.compile(r"\bmodel\s+size\s*[:|]?\s*(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
@@ -622,13 +627,8 @@ def _direct_size_hint_from_text(text: str) -> int:
         return 0
     value_text, unit_text = parts
     unit = unit_text.lower()
-    if unit == "kb":
-        multiplier = _SIZE_HINT_KB
-    elif unit == "mb":
-        multiplier = _SIZE_HINT_MB
-    elif unit == "gb":
-        multiplier = _SIZE_HINT_GB
-    else:
+    multiplier = _SIZE_HINT_MULTIPLIERS.get(unit)
+    if multiplier is None:
         return 0
     try:
         value = float(value_text)
@@ -645,13 +645,7 @@ def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:
     if not match:
         return 0
     value = float(match.group(1))
-    unit = match.group(2).lower()
-    if unit == "kb":
-        multiplier = _SIZE_HINT_KB
-    elif unit == "mb":
-        multiplier = _SIZE_HINT_MB
-    else:
-        multiplier = _SIZE_HINT_GB
+    multiplier = _SIZE_HINT_MULTIPLIERS[match.group(2).lower()]
     return int(value * multiplier)
 
 


### PR DESCRIPTION
## Summary
- Reuse a shared Hub catalog size-hint unit multiplier map for direct and regex-parsed size hints.
- Keeps parsing behavior unchanged while reducing repeated branch work in the registered Hub size-hint path.

## Plan or Spec
- N/A: this is a scoped internal performance optimization for an already registered PR-scoped probe path and does not change product behavior or workflow.

## Commands Run
```text
# Baseline probe on origin/main detached worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
{"checksum": 3424780288.0, "elapsed_ms_mean": 1472.63960018754, "matched_hint_count": 80000.0, "peak_bytes_mean": 1833.0, "sample_count": 5.0, "size_hint_calls_mean": 40000.0}

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
51 passed in 0.19s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_hub_catalog.py::test_size_hint_parsers_cover_units_and_invalid_values services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
51 passed in 0.34s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
TOTAL 4 0 100%

# Head probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
{"checksum": 3424780288.0, "elapsed_ms_mean": 1455.746868206188, "matched_hint_count": 80000.0, "peak_bytes_mean": 1833.0, "sample_count": 5.0, "size_hint_calls_mean": 40000.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json` covers `services/mlx-worker-python/worker/model_ops/hub_catalog.py` and includes focused `test_command`, `coverage_command`, and `probe_command`.
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Local Linux probe delta: old_mean=1472.639600 ms, new_mean=1455.746868 ms, delta_ms=-16.892732, speedup=1.0116x. Metrics are local synthetic probe evidence; GitHub Actions PR-scoped performance must also validate the registered probe.

## Known Gaps
- Full repository gates were not run locally; this PR is limited to the registered Python Hub catalog size-hint slice.
- CI is required for the final registered PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or documented as N/A.
- [x] Protocol changes include regenerated generated artifacts, or N/A.
- [x] Dependency changes include updated lockfiles, or N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
