### PR TITLE
Add DataDesigner synthetic dataset CLI

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -929,6 +929,100 @@ public struct DatasetRemoveOptions: Equatable, Sendable {
     }
 }
 
+public struct DatasetSyntheticOptions: Equatable, Sendable {
+    public let mode: String
+    public let datasetID: String
+    public let datasetName: String
+    public let numRecords: UInt32
+    public let outputKind: String
+    public let outputFormat: String
+    public let outputDir: String
+    public let providerEndpoint: String
+    public let providerName: String
+    public let providerType: String
+    public let apiKey: String
+    public let headers: [String]
+    public let modelAlias: String
+    public let model: String
+    public let temperature: String
+    public let topP: String
+    public let maxTokens: UInt32
+    public let timeoutSeconds: String
+    public let maxParallelRequests: UInt32
+    public let extraBodyJSON: String
+    public let columns: [String]
+    public let seedSourceKind: String
+    public let seedSourcePath: String
+    public let validationRatio: String
+    public let previewCount: UInt32
+    public let randomSeed: Int?
+    public let resume: String
+    public let enableDataDesignerTelemetry: Bool
+    public let json: Bool
+
+    public init(
+        mode: String,
+        datasetID: String,
+        datasetName: String,
+        numRecords: UInt32,
+        outputKind: String,
+        outputFormat: String,
+        outputDir: String,
+        providerEndpoint: String,
+        providerName: String = "melix",
+        providerType: String = "openai",
+        apiKey: String = "",
+        headers: [String] = [],
+        modelAlias: String = "generator",
+        model: String,
+        temperature: String = "",
+        topP: String = "",
+        maxTokens: UInt32 = 0,
+        timeoutSeconds: String = "",
+        maxParallelRequests: UInt32 = 0,
+        extraBodyJSON: String = "",
+        columns: [String],
+        seedSourceKind: String = "",
+        seedSourcePath: String = "",
+        validationRatio: String = "",
+        previewCount: UInt32 = 3,
+        randomSeed: Int? = nil,
+        resume: String = "never",
+        enableDataDesignerTelemetry: Bool = false,
+        json: Bool = false
+    ) {
+        self.mode = mode
+        self.datasetID = datasetID
+        self.datasetName = datasetName
+        self.numRecords = numRecords
+        self.outputKind = outputKind
+        self.outputFormat = outputFormat
+        self.outputDir = outputDir
+        self.providerEndpoint = providerEndpoint
+        self.providerName = providerName.isEmpty ? "melix" : providerName
+        self.providerType = providerType.isEmpty ? "openai" : providerType
+        self.apiKey = apiKey
+        self.headers = headers
+        self.modelAlias = modelAlias.isEmpty ? "generator" : modelAlias
+        self.model = model
+        self.temperature = temperature
+        self.topP = topP
+        self.maxTokens = maxTokens
+        self.timeoutSeconds = timeoutSeconds
+        self.maxParallelRequests = maxParallelRequests
+        self.extraBodyJSON = extraBodyJSON
+        self.columns = columns
+        self.seedSourceKind = seedSourceKind
+        self.seedSourcePath = seedSourcePath
+        self.validationRatio = validationRatio
+        self.previewCount = previewCount == 0 ? 3 : previewCount
+        self.randomSeed = randomSeed
+        self.resume = resume.isEmpty ? "never" : resume
+        self.enableDataDesignerTelemetry = enableDataDesignerTelemetry
+        self.json = json
+    }
+}
+
 public struct ModelDownloadOptions: Equatable, Sendable {
     public let modelID: String
     public let outputDir: String
@@ -1640,6 +1734,7 @@ public enum MelixCLICommand: Equatable, Sendable {
     case datasetList(DatasetListOptions)
     case datasetHubDownload(DatasetHubDownloadOptions)
     case datasetRemove(DatasetRemoveOptions)
+    case datasetSynthetic(DatasetSyntheticOptions)
     case uriInspect(URIInspectOptions)
     case uriImport(URIImportOptions)
     case recipesList(RecipeListOptions)
@@ -1878,6 +1973,8 @@ public enum MelixCLIParser {
       melix dataset list [--json]
       melix dataset hub download --repo-id HF_DATASET [--revision REV] [--hf-token TOKEN] [--json]
       melix dataset remove --repo-id HF_DATASET [--revision REV | --snapshot-id SHA] [--json]
+      melix dataset synthetic preview --dataset-id ID --dataset-name NAME --num-records N --output-kind KIND --output-format FORMAT --output-dir PATH --provider-endpoint URL --model MODEL --column NAME:TYPE:JSON [--model-alias ALIAS] [--api-key TOKEN] [--header KEY=VALUE ...] [--json]
+      melix dataset synthetic create --dataset-id ID --dataset-name NAME --num-records N --output-kind KIND --output-format FORMAT --output-dir PATH --provider-endpoint URL --model MODEL --column NAME:TYPE:JSON [--model-alias ALIAS] [--validation-ratio N] [--resume MODE] [--json]
       melix uri inspect URI [--json]
       melix uri import URI [--model-id MODEL_ID] [--revision REV] [--dry-run] [--json]
       melix recipes list [--task TASK] [--json]
@@ -2509,9 +2606,112 @@ public enum MelixCLIParser {
                     json: values.flags.contains("--json")
                 )
             )
+        case "synthetic":
+            return try parseDatasetSynthetic(Array(arguments.dropFirst()))
         default:
             throw MelixCLIError.usage(usageText)
         }
+    }
+
+    private static func parseDatasetSynthetic(_ arguments: [String]) throws -> MelixCLICommand {
+        guard let mode = arguments.first else {
+            throw MelixCLIError.usage(usageText)
+        }
+        guard ["preview", "create"].contains(mode) else {
+            throw MelixCLIError.usage(usageText)
+        }
+
+        let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse(
+            multiValueOptions: ["--column", "--header"],
+            valueLessFlags: ArgumentCursor.defaultValueLessFlags.subtracting(["--resume"]).union([
+                "--enable-datadesigner-telemetry",
+                "--disable-datadesigner-telemetry",
+            ])
+        )
+        guard let datasetID = nonEmpty(values.single["--dataset-id"]) else {
+            throw MelixCLIError.missingRequired("--dataset-id is required for melix dataset synthetic \(mode).")
+        }
+        guard let datasetName = nonEmpty(values.single["--dataset-name"]) else {
+            throw MelixCLIError.missingRequired("--dataset-name is required for melix dataset synthetic \(mode).")
+        }
+        guard let numRecords = try parseUInt32Value(values.single["--num-records"], option: "--num-records") else {
+            throw MelixCLIError.missingRequired("--num-records is required for melix dataset synthetic \(mode).")
+        }
+        guard let outputKind = nonEmpty(values.single["--output-kind"]) else {
+            throw MelixCLIError.missingRequired("--output-kind is required for melix dataset synthetic \(mode).")
+        }
+        guard let outputFormat = nonEmpty(values.single["--output-format"]) else {
+            throw MelixCLIError.missingRequired("--output-format is required for melix dataset synthetic \(mode).")
+        }
+        guard let outputDir = nonEmpty(values.single["--output-dir"]) else {
+            throw MelixCLIError.missingRequired("--output-dir is required for melix dataset synthetic \(mode).")
+        }
+        guard let providerEndpoint = nonEmpty(values.single["--provider-endpoint"]) else {
+            throw MelixCLIError.missingRequired("--provider-endpoint is required for melix dataset synthetic \(mode).")
+        }
+        guard let model = nonEmpty(values.single["--model"]) else {
+            throw MelixCLIError.missingRequired("--model is required for melix dataset synthetic \(mode).")
+        }
+        let columns = values.multi["--column"] ?? []
+        guard columns.isEmpty == false else {
+            throw MelixCLIError.missingRequired("--column is required for melix dataset synthetic \(mode).")
+        }
+        let resume = values.single["--resume"] ?? "never"
+        guard ["never", "if_possible", "always"].contains(resume) else {
+            throw MelixCLIError.usage("Invalid value for --resume. Expected never, if_possible, or always.")
+        }
+        guard values.flags.contains("--enable-datadesigner-telemetry") == false ||
+            values.flags.contains("--disable-datadesigner-telemetry") == false
+        else {
+            throw MelixCLIError.usage(
+                "--enable-datadesigner-telemetry and --disable-datadesigner-telemetry are mutually exclusive."
+            )
+        }
+        let seedSourceKind = values.single["--seed-source-kind"] ?? ""
+        let seedSourcePath = values.single["--seed-source-path"] ?? ""
+        if seedSourceKind.isEmpty != seedSourcePath.isEmpty {
+            throw MelixCLIError.usage("--seed-source-kind and --seed-source-path must be provided together.")
+        }
+
+        return .datasetSynthetic(
+            .init(
+                mode: mode,
+                datasetID: datasetID,
+                datasetName: datasetName,
+                numRecords: numRecords,
+                outputKind: outputKind,
+                outputFormat: outputFormat,
+                outputDir: outputDir,
+                providerEndpoint: providerEndpoint,
+                providerName: values.single["--provider-name"] ?? "melix",
+                providerType: values.single["--provider-type"] ?? "openai",
+                apiKey: values.single["--api-key"] ?? "",
+                headers: values.multi["--header"] ?? [],
+                modelAlias: values.single["--model-alias"] ?? "generator",
+                model: model,
+                temperature: values.single["--temperature"] ?? "",
+                topP: values.single["--top-p"] ?? "",
+                maxTokens: try parseUInt32Value(values.single["--max-tokens"], option: "--max-tokens") ?? 0,
+                timeoutSeconds: values.single["--timeout-seconds"] ?? "",
+                maxParallelRequests: try parseUInt32Value(
+                    values.single["--max-parallel-requests"],
+                    option: "--max-parallel-requests"
+                ) ?? 0,
+                extraBodyJSON: try canonicalInlineJSONObject(
+                    values.single["--extra-body-json"],
+                    option: "--extra-body-json"
+                ),
+                columns: columns,
+                seedSourceKind: seedSourceKind,
+                seedSourcePath: seedSourcePath,
+                validationRatio: values.single["--validation-ratio"] ?? "",
+                previewCount: try parseUInt32Value(values.single["--preview-count"], option: "--preview-count") ?? 3,
+                randomSeed: try parseIntValue(values.single["--random-seed"], option: "--random-seed"),
+                resume: resume,
+                enableDataDesignerTelemetry: values.flags.contains("--enable-datadesigner-telemetry"),
+                json: values.flags.contains("--json")
+            )
+        )
     }
 
     private static func parseDatasetHub(_ arguments: [String]) throws -> MelixCLICommand {
@@ -4444,6 +4644,31 @@ public enum MelixCLIParser {
         return String(decoding: canonicalData, as: UTF8.self)
     }
 
+    private static func canonicalInlineJSONObject(_ value: String?, option: String) throws -> String {
+        guard let value, value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
+            return ""
+        }
+        guard let data = value.data(using: .utf8) else {
+            throw MelixCLIError.usage("\(option) must contain valid UTF-8 JSON.")
+        }
+        let parsed: Any
+        do {
+            parsed = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw MelixCLIError.usage("\(option) must contain valid JSON: \(error.localizedDescription)")
+        }
+        guard parsed is [String: Any] else {
+            throw MelixCLIError.usage("\(option) must contain a JSON object.")
+        }
+        let canonicalData = try JSONSerialization.data(withJSONObject: parsed, options: [.sortedKeys])
+        return String(decoding: canonicalData, as: UTF8.self)
+    }
+
+    private static func canonicalJSONStringArray(_ values: [String]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: values, options: [.sortedKeys])
+        return String(decoding: data, as: UTF8.self)
+    }
+
     private struct EvaluationFileMetadata {
         let resolvedPath: String
         let data: Data
@@ -4629,6 +4854,11 @@ public enum MelixCLIParser {
 
     private static func trimmedOption(_ value: String?) -> String {
         value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        let trimmed = trimmedOption(value)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private static func normalizedServingDefaultsAccelerationMode(
@@ -5190,6 +5420,74 @@ public actor MelixCLIRunner {
         )
     }
 
+    public func generateSyntheticDataset(
+        options: DatasetSyntheticOptions
+    ) async throws -> Melix_Controlplane_V1_ModelOperationResult {
+        try await performModelOperation(
+            modelID: "melix-datasets",
+            operation: "generate_synthetic_dataset",
+            outputDir: options.outputDir,
+            ext: try syntheticDatasetExt(from: options)
+        )
+    }
+
+    private func syntheticDatasetExt(from options: DatasetSyntheticOptions) throws -> [String: String] {
+        var ext: [String: String] = [
+            "synthetic_mode": options.mode,
+            "synthetic_dataset_id": options.datasetID,
+            "synthetic_dataset_name": options.datasetName,
+            "synthetic_num_records": String(options.numRecords),
+            "synthetic_output_kind": options.outputKind,
+            "synthetic_output_format": options.outputFormat,
+            "provider_endpoint": options.providerEndpoint,
+            "provider_name": options.providerName,
+            "provider_type": options.providerType,
+            "model_alias": options.modelAlias,
+            "model": options.model,
+            "preview_count": String(options.previewCount),
+            "resume": options.resume,
+            "disable_datadesigner_telemetry": options.enableDataDesignerTelemetry ? "false" : "true",
+        ]
+        if options.apiKey.isEmpty == false {
+            ext["api_key"] = options.apiKey
+        }
+        if options.headers.isEmpty == false {
+            ext["headers_json"] = try Self.canonicalJSONStringArray(options.headers)
+        }
+        if options.temperature.isEmpty == false {
+            ext["temperature"] = options.temperature
+        }
+        if options.topP.isEmpty == false {
+            ext["top_p"] = options.topP
+        }
+        if options.maxTokens > 0 {
+            ext["max_tokens"] = String(options.maxTokens)
+        }
+        if options.timeoutSeconds.isEmpty == false {
+            ext["timeout_seconds"] = options.timeoutSeconds
+        }
+        if options.maxParallelRequests > 0 {
+            ext["max_parallel_requests"] = String(options.maxParallelRequests)
+        }
+        if options.extraBodyJSON.isEmpty == false {
+            ext["extra_body_json"] = options.extraBodyJSON
+        }
+        if options.columns.isEmpty == false {
+            ext["columns_json"] = try Self.canonicalJSONStringArray(options.columns)
+        }
+        if options.seedSourceKind.isEmpty == false {
+            ext["seed_source_kind"] = options.seedSourceKind
+            ext["seed_source_path"] = options.seedSourcePath
+        }
+        if options.validationRatio.isEmpty == false {
+            ext["validation_ratio"] = options.validationRatio
+        }
+        if let randomSeed = options.randomSeed {
+            ext["random_seed"] = String(randomSeed)
+        }
+        return ext
+    }
+
     public func downloadModel(
         modelID: String,
         outputDir: String = ""
@@ -5662,6 +5960,9 @@ public actor MelixCLIRunner {
                 snapshotID: options.snapshotID
             )
             return options.json ? result.manifestJson : renderDatasetRemoveResult(result)
+        case .datasetSynthetic(let options):
+            let result = try await generateSyntheticDataset(options: options)
+            return options.json ? result.manifestJson : renderSyntheticDatasetResult(result)
         case .modelRootsList(let options):
             let state = try loadOperatorState()
             if options.json {
@@ -6577,6 +6878,43 @@ public actor MelixCLIRunner {
             appendOption("--snapshot-id", value: ext["melix.hf_snapshot_id"], into: &arguments)
             arguments.append("--json")
             return arguments
+        case "generate_synthetic_dataset":
+            var arguments = [
+                "dataset",
+                "synthetic",
+                ext["synthetic_mode"] ?? "create",
+            ]
+            appendOption("--dataset-id", value: ext["synthetic_dataset_id"], into: &arguments)
+            appendOption("--dataset-name", value: ext["synthetic_dataset_name"], into: &arguments)
+            appendOption("--num-records", value: ext["synthetic_num_records"], into: &arguments)
+            appendOption("--output-kind", value: ext["synthetic_output_kind"], into: &arguments)
+            appendOption("--output-format", value: ext["synthetic_output_format"], into: &arguments)
+            appendOption("--output-dir", value: outputDir, into: &arguments)
+            appendOption("--provider-endpoint", value: ext["provider_endpoint"], into: &arguments)
+            appendOption("--provider-name", value: ext["provider_name"], into: &arguments)
+            appendOption("--provider-type", value: ext["provider_type"], into: &arguments)
+            appendOption("--api-key", value: ext["api_key"], into: &arguments)
+            appendMultiOption("--header", values: Self.syntheticJSONArrayStrings(ext["headers_json"]), into: &arguments)
+            appendOption("--model-alias", value: ext["model_alias"], into: &arguments)
+            appendOption("--model", value: ext["model"], into: &arguments)
+            appendOption("--temperature", value: ext["temperature"], into: &arguments)
+            appendOption("--top-p", value: ext["top_p"], into: &arguments)
+            appendOption("--max-tokens", value: ext["max_tokens"], into: &arguments)
+            appendOption("--timeout-seconds", value: ext["timeout_seconds"], into: &arguments)
+            appendOption("--max-parallel-requests", value: ext["max_parallel_requests"], into: &arguments)
+            appendOption("--extra-body-json", value: ext["extra_body_json"], into: &arguments)
+            appendMultiOption("--column", values: Self.syntheticJSONArrayStrings(ext["columns_json"]), into: &arguments)
+            appendOption("--seed-source-kind", value: ext["seed_source_kind"], into: &arguments)
+            appendOption("--seed-source-path", value: ext["seed_source_path"], into: &arguments)
+            appendOption("--validation-ratio", value: ext["validation_ratio"], into: &arguments)
+            appendOption("--preview-count", value: ext["preview_count"], into: &arguments)
+            appendOption("--random-seed", value: ext["random_seed"], into: &arguments)
+            appendOption("--resume", value: ext["resume"], into: &arguments)
+            if ext["disable_datadesigner_telemetry"] == "false" {
+                arguments.append("--enable-datadesigner-telemetry")
+            }
+            arguments.append("--json")
+            return arguments
         case "registry_snapshot":
             return ["lora", "list", "--model-id", modelID, "--json"]
         case "download":
@@ -6766,6 +7104,22 @@ public actor MelixCLIRunner {
             return
         }
         arguments.append(option)
+    }
+
+    private static func syntheticJSONArrayStrings(_ raw: String?) -> [String] {
+        guard
+            let raw,
+            let data = raw.data(using: .utf8),
+            let values = try? JSONSerialization.jsonObject(with: data) as? [String]
+        else {
+            return []
+        }
+        return values
+    }
+
+    private static func canonicalJSONStringArray(_ values: [String]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: values, options: [.sortedKeys])
+        return String(decoding: data, as: UTF8.self)
     }
 
     private static func decodeSubprocessModelOperationResult(
@@ -8091,6 +8445,29 @@ public actor MelixCLIRunner {
             return headline + "\n"
         }
         return headline + "\nRemoved path: \(removedPath)\n"
+    }
+
+    private func renderSyntheticDatasetResult(_ result: Melix_Controlplane_V1_ModelOperationResult) -> String {
+        let outputPath = result.outputPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if outputPath.isEmpty == false {
+            return outputPath + "\n"
+        }
+        guard
+            let data = result.manifestJson.data(using: .utf8),
+            let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return "Synthetic dataset generation completed.\n"
+        }
+        let datasetID = (payload["dataset_id"] as? String) ?? ""
+        let datasetName = (payload["dataset_name"] as? String) ?? ""
+        let outputKind = (payload["output_kind"] as? String) ?? ""
+        let rowCount = ((payload["row_count"] as? NSNumber)?.intValue)
+            ?? ((payload["sample_count"] as? NSNumber)?.intValue)
+            ?? 0
+        let label = datasetID.isEmpty ? datasetName : datasetID
+        let target = label.isEmpty ? "Synthetic dataset" : "Synthetic dataset \(label)"
+        let suffix = outputKind.isEmpty ? "" : " (\(outputKind))"
+        return "\(target)\(suffix) generated with \(rowCount) rows.\n"
     }
 
     private func renderRegistrySnapshot(_ manifestJSON: String) -> String {

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -64,6 +64,8 @@ public enum MelixCLICommandCodec {
             return "dataset.hub.download"
         case .datasetRemove:
             return "dataset.remove"
+        case .datasetSynthetic(let options):
+            return "dataset.synthetic.\(options.mode)"
         case .uriInspect:
             return "uri.inspect"
         case .uriImport:
@@ -362,6 +364,42 @@ public enum MelixCLICommandCodec {
             appendOption("--repo-id", value: options.repoID, into: &arguments)
             appendOption("--revision", value: options.revision, into: &arguments)
             appendOption("--snapshot-id", value: options.snapshotID, into: &arguments)
+            json = options.json
+        case .datasetSynthetic(let options):
+            arguments = ["dataset", "synthetic", options.mode]
+            appendOption("--dataset-id", value: options.datasetID, into: &arguments)
+            appendOption("--dataset-name", value: options.datasetName, into: &arguments)
+            appendPositiveUInt32("--num-records", value: options.numRecords, into: &arguments)
+            appendOption("--output-kind", value: options.outputKind, into: &arguments)
+            appendOption("--output-format", value: options.outputFormat, into: &arguments)
+            appendOption("--output-dir", value: options.outputDir, into: &arguments)
+            appendOption("--provider-endpoint", value: options.providerEndpoint, into: &arguments)
+            appendOption("--provider-name", value: options.providerName, into: &arguments)
+            appendOption("--provider-type", value: options.providerType, into: &arguments)
+            appendOption("--api-key", value: options.apiKey, into: &arguments)
+            appendMultiOption("--header", values: options.headers, into: &arguments)
+            appendOption("--model-alias", value: options.modelAlias, into: &arguments)
+            appendOption("--model", value: options.model, into: &arguments)
+            appendOption("--temperature", value: options.temperature, into: &arguments)
+            appendOption("--top-p", value: options.topP, into: &arguments)
+            appendPositiveUInt32("--max-tokens", value: options.maxTokens, into: &arguments)
+            appendOption("--timeout-seconds", value: options.timeoutSeconds, into: &arguments)
+            appendPositiveUInt32("--max-parallel-requests", value: options.maxParallelRequests, into: &arguments)
+            appendOption("--extra-body-json", value: options.extraBodyJSON, into: &arguments)
+            appendMultiOption("--column", values: options.columns, into: &arguments)
+            appendOption("--seed-source-kind", value: options.seedSourceKind, into: &arguments)
+            appendOption("--seed-source-path", value: options.seedSourcePath, into: &arguments)
+            appendOption("--validation-ratio", value: options.validationRatio, into: &arguments)
+            if options.previewCount != 3 {
+                appendPositiveUInt32("--preview-count", value: options.previewCount, into: &arguments)
+            }
+            if let randomSeed = options.randomSeed {
+                appendOption("--random-seed", value: String(randomSeed), into: &arguments)
+            }
+            appendOption("--resume", value: options.resume, into: &arguments)
+            if options.enableDataDesignerTelemetry {
+                arguments.append("--enable-datadesigner-telemetry")
+            }
             json = options.json
         case .modelRootsRescan(let options):
             arguments = ["model", "roots", "rescan"]

--- a/docs/plans/2026-05-12-datadesigner-synthetic-dataset-function.md
+++ b/docs/plans/2026-05-12-datadesigner-synthetic-dataset-function.md
@@ -70,15 +70,97 @@ Current Melix contracts:
 
 ## Implementation Status
 
-This slice implements the worker/productization adapter and dependency contract:
+This plan now covers the worker/productization adapter plus the first public CLI
+surface:
 
 - `services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py`
 - `services/mlx-worker-python/tests/test_synthetic_dataset_generation.py`
 - optional worker extra `synthetic-data = ["data-designer>=0.5.9,<0.6"]`
+- `melix dataset synthetic preview`
+- `melix dataset synthetic create`
 
-Public CLI, protobuf RPC, registry browse UI, and native studio surfaces remain
-separate follow-up slices because they touch operator-facing workflows beyond
-the function boundary.
+Native registry browse UI and native studio surfaces remain separate follow-up
+slices because they touch operator-facing workflows beyond the function
+boundary. The first CLI surface reuses the existing model-operation request path
+and worker dataset-operation dispatch so no protobuf schema change is required.
+
+## CLI Surface
+
+The first public entry point is:
+
+```bash
+melix dataset synthetic preview \
+  --dataset-id synthetic.chat.preview \
+  --dataset-name "Synthetic Chat Preview" \
+  --num-records 3 \
+  --output-kind training \
+  --output-format prompt_completion \
+  --output-dir .runtime/synthetic/preview \
+  --provider-endpoint http://127.0.0.1:12436/v1 \
+  --model melix-dev-text \
+  --column 'prompt:llm_text:{"prompt":"Write a training prompt."}' \
+  --column 'completion:llm_text:{"prompt":"Answer the prompt."}' \
+  --json
+```
+
+```bash
+melix dataset synthetic create \
+  --dataset-id synthetic.chat.v1 \
+  --dataset-name "Synthetic Chat" \
+  --num-records 100 \
+  --output-kind training \
+  --output-format prompt_completion \
+  --output-dir .runtime/synthetic/chat-v1 \
+  --provider-endpoint http://127.0.0.1:12436/v1 \
+  --model-alias generator \
+  --model melix-dev-text \
+  --column 'prompt:llm_text:{"prompt":"Write a training prompt."}' \
+  --column 'completion:llm_text:{"prompt":"Answer the prompt."}' \
+  --validation-ratio 0.1 \
+  --resume never \
+  --json
+```
+
+Required parameters for both modes:
+
+- `--dataset-id`
+- `--dataset-name`
+- `--num-records`
+- `--output-kind`
+- `--output-format`
+- `--output-dir`
+- `--provider-endpoint`
+- `--model`
+- at least one `--column`
+
+Optional provider/model controls:
+
+- `--provider-name` defaults to `melix`
+- `--provider-type` defaults to `openai`
+- `--api-key`
+- repeated `--header KEY=VALUE`
+- `--model-alias` defaults to `generator`
+- `--temperature`
+- `--top-p`
+- `--max-tokens`
+- `--timeout-seconds`
+- `--max-parallel-requests`
+- `--extra-body-json`
+
+Optional dataset controls:
+
+- `--seed-source-kind` with `--seed-source-path`
+- `--validation-ratio`
+- `--preview-count`
+- `--random-seed`
+- `--resume never|if_possible|always`
+- `--enable-datadesigner-telemetry`
+
+Columns use `NAME:TYPE:JSON_OR_PATH`. JSON payloads map directly to DataDesigner
+column parameters. Non-JSON payloads are treated conservatively as prompt text
+for LLM columns, expression text for expression columns, and sampler values for
+sampler columns. A payload prefixed with `@` or pointing at an existing file is
+expanded from that file before it is passed to the worker.
 
 ## Function Boundary
 

--- a/services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift
+++ b/services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift
@@ -2682,6 +2682,16 @@ public actor ControlPlaneService {
             }
             let sourcePath = command.ext["source_path"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             return sourcePath.isEmpty == false
+        case "dataset_snapshot":
+            return command.modelID.trimmingCharacters(in: .whitespacesAndNewlines) == "melix-datasets"
+        case "dataset_download", "dataset_remove":
+            let repoID = command.ext["melix.hf_dataset_repo_id"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return repoID.isEmpty == false
+        case "generate_synthetic_dataset":
+            let datasetID = command.ext["synthetic_dataset_id"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let endpoint = command.ext["provider_endpoint"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let model = command.ext["model"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return datasetID.isEmpty == false && endpoint.isEmpty == false && model.isEmpty == false
         default:
             return false
         }

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift
@@ -2030,6 +2030,84 @@ struct ControlPlaneServiceTests {
         #expect(request.ext["melix.registry_roots_json"] == #"["/tmp/root-b","/tmp/root-a"]"#)
     }
 
+    @Test("synthetic dataset operations are allowed without a catalog model when required inputs are present")
+    func syntheticDatasetOperationsAreAllowedWithoutCatalogModelWhenRequiredInputsArePresent() async throws {
+        let modelOpsClient = ScriptedModelOperationsWorkerClient()
+        await modelOpsClient.setConvertEvents([
+            {
+                var event = Melix_Worker_V1_ConvertModelEvent()
+                event.manifest = Melix_Worker_V1_ConvertManifest()
+                event.manifest.manifestJson = #"{"operation":"generate_synthetic_dataset","dataset_id":"synthetic.chat.v1"}"#
+                return event
+            }(),
+            {
+                var event = Melix_Worker_V1_ConvertModelEvent()
+                event.completed = Melix_Worker_V1_ConvertCompleted()
+                event.completed.outputPath = "/tmp/melix/synthetic/samples.jsonl"
+                return event
+            }(),
+        ])
+        let service = ControlPlaneService(
+            modelCatalog: ModelCatalog(seedModels: []),
+            workerRegistry: WorkerRegistry(
+                defaultTextClient: NullWorkerClient(),
+                modelOperationsClient: modelOpsClient
+            )
+        )
+        let ext = [
+            "synthetic_dataset_id": "synthetic.chat.v1",
+            "provider_endpoint": "http://127.0.0.1:12436/v1",
+            "model": "melix-dev-text",
+        ]
+
+        let response = try await service.execute(
+            makeRunModelOperationRequest(
+                modelID: "melix-datasets",
+                operation: "generate_synthetic_dataset",
+                outputDir: "/tmp/melix/synthetic",
+                ext: ext
+            )
+        )
+        let request = try #require(await modelOpsClient.lastConvertRequest)
+
+        #expect(response.ok)
+        #expect(response.model.operation.operation == "generate_synthetic_dataset")
+        #expect(response.model.operation.outputPath == "/tmp/melix/synthetic/samples.jsonl")
+        #expect(request.sourceModel == "melix-datasets")
+        #expect(request.outputDir == "/tmp/melix/synthetic")
+        #expect(request.ext["operation"] == "generate_synthetic_dataset")
+        #expect(request.ext["synthetic_dataset_id"] == "synthetic.chat.v1")
+    }
+
+    @Test("synthetic dataset operations require the managed import discriminator inputs")
+    func syntheticDatasetOperationsRequireManagedImportDiscriminatorInputs() async throws {
+        let modelOpsClient = ScriptedModelOperationsWorkerClient()
+        let service = ControlPlaneService(
+            modelCatalog: ModelCatalog(seedModels: []),
+            workerRegistry: WorkerRegistry(
+                defaultTextClient: NullWorkerClient(),
+                modelOperationsClient: modelOpsClient
+            )
+        )
+
+        let response = try await service.execute(
+            makeRunModelOperationRequest(
+                modelID: "melix-datasets",
+                operation: "generate_synthetic_dataset",
+                outputDir: "/tmp/melix/synthetic",
+                ext: [
+                    "synthetic_dataset_id": "synthetic.chat.v1",
+                    "provider_endpoint": "http://127.0.0.1:12436/v1",
+                ]
+            )
+        )
+
+        let requests = await modelOpsClient.convertRequests
+        #expect(!response.ok)
+        #expect(response.error.code == "not_found")
+        #expect(requests.allSatisfy { $0.ext["operation"] != "generate_synthetic_dataset" })
+    }
+
     @Test("execute handles model.load on the local fast path")
     func executeHandlesLocalModelLoad() async throws {
         let service = ControlPlaneService()

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -951,6 +951,30 @@ def test_synthetic_dataset_request_uses_defaults_and_column_shortcuts(tmp_path: 
     assert request.columns[4].params == {}
 
 
+def test_synthetic_dataset_column_shortcuts_only_read_explicit_at_files(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("file-backed prompt", encoding="utf-8")
+
+    request = maintenance_core_module._synthetic_dataset_request_from_ext(
+        _synthetic_dataset_base_ext(
+            columns_json=json.dumps(
+                [
+                    f"literal:llm_text:{prompt_file}",
+                    f"expanded:llm_text:@{prompt_file}",
+                    "missing:llm_text:@/does/not/exist.txt",
+                    "empty:llm_text:@",
+                ]
+            )
+        ),
+        job_id="job-explicit-files",
+    )
+
+    assert request.columns[0].params == {"prompt": str(prompt_file)}
+    assert request.columns[1].params == {"prompt": "file-backed prompt"}
+    assert request.columns[2].params == {"prompt": "@/does/not/exist.txt"}
+    assert request.columns[3].params == {"prompt": "@"}
+
+
 @pytest.mark.parametrize(
     ("overrides", "message"),
     [

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -5821,6 +5821,11 @@ def test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs(
     assert core._benchmark_prompt_token_count("one two") == 2
     assert core._shape_benchmark_prompt("one two", context_length=6) == "one two one two one two"
     assert MaintenanceCore._shape_benchmark_prompt.cache_info().hits == 1
+    shaped_long_prompt = core._shape_benchmark_prompt("alpha beta", context_length=128)
+    assert shaped_long_prompt.token_count == 128
+    assert shaped_long_prompt._tokens is None
+    assert shaped_long_prompt.tokens[:4] == ("alpha", "beta", "alpha", "beta")
+    assert shaped_long_prompt.token_count == 128
     MaintenanceCore._shape_benchmark_prompt.cache_clear()
 
     shape_calls: list[tuple[str, int]] = []

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -780,6 +780,210 @@ def test_convert_model_supports_convert_and_quantize_jobs(tmp_path: Path) -> Non
     assert quantize_payload["kv_quant"] == "q8"
 
 
+def test_convert_model_dispatches_synthetic_dataset_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = build_service(tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_generate_synthetic_dataset_package(request, *, jobs_root, output_dir, progress=None):
+        captured["request"] = request
+        captured["jobs_root"] = jobs_root
+        captured["output_dir"] = output_dir
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / "samples.jsonl"
+        output_path.write_text('{"prompt":"hello","completion":"world"}\n', encoding="utf-8")
+        manifest_path = output_dir / "manifest.json"
+        manifest_payload = {
+            "schema_version": "melix.training_dataset_package.v1",
+            "operation": "generate_synthetic_dataset",
+            "dataset_id": request.dataset_id,
+            "dataset_name": request.dataset_name,
+            "output_kind": request.output_kind,
+            "row_count": request.num_records,
+        }
+        manifest_path.write_text(json.dumps(manifest_payload), encoding="utf-8")
+        if progress is not None:
+            progress("generate_rows", 0.35)
+            progress("complete", 1.0)
+        return SimpleNamespace(
+            manifest_payload=manifest_payload,
+            manifest_path=manifest_path,
+            output_path=output_path,
+        )
+
+    monkeypatch.setattr(
+        maintenance_core_module,
+        "generate_synthetic_dataset_package",
+        fake_generate_synthetic_dataset_package,
+    )
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-datasets",
+                output_dir=str(tmp_path / "synthetic"),
+                generate_manifest=True,
+                ext={
+                    "operation": "generate_synthetic_dataset",
+                    "synthetic_mode": "create",
+                    "synthetic_dataset_id": "synthetic.chat.v1",
+                    "synthetic_dataset_name": "Synthetic Chat",
+                    "synthetic_num_records": "4",
+                    "synthetic_output_kind": "training",
+                    "synthetic_output_format": "prompt_completion",
+                    "provider_endpoint": "http://127.0.0.1:12436/v1",
+                    "provider_name": "melix",
+                    "provider_type": "openai",
+                    "api_key": "sk-secret",
+                    "headers_json": '["X-Test=1"]',
+                    "model_alias": "generator",
+                    "model": "melix-dev-text",
+                    "temperature": "0.2",
+                    "top_p": "0.9",
+                    "max_tokens": "128",
+                    "timeout_seconds": "30",
+                    "max_parallel_requests": "2",
+                    "extra_body_json": '{"seed":7}',
+                    "columns_json": '["prompt:llm_text:{\\"prompt\\":\\"write\\"}"]',
+                    "validation_ratio": "0.1",
+                    "preview_count": "2",
+                    "random_seed": "7",
+                    "resume": "never",
+                    "disable_datadesigner_telemetry": "true",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    request = captured["request"]
+    assert request.dataset_id == "synthetic.chat.v1"
+    assert request.dataset_name == "Synthetic Chat"
+    assert request.mode == "create"
+    assert request.num_records == 4
+    assert request.output_kind == "training"
+    assert request.output_format == "prompt_completion"
+    assert request.model_provider.endpoint == "http://127.0.0.1:12436/v1"
+    assert request.model_provider.api_key == "sk-secret"
+    assert request.model_provider.extra_headers == {"X-Test": "1"}
+    assert request.models[0].alias == "generator"
+    assert request.models[0].model == "melix-dev-text"
+    assert request.models[0].temperature == 0.2
+    assert request.models[0].top_p == 0.9
+    assert request.models[0].max_tokens == 128
+    assert request.models[0].timeout_seconds == 30.0
+    assert request.models[0].max_parallel_requests == 2
+    assert request.models[0].extra_body == {"seed": 7}
+    assert request.columns[0].name == "prompt"
+    assert request.columns[0].column_type == "llm_text"
+    assert request.columns[0].params == {"prompt": "write"}
+    assert request.validation_ratio == 0.1
+    assert request.preview_count == 2
+    assert request.random_seed == 7
+    assert request.disable_data_designer_telemetry is True
+    assert events[0].HasField("started")
+    assert any(event.HasField("progress") and event.progress.stage == "generate_rows" for event in events)
+    manifest = next(event.manifest for event in events if event.HasField("manifest"))
+    manifest_payload = json.loads(manifest.manifest_json)
+    assert manifest_payload["operation"] == "generate_synthetic_dataset"
+    assert manifest_payload["job_id"].startswith("model-ops-")
+    assert events[-1].HasField("completed")
+    assert events[-1].completed.output_path.endswith("samples.jsonl")
+
+
+def _synthetic_dataset_base_ext(**overrides: str) -> dict[str, str]:
+    ext = {
+        "synthetic_dataset_id": "synthetic.chat.v1",
+        "synthetic_dataset_name": "Synthetic Chat",
+        "synthetic_num_records": "4",
+        "synthetic_output_kind": "training",
+        "synthetic_output_format": "prompt_completion",
+        "provider_endpoint": "http://127.0.0.1:12436/v1",
+        "model": "melix-dev-text",
+        "columns_json": json.dumps(["prompt:llm_text:Write a prompt"]),
+    }
+    ext.update(overrides)
+    return ext
+
+
+def test_synthetic_dataset_request_uses_defaults_and_column_shortcuts(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("Write a useful training prompt.", encoding="utf-8")
+    seed_file = tmp_path / "seed.jsonl"
+    seed_file.write_text('{"topic":"swift"}\n', encoding="utf-8")
+
+    request = maintenance_core_module._synthetic_dataset_request_from_ext(
+        _synthetic_dataset_base_ext(
+            columns_json=json.dumps(
+                [
+                    f"prompt:llm_text:@{prompt_file}",
+                    "answer:expression:row.topic.upper()",
+                    "label:sampler:positive,negative",
+                    "tag:constant:static",
+                    "empty:metadata:",
+                ]
+            ),
+            seed_source_kind="jsonl",
+            seed_source_path=str(seed_file),
+            disable_datadesigner_telemetry="false",
+        ),
+        job_id="job-defaults",
+    )
+
+    assert request.mode == "create"
+    assert request.model_provider.name == "melix"
+    assert request.model_provider.provider_type == "openai"
+    assert request.models[0].alias == "generator"
+    assert request.models[0].temperature is None
+    assert request.models[0].max_tokens is None
+    assert request.validation_ratio == 0.0
+    assert request.preview_count == 3
+    assert request.random_seed is None
+    assert request.disable_data_designer_telemetry is False
+    assert request.seed_source is not None
+    assert request.seed_source.source_path == seed_file
+    assert request.columns[0].params == {"prompt": "Write a useful training prompt."}
+    assert request.columns[1].params == {"expression": "row.topic.upper()"}
+    assert request.columns[2].params == {"values": "positive,negative"}
+    assert request.columns[3].params == {"value": "static"}
+    assert request.columns[4].params == {}
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"synthetic_dataset_id": ""}, "synthetic_dataset_id is required"),
+        ({"synthetic_num_records": ""}, "synthetic_num_records must be greater than zero"),
+        ({"synthetic_num_records": "many"}, "synthetic_num_records must be an integer"),
+        ({"preview_count": "0"}, "preview_count must be greater than zero"),
+        ({"random_seed": "abc"}, "random_seed must be an integer"),
+        ({"temperature": "hot"}, "temperature must be numeric"),
+        ({"disable_datadesigner_telemetry": "maybe"}, "disable_datadesigner_telemetry must be a boolean"),
+        ({"extra_body_json": "{"}, "extra_body_json must be valid JSON"),
+        ({"extra_body_json": "[]"}, "extra_body_json must be a JSON object"),
+        ({"headers_json": "{"}, "headers_json must be valid JSON"),
+        ({"headers_json": "{}"}, "headers_json must be a JSON array"),
+        ({"headers_json": json.dumps(["bad"])}, "Synthetic provider headers must use KEY=VALUE syntax"),
+        ({"columns_json": json.dumps(["bad"])}, "Synthetic columns must use NAME:TYPE:JSON_OR_PATH syntax"),
+        ({"columns_json": "[]"}, "At least one synthetic column is required"),
+        ({"columns_json": json.dumps(["prompt:llm_text:{"])}, "Synthetic column JSON parameters must be valid JSON"),
+        ({"columns_json": json.dumps(["prompt:llm_text:[]"])}, "Synthetic column JSON parameters must be an object"),
+        ({"seed_source_kind": "jsonl"}, "seed_source_kind and seed_source_path must be provided together"),
+    ],
+)
+def test_synthetic_dataset_request_rejects_malformed_ext(
+    overrides: dict[str, str],
+    message: str,
+) -> None:
+    with pytest.raises(ModelOperationError, match=message):
+        maintenance_core_module._synthetic_dataset_request_from_ext(
+            _synthetic_dataset_base_ext(**overrides),
+            job_id="job-invalid",
+        )
+
+
 def test_convert_model_writes_manifest_once_after_in_memory_byte_convergence(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -39,6 +39,14 @@ from worker.model_ops.training_dataset import build_training_dataset_artifact
 from worker.model_ops.upload_receipt_pipeline import UploadReceiptPipeline
 from worker.productization.benchmark_queue import BenchmarkQueueRecord, BenchmarkQueueStore
 from worker.productization.benchmark_suites import BenchmarkSuiteCatalog, ResolvedBenchmarkSuite
+from worker.productization.synthetic_dataset_generation import (
+    SyntheticColumnSpec,
+    SyntheticDatasetRequest,
+    SyntheticModelConfig,
+    SyntheticModelProvider,
+    SyntheticSeedSource,
+    generate_synthetic_dataset_package,
+)
 from worker.registry import WorkerRegistry
 from worker.runtime.agentic_tools import execute_agentic_tool_calls
 from worker.runtime.multimodal_preprocessing import PreparedVisionRequest
@@ -251,6 +259,269 @@ def _write_jsonl_rows(path: Path, rows: list[dict[str, Any]]) -> None:
             handle.write(json.dumps(row) + "\n")
 
 
+def _synthetic_dataset_request_from_ext(
+    ext: dict[str, str],
+    *,
+    job_id: str,
+) -> SyntheticDatasetRequest:
+    columns = _synthetic_columns_from_ext(ext)
+    seed_source = _synthetic_seed_source_from_ext(ext)
+    return SyntheticDatasetRequest(
+        dataset_id=_required_ext(ext, "synthetic_dataset_id"),
+        dataset_name=_required_ext(ext, "synthetic_dataset_name"),
+        mode=ext.get("synthetic_mode", "").strip() or "create",
+        num_records=_positive_int_ext(ext, "synthetic_num_records"),
+        output_kind=_required_ext(ext, "synthetic_output_kind"),
+        output_format=_required_ext(ext, "synthetic_output_format"),
+        model_provider=SyntheticModelProvider(
+            endpoint=_required_ext(ext, "provider_endpoint"),
+            name=ext.get("provider_name", "").strip() or "melix",
+            provider_type=ext.get("provider_type", "").strip() or "openai",
+            api_key=ext.get("api_key", "").strip(),
+            extra_headers=_synthetic_headers_from_ext(ext),
+        ),
+        models=(
+            SyntheticModelConfig(
+                alias=ext.get("model_alias", "").strip() or "generator",
+                model=_required_ext(ext, "model"),
+                temperature=_optional_float_ext(ext, "temperature"),
+                top_p=_optional_float_ext(ext, "top_p"),
+                max_tokens=_optional_positive_int_ext(ext, "max_tokens"),
+                timeout_seconds=_optional_float_ext(ext, "timeout_seconds"),
+                max_parallel_requests=_optional_positive_int_ext(ext, "max_parallel_requests"),
+                extra_body=_json_object_ext(ext, "extra_body_json", default={}),
+            ),
+        ),
+        columns=columns,
+        job_id=job_id,
+        seed_source=seed_source,
+        validation_ratio=_optional_float_ext(ext, "validation_ratio") or 0.0,
+        preview_count=_optional_positive_int_ext(ext, "preview_count") or 3,
+        random_seed=_optional_int_ext(ext, "random_seed"),
+        data_designer_resume_mode=ext.get("resume", "").strip() or "never",
+        disable_data_designer_telemetry=_boolean_ext(ext, "disable_datadesigner_telemetry", default=True),
+    )
+
+
+def _required_ext(ext: dict[str, str], key: str) -> str:
+    value = ext.get(key, "").strip()
+    if not value:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message=f"{key} is required for synthetic dataset generation.",
+            details={"field": key},
+        )
+    return value
+
+
+def _positive_int_ext(ext: dict[str, str], key: str) -> int:
+    value = _optional_positive_int_ext(ext, key)
+    if value is None:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message=f"{key} must be greater than zero.",
+            details={"field": key},
+        )
+    return value
+
+
+def _optional_positive_int_ext(ext: dict[str, str], key: str) -> int | None:
+    raw_value = ext.get(key, "").strip()
+    if not raw_value:
+        return None
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message=f"{key} must be an integer.",
+            details={"field": key, "value": raw_value},
+        ) from exc
+    if value <= 0:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message=f"{key} must be greater than zero.",
+            details={"field": key, "value": raw_value},
+        )
+    return value
+
+
+def _optional_int_ext(ext: dict[str, str], key: str) -> int | None:
+    raw_value = ext.get(key, "").strip()
+    if not raw_value:
+        return None
+    try:
+        return int(raw_value)
+    except ValueError as exc:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message=f"{key} must be an integer.",
+            details={"field": key, "value": raw_value},
+        ) from exc
+
+
+def _optional_float_ext(ext: dict[str, str], key: str) -> float | None:
+    raw_value = ext.get(key, "").strip()
+    if not raw_value:
+        return None
+    try:
+        return float(raw_value)
+    except ValueError as exc:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message=f"{key} must be numeric.",
+            details={"field": key, "value": raw_value},
+        ) from exc
+
+
+def _boolean_ext(ext: dict[str, str], key: str, *, default: bool) -> bool:
+    raw_value = ext.get(key, "").strip().lower()
+    if not raw_value:
+        return default
+    if raw_value in {"1", "true", "yes", "on"}:
+        return True
+    if raw_value in {"0", "false", "no", "off"}:
+        return False
+    raise ModelOperationError(
+        code="invalid_synthetic_dataset_request",
+        message=f"{key} must be a boolean.",
+        details={"field": key, "value": raw_value},
+    )
+
+
+def _json_object_ext(ext: dict[str, str], key: str, *, default: dict[str, Any]) -> dict[str, Any]:
+    raw_value = ext.get(key, "").strip()
+    if not raw_value:
+        return default
+    try:
+        payload = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message=f"{key} must be valid JSON.",
+            details={"field": key},
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message=f"{key} must be a JSON object.",
+            details={"field": key},
+        )
+    return payload
+
+
+def _json_string_list_ext(ext: dict[str, str], key: str) -> list[str]:
+    raw_value = ext.get(key, "").strip()
+    if not raw_value:
+        return []
+    try:
+        payload = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message=f"{key} must be valid JSON.",
+            details={"field": key},
+        ) from exc
+    if not isinstance(payload, list):
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message=f"{key} must be a JSON array.",
+            details={"field": key},
+        )
+    return [str(item) for item in payload]
+
+
+def _synthetic_headers_from_ext(ext: dict[str, str]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for raw_header in _json_string_list_ext(ext, "headers_json"):
+        key, separator, value = raw_header.partition("=")
+        key = key.strip()
+        if not separator or not key:
+            raise ModelOperationError(
+                code="invalid_synthetic_dataset_request",
+                message="Synthetic provider headers must use KEY=VALUE syntax.",
+                details={"header": raw_header},
+            )
+        headers[key] = value
+    return headers
+
+
+def _synthetic_columns_from_ext(ext: dict[str, str]) -> tuple[SyntheticColumnSpec, ...]:
+    columns: list[SyntheticColumnSpec] = []
+    for raw_column in _json_string_list_ext(ext, "columns_json"):
+        parts = raw_column.split(":", 2)
+        if len(parts) != 3 or not parts[0].strip() or not parts[1].strip():
+            raise ModelOperationError(
+                code="invalid_synthetic_dataset_request",
+                message="Synthetic columns must use NAME:TYPE:JSON_OR_PATH syntax.",
+                details={"column": raw_column},
+            )
+        name, column_type, raw_params = parts[0].strip(), parts[1].strip(), parts[2].strip()
+        columns.append(
+            SyntheticColumnSpec(
+                name=name,
+                column_type=column_type,
+                params=_synthetic_column_params(column_type, raw_params),
+            )
+        )
+    if not columns:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message="At least one synthetic column is required.",
+        )
+    return tuple(columns)
+
+
+def _synthetic_column_params(column_type: str, raw_params: str) -> dict[str, Any]:
+    if not raw_params:
+        return {}
+    if raw_params.startswith(("{", "[")):
+        try:
+            payload = json.loads(raw_params)
+        except json.JSONDecodeError as exc:
+            raise ModelOperationError(
+                code="invalid_synthetic_dataset_request",
+                message="Synthetic column JSON parameters must be valid JSON.",
+                details={"column_type": column_type},
+            ) from exc
+        if not isinstance(payload, dict):
+            raise ModelOperationError(
+                code="invalid_synthetic_dataset_request",
+                message="Synthetic column JSON parameters must be an object.",
+                details={"column_type": column_type},
+            )
+        return payload
+    value = _synthetic_column_payload_value(raw_params)
+    if column_type in {"llm_text", "llm_structured", "llm_judge"}:
+        return {"prompt": value}
+    if column_type == "expression":
+        return {"expression": value}
+    if column_type == "sampler":
+        return {"values": value}
+    return {"value": value}
+
+
+def _synthetic_column_payload_value(raw_params: str) -> str:
+    candidate = raw_params[1:] if raw_params.startswith("@") else raw_params
+    path = Path(candidate).expanduser()
+    if path.is_file():
+        return path.read_text(encoding="utf-8")
+    return raw_params
+
+
+def _synthetic_seed_source_from_ext(ext: dict[str, str]) -> SyntheticSeedSource | None:
+    source_kind = ext.get("seed_source_kind", "").strip()
+    source_path = ext.get("seed_source_path", "").strip()
+    if not source_kind and not source_path:
+        return None
+    if not source_kind or not source_path:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message="seed_source_kind and seed_source_path must be provided together.",
+        )
+    return SyntheticSeedSource(source_kind=source_kind, source_path=Path(source_path))
+
+
 class MaintenanceCore:
     def __init__(
         self,
@@ -401,6 +672,7 @@ class MaintenanceCore:
             "dataset_snapshot",
             "dataset_download",
             "dataset_remove",
+            "generate_synthetic_dataset",
         }:
             yield maintenance_pb2.ConvertModelEvent(
                 failed=maintenance_pb2.ConvertFailed(
@@ -445,7 +717,7 @@ class MaintenanceCore:
                 started=maintenance_pb2.ConvertStarted(job_id=job.job_id)
             )
 
-            if operation in {"dataset_snapshot", "dataset_download", "dataset_remove"}:
+            if operation in {"dataset_snapshot", "dataset_download", "dataset_remove", "generate_synthetic_dataset"}:
                 try:
                     result = self._run_dataset_operation(
                         operation=operation,
@@ -1846,6 +2118,7 @@ class MaintenanceCore:
             "dataset_snapshot": "dataset_snapshot.json",
             "dataset_download": "dataset_download.json",
             "dataset_remove": "dataset_remove.json",
+            "generate_synthetic_dataset": "generate_synthetic_dataset.json",
         }[operation]
         return output_dir / filename
 
@@ -1890,9 +2163,10 @@ class MaintenanceCore:
                 or request.source_model
                 or operation
             )
-        if operation in {"dataset_download", "dataset_remove", "dataset_snapshot"}:
+        if operation in {"dataset_download", "dataset_remove", "dataset_snapshot", "generate_synthetic_dataset"}:
             return (
-                request.ext.get("melix.hf_dataset_repo_id", "")
+                request.ext.get("synthetic_dataset_id", "")
+                or request.ext.get("melix.hf_dataset_repo_id", "")
                 or request.ext.get("repo_id", "")
                 or request.source_model
                 or operation
@@ -1961,6 +2235,31 @@ class MaintenanceCore:
                 "manifest": result.manifest,
                 "progress_events": progress_events,
                 "output_path": output_dir / "dataset_remove.json",
+            }
+
+        if operation == "generate_synthetic_dataset":
+            synthetic_progress: list[tuple[str, float]] = []
+
+            def record_synthetic_progress(stage: str, pct: float) -> None:
+                synthetic_progress.append((stage, pct))
+
+            synthetic_request = _synthetic_dataset_request_from_ext(
+                ext,
+                job_id=job_id,
+            )
+            package = generate_synthetic_dataset_package(
+                synthetic_request,
+                jobs_root=self._jobs_root,
+                output_dir=output_dir,
+                progress=record_synthetic_progress,
+            )
+            manifest = dict(package.manifest_payload)
+            manifest.setdefault("job_id", job_id)
+            progress_events.extend(synthetic_progress)
+            return {
+                "manifest": manifest,
+                "progress_events": progress_events,
+                "output_path": package.output_path,
             }
 
         raise ModelOperationError(

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -502,7 +502,11 @@ def _synthetic_column_params(column_type: str, raw_params: str) -> dict[str, Any
 
 
 def _synthetic_column_payload_value(raw_params: str) -> str:
-    candidate = raw_params[1:] if raw_params.startswith("@") else raw_params
+    if not raw_params.startswith("@"):
+        return raw_params
+    candidate = raw_params[1:]
+    if not candidate:
+        return raw_params
     path = Path(candidate).expanduser()
     if path.is_file():
         return path.read_text(encoding="utf-8")

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -59,25 +59,29 @@ logger = logging.getLogger(__name__)
 
 
 class ShapedBenchmarkPrompt(str):
-    __slots__ = ("_tokens",)
+    __slots__ = ("_tokens", "token_count")
 
-    def __new__(cls, value: str, tokens: tuple[str, ...]) -> ShapedBenchmarkPrompt:
+    def __new__(
+        cls,
+        value: str,
+        tokens: tuple[str, ...] | None,
+        token_count: int,
+    ) -> ShapedBenchmarkPrompt:
         prompt = str.__new__(cls, value)
         prompt._tokens = tokens
+        prompt.token_count = token_count
         return prompt
 
     def split(self, sep: str | None = None, maxsplit: int = -1) -> list[str]:
         if sep is None and maxsplit == -1:
-            return list(self._tokens)
+            return list(self.tokens)
         return str(self).split(sep, maxsplit)
 
     @property
     def tokens(self) -> tuple[str, ...]:
+        if self._tokens is None:
+            self._tokens = tuple(str(self).split())
         return self._tokens
-
-    @property
-    def token_count(self) -> int:
-        return len(self._tokens)
 
 
 @dataclass(frozen=True)
@@ -4030,12 +4034,14 @@ class MaintenanceCore:
             tokens = ["benchmark"]
         if len(tokens) >= context_length:
             shaped_tokens = tuple(tokens[:context_length])
-            return ShapedBenchmarkPrompt(" ".join(shaped_tokens), shaped_tokens)
+            return ShapedBenchmarkPrompt(" ".join(shaped_tokens), shaped_tokens, len(shaped_tokens))
         full_repeats, remainder = divmod(context_length, len(tokens))
-        shaped_tokens = tuple(tokens * full_repeats + tokens[:remainder])
+        base_prompt = " ".join(tokens)
         if remainder:
-            return ShapedBenchmarkPrompt(" ".join(shaped_tokens), shaped_tokens)
-        return ShapedBenchmarkPrompt(" ".join(shaped_tokens), shaped_tokens)
+            shaped_prompt = (base_prompt + " ") * full_repeats + " ".join(tokens[:remainder])
+        else:
+            shaped_prompt = ((base_prompt + " ") * full_repeats).rstrip()
+        return ShapedBenchmarkPrompt(shaped_prompt, None, context_length)
 
     @staticmethod
     def _benchmark_prompt_token_count(prompt: str) -> int:

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -857,6 +857,7 @@ struct MelixCLIParserTests {
             (.datasetList(.init(json: true)), "dataset.list"),
             (.datasetHubDownload(.init(repoID: "org/dataset", revision: "main", json: true)), "dataset.hub.download"),
             (.datasetRemove(.init(repoID: "org/dataset", revision: "main", snapshotID: "abc123", json: true)), "dataset.remove"),
+            (.datasetSynthetic(.init(mode: "preview", datasetID: "synthetic.chat.v1", datasetName: "Synthetic Chat", numRecords: 4, outputKind: "training", outputFormat: "prompt_completion", outputDir: "/tmp/synth", providerEndpoint: "http://127.0.0.1:12436/v1", model: "melix-dev-text", columns: ["prompt:llm_text:{\"prompt\":\"write\"}"], json: true)), "dataset.synthetic.preview"),
             (.uriInspect(.init(uri: "hf://model/org/model", json: true)), "uri.inspect"),
             (.uriImport(.init(uri: "hf://model/org/model", modelID: "model", revision: "main", dryRun: true, json: true)), "uri.import"),
             (.recipesList(.init(task: "import", json: true)), "recipes.list"),
@@ -952,6 +953,7 @@ struct MelixCLIParserTests {
             .datasetList(.init(json: true)),
             .datasetHubDownload(.init(repoID: "org/dataset", revision: "main", json: true)),
             .datasetRemove(.init(repoID: "org/dataset", revision: "main", snapshotID: "abc123", json: true)),
+            .datasetSynthetic(.init(mode: "create", datasetID: "synthetic.chat.v1", datasetName: "Synthetic Chat", numRecords: 4, outputKind: "training", outputFormat: "prompt_completion", outputDir: "/tmp/synth", providerEndpoint: "http://127.0.0.1:12436/v1", providerName: "melix", providerType: "openai", headers: ["X-Melix-Test=1"], modelAlias: "generator", model: "melix-dev-text", temperature: "0.2", topP: "0.9", maxTokens: 128, timeoutSeconds: "30", maxParallelRequests: 2, extraBodyJSON: "{\"seed\":7}", columns: ["prompt:llm_text:{\"prompt\":\"write\"}"], validationRatio: "0.1", randomSeed: 7, resume: "never", enableDataDesignerTelemetry: true, json: true)),
             .uriInspect(.init(uri: "hf://model/org/model", json: true)),
             .uriImport(.init(uri: "hf://model/org/model", modelID: "model", revision: "main", dryRun: true, json: true)),
             .recipesList(.init(task: "import", json: true)),
@@ -1281,6 +1283,162 @@ struct MelixCLIParserTests {
         #expect(removeOptions.revision == "main")
         #expect(removeOptions.snapshotID == "abc123")
         #expect(removeOptions.json)
+    }
+
+    @Test("parses dataset synthetic preview and create commands")
+    func parsesDatasetSyntheticPreviewAndCreateCommands() throws {
+        let previewCommand = try MelixCLIParser.parse([
+            "dataset",
+            "synthetic",
+            "preview",
+            "--dataset-id", "synthetic.chat.preview",
+            "--dataset-name", "Synthetic Chat Preview",
+            "--num-records", "3",
+            "--output-kind", "training",
+            "--output-format", "prompt_completion",
+            "--output-dir", "/tmp/synthetic-preview",
+            "--provider-endpoint", "http://127.0.0.1:12436/v1",
+            "--model", "melix-dev-text",
+            "--column", "prompt:llm_text:{\"prompt\":\"write a prompt\"}",
+            "--column", "completion:llm_text:{\"prompt\":\"answer it\"}",
+            "--json",
+        ])
+        let createCommand = try MelixCLIParser.parse([
+            "dataset",
+            "synthetic",
+            "create",
+            "--dataset-id", "synthetic.chat.create",
+            "--dataset-name", "Synthetic Chat Create",
+            "--num-records", "10",
+            "--output-kind", "training",
+            "--output-format", "prompt_completion",
+            "--output-dir", "/tmp/synthetic-create",
+            "--provider-endpoint", "http://127.0.0.1:12436/v1",
+            "--provider-name", "melix",
+            "--provider-type", "openai",
+            "--api-key", "sk-test",
+            "--header", "X-Test=1",
+            "--model-alias", "generator",
+            "--model", "melix-dev-text",
+            "--temperature", "0.2",
+            "--top-p", "0.9",
+            "--max-tokens", "128",
+            "--timeout-seconds", "30",
+            "--max-parallel-requests", "2",
+            "--extra-body-json", "{\"seed\":7}",
+            "--column", "prompt:llm_text:{\"prompt\":\"write a prompt\"}",
+            "--validation-ratio", "0.1",
+            "--preview-count", "2",
+            "--random-seed", "7",
+            "--resume", "if_possible",
+            "--enable-datadesigner-telemetry",
+            "--json",
+        ])
+
+        guard case .datasetSynthetic(let previewOptions) = previewCommand else {
+            Issue.record("Expected datasetSynthetic preview command")
+            return
+        }
+        guard case .datasetSynthetic(let createOptions) = createCommand else {
+            Issue.record("Expected datasetSynthetic create command")
+            return
+        }
+
+        #expect(previewOptions.mode == "preview")
+        #expect(previewOptions.datasetID == "synthetic.chat.preview")
+        #expect(previewOptions.numRecords == 3)
+        #expect(previewOptions.outputKind == "training")
+        #expect(previewOptions.outputFormat == "prompt_completion")
+        #expect(previewOptions.outputDir == "/tmp/synthetic-preview")
+        #expect(previewOptions.providerEndpoint == "http://127.0.0.1:12436/v1")
+        #expect(previewOptions.modelAlias == "generator")
+        #expect(previewOptions.columns.count == 2)
+        #expect(previewOptions.previewCount == 3)
+        #expect(previewOptions.enableDataDesignerTelemetry == false)
+        #expect(previewOptions.json)
+
+        #expect(createOptions.mode == "create")
+        #expect(createOptions.datasetID == "synthetic.chat.create")
+        #expect(createOptions.datasetName == "Synthetic Chat Create")
+        #expect(createOptions.numRecords == 10)
+        #expect(createOptions.apiKey == "sk-test")
+        #expect(createOptions.headers == ["X-Test=1"])
+        #expect(createOptions.temperature == "0.2")
+        #expect(createOptions.topP == "0.9")
+        #expect(createOptions.maxTokens == 128)
+        #expect(createOptions.timeoutSeconds == "30")
+        #expect(createOptions.maxParallelRequests == 2)
+        #expect(createOptions.extraBodyJSON == #"{"seed":7}"#)
+        #expect(createOptions.validationRatio == "0.1")
+        #expect(createOptions.previewCount == 2)
+        #expect(createOptions.randomSeed == 7)
+        #expect(createOptions.resume == "if_possible")
+        #expect(createOptions.enableDataDesignerTelemetry)
+    }
+
+    @Test("rejects malformed dataset synthetic commands")
+    func rejectsMalformedDatasetSyntheticCommands() {
+        func base(_ extra: [String] = []) -> [String] {
+            [
+                "dataset",
+                "synthetic",
+                "create",
+                "--dataset-id", "synthetic.chat.create",
+                "--dataset-name", "Synthetic Chat Create",
+                "--num-records", "10",
+                "--output-kind", "training",
+                "--output-format", "prompt_completion",
+                "--output-dir", "/tmp/synthetic-create",
+                "--provider-endpoint", "http://127.0.0.1:12436/v1",
+                "--model", "melix-dev-text",
+                "--column", #"prompt:llm_text:{"prompt":"write"}"#,
+            ] + extra
+        }
+
+        #expect(throws: MelixCLIError.missingRequired("--dataset-name is required for melix dataset synthetic create.")) {
+            try MelixCLIParser.parse(base().filter { $0 != "--dataset-name" && $0 != "Synthetic Chat Create" })
+        }
+        #expect(throws: MelixCLIError.missingRequired("--num-records is required for melix dataset synthetic create.")) {
+            try MelixCLIParser.parse(base().filter { $0 != "--num-records" && $0 != "10" })
+        }
+        #expect(throws: MelixCLIError.missingRequired("--output-kind is required for melix dataset synthetic create.")) {
+            try MelixCLIParser.parse(base().filter { $0 != "--output-kind" && $0 != "training" })
+        }
+        #expect(throws: MelixCLIError.missingRequired("--output-format is required for melix dataset synthetic create.")) {
+            try MelixCLIParser.parse(base().filter { $0 != "--output-format" && $0 != "prompt_completion" })
+        }
+        #expect(throws: MelixCLIError.missingRequired("--output-dir is required for melix dataset synthetic create.")) {
+            try MelixCLIParser.parse(base().filter { $0 != "--output-dir" && $0 != "/tmp/synthetic-create" })
+        }
+        #expect(throws: MelixCLIError.missingRequired("--provider-endpoint is required for melix dataset synthetic create.")) {
+            try MelixCLIParser.parse(base().filter { $0 != "--provider-endpoint" && $0 != "http://127.0.0.1:12436/v1" })
+        }
+        #expect(throws: MelixCLIError.missingRequired("--model is required for melix dataset synthetic create.")) {
+            try MelixCLIParser.parse(base().filter { $0 != "--model" && $0 != "melix-dev-text" })
+        }
+        #expect(throws: MelixCLIError.missingRequired("--column is required for melix dataset synthetic create.")) {
+            try MelixCLIParser.parse(base().filter { $0 != "--column" && $0 != #"prompt:llm_text:{"prompt":"write"}"# })
+        }
+        #expect(throws: MelixCLIError.usage("Invalid value for --resume. Expected never, if_possible, or always.")) {
+            try MelixCLIParser.parse(base(["--resume", "later"]))
+        }
+        #expect(throws: MelixCLIError.usage("--enable-datadesigner-telemetry and --disable-datadesigner-telemetry are mutually exclusive.")) {
+            try MelixCLIParser.parse(base(["--enable-datadesigner-telemetry", "--disable-datadesigner-telemetry"]))
+        }
+        #expect(throws: MelixCLIError.usage("--seed-source-kind and --seed-source-path must be provided together.")) {
+            try MelixCLIParser.parse(base(["--seed-source-kind", "jsonl"]))
+        }
+        do {
+            _ = try MelixCLIParser.parse(base(["--extra-body-json", "{"]))
+            Issue.record("Expected invalid extra body JSON to fail.")
+        } catch let error as MelixCLIError {
+            #expect(error.errorDescription?.contains("--extra-body-json must contain valid JSON") == true)
+        } catch {
+            Issue.record("Expected MelixCLIError, got \(error).")
+        }
+        #expect(throws: MelixCLIError.usage("--extra-body-json must contain a JSON object.")) {
+            try MelixCLIParser.parse(base(["--extra-body-json", "[]"]))
+        }
     }
 
     @Test("parses uri resolver commands")
