### PR TITLE
perf: streamline video uri identity framing

### DIFF
--- a/docs/plans/2026-05-09-video-uri-identity-hash-single-encode.md
+++ b/docs/plans/2026-05-09-video-uri-identity-hash-single-encode.md
@@ -23,10 +23,10 @@ This slice also updates the probe and coverage commands for this entry to use
 ## Optimization Hypothesis
 
 URI video preprocessing builds a stable identity hash for every URI input. The
-previous implementation repeatedly encoded each field and called
-`digest.update()` twice per field. Building the NUL-framed payload as one string
-and encoding it once preserves the exact digest bytes while reducing per-call
-Python hashing overhead.
+current single-encode implementation still allocates a tuple and dispatches
+through `str.join(...)` for each call. Rendering the same NUL-framed payload with
+adjacent f-strings preserves the exact digest bytes while avoiding the per-call
+tuple/join overhead in the hot path.
 
 ## Behavior Guard
 

--- a/services/mlx-worker-python/worker/runtime/video_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/video_preprocessing.py
@@ -216,19 +216,9 @@ def _uri_identity_hash(
     start_ms: int,
     end_ms: int,
 ) -> str:
-    framed_payload = "\0".join(
-        (
-            uri,
-            mime_type,
-            format_name,
-            filename,
-            str(byte_length),
-            str(duration_ms),
-            str(frame_budget),
-            str(start_ms),
-            str(end_ms),
-            "",
-        )
+    framed_payload = (
+        f"{uri}\0{mime_type}\0{format_name}\0{filename}\0"
+        f"{byte_length}\0{duration_ms}\0{frame_budget}\0{start_ms}\0{end_ms}\0"
     )
     return hashlib.sha256(framed_payload.encode("utf-8")).hexdigest()
 


### PR DESCRIPTION
## Summary
- Streamlines video URI identity hash framing by replacing the per-call tuple + `str.join(...)` path with adjacent f-string rendering of the same NUL-framed payload.
- Keeps the existing digest contract pinned by the focused video preprocessing tests.

## Plan or Spec
- `docs/plans/2026-05-09-video-uri-identity-hash-single-encode.md`
- Registered PR-scoped probe: `video-preprocessing-uri-byte-length-reuse`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics
# 24 passed in 4.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/video_preprocessing_uri_probe.py
# 24 passed in 10.69s; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/video_preprocessing_uri_probe.py
# {"byte_length_getattrs_per_call": 1.0, "elapsed_ms_mean": 772.9322149418294, "iterations_per_sample": 50000.0, "parse_calls_per_call": 1.0, "sample_count": 5.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id video-preprocessing-uri-byte-length-reuse --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-main --head-repo "$PWD" --output /tmp/video_uri_identity_fstring_probe.json
# base elapsed_ms_mean=795.5128628760576; head elapsed_ms_mean=785.796609474346; coverage TOTAL 1 0 100%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%` for the touched video preprocessing line.
- Registered local probe (`video-preprocessing-uri-byte-length-reuse`):
  - `base elapsed_ms_mean=795.5128628760576`
  - `head elapsed_ms_mean=785.796609474346`
  - `delta_ms=-9.716253401711583`
  - `speedup=1.24%`
  - `byte_length_getattrs_per_call=1.0` unchanged
  - `parse_calls_per_call=1.0` unchanged
- CI PR-scoped performance validation is still required before merge.

## Known Gaps
- Local Linux validation covers the Python path only; CI must confirm the registered PR-scoped performance workflow on the PR.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
