### PR TITLE
perf: avoid Path allocation in Swift binary resolution

### DIFF
--- a/docs/plans/2026-05-15-integration-swift-binary-stat-str.md
+++ b/docs/plans/2026-05-15-integration-swift-binary-stat-str.md
@@ -1,0 +1,44 @@
+# Integration Swift binary resolution string-stat slice
+
+## Goal
+
+Reduce Linux-verifiable integration helper overhead when resolving Swift product
+binaries from large `.build` directories. The slice keeps executable selection
+semantics unchanged while avoiding per-candidate `Path` object construction on
+the hot scan path.
+
+## Probe coverage
+
+The affected path is covered by the registered PR-scoped probe
+`integration-swift-binary-resolution-scandir` in
+`infra/perf/pr_scoped_probes.json`. The probe already exposes focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `tests/integration/helpers.py`
+- `tests/integration/test_helper_binary_resolution.py`
+- `tests/integration/test_helper_remove_tree.py`
+- `scripts/integration_swift_binary_resolution_probe.py`
+- `scripts/integration_remove_tree_probe.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Slice
+
+`_newest_executable_swift_product_binary()` now keeps candidate paths as strings
+while scanning and stats them with `os.stat()`. It converts only the final
+selected candidate back to `Path`, preserving the public resolver return type,
+mtime/depth tie breaker, executable checks, and missing-build-root behavior.
+
+## Local evidence
+
+Linux local registered probe (`scripts/integration_swift_binary_resolution_probe.py`,
+three runs, default 5 samples/run, `candidate_count=1501`):
+
+- base `elapsed_ms_mean` samples: `77.889960`, `75.589246`, `82.483022`
+- head `elapsed_ms_mean` samples: `23.271438`, `23.711962`, `23.205934`
+- aggregate base mean `78.654076 ms`; aggregate head mean `23.396445 ms`
+- delta `-55.257631 ms` (`-70.25%`)
+- base `peak_bytes_mean` average `3659.8`; head `peak_bytes_mean` average `2154.2`
+- `candidate_count=1501` in all runs
+
+Focused pytest and changed-scope coverage passed locally with 100% changed-line
+coverage for the modified lines.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -460,15 +460,16 @@ def _swift_product_binary_candidates(build_root: Path, product_name: str) -> lis
 
 
 def _newest_executable_swift_product_binary(build_root: Path, product_name: str) -> Path | None:
-    newest_candidate: Path | None = None
+    newest_candidate: str | None = None
     newest_key: tuple[float, int] | None = None
     flat_depth = 0
     scoped_depth = 1
+    build_root_path = os.fspath(build_root)
 
-    def consider(candidate: Path, *, depth: int) -> None:
+    def consider(candidate: str, *, depth: int) -> None:
         nonlocal newest_candidate, newest_key
         try:
-            candidate_stat = candidate.stat()
+            candidate_stat = os.stat(candidate)
         except OSError:
             return
         if not (stat.S_ISREG(candidate_stat.st_mode) and (candidate_stat.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))):
@@ -478,17 +479,17 @@ def _newest_executable_swift_product_binary(build_root: Path, product_name: str)
             newest_candidate = candidate
             newest_key = candidate_key
 
-    consider(build_root / "debug" / product_name, depth=flat_depth)
+    consider(os.path.join(build_root_path, "debug", product_name), depth=flat_depth)
     try:
-        entries = os.scandir(build_root)
+        entries = os.scandir(build_root_path)
     except FileNotFoundError:
-        return newest_candidate
+        return Path(newest_candidate) if newest_candidate is not None else None
 
     with entries:
         for entry in entries:
             if entry.name != "debug" and entry.is_dir(follow_symlinks=False):
-                consider(Path(entry.path) / "debug" / product_name, depth=scoped_depth)
-    return newest_candidate
+                consider(os.path.join(entry.path, "debug", product_name), depth=scoped_depth)
+    return Path(newest_candidate) if newest_candidate is not None else None
 
 
 def resolve_scoped_swift_product_binary(repo_root: Path, *, scope: str, product_name: str) -> Path:

--- a/tests/integration/test_helper_binary_resolution.py
+++ b/tests/integration/test_helper_binary_resolution.py
@@ -149,16 +149,16 @@ def test_resolve_swift_product_binary_stats_each_candidate_once(
     os.utime(flat, (1, 1))
     os.utime(preferred, (2, 2))
 
-    original_stat = Path.stat
+    original_stat = helpers.os.stat
     product_stats = 0
 
-    def counting_stat(self: Path, *args: object, **kwargs: object):
+    def counting_stat(path: str, *args: object, **kwargs: object):
         nonlocal product_stats
-        if self.name == "melix-text-worker-swift":
+        if os.path.basename(path) == "melix-text-worker-swift":
             product_stats += 1
-        return original_stat(self, *args, **kwargs)
+        return original_stat(path, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "stat", counting_stat)
+    monkeypatch.setattr(helpers.os, "stat", counting_stat)
 
     resolved = helpers.resolve_swift_product_binary(
         repo_root,


### PR DESCRIPTION
## Summary
- Avoid per-candidate `Path` object construction in integration Swift binary resolution.
- Keep candidate paths as strings through the scan/stat loop and convert only the selected executable back to `Path`.
- Update the candidate-stat regression test to count the new `os.stat()` path without changing resolver behavior.

## Plan or Spec
- `docs/plans/2026-05-15-integration-swift-binary-stat-str.md`
- Registered probe: `integration-swift-binary-resolution-scandir` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json tests/integration/helpers.py tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/integration_swift_binary_resolution_probe.py scripts/integration_remove_tree_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT="$PWD" MELIX_REMOVE_TREE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/integration_swift_binary_resolution_probe.py` (3x on base and head)

## Coverage and Metrics
- Focused tests: 17 passed.
- Changed-scope coverage: `TOTAL 14 0 100%`.
- Local registered probe, three runs, default 5 samples/run, `candidate_count=1501`:
  - base `elapsed_ms_mean`: `77.889960`, `75.589246`, `82.483022`
  - head `elapsed_ms_mean`: `23.271438`, `23.711962`, `23.205934`
  - aggregate base mean `78.654076 ms`; aggregate head mean `23.396445 ms`
  - delta `-55.257631 ms` (`-70.25%`)
  - base `peak_bytes_mean` average `3659.8`; head `peak_bytes_mean` average `2154.2`
- CI registered probe validation is required before merge.

## Known Gaps
- Linux-local validation covers the Python integration helper and registered probe. Swift runtime behavior is not claimed from Linux local tests.
- The registered probe also reports remove-tree metrics; this slice does not change remove-tree behavior.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows improvement.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
