### PR TITLE
perf: skip tiny vision image token divisions

### DIFF
--- a/docs/plans/2026-05-11-vision-family-token-media-aggregation.md
+++ b/docs/plans/2026-05-11-vision-family-token-media-aggregation.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This Python-only performance slice keeps `ResolvedVisionFamilyConfig.prompt_token_count()` behavior unchanged while reducing per-frame arithmetic in media-token accounting.
+This Python-only performance slice keeps `ResolvedVisionFamilyConfig.prompt_token_count()` behavior unchanged while reducing integer division work in image-token accounting.
 
 ## Registered Probe
 
@@ -14,7 +14,7 @@ The affected path is covered by the PR-scoped `vision-family-prompt-token-count-
 
 ## Optimization Hypothesis
 
-The current prompt token path already caches prompt whitespace scans. Remaining hot work in this probe is media token aggregation across images and video frame policies. Keeping image minimum clamping inline and aggregating video frame counts once should reduce loop work while preserving the existing minimum-one-token semantics for empty or non-positive frame policies.
+The current prompt token path already caches prompt whitespace scans. Remaining hot work in this probe is media token aggregation across images and video frame policies. This slice avoids integer division for image inputs that cannot exceed the one-token minimum, while preserving the existing minimum-one-token semantics for tiny images.
 
 ## Verification Plan
 

--- a/services/mlx-worker-python/worker/runtime/vision_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/vision_family_adapters.py
@@ -80,9 +80,10 @@ class ResolvedVisionFamilyConfig:
         if image_token_divisor < 1:
             image_token_divisor = 1
         image_tokens = 0
+        image_multi_token_threshold = image_token_divisor * 2
         for image in prepared_request.images:
-            token_count = len(image.bytes_data) // image_token_divisor
-            image_tokens += token_count if token_count > 1 else 1
+            byte_count = len(image.bytes_data)
+            image_tokens += byte_count // image_token_divisor if byte_count >= image_multi_token_threshold else 1
 
         video_frame_token_cost = self.video_frame_token_cost
         if video_frame_token_cost < 1:


### PR DESCRIPTION
## Summary
- Skip integer division for tiny vision image payloads that would clamp to the one-token minimum anyway.
- Update the vision-family performance plan to describe this narrower image-token accounting slice.

## Plan or Spec
- Updated `docs/plans/2026-05-11-vision-family-token-media-aggregation.md`.
- Existing registered PR-scoped probe: `vision-family-prompt-token-count-scan` in `infra/perf/pr_scoped_probes.json` covers `services/mlx-worker-python/worker/runtime/vision_family_adapters.py` and includes focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `git fetch origin --prune`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_cached_prompt_scan services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_clamps_media_minimums services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_cached_prompt_scan services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_clamps_media_minimums services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/vision_family_adapters.py services/mlx-worker-python/worker/runtime/token_counting.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/vision_family_prompt_token_count_probe.py`
- Baseline probe on `origin/main` (`fe4d5f83`): `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/vision_family_prompt_token_count_probe.py`
- Candidate probe on this branch (`aaf840ad`): `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/vision_family_prompt_token_count_probe.py`
- `git diff --check origin/main...HEAD`

## Coverage and Metrics
- Focused tests: 5 passed in 0.48s.
- Changed-scope coverage: `TOTAL 0 0 100%` (the changed production line is exercised by the focused tests; changed-scope tool reported no measurable changed lines after branch/main comparison for the registered scope).
- Local registered probe baseline (`origin/main` `fe4d5f83`): `elapsed_ms_mean=4.301696749670165`, `peak_bytes_mean=235.42857142857142`, `split_calls_mean=0.0`, `token_count=1309.0`.
- Local registered probe candidate (`aaf840ad`): `elapsed_ms_mean=4.152589876736913`, `peak_bytes_mean=235.42857142857142`, `split_calls_mean=0.0`, `token_count=1309.0`.
- Local delta: `-0.14910687293325206 ms` (`~3.47%` faster) with unchanged token count.

## Known Gaps
- This is a Python-only Linux-local validation slice; GitHub Actions must still run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registered probe has focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage command completed.
- [x] Local baseline and candidate probe metrics captured.
- [ ] PR-scoped performance CI completed successfully.
- [ ] Required PR checks completed successfully.
