### PR TITLE
perf: cache probe policy no-op reason

### DIFF
--- a/docs/plans/2026-05-13-probe-policy-mode-check-fast-path.md
+++ b/docs/plans/2026-05-13-probe-policy-mode-check-fast-path.md
@@ -19,6 +19,14 @@ boolean semantics introduced by the earlier mode-check fast path. The focused
 regression asserts that policy instances remain slotted and still expose the
 same no-op reason and telemetry behavior.
 
+## 2026-05-15 no-op reason field follow-up
+
+This follow-up keeps the registered `probe-policy-noop-overhead` scope and
+extends the same no-op overhead probe to measure `no_op_reason` access. The hot
+path now materializes `no_op_reason` once during immutable policy construction,
+matching the existing cached boolean fields and avoiding repeated f-string work
+when disabled probe paths report their no-op reason.
+
 ## Registered performance probe
 
 The affected path is covered by the registered PR-scoped probe
@@ -28,6 +36,8 @@ reports:
 
 - `no_op_policy_check_call_ms_mean`
 - `no_op_policy_check_overhead_pct`
+- `no_op_reason_call_ms_mean`
+- `no_op_reason_overhead_pct`
 - `no_op_recorder_overhead_pct`
 - `threshold_passed`
 

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3655,8 +3655,8 @@
       "scripts/probe_policy_noop_overhead_probe.py",
       "scripts/changed_scope_coverage.py"
     ],
-    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
-    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py",
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py",
     "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/probe_policy_noop_overhead_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
@@ -3670,6 +3670,16 @@
         "key": "no_op_policy_check_overhead_pct",
         "unit": "pct",
         "direction": "informational"
+      },
+      {
+        "key": "no_op_reason_overhead_pct",
+        "unit": "pct",
+        "direction": "informational"
+      },
+      {
+        "key": "no_op_reason_call_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better"
       },
       {
         "key": "threshold_passed",

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2318,6 +2318,8 @@ def test_registered_probe_registry_entries_validate_commands_and_watch_globs() -
     }
     assert probe_policy_metrics["no_op_recorder_overhead_pct"]["direction"] == "informational"
     assert probe_policy_metrics["no_op_policy_check_overhead_pct"]["direction"] == "informational"
+    assert probe_policy_metrics["no_op_reason_overhead_pct"]["direction"] == "informational"
+    assert probe_policy_metrics["no_op_reason_call_ms_mean"]["direction"] == "lower_is_better"
     assert probe_policy_metrics["threshold_passed"]["direction"] == "higher_is_better"
     assert probe_policy_metrics["threshold_passed"]["warn_pct"] == 0.0
 
