### PR TITLE
perf: speed rerank top-k one selection

### DIFF
--- a/docs/plans/2026-05-15-rerank-top-k-one-fast-max.md
+++ b/docs/plans/2026-05-15-rerank-top-k-one-fast-max.md
@@ -1,0 +1,39 @@
+# Rerank top-k=1 max-index scan performance slice
+
+## Scope
+
+This slice keeps rerank ordering semantics unchanged while tightening the bounded
+`top_k=1` fast path in `RerankCore._rank_scores`.
+
+## Probe coverage
+
+The affected path is already covered by the registered PR-scoped probe
+`rerank-core-top-k-heap-selection` in `infra/perf/pr_scoped_probes.json`. That
+entry includes focused `test_command`, `coverage_command`, and `probe_command`
+commands and watches:
+
+- `services/mlx-worker-python/worker/engine/rerank_core.py`
+- `services/mlx-worker-python/tests/test_rerank_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/rerank_top_k_probe.py`
+
+## Implementation plan
+
+- Preserve the existing full-sort and bounded heap behavior for `top_k` values
+  other than one.
+- Replace the Python-level manual best-score loop for `top_k=1` with the built-in
+  `max(range(len(scores)), key=scores.__getitem__)`, which keeps first-index
+  tie-breaking while moving the comparison loop into the built-in implementation.
+- Reuse existing rerank regression tests and the registered probe to validate
+  behavior and performance.
+
+## Validation
+
+Local Linux validation must include:
+
+- focused rerank test command from the registered probe
+- changed-scope coverage command from the registered probe
+- `scripts/rerank_top_k_probe.py` probe command
+
+The CI PR-scoped performance workflow remains the merge gate for the registered
+probe report.

--- a/services/mlx-worker-python/worker/engine/rerank_core.py
+++ b/services/mlx-worker-python/worker/engine/rerank_core.py
@@ -50,14 +50,8 @@ class RerankCore:
     def _rank_scores(scores: list[float], *, top_k: int | None) -> list[tuple[int, float]]:
         if top_k is not None and top_k < len(scores):
             if top_k == 1:
-                best_index = 0
-                best_score = scores[0]
-                for index in range(1, len(scores)):
-                    score = scores[index]
-                    if score > best_score:
-                        best_index = index
-                        best_score = score
-                return [(best_index, best_score)]
+                best_index = max(range(len(scores)), key=scores.__getitem__)
+                return [(best_index, scores[best_index])]
             return [
                 (index, score)
                 for _negative_score, index, score in heapq.nsmallest(


### PR DESCRIPTION
## Summary
- Speeds up the rerank `top_k=1` fast path by replacing the Python-level manual best-score loop with `max(range(len(scores)), key=scores.__getitem__)`.
- Keeps first-index tie-breaking and leaves the bounded heap/full-sort paths unchanged.
- Adds a scoped plan documenting the registered PR-scoped probe coverage for this slice.

## Plan or Spec
- `docs/plans/2026-05-15-rerank-top-k-one-fast-max.md`
- Existing registered probe: `rerank-core-top-k-heap-selection` in `infra/perf/pr_scoped_probes.json` with focused test, coverage, and probe commands.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_preserves_sort_contract_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_uses_single_scan_for_top_k_one services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_uses_heap_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_keeps_full_sort_when_unbounded services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_returns_sorted_scores_and_honors_top_k services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_rerank_core_top_k_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_rerank_top_k_probe_script_emits_top_k_one_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/rerank_core.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/rerank_top_k_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/rerank_top_k_probe.py` repeated on `origin/main` and this branch for three local probe runs each.
- `git diff --check`

## Coverage and Metrics
- Focused tests: 8 passed.
- Changed-scope coverage: 100.00% (`2/2` measurable changed lines covered).
- Local Linux probe, `elapsed_ms_mean` three-run mean:
  - `origin/main`: `2439.966887 ms`
  - this branch: `2383.984596 ms`
  - delta: `-55.982291 ms`
  - speedup: `1.02348x`
- Registered PR-scoped performance CI is required as the merge gate for the final probe report.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime behavior is changed.
- The observed local probe gain is modest, so CI probe variance should be checked before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before starting the slice.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions, including PR-scoped performance, completed successfully.
