### PR TITLE
perf: cache serving diagnostics JSON string literals

### DIFF
--- a/docs/plans/2026-05-16-serving-diagnostics-json-string-literal-cache.md
+++ b/docs/plans/2026-05-16-serving-diagnostics-json-string-literal-cache.md
@@ -1,0 +1,48 @@
+# Serving diagnostics JSON string literal cache
+
+## Scope
+
+Optimize the Python serving diagnostics debug-event JSONL fast path in
+`services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`serving-diagnostics-debug-queue-bounds` in
+`infra/perf/pr_scoped_probes.json`. The probe defines focused
+`test_command`, `coverage_command`, and `probe_command` entries and reports
+queue elapsed time, serialization elapsed time, retained/dropped counts, a
+serialization checksum, and serialized byte count.
+
+## Change
+
+The debug queue probe writes thousands of events that commonly reuse the same
+`request_id`, `phase`, and `status` strings. The existing empty-attribute JSONL
+fast path already builds the row directly, but it still escaped those repeated
+string values for every event row. This slice adds a bounded cache around
+`json.encoder.encode_basestring_ascii` and uses it only in the direct JSONL event
+line path.
+
+Behavior remains unchanged because the cached value is exactly the same escaped
+JSON string literal produced by the previous encoder call. The cache is bounded
+to avoid unbounded growth if a workload emits high-cardinality identifiers.
+
+## Validation plan
+
+1. Run the focused serving diagnostics tests plus the PR-scoped probe registry
+   tests for this probe.
+2. Run changed-scope coverage for the changed source path and probe/test files.
+3. Run the registered probe locally on Linux against `origin/main` and this
+   branch before pushing.
+4. Use PR-scoped performance CI as the final registered probe gate before merge.
+
+## Local result
+
+Local Linux probe, `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=30`:
+
+- base (`origin/main`): `serialization_elapsed_ms_mean=0.959244`,
+  `elapsed_ms_mean=5.504467`
+- head: `serialization_elapsed_ms_mean=0.917456`, `elapsed_ms_mean=5.482098`
+- serialization delta: `-0.041788 ms` (`-4.36%`)
+- checksum and serialized byte count unchanged:
+  `serialization_checksum=260064`, `serialized_bytes=10944`

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -7,6 +7,7 @@ import time
 from collections import deque
 from collections.abc import Mapping
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any
@@ -21,6 +22,11 @@ _JSON_COMPACT_SEPARATORS = (",", ":")
 _JSONL_ENCODER = json.JSONEncoder(sort_keys=True, separators=_JSON_COMPACT_SEPARATORS)
 _JSON_STRING_ENCODER = json.encoder.encode_basestring_ascii
 _SET_FROZEN_ATTR = object.__setattr__
+
+
+@lru_cache(maxsize=1024)
+def _json_string_literal(value: str) -> str:
+    return _JSON_STRING_ENCODER(value)
 
 
 class ServingDiagnosticsComparisonError(ValueError):
@@ -500,7 +506,7 @@ def _empty_attribute_event_json_line(event: ServingDiagnosticsEvent) -> str | No
         return None
     if not math.isfinite(duration_ms):
         return None
-    encode_string = _JSON_STRING_ENCODER
+    encode_string = _json_string_literal
     return (
         '{"attributes":{},"duration_ms":'
         f"{duration_ms!r}"


### PR DESCRIPTION
## Summary
- Cache repeated JSON string literal escaping in the serving diagnostics empty-attribute JSONL fast path.
- Keep the cache bounded and scoped to the direct event-line path.
- Document the registered probe and local Linux probe result for this slice.

## Plan or Spec
- `docs/plans/2026-05-16-serving-diagnostics-json-string-literal-cache.md`
- Registered probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands` → 33 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py` → TOTAL 5 0 100%
- `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=30 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` on `origin/main` and head
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python ruff check services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py` → All checks passed
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 5 0 100%`).
- Local registered-probe equivalent, Linux, `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=30`:
  - base (`origin/main`): `serialization_elapsed_ms_mean=0.959244`, `elapsed_ms_mean=5.504467`
  - head: `serialization_elapsed_ms_mean=0.917456`, `elapsed_ms_mean=5.482098`
  - serialization delta: `-0.041788 ms` (`-4.36%`)
  - `serialization_checksum=260064` and `serialized_bytes=10944` on both base and head
- CI PR-scoped performance is required for final registered probe validation before merge.

## Known Gaps
- Local validation is Linux-only. This slice only changes Python serving diagnostics serialization, so no Swift runtime effect is claimed.
- The registered probe command in CI remains the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage met the 95% requirement.
- [x] Local registered-probe-equivalent metrics show improvement.
- [ ] PR-scoped performance CI completed successfully.
- [ ] All PR checks are green before merge.
