### PR TITLE
perf: batch serving diagnostics JSONL writes

### DIFF
--- a/docs/plans/2026-05-14-serving-diagnostics-jsonl-compact-serialization.md
+++ b/docs/plans/2026-05-14-serving-diagnostics-jsonl-compact-serialization.md
@@ -3,8 +3,9 @@
 ## Scope
 
 This Python-only slice narrows the serving diagnostics debug bundle hot path by
-writing event JSONL rows with compact JSON separators while preserving sorted key
-order and line-delimited JSON semantics.
+writing event JSONL rows with compact JSON separators and batching those rows
+into a single file write while preserving sorted key order and line-delimited
+JSON semantics.
 
 ## Registered probe
 

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -477,17 +477,18 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
 
 
 def _write_jsonl(path: Path, rows: Any) -> None:
-    with path.open("w", encoding="utf-8") as handle:
-        encode = _JSONL_ENCODER.encode
-        write = handle.write
-        for row in rows:
-            if isinstance(row, ServingDiagnosticsEvent):
-                fast_line = _empty_attribute_event_json_line(row)
-                if fast_line is not None:
-                    write(fast_line + "\n")
-                    continue
-                row = row.to_dict()
-            write(encode(row) + "\n")
+    encode = _JSONL_ENCODER.encode
+    lines: list[str] = []
+    append_line = lines.append
+    for row in rows:
+        if isinstance(row, ServingDiagnosticsEvent):
+            fast_line = _empty_attribute_event_json_line(row)
+            if fast_line is not None:
+                append_line(fast_line + "\n")
+                continue
+            row = row.to_dict()
+        append_line(encode(row) + "\n")
+    path.write_text("".join(lines), encoding="utf-8")
 
 
 def _empty_attribute_event_json_line(event: ServingDiagnosticsEvent) -> str | None:


### PR DESCRIPTION
## Summary
- Batch serving diagnostics `events.jsonl` rows into one text write after JSON encoding.
- Preserve newline-delimited JSON semantics, sorted keys, and compact row output.
- Update the existing serving diagnostics JSONL performance plan to describe the batched-write slice.

## Plan or Spec
- `docs/plans/2026-05-14-serving-diagnostics-jsonl-compact-serialization.md`
- Registered PR-scoped probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 33 passed in 0.69s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# 33 passed in 0.25s; TOTAL 12 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# {"capacity": 64.0, "dropped_count": 4032.0, "elapsed_ms_mean": 5.677813, "event_count": 4096.0, "retained_count": 64.0, "sample_count": 5.0, "serialization_checksum": 260064.0, "serialization_elapsed_ms_mean": 1.047477, "serialized_bytes": 10880.0}

MELIX_SERVING_DIAGNOSTICS_QUEUE_CAPACITY=512 MELIX_SERVING_DIAGNOSTICS_QUEUE_EVENTS=8192 MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=7 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# origin/main: {"capacity": 512.0, "dropped_count": 7680.0, "elapsed_ms_mean": 11.136287, "event_count": 8192.0, "retained_count": 512.0, "sample_count": 7.0, "serialization_checksum": 4062976.0, "serialization_elapsed_ms_mean": 2.881937, "serialized_bytes": 87040.0}
# head:        {"capacity": 512.0, "dropped_count": 7680.0, "elapsed_ms_mean": 10.920884, "event_count": 8192.0, "retained_count": 512.0, "sample_count": 7.0, "serialization_checksum": 4062976.0, "serialization_elapsed_ms_mean": 2.703426, "serialized_bytes": 87040.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%`.
- Local registered probe (default): `elapsed_ms_mean=5.677813`, `serialization_elapsed_ms_mean=1.047477`, `serialized_bytes=10880`.
- Local base/head comparison with capacity 512 and 8192 events:
  - `serialization_elapsed_ms_mean`: `2.881937 ms -> 2.703426 ms` (`-0.178511 ms`, about `6.19%` faster).
  - `elapsed_ms_mean`: `11.136287 ms -> 10.920884 ms` (`-0.215403 ms`, about `1.93%` faster).
  - `serialized_bytes`: unchanged at `87040`; `serialization_checksum`: unchanged at `4062976`.
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- Linux local validation covers the Python path only; no Swift runtime effect is involved in this slice.
- The batch write intentionally keeps bounded debug diagnostics in memory before writing; the registered debug queue remains bounded by `max_events`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
