### PR TITLE
perf: fast-path model weight suffix checks

### DIFF
--- a/docs/plans/2026-05-15-runtime-utils-weight-suffix-fast-path.md
+++ b/docs/plans/2026-05-15-runtime-utils-weight-suffix-fast-path.md
@@ -1,0 +1,34 @@
+# Runtime Utils Weight Suffix Fast Path
+
+## Scope
+
+This performance slice is limited to the Python worker helper that scans top-level model weight files in `services/mlx-worker-python/worker/runtime/runtime_utils.py`.
+
+## Registered Probe
+
+Affected path is covered by the registered PR-scoped probe `runtime-utils-top-level-weight-streaming` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and repeatedly calls `estimate_model_weight_resident_bytes(...)` over a synthetic flat model directory. Relevant metrics:
+
+- `elapsed_ms_mean` (`lower_is_better`)
+- `peak_bytes_mean` (`lower_is_better`)
+
+## Optimization Slice
+
+`_weight_dir_entry_file_size(...)` previously used `os.path.splitext(entry.name)[1].lower()` for every scanned directory entry. Most generated and downloaded model weight files already use lowercase suffixes, so the slice adds a lowercase-suffix fast path using `str.endswith(...)` before falling back to the case-insensitive path for mixed-case compatibility.
+
+This keeps behavior unchanged for mixed-case suffixes while avoiding `splitext(...)` tuple construction and suffix normalization on the common lowercase weight-file path.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage, and registered probe locally on Linux before opening a PR:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_top_level_weights_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_top_level_weights_probe.py
+```
+
+CI remains the merge gate for the registered PR-scoped performance report.

--- a/services/mlx-worker-python/tests/test_runtime_utils.py
+++ b/services/mlx-worker-python/tests/test_runtime_utils.py
@@ -328,6 +328,7 @@ def test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors() -> 
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("broken.safetensors", is_file_raises=True)) == 0
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("missing.safetensors", stat_raises=True)) == 0
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("model.safetensors")) == 13
+    assert runtime_utils._weight_dir_entry_file_size(FakeEntry("adapter.SAFEtensors")) == 13
 
 
 def test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory(

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -177,7 +177,10 @@ def _top_level_weight_file_bytes(model_dir: Path) -> int:
 
 
 def _weight_dir_entry_file_size(entry: os.DirEntry[str]) -> int:
-    if os.path.splitext(entry.name)[1].lower() not in _MODEL_WEIGHT_SUFFIXES:
+    name = entry.name
+    if not name.endswith(_MODEL_WEIGHT_SUFFIXES) and not name.lower().endswith(
+        _MODEL_WEIGHT_SUFFIXES,
+    ):
         return 0
     try:
         if not entry.is_file():


### PR DESCRIPTION
## Summary
- Fast-path lowercase model weight suffix checks in `runtime_utils._weight_dir_entry_file_size(...)` before falling back to case-insensitive matching.
- Preserve mixed-case suffix behavior with focused regression coverage.
- Document the slice and registered probe evidence plan.

## Plan or Spec
- `docs/plans/2026-05-15-runtime-utils-weight-suffix-fast-path.md`
- Registered probe: `runtime-utils-top-level-weight-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline before implementation (origin/main worktree)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_top_level_weights_probe.py
  elapsed_ms_mean=263.38094933889806, peak_bytes_mean=2040.8, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_top_level_weights_probe.py
  elapsed_ms_mean=261.40245962888, peak_bytes_mean=2040.8, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_top_level_weights_probe.py
  elapsed_ms_mean=284.54907783307135, peak_bytes_mean=2040.8, exit 0

# Focused tests after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics
  9 passed in 0.70s, exit 0

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused test list>
  9 passed in 0.23s, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
  Wrote JSON report to coverage.json, exit 0
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_top_level_weights_probe.py
  TOTAL 3 0 100%, exit 0

# Registered probe after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_top_level_weights_probe.py
  elapsed_ms_mean=196.17977640591562, peak_bytes_mean=2040.8, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_top_level_weights_probe.py
  elapsed_ms_mean=204.91301622241735, peak_bytes_mean=2040.8, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_top_level_weights_probe.py
  elapsed_ms_mean=204.66989087872207, peak_bytes_mean=2040.8, exit 0

git diff --check
  exit 0
git status --short
  clean before push, exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Local Linux registered probe (`runtime-utils-top-level-weight-streaming`): old_mean=269.77749560028315 ms, new_mean=201.92089450235167 ms, delta_ms=-67.85660109793147, speedup=1.3360553709172538x, improvement=25.152802663151512% lower elapsed time.
- `peak_bytes_mean` stayed flat at 2040.8 bytes.
- CI PR-scoped performance report is still required as the merge gate.

## Known Gaps
- Local validation covers the Python/Linux path only; no Swift runtime effect is claimed.
- CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; probe overhead is the probe workload itself and no production observability was added.
- [x] Deferred work and known gaps are stated explicitly.
