### PR TITLE
perf: streamline probe policy cached flags

### DIFF
--- a/docs/plans/2026-05-13-probe-policy-mode-check-fast-path.md
+++ b/docs/plans/2026-05-13-probe-policy-mode-check-fast-path.md
@@ -8,6 +8,17 @@ focused tests. It keeps probe mode semantics unchanged while avoiding per-call
 temporary set allocation and repeated enum comparisons in the hot
 `telemetry_enabled` and `evidence_enabled` properties.
 
+## 2026-05-14 direct cached-field follow-up
+
+The current slice keeps the same behavior and registered probe but narrows the
+hot-path instance layout itself: `ProbePolicy` now uses dataclass slots and
+stores `telemetry_enabled` / `evidence_enabled` as direct cached fields rather
+than private fields behind property descriptors. This removes an extra Python
+function call from the default no-op policy check while retaining the cached
+boolean semantics introduced by the earlier mode-check fast path. The focused
+regression asserts that policy instances remain slotted and still expose the
+same no-op reason and telemetry behavior.
+
 ## Registered performance probe
 
 The affected path is covered by the registered PR-scoped probe

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -46,6 +46,14 @@ def test_probe_policy_evidence_enabled_only_for_evidence_modes() -> None:
     assert ProbePolicy(mode=ProbeMode.DEBUG).evidence_enabled is True
 
 
+def test_probe_policy_uses_slots_for_hot_path_instances() -> None:
+    policy = ProbePolicy(mode=ProbeMode.MINIMAL)
+
+    assert not hasattr(policy, "__dict__")
+    assert policy.telemetry_enabled is False
+    assert policy.no_op_reason == "probe_mode_minimal"
+
+
 def test_no_op_probe_policy_overhead_metrics_are_thresholded() -> None:
     metrics = measure_no_op_probe_policy_overhead(iterations=16, samples=1, threshold_pct=10_000.0)
     payload = metrics.to_dict()

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -17,31 +17,23 @@ class ProbeMode(StrEnum):
     DEBUG = "debug"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ProbePolicy:
     mode: ProbeMode = ProbeMode.MINIMAL
     source_value: str = ""
     fallback_applied: bool = False
-    _telemetry_enabled: bool = field(init=False, repr=False, compare=False)
-    _evidence_enabled: bool = field(init=False, repr=False, compare=False)
+    telemetry_enabled: bool = field(init=False, repr=False, compare=False)
+    evidence_enabled: bool = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         mode = self.mode
         evidence_enabled = mode is ProbeMode.EVIDENCE or mode is ProbeMode.DEBUG
         object.__setattr__(
             self,
-            "_telemetry_enabled",
+            "telemetry_enabled",
             mode is ProbeMode.SAMPLED or evidence_enabled,
         )
-        object.__setattr__(self, "_evidence_enabled", evidence_enabled)
-
-    @property
-    def telemetry_enabled(self) -> bool:
-        return self._telemetry_enabled
-
-    @property
-    def evidence_enabled(self) -> bool:
-        return self._evidence_enabled
+        object.__setattr__(self, "evidence_enabled", evidence_enabled)
 
     @property
     def no_op_reason(self) -> str:


### PR DESCRIPTION
## Summary
- Streamline `ProbePolicy` hot-path cached booleans by storing `telemetry_enabled` and `evidence_enabled` as direct slotted dataclass fields.
- Add a focused regression that keeps `ProbePolicy` instances slotted while preserving the default no-op policy behavior.
- Update the probe policy performance plan with the direct cached-field follow-up slice.

## Plan or Spec
- Updated `docs/plans/2026-05-13-probe-policy-mode-check-fast-path.md` with the 2026-05-14 direct cached-field follow-up.
- The touched path is already covered by the registered PR-scoped probe `probe-policy-noop-overhead`, with focused `test_command`, `coverage_command`, and `probe_command` entries in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `python3 - <<'PY' ...` to verify `probe-policy-noop-overhead` has runner, watch globs, and focused test/coverage/probe commands.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py`
- `for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py; done`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 10 passed.
- Changed-scope coverage: 100.00% (9/9 measurable changed lines).
- Local registered probe, new implementation (`no_op_policy_check_call_ms_mean`, 3 runs): `0.000046846`, `0.000048462`, `0.000050814` ms; mean `0.000048707` ms; `threshold_passed=1.0` in all runs.
- Local baseline from `origin/main` (`no_op_policy_check_call_ms_mean`, 3 runs): `0.000071045`, `0.000068788`, `0.000070188` ms; mean `0.000070007` ms.
- Local delta: `-0.000021300` ms mean, about `30.43%` faster for the registered policy-check metric.
- CI PR-scoped performance is required as the authoritative registered-probe gate before merge.

## Known Gaps
- This is a Python-only slice verified locally on Linux. No Swift runtime behavior is changed.
- Microprobe timings are noisy at nanosecond scale; merge is gated on the registered PR-scoped performance workflow.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Registered PR-scoped probe exists for the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally and showed improvement.
- [ ] GitHub Actions and PR-scoped performance workflow are green.
