### PR TITLE
perf: slot video preprocessing records

### DIFF
--- a/docs/plans/2026-05-15-video-prepared-input-slots.md
+++ b/docs/plans/2026-05-15-video-prepared-input-slots.md
@@ -1,0 +1,35 @@
+# Video Prepared Input Slots Performance Slice
+
+## Scope
+
+This Python-only slice is limited to video preprocessing record containers in
+`services/mlx-worker-python/worker/runtime/video_preprocessing.py`. It preserves
+video request parsing, URI validation, filename/format inference, identity hash
+construction, and public field access while removing per-instance `__dict__`
+allocation for the prepared input and parsed reference records.
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped registered probe
+`video-preprocessing-uri-byte-length-reuse` in
+`infra/perf/pr_scoped_probes.json`. The registry entry watches
+`video_preprocessing.py`, `test_video_preprocessing.py`, the PR-scoped
+performance tests, and `scripts/video_preprocessing_uri_probe.py`; it includes
+focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+The probe reports elapsed time, parsed-reference call counts, byte-length read
+counts, and checksum stability for repeated URI preprocessing.
+
+## Implementation Plan
+
+1. Add regression coverage proving `PreparedVideoInput` and
+   `ParsedVideoReference` are slotted while retaining field access.
+2. Add `slots=True` to both frozen dataclasses.
+3. Run the registered focused tests, changed-scope coverage, and local Linux
+   probe before pushing.
+4. Use the PR-scoped performance CI report as the merge gate.
+
+## Validation Boundary
+
+This is a Python-only slice and can be locally verified on Linux. No Swift
+runtime effect is claimed for this slice.

--- a/services/mlx-worker-python/tests/test_video_preprocessing.py
+++ b/services/mlx-worker-python/tests/test_video_preprocessing.py
@@ -48,6 +48,29 @@ def test_prepare_video_input_accepts_inline_bytes_with_explicit_metadata() -> No
     )
 
 
+def test_prepared_video_records_use_slots_without_changing_fields() -> None:
+    prepared = PreparedVideoInput(
+        source_kind="uri",
+        reference="https://example.com/media/demo.mov",
+        bytes_data=b"",
+        mime_type="video/quicktime",
+        format="mov",
+        filename="demo.mov",
+        byte_length=123,
+        duration_ms=1_000,
+        frame_budget=4,
+        start_ms=0,
+        end_ms=1_000,
+        sha256_hex="a" * 64,
+    )
+    parsed = _parse_video_reference("https://example.com/media/demo.mov")
+
+    assert not hasattr(prepared, "__dict__")
+    assert not hasattr(parsed, "__dict__")
+    assert prepared.filename == "demo.mov"
+    assert parsed.path_suffix == "mov"
+
+
 def test_prepare_video_input_accepts_uri_and_infers_format_from_reference() -> None:
     part = common_pb2.MessagePart(
         video_uri="https://example.com/media/demo.mov",

--- a/services/mlx-worker-python/worker/runtime/video_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/video_preprocessing.py
@@ -19,7 +19,7 @@ SUPPORTED_VIDEO_MIME_TYPES = {
 MAX_VIDEO_FRAME_BUDGET = 128
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PreparedVideoInput:
     source_kind: str
     reference: str
@@ -35,7 +35,7 @@ class PreparedVideoInput:
     sha256_hex: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ParsedVideoReference:
     raw: str
     scheme: str


### PR DESCRIPTION
## Summary
- Add `slots=True` to `PreparedVideoInput` and `ParsedVideoReference` in the video preprocessing URI hot path.
- Add regression coverage proving both record containers no longer allocate `__dict__` while preserving field access.
- Add a scoped plan for the Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-05-15-video-prepared-input-slots.md`
- Registered probe: `video-preprocessing-uri-byte-length-reuse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/video_preprocessing_uri_probe.py`
- Baseline: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/video_preprocessing_uri_probe.py` on `origin/main`
- Candidate: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/video_preprocessing_uri_probe.py` on this branch
- `git diff --check`

## Coverage and Metrics
- Focused tests: 24 passed.
- Changed-scope coverage: 100% total (9/9 measurable changed lines).
- Local Linux probe (`video_preprocessing_uri_probe.py`, 5 samples x 50,000 iterations):
  - `origin/main` `elapsed_ms_mean=788.2248853798956`
  - branch `elapsed_ms_mean=770.3320486471057`
  - delta `-17.892836732789874 ms`, speedup `2.270016725514341%`
  - `parse_calls_per_call=1.0`, `byte_length_getattrs_per_call=1.0` unchanged.

## Known Gaps
- Python-only slice; no Swift runtime effect is claimed.
- Registered PR-scoped performance CI report is required before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed on Linux.
- [x] Changed-scope coverage met the >=95% requirement.
- [x] Local registered probe compared `origin/main` vs branch.
- [ ] GitHub Actions and registered PR-scoped performance report completed successfully.
