### PR TITLE
perf: bind validation split digest helper

### DIFF
--- a/docs/plans/2026-05-16-training-validation-digest-binding.md
+++ b/docs/plans/2026-05-16-training-validation-digest-binding.md
@@ -1,0 +1,27 @@
+# Training Validation Split Digest Binding Slice
+
+## Scope
+
+This Python-only performance slice is limited to the deterministic validation split helper in `services/mlx-worker-python/worker/model_ops/training_dataset.py`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe `training-dataset-validation-split-nsmallest` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset.py`
+- `services/mlx-worker-python/tests/test_training_dataset_builder.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Optimization Slice
+
+`_deterministic_validation_split(...)` hashes every sample before selecting the deterministic train or validation subset. This slice binds `_canonical_sample_digest` into a local name before constructing the ranked-sample generator so the hot generator loop avoids repeated global lookup while preserving the existing heap selection and stable output ordering.
+
+The change intentionally does not alter split sizing, digest contents, heap direction, or train/validation ordering semantics.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage, and registered probe locally on Linux before pushing. Compare the registered probe output against a pre-change baseline captured from `origin/main` in the same worktree.
+
+CI remains the merge gate for the registered PR-scoped performance report.

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1743,9 +1743,10 @@ def _deterministic_validation_split(
     validation_count = int(round(sample_count * validation_ratio))
     validation_count = max(1, min(sample_count - 1, validation_count))
     train_count = sample_count - validation_count
+    canonical_sample_digest = _canonical_sample_digest
     ranked_samples = (
         (
-            _canonical_sample_digest(sample),
+            canonical_sample_digest(sample),
             index,
         )
         for index, sample in enumerate(samples)


### PR DESCRIPTION
## Summary
- Bind `_canonical_sample_digest` locally inside `_deterministic_validation_split(...)` so the ranked-sample generator avoids repeated global helper lookup while hashing large validation-split candidates.
- Add the governing plan for this registered Python performance slice.

## Plan or Spec
- `docs/plans/2026-05-16-training-validation-digest-binding.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_build_training_dataset_artifact_loads_existing_package_and_helper_branches services/mlx-worker-python/tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_applies_manifest_overrides services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 4 passed in 0.25s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_build_training_dataset_artifact_loads_existing_package_and_helper_branches services/mlx-worker-python/tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_applies_manifest_overrides services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
# local base-vs-head probe comparison for training-dataset-validation-split-nsmallest workload
PY
# base_elapsed_ms_mean=923.0474, head_elapsed_ms_mean=903.5935, delta_ms=-19.4539, speedup=1.0215x

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%` for `services/mlx-worker-python/worker/model_ops/training_dataset.py` plus focused tests.
- Registered probe: `training-dataset-validation-split-nsmallest` covers this path with focused `test_command`, `coverage_command`, and `probe_command` entries in `infra/perf/pr_scoped_probes.json`.
- Local Linux base-vs-head probe: `base_elapsed_ms_mean=923.0474 ms`, `head_elapsed_ms_mean=903.5935 ms`, `delta_ms=-19.4539 ms`, `speedup=1.0215x`; `validation_count=28500`, `checksum=427535201`.
- CI PR-scoped performance report is required as the merge-gate validation source.

## Known Gaps
- Full repository gates were not run locally; this is a Python-only registered slice and CI remains the full merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
