### PR TITLE
fix: address capability receipt gaps found in PR #1050 review

### DIFF
--- a/Sources/MelixCLICore/MelixRuntimeDiscovery.swift
+++ b/Sources/MelixCLICore/MelixRuntimeDiscovery.swift
@@ -278,7 +278,7 @@ struct MelixRuntimeDiscoveryBuilder {
     }
 
     func capabilitiesPayload(modelQuery: String = "") -> [String: Any] {
-        let seedModels = ModelCatalog.phaseFiveSeedModels().map { model in
+        let seedModels = ModelCatalog.phaseSevenContractSeedModels().map { model in
             [
                 "model_id": model.modelID,
                 "kind": model.kind,

--- a/services/control-plane-swift/Sources/ModelCatalog/ModelCapabilityReceipts.swift
+++ b/services/control-plane-swift/Sources/ModelCatalog/ModelCapabilityReceipts.swift
@@ -206,6 +206,7 @@ public enum ModelCapabilityReceipts {
         case .unsupportedReasonRuntimeUnavailable:
             return "runtime_unavailable"
         case .unsupportedReasonExperimentalUnverified:
+            // Reserved: not yet assigned by any code path; present for schema completeness.
             return "experimental_unverified"
         case .unspecified:
             return "unspecified"
@@ -223,6 +224,7 @@ public enum ModelCapabilityReceipts {
         case .capabilityUnsupported:
             return "unsupported"
         case .capabilityExperimental:
+            // Reserved: not yet assigned by any code path; present for schema completeness.
             return "experimental"
         case .capabilityMetadataInconsistent:
             return "metadata_inconsistent"
@@ -512,6 +514,10 @@ public enum ModelCapabilityReceipts {
         if speculativeHead.configured,
            speculativeHead.state == .capabilityMetadataInconsistent {
             return (.capabilityMetadataInconsistent, .unsupportedReasonMetadataInconsistent, speculativeHead.recoveryHint)
+        }
+        if speculativeHead.configured,
+           speculativeHead.state == .capabilityUnsupported {
+            return (.capabilityUnsupported, .unsupportedReasonRuntimeUnavailable, speculativeHead.recoveryHint)
         }
         return (.capabilitySupported, .unsupportedReasonNone, "")
     }

--- a/services/control-plane-swift/Sources/ModelCatalog/ModelCapabilityReceipts.swift
+++ b/services/control-plane-swift/Sources/ModelCatalog/ModelCapabilityReceipts.swift
@@ -517,7 +517,7 @@ public enum ModelCapabilityReceipts {
         }
         if speculativeHead.configured,
            speculativeHead.state == .capabilityUnsupported {
-            return (.capabilityUnsupported, .unsupportedReasonRuntimeUnavailable, speculativeHead.recoveryHint)
+            return (speculativeHead.state, speculativeHead.unsupportedReason, speculativeHead.recoveryHint)
         }
         return (.capabilitySupported, .unsupportedReasonNone, "")
     }

--- a/services/control-plane-swift/Sources/ModelCatalog/ModelCatalogPresentation.swift
+++ b/services/control-plane-swift/Sources/ModelCatalog/ModelCatalogPresentation.swift
@@ -73,10 +73,10 @@ public enum ModelCatalogPresentation {
         var metadata: [String: String] = [
             "melix.capability.receipt_present": "true",
             "melix.capability.receipt_schema": receipt.schemaVersion,
-            "melix.acceleration.requested_mode": ModelCapabilityReceipts.accelerationModeIdentifier(
+            "melix.acceleration.requested_acceleration_mode": ModelCapabilityReceipts.accelerationModeIdentifier(
                 receipt.acceleration.requestedAccelerationMode
             ),
-            "melix.acceleration.resolved_mode": ModelCapabilityReceipts.accelerationModeIdentifier(
+            "melix.acceleration.resolved_acceleration_mode": ModelCapabilityReceipts.accelerationModeIdentifier(
                 receipt.acceleration.resolvedAccelerationMode
             ),
             "melix.acceleration.supported_modes": receipt.acceleration.supportedModes

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ModelCatalogTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ModelCatalogTests.swift
@@ -231,6 +231,22 @@ struct ModelCatalogTests {
         #expect(unavailableReceipt.speculativeHead.state == .capabilityUnsupported)
         #expect(unavailableReceipt.speculativeHead.unsupportedReason == .unsupportedReasonRuntimeUnavailable)
 
+        var speculativeHeadUnavailable = ModelCatalog.devTextModel()
+        speculativeHeadUnavailable.settings.ext["melix.acceleration.supported_modes"] = "baseline,speculative_decode"
+        speculativeHeadUnavailable.settings.ext["melix.acceleration.valid_draft_model_ids"] = "draft"
+        speculativeHeadUnavailable.settings.ext["melix.speculative_head.configured"] = "true"
+        speculativeHeadUnavailable.settings.ext["melix.speculative_head.configured_layers"] = "4"
+        speculativeHeadUnavailable.settings.ext["melix.speculative_head.indexed_layers"] = "4"
+        speculativeHeadUnavailable.settings.ext["melix.speculative_head.runtime_available"] = "false"
+        speculativeHeadUnavailable.settings.ext["melix.speculative_head.artifact_available"] = "false"
+        let speculativeHeadRefusal = ModelCapabilityReceipts.validateAcceleration(
+            model: speculativeHeadUnavailable,
+            requestedMode: .speculativeDecode,
+            draftModelID: "draft"
+        )
+        #expect(speculativeHeadRefusal.ok == false)
+        #expect(speculativeHeadRefusal.unsupportedReason == .unsupportedReasonRuntimeUnavailable)
+
         var payloadModel = ModelCatalog.devTextModel()
         payloadModel.settings.defaultAccelerationMode = .speculativeDecode
         payloadModel.settings.ext["melix.acceleration.supported_modes"] = "baseline,speculative_decode"
@@ -253,6 +269,10 @@ struct ModelCatalogTests {
         #expect(drafts.first?["state"] as? String == "supported")
         #expect(speculativeHead["configured_layers"] as? NSNumber == 1)
         #expect(metadata["melix.acceleration.valid_draft_model_ids"] == "draft-a")
+        #expect(metadata["melix.acceleration.requested_acceleration_mode"] != nil)
+        #expect(metadata["melix.acceleration.resolved_acceleration_mode"] != nil)
+        #expect(metadata["melix.acceleration.requested_mode"] == nil)
+        #expect(metadata["melix.acceleration.resolved_mode"] == nil)
     }
 
     @Test("presentation maps capability classes to public identifiers")

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ModelCatalogTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ModelCatalogTests.swift
@@ -246,6 +246,7 @@ struct ModelCatalogTests {
         )
         #expect(speculativeHeadRefusal.ok == false)
         #expect(speculativeHeadRefusal.unsupportedReason == .unsupportedReasonRuntimeUnavailable)
+        #expect(speculativeHeadRefusal.receipt.state == .capabilityUnsupported)
 
         var payloadModel = ModelCatalog.devTextModel()
         payloadModel.settings.defaultAccelerationMode = .speculativeDecode

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -576,6 +576,8 @@ struct MelixCLIRunnerTests {
         #expect(receipt["schema_version"] as? String == "melix.model_capability_receipt.v1")
         #expect(acceleration["requested_acceleration_mode"] as? String == "baseline")
         #expect(suggestions.contains { $0["model_id"] as? String == "mlx-community/Qwen3.5-9B-MLX-4bit" })
+        #expect(models.contains { $0["model_id"] as? String == "melix-dev-vlm" })
+        #expect(models.contains { $0["model_id"] as? String == "melix-dev-image" })
 
         let fullIDCapabilities = try #require(parseJSONObject(try await runner.run(.capabilities(.init(json: true, modelQuery: "mlx-community/Qwen3.5-9B-MLX-4bit")))))
         let fullIDAlias = try #require(fullIDCapabilities["model_alias_discovery"] as? [String: Any])


### PR DESCRIPTION
## Summary

Follow-up to #1050. Four gaps identified during post-merge review:

- **Key name inconsistency** (`ModelCatalogPresentation`): `capabilityReceiptPublicMetadata` was emitting short-form keys (`melix.acceleration.requested_mode`, `melix.acceleration.resolved_mode`) while `accelerationAuditMetadata` emits long-form keys (`…requested_acceleration_mode`, `…resolved_acceleration_mode`). Normalized to long form everywhere.
- **Speculative-head `capabilityUnsupported` bypass** (`validateSpeculativeDecode`): When `speculativeHead.configured == true` and `speculativeHead.state == .capabilityUnsupported` (runtime/artifact unavailable), validation was falling through to `.capabilitySupported`. Added the missing guard symmetric with the existing metadata-inconsistency check.
- **Reserved enum values undocumented** (`ModelCapabilityReceipts`): `CAPABILITY_EXPERIMENTAL` and `UNSUPPORTED_REASON_EXPERIMENTAL_UNVERIFIED` are never emitted. Added reserved comments so future readers understand intent.
- **CLI capabilities surface incomplete** (`MelixRuntimeDiscovery`): `capabilitiesPayload` used `phaseFiveSeedModels()` while HTTP `/api/capabilities` uses all loaded models. Switched to `phaseSevenContractSeedModels()`.

## Plan or Spec

Post-merge review of #1050 identified four correctness/consistency gaps. No design doc required; each fix is a targeted, self-contained change to an existing function with accompanying test coverage.

## Commands Run

```text
git diff --stat
# 5 files changed, 31 insertions(+), 3 deletions(-)

grep -rn "melix.acceleration.requested_mode" services/ Sources/
# confirmed short-form keys only appeared in ModelCatalogPresentation.swift

grep -n "validateSpeculativeDecode\|capabilityUnsupported" services/control-plane-swift/Sources/ModelCatalog/ModelCapabilityReceipts.swift
# confirmed missing guard for capabilityUnsupported in validateSpeculativeDecode

grep -n "phaseFiveSeedModels\|phaseSevenContractSeedModels" Sources/MelixCLICore/MelixRuntimeDiscovery.swift
# confirmed CLI was calling phaseFiveSeedModels; LocalRuntimeFactory already uses phaseSevenContractSeedModels
```

## Coverage and Metrics

- `ModelCatalogTests`: added assertion that `validateAcceleration` returns `unsupportedReasonRuntimeUnavailable` when speculative head is configured but runtime unavailable and speculative decode is requested (previously the untested path returned `.capabilitySupported`).
- `ModelCatalogTests`: added assertions that `publicAPIMetadata` exposes long-form acceleration mode keys and not the old short-form keys.
- `MelixCLIRunnerTests`: added assertions that `melix-dev-vlm` and `melix-dev-image` appear in the `melix capabilities --json` models array.

## Known Gaps

- Tests in `ModelCatalogTests` that use `phaseFiveSeedModels()` directly for catalog construction remain on phase five; they are scoped to text/embedding/rerank/modelops behaviour and do not need updating.
- `CAPABILITY_EXPERIMENTAL` and `UNSUPPORTED_REASON_EXPERIMENTAL_UNVERIFIED` are now documented as reserved but still have no assignment logic. A follow-up is needed when experimental model support is implemented.

## Test plan

- [ ] `ModelCatalogTests`: new speculative-head unavailable refusal assertion passes
- [ ] `ModelCatalogTests`: long-form key assertions pass; short-form key absence assertions pass
- [ ] `MelixCLIRunnerTests`: VLM and image model presence assertions pass

https://claude.ai/code/session_014iPNBWq3nWASTrh4B1vCwM