### PR TITLE
perf: slot no-op probe policy metrics

### DIFF
--- a/docs/plans/2026-05-16-probe-policy-noop-recorder-slots.md
+++ b/docs/plans/2026-05-16-probe-policy-noop-recorder-slots.md
@@ -1,0 +1,30 @@
+# Probe policy no-op recorder slots performance slice
+
+## Scope
+
+This Python-only performance slice is limited to the no-op probe policy overhead helper in `services/mlx-worker-python/worker/productization/probe_policy_overhead.py`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/probe_policy.py`
+- `services/mlx-worker-python/worker/productization/probe_policy_overhead.py`
+- `services/mlx-worker-python/tests/test_probe_policy.py`
+- `scripts/probe_policy_noop_overhead_probe.py`
+- PR-scoped performance registry tests
+
+## Optimization
+
+The no-op recorder participates in disabled-probe hot paths and should stay allocation-light. This slice gives `NoOpProbeRecorder` explicit empty slots and makes the `ProbeOverheadMetrics` dataclass slotted as well. The change preserves the existing static `record` call surface while removing per-instance dictionaries from the recorder and metrics result objects.
+
+## Validation Plan
+
+1. Run the focused registered pytest command for `probe-policy-noop-overhead`.
+2. Run changed-scope coverage through the registered coverage command.
+3. Run the registered `probe-policy-noop-overhead` probe locally on Linux before and after the change and compare `no_op_recorder_call_ms_mean`, `no_op_recorder_overhead_pct`, and `threshold_passed`.
+4. Require the PR-scoped performance workflow to run the registered probe in CI before merge.
+
+## Linux Boundary
+
+This slice is Python-only and locally verifiable on Linux. Swift/macOS runtime effects are not involved.

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from worker.productization.probe_policy_overhead import measure_no_op_probe_policy_overhead
+from worker.productization.probe_policy_overhead import (
+    NoOpProbeRecorder,
+    measure_no_op_probe_policy_overhead,
+)
 from worker.productization.probe_policy import ProbeMode, ProbePolicy, probe_policy_from_env
 
 
@@ -53,6 +56,15 @@ def test_probe_policy_uses_slots_for_hot_path_instances() -> None:
     assert policy.telemetry_enabled is False
     assert policy.no_op_reason == "probe_mode_minimal"
     assert ProbePolicy(mode=ProbeMode.EVIDENCE).no_op_reason == ""
+
+
+def test_no_op_probe_recorder_and_metrics_use_slots_for_hot_path() -> None:
+    recorder = NoOpProbeRecorder()
+    metrics = measure_no_op_probe_policy_overhead(iterations=1, samples=1)
+
+    assert not hasattr(recorder, "__dict__")
+    assert not hasattr(metrics, "__dict__")
+    assert recorder.record() is None
 
 
 def test_no_op_probe_policy_overhead_metrics_are_thresholded() -> None:

--- a/services/mlx-worker-python/worker/productization/probe_policy_overhead.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy_overhead.py
@@ -13,10 +13,12 @@ def _no_op_call() -> None:
 
 
 class NoOpProbeRecorder:
+    __slots__ = ()
+
     record = staticmethod(_no_op_call)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ProbeOverheadMetrics:
     sample_count: int
     iteration_count: int


### PR DESCRIPTION
## Summary
- Add empty slots to the no-op probe recorder so disabled-probe hot-path recorder instances do not carry per-instance dictionaries.
- Make `ProbeOverheadMetrics` slotted and add regression coverage for the recorder/metrics slot contract.
- Document the focused Python performance slice and its registered probe boundary.

## Plan or Spec
- `docs/plans/2026-05-16-probe-policy-noop-recorder-slots.md`
- Registered PR-scoped probe: `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=200000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py` (3x before, 3x after)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `12 passed in 0.59s`.
- Changed-scope coverage: `TOTAL 9 0 100%`.
- Local registered probe baseline (3 runs, `no_op_recorder_call_ms_mean`): old_mean=`0.000038565333 ms`.
- Local registered probe after change (3 runs, `no_op_recorder_call_ms_mean`): new_mean=`0.000037954667 ms`, delta=`-0.000000610667 ms`, speedup=`1.58%`.
- Registered probe sanity after verification: `threshold_passed=1.0`, `no_op_recorder_overhead_pct=0.77954`, `no_op_recorder_call_ms_mean=0.000036845 ms`.
- CI PR-scoped performance probe is required before merge.

## Known Gaps
- Linux-only local validation; no Swift/macOS runtime path is affected.
- The recorder call metric is very small and noisy, so the acceptance criterion is preserving the registered threshold while moving the call mean in the right direction.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally on Linux.
- [ ] PR-scoped performance workflow completed successfully in CI.
- [ ] All PR checks are green before merge.
