### PR TITLE
perf: unpack hub size direct parser tokens

### DIFF
--- a/docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md
+++ b/docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md
@@ -28,6 +28,12 @@ like `128 MB`; values with additional words still return `0` from the direct par
 existing generic `_size_hint_from_text(...)` fallback can handle labeled text such as
 `Model size: 7 MB`.
 
+## 2026-05-16 Slice: Direct Parser Unpack Split
+
+Keep the same two-token direct-parser semantics, but unpack `text.split()` directly and handle
+`ValueError` for non-two-token values. This removes the temporary `parts` list length branch and
+keeps invalid/labeled values on the existing generic parser fallback path.
+
 ## Success Metrics
 
 - Preserve all existing size-hint parsing behavior by falling back to `_size_hint_from_text(...)` when the direct parser cannot handle the value.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -726,6 +726,7 @@ def test_size_hint_parsers_cover_units_and_invalid_values() -> None:
     assert hub_catalog_module._direct_size_hint_from_text("512 tb") == 0
     assert hub_catalog_module._direct_size_hint_from_text("not-a-number MB") == 0
     assert hub_catalog_module._direct_size_hint_from_text("model size 512 MB") == 0
+    assert hub_catalog_module._direct_size_hint_from_text("512 MB extra") == 0
 
     assert _size_hint_from_text("Model size: 512 kb", allow_bare=False) == 512 * KB
     assert _size_hint_from_text("Model size: 1.5 MB", allow_bare=False) == int(1.5 * MB)

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -622,19 +622,17 @@ def _size_hint_bytes(payload: dict[str, Any]) -> int:
 
 
 def _direct_size_hint_from_text(text: str) -> int:
-    parts = text.split(maxsplit=2)
-    if len(parts) != 2:
+    try:
+        value_text, unit_text = text.split()
+    except ValueError:
         return 0
-    value_text, unit_text = parts
-    unit = unit_text.lower()
-    multiplier = _SIZE_HINT_MULTIPLIERS.get(unit)
+    multiplier = _SIZE_HINT_MULTIPLIERS.get(unit_text.lower())
     if multiplier is None:
         return 0
     try:
-        value = float(value_text)
+        return int(float(value_text) * multiplier)
     except ValueError:
         return 0
-    return int(value * multiplier)
 
 
 def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:


### PR DESCRIPTION
## Summary
- Optimizes the Hub catalog direct `cardData.model_size` parser by unpacking the expected two-token value directly instead of materializing and length-checking an intermediate `parts` list.
- Adds regression coverage for extra-token direct values so they continue to fall back through the generic parser path.

## Plan or Spec
- `docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md`
- Behavior docs updated with the 2026-05-16 direct parser unpack split slice.

## Commands Run
```text
# Baseline probe on origin/main (MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000, SAMPLES=5), 3 runs:
# elapsed_ms_mean: 1447.8544448502362, 1450.90036354959, 1509.6117642242461
# mean of means: 1469.455524208024

# Head probe, same settings, 3 runs:
# elapsed_ms_mean: 1460.6118134222925, 1452.5464182719588, 1472.6048259995878
# mean of means: 1461.9210192312796

# Registered focused test command for hub-catalog-size-hint-regex-precompile
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...
# 52 passed in 0.85s

# Registered changed-scope coverage command for hub-catalog-size-hint-regex-precompile
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && ... changed_scope_coverage.py ...
# TOTAL 6 0 100%

# Registered local probe command for hub-catalog-size-hint-regex-precompile
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# {"checksum": 3424780288.0, "elapsed_ms_mean": 1449.932255409658, "matched_hint_count": 80000.0, "peak_bytes_mean": 1833.0, "sample_count": 5.0, "size_hint_calls_mean": 40000.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (6/6 measurable changed lines).
- Registered probe: `hub-catalog-size-hint-regex-precompile`.
- Local Linux probe delta across 3 repeated runs: old_mean=1469.456 ms, new_mean=1461.921 ms, delta_ms=-7.535, speedup=1.005x. `size_hint_calls_mean` remained 40000.0 and checksum remained 3424780288.0.
- CI PR-scoped performance must run the registered probe for merge validation.

## Known Gaps
- Local validation is Linux-only for this Python slice; no Swift runtime effects are claimed.
- The measured speedup is small because this slice removes a narrow direct-parser branch cost inside the larger probe workload.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: N/A, parser-only Python performance slice using existing PR-scoped probe.
- [x] Deferred work and known gaps are stated explicitly.
