### PR TITLE
perf: scan only statement nodes for code-eval asserts

### DIFF
--- a/docs/plans/2026-05-16-code-eval-assert-count-performance.md
+++ b/docs/plans/2026-05-16-code-eval-assert-count-performance.md
@@ -26,6 +26,9 @@ existing syntax-error and no-assert fallback metrics.
 
 ## Expected outcome
 
-Reduce mean elapsed time for uncached valid assert-heavy `_count_tests()` calls
-by binding the AST walker, assert type, and `isinstance` lookup once in a helper
-instead of resolving those globals inside each generator predicate call.
+Reduce mean elapsed time for valid assert-heavy `_count_tests()` calls by
+counting only statement nodes in the parsed AST. Assert expressions cannot
+contain statement-level asserts, so the helper now traverses nested statement
+containers (`body`, `orelse`, handlers, class/function bodies, etc.) and skips
+expression subtrees after each `ast.Assert` node while preserving fallback
+behavior for syntax errors and no-assert payloads.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -377,12 +377,34 @@ def test_count_tests_reuses_cached_counts_for_repeated_payloads() -> None:
 
 def test_count_assert_nodes_counts_nested_asserts() -> None:
     module = code_eval_runner.ast.parse(
-        "assert identity(1) == 1\nif enabled:\n    assert identity(2) == 2",
+        textwrap.dedent(
+            """
+            assert identity(1) == 1
+            if enabled:
+                assert identity(2) == 2
+            else:
+                with context:
+                    assert identity(3) == 3
+            try:
+                assert identity(4) == 4
+            except Exception:
+                assert identity(5) == 5
+            finally:
+                assert identity(6) == 6
+            def check():
+                assert identity(7) == 7
+            class Nested:
+                assert identity(8) == 8
+            match status:
+                case "ok":
+                    assert identity(9) == 9
+            """
+        ),
         filename="<tests>",
         mode="exec",
     )
 
-    assert code_eval_runner._count_assert_nodes(module) == 2
+    assert code_eval_runner._count_assert_nodes(module) == 9
 
 
 def test_count_assert_nodes_returns_zero_without_asserts() -> None:

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -251,17 +251,23 @@ def _count_tests(test_code: str) -> int:
 def _count_assert_nodes(
     module: ast.AST,
     *,
-    _iter_child_nodes=ast.iter_child_nodes,
+    _stmt_container_types=(ast.stmt, ast.ExceptHandler, ast.match_case),
     _assert_type=ast.Assert,
     _isinstance=isinstance,
 ) -> int:
     count = 0
-    stack = [module]
+    stack = list(getattr(module, "body", ()))
     while stack:
         node = stack.pop()
         if _isinstance(node, _assert_type):
             count += 1
-        stack.extend(_iter_child_nodes(node))
+            continue
+        for field_name in node._fields:
+            child = getattr(node, field_name, None)
+            if _isinstance(child, list):
+                stack.extend(
+                    item for item in child if _isinstance(item, _stmt_container_types)
+                )
     return count
 
 


### PR DESCRIPTION
## Summary
- Optimize code-evaluation assert counting by traversing only statement containers in the parsed AST.
- Preserve syntax-error and no-assert fallback behavior while skipping expression subtrees under each `ast.Assert` node.
- Expand regression coverage for nested assert statements in if/else, with, try/except/finally, function/class bodies, and match cases.

## Plan or Spec
- Updated `docs/plans/2026-05-16-code-eval-assert-count-performance.md` with the statement-container traversal slice.
- Registered probe coverage already exists via `code-eval-count-tests-line-scan` in `infra/perf/pr_scoped_probes.json` with focused test, coverage, and probe commands for this path.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_assert_nodes_counts_nested_asserts services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_reuses_cached_counts_for_repeated_payloads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_count_tests_probe_script_emits_metrics` (baseline spot check, exit 0)
- `for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_count_tests_probe.py; done` (baseline probe, exit 0)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` focused registered test set plus expanded assert test (exit 0)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_count_tests_probe.py` (exit 0)
- `for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_count_tests_probe.py; done` (head probe, exit 0)
- `git diff --check` (exit 0)

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 7 0 100%`).
- Baseline local registered probe `assert_elapsed_ms_mean` runs: 2168.705 ms, 2185.065 ms, 2104.694 ms; mean 2152.821 ms.
- Head local registered probe `assert_elapsed_ms_mean` runs: 72.936 ms, 70.515 ms, 68.131 ms; mean 70.527 ms.
- Local delta: -2082.294 ms (-96.72%), about 30.52x faster for the pre-parsed assert-node count metric.
- Fallback metric remained stable locally (`elapsed_ms_mean` ~1.8 ms, syntax_count 5334, no_assert_count 6002).
- CI PR-scoped performance report is required before merge and will be used as the registered probe validation source.

## Known Gaps
- Linux local validation covers the Python path only; no Swift runtime effect is claimed.
- The workflow may report context probes unrelated to this direct slice; merge decision should use the direct `code-eval-count-tests-line-scan` probe plus required checks.

## Evidence Checklist
- [x] Registered PR-scoped probe confirmed for affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe executed locally with 3 baseline and 3 head samples.
- [x] `git diff --check` passed.
- [ ] GitHub Actions required checks green.
- [ ] PR-scoped performance `code-eval-count-tests-line-scan` report completed successfully.
