### PR TITLE
perf: use direct JSON string escaping for diagnostics

### DIFF
--- a/docs/plans/2026-05-16-serving-diagnostics-json-string-encoder.md
+++ b/docs/plans/2026-05-16-serving-diagnostics-json-string-encoder.md
@@ -1,0 +1,40 @@
+# Serving diagnostics JSON string encoder fast path
+
+## Scope
+
+This Python-only performance slice targets the default-attribute serving
+diagnostics event JSONL fast path in
+`services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+The previous fast path used a dedicated `JSONEncoder(...).encode` bound method
+for each event string field even though only JSON string escaping is needed.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`serving-diagnostics-debug-queue-bounds` in
+`infra/perf/pr_scoped_probes.json`. The probe has focused `test_command`,
+`coverage_command`, and `probe_command` entries for the serving diagnostics
+module, tests, and `scripts/serving_diagnostics_queue_probe.py`.
+
+## Optimization plan
+
+- Preserve the compact JSONL byte layout, sorted key order, and ASCII escaping
+  behavior of the default-attribute event fast path.
+- Replace the generic JSONEncoder string encode bound method with
+  `json.encoder.encode_basestring_ascii`, which directly performs the same
+  string escaping used by the default JSON encoder.
+- Extend the focused JSONL fast-path regression test to include non-ASCII text
+  so the optimized encoder continues to prove ASCII escape parity.
+
+## Local evidence
+
+Linux local probe with `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=30`:
+
+- base (`origin/main`): `serialization_elapsed_ms_mean=1.049969`,
+  `elapsed_ms_mean=5.881154`
+- head: `serialization_elapsed_ms_mean=0.884999`, `elapsed_ms_mean=5.347447`
+- serialization delta: `-0.164970 ms` (`-15.71%`)
+- `serialization_checksum=260064` and `serialized_bytes=10944` on both base and head
+
+Focused tests, changed-scope coverage, and `ruff check` passed locally on Linux.
+CI PR-scoped performance remains the merge gate.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -538,7 +538,7 @@ def test_serving_diagnostics_events_jsonl_streams_default_attribute_rows(
     )
     event = ServingDiagnosticsEvent(
         request_id='req-"quoted"',
-        phase="decode",
+        phase="decode-音声",
         event_index=7,
         status="completed",
         duration_ms=0.001,
@@ -563,7 +563,7 @@ def test_serving_diagnostics_events_jsonl_streams_default_attribute_rows(
     line = paths["events"].read_text(encoding="utf-8")
     assert line == (
         '{"attributes":{},"duration_ms":0.001,"event_index":7,'
-        '"phase":"decode","request_id":"req-\\"quoted\\"",'
+        '"phase":"decode-\\u97f3\\u58f0","request_id":"req-\\"quoted\\"",'
         '"schema_version":"melix.serving_diagnostics.event.v1",'
         '"status":"completed"}\n'
     )

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -19,7 +19,7 @@ SERVING_DIAGNOSTICS_COMPARISON_SCHEMA_VERSION = "melix.serving_diagnostics.compa
 _EMPTY_EVENT_ATTRIBUTES: Mapping[str, object] = MappingProxyType({})
 _JSON_COMPACT_SEPARATORS = (",", ":")
 _JSONL_ENCODER = json.JSONEncoder(sort_keys=True, separators=_JSON_COMPACT_SEPARATORS)
-_JSON_STRING_ENCODER = json.JSONEncoder(separators=_JSON_COMPACT_SEPARATORS).encode
+_JSON_STRING_ENCODER = json.encoder.encode_basestring_ascii
 _SET_FROZEN_ATTR = object.__setattr__
 
 


### PR DESCRIPTION
## Summary
- Use `json.encoder.encode_basestring_ascii` for the serving diagnostics default-event JSONL fast path instead of a generic `JSONEncoder.encode` bound method.
- Extend the focused fast-path JSONL test to cover non-ASCII escaping parity.
- Document the slice and local probe evidence.

## Plan or Spec
- `docs/plans/2026-05-16-serving-diagnostics-json-string-encoder.md`
- Registered probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands` → 33 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py` → TOTAL 1 0 100%
- `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=30 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` on `origin/main` and head
- `uv run --project services/mlx-worker-python ruff check services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py` → All checks passed
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 1 0 100%`).
- Local registered-probe equivalent, Linux, `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=30`:
  - base (`origin/main`): `serialization_elapsed_ms_mean=1.049969`, `elapsed_ms_mean=5.881154`
  - head: `serialization_elapsed_ms_mean=0.884999`, `elapsed_ms_mean=5.347447`
  - serialization delta: `-0.164970 ms` (`-15.71%`)
  - `serialization_checksum=260064` and `serialized_bytes=10944` on both base and head
- CI PR-scoped performance is required for final registered probe validation before merge.

## Known Gaps
- Local validation is Linux-only. This slice only changes Python serving diagnostics serialization, so no Swift runtime effect is claimed.
- The registered probe command in CI remains the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage met the 95% requirement.
- [x] Local registered-probe-equivalent metrics show improvement.
- [ ] PR-scoped performance CI completed successfully.
- [ ] All PR checks are green before merge.
