### PR TITLE
perf: reduce code eval assert count peak memory

### DIFF
--- a/docs/plans/2026-05-16-code-eval-assert-node-loop.md
+++ b/docs/plans/2026-05-16-code-eval-assert-node-loop.md
@@ -1,0 +1,36 @@
+# Code Evaluation Assert Node Stack Slice
+
+## Scope
+
+This Python-only performance slice is limited to valid assert-node counting in
+`services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`code-eval-count-tests-line-scan` in `infra/perf/pr_scoped_probes.json`. The
+registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries. Its checked-in probe exercises repeated
+`_count_assert_nodes()` calls under `tracemalloc`, so the registered
+`peak_bytes_mean` metric captures allocation pressure for this helper.
+
+## Optimization
+
+`_count_assert_nodes()` previously used `ast.walk()`, which creates and manages
+an internal queue while yielding every AST node. This slice replaces it with a
+single explicit stack over `ast.iter_child_nodes()`. The traversal order is not
+observable because the helper only counts `ast.Assert` nodes, and behavior stays
+unchanged for nested asserts and modules without asserts.
+
+## Verification Plan
+
+- Run focused code-evaluation count tests, including the new no-assert helper
+  regression check.
+- Run changed-scope coverage through the registered probe coverage command.
+- Run the registered `code-eval-count-tests-line-scan` probe locally on Linux
+  before and after the change and compare `peak_bytes_mean` and elapsed metrics.
+
+## Linux Boundary
+
+This slice is Python-only and locally verifiable on Linux. Swift/macOS runtime
+effects are not involved.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -385,6 +385,16 @@ def test_count_assert_nodes_counts_nested_asserts() -> None:
     assert code_eval_runner._count_assert_nodes(module) == 2
 
 
+def test_count_assert_nodes_returns_zero_without_asserts() -> None:
+    module = code_eval_runner.ast.parse(
+        "value = identity(1)\nif enabled:\n    value += identity(2)",
+        filename="<tests>",
+        mode="exec",
+    )
+
+    assert code_eval_runner._count_assert_nodes(module) == 0
+
+
 def test_count_nonblank_test_lines_matches_splitlines_semantics() -> None:
     test_code = "\n assert one\r\n\t\rassert two\n   \nassert three"
 

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -251,11 +251,18 @@ def _count_tests(test_code: str) -> int:
 def _count_assert_nodes(
     module: ast.AST,
     *,
-    _walk=ast.walk,
+    _iter_child_nodes=ast.iter_child_nodes,
     _assert_type=ast.Assert,
     _isinstance=isinstance,
 ) -> int:
-    return sum(1 for node in _walk(module) if _isinstance(node, _assert_type))
+    count = 0
+    stack = [module]
+    while stack:
+        node = stack.pop()
+        if _isinstance(node, _assert_type):
+            count += 1
+        stack.extend(_iter_child_nodes(node))
+    return count
 
 
 def _count_nonblank_test_lines(test_code: str) -> int:


### PR DESCRIPTION
## Summary
- Replace `ast.walk()` in code-evaluation assert counting with an explicit stack over `ast.iter_child_nodes()` to reduce traversal allocation pressure.
- Add a no-assert helper regression test so the optimized counter preserves zero-count behavior.
- Document the slice and its registered PR-scoped probe coverage.

## Plan or Spec
- `docs/plans/2026-05-16-code-eval-assert-node-loop.md`

## Commands Run
```text
# Baseline registered probe on origin/main (3 runs), exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_count_tests_probe.py
baseline elapsed_ms_mean runs: 1.823933695, 1.751980511, 1.930198832
baseline peak_bytes_mean runs: 200117.142857, 200117.142857, 200117.142857

# Focused tests, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_reuses_cached_counts_for_repeated_payloads \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_assert_nodes_counts_nested_asserts \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_assert_nodes_returns_zero_without_asserts \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_fallback_avoids_splitlines_materialization \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_avoids_splitlines_materialization \
  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fast_path_skips_ast_parse \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_count_tests_probe_script_emits_metrics
11 passed in 18.85s

# Changed-scope coverage, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/engine/code_eval_runner.py \
  services/mlx-worker-python/tests/test_code_eval_runner.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/code_eval_count_tests_probe.py
TOTAL 11 0 100%

# Registered probe after change (3 runs), exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_count_tests_probe.py
head elapsed_ms_mean runs: 1.815990911, 1.782439150, 1.838403887
head peak_bytes_mean runs: 83066.0, 83066.0, 83066.0

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Local registered probe (mean of 3 runs):
  - `elapsed_ms_mean`: 1.835371 ms -> 1.812278 ms (`-0.023093 ms`, `-1.26%`).
  - `peak_bytes_mean`: 200117.142857 bytes -> 83066.0 bytes (`-117051.142857 bytes`, `-58.49%`).
- CI PR-scoped performance report is required before merge for the registered probe result.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this Linux slice used the focused registered Python test, coverage, and probe commands.
- Swift/macOS runtime effects are not involved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode changes; existing PR-scoped probe measured the path.
- [x] Deferred work and known gaps are stated explicitly.
