### PR TITLE
perf: slot hub catalog result records

### DIFF
--- a/docs/plans/2026-05-15-hub-catalog-record-slots.md
+++ b/docs/plans/2026-05-15-hub-catalog-record-slots.md
@@ -1,0 +1,34 @@
+# Hub catalog record slots performance slice
+
+## Scope
+
+This Python-only performance slice is limited to Hub catalog result record objects. It keeps search/card response fields, dataclass immutability, and downstream access semantics unchanged while reducing per-record allocation overhead.
+
+Affected implementation path:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+
+Affected test and probe paths:
+
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_tag_normalization_probe.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+
+## Registered Probe
+
+The affected path is covered by existing PR-scoped probes in `infra/perf/pr_scoped_probes.json`; the focused local verification uses `hub-catalog-tag-normalization-single-pass` because that registered probe watches `hub_catalog.py`, includes focused `test_command`, `coverage_command`, and `probe_command` entries, and constructs Hub catalog summary records over a synthetic model payload set.
+
+## Optimization
+
+`HubModelSummaryRecord`, `HubSearchPage`, and `HubModelCardRecord` now use frozen slotted dataclasses. This removes the per-instance `__dict__` allocation for catalog result containers while preserving field access, constructor signatures, and frozen behavior.
+
+## Verification Plan
+
+Run the registered focused local commands on Linux before pushing:
+
+1. Focused pytest for Hub catalog behavior and registered probe selection.
+2. Changed-scope coverage via the registered `coverage_command`.
+3. The registered `hub-catalog-tag-normalization-single-pass` probe on `origin/main` and on this branch, using repeated samples.
+
+The registered PR-scoped performance CI report remains the merge gate.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -11,6 +11,9 @@ import worker.model_ops.hub_catalog as hub_catalog_module
 from worker.model_ops.hub_catalog import (
     HubCatalog,
     HubCatalogError,
+    HubModelCardRecord,
+    HubModelSummaryRecord,
+    HubSearchPage,
     _bytes_per_parameter,
     _is_mlx_compatible,
     _local_fit_evidence,
@@ -22,6 +25,44 @@ from worker.model_ops.hub_catalog import (
 KB = 1024
 MB = 1024 ** 2
 GB = 1024 ** 3
+
+
+def test_hub_catalog_records_use_slots() -> None:
+    summary = HubModelSummaryRecord(
+        repo_id="owner/model",
+        author="owner",
+        model_name="model",
+        summary="summary",
+        pipeline_tag="text-generation",
+        tags=["mlx"],
+        downloads=1,
+        likes=2,
+        mlx_compatible=True,
+        library_name="mlx",
+        sibling_files=["config.json"],
+        last_modified="2026-05-15T00:00:00Z",
+    )
+    page = HubSearchPage(items=[summary], next_cursor="cursor")
+    card = HubModelCardRecord(
+        repo_id="owner/model",
+        author="owner",
+        model_name="model",
+        summary="summary",
+        license="mit",
+        pipeline_tag="text-generation",
+        tags=["mlx"],
+        downloads=1,
+        likes=2,
+        mlx_compatible=True,
+        library_name="mlx",
+        sibling_files=["config.json"],
+        base_models=[],
+        last_modified="2026-05-15T00:00:00Z",
+    )
+
+    assert hasattr(summary, "__dict__") is False
+    assert hasattr(page, "__dict__") is False
+    assert hasattr(card, "__dict__") is False
 
 
 def test_quantization_summary_preserves_alias_order_from_lowered_tags() -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -26,7 +26,7 @@ _SIZE_HINT_MULTIPLIERS = {
 
 _BARE_SIZE_HINT_RE = re.compile(r"(?:model\s+size\s*[:|]?\s*)?(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
 _EXPLICIT_SIZE_HINT_RE = re.compile(r"\bmodel\s+size\s*[:|]?\s*(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class HubModelSummaryRecord:
     repo_id: str
     author: str
@@ -50,13 +50,13 @@ class HubModelSummaryRecord:
     recommended_action: str = "inspect_metadata"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class HubSearchPage:
     items: list[HubModelSummaryRecord]
     next_cursor: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class HubModelCardRecord:
     repo_id: str
     author: str


### PR DESCRIPTION
## Summary
- Convert Hub catalog result container dataclasses to frozen slotted dataclasses.
- Add a focused regression test that confirms summary/page/card records no longer allocate per-instance `__dict__` storage.
- Keep the slice Python-only and limited to Hub catalog record allocation overhead.

## Plan or Spec
- `docs/plans/2026-05-15-hub-catalog-record-slots.md`

## Commands Run
```text
# Branch/worktree preflight
cd /root/.hermes/profiles/coder/workspace/melix
git status --short
git fetch origin
git reset --hard origin/main
git status --short && git branch --show-current && git rev-parse --short HEAD

# Focused tests on perf/hub-catalog-record-slots-20260515
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
Result: exit 0; 52 passed in 0.20s.

# Changed-scope coverage on perf/hub-catalog-record-slots-20260515
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py
Result: exit 0; 52 passed in 0.35s; changed-scope coverage TOTAL 0 0 100%.

# Registered probe baseline on origin/main (3 invocations, each sample_count=5)
Registered `Hub catalog tag normalization single pass` probe command from infra/perf/pr_scoped_probes.json.
Results elapsed_ms_mean: 265.2366301510483, 247.65601619146764, 244.8831764049828; peak_bytes_mean: 10075591.6 each run.

# Registered probe on this branch (3 invocations, each sample_count=5)
Registered `Hub catalog tag normalization single pass` probe command from infra/perf/pr_scoped_probes.json.
Results elapsed_ms_mean: 236.86830778606236, 252.39818221889436, 246.71952780336142; peak_bytes_mean: 9835442.8 each run.

git diff --check origin/main...HEAD
Result: exit 0.
```

## Coverage and Metrics
- Changed-scope coverage: 100% from `scripts/changed_scope_coverage.py` (no measurable changed executable lines in the diff reported by the tool; aggregate result `TOTAL 0 0 100%`).
- Registered probe: `Hub catalog tag normalization single pass` in `infra/perf/pr_scoped_probes.json`; it watches `services/mlx-worker-python/worker/model_ops/hub_catalog.py` and includes focused `test_command`, `coverage_command`, and `probe_command` entries.
- Local Linux probe comparison across 3 invocations (each invocation reports `sample_count=5`):
  - `origin/main`: elapsed mean across invocations `252.5919409158329 ms`; peak bytes `10075591.6`.
  - This branch: elapsed mean across invocations `245.3286726027727 ms`; peak bytes `9835442.8`.
  - Delta: `-7.263268313060195 ms` elapsed, `1.029606275679079x` speedup, `-240148.79999999888 bytes` peak memory (`-2.383470961645556%`).
- CI PR-scoped performance report is required as the merge gate for the registered probe validation.

## Known Gaps
- Full repository gates (`make swift-test`, `make py-test`, `make integration-test`) were not run locally; this Python slice used the registered focused Hub catalog test, coverage, and probe commands.
- No Swift runtime validation applies to this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead is bounded to CI/local synthetic probe execution and does not alter runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