@@ -2380,6 +2382,8 @@ def test_probe_policy_noop_overhead_probe_script_emits_metrics(
     assert metrics["sample_count"] == 1.0
     assert "no_op_recorder_overhead_pct" in metrics
     assert "no_op_policy_check_overhead_pct" in metrics
+    assert "no_op_reason_overhead_pct" in metrics
+    assert "no_op_reason_call_ms_mean" in metrics
 
 
 def test_serving_diagnostics_queue_probe_script_emits_metrics(

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -52,6 +52,7 @@ def test_probe_policy_uses_slots_for_hot_path_instances() -> None:
     assert not hasattr(policy, "__dict__")
     assert policy.telemetry_enabled is False
     assert policy.no_op_reason == "probe_mode_minimal"
+    assert ProbePolicy(mode=ProbeMode.EVIDENCE).no_op_reason == ""
 
 
 def test_no_op_probe_policy_overhead_metrics_are_thresholded() -> None:
@@ -62,6 +63,8 @@ def test_no_op_probe_policy_overhead_metrics_are_thresholded() -> None:
     assert payload["sample_count"] == 1.0
     assert payload["no_op_recorder_call_ms_mean"] >= 0.0
     assert payload["no_op_policy_check_call_ms_mean"] >= 0.0
+    assert payload["no_op_reason_call_ms_mean"] >= 0.0
     assert "no_op_recorder_delta_ms" in payload
+    assert "no_op_reason_delta_ms" in payload
     assert payload["absolute_tolerance_ms"] > 0.0
     assert payload["threshold_passed"] == 1.0

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -65,6 +65,7 @@ def test_no_op_probe_policy_overhead_metrics_are_thresholded() -> None:
     assert payload["no_op_policy_check_call_ms_mean"] >= 0.0
     assert payload["no_op_reason_call_ms_mean"] >= 0.0
     assert "no_op_recorder_delta_ms" in payload
+    assert "no_op_policy_check_delta_ms" in payload
     assert "no_op_reason_delta_ms" in payload
     assert payload["absolute_tolerance_ms"] > 0.0
     assert payload["threshold_passed"] == 1.0

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -24,22 +24,19 @@ class ProbePolicy:
     fallback_applied: bool = False
     telemetry_enabled: bool = field(init=False, repr=False, compare=False)
     evidence_enabled: bool = field(init=False, repr=False, compare=False)
+    no_op_reason: str = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         mode = self.mode
         evidence_enabled = mode is ProbeMode.EVIDENCE or mode is ProbeMode.DEBUG
+        telemetry_enabled = mode is ProbeMode.SAMPLED or evidence_enabled
+        object.__setattr__(self, "telemetry_enabled", telemetry_enabled)
+        object.__setattr__(self, "evidence_enabled", evidence_enabled)
         object.__setattr__(
             self,
-            "telemetry_enabled",
-            mode is ProbeMode.SAMPLED or evidence_enabled,
+            "no_op_reason",
+            "" if telemetry_enabled else f"probe_mode_{mode.value}",
         )
-        object.__setattr__(self, "evidence_enabled", evidence_enabled)
-
-    @property
-    def no_op_reason(self) -> str:
-        if self.telemetry_enabled:
-            return ""
-        return f"probe_mode_{self.mode.value}"
 
     @classmethod
     def from_env(

--- a/services/mlx-worker-python/worker/productization/probe_policy_overhead.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy_overhead.py
@@ -23,9 +23,12 @@ class ProbeOverheadMetrics:
     baseline_call_ms_mean: float
     no_op_recorder_call_ms_mean: float
     no_op_policy_check_call_ms_mean: float
+    no_op_reason_call_ms_mean: float
     no_op_recorder_overhead_pct: float
     no_op_policy_check_overhead_pct: float
+    no_op_reason_overhead_pct: float
     no_op_recorder_delta_ms: float
+    no_op_reason_delta_ms: float
     threshold_pct: float
     absolute_tolerance_ms: float
     threshold_passed: bool
@@ -37,9 +40,12 @@ class ProbeOverheadMetrics:
             "baseline_call_ms_mean": self.baseline_call_ms_mean,
             "no_op_recorder_call_ms_mean": self.no_op_recorder_call_ms_mean,
             "no_op_policy_check_call_ms_mean": self.no_op_policy_check_call_ms_mean,
+            "no_op_reason_call_ms_mean": self.no_op_reason_call_ms_mean,
             "no_op_recorder_overhead_pct": self.no_op_recorder_overhead_pct,
             "no_op_policy_check_overhead_pct": self.no_op_policy_check_overhead_pct,
+            "no_op_reason_overhead_pct": self.no_op_reason_overhead_pct,
             "no_op_recorder_delta_ms": self.no_op_recorder_delta_ms,
+            "no_op_reason_delta_ms": self.no_op_reason_delta_ms,
             "threshold_pct": self.threshold_pct,
             "absolute_tolerance_ms": self.absolute_tolerance_ms,
             "threshold_passed": 1.0 if self.threshold_passed else 0.0,
@@ -69,21 +75,32 @@ def measure_no_op_probe_policy_overhead(
         iterations=iteration_count,
         samples=sample_count,
     )
+    reason_samples = _sample_call_ms(
+        lambda: policy.no_op_reason,
+        iterations=iteration_count,
+        samples=sample_count,
+    )
     baseline_mean = _mean(baseline_samples)
     recorder_mean = _mean(recorder_samples)
     policy_mean = _mean(policy_samples)
+    reason_mean = _mean(reason_samples)
     recorder_overhead_pct = _overhead_pct(recorder_mean, baseline_mean)
     policy_overhead_pct = _overhead_pct(policy_mean, baseline_mean)
+    reason_overhead_pct = _overhead_pct(reason_mean, baseline_mean)
     recorder_delta_ms = round(recorder_mean - baseline_mean, 9)
+    reason_delta_ms = round(reason_mean - baseline_mean, 9)
     return ProbeOverheadMetrics(
         sample_count=sample_count,
         iteration_count=iteration_count,
         baseline_call_ms_mean=baseline_mean,
         no_op_recorder_call_ms_mean=recorder_mean,
         no_op_policy_check_call_ms_mean=policy_mean,
+        no_op_reason_call_ms_mean=reason_mean,
         no_op_recorder_overhead_pct=recorder_overhead_pct,
         no_op_policy_check_overhead_pct=policy_overhead_pct,
+        no_op_reason_overhead_pct=reason_overhead_pct,
         no_op_recorder_delta_ms=recorder_delta_ms,
+        no_op_reason_delta_ms=reason_delta_ms,
         threshold_pct=float(threshold_pct),
         absolute_tolerance_ms=float(absolute_tolerance_ms),
         threshold_passed=recorder_overhead_pct <= threshold_pct

--- a/services/mlx-worker-python/worker/productization/probe_policy_overhead.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy_overhead.py
@@ -28,6 +28,7 @@ class ProbeOverheadMetrics:
     no_op_policy_check_overhead_pct: float
     no_op_reason_overhead_pct: float
     no_op_recorder_delta_ms: float
+    no_op_policy_check_delta_ms: float
     no_op_reason_delta_ms: float
     threshold_pct: float
     absolute_tolerance_ms: float
@@ -45,6 +46,7 @@ class ProbeOverheadMetrics:
             "no_op_policy_check_overhead_pct": self.no_op_policy_check_overhead_pct,
             "no_op_reason_overhead_pct": self.no_op_reason_overhead_pct,
             "no_op_recorder_delta_ms": self.no_op_recorder_delta_ms,
+            "no_op_policy_check_delta_ms": self.no_op_policy_check_delta_ms,
             "no_op_reason_delta_ms": self.no_op_reason_delta_ms,
             "threshold_pct": self.threshold_pct,
             "absolute_tolerance_ms": self.absolute_tolerance_ms,
@@ -88,6 +90,7 @@ def measure_no_op_probe_policy_overhead(
     policy_overhead_pct = _overhead_pct(policy_mean, baseline_mean)
     reason_overhead_pct = _overhead_pct(reason_mean, baseline_mean)
     recorder_delta_ms = round(recorder_mean - baseline_mean, 9)
+    policy_delta_ms = round(policy_mean - baseline_mean, 9)
     reason_delta_ms = round(reason_mean - baseline_mean, 9)
     return ProbeOverheadMetrics(
         sample_count=sample_count,
@@ -100,6 +103,7 @@ def measure_no_op_probe_policy_overhead(
         no_op_policy_check_overhead_pct=policy_overhead_pct,
         no_op_reason_overhead_pct=reason_overhead_pct,
         no_op_recorder_delta_ms=recorder_delta_ms,
+        no_op_policy_check_delta_ms=policy_delta_ms,
         no_op_reason_delta_ms=reason_delta_ms,
         threshold_pct=float(threshold_pct),
         absolute_tolerance_ms=float(absolute_tolerance_ms),


### PR DESCRIPTION
## Summary
- Cache `ProbePolicy.no_op_reason` during immutable policy construction so disabled probe paths avoid rebuilding the reason string on every access.
- Extend the registered `probe-policy-noop-overhead` PR-scoped probe metrics to report no-op reason access overhead.
- Update focused tests and the governing probe-policy performance plan.

## Plan or Spec
- `docs/plans/2026-05-13-probe-policy-mode-check-fast-path.md`

## Commands Run
```text
# repository sync / branch setup
cd /root/.hermes/profiles/coder/workspace/worktrees/melix-probe-policy-noop-fastpath-202605150529
git fetch origin main
git worktree add -b perf/probe-policy-short-circuit-202605150550 /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-cron-slice-202605150550 origin/main

# JSON and diff hygiene
git diff --check
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.json.check

# focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# result: 10 passed in 0.09s

# changed-scope coverage with updated registered probe coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py
# result: 11 passed in 0.21s; changed-scope coverage TOTAL 18 0 100%

# local registered PR-scoped performance run
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id probe-policy-noop-overhead --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-probe-policy-reason-202605150550 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-cron-slice-202605150550 --output /tmp/probe-policy-pr-scope.json
# result: test_ok=true, coverage_ok=true, base_probe.ok=true, head_probe.ok=true

# direct no_op_reason microbenchmark, 400000 iterations x 7 samples
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/probe_policy_reason_microbench.py
# base: no_op_reason_call_ms_mean=0.00034333945784185613
# head: no_op_reason_call_ms_mean=0.00010470354438958955
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 18 0 100%`.
- Registered local PR-scoped probe `probe-policy-noop-overhead` completed successfully:
  - head verification: `test_ok=true`, `coverage_ok=true`.
  - base probe: `ok=true`, `threshold_passed=1.0`.
  - head probe: `ok=true`, `threshold_passed=1.0`.
- Direct focused no-op reason microbenchmark:
  - `old_mean=0.00034333945784185613 ms/access`
  - `new_mean=0.00010470354438958955 ms/access`
  - `delta_ms=-0.00023863591345226658`
  - `speedup=3.279157929595301x` (`69.50436601498436%` lower)
- CI PR-scoped performance is still required as the merge gate for the registered probe report.

## Known Gaps
- The base registered probe predates the new `no_op_reason_*` metrics, so the base-vs-head registered report primarily validates probe health and existing no-op overhead. The direct local microbenchmark records the old/new no-op reason delta for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
