### PR TITLE
perf: fast path serving diagnostics event serialization

### DIFF
--- a/docs/plans/2026-05-13-serving-diagnostics-queue-overflow-fast-path.md
+++ b/docs/plans/2026-05-13-serving-diagnostics-queue-overflow-fast-path.md
@@ -16,6 +16,12 @@ so avoiding the generated initializer's repeated global `object.__setattr__`
 lookups targets the dominant local Linux cost without changing serialized
 diagnostics payloads.
 
+This slice then targets the registered probe's serialization phase: the common
+debug-event path already stores `event_index` as an exact `int` and `duration_ms`
+as an exact `float`, so `ServingDiagnosticsEvent.to_dict()` can skip redundant
+numeric constructor calls while retaining the previous coercion behavior for
+non-exact numeric inputs.
+
 ## Affected Paths
 
 - `services/mlx-worker-python/worker/productization/serving_diagnostics.py`

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -275,6 +275,23 @@ def test_serving_diagnostics_empty_event_attributes_skip_stable_json_object(
     assert event.to_dict()["attributes"] == {}
 
 
+def test_serving_diagnostics_event_to_dict_preserves_numeric_coercion() -> None:
+    event = ServingDiagnosticsEvent(
+        request_id="req-numeric-coercion",
+        phase="decode",
+        event_index=True,
+        status="completed",
+        duration_ms=3,
+    )
+
+    payload = event.to_dict()
+
+    assert payload["event_index"] == 1
+    assert type(payload["event_index"]) is int
+    assert payload["duration_ms"] == 3.0
+    assert type(payload["duration_ms"]) is float
+
+
 def test_serving_diagnostics_bounded_queue_serializes_append_during_snapshot() -> None:
     first_event = ServingDiagnosticsEvent(
         request_id="req-concurrent",

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -166,13 +166,19 @@ class ServingDiagnosticsEvent:
 
     def to_dict(self) -> dict[str, object]:
         attributes = self.attributes
+        event_index = self.event_index
+        duration_ms = self.duration_ms
         return {
             "schema_version": SERVING_DIAGNOSTICS_EVENT_SCHEMA_VERSION,
             "request_id": self.request_id,
             "phase": self.phase,
-            "event_index": int(self.event_index),
+            "event_index": event_index
+            if type(event_index) is int
+            else int(event_index),
             "status": self.status,
-            "duration_ms": float(self.duration_ms),
+            "duration_ms": duration_ms
+            if type(duration_ms) is float
+            else float(duration_ms),
             "attributes": {} if not attributes else _stable_json_object(attributes),
         }
 


### PR DESCRIPTION
## Summary
- Fast-path `ServingDiagnosticsEvent.to_dict()` for the common exact `int`/`float` debug-event primitives.
- Preserve previous numeric coercion behavior for non-exact inputs with a focused regression test.
- Update the serving diagnostics queue performance plan with the serialization slice and registered probe scope.

## Plan or Spec
- `docs/plans/2026-05-13-serving-diagnostics-queue-overflow-fast-path.md`
- Registered probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py`
- `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=15 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` on origin/main and this branch, repeated in paired runs.
- `git diff --check`

## Coverage and Metrics
- Focused tests: `29 passed in 0.67s`.
- Changed-scope coverage: `TOTAL 9 0 100%`.
- Local Linux probe, paired 15-sample runs:
  - Initial comparison: base `elapsed_ms_mean=6.122388`, `serialization_elapsed_ms_mean=0.031764`; head `elapsed_ms_mean=5.609372`, `serialization_elapsed_ms_mean=0.030392`.
  - Three follow-up paired runs showed serialization means base/head: `0.055462/0.028131`, `0.029505/0.027882`, `0.029266/0.032100` ms. Mean serialization delta across the three follow-up pairs: `-0.008707 ms` (~23.0% lower). Overall queue append elapsed remained noise-bound because this slice only changes `to_dict()` serialization.
- Registered PR-scoped performance CI is required before merge and is the merge gate for the probe report.

## Known Gaps
- No Swift runtime validation is involved; this is a Python-only slice verified locally on Linux.
- Overall `elapsed_ms_mean` is expected to be noise-bound because the optimization targets `serialization_elapsed_ms_mean` only.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Confirmed affected path is covered by a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Added/updated regression coverage before the implementation decision.
- [x] Ran focused tests locally.
- [x] Ran changed-scope coverage locally.
- [x] Ran local registered probe comparison on Linux.
- [ ] GitHub Actions and registered PR-scoped performance report completed successfully.
