### PR TITLE
perf: cache event actor semantic values

### DIFF
--- a/docs/plans/2026-05-16-event-extraction-actor-field-cache.md
+++ b/docs/plans/2026-05-16-event-extraction-actor-field-cache.md
@@ -1,0 +1,45 @@
+# Event Extraction Actor Field Cache Performance Slice
+
+## Scope
+
+This Python-only slice targets semantic event-extraction actor field expansion in
+`services/mlx-worker-python/worker/productization/event_extraction.py`.
+
+The behavior remains unchanged: actor fields are still validated as nullable
+string arrays, trimmed, deduplicated, and expanded so group aliases such as
+`我们`, `双方`, and normalized variants resolve to `speaker_1` and `speaker_2`.
+
+## Registered probe
+
+The affected path is already covered by PR-scoped probe
+`event-extraction-group-actor-alias-cache` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/productization/event_extraction.py`
+- `services/mlx-worker-python/tests/test_event_extraction.py`
+- `scripts/event_extraction_actor_alias_probe.py`
+
+The probe repeatedly calls `_semantic_field_values("actor", event)` on a stable
+synthetic actor list and reports `elapsed_ms_mean`, `normalize_calls_mean`,
+`peak_bytes_mean`, and workload-size guardrails.
+
+## Plan
+
+1. Keep the existing group-alias expansion and normalization semantics.
+2. Add a small raw actor-field tuple cache so repeated semantic scoring of the
+   same actor list reuses normalized/expanded actor values.
+3. Keep non-actor field handling on the direct normalization path.
+4. Clear the new cache in focused tests and the probe so monkeypatched
+   normalization counters remain deterministic.
+5. Verify with focused pytest, changed-scope coverage, and the registered local
+   probe on Linux before PR creation.
+
+## Success criteria
+
+- Focused event-extraction tests pass.
+- Changed-scope coverage for the modified Python/probe/test files is at least
+  95 percent.
+- Local registered probe shows lower `elapsed_ms_mean` versus the `origin/main`
+  baseline without behavior changes.
+- PR-scoped performance CI selects and completes the registered probe.

--- a/scripts/event_extraction_actor_alias_probe.py
+++ b/scripts/event_extraction_actor_alias_probe.py
@@ -44,6 +44,7 @@ def _actor_values(value_count: int) -> list[str]:
 
 
 def _run_probe(*, value_count: int, iterations: int, samples: int) -> dict[str, float]:
+    event_extraction_module._cached_semantic_actor_field_values.cache_clear()
     event_extraction_module._expanded_semantic_actor_values.cache_clear()
     event_extraction_module._is_group_actor_alias.cache_clear()
     original_normalize = event_extraction_module._normalize_similarity_text

--- a/services/mlx-worker-python/tests/test_event_extraction.py
+++ b/services/mlx-worker-python/tests/test_event_extraction.py
@@ -718,6 +718,7 @@ def test_evaluate_event_extraction_semantic_judge_matches_event_and_values(tmp_p
 def test_semantic_field_values_reuses_cached_group_actor_aliases(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    event_extraction_module._cached_semantic_actor_field_values.cache_clear()
     event_extraction_module._expanded_semantic_actor_values.cache_clear()
     event_extraction_module._is_group_actor_alias.cache_clear()
     calls: list[str] = []
@@ -734,6 +735,7 @@ def test_semantic_field_values_reuses_cached_group_actor_aliases(
         {"actor": [" 我们 ", "我们", "我 们", "speaker_1", "speaker_1", "咱们", "speaker_2", "双方"]},
     ) == ["speaker_1", "speaker_2"]
     assert calls == ["我 们"]
+    event_extraction_module._cached_semantic_actor_field_values.cache_clear()
     event_extraction_module._expanded_semantic_actor_values.cache_clear()
     event_extraction_module._is_group_actor_alias.cache_clear()
 
@@ -741,6 +743,7 @@ def test_semantic_field_values_reuses_cached_group_actor_aliases(
 def test_semantic_field_values_caches_repeated_group_actor_expansion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    event_extraction_module._cached_semantic_actor_field_values.cache_clear()
     event_extraction_module._expanded_semantic_actor_values.cache_clear()
     event_extraction_module._is_group_actor_alias.cache_clear()
     calls: list[str] = []
@@ -756,6 +759,7 @@ def test_semantic_field_values_caches_repeated_group_actor_expansion(
     assert event_extraction_module._semantic_field_values("actor", event) == ["speaker_1", "speaker_2"]
     assert event_extraction_module._semantic_field_values("actor", event) == ["speaker_1", "speaker_2"]
     assert calls == ["我 们"]
+    event_extraction_module._cached_semantic_actor_field_values.cache_clear()
     event_extraction_module._expanded_semantic_actor_values.cache_clear()
     event_extraction_module._is_group_actor_alias.cache_clear()
 
@@ -774,6 +778,11 @@ def test_semantic_field_values_normalizes_and_deduplicates_in_one_pass(monkeypat
         {"action": [" 见面 ", "", "见面", "吃饭"]},
     ) == ["见面", "吃饭"]
     assert event_extraction_module._semantic_field_values("time", {"time": None}) == []
+    assert event_extraction_module._semantic_field_values("actor", {"actor": None}) == []
+    with pytest.raises(ValueError):
+        event_extraction_module._semantic_field_values("actor", {"actor": "我们"})
+    with pytest.raises(ValueError):
+        event_extraction_module._semantic_field_values("actor", {"actor": ["我们", 1]})
     with pytest.raises(ValueError):
         event_extraction_module._semantic_field_values("time", {"time": "明天"})
     with pytest.raises(ValueError):

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -1717,10 +1717,30 @@ def _semantic_action_match_payload(
 
 
 def _semantic_field_values(field_name: str, event: dict[str, object]) -> list[str]:
-    values = _normalize_unique_event_field(event.get(field_name))
-    if field_name != "actor":
-        return values
-    return list(_expanded_semantic_actor_values(tuple(values)))
+    value = event.get(field_name)
+    if field_name == "actor":
+        return list(_cached_semantic_actor_field_values(_event_field_cache_key(value)))
+    return _normalize_unique_event_field(value)
+
+
+def _event_field_cache_key(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError("event field values must be null or a list of strings")
+    values: list[str] = []
+    values_append = values.append
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError("event field values must be null or a list of strings")
+        values_append(item)
+    return tuple(values)
+
+
+@lru_cache(maxsize=1024)
+def _cached_semantic_actor_field_values(values: tuple[str, ...]) -> tuple[str, ...]:
+    normalized_values = _normalize_unique_event_field(list(values))
+    return _expanded_semantic_actor_values(tuple(normalized_values))
 
 
 def _normalize_unique_event_field(value: object) -> list[str]:


### PR DESCRIPTION
## Summary
- Cache semantic actor field normalization/expansion from the raw actor list tuple so repeated event-extraction semantic scoring can reuse actor values.
- Keep non-actor field handling on the existing direct normalization path.
- Clear the new actor-field cache in focused tests and the registered probe so monkeypatched normalization counters remain deterministic.

## Plan or Spec
- `docs/plans/2026-05-16-event-extraction-actor-field-cache.md`

## Commands Run
```text
# focused tests (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_reuses_cached_group_actor_aliases services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_caches_repeated_group_actor_expansion services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_normalizes_and_deduplicates_in_one_pass services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_expands_group_actor_aliases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_actor_alias_probe_script_emits_metrics
# result: 7 passed in 0.48s

# changed-scope coverage (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_reuses_cached_group_actor_aliases services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_caches_repeated_group_actor_expansion services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_normalizes_and_deduplicates_in_one_pass services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_expands_group_actor_aliases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_actor_alias_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_actor_alias_probe.py
# result: TOTAL 30 0 100%

# local registered probe compare (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id event-extraction-group-actor-alias-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/event_actor_alias_probe_compare.json
# result: base/head probe and head verification ok
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 30 0 100%`.
- Registered probe: `event-extraction-group-actor-alias-cache`.
- Local probe compare:
  - `elapsed_ms_mean`: base `4.950415808707476`, head `4.386476241052151`, delta `-0.563940 ms` (`11.39%` faster).
  - `normalize_calls_mean`: base `0.6`, head `0.6`.
  - `peak_bytes_mean`: base `5333.2`, head `6000.4` (informational metric; small cache overhead).
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Full repository test suite was not run locally; this slice used the registered focused test/coverage/probe path.
- Linux local validation covers the Python path only; no Swift runtime effects are expected in this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
