### PR TITLE
perf: avoid code eval payload int cursor allocation

### DIFF
--- a/docs/plans/2026-05-15-code-eval-payload-int-cursor.md
+++ b/docs/plans/2026-05-15-code-eval-payload-int-cursor.md
@@ -1,0 +1,40 @@
+# Code Eval Payload Integer Cursor
+
+## Scope
+
+This Python-only performance slice is limited to the code-evaluation payload fast
+path in `services/mlx-worker-python/worker/engine/code_eval_runner.py`. It does
+not change sandbox execution, code-block extraction, stdio tail handling,
+protobuf artifacts, Swift, or macOS runtime behavior.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe
+`code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`. The probe
+entry includes focused `test_command`, `coverage_command`, and `probe_command`
+values and reports `elapsed_ms_mean`, `peak_bytes_mean`, `payload_bytes`,
+`sample_count`, and `iteration_count`.
+
+## Optimization
+
+`_extract_code_eval_payload_fields()` advances its next JSON key search cursor
+after parsing integer fields. The previous cursor update rebuilt the parsed
+integer as `str(value)` only to measure its digit length. This slice returns the
+integer parser's end cursor together with the parsed value so the caller can
+advance without a transient string allocation.
+
+## Verification plan
+
+- Run the registered focused pytest command locally on Linux.
+- Run the registered changed-scope coverage command locally on Linux and require
+  at least 95% for the changed executable scope.
+- Run the registered `code-eval-payload-json-bytes` probe against `origin/main`
+  and `HEAD` and compare `elapsed_ms_mean` and `peak_bytes_mean`.
+- Use the PR-scoped performance workflow as the merge gate after push.
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage remains at or above 95%.
+- The local registered probe preserves payload semantics and shows a clear or
+  noise-bounded improvement in `elapsed_ms_mean` without increasing peak memory.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -925,6 +925,7 @@ def test_payload_fast_path_field_extractors_cover_malformed_edges() -> None:
     assert code_eval_runner._extract_json_string_field(b'{"failure_detail":"oops}', "failure_detail") is None
     assert code_eval_runner._extract_json_int_field(b'{"tests_passed":-7}', "tests_passed") == -7
     assert code_eval_runner._extract_json_int_field(b'{"tests_total":12345}', "tests_total") == 12345
+    assert code_eval_runner._extract_json_int_field_value_and_end(b'-42, "next": 1', 0) == (-42, 3)
     assert code_eval_runner._extract_json_int_field(b'{"tests_total":-}', "tests_total") is None
     assert code_eval_runner._extract_json_int_field(b'{"tests_total": }', "tests_total") is None
 

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -382,11 +382,12 @@ def _extract_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, object]
                 search_start = value_start + len(value) + 1
             continue
 
-        value = _extract_json_int_field_at(payload_bytes, value_start)
-        if value is None:
+        int_result = _extract_json_int_field_value_and_end(payload_bytes, value_start)
+        if int_result is None:
             return None
+        value, value_end = int_result
         payload[key] = value
-        search_start = value_start + len(str(value))
+        search_start = value_end
 
     if _code_eval_payload_has_required_string_fields(payload):
         return payload
@@ -461,6 +462,17 @@ def _extract_json_int_field_with_token(payload_bytes: bytes, key_token: bytes) -
 
 
 def _extract_json_int_field_at(payload_bytes: bytes, start: int | None) -> int | None:
+    result = _extract_json_int_field_value_and_end(payload_bytes, start)
+    if result is None:
+        return None
+    value, _end = result
+    return value
+
+
+def _extract_json_int_field_value_and_end(
+    payload_bytes: bytes,
+    start: int | None,
+) -> tuple[int, int] | None:
     if start is None:
         return None
     cursor = start
@@ -482,7 +494,7 @@ def _extract_json_int_field_at(payload_bytes: bytes, start: int | None) -> int |
         cursor += 1
     if digit_count == 0:
         return None
-    return sign * value
+    return sign * value, cursor
 
 
 def _read_limited_stdio(path: Path, byte_limit: int) -> tuple[str, int]:


### PR DESCRIPTION
## Summary
- Avoid a transient `str(value)` allocation while advancing the code-evaluation payload fast-path cursor after integer fields.
- Keep the existing JSON integer helper behavior by delegating to a value+end-cursor parser.
- Add a focused regression assertion and a governing plan for this slice.

## Plan or Spec
- `docs/plans/2026-05-15-code-eval-payload-int-cursor.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_required_field_check_preserves_fast_path_gate services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
# exit 0; 9 passed in 1.73s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_required_field_check_preserves_fast_path_gate services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py
# exit 0; 9 passed; TOTAL 12 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-payload-json-bytes --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-code-eval-int-cursor-20260515233457 --head-repo "$PWD" --output /tmp/code_eval_payload_int_cursor_probe.json
# exit 0; head verification passed; base/head probe completed

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%`.
- Registered local probe: `code-eval-payload-json-bytes`.
- Local probe metrics: `elapsed_ms_mean` base `132.63604444052493` ms → head `124.83876567733076` ms (delta `-7.79727876319417` ms, about `5.88%` faster); `peak_bytes_mean` unchanged at `60425.0` bytes; `payload_bytes=55474.0`, `sample_count=7.0`, `iteration_count=1200.0`.
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- Full repository test gates were not run locally; this Linux slice used the focused registered Python commands.
- The registry entry's existing focused test selector still includes `test_scope_report_selects_code_eval_stdio_probe`; it passed and was not changed because this slice only changes payload integer cursor handling.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; probe overhead is limited to synthetic CI/local probe execution and not production runtime.
- [x] Deferred work and known gaps are stated explicitly.