@@ -3890,6 +4048,12 @@ struct MelixCLIParserTests {
         try assertError(
             for: ["dataset", "remove"],
             equals: .missingRequired("--repo-id is required for melix dataset remove.")
+        )
+        try assertError(for: ["dataset", "synthetic"], equals: .usage(MelixCLIParser.usageText))
+        try assertError(for: ["dataset", "synthetic", "unknown"], equals: .usage(MelixCLIParser.usageText))
+        try assertError(
+            for: ["dataset", "synthetic", "preview"],
+            equals: .missingRequired("--dataset-id is required for melix dataset synthetic preview.")
         )
         try assertError(for: ["server"], equals: .usage(MelixCLIParser.usageText))
         try assertError(for: ["server", "hibernate"], equals: .usage(MelixCLIParser.usageText))

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -4237,6 +4237,128 @@ struct MelixCLIRunnerTests {
         #expect(call.ext["melix.hf_snapshot_id"] == "abc123")
     }
 
+    @Test("dataset synthetic forwards DataDesigner generation request")
+    func datasetSyntheticForwardsDataDesignerGenerationRequest() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(makeModelOperationResult(
+            outputPath: "/tmp/melix/synthetic-chat",
+            manifestJSON: #"""
+            {
+              "operation": "generate_synthetic_dataset",
+              "schema_version": "melix.training_dataset_package.v1",
+              "dataset_id": "synthetic.chat.v1",
+              "dataset_name": "Synthetic Chat",
+              "output_kind": "training",
+              "row_count": 4,
+              "datadesigner": {
+                "provider": {
+                  "api_key": "[REDACTED]"
+                }
+              }
+            }
+            """#
+        ))
+
+        let output = try await MelixCLIRunner(client: client).run(.datasetSynthetic(.init(
+            mode: "create",
+            datasetID: "synthetic.chat.v1",
+            datasetName: "Synthetic Chat",
+            numRecords: 4,
+            outputKind: "training",
+            outputFormat: "prompt_completion",
+            outputDir: "/tmp/melix/synthetic-chat",
+            providerEndpoint: "http://127.0.0.1:12436/v1",
+            apiKey: "sk-secret",
+            headers: ["X-Test=1"],
+            modelAlias: "generator",
+            model: "melix-dev-text",
+            temperature: "0.2",
+            topP: "0.9",
+            maxTokens: 128,
+            timeoutSeconds: "30",
+            maxParallelRequests: 2,
+            extraBodyJSON: #"{"seed":7}"#,
+            columns: [
+                #"prompt:llm_text:{"prompt":"write a prompt"}"#,
+                #"completion:llm_text:{"prompt":"answer it"}"#,
+            ],
+            validationRatio: "0.1",
+            previewCount: 2,
+            randomSeed: 7,
+            resume: "never",
+            json: true
+        )))
+        let call = try #require(await client.lastModelOperationCall)
+        let payload = try #require(parseJSONObject(output))
+
+        #expect(call.modelID == "melix-datasets")
+        #expect(call.operation == "generate_synthetic_dataset")
+        #expect(call.outputDir == "/tmp/melix/synthetic-chat")
+        #expect(call.ext["synthetic_mode"] == "create")
+        #expect(call.ext["synthetic_dataset_id"] == "synthetic.chat.v1")
+        #expect(call.ext["synthetic_dataset_name"] == "Synthetic Chat")
+        #expect(call.ext["synthetic_num_records"] == "4")
+        #expect(call.ext["synthetic_output_kind"] == "training")
+        #expect(call.ext["synthetic_output_format"] == "prompt_completion")
+        #expect(call.ext["provider_endpoint"] == "http://127.0.0.1:12436/v1")
+        #expect(call.ext["provider_name"] == "melix")
+        #expect(call.ext["provider_type"] == "openai")
+        #expect(call.ext["api_key"] == "sk-secret")
+        #expect(call.ext["model_alias"] == "generator")
+        #expect(call.ext["model"] == "melix-dev-text")
+        #expect(call.ext["temperature"] == "0.2")
+        #expect(call.ext["top_p"] == "0.9")
+        #expect(call.ext["max_tokens"] == "128")
+        #expect(call.ext["timeout_seconds"] == "30")
+        #expect(call.ext["max_parallel_requests"] == "2")
+        #expect(call.ext["extra_body_json"] == #"{"seed":7}"#)
+        #expect(call.ext["validation_ratio"] == "0.1")
+        #expect(call.ext["preview_count"] == "2")
+        #expect(call.ext["random_seed"] == "7")
+        #expect(call.ext["resume"] == "never")
+        #expect(call.ext["disable_datadesigner_telemetry"] == "true")
+        #expect(call.ext["headers_json"] == #"["X-Test=1"]"#)
+        #expect(call.ext["columns_json"]?.contains("prompt:llm_text") == true)
+        #expect(payload["dataset_id"] as? String == "synthetic.chat.v1")
+        #expect(output.contains("sk-secret") == false)
+    }
+
+    @Test("dataset synthetic supports plain text render seed source and subprocess argv")
+    func datasetSyntheticSupportsPlainTextRenderSeedSourceAndSubprocessArgv() async throws {
+        let client = StubControlPlaneXPCClient()
+        await client.setModelOperationResult(makeModelOperationResult(
+            outputPath: "",
+            manifestJSON: #"""
+            {
+              "operation": "generate_synthetic_dataset",
+              "dataset_name": "Synthetic Preview",
+              "output_kind": "raw_jsonl",
+              "sample_count": 3
+            }
+            """#
+        ))
+
+        let output = try await MelixCLIRunner(client: client).run(.datasetSynthetic(.init(
+            mode: "preview",
+            datasetID: "synthetic.preview.v1",
+            datasetName: "Synthetic Preview",
+            numRecords: 3,
+            outputKind: "raw_jsonl",
+            outputFormat: "jsonl",
+            outputDir: "/tmp/melix/synthetic-preview",
+            providerEndpoint: "http://127.0.0.1:12436/v1",
+            model: "melix-dev-text",
+            columns: [#"prompt:llm_text:{"prompt":"write"}"#],
+            seedSourceKind: "jsonl",
+            seedSourcePath: "/tmp/seeds.jsonl"
+        )))
+        let call = try #require(await client.lastModelOperationCall)
+
+        #expect(output == "Synthetic dataset Synthetic Preview (raw_jsonl) generated with 3 rows.\n")
+        #expect(call.ext["seed_source_kind"] == "jsonl")
+        #expect(call.ext["seed_source_path"] == "/tmp/seeds.jsonl")
+    }
+
     @Test("dataset remove renders manifest summary when worker output path is empty")
     func datasetRemoveRendersManifestSummaryWhenWorkerOutputPathIsEmpty() async throws {
         let client = StubControlPlaneXPCClient()
@@ -7223,6 +7345,79 @@ struct MelixCLIRunnerTests {
         #expect(commands[0] == ["dataset", "list", "--json"])
         #expect(commands[1] == ["dataset", "hub", "download", "--repo-id", "org/dataset", "--revision", "main", "--hf-token", "hf_secret", "--json"])
         #expect(commands[2] == ["dataset", "remove", "--repo-id", "org/dataset", "--revision", "main", "--snapshot-id", "abc123", "--json"])
+    }
+
+    @Test("subprocess-backed synthetic dataset operation builds public melix arguments")
+    func subprocessBackedSyntheticDatasetOperationBuildsPublicCLIArguments() async throws {
+        let client = StubControlPlaneXPCClient()
+        let executor = RecordingCLICommandExecutor(
+            responses: [
+                #"{"operation":"generate_synthetic_dataset","job_id":"synthetic-job-1","output_path":"/tmp/melix/synthetic/samples.jsonl","dataset_id":"synthetic.chat.v1"}"#,
+            ]
+        )
+        let runner = MelixCLIRunner(
+            client: client,
+            commandExecutor: executor.run
+        )
+
+        let result = try await runner.performModelOperation(
+            modelID: "melix-datasets",
+            operation: "generate_synthetic_dataset",
+            outputDir: "/tmp/melix/synthetic",
+            ext: [
+                "synthetic_mode": "preview",
+                "synthetic_dataset_id": "synthetic.chat.v1",
+                "synthetic_dataset_name": "Synthetic Chat",
+                "synthetic_num_records": "3",
+                "synthetic_output_kind": "training",
+                "synthetic_output_format": "prompt_completion",
+                "provider_endpoint": "http://127.0.0.1:12436/v1",
+                "provider_name": "melix",
+                "provider_type": "openai",
+                "api_key": "sk-secret",
+                "headers_json": #"["X-Test=1"]"#,
+                "model_alias": "generator",
+                "model": "melix-dev-text",
+                "temperature": "0.2",
+                "top_p": "0.9",
+                "max_tokens": "128",
+                "timeout_seconds": "30",
+                "max_parallel_requests": "2",
+                "extra_body_json": #"{"seed":7}"#,
+                "columns_json": #"["prompt:llm_text:{\"prompt\":\"write\"}"]"#,
+                "seed_source_kind": "jsonl",
+                "seed_source_path": "/tmp/seeds.jsonl",
+                "validation_ratio": "0.1",
+                "preview_count": "2",
+                "random_seed": "7",
+                "resume": "if_possible",
+                "disable_datadesigner_telemetry": "false",
+            ]
+        )
+        let commands = await executor.commands
+        let command = try #require(commands.first)
+
+        #expect(await client.lastModelOperationCall == nil)
+        #expect(result.outputPath == "/tmp/melix/synthetic/samples.jsonl")
+        #expect(Array(command.prefix(3)) == ["dataset", "synthetic", "preview"])
+        #expect(command.contains("--dataset-id"))
+        #expect(command.contains("synthetic.chat.v1"))
+        #expect(command.contains("--output-dir"))
+        #expect(command.contains("/tmp/melix/synthetic"))
+        #expect(command.contains("--provider-endpoint"))
+        #expect(command.contains("http://127.0.0.1:12436/v1"))
+        #expect(command.contains("--header"))
+        #expect(command.contains("X-Test=1"))
+        #expect(command.contains("--model"))
+        #expect(command.contains("melix-dev-text"))
+        #expect(command.contains("--extra-body-json"))
+        #expect(command.contains(#"{"seed":7}"#))
+        #expect(command.contains("--column"))
+        #expect(command.contains(#"prompt:llm_text:{"prompt":"write"}"#))
+        #expect(command.contains("--seed-source-kind"))
+        #expect(command.contains("/tmp/seeds.jsonl"))
+        #expect(command.contains("--enable-datadesigner-telemetry"))
+        #expect(command.contains("--json"))
     }
 
     @Test("subprocess-backed legacy alignment training mode uses alignment train")


### PR DESCRIPTION
## Summary
- Add the public `melix dataset synthetic preview` and `melix dataset synthetic create` CLI surface for DataDesigner synthetic dataset generation.
- Forward CLI parameters through the command codec and runner into the existing model-operation path, then build a `SyntheticDatasetRequest` in the Python worker before calling the DataDesigner generator.
- Allow the control plane to route synthetic dataset operations without requiring a catalog model when the required discriminator inputs are present.
- Update the DataDesigner synthetic dataset plan with the new CLI examples, required parameters, optional controls, and column syntax.

## Plan or Spec
- `docs/plans/2026-05-12-datadesigner-synthetic-dataset-function.md`

## Commands Run
```text
make bootstrap
# pass: configured .githooks and confirmed the locked Python environment.

make proto
# pass: ./scripts/proto_gen.sh completed; no protobuf schema or generated artifact changes were produced.

git diff --check
# pass.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage erase &&
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
  services/mlx-worker-python/tests/test_maintenance_service.py::test_synthetic_dataset_request_uses_defaults_and_column_shortcuts \
  services/mlx-worker-python/tests/test_maintenance_service.py::test_synthetic_dataset_column_shortcuts_only_read_explicit_at_files \
  services/mlx-worker-python/tests/test_maintenance_service.py::test_synthetic_dataset_request_rejects_malformed_ext &&
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o .runtime/coverage/datadesigner-review-python-coverage.json &&
python3 scripts/changed_scope_coverage.py --coverage-json .runtime/coverage/datadesigner-review-python-coverage.json services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_maintenance_service.py
# pass: 19 passed in 0.29s; changed-line coverage 100.00%.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage erase &&
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=services/mlx-worker-python/worker -m pytest -q \
  services/mlx-worker-python/tests/test_maintenance_service.py::test_convert_model_dispatches_synthetic_dataset_generation \
  services/mlx-worker-python/tests/test_maintenance_service.py::test_synthetic_dataset_request_uses_defaults_and_column_shortcuts \
  services/mlx-worker-python/tests/test_maintenance_service.py::test_synthetic_dataset_request_rejects_malformed_ext \
  services/mlx-worker-python/tests/test_synthetic_dataset_generation.py &&
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o .runtime/coverage/datadesigner-python-coverage.json &&
python3 scripts/changed_scope_coverage.py --coverage-json .runtime/coverage/datadesigner-python-coverage.json services/mlx-worker-python/worker/engine/maintenance_core.py
# pass: 66 passed in 3.49s; changed-line coverage 99.28%.

swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests/dataset|MelixCLIRunnerTests/subprocessBackedSyntheticDatasetOperationBuildsPublicCLIArguments' &&
python3.11 scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata Sources/MelixCLICore/MelixCLI.swift Sources/MelixCLICore/MelixCLICommandCodec.swift tests/MelixCLITests/MelixCLIParserTests.swift tests/MelixCLITests/MelixCLIRunnerTests.swift
# pass: 98 tests in 2 suites passed; changed-line coverage 97.67%.

swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'ControlPlaneServiceTests/syntheticDatasetOperationsAreAllowedWithoutCatalogModelWhenRequiredInputsArePresent|ControlPlaneServiceTests/syntheticDatasetOperationsRequireManagedImportDiscriminatorInputs' &&
python3.11 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift
# pass: 2 tests in 1 suite passed; changed-scope coverage 96.43% aggregate.

MELIX_SWIFTPM_ISOLATED_ROOT="$PWD/.runtime/swiftpm-probe-isolated" PATH="$PWD/.runtime/swift-wrapper:$PATH" \
  MELIX_PRE_COMMIT_ALLOW_PERF_REGRESSION=1 \
  MELIX_PRE_COMMIT_PERF_REGRESSION_REASON="Elapsed-only local microbench noise under concurrent local pre-commit load; focused tests and coverage pass, structural call-count metrics are unchanged, and the changed synthetic dataset path does not alter the regressed hot loops." \
  git commit -m "Add DataDesigner synthetic dataset CLI" -m "Tests: Python synthetic dataset maintenance coverage, CLI parser/runner focused Swift coverage, and control-plane managed import coverage all pass with changed-line coverage above 95%."
# pass: pre-commit ran make swift-test, make py-test, make integration-test, and PR-scoped performance probes; commit 6fc15222 was created.

git commit -m "Require explicit synthetic column file references" -m "Tests: focused synthetic dataset maintenance coverage passes with 100% changed-line coverage for the review fix."
# pass: pre-commit ran make swift-test, make py-test, make integration-test, and PR-scoped performance probes without a performance-regression override; commit d0a07952 was created.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage erase &&
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
  services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs &&
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o .runtime/coverage/prompt-shape-coverage.json &&
python3 scripts/changed_scope_coverage.py --coverage-json .runtime/coverage/prompt-shape-coverage.json \
  services/mlx-worker-python/worker/engine/maintenance_core.py \
  services/mlx-worker-python/tests/test_maintenance_service.py
# pass: 1 passed in 0.88s; changed-line coverage 100.00%.

UV_PYTHON=/Users/chenyu/.local/share/uv/python/cpython-3.12-macos-aarch64-none/bin/python3.12 \
/Users/chenyu/.local/share/uv/python/cpython-3.12-macos-aarch64-none/bin/python3.12 \
  .runtime/local-prompt-shape-probe/head/scripts/pr_scoped_performance_run.py \
  --registry .runtime/local-prompt-shape-probe/head/infra/perf/pr_scoped_probes.json \
  --probe-id maintenance-prompt-shape-vector-repeat \
  --base-repo "$PWD/.runtime/local-prompt-shape-probe/base" \
  --head-repo "$PWD/.runtime/local-prompt-shape-probe/head" \
  --output .runtime/local-prompt-shape-probe/result.json
# pass: base elapsed_ms_mean 0.180417 ms, head elapsed_ms_mean 0.076025 ms; token_count_mean stayed 5160960.000 -> 5160960.000.

MELIX_PRE_COMMIT_ALLOW_PERF_REGRESSION=1 \
MELIX_PRE_COMMIT_PERF_REGRESSION_REASON="Elapsed-only local pre-commit noise outside the prompt-shape fix: maintenance-prompt-shape-vector-repeat improved from 0.193 ms to 0.078 ms with token_count unchanged, while upload-receipt and bundle-artifact structural metrics stayed neutral (0.000 -> 0.000) and touched code only changes ShapedBenchmarkPrompt." \
git commit -m "Optimize shaped benchmark prompt token counts" -m "Tests: focused prompt-shape coverage and local maintenance-prompt-shape-vector-repeat probe pass with head faster than base and stable token counts."
# pass: final pre-commit rerun completed make swift-test, make py-test, make integration-test, and PR-scoped performance; report status ok; commit c0ec0774 was created.
```

## Coverage and Metrics
- Python changed scope: `services/mlx-worker-python/worker/engine/maintenance_core.py` focused coverage reported 99.28% changed-line coverage; focused tests reported `66 passed`.
- Review-fix Python changed scope: `services/mlx-worker-python/worker/engine/maintenance_core.py` and `services/mlx-worker-python/tests/test_maintenance_service.py` reported 100.00% changed-line coverage; focused tests reported `19 passed`.
- Root Swift CLI changed scope: `Sources/MelixCLICore/MelixCLI.swift`, `Sources/MelixCLICore/MelixCLICommandCodec.swift`, and related CLI tests reported 97.67% changed-line coverage; focused tests reported `98 tests in 2 suites passed`.
- Control-plane Swift changed scope: synthetic managed-import gate tests reported 96.43% aggregate changed-scope coverage; focused tests reported `2 tests in 1 suite passed`.
- Full pre-commit gate:
  - `make swift-test`: pass.
  - `make py-test`: pass, `2618 passed, 14 skipped, 2 warnings`.
  - `make integration-test`: pass, `113 passed, 1 skipped`.
- PR-scoped performance report: `.runtime/pre-commit-performance/20260515-010657-2255e16b/report/report.md`.
  - Swift CLI JSON envelope probe passed after isolating SwiftPM scratch/cache in `.runtime`.
  - One direct `model-ops-bundle-artifact-byte-accounting` elapsed-only microbenchmark regression was allowed with `MELIX_PRE_COMMIT_ALLOW_PERF_REGRESSION=1`; structural metric `bundle_scandir_calls_mean` stayed neutral at `0.000 -> 0.000`, and the changed synthetic dataset path does not alter the measured hot loop.
- Review-fix PR-scoped performance report: `.runtime/pre-commit-performance/20260515-023326-6fc15222/report/report.md`.
  - Status `ok`: 6 direct/gated probes, 0 regressions, 0 context regressions, 0 verification failures.
  - The previously reported `maintenance-prompt-shape-vector-repeat` regression did not reproduce locally: elapsed time moved `0.197 ms -> 0.193 ms`, and invariant `token_count_mean` stayed neutral at `5160960.000 -> 5160960.000`.
- GitHub PR-scoped performance report for PR #1054: `.runtime/pr-1054-performance/pr-scoped-performance-report/report.md`.
  - Current report status is `regression` because `maintenance-prompt-shape-vector-repeat` elapsed time moved from `0.348 ms` to `0.456 ms`; invariant `token_count_mean` stayed neutral at `5160960.000 -> 5160960.000`.
  - All other direct probes passed; there were no context regressions or verification failures.
- Follow-up prompt-shape fix:
  - Focused changed scope for `maintenance_core.py` and `test_maintenance_service.py` reported 100.00% changed-line coverage; focused test reported `1 passed`.
  - Local equivalent `maintenance-prompt-shape-vector-repeat` probe reported head faster than base: `0.180417 ms -> 0.076025 ms`; invariant `token_count_mean` stayed neutral at `5160960.000 -> 5160960.000`.
- Follow-up full pre-commit PR-scoped performance report: `.runtime/pre-commit-performance/20260515-033031-d0a07952/report/report.md`.
  - Status `ok`: 6 direct/gated probes, 0 regressions, 0 context regressions, 0 verification failures.
  - `maintenance-prompt-shape-vector-repeat` reported `ok`: elapsed time moved `0.188 ms -> 0.179 ms`, and invariant `token_count_mean` stayed neutral at `5160960.000 -> 5160960.000`.
  - Related selected probes also reported `ok`; the final report did not require a performance-regression allowance.
- Observability mode: evidence. Synthetic dataset generation continues to emit DataDesigner package manifests/progress through the existing generator path; the CLI exposes `--enable-datadesigner-telemetry` and `--disable-datadesigner-telemetry` without adding a new always-on runtime metric.
- Probe overhead: N/A. This change adds no new PR-scoped performance probe or always-on observability instrumentation; existing pre-commit probes covered the touched maintenance/model-ops/CLI surfaces.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protobuf schema changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
