### PR TITLE
perf: compact serving diagnostics jsonl rows

### DIFF
--- a/docs/plans/2026-05-14-serving-diagnostics-jsonl-compact-serialization.md
+++ b/docs/plans/2026-05-14-serving-diagnostics-jsonl-compact-serialization.md
@@ -1,0 +1,28 @@
+# Serving Diagnostics JSONL Compact Serialization Performance Slice
+
+## Scope
+
+This Python-only slice narrows the serving diagnostics debug bundle hot path by
+writing event JSONL rows with compact JSON separators while preserving sorted key
+order and line-delimited JSON semantics.
+
+## Registered probe
+
+The affected path is already covered by the PR-scoped registered probe
+`serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.
+This slice extends that probe so `serialization_elapsed_ms_mean` exercises the
+actual `write_serving_diagnostics_bundle(...)` JSONL writer and adds
+`serialized_bytes` as a lower-is-better metric for the compact-row output.
+
+## Linux verification plan
+
+- Focused pytest for `services/mlx-worker-python/tests/test_serving_diagnostics.py`.
+- Registered probe tests in `services/mlx-worker-python/tests/test_pr_scoped_performance.py`.
+- Changed-scope coverage through the registered probe `coverage_command`.
+- Registered probe command locally on Linux.
+
+## Behavior compatibility
+
+Events remain newline-delimited JSON objects with stable `sort_keys=True` output.
+Only insignificant spaces after JSON separators are removed for the `events.jsonl`
+artifact; consumers parse the same JSON object shape.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3722,6 +3722,12 @@
         "key": "serialization_checksum",
         "unit": "index-sum",
         "direction": "informational"
+      },
+      {
+        "key": "serialized_bytes",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
       }
     ]
   }

--- a/scripts/serving_diagnostics_queue_probe.py
+++ b/scripts/serving_diagnostics_queue_probe.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 import statistics
+import tempfile
 import time
 from pathlib import Path
 
@@ -16,6 +17,8 @@ sys.path.insert(0, str(ROOT / "services/mlx-worker-python"))
 from worker.productization.serving_diagnostics import (  # noqa: E402
     BoundedServingDiagnosticsEventQueue,
     ServingDiagnosticsEvent,
+    ServingDiagnosticsRequestSummary,
+    write_serving_diagnostics_bundle,
 )
 
 
@@ -27,7 +30,21 @@ def main() -> int:
     serialization_samples: list[float] = []
     dropped = 0
     retained = 0
+    serialized_bytes = 0
     serialization_checksum = 0
+    summary = ServingDiagnosticsRequestSummary(
+        request_id="req-probe",
+        task_kind="text-generation",
+        model_id="melix-dev-text",
+        runtime_kind="deterministic",
+        acceleration_mode="baseline",
+        prompt_protocol_id="chat.completions.v1",
+        prompt_digest="sha256:prompt",
+        prompt_template_digest="sha256:template",
+        generation_config={},
+        status="completed",
+        finish_reason="stop",
+    )
     for sample_index in range(max(sample_count, 1)):
         queue = BoundedServingDiagnosticsEventQueue(max_events=capacity)
         started = time.perf_counter()
@@ -46,10 +63,22 @@ def main() -> int:
         dropped = snapshot.dropped_count
         retained = len(snapshot.events)
         serialize_started = time.perf_counter()
-        checksum = 0
-        for event in snapshot.events:
-            checksum += int(event.to_dict()["event_index"])
-        serialization_checksum = checksum
+        with tempfile.TemporaryDirectory() as directory:
+            paths = write_serving_diagnostics_bundle(
+                output_root=Path(directory),
+                bundle_id=f"diag-probe-{sample_index}",
+                invocation={},
+                effective_config={},
+                model_refs={},
+                request_summary=summary,
+                events=snapshot,
+                diagnostics_mode="debug",
+            )
+            event_rows = paths["events"].read_text(encoding="utf-8").splitlines()
+            serialization_checksum = sum(
+                int(json.loads(line)["event_index"]) for line in event_rows
+            )
+            serialized_bytes = paths["events"].stat().st_size
         serialization_samples.append((time.perf_counter() - serialize_started) * 1000.0)
     print(
         json.dumps(
@@ -60,6 +89,7 @@ def main() -> int:
                 "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
                 "serialization_elapsed_ms_mean": round(statistics.fmean(serialization_samples), 6),
                 "serialization_checksum": float(serialization_checksum),
+                "serialized_bytes": float(serialized_bytes),
                 "dropped_count": float(dropped),
                 "retained_count": float(retained),
             },

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -454,6 +454,48 @@ def test_serving_diagnostics_serializes_sets_as_stable_arrays(tmp_path: Path) ->
     assert event_payload["attributes"]["frozen"] == [1, 2, 3]
 
 
+def test_serving_diagnostics_events_jsonl_uses_compact_stable_lines(tmp_path: Path) -> None:
+    summary = ServingDiagnosticsRequestSummary(
+        request_id="req-compact",
+        task_kind="text-generation",
+        model_id="melix-dev-text",
+        runtime_kind="deterministic",
+        acceleration_mode="baseline",
+        prompt_protocol_id="chat.completions.v1",
+        prompt_digest="sha256:prompt",
+        prompt_template_digest="sha256:template",
+        generation_config={},
+        status="completed",
+        finish_reason="stop",
+    )
+    event = ServingDiagnosticsEvent(
+        request_id="req-compact",
+        phase="decode",
+        event_index=7,
+        status="completed",
+        attributes={"beta": 2, "alpha": 1},
+    )
+
+    paths = write_serving_diagnostics_bundle(
+        output_root=tmp_path,
+        bundle_id="diag-compact",
+        invocation={},
+        effective_config={},
+        model_refs={},
+        request_summary=summary,
+        events=(event,),
+        diagnostics_mode="debug",
+    )
+
+    line = paths["events"].read_text(encoding="utf-8")
+    assert line == (
+        '{"attributes":{"alpha":1,"beta":2},"duration_ms":0.0,'
+        '"event_index":7,"phase":"decode","request_id":"req-compact",'
+        '"schema_version":"melix.serving_diagnostics.event.v1",'
+        '"status":"completed"}\n'
+    )
+
+
 @pytest.mark.parametrize("value", (0, -1, "0", "bad", None))
 def test_validate_prefill_chunk_size_rejects_invalid_overrides(value: object) -> None:
     with pytest.raises(ValueError, match="prefill_chunk_size"):

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -17,6 +17,8 @@ SERVING_DIAGNOSTICS_REQUEST_SCHEMA_VERSION = "melix.serving_diagnostics.request_
 SERVING_DIAGNOSTICS_EVENT_SCHEMA_VERSION = "melix.serving_diagnostics.event.v1"
 SERVING_DIAGNOSTICS_COMPARISON_SCHEMA_VERSION = "melix.serving_diagnostics.comparison.v1"
 _EMPTY_EVENT_ATTRIBUTES: Mapping[str, object] = MappingProxyType({})
+_JSON_COMPACT_SEPARATORS = (",", ":")
+_JSONL_ENCODER = json.JSONEncoder(sort_keys=True, separators=_JSON_COMPACT_SEPARATORS)
 _SET_FROZEN_ATTR = object.__setattr__
 
 
@@ -473,5 +475,7 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
 
 def _write_jsonl(path: Path, rows: Any) -> None:
     with path.open("w", encoding="utf-8") as handle:
+        encode = _JSONL_ENCODER.encode
+        write = handle.write
         for row in rows:
-            handle.write(json.dumps(row, sort_keys=True) + "\n")
+            write(encode(row) + "\n")


### PR DESCRIPTION
## Summary
- Compact serving diagnostics `events.jsonl` rows by using a reusable JSON encoder with `sort_keys=True` and compact separators.
- Add a regression test proving stable compact JSONL output.
- Extend the registered `serving-diagnostics-debug-queue-bounds` probe so serialization measures the actual bundle writer and reports `serialized_bytes`.

## Plan or Spec
- Updated `docs/plans/2026-05-14-serving-diagnostics-jsonl-compact-serialization.md` for this Python-only slice.
- Registered probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/servdiag_jsonl_compare.py "$PWD"` (3 repeated samples)
- `python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.json.check`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: 30 passed.
- Changed-scope coverage: 100% (19/19 changed measurable lines).
- Registered local probe output: `elapsed_ms_mean=5.586664`, `serialization_elapsed_ms_mean=1.193458`, `serialized_bytes=10880`, `dropped_count=4032`, `retained_count=64`.
- Local old-vs-new microprobe over 4096 serialized events (3 repeated runs):
  - Run 1: old `17.390361ms` / `773034 bytes`; new `13.416962ms` / `719786 bytes`; delta `-3.973399ms`, `-6.888183%` bytes.
  - Run 2: old `19.034271ms` / `773034 bytes`; new `14.308202ms` / `719786 bytes`; delta `-4.726069ms`, `-6.888183%` bytes.
  - Run 3: old `17.082614ms` / `773034 bytes`; new `13.438727ms` / `719786 bytes`; delta `-3.643887ms`, `-6.888183%` bytes.

## Known Gaps
- Linux local validation covers the Python writer and synthetic probe only.
- The registered PR-scoped performance workflow must run in CI before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe command ran locally.
- [x] Local metrics show improved serialization time and smaller JSONL bytes.
- [ ] GitHub Actions and registered PR-scoped performance report completed successfully.
