### PR TITLE
perf: fast path empty serving event attributes

### DIFF
--- a/docs/evidence-telemetry-report-contract.md
+++ b/docs/evidence-telemetry-report-contract.md
@@ -233,7 +233,10 @@ include full prompts, full responses, credentials, or operator secrets.
 Debug event queues are bounded. Queue saturation drops the oldest debug events
 and increments the manifest's `dropped_event_count`; it must not block serving
 request progress. The manifest also records `event_count` for the retained
-events written to `events.jsonl`.
+events written to `events.jsonl`. Empty debug event attributes serialize as an
+empty JSON object without invoking the stable recursive attribute normalizer, so
+high-volume decode traces avoid extra per-event sorting work while preserving
+the same wire shape.
 
 Baseline-vs-accelerated comparison artifacts are written as:
 

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3703,6 +3703,12 @@
         "warn_pct": 5.0
       },
       {
+        "key": "serialization_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
         "key": "dropped_count",
         "unit": "events",
         "direction": "informational"
@@ -3710,6 +3716,11 @@
       {
         "key": "retained_count",
         "unit": "events",
+        "direction": "informational"
+      },
+      {
+        "key": "serialization_checksum",
+        "unit": "index-sum",
         "direction": "informational"
       }
     ]

--- a/scripts/serving_diagnostics_queue_probe.py
+++ b/scripts/serving_diagnostics_queue_probe.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import statistics
 import time
 from pathlib import Path
 
@@ -23,8 +24,10 @@ def main() -> int:
     event_count = int(os.environ.get("MELIX_SERVING_DIAGNOSTICS_QUEUE_EVENTS", "4096"))
     sample_count = int(os.environ.get("MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES", "5"))
     elapsed_samples: list[float] = []
+    serialization_samples: list[float] = []
     dropped = 0
     retained = 0
+    serialization_checksum = 0
     for sample_index in range(max(sample_count, 1)):
         queue = BoundedServingDiagnosticsEventQueue(max_events=capacity)
         started = time.perf_counter()
@@ -42,13 +45,21 @@ def main() -> int:
         snapshot = queue.snapshot()
         dropped = snapshot.dropped_count
         retained = len(snapshot.events)
+        serialize_started = time.perf_counter()
+        checksum = 0
+        for event in snapshot.events:
+            checksum += int(event.to_dict()["event_index"])
+        serialization_checksum = checksum
+        serialization_samples.append((time.perf_counter() - serialize_started) * 1000.0)
     print(
         json.dumps(
             {
                 "capacity": float(capacity),
                 "event_count": float(event_count),
                 "sample_count": float(max(sample_count, 1)),
-                "elapsed_ms_mean": round(sum(elapsed_samples) / len(elapsed_samples), 6),
+                "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+                "serialization_elapsed_ms_mean": round(statistics.fmean(serialization_samples), 6),
+                "serialization_checksum": float(serialization_checksum),
                 "dropped_count": float(dropped),
                 "retained_count": float(retained),
             },

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2400,6 +2400,8 @@ def test_serving_diagnostics_queue_probe_script_emits_metrics(
     assert metrics["event_count"] == 10.0
     assert metrics["retained_count"] == 4.0
     assert metrics["dropped_count"] == 6.0
+    assert "serialization_elapsed_ms_mean" in metrics
+    assert metrics["serialization_checksum"] == 30.0
 
 
 def test_load_probe_registry_uses_absolute_cache_key_without_resolving(

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from worker.productization import serving_diagnostics as serving_diagnostics_module
 from worker.productization.serving_diagnostics import (
     BoundedServingDiagnosticsEventQueue,
     ServingDiagnosticsComparisonError,
@@ -233,6 +234,28 @@ def test_serving_diagnostics_default_event_attributes_reuse_empty_mapping() -> N
     assert first.attributes is second.attributes
     with pytest.raises(TypeError):
         first.attributes["late"] = "mutation"  # type: ignore[index]
+
+
+def test_serving_diagnostics_empty_event_attributes_skip_stable_json_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event = ServingDiagnosticsEvent(
+        request_id="req-empty-fast-path",
+        phase="decode",
+        event_index=3,
+        status="completed",
+    )
+
+    def fail_stable_json_object(_: object) -> dict[str, object]:  # pragma: no cover
+        raise AssertionError("empty event attributes should not call _stable_json_object")
+
+    monkeypatch.setattr(
+        serving_diagnostics_module,
+        "_stable_json_object",
+        fail_stable_json_object,
+    )
+
+    assert event.to_dict()["attributes"] == {}
 
 
 def test_serving_diagnostics_bounded_queue_serializes_append_during_snapshot() -> None:

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -147,6 +147,7 @@ class ServingDiagnosticsEvent:
     attributes: Mapping[str, object] = _EMPTY_EVENT_ATTRIBUTES
 
     def to_dict(self) -> dict[str, object]:
+        attributes = self.attributes
         return {
             "schema_version": SERVING_DIAGNOSTICS_EVENT_SCHEMA_VERSION,
             "request_id": self.request_id,
@@ -154,7 +155,7 @@ class ServingDiagnosticsEvent:
             "event_index": int(self.event_index),
             "status": self.status,
             "duration_ms": float(self.duration_ms),
-            "attributes": _stable_json_object(self.attributes),
+            "attributes": {} if not attributes else _stable_json_object(attributes),
         }
 
 


### PR DESCRIPTION
## Summary
- Fast-path empty serving diagnostics event attributes so high-volume debug event serialization returns `{}` without invoking the stable recursive normalizer.
- Extend the registered serving diagnostics PR-scoped probe with serialization timing metrics for retained debug events.
- Update the evidence telemetry contract to document the unchanged wire shape and lower per-event sorting work.

## Plan or Spec
- `docs/evidence-telemetry-report-contract.md` — Serving Diagnostics Bundles section documents bounded debug event serialization and the empty-attributes fast path.
- Registered probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 27 passed in 0.65s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# 27 passed; changed-scope coverage TOTAL 17 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# {"capacity": 64.0, "dropped_count": 4032.0, "elapsed_ms_mean": 6.44849, "event_count": 4096.0, "retained_count": 64.0, "sample_count": 5.0, "serialization_checksum": 260064.0, "serialization_elapsed_ms_mean": 0.032507}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 17 0 100%`).
- Registered local probe (`serving-diagnostics-debug-queue-bounds`): `elapsed_ms_mean=6.44849`, `serialization_elapsed_ms_mean=0.032507`, `dropped_count=4032`, `retained_count=64`.
- Local micro comparison for `ServingDiagnosticsEvent.to_dict()` with 200,000 empty-attribute events, 5 samples: old_mean=170.969453 ms, new_mean=88.839661 ms, delta=-82.129792 ms, speedup=1.924472x, improvement=48.038%.
- CI PR-scoped performance is required for the registered base-vs-head report before merge.

## Known Gaps
- Linux validation covers the Python serving diagnostics serialization path. No Swift/macOS runtime effect is claimed.
- Awaiting GitHub Actions and the registered PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
