### PR TITLE
perf: reuse code eval json whitespace constant

### DIFF
--- a/docs/plans/2026-05-15-code-eval-json-whitespace-constant.md
+++ b/docs/plans/2026-05-15-code-eval-json-whitespace-constant.md
@@ -1,0 +1,33 @@
+# Code Eval Payload JSON Whitespace Constant
+
+## Goal
+
+Reuse the module-level JSON payload whitespace byte constant inside the code-evaluation payload field scanner instead of rebuilding the same bytes literal checks for each separator skip loop.
+
+## Scope
+
+This slice is Python-only under `services/mlx-worker-python` and is locally verifiable on Linux with focused tests, changed-scope coverage, and the registered PR-scoped performance probe.
+
+## Touched files
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `docs/plans/2026-05-15-code-eval-json-whitespace-constant.md`
+
+## Registered performance probe
+
+Use the existing `code-eval-payload-json-bytes` registered PR-scoped probe in `infra/perf/pr_scoped_probes.json`. The registry entry already covers `services/mlx-worker-python/worker/engine/code_eval_runner.py` and includes focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+The probe reports:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- `payload_bytes`
+- `sample_count`
+- `iteration_count`
+
+## Success metrics
+
+- Focused pytest passes for the code-eval payload fast path and registered probe smoke tests.
+- Changed-scope coverage for the touched Python path is at least 95%.
+- The local registered probe reports lower mean elapsed time or neutral elapsed time with unchanged/lower peak bytes.
+- `git diff --check` passes.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -351,12 +351,13 @@ def _json_field_value_start(payload_bytes: bytes, key: str) -> int | None:
         return None
     cursor = key_index + len(key_token)
     payload_length = len(payload_bytes)
-    while cursor < payload_length and payload_bytes[cursor] in b" \t\r\n":
+    whitespace = _JSON_PAYLOAD_WHITESPACE
+    while cursor < payload_length and payload_bytes[cursor] in whitespace:
         cursor += 1
     if cursor >= payload_length or payload_bytes[cursor] != ord(":"):
         return None
     cursor += 1
-    while cursor < payload_length and payload_bytes[cursor] in b" \t\r\n":
+    while cursor < payload_length and payload_bytes[cursor] in whitespace:
         cursor += 1
     if cursor >= payload_length:
         return None


### PR DESCRIPTION
## Summary
- Reuse the module-level JSON payload whitespace byte constant inside the code-eval payload fast-path field scanner.
- Keep the optimization scoped to separator skipping in `_json_field_value_start(...)`; no behavior or schema changes.

## Plan or Spec
- `docs/plans/2026-05-15-code-eval-json-whitespace-constant.md`

## Commands Run
```text
# Baseline local probe before edits
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
# exit 0; elapsed_ms_mean=226.96676258263844, peak_bytes_mean=60425.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
# exit 0; 7 passed in 2.34s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py
# exit 0; 7 passed in 7.07s; TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
# exit 0; elapsed_ms_mean=210.50788701644964, peak_bytes_mean=60425.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-payload-json-bytes --base-repo /tmp/melix-code-eval-json-whitespace-base --head-repo "$PWD" --output /tmp/code-eval-payload-json-whitespace-probe.json
# exit 0; head verification ok; base_probe elapsed_ms_mean=215.53597150237434; head_probe elapsed_ms_mean=215.17086887199963

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for `code_eval_runner.py` changed lines.
- Registered probe: `code-eval-payload-json-bytes` has focused `test_command`, `coverage_command`, and `probe_command` entries in `infra/perf/pr_scoped_probes.json` and covers the changed file.
- Local registered runner delta: `old_mean=215.53597150237434 ms`, `new_mean=215.17086887199963 ms`, `delta_ms=-0.365103`, `speedup=0.1694%`, `peak_bytes_mean` unchanged at `60425.0`.
- CI PR-scoped performance workflow is required as the authoritative registered-probe validation before merge.

## Known Gaps
- None for this Python-only slice. Full repository test gates were not run locally; focused registered test/coverage/probe commands were run.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability/debug mode changes.
- [x] Deferred work and known gaps are stated explicitly.
