### PR TITLE
perf: stream default serving diagnostic event rows

### DIFF
--- a/docs/plans/2026-05-15-serving-diagnostics-default-event-jsonl.md
+++ b/docs/plans/2026-05-15-serving-diagnostics-default-event-jsonl.md
@@ -1,0 +1,31 @@
+# Serving diagnostics default event JSONL streaming
+
+## Scope
+
+This Python-only performance slice targets serving diagnostics event JSONL output
+in `services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+The debug queue commonly retains events with the default empty attributes mapping,
+and the registered queue probe serializes those retained events in each sample.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `serving-diagnostics-debug-queue-bounds` in
+`infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`,
+`coverage_command`, and `probe_command` entries for the serving diagnostics
+module, tests, and probe script.
+
+## Optimization Plan
+
+- Preserve the public JSONL key order, compact formatting, string escaping, and
+  numeric coercion fallback behavior for non-default/non-exact event rows.
+- Add a focused regression test proving default-attribute event JSONL rows can be
+  streamed without materializing `ServingDiagnosticsEvent.to_dict()` payloads.
+- Route `_write_jsonl()` through a narrow fast path for `ServingDiagnosticsEvent`
+  instances with default empty attributes and exact `int`/`float` numeric fields;
+  fall back to the existing stable encoder for all other rows.
+
+## Validation
+
+Run the registered probe locally on Linux with focused tests and changed-scope
+coverage before opening the PR. CI PR-scoped performance remains the merge gate.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -519,6 +519,110 @@ def test_serving_diagnostics_events_jsonl_uses_compact_stable_lines(tmp_path: Pa
     )
 
 
+def test_serving_diagnostics_events_jsonl_streams_default_attribute_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = ServingDiagnosticsRequestSummary(
+        request_id="req-empty-jsonl",
+        task_kind="text-generation",
+        model_id="melix-dev-text",
+        runtime_kind="deterministic",
+        acceleration_mode="baseline",
+        prompt_protocol_id="chat.completions.v1",
+        prompt_digest="sha256:prompt",
+        prompt_template_digest="sha256:template",
+        generation_config={},
+        status="completed",
+        finish_reason="stop",
+    )
+    event = ServingDiagnosticsEvent(
+        request_id='req-"quoted"',
+        phase="decode",
+        event_index=7,
+        status="completed",
+        duration_ms=0.001,
+    )
+
+    def fail_to_dict(_: object) -> dict[str, object]:  # pragma: no cover
+        raise AssertionError("default-attribute JSONL rows should not materialize event dicts")
+
+    monkeypatch.setattr(ServingDiagnosticsEvent, "to_dict", fail_to_dict)
+
+    paths = write_serving_diagnostics_bundle(
+        output_root=tmp_path,
+        bundle_id="diag-empty-jsonl",
+        invocation={},
+        effective_config={},
+        model_refs={},
+        request_summary=summary,
+        events=(event,),
+        diagnostics_mode="debug",
+    )
+
+    line = paths["events"].read_text(encoding="utf-8")
+    assert line == (
+        '{"attributes":{},"duration_ms":0.001,"event_index":7,'
+        '"phase":"decode","request_id":"req-\\"quoted\\"",'
+        '"schema_version":"melix.serving_diagnostics.event.v1",'
+        '"status":"completed"}\n'
+    )
+
+
+def test_serving_diagnostics_events_jsonl_falls_back_for_non_exact_numeric_fields(
+    tmp_path: Path,
+) -> None:
+    summary = ServingDiagnosticsRequestSummary(
+        request_id="req-fallback-jsonl",
+        task_kind="text-generation",
+        model_id="melix-dev-text",
+        runtime_kind="deterministic",
+        acceleration_mode="baseline",
+        prompt_protocol_id="chat.completions.v1",
+        prompt_digest="sha256:prompt",
+        prompt_template_digest="sha256:template",
+        generation_config={},
+        status="completed",
+        finish_reason="stop",
+    )
+    event = ServingDiagnosticsEvent(
+        request_id="req-fallback",
+        phase="decode",
+        event_index=True,
+        status="completed",
+        duration_ms=1,
+    )
+    nonfinite_event = ServingDiagnosticsEvent(
+        request_id="req-nonfinite",
+        phase="decode",
+        event_index=2,
+        status="completed",
+        duration_ms=float("inf"),
+    )
+
+    paths = write_serving_diagnostics_bundle(
+        output_root=tmp_path,
+        bundle_id="diag-fallback-jsonl",
+        invocation={},
+        effective_config={},
+        model_refs={},
+        request_summary=summary,
+        events=(event, nonfinite_event),
+        diagnostics_mode="debug",
+    )
+
+    rows = [
+        json.loads(line)
+        for line in paths["events"].read_text(encoding="utf-8").splitlines()
+    ]
+    payload = rows[0]
+    assert payload["event_index"] == 1
+    assert type(payload["event_index"]) is int
+    assert payload["duration_ms"] == 1.0
+    assert type(payload["duration_ms"]) is float
+    assert rows[1]["duration_ms"] == float("inf")
+
+
 @pytest.mark.parametrize("value", (0, -1, "0", "bad", None))
 def test_validate_prefill_chunk_size_rejects_invalid_overrides(value: object) -> None:
     with pytest.raises(ValueError, match="prefill_chunk_size"):

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -19,6 +19,7 @@ SERVING_DIAGNOSTICS_COMPARISON_SCHEMA_VERSION = "melix.serving_diagnostics.compa
 _EMPTY_EVENT_ATTRIBUTES: Mapping[str, object] = MappingProxyType({})
 _JSON_COMPACT_SEPARATORS = (",", ":")
 _JSONL_ENCODER = json.JSONEncoder(sort_keys=True, separators=_JSON_COMPACT_SEPARATORS)
+_JSON_STRING_ENCODER = json.JSONEncoder(separators=_JSON_COMPACT_SEPARATORS).encode
 _SET_FROZEN_ATTR = object.__setattr__
 
 
@@ -296,7 +297,7 @@ def write_serving_diagnostics_bundle(
     _write_json(manifest_path, manifest)
     _write_json(effective_config_path, _stable_json_object(effective_config))
     _write_json(request_summary_path, request_summary.to_dict())
-    _write_jsonl(events_path, (event.to_dict() for event in event_rows))
+    _write_jsonl(events_path, event_rows)
     return {
         "bundle_root": bundle_root,
         "manifest": manifest_path,
@@ -480,5 +481,37 @@ def _write_jsonl(path: Path, rows: Any) -> None:
         encode = _JSONL_ENCODER.encode
         write = handle.write
         for row in rows:
+            if isinstance(row, ServingDiagnosticsEvent):
+                fast_line = _empty_attribute_event_json_line(row)
+                if fast_line is not None:
+                    write(fast_line)
+                    write("\n")
+                    continue
+                row = row.to_dict()
             write(encode(row))
             write("\n")
+
+
+def _empty_attribute_event_json_line(event: ServingDiagnosticsEvent) -> str | None:
+    if event.attributes is not _EMPTY_EVENT_ATTRIBUTES:
+        return None
+    event_index = event.event_index
+    duration_ms = event.duration_ms
+    if type(event_index) is not int or type(duration_ms) is not float:
+        return None
+    if not math.isfinite(duration_ms):
+        return None
+    encode_string = _JSON_STRING_ENCODER
+    return (
+        '{"attributes":{},"duration_ms":'
+        f"{duration_ms!r}"
+        ',"event_index":'
+        f"{event_index}"
+        ',"phase":'
+        f"{encode_string(event.phase)}"
+        ',"request_id":'
+        f"{encode_string(event.request_id)}"
+        ',"schema_version":"melix.serving_diagnostics.event.v1","status":'
+        f"{encode_string(event.status)}"
+        "}"
+    )


### PR DESCRIPTION
## Summary
- Stream default-attribute serving diagnostics event JSONL rows without materializing `ServingDiagnosticsEvent.to_dict()` dictionaries.
- Preserve the existing stable JSONL output, string escaping, and fallback behavior for non-default attributes, non-exact numeric fields, and non-finite durations.
- Add focused regression coverage for the fast path and fallback path.

## Plan or Spec
- `docs/plans/2026-05-15-serving-diagnostics-default-event-jsonl.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py::test_serving_diagnostics_events_jsonl_streams_default_attribute_rows
# exit 0; 1 passed in 0.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 32 passed in 0.11s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# exit 0; 33 passed; TOTAL 39 0 100%

MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=15 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id serving-diagnostics-debug-queue-bounds --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/serving_event_jsonl_fastpath_probe15.json
# exit 0; head verification passed; base/head probe completed

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 39 0 100%`.
- Registered probe: `serving-diagnostics-debug-queue-bounds`.
- Local Linux probe output with 15 samples:
  - base: `elapsed_ms_mean=6.241663`, `serialization_elapsed_ms_mean=1.395872`, `serialized_bytes=10944.0`
  - head: `elapsed_ms_mean=5.838662`, `serialization_elapsed_ms_mean=1.172040`, `serialized_bytes=10944.0`
  - delta: `elapsed_ms_mean -0.403001 ms` (~6.46% faster), `serialization_elapsed_ms_mean -0.223832 ms` (~16.04% faster), serialized bytes unchanged.
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Python-only slice verified locally on Linux; no Swift runtime effect is claimed.
- The default registered probe uses 5 samples and can be noisy for the append-only `elapsed_ms_mean`; local acceptance used 15 samples to stabilize the serialization-path comparison. CI registered probe validation remains required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead N/A because production instrumentation is unchanged.
- [x] Deferred work and known gaps are stated explicitly.
