### PR TITLE
perf: skip lowercase non-weight filename copies

### DIFF
--- a/docs/plans/2026-05-16-runtime-utils-lowercase-nonweight-fastpath.md
+++ b/docs/plans/2026-05-16-runtime-utils-lowercase-nonweight-fastpath.md
@@ -1,0 +1,23 @@
+# Runtime utils lowercase non-weight filename fast path
+
+## Scope
+
+This Python-only performance slice is limited to top-level model weight byte estimation in `services/mlx-worker-python/worker/runtime/runtime_utils.py`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `runtime-utils-top-level-weight-streaming` in `infra/perf/pr_scoped_probes.json`. That registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for the runtime utils top-level weight scan path.
+
+## Optimization
+
+The top-level weight scan checks every directory entry with `_is_model_weight_filename()` before calling `DirEntry.is_file()` and `DirEntry.stat()`. Synthetic and real model bundles commonly include many lowercase non-weight files such as `README.md`, tokenizer JSON, and text artifacts. After the exact lowercase weight suffix check fails, this slice uses `str.islower()` to reject lowercase non-weight names without allocating a lowercase copy. Mixed-case weight suffixes still fall back to `name.lower()` so existing case-insensitive weight detection is preserved.
+
+## Verification Plan
+
+- Run focused runtime utility tests for indexed and top-level weight accounting.
+- Run changed-scope coverage through the registered probe coverage command.
+- Run the registered `runtime-utils-top-level-weight-streaming` probe locally on Linux before and after the change and compare `elapsed_ms_mean` and `peak_bytes_mean`.
+
+## Linux Boundary
+
+This slice is Python-only and locally verifiable on Linux. Swift/macOS runtime effects are not involved.

--- a/services/mlx-worker-python/tests/test_runtime_utils.py
+++ b/services/mlx-worker-python/tests/test_runtime_utils.py
@@ -328,12 +328,14 @@ def test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors() -> 
             return FakeStat()
 
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("README.md")) == 0
+    assert runtime_utils._weight_dir_entry_file_size(FakeEntry("notes.txt")) == 0
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry(".bin")) == 0
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("nested.safetensors", is_file=False)) == 0
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("broken.safetensors", is_file_raises=True)) == 0
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("missing.safetensors", stat_raises=True)) == 0
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("model.safetensors")) == 13
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("adapter.SAFEtensors")) == 13
+    assert runtime_utils._weight_dir_entry_file_size(FakeEntry("MODEL.BIN")) == 13
 
 
 def test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory(

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -179,6 +179,8 @@ def _top_level_weight_file_bytes(model_dir: Path) -> int:
 def _is_model_weight_filename(name: str) -> bool:
     if name.endswith(_MODEL_WEIGHT_SUFFIXES):
         return name not in _MODEL_WEIGHT_SUFFIXES
+    if name.islower():
+        return False
     lower_name = name.lower()
     return (
         lower_name not in _MODEL_WEIGHT_SUFFIXES


### PR DESCRIPTION
## Summary
- Add a lowercase non-weight filename fast path in `runtime_utils._is_model_weight_filename()` so common non-weight artifacts skip allocating `name.lower()` after the exact suffix check fails.
- Extend runtime utility coverage for lowercase non-weight files and uppercase weight suffix preservation.

## Plan or Spec
- `docs/plans/2026-05-16-runtime-utils-lowercase-nonweight-fastpath.md`
- Registered probe: `runtime-utils-top-level-weight-streaming` in `infra/perf/pr_scoped_probes.json` includes focused `test_command`, `coverage_command`, and `probe_command` entries for the affected path.

## Commands Run
```text
# Baseline probe on origin/main before the code change (exit 0)
uv --version
python3 --version
for i in 1 2 3; do uv run --project services/mlx-worker-python python3 scripts/runtime_utils_top_level_weights_probe.py; done
# elapsed_ms_mean: 187.222912, 184.103278, 189.392277

# Focused tests after change (exit 0)
cd services/mlx-worker-python && uv run python3 -m pytest -q \
  tests/test_runtime_utils.py::test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors \
  tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries \
  tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights \
  tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics
# 4 passed in 0.10s

# Focused coverage after change (exit 0 for tests; changed-scope report exit 0 after remapping service-root coverage paths to repo-root paths)
cd services/mlx-worker-python && uv run python3 -m coverage run -m pytest -q \
  tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards \
  tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights \
  tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries \
  tests/test_runtime_utils.py::test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors \
  tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory \
  tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors \
  ../mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics
# 7 passed in 0.17s
python3 scripts/changed_scope_coverage.py --coverage-json coverage.remapped.json \
  services/mlx-worker-python/worker/runtime/runtime_utils.py \
  services/mlx-worker-python/tests/test_runtime_utils.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/runtime_utils_top_level_weights_probe.py
# TOTAL 4 0 100%

# Registered probe after change (exit 0)
for i in 1 2 3; do uv run --project services/mlx-worker-python python3 scripts/runtime_utils_top_level_weights_probe.py; done
# elapsed_ms_mean: 183.765105, 191.752841, 182.115914

# Hygiene (exit 0)
git diff --check
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%` for the runtime utility/test changed lines.
- Registered local probe `runtime-utils-top-level-weight-streaming` on Linux:
  - old_mean=186.906156 ms
  - new_mean=185.877953 ms
  - delta_ms=-1.028202 ms
  - speedup=1.005532x
  - improvement=0.550%
  - peak_bytes_mean remained 2040.8 bytes in both samples.
- CI is required to validate the registered PR-scoped performance report for this PR.

## Known Gaps
- The local coverage command was run from `services/mlx-worker-python` because this Linux environment blocks explicit `PYTHONPATH`; coverage JSON paths were remapped to repo-root paths before running `scripts/changed_scope_coverage.py`.
- No Swift/macOS runtime validation is claimed or needed for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change.
- [x] Deferred work and known gaps are stated explicitly.
