### PR TITLE
perf: bind serving diagnostics event setter

### DIFF
--- a/docs/plans/2026-05-16-serving-diagnostics-event-init-local-binding.md
+++ b/docs/plans/2026-05-16-serving-diagnostics-event-init-local-binding.md
@@ -1,0 +1,20 @@
+# Serving Diagnostics Event Init Local Binding
+
+## Slice
+
+Reduce per-event construction overhead in the serving diagnostics debug queue path by binding `object.__setattr__` through the `ServingDiagnosticsEvent.__init__` default arguments instead of resolving the module-level binding inside every event construction.
+
+## Probe Coverage
+
+The affected path is covered by the registered PR-scoped probe `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`. The probe defines focused `test_command`, `coverage_command`, and `probe_command` entries for `services/mlx-worker-python/worker/productization/serving_diagnostics.py`, the serving diagnostics unit tests, the PR-scoped probe tests, and `scripts/serving_diagnostics_queue_probe.py`.
+
+## Verification Plan
+
+- Run the focused registered test command for `serving-diagnostics-debug-queue-bounds`.
+- Run the registered coverage command and confirm changed-scope coverage remains at least 95%.
+- Run the registered probe locally on Linux against `origin/main` and this head worktree.
+- Use GitHub Actions PR-scoped performance results as the merge gate after opening the PR.
+
+## Expected Behavior
+
+No artifact schema or diagnostics queue behavior changes. The slice only removes repeated per-event local rebinding overhead during `ServingDiagnosticsEvent` construction.

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -164,14 +164,14 @@ class ServingDiagnosticsEvent:
         status: str,
         duration_ms: float = 0.0,
         attributes: Mapping[str, object] = _EMPTY_EVENT_ATTRIBUTES,
+        _set_attr: Any = _SET_FROZEN_ATTR,
     ) -> None:
-        set_attr = _SET_FROZEN_ATTR
-        set_attr(self, "request_id", request_id)
-        set_attr(self, "phase", phase)
-        set_attr(self, "event_index", event_index)
-        set_attr(self, "status", status)
-        set_attr(self, "duration_ms", duration_ms)
-        set_attr(self, "attributes", attributes)
+        _set_attr(self, "request_id", request_id)
+        _set_attr(self, "phase", phase)
+        _set_attr(self, "event_index", event_index)
+        _set_attr(self, "status", status)
+        _set_attr(self, "duration_ms", duration_ms)
+        _set_attr(self, "attributes", attributes)
 
     def to_dict(self) -> dict[str, object]:
         attributes = self.attributes


### PR DESCRIPTION
## Summary
- Bind `object.__setattr__` as a default argument in `ServingDiagnosticsEvent.__init__` so debug-queue event construction avoids rebinding the setter on every event.
- Add a focused plan documenting the serving diagnostics event-init performance slice.

## Plan or Spec
- `docs/plans/2026-05-16-serving-diagnostics-event-init-local-binding.md`
- Registered PR-scoped probe: `serving-diagnostics-debug-queue-bounds`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 33 passed in 0.67s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# 33 passed in 0.26s; TOTAL 6 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id serving-diagnostics-debug-queue-bounds --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/serving_diag_event_init_probe.json
# head verification ok; base/head probe ok

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 6 0 100%`.
- Local registered probe (`serving-diagnostics-debug-queue-bounds`, Linux):
  - `elapsed_ms_mean`: base `5.588252`, head `5.378704`, delta `-0.209548 ms` (`~3.75%` lower).
  - `serialization_elapsed_ms_mean`: base `0.967644`, head `0.909240`, delta `-0.058404 ms` (`~6.04%` lower).
  - `serialized_bytes`: base `10944`, head `10944` (unchanged).
  - Informational behavior metrics unchanged: `dropped_count=4032`, `retained_count=64`, `serialization_checksum=260064`.
- CI PR-scoped performance workflow is required before merge and should publish the registered probe report for this slice.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python performance slice.
- No Swift runtime validation applies to this Python-only change.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: debug diagnostics queue; probe overhead measured by `serving-diagnostics-debug-queue-bounds`.
- [x] Deferred work and known gaps are stated explicitly.
