### PR TITLE
perf: split changed-scope diff text on newline

### DIFF
--- a/docs/plans/2026-05-16-changed-scope-diff-newline-split.md
+++ b/docs/plans/2026-05-16-changed-scope-diff-newline-split.md
@@ -1,0 +1,36 @@
+# Changed-scope coverage diff newline split performance slice
+
+## Scope
+
+This slice targets only `scripts/changed_scope_coverage.py` diff parsing for
+changed-scope coverage reports. The parser consumes `git diff --unified=0`
+output, which is newline-delimited text produced by Git.
+
+## Probe coverage
+
+The affected path is covered by the registered PR-scoped probe
+`changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `scripts/changed_scope_coverage.py`
+- `tests/test_changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_parse_probe.py`
+- PR-scoped performance registry tests
+
+## Optimization
+
+Use the Git diff newline delimiter directly (`split("\n")`) instead of the
+more general `splitlines()` helper in the hot parser loop. The parser only needs
+Git's `\n` line separator, so this avoids the extra universal-newline handling
+while preserving changed-line results for the existing diff fixtures and probe
+shape.
+
+## Validation plan
+
+1. Run the focused changed-scope coverage tests.
+2. Run changed-scope coverage for the touched files.
+3. Run the registered `changed-scope-coverage-diff-parser` probe locally on
+   Linux and compare against the pre-change baseline.
+4. Require the PR-scoped performance workflow to run the registered probe in CI
+   before merge.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -49,7 +49,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     changed_by_path: dict[str, set[int]] = {}
     current_changed_lines: set[int] | None = None
     new_line: int | None = None
-    for line in diff_text.splitlines():
+    for line in diff_text.split("\n"):
         first_char = line[0] if line else ""
         if first_char == "d" and line.startswith(_DIFF_HEADER_PREFIX):
             separator_index = line.find(_DIFF_HEADER_SEPARATOR, len(_DIFF_HEADER_PREFIX))


### PR DESCRIPTION
## Summary
- Optimize the changed-scope coverage diff parser by splitting Git diff text on the known newline delimiter instead of using the general-purpose `splitlines()` helper.
- Add a focused plan for this performance slice and its registered probe validation.

## Plan or Spec
- `docs/plans/2026-05-16-changed-scope-diff-newline-split.md`
- Registered PR-scoped probe: `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe on origin/main before the change (3 runs; exit 0)
python3 scripts/changed_scope_coverage_parse_probe.py
elapsed_ms_mean: 3.9313834665032723, 3.3518665780623755, 3.2374444611681006

# Local probe after the change (4 runs; exit 0)
python3 scripts/changed_scope_coverage_parse_probe.py
elapsed_ms_mean: 3.3937501333033047, 3.1452216402006647, 3.247336503894379, 3.3042802048536637

# Focused tests (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
25 passed in 0.69s

# Changed-scope coverage (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/changed_scope_coverage_parse_probe.py docs/plans/2026-05-16-changed-scope-diff-newline-split.md
TOTAL 1 0 100%

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Local registered probe metric: old_mean=3.506898168577916 ms, new_mean=3.272647120563003 ms, delta=-0.23425104801491292 ms, speedup=1.0715784621394238x (6.679721986621133% faster).
- CI PR-scoped performance must still run the registered `changed-scope-coverage-diff-parser` probe before merge.

## Known Gaps
- Full repository gates were not run locally; this is a small Python tooling slice covered by the focused tests, changed-scope coverage, and registered local probe above.
- CI is required for the final registered PR-scoped performance report validation before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change; existing PR-scoped probe measures this slice.
- [x] Deferred work and known gaps are stated explicitly.
