### PR TITLE
perf: bind whitespace token space predicate

### DIFF
--- a/docs/plans/2026-05-16-whitespace-token-count-isspace-binding.md
+++ b/docs/plans/2026-05-16-whitespace-token-count-isspace-binding.md
@@ -1,0 +1,41 @@
+# Whitespace token count isspace binding slice
+
+## Scope
+
+This Python-only performance slice is limited to the shared whitespace token
+counter used by vision-family prompt token accounting:
+
+- `services/mlx-worker-python/worker/runtime/token_counting.py`
+- existing focused regression coverage in `services/mlx-worker-python/tests/test_vision_runtime.py`
+
+## Registered probe
+
+The affected path is already covered by the PR-scoped probe
+`vision-family-prompt-token-count-scan` in
+`infra/perf/pr_scoped_probes.json`. The registry entry watches
+`token_counting.py` and provides focused `test_command`, `coverage_command`, and
+`probe_command` entries.
+
+## Optimization
+
+Bind `str.isspace` once before the scan loop so repeated prompt-token scans avoid
+per-character bound-method lookup while preserving the current Unicode whitespace
+semantics and the no-`split()` allocation contract.
+
+## Verification plan
+
+Run the registered focused commands locally on Linux:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_cached_prompt_scan services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_clamps_media_minimums services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_cached_prompt_scan services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_clamps_media_minimums services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/vision_family_adapters.py services/mlx-worker-python/worker/runtime/token_counting.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/vision_family_prompt_token_count_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/vision_family_prompt_token_count_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id vision-family-prompt-token-count-scan --base-repo <origin-main-worktree> --head-repo "$PWD" --output /tmp/vision-family-prompt-token-count-scan.json
+```
+
+## Acceptance criteria
+
+- Focused behavior tests pass.
+- Changed-scope coverage remains at least 95%.
+- The registered probe reports no `split()` calls and lower `elapsed_ms_mean`
+  versus `origin/main`.

--- a/services/mlx-worker-python/worker/runtime/token_counting.py
+++ b/services/mlx-worker-python/worker/runtime/token_counting.py
@@ -7,8 +7,9 @@ from functools import lru_cache
 def whitespace_token_count(text: str) -> int:
     token_count = 0
     in_token = False
+    is_space = str.isspace
     for character in text:
-        if character.isspace():
+        if is_space(character):
             in_token = False
         elif not in_token:
             token_count += 1


### PR DESCRIPTION
## Summary
- Bind `str.isspace` once in the shared whitespace token scanner to avoid per-character bound-method lookup during repeated prompt-token scans.
- Keep the existing no-`split()` allocation contract and Unicode whitespace semantics.

## Plan or Spec
- `docs/plans/2026-05-16-whitespace-token-count-isspace-binding.md`
- Registered probe: `vision-family-prompt-token-count-scan` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_cached_prompt_scan services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_clamps_media_minimums services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics
# 5 passed in 1.65s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_cached_prompt_scan services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_clamps_media_minimums services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/vision_family_adapters.py services/mlx-worker-python/worker/runtime/token_counting.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/vision_family_prompt_token_count_probe.py
# 5 passed in 1.39s; TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/vision_family_prompt_token_count_probe.py
# {"elapsed_ms_mean": 4.155737846823675, "peak_bytes_mean": 235.42857142857142, "split_calls_mean": 0.0, "token_count": 1309.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id vision-family-prompt-token-count-scan --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-vision-token-local-bindings-20260516183501 --head-repo "$PWD" --output /tmp/vision-family-prompt-token-count-scan.json
# head verification ok; base/head probes ok
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%` for the registered focused scope.
- Registered local probe comparison (`vision-family-prompt-token-count-scan`):
  - base `elapsed_ms_mean=4.461416974663734`
  - head `elapsed_ms_mean=4.096673036526356`
  - delta `-0.36474393813737815 ms` (~8.18% faster)
  - `split_calls_mean=0.0` on both base and head
  - `peak_bytes_mean=235.42857142857142` on both base and head

## Known Gaps
- CI must rerun the registered PR-scoped performance workflow before merge.
- Local validation was Linux/Python-only; no Swift runtime behavior is changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
