### PR TITLE
perf: slot startup failure reports

### DIFF
--- a/docs/plans/2026-05-15-startup-failure-report-slots.md
+++ b/docs/plans/2026-05-15-startup-failure-report-slots.md
@@ -1,0 +1,30 @@
+# Startup Failure Report Slots Slice
+
+## Scope
+
+This Python-only performance slice is limited to the startup failure classification result object in `services/mlx-worker-python/worker/productization/startup_signals.py`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe `startup-signals-lazy-worker-log-excerpts` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/startup_signals.py`
+- `services/mlx-worker-python/tests/test_startup_signals.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/startup_signals_log_probe.py`
+
+This slice extends the existing probe metrics with `report_alloc_elapsed_ms_mean`, `report_alloc_peak_bytes_mean`, and `report_has_dict_mean` so the allocation impact of slots is measured directly alongside the existing startup failure classification timings.
+
+## Optimization Slice
+
+`StartupFailureReport` is allocated on every startup failure classification path. This slice adds dataclass slots to remove the per-instance `__dict__` while preserving the frozen dataclass API and `to_dict()` payload.
+
+The change intentionally does not modify log-reading decisions, classification labels, summaries, or manifest fields.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage, and registered probe locally on Linux before pushing. Compare the registered probe output against a pre-change baseline captured from `origin/main` in the same worktree.
+
+CI remains the merge gate for the registered PR-scoped performance report.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2940,6 +2940,24 @@
         "key": "trailing_whitespace_bytes",
         "unit": "bytes",
         "direction": "informational"
+      },
+      {
+        "key": "report_alloc_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "report_alloc_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "report_has_dict_mean",
+        "unit": "bool",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
       }
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics",

--- a/scripts/startup_signals_log_probe.py
+++ b/scripts/startup_signals_log_probe.py
@@ -88,6 +88,37 @@ def _measure_tail_scan(log_path: Path, *, iterations: int) -> tuple[float, float
     return statistics.fmean(elapsed_samples), statistics.fmean(peak_samples)
 
 
+def _measure_report_allocations(*, iterations: int) -> tuple[float, float, float]:
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    has_dict_samples: list[float] = []
+    for _ in range(5):
+        tracemalloc.start()
+        started = time.perf_counter()
+        reports = [
+            startup_signals.StartupFailureReport(
+                classification="control_plane_crash",
+                summary="Control plane crashed before startup completed.",
+                detail="Inspect the control-plane logs for the crash cause.",
+                http_port=12436,
+                ready_probe_url="http://127.0.0.1:12436/v1/models",
+                primary_log_path="control-plane.stderr.log",
+                log_excerpt="fatal error: control plane crashed",
+            )
+            for _ in range(iterations)
+        ]
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_samples.append(float(peak))
+        has_dict_samples.append(1.0 if hasattr(reports[0], "__dict__") else 0.0)
+    return (
+        statistics.fmean(elapsed_samples),
+        statistics.fmean(peak_samples),
+        statistics.fmean(has_dict_samples),
+    )
+
+
 def main() -> int:
     iterations = 400
     samples = 5
@@ -153,6 +184,9 @@ def main() -> int:
             worker_exists.append(exists / iterations)
 
         tail_elapsed_mean, tail_peak_mean = _measure_tail_scan(tail_log, iterations=iterations)
+        report_alloc_elapsed_mean, report_alloc_peak_mean, report_has_dict_mean = (
+            _measure_report_allocations(iterations=iterations * 10)
+        )
 
     print(
         json.dumps(
@@ -176,6 +210,9 @@ def main() -> int:
                     6,
                 ),
                 "iterations": float(iterations),
+                "report_alloc_elapsed_ms_mean": round(report_alloc_elapsed_mean, 6),
+                "report_alloc_peak_bytes_mean": round(report_alloc_peak_mean, 6),
+                "report_has_dict_mean": round(report_has_dict_mean, 6),
                 "sample_count": float(samples),
                 "tail_scan_elapsed_ms_mean": round(tail_elapsed_mean, 6),
                 "tail_scan_peak_bytes_mean": round(tail_peak_mean, 6),

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -3115,6 +3115,9 @@ def test_startup_signals_probe_script_emits_metrics(capsys: pytest.CaptureFixtur
     assert payload["worker_crash_elapsed_ms_mean"] > 0
     assert payload["worker_crash_log_path_exists_checks_mean"] == 0.0
     assert payload["worker_crash_log_reads_mean"] == 1.0
+    assert payload["report_alloc_elapsed_ms_mean"] > 0
+    assert payload["report_alloc_peak_bytes_mean"] > 0
+    assert payload["report_has_dict_mean"] == 0.0
     assert payload["tail_scan_elapsed_ms_mean"] > 0
     assert payload["tail_scan_peak_bytes_mean"] > 0
     assert payload["trailing_whitespace_bytes"] == 80000.0

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -214,6 +214,31 @@ def test_classify_startup_failure_reports_host_port_conflict(tmp_path: Path) -> 
     assert "Address already in use" in report.log_excerpt
 
 
+def test_startup_failure_report_uses_slots_without_changing_dict_payload(tmp_path: Path) -> None:
+    control_plane_stderr = tmp_path / "control-plane.stderr.log"
+    control_plane_stderr.write_text("fatal error: boot failed\n", encoding="utf-8")
+
+    report = classify_startup_failure(
+        {
+            "http_port": 11434,
+            "ready_probe_url": "http://127.0.0.1:11434/v1/models",
+            "control_plane_stderr_path": str(control_plane_stderr),
+        },
+        error_text="handshake failed",
+    )
+
+    assert not hasattr(report, "__dict__")
+    assert report.to_dict() == {
+        "classification": "control_plane_crash",
+        "summary": "Control plane crashed before startup completed.",
+        "detail": "Melix never reached http://127.0.0.1:11434/v1/models. Inspect the control-plane logs for the crash cause.",
+        "http_port": 11434,
+        "ready_probe_url": "http://127.0.0.1:11434/v1/models",
+        "primary_log_path": str(control_plane_stderr),
+        "log_excerpt": "fatal error: boot failed",
+    }
+
+
 def test_classify_startup_failure_skips_log_reads_when_error_text_reports_port_conflict(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -36,7 +36,7 @@ class UpdateCheckResult:
     detail: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class StartupFailureReport:
     classification: str
     summary: str


### PR DESCRIPTION
## Summary
- Add `slots=True` to `StartupFailureReport` to remove the per-instance `__dict__` on startup failure classification results.
- Extend the registered startup-signals PR-scoped probe with report allocation metrics.
- Add regression coverage proving the serialized startup failure payload is unchanged.

## Plan or Spec
- `docs/plans/2026-05-15-startup-failure-report-slots.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# 35 passed in 1.13s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py
# TOTAL 25 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py
# {"conflict_elapsed_ms_mean": 0.81881, "control_crash_elapsed_ms_mean": 9.086927, "direct_control_crash_elapsed_ms_mean": 0.822141, "report_alloc_elapsed_ms_mean": 14.772321, "report_alloc_peak_bytes_mean": 385355.2, "report_has_dict_mean": 0.0, "tail_scan_elapsed_ms_mean": 148.379883, "worker_crash_elapsed_ms_mean": 9.469219, ...}

python3 <origin/main allocation comparison script>
# old peak_bytes_mean=577692.8, new peak_bytes_mean=385288.0, delta_peak_bytes=-192404.8, speedup=1.050485, old has_dict=1.0, new has_dict=0.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 25 0 100%`).
- Registered local probe: `startup_signals_log_probe.py` completed successfully.
- Allocation micro-compare against `origin/main`: report allocation peak bytes decreased from `577692.8` to `385288.0` bytes for 4000 retained reports (`-192404.8` bytes), with elapsed speedup `1.050485x`; `report_has_dict_mean` changed from `1.0` to `0.0`.
- PR-scoped performance CI is required for the registered probe report before merge.

## Known Gaps
- Local Linux verification covers Python behavior and probe execution only; GitHub Actions PR-scoped performance remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: N/A; this updates an existing PR-scoped performance probe only.
- [x] Deferred work and known gaps are stated explicitly.
