### PR TITLE
perf: streamline serving diagnostics event init

### DIFF
--- a/docs/plans/2026-05-13-serving-diagnostics-queue-overflow-fast-path.md
+++ b/docs/plans/2026-05-13-serving-diagnostics-queue-overflow-fast-path.md
@@ -2,12 +2,19 @@
 
 ## Scope
 
-This Python-only slice optimizes the debug serving diagnostics event queue after
-it reaches its configured bound. The queue is append-only for a request bundle,
-so once the first event has been dropped every later append is also an overflow.
-The implementation can reuse that state instead of rechecking the current deque
-length on each saturated append. The queue object also uses explicit slots so
-this high-frequency debug buffer does not carry a per-instance dictionary.
+This Python-only slice optimizes the debug serving diagnostics event queue and
+the high-frequency event objects it stores. After the queue reaches its
+configured bound, every later append is also an overflow, so the queue can reuse
+that state instead of rechecking the current deque length on each saturated
+append. The queue object, event objects, and snapshots use explicit slots so the
+debug buffer does not carry unnecessary per-instance dictionaries.
+
+This follow-up slice keeps the same immutable `ServingDiagnosticsEvent` public
+contract but supplies a module-cached local-binding initializer for the frozen
+slots dataclass. The registered probe constructs thousands of events per sample,
+so avoiding the generated initializer's repeated global `object.__setattr__`
+lookups targets the dominant local Linux cost without changing serialized
+diagnostics payloads.
 
 ## Affected Paths
 
@@ -23,6 +30,7 @@ The affected path is covered by the existing
 `test_command`, `coverage_command`, and `probe_command` values and reports:
 
 - `elapsed_ms_mean` (`lower_is_better`)
+- `serialization_elapsed_ms_mean` (`lower_is_better`)
 - `dropped_count` (`informational`)
 - `retained_count` (`informational`)
 

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -213,6 +213,23 @@ def test_serving_diagnostics_event_instances_use_slots_for_debug_queue() -> None
 
     assert hasattr(event, "__dict__") is False
     assert event.to_dict()["attributes"] == {"token": "***"}
+    with pytest.raises(AttributeError):
+        event.status = "mutated"  # type: ignore[misc]
+
+
+def test_serving_diagnostics_queue_snapshot_uses_slots_for_debug_queue() -> None:
+    event = ServingDiagnosticsEvent(
+        request_id="req-snapshot-slots",
+        phase="decode",
+        event_index=1,
+        status="completed",
+    )
+    queue = BoundedServingDiagnosticsEventQueue(max_events=1)
+    queue.append(event)
+    queue_snapshot = queue.snapshot()
+
+    assert hasattr(queue_snapshot, "__dict__") is False
+    assert queue_snapshot.events == (event,)
 
 
 def test_serving_diagnostics_default_event_attributes_reuse_empty_mapping() -> None:

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -17,13 +17,14 @@ SERVING_DIAGNOSTICS_REQUEST_SCHEMA_VERSION = "melix.serving_diagnostics.request_
 SERVING_DIAGNOSTICS_EVENT_SCHEMA_VERSION = "melix.serving_diagnostics.event.v1"
 SERVING_DIAGNOSTICS_COMPARISON_SCHEMA_VERSION = "melix.serving_diagnostics.comparison.v1"
 _EMPTY_EVENT_ATTRIBUTES: Mapping[str, object] = MappingProxyType({})
+_SET_FROZEN_ATTR = object.__setattr__
 
 
 class ServingDiagnosticsComparisonError(ValueError):
     pass
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ServingDiagnosticsQueueSnapshot:
     events: tuple[ServingDiagnosticsEvent, ...]
     dropped_count: int
@@ -137,7 +138,7 @@ class ServingDiagnosticsRequestSummary:
         }
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, init=False)
 class ServingDiagnosticsEvent:
     request_id: str
     phase: str
@@ -145,6 +146,23 @@ class ServingDiagnosticsEvent:
     status: str
     duration_ms: float = 0.0
     attributes: Mapping[str, object] = _EMPTY_EVENT_ATTRIBUTES
+
+    def __init__(
+        self,
+        request_id: str,
+        phase: str,
+        event_index: int,
+        status: str,
+        duration_ms: float = 0.0,
+        attributes: Mapping[str, object] = _EMPTY_EVENT_ATTRIBUTES,
+    ) -> None:
+        set_attr = _SET_FROZEN_ATTR
+        set_attr(self, "request_id", request_id)
+        set_attr(self, "phase", phase)
+        set_attr(self, "event_index", event_index)
+        set_attr(self, "status", status)
+        set_attr(self, "duration_ms", duration_ms)
+        set_attr(self, "attributes", attributes)
 
     def to_dict(self) -> dict[str, object]:
         attributes = self.attributes


### PR DESCRIPTION
## Summary
- Add a module-cached initializer for frozen `ServingDiagnosticsEvent` slots objects to reduce repeated `object.__setattr__` lookup overhead in the debug queue probe.
- Slot `ServingDiagnosticsQueueSnapshot` and cover snapshot/event immutability behavior.
- Update the serving diagnostics queue performance plan with the follow-up slice and metrics.

## Plan or Spec
- `docs/plans/2026-05-13-serving-diagnostics-queue-overflow-fast-path.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py::test_serving_diagnostics_event_instances_use_slots_for_debug_queue services/mlx-worker-python/tests/test_serving_diagnostics.py::test_serving_diagnostics_default_event_attributes_reuse_empty_mapping services/mlx-worker-python/tests/test_serving_diagnostics.py::test_serving_diagnostics_bounded_queue_drops_oldest_without_blocking
# 3 passed in 0.08s

Registered test_command for serving-diagnostics-debug-queue-bounds
# 28 passed in 0.11s

Registered coverage_command for serving-diagnostics-debug-queue-bounds
# 28 passed in 0.25s; changed-scope coverage TOTAL 20 0 100%

Registered probe_command for serving-diagnostics-debug-queue-bounds
# {"capacity": 64.0, "dropped_count": 4032.0, "elapsed_ms_mean": 5.975755, "event_count": 4096.0, "retained_count": 64.0, "sample_count": 5.0, "serialization_checksum": 260064.0, "serialization_elapsed_ms_mean": 0.029036}

MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=30 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# origin/main: elapsed_ms_mean=6.894670, serialization_elapsed_ms_mean=0.031938
# branch:      elapsed_ms_mean=5.496453, serialization_elapsed_ms_mean=0.028700

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (20/20 measurable changed lines covered).
- Registered local probe (default): `elapsed_ms_mean=5.975755`, `serialization_elapsed_ms_mean=0.029036`, `dropped_count=4032`, `retained_count=64`.
- Local 30-sample comparison: `old_mean=6.894670 ms`, `new_mean=5.496453 ms`, `delta_ms=-1.398217`, `speedup=20.28%` for append/event construction path. Serialization also moved from `0.031938 ms` to `0.028700 ms`.
- Registered PR-scoped performance CI is required before merge and is the hosted merge gate for the probe report.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed or expected for this slice.
- The default 5-sample probe remains naturally noisy, so the PR also records a 30-sample local comparison for stability; CI registered probe remains authoritative for merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
