### PR TITLE
perf: coalesce serving diagnostics jsonl writes

### DIFF
--- a/docs/plans/2026-05-13-serving-diagnostics-queue-overflow-fast-path.md
+++ b/docs/plans/2026-05-13-serving-diagnostics-queue-overflow-fast-path.md
@@ -22,6 +22,12 @@ as an exact `float`, so `ServingDiagnosticsEvent.to_dict()` can skip redundant
 numeric constructor calls while retaining the previous coercion behavior for
 non-exact numeric inputs.
 
+The 2026-05-15 follow-up keeps the same debug-event JSONL bytes but coalesces
+the serialized row and newline into one `write()` call per row. The registered
+probe's serialization phase writes retained queue rows on every sample, so this
+slice reduces Python-level file-write dispatch without changing queue overflow
+semantics or the emitted diagnostics artifact shape.
+
 ## Affected Paths
 
 - `services/mlx-worker-python/worker/productization/serving_diagnostics.py`

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -484,12 +484,10 @@ def _write_jsonl(path: Path, rows: Any) -> None:
             if isinstance(row, ServingDiagnosticsEvent):
                 fast_line = _empty_attribute_event_json_line(row)
                 if fast_line is not None:
-                    write(fast_line)
-                    write("\n")
+                    write(fast_line + "\n")
                     continue
                 row = row.to_dict()
-            write(encode(row))
-            write("\n")
+            write(encode(row) + "\n")
 
 
 def _empty_attribute_event_json_line(event: ServingDiagnosticsEvent) -> str | None:


### PR DESCRIPTION
## Summary
- Rebased on current `origin/main` after #1075 merged.
- Coalesces serving diagnostics JSONL row writes so each row and trailing newline are written with one `write()` call.
- Keeps the debug queue overflow behavior and emitted diagnostics JSONL bytes unchanged.

## Plan or Spec
- `docs/plans/2026-05-13-serving-diagnostics-queue-overflow-fast-path.md`

## Commands Run
```text
$ git diff --check
# exit 0

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 33 passed in 0.67s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# exit 0; TOTAL 0 0 100% after rebase (focused tests cover the registered scope; no measurable changed lines remained in changed-scope diff comparison).

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id serving-diagnostics-debug-queue-bounds --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-main --head-repo "$PWD" --output /tmp/serving-diagnostics-probe-rebased.json
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 0 0 100%` after rebase; focused registered-scope tests passed.
- Registered probe: `serving-diagnostics-debug-queue-bounds`.
- Local Linux registered probe after rebase:
  - `elapsed_ms_mean`: base `6.337444`, head `5.716841`, delta `-0.620603 ms` (`-9.79%`, `1.1086x`).
  - `serialization_elapsed_ms_mean`: base `1.446116`, head `1.084321`, delta `-0.361795 ms` (`-25.02%`, `1.3337x`).
  - `dropped_count`: `4032`, `retained_count`: `64`, `serialization_checksum`: `260064`, `serialized_bytes`: `10880` unchanged.
- CI PR-scoped performance workflow is required as the merge gate for the registered probe validation after this rebase push.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this narrow Python serialization slice.
- Swift runtime effects are not applicable; this is a Python-only Linux-verifiable slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Debug diagnostics path; probe overhead is covered by the registered local and CI probe.
- [x] Deferred work and known gaps are stated explicitly.