### PR TITLE
perf: localize changed-scope parser hot loop

### DIFF
--- a/docs/plans/2026-05-16-changed-scope-add-bound-method.md
+++ b/docs/plans/2026-05-16-changed-scope-add-bound-method.md
@@ -1,0 +1,35 @@
+# Changed-scope coverage parser local bindings performance slice
+
+## Scope
+
+This slice targets only `scripts/changed_scope_coverage.py` diff parsing for
+changed-scope coverage reports. The parser consumes `git diff --unified=0`
+output and records added-line numbers for each changed file.
+
+## Probe coverage
+
+The affected path is covered by the registered PR-scoped probe
+`changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `scripts/changed_scope_coverage.py`
+- `tests/test_changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_parse_probe.py`
+- PR-scoped performance registry tests
+
+## Optimization
+
+Keep the parser's most frequent operations local to the hot loop. Bind the
+per-file `set.add` method once when a diff header selects the current
+changed-file bucket, and parse hunk new-start offsets inline so each hunk avoids
+an extra helper call while preserving the same malformed-header reset behavior.
+
+## Validation plan
+
+1. Run the focused changed-scope coverage tests.
+2. Run changed-scope coverage for the touched files.
+3. Run the registered `changed-scope-coverage-diff-parser` probe locally on
+   Linux and compare against the pre-change baseline.
+4. Require the PR-scoped performance workflow to run the registered probe in CI
+   before merge.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -47,27 +47,41 @@ def _parse_hunk_new_start(line: str) -> int | None:
 
 def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     changed_by_path: dict[str, set[int]] = {}
-    current_changed_lines: set[int] | None = None
+    add_changed_line = None
     new_line: int | None = None
     for line in diff_text.split("\n"):
         first_char = line[0] if line else ""
         if first_char == "d" and line.startswith(_DIFF_HEADER_PREFIX):
             separator_index = line.find(_DIFF_HEADER_SEPARATOR, len(_DIFF_HEADER_PREFIX))
-            current_changed_lines = None
+            add_changed_line = None
             if separator_index >= 0:
                 current_path = line[separator_index + len(_DIFF_HEADER_SEPARATOR) :]
-                current_changed_lines = changed_by_path.setdefault(current_path, set())
+                add_changed_line = changed_by_path.setdefault(current_path, set()).add
             new_line = None
             continue
         if first_char == "@" and line.startswith("@@"):
-            new_line = _parse_hunk_new_start(line)
+            new_range_index = line.find(" +")
+            if new_range_index < 0:
+                new_line = None
+                continue
+            digit_index = new_range_index + 2
+            end_index = digit_index
+            line_length = len(line)
+            value = 0
+            while end_index < line_length:
+                digit = ord(line[end_index]) - 48
+                if digit < 0 or digit > 9:
+                    break
+                value = value * 10 + digit
+                end_index += 1
+            new_line = value if end_index != digit_index else None
             continue
-        if current_changed_lines is None or new_line is None:
+        if add_changed_line is None or new_line is None:
             continue
         if first_char == "\\" and line.startswith("\\ "):
             continue
         if first_char == "+":
-            current_changed_lines.add(new_line)
+            add_changed_line(new_line)
             new_line += 1
         elif first_char == "-":
             continue


### PR DESCRIPTION
## Summary
- Keep changed-scope diff parser hot-loop operations local by binding the active changed-line set's `add` method once per diff file.
- Inline the hunk new-start offset parse inside the same hot loop, avoiding an extra helper call per hunk while preserving malformed-header behavior.

## Plan or Spec
- `docs/plans/2026-05-16-changed-scope-add-bound-method.md`
- Registered PR-scoped probe: `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
25 passed in 0.16s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
25 passed in 0.50s
TOTAL 15 0 100%

$ for i in 1 2 3 4 5; do python3 scripts/changed_scope_coverage_parse_probe.py; done  # origin/main baseline
elapsed_ms_mean samples: 3.311699586144338, 3.412723289026568, 3.243221202865243, 3.1940092449076474, 3.214935694510738

$ for i in 1 2 3 4 5; do python3 scripts/changed_scope_coverage_parse_probe.py; done  # head
elapsed_ms_mean samples: 2.9376857758810124, 3.573120746295899, 3.093018021900207, 2.97267372176672, 2.920692514938613

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 15 0 100%`.
- Local Linux probe baseline from `origin/main`: mean `3.275317803490907 ms` across five `elapsed_ms_mean` probe runs.
- Local Linux probe after the change: mean `3.0994381561564905 ms` across five `elapsed_ms_mean` probe runs.
- Delta: `-0.1758796473344164 ms`, about `5.369849824861574%` faster.
- CI must run the registered PR-scoped performance workflow and report for `changed-scope-coverage-diff-parser` before merge.
- Observability/probe overhead: N/A; this changes local coverage tooling only, not runtime observability behavior.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this Linux-local slice used the registered focused tests, changed-scope coverage, and registered probe.
- Registered PR-scoped performance CI is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.