### PR TITLE
Run release gates for rc branch creation

### DIFF
--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -1,6 +1,7 @@
 name: release-gates
 
 on:
+  create:
   workflow_dispatch:
   schedule:
     - cron: "0 9 * * *"
@@ -27,6 +28,11 @@ concurrency:
 
 jobs:
   release-gates:
+    if: >-
+      ${{
+        github.event_name != 'create' ||
+        (github.event.ref_type == 'branch' && startsWith(github.event.ref, 'rc/'))
+      }}
     runs-on: macos-15
 
     steps:

--- a/docs/runbooks/phase-8-release-gates.md
+++ b/docs/runbooks/phase-8-release-gates.md
@@ -20,6 +20,10 @@ Execute the release gate and emit JSON evidence:
 make phase8-release-gate PHASE8_RELEASE_GATE_ARGS="--json"
 ```
 
+The GitHub Actions workflow also runs automatically when a new release-candidate branch is
+created with the `rc/` prefix, for example `rc/2026-05-15`. Other branch or tag creation
+events are ignored by the release-gates job.
+
 The release gate checks:
 
 - install asset generation


### PR DESCRIPTION
## Summary
- Run the release-gates workflow when a new `rc/*` release-candidate branch is created.
- Document the new release-candidate branch trigger in the Phase 8 release gate runbook.

## Plan or Spec
- `docs/runbooks/phase-8-release-gates.md` governs release gate operation and now documents the `rc/*` create trigger.

## Commands Run
```text
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-gates.yml"); puts "yaml ok"' -> passed
uv run --project services/mlx-worker-python python - <<'PY' ... trigger assertions ... PY -> passed
git diff --check -> passed
pre-commit: make swift-test -> passed
pre-commit: make py-test -> passed, 2593 passed, 14 skipped
pre-commit: make integration-test -> failed once in tests/integration/test_recovery_flows.py::test_warm_followup_prefers_hot_route_and_records_ttft_delta (HTTP TTFT jitter assertion: warm 224.3ms, cold 102.6ms, budget +100ms)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest tests/integration/test_recovery_flows.py::test_warm_followup_prefers_hot_route_and_records_ttft_delta -q -> passed
uv run --project services/mlx-worker-python python scripts/validate_pr_evidence.py --body-file .runtime/pr-bodies/release-gates-rc-create.md -> passed
```

## Coverage and Metrics
- N/A: workflow trigger and runbook-only change; no executable production code path or measurable coverage scope changed.
- Metrics: N/A for the same reason. The release gate's existing metrics collection is unchanged; only the GitHub Actions trigger condition changed.
- Observability mode/probe overhead: N/A, no observability probe behavior changed.

## Known Gaps
- The `release-gates` workflow is currently disabled manually in GitHub Actions; it must be re-enabled for the new `rc/*` create trigger to run.
- Full `make phase8-release-gate` was not run because this change only adjusts when the existing gate starts.
- Full pre-commit completed `make swift-test` and `make py-test`, then hit an unrelated timing-sensitive integration-test TTFT jitter assertion; the exact failed test passed on focused retry.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
