### PR TITLE
perf: write serving diagnostics JSONL as bytes

### DIFF
--- a/docs/plans/2026-05-16-serving-diagnostics-jsonl-bytes-write.md
+++ b/docs/plans/2026-05-16-serving-diagnostics-jsonl-bytes-write.md
@@ -1,0 +1,48 @@
+# Serving diagnostics JSONL byte write optimization
+
+## Scope
+
+Optimize the Python serving diagnostics debug-event JSONL writer in
+`services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`serving-diagnostics-debug-queue-bounds` in
+`infra/perf/pr_scoped_probes.json`. The probe defines focused `test_command`,
+`coverage_command`, and `probe_command` entries and reports queue elapsed time,
+serialization elapsed time, retained/dropped counts, a serialization checksum,
+and serialized byte count.
+
+## Change
+
+`_write_jsonl(...)` already accumulates exact UTF-8 JSONL text before writing the
+file. This slice writes that payload through `Path.write_bytes(...)` after an
+explicit UTF-8 encode instead of routing it through `Path.write_text(...)` and the
+text I/O layer.
+
+Behavior remains unchanged because the encoded bytes are the same UTF-8 payload
+that `write_text(..., encoding="utf-8")` produced. The probe checksum and
+serialized byte count are the parity guard for this narrow writer change.
+
+## Validation plan
+
+1. Run the focused serving diagnostics tests plus the PR-scoped probe registry
+   tests for this probe.
+2. Run changed-scope coverage for the changed source path and probe/test files.
+3. Run the registered probe locally on Linux against `origin/main` and this branch
+   before pushing.
+4. Use PR-scoped performance CI as the final registered probe gate before merge.
+
+## Local result
+
+Local Linux probe, `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=50`:
+
+- base (`origin/main`, e6a6f66f): `serialization_elapsed_ms_mean=0.988866`,
+  `elapsed_ms_mean=5.396617`
+- head: `serialization_elapsed_ms_mean=0.942207`, `elapsed_ms_mean=5.543796`
+- serialization delta: `-0.046659 ms` (`-4.72%`)
+- checksum and serialized byte count unchanged:
+  `serialization_checksum=260064`, `serialized_bytes=10944`
+- queue append elapsed is outside this writer slice and remained within the
+  registered probe warning band in local sampling.

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -494,7 +494,7 @@ def _write_jsonl(path: Path, rows: Any) -> None:
                 continue
             row = row.to_dict()
         append_line(encode(row) + "\n")
-    path.write_text("".join(lines), encoding="utf-8")
+    path.write_bytes("".join(lines).encode("utf-8"))
 
 
 def _empty_attribute_event_json_line(event: ServingDiagnosticsEvent) -> str | None:


### PR DESCRIPTION
## Summary
- Write serving diagnostics JSONL payloads with an explicit UTF-8 byte write instead of `Path.write_text(...)` through the text I/O layer.
- Keep JSONL contents unchanged; checksum and serialized byte count remain identical in the registered probe.

## Plan or Spec
- `docs/plans/2026-05-16-serving-diagnostics-jsonl-bytes-write.md`
- Registered PR-scoped probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 33 passed in 0.69s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 33 passed in 0.25s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=50 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# {"capacity": 64.0, "dropped_count": 4032.0, "elapsed_ms_mean": 5.538247, "event_count": 4096.0, "retained_count": 64.0, "sample_count": 50.0, "serialization_checksum": 260064.0, "serialization_elapsed_ms_mean": 0.946607, "serialized_bytes": 10944.0}
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Local base/head registered probe comparison (`MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=50`):
  - base `origin/main` e6a6f66f: `serialization_elapsed_ms_mean=0.988866`, `elapsed_ms_mean=5.396617`
  - head: `serialization_elapsed_ms_mean=0.942207`, `elapsed_ms_mean=5.543796`
  - serialization delta: `-0.046659 ms` (`-4.72%`)
  - parity: `serialization_checksum=260064`, `serialized_bytes=10944` unchanged
- CI PR-scoped performance report is required before merge for the registered probe comparison.

## Known Gaps
- Queue append elapsed is outside this writer slice; local sampling showed it within the registered probe warning band but slightly noisier than base.
- No Swift runtime validation is applicable; this is a Linux-verifiable Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Debug JSONL writer path; registered probe overhead/effect recorded above.
- [x] Deferred work and known gaps are stated explicitly.
