### PR TITLE
perf: streamline changed-scope hunk dispatch

### DIFF
--- a/docs/plans/2026-05-16-changed-scope-hunk-prefix-check.md
+++ b/docs/plans/2026-05-16-changed-scope-hunk-prefix-check.md
@@ -1,0 +1,36 @@
+# Changed-scope coverage hunk prefix check performance slice
+
+## Scope
+
+This slice targets only the hot diff parser in `scripts/changed_scope_coverage.py`.
+The parser consumes `git diff --unified=0` output and records added-line numbers
+for changed-scope coverage reports.
+
+## Probe coverage
+
+The affected path is covered by the registered PR-scoped probe
+`changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`. The
+registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `scripts/changed_scope_coverage.py`
+- `tests/test_changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_parse_probe.py`
+- PR-scoped performance registry tests
+
+## Optimization
+
+Keep the per-line parser dispatch minimal by localizing the diff-header prefix
+constants once per parse call and replacing the hunk-header `startswith("@@")`
+check in the hot loop with direct character checks after the first-character
+dispatch. This preserves the existing malformed-header reset behavior while
+avoiding repeated global lookups and one method call per hunk header.
+
+## Validation plan
+
+1. Run the focused changed-scope coverage tests.
+2. Run changed-scope coverage for the touched files.
+3. Run the registered `changed-scope-coverage-diff-parser` probe locally on
+   Linux and compare against the pre-change baseline.
+4. Require the PR-scoped performance workflow to run the registered probe in CI
+   before merge.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -47,19 +47,23 @@ def _parse_hunk_new_start(line: str) -> int | None:
 
 def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     changed_by_path: dict[str, set[int]] = {}
+    header_prefix = _DIFF_HEADER_PREFIX
+    header_separator = _DIFF_HEADER_SEPARATOR
+    header_prefix_len = len(header_prefix)
+    header_separator_len = len(header_separator)
     add_changed_line = None
     new_line: int | None = None
     for line in diff_text.split("\n"):
         first_char = line[0] if line else ""
-        if first_char == "d" and line.startswith(_DIFF_HEADER_PREFIX):
-            separator_index = line.find(_DIFF_HEADER_SEPARATOR, len(_DIFF_HEADER_PREFIX))
+        if first_char == "d" and line.startswith(header_prefix):
+            separator_index = line.find(header_separator, header_prefix_len)
             add_changed_line = None
             if separator_index >= 0:
-                current_path = line[separator_index + len(_DIFF_HEADER_SEPARATOR) :]
+                current_path = line[separator_index + header_separator_len :]
                 add_changed_line = changed_by_path.setdefault(current_path, set()).add
             new_line = None
             continue
-        if first_char == "@" and line.startswith("@@"):
+        if first_char == "@" and len(line) > 1 and line[1] == "@":
             new_range_index = line.find(" +")
             if new_range_index < 0:
                 new_line = None


### PR DESCRIPTION
## Summary
- Streamlines the changed-scope coverage diff parser by localizing diff-header constants once per parse call.
- Replaces the hot-loop `startswith("@@")` hunk check with direct character dispatch after the existing first-character check.
- Adds a focused plan for this single performance slice.

## Plan or Spec
- `docs/plans/2026-05-16-changed-scope-hunk-prefix-check.md`
- Registered probe coverage: `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json` already covers `scripts/changed_scope_coverage.py` with focused test, coverage, and probe commands.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- Baseline/new comparison script importing `HEAD:scripts/changed_scope_coverage.py` and the working tree parser: old_mean=3.168661 ms, new_mean=3.003403 ms, delta=-0.165258 ms, speedup=5.215385%.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage_parse_probe.py` (3 local runs after the change)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 25 passed.
- Changed-scope coverage: 8 measurable changed lines, 8 covered, 0 missed, TOTAL 8 0 100%.
- Local registered probe after the change (3 runs): elapsed_ms_mean=2.932922, 3.008562, 2.910181 ms; changed_line_count=7680; file_count=240; line_count=16080.
- Local old/new comparison on the same synthetic diff: old_mean=3.168661 ms, new_mean=3.003403 ms, speedup=5.215385%, delta_ms=-0.165258.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation is Linux-only. This Python slice is locally executable and covered by the registered Ubuntu PR-scoped probe.
- CI must confirm the registered probe report has no direct regression before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% for measurable changed lines.
- [x] Registered probe ran locally on Linux.
- [x] PR-scoped performance CI must complete successfully before merge.
