### PR TITLE
perf: elide redundant code block branch

### DIFF
--- a/docs/plans/2026-05-15-code-eval-code-block-branch-elision.md
+++ b/docs/plans/2026-05-15-code-eval-code-block-branch-elision.md
@@ -1,0 +1,36 @@
+# Code Evaluation Code Block Branch Elision
+
+## Scope
+
+This Python-only slice keeps the code evaluation candidate extraction semantics
+unchanged while removing a redundant nested `opening >= 0` guard from the hot
+path in `extract_candidate_code`.
+
+## Affected Paths
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/code_eval_code_block_extract_probe.py`
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`code-eval-code-block-last-match-streaming` in
+`infra/perf/pr_scoped_probes.json`. The probe includes focused
+`test_command`, `coverage_command`, and `probe_command` entries and measures
+last-code-block extraction over a synthetic response containing 2,500 fenced
+blocks.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command, and local
+probe on Linux before pushing. GitHub Actions remain the merge gate for the
+full PR-scoped performance report.
+
+## Expected Outcome
+
+The branch removes one always-true conditional from the last-match extraction
+path. The primary metric is probe `elapsed_ms_mean`; because the edit is very
+small, stable parity with no probe regression is acceptable, with any speedup
+reported from the local and CI probe output.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -23,6 +23,10 @@ def test_extract_candidate_code_handles_empty_plaintext_and_code_blocks() -> Non
         "print('hi')",
         "parsed_code_block",
     )
+    assert code_eval_runner.extract_candidate_code("```python\n\n```") == (
+        "",
+        "parsed_code_block",
+    )
     assert code_eval_runner.extract_candidate_code(
         "first attempt:\n```python\nprint('old')\n```\nfinal answer:\n```python\nprint('new')\n```"
     ) == ("print('new')", "parsed_code_block")

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -47,18 +47,17 @@ def extract_candidate_code(raw_response: str) -> tuple[str, str]:
     if closing >= 0:
         opening = normalized.rfind("```", 0, closing)
         if opening >= 0:
+            content_start = _code_block_content_start(normalized, opening + 3)
+            candidate = normalized[content_start:closing].strip()
+            if candidate:
+                return candidate, "parsed_code_block"
+            if normalized.count("```") % 2 == 0:
+                return candidate, "parsed_code_block"
+            closing = opening
+            opening = normalized.rfind("```", 0, closing)
             if opening >= 0:
                 content_start = _code_block_content_start(normalized, opening + 3)
-                candidate = normalized[content_start:closing].strip()
-                if candidate:
-                    return candidate, "parsed_code_block"
-                if normalized.count("```") % 2 == 0:
-                    return candidate, "parsed_code_block"
-                closing = opening
-                opening = normalized.rfind("```", 0, closing)
-                if opening >= 0:
-                    content_start = _code_block_content_start(normalized, opening + 3)
-                    return normalized[content_start:closing].strip(), "parsed_code_block"
+                return normalized[content_start:closing].strip(), "parsed_code_block"
 
     return normalized, "parsed_code"
 


### PR DESCRIPTION
## Summary
- Removes a redundant nested `opening >= 0` branch from `extract_candidate_code` after the outer guard has already proven the same condition.
- Adds an explicit empty fenced Python block assertion to keep the even-fence empty-candidate behavior covered.
- Documents the slice and its registered PR-scoped performance probe.

## Plan or Spec
- `docs/plans/2026-05-15-code-eval-code-block-branch-elision.md`
- Registered probe: `code-eval-code-block-last-match-streaming` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# Baseline before the code change (origin/main in this worktree)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# exit 0; 4 passed in 0.65s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py
# exit 0; {"block_count": 2500.0, "elapsed_ms_mean": 0.028661019834024564, "extracted_chars_mean": 37.0, "peak_bytes_mean": 245.0, "sample_count": 7.0}

# Head verification
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# exit 0; 4 passed in 0.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# exit 0; 4 passed in 0.20s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# exit 0; Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py
# exit 0; TOTAL 10 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py
# exit 0; {"block_count": 2500.0, "elapsed_ms_mean": 0.028796959668397903, "extracted_chars_mean": 37.0, "peak_bytes_mean": 245.0, "sample_count": 7.0}

python3 - <<'PY'
# Local old-vs-new repeated micro-comparison over 50,000 extracts/sample.
PY
# exit 0; old_mean=2536.5106978653266 ms, new_mean=2525.600093383608 ms, delta_ms=-10.910604481718565, speedup_pct=0.43014226160767616

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 10 0 100%`).
- Registered local probe (`code_eval_code_block_extract_probe.py`):
  - baseline `elapsed_ms_mean=0.028661019834024564`, `peak_bytes_mean=245.0`
  - head `elapsed_ms_mean=0.028796959668397903`, `peak_bytes_mean=245.0`
  - one-shot probe elapsed is effectively noise-level/informational; peak bytes are unchanged.
- Repeated local old-vs-new micro-comparison (50,000 extracts/sample, 7 samples): `old_mean=2536.5106978653266 ms`, `new_mean=2525.600093383608 ms`, `delta_ms=-10.910604481718565`, `speedup_pct=0.43014226160767616`.
- CI PR-scoped performance report is required before merge and must include the registered `code-eval-code-block-last-match-streaming` probe.

## Known Gaps
- Full repository gates were not run locally; this Linux slice used the focused registered Python test, changed-scope coverage, and local probe.
- The registered probe's `elapsed_ms_mean` is informational for this tiny branch-elision slice, so CI report parity/no regression plus the repeated local micro-comparison are used as the acceptance evidence.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no new probe overhead added.
- [x] Deferred work and known gaps are stated explicitly.
