### PR TITLE
perf: slot serving diagnostics request summaries

### DIFF
--- a/docs/plans/2026-05-15-serving-diagnostics-request-summary-slots.md
+++ b/docs/plans/2026-05-15-serving-diagnostics-request-summary-slots.md
@@ -1,0 +1,35 @@
+# Serving Diagnostics Request Summary Slots Slice
+
+## Scope
+
+This slice keeps the existing serving diagnostics bundle behavior unchanged and
+narrows the Python object allocation footprint for request summary records by
+adding dataclass slots to `ServingDiagnosticsRequestSummary`.
+
+## Probe Coverage
+
+The affected path is already covered by the registered PR-scoped performance
+probe `serving-diagnostics-debug-queue-bounds` in
+`infra/perf/pr_scoped_probes.json`.
+
+The probe includes:
+
+- `test_command` covering `services/mlx-worker-python/tests/test_serving_diagnostics.py`
+  and PR-scoped probe selection/script tests.
+- `coverage_command` replaying the same focused test set under coverage.
+- `probe_command` invoking `scripts/serving_diagnostics_queue_probe.py` with
+  command-json metrics.
+
+## Implementation Plan
+
+1. Add `slots=True` to `ServingDiagnosticsRequestSummary`.
+2. Keep serialization keys and value coercion unchanged.
+3. Run the focused registered tests, changed-scope coverage, and registered
+   probe locally on Linux.
+4. Accept only if behavior remains stable and the registered probe shows a
+   non-regressing or improved direction.
+
+## Validation Boundary
+
+This is a Python-only slice and can be locally verified on Linux. No Swift
+runtime effect is claimed for this slice.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -103,6 +103,7 @@ def test_serving_diagnostics_bundle_writes_stable_layout_and_prefill_fields(
     assert request_payload["cache_restored_tokens"] == 64
     assert request_payload["cache_computed_tokens"] == 64
     assert request_payload["finish_reason"] == "stop"
+    assert not hasattr(summary, "__dict__")
 
     event_rows = [
         json.loads(line)

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -75,7 +75,7 @@ class BoundedServingDiagnosticsEventQueue:
             )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ServingDiagnosticsRequestSummary:
     request_id: str
     task_kind: str


### PR DESCRIPTION
## Summary
- Add `slots=True` to `ServingDiagnosticsRequestSummary` to remove per-instance `__dict__` allocation on the serving diagnostics bundle path.
- Add a focused regression assertion that request summaries remain slotted while existing JSON output stays unchanged.
- Record the slice plan and validation boundary under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-05-15-serving-diagnostics-request-summary-slots.md`
- Registered PR-scoped performance probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline (origin/main, detached worktree) registered probe, 3 runs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
exit 0; elapsed_ms_mean samples: 6.660810, 5.575572, 5.945824; serialization_elapsed_ms_mean samples: 1.397945, 1.199244, 1.276379

# Focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
exit 0; 31 passed in 0.17s

# Changed-scope coverage from the registered coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
exit 0; TOTAL 2 0 100%

# Head registered probe, 3 runs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
exit 0; elapsed_ms_mean samples: 5.477203, 5.989006, 5.477418; serialization_elapsed_ms_mean samples: 1.259189, 1.352165, 1.234074

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Registered probe local Linux comparison, 3 runs each:
  - `elapsed_ms_mean`: old_mean=6.060735 ms, new_mean=5.647876 ms, delta=-0.412860 ms, speedup=6.812%.
  - `serialization_elapsed_ms_mean`: old_mean=1.291189 ms, new_mean=1.281809 ms, delta=-0.009380 ms, speedup=0.726%.
  - `serialized_bytes`: unchanged at 10880 bytes.
  - `dropped_count`: unchanged at 4032 events; `retained_count`: unchanged at 64 events.
- CI must run the registered PR-scoped performance workflow and publish the authoritative PR probe report before merge.

## Known Gaps
- Full repository gates were not run locally; this slice used the registered focused Python tests, changed-scope coverage, and registered probe on Linux.
- No Swift runtime effect is claimed for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Debug diagnostics path; no new observability mode; overhead recorded via registered probe metrics.
- [x] Deferred work and known gaps are stated explicitly.
