### PR TITLE
perf: avoid diagnostics jsonl row concatenation

### DIFF
--- a/docs/plans/2026-05-15-serving-diagnostics-jsonl-newline-write.md
+++ b/docs/plans/2026-05-15-serving-diagnostics-jsonl-newline-write.md
@@ -1,0 +1,35 @@
+# Serving diagnostics JSONL newline write slice
+
+## Goal
+
+Reduce debug serving diagnostics JSONL serialization overhead for bounded event
+queue captures without changing the JSONL payload or diagnostics bundle layout.
+
+## Probe coverage
+
+The affected path is covered by the registered PR-scoped probe
+`serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.
+That probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/serving_diagnostics.py`
+- `services/mlx-worker-python/tests/test_serving_diagnostics.py`
+- `scripts/serving_diagnostics_queue_probe.py`
+
+## Slice
+
+`_write_jsonl` now writes the encoded JSON payload and newline separately. This
+avoids allocating a fresh concatenated string for every diagnostics event row
+while preserving the exact byte output.
+
+## Local evidence
+
+Linux local probe with `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=9`:
+
+- base `serialization_elapsed_ms_mean=1.382938`, `elapsed_ms_mean=5.729605`
+- head `serialization_elapsed_ms_mean=1.215733`, `elapsed_ms_mean=5.759658`
+- serialization delta `-0.167205 ms` (`-12.09%`)
+- `serialized_bytes=10880` and `serialization_checksum=260064` on both base and head
+
+Focused tests and changed-scope coverage passed locally with 100% changed-line
+coverage for the modified lines.

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -480,4 +480,5 @@ def _write_jsonl(path: Path, rows: Any) -> None:
         encode = _JSONL_ENCODER.encode
         write = handle.write
         for row in rows:
-            write(encode(row) + "\n")
+            write(encode(row))
+            write("\n")


### PR DESCRIPTION
## Summary
- Avoid per-row string concatenation in serving diagnostics JSONL writes by writing the encoded payload and newline separately.
- Keep the diagnostics JSONL byte output, manifest layout, retained/dropped event accounting, and public evidence semantics unchanged.

## Plan or Spec
- Added `docs/plans/2026-05-15-serving-diagnostics-jsonl-newline-write.md` for this slice.
- Uses the registered PR-scoped probe `serving-diagnostics-debug-queue-bounds` from `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py`
- `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=9 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` on base and head worktrees
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 31 passed locally.
- Changed-scope coverage: 100% for modified lines in `serving_diagnostics.py`.
- Local Linux probe, `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=9`:
  - base: `serialization_elapsed_ms_mean=1.382938`, `elapsed_ms_mean=5.729605`
  - head: `serialization_elapsed_ms_mean=1.215733`, `elapsed_ms_mean=5.759658`
  - serialization delta: `-0.167205 ms` (`-12.09%`)
  - invariant metrics: `serialized_bytes=10880`, `serialization_checksum=260064` on both base and head
- Registered CI probe validation is required before merge.

## Known Gaps
- Local validation is Linux-only Python validation; no Swift runtime effect is involved in this slice.
- Overall queue append timing is effectively neutral/noisy; the measurable intended win is the JSONL serialization submetric.

## Evidence Checklist
- [x] Registered PR-scoped probe exists and includes focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage passed at 100% for modified lines.
- [x] Local registered probe command passed and preserved output invariants.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
