### PR TITLE
perf: streamline startup failure pattern checks

### DIFF
--- a/docs/plans/2026-05-14-startup-failure-pattern-check-performance.md
+++ b/docs/plans/2026-05-14-startup-failure-pattern-check-performance.md
@@ -1,0 +1,43 @@
+# Startup Failure Pattern Check Performance Slice
+
+## Goal
+
+Reduce avoidable Python allocation and repeated scanning in startup failure
+classification while preserving the existing direct-error, control-plane-log, and
+worker-log classification behavior.
+
+## Scope
+
+This slice is limited to `worker.productization.startup_signals` startup failure
+pattern checks and the already registered `startup-signals-lazy-worker-log-excerpts`
+PR-scoped performance probe. It does not change update-channel version parsing,
+startup log excerpt semantics, diagnostic report schemas, or runtime startup
+behavior.
+
+## Change
+
+- Store startup classification pattern sets as immutable tuples.
+- Replace generator-based `any(pattern in value ...)` checks with a small direct
+  helper that short-circuits without allocating a generator for each
+  classification pass.
+- Avoid rebuilding and rescanning `error_text` after the direct-error fast path has
+  already ruled out direct port-conflict and crash patterns; subsequent checks now
+  scan only the lowercased control-plane log excerpt.
+
+## Metrics
+
+Primary registered probe: `startup-signals-lazy-worker-log-excerpts`.
+
+- `conflict_elapsed_ms_mean`: lower is better for direct error-text conflicts.
+- `control_crash_elapsed_ms_mean`: lower is better for control-plane log
+  classification.
+- `worker_crash_elapsed_ms_mean`: lower is better for worker log classification.
+- `tail_scan_elapsed_ms_mean`: informational for this slice; tail scanning itself
+  is unchanged.
+- Log read and path-exists counters must remain unchanged.
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and probe
+command from `infra/perf/pr_scoped_probes.json` before opening the PR. The
+PR-scoped performance workflow must complete successfully before merge.

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -8,20 +8,20 @@ from pathlib import Path
 from typing import Any, Iterator, Mapping
 
 
-PORT_CONFLICT_PATTERNS = [
+PORT_CONFLICT_PATTERNS = (
     "address already in use",
     "eaddrinuse",
     "bind() failed",
     "port is already in use",
-]
-CRASH_PATTERNS = [
+)
+CRASH_PATTERNS = (
     "fatal error",
     "traceback",
     "uncaught",
     "assertion failed",
     "terminated",
     "abort trap",
-]
+)
 _BYTE_WHITESPACE = bytes(value for value in range(256) if chr(value).isspace())
 
 
