### PR TITLE
perf: fast-path empty serving diagnostics event attributes

### DIFF
--- a/docs/plans/2026-05-14-serving-diagnostics-event-empty-attributes-fast-path.md
+++ b/docs/plans/2026-05-14-serving-diagnostics-event-empty-attributes-fast-path.md
@@ -1,0 +1,28 @@
+# Serving diagnostics empty event attributes fast path
+
+## Scope
+
+This Python performance slice is limited to `ServingDiagnosticsEvent.to_dict()` in the serving diagnostics bundle writer. The queue probe workload serializes retained debug events that commonly use the default empty attributes mapping, so this slice keeps behavior unchanged while avoiding the generic mapping normalization path for that canonical empty value.
+
+## Registered probe
+
+The affected path is already covered by the PR-scoped probe `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.
+
+The registered entry includes:
+
+- `test_command` for `services/mlx-worker-python/tests/test_serving_diagnostics.py` and PR-scoped probe dispatch tests.
+- `coverage_command` for changed-scope coverage over the serving diagnostics source, tests, probe dispatch tests, and probe script.
+- `probe_command` invoking `scripts/serving_diagnostics_queue_probe.py` with command-json metrics.
+
+## Verification plan
+
+1. Add a regression test proving default empty event attributes and explicit empty mappings serialize equivalently.
+2. Implement only the canonical empty-attributes fast path in `ServingDiagnosticsEvent.to_dict()`.
+3. Run the registered focused tests, changed-scope coverage, and local Linux probe before opening the PR.
+4. Use GitHub Actions PR-scoped performance as the merge gate for base-vs-head probe validation.
+
+## Expected metrics
+
+Primary metric: `serialization_elapsed_ms_mean` from `serving-diagnostics-debug-queue-bounds`, direction lower-is-better.
+
+Secondary metrics: `elapsed_ms_mean`, `serialized_bytes`, `dropped_count`, `retained_count`, and `serialization_checksum` must remain stable or explainably equivalent.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -121,6 +121,28 @@ def test_serving_diagnostics_bundle_writes_stable_layout_and_prefill_fields(
     ]
 
 
+def test_serving_diagnostics_event_empty_attributes_match_explicit_empty_mapping() -> None:
+    default_event = ServingDiagnosticsEvent(
+        request_id="req-empty-default",
+        phase="decode",
+        event_index=1,
+        status="completed",
+    )
+    explicit_empty_event = ServingDiagnosticsEvent(
+        request_id="req-empty-explicit",
+        phase="decode",
+        event_index=1,
+        status="completed",
+        attributes={},
+    )
+
+    default_payload = default_event.to_dict()
+    explicit_payload = explicit_empty_event.to_dict()
+
+    assert default_payload["attributes"] == {}
+    assert explicit_payload["attributes"] == {}
+
+
 def test_serving_diagnostics_bounded_queue_drops_oldest_without_blocking(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -181,7 +181,9 @@ class ServingDiagnosticsEvent:
             "duration_ms": duration_ms
             if type(duration_ms) is float
             else float(duration_ms),
-            "attributes": {} if not attributes else _stable_json_object(attributes),
+            "attributes": {}
+            if attributes is _EMPTY_EVENT_ATTRIBUTES
+            else _stable_json_object(attributes),
         }
 
 


### PR DESCRIPTION
## Summary
- Fast-path `ServingDiagnosticsEvent.to_dict()` for the canonical empty attributes mapping used by default debug queue events.
- Add a regression test proving default empty attributes and explicit empty mappings serialize equivalently.
- Document the slice and registered probe gate in a focused plan.

## Plan or Spec
- `docs/plans/2026-05-14-serving-diagnostics-event-empty-attributes-fast-path.md`
- Registered probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py`

## Coverage and Metrics
- Focused tests: `31 passed in 0.71s`.
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Registered local probe default workload: `serialization_elapsed_ms_mean=1.252575`, `elapsed_ms_mean=5.887303`, `serialized_bytes=10880`, `dropped_count=4032`, `retained_count=64`.
- Larger local comparison (`MELIX_SERVING_DIAGNOSTICS_QUEUE_CAPACITY=4096`, `MELIX_SERVING_DIAGNOSTICS_QUEUE_EVENTS=4096`, `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=7`, 3 runs each): base `serialization_elapsed_ms_mean=27.522143`, head `26.719668`, delta `-0.802475 ms` (`2.916%` faster). `serialized_bytes=695210` and `serialization_checksum=8386560` stayed stable.

## Known Gaps
- Local Linux probe validates the Python serialization path only; GitHub Actions PR-scoped performance remains the merge gate for registered base-vs-head reporting.
- The default registered probe retains 64 events, so the largest local effect is clearer under the documented high-retention comparison.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused regression test added for behavior parity.
- [x] Focused local tests passed.
- [x] Changed-scope coverage passed at 100%.
- [x] Registered local probe ran on Linux.
- [ ] PR-scoped performance workflow completed successfully in CI.