@@ -216,7 +216,7 @@ def classify_startup_failure(
     error_lower = error_text.lower()
     primary_log_path = str(manifest.get("control_plane_stderr_path", ""))
 
-    if any(pattern in error_lower for pattern in PORT_CONFLICT_PATTERNS):
+    if _contains_any(error_lower, PORT_CONFLICT_PATTERNS):
         summary = f"Configured HTTP port {http_port} is already in use."
         detail = (
             f"The control plane could not bind to {ready_probe_url}. "
@@ -224,7 +224,7 @@ def classify_startup_failure(
         )
         excerpt = error_text
         classification = "host_port_conflict"
-    elif any(pattern in error_lower for pattern in CRASH_PATTERNS):
+    elif _contains_any(error_lower, CRASH_PATTERNS):
         summary = "Control plane crashed before startup completed."
         detail = f"Melix never reached {ready_probe_url}. Inspect the control-plane logs for the crash cause."
         excerpt = error_text
@@ -234,9 +234,9 @@ def classify_startup_failure(
             manifest.get("control_plane_stderr_path"),
             manifest.get("control_plane_stdout_path"),
         )
-        combined_control_plane = f"{error_lower}\n{control_plane_excerpt.lower()}"
+        control_plane_lower = control_plane_excerpt.lower()
 
-        if any(pattern in combined_control_plane for pattern in PORT_CONFLICT_PATTERNS):
+        if _contains_any(control_plane_lower, PORT_CONFLICT_PATTERNS):
             summary = f"Configured HTTP port {http_port} is already in use."
             detail = (
                 f"The control plane could not bind to {ready_probe_url}. "
@@ -244,7 +244,7 @@ def classify_startup_failure(
             )
             excerpt = control_plane_excerpt
             classification = "host_port_conflict"
-        elif control_plane_excerpt and any(pattern in combined_control_plane for pattern in CRASH_PATTERNS):
+        elif control_plane_excerpt and _contains_any(control_plane_lower, CRASH_PATTERNS):
             summary = "Control plane crashed before startup completed."
             detail = f"Melix never reached {ready_probe_url}. Inspect the control-plane logs for the crash cause."
             excerpt = control_plane_excerpt
@@ -257,7 +257,7 @@ def classify_startup_failure(
                 manifest.get("swift_text_worker_stdout_path"),
             )
             combined_worker = worker_excerpt_value.lower()
-            if worker_excerpt_value and any(pattern in combined_worker for pattern in CRASH_PATTERNS):
+            if worker_excerpt_value and _contains_any(combined_worker, CRASH_PATTERNS):
                 primary_log_path = str(
                     manifest.get("python_worker_stderr_path")
                     or manifest.get("swift_text_worker_stderr_path")
@@ -282,6 +282,13 @@ def classify_startup_failure(
         primary_log_path=primary_log_path,
         log_excerpt=excerpt,
     )
+
+
+def _contains_any(value: str, patterns: tuple[str, ...]) -> bool:
+    for pattern in patterns:
+        if pattern in value:
+            return True
+    return False
 
 
 def _log_excerpt(*paths: object) -> str:


### PR DESCRIPTION
## Summary
- Streamline startup failure classification pattern checks by using immutable pattern tuples and a small direct short-circuit helper instead of generator-based `any(...)` checks.
- Avoid rebuilding/rescanning `error_text` after the direct-error fast path has already ruled out direct port-conflict and crash signatures.
- Add a focused plan for this single startup-failure pattern-check performance slice.

## Plan or Spec
- `docs/plans/2026-05-14-startup-failure-pattern-check-performance.md`

## Commands Run
```text
# Baseline before code changes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# exit 0; 33 passed in 1.64s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py
# exit 0; baseline metrics captured below

# Head after code changes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# exit 0; 33 passed in 1.07s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py
# exit 0; changed-scope coverage 100.00% (13/13)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py
# exit 0; head metrics captured below

for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py; done
# exit 0; three repeated head probe runs captured below

git diff --check
# exit 0
```

## Coverage and Metrics
- Registered probe: `startup-signals-lazy-worker-log-excerpts` in `infra/perf/pr_scoped_probes.json`; it already has focused `test_command`, `coverage_command`, and `probe_command` entries for `services/mlx-worker-python/worker/productization/startup_signals.py`.
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Baseline probe (single pre-change local run):
  - `conflict_elapsed_ms_mean=0.971411`
  - `control_crash_elapsed_ms_mean=10.436803`
  - `direct_control_crash_elapsed_ms_mean=1.097563`
  - `worker_crash_elapsed_ms_mean=10.987258`
  - `tail_scan_elapsed_ms_mean=153.593886` (tail scan unchanged/informational)
- Head probe repeated 3-run mean:
  - `conflict_elapsed_ms_mean=0.875323` (`-0.096088 ms`, `-9.89%`, `1.1098x`)
  - `control_crash_elapsed_ms_mean=9.920224` (`-0.516579 ms`, `-4.95%`, `1.0521x`)
  - `direct_control_crash_elapsed_ms_mean=0.901578` (`-0.195985 ms`, `-17.86%`, `1.2174x`)
  - `worker_crash_elapsed_ms_mean=10.451782` (`-0.535476 ms`, `-4.87%`, `1.0512x`)
  - `tail_scan_elapsed_ms_mean=154.545590` (`+0.951704 ms`, `+0.62%`; informational and unrelated to this slice)
- Log read/path-exists counters stayed unchanged (`0.0` direct conflict/direct crash reads, `1.0` log read for log-classified crashes, `0.0` exists checks).
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation was Linux/Python only. This slice does not touch Swift runtime paths.
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; the PR-scoped CI gates are required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: debug startup failure classification; probe overhead measured by existing registered PR-scoped probe counters.
- [x] Deferred work and known gaps are stated explicitly.
