### PR TITLE
perf: fast-path normalized option answers

### DIFF
--- a/docs/plans/2026-05-16-evaluation-normalized-option-fastpath.md
+++ b/docs/plans/2026-05-16-evaluation-normalized-option-fastpath.md
@@ -1,0 +1,35 @@
+# Evaluation Normalized Option Fast Path
+
+## Goal
+
+Reduce avoidable numeric-shape regex checks in evaluation answer normalization for
+single-letter multiple-choice answers while preserving the existing normalized
+answer contract.
+
+## Scope
+
+This slice is limited to `EvaluationCore._normalized_answer()` and the existing
+registered PR-scoped probe `evaluation-answer-normalization-fast-path`.
+
+## Change
+
+`_normalized_answer()` now handles already-stripped single-character option
+answers before numeric detection. Single-letter answers still return the
+canonical uppercase option, numeric strings still use numeric normalization, and
+free-text answers keep the existing whitespace/case-fold behavior.
+
+## Metrics
+
+Primary registered probe: `evaluation-answer-normalization-fast-path`.
+
+- `elapsed_ms_mean`: lower is better.
+- `numeric_extract_calls_mean`: lower is better; should remain unchanged because
+  the slice avoids the numeric shape check, not the numeric extractor itself.
+- `option_extract_calls_mean`: lower is better; should remain unchanged for the
+  registered workload because option answers are still normalized as options.
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and
+registered probe locally on Linux. The PR-scoped performance workflow remains the
+merge gate for the scheduled slice.

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -3421,14 +3421,14 @@ class EvaluationCore:
     @staticmethod
     def _normalized_answer(value: str) -> str:
         stripped = EvaluationCore._strip_wrapping(value)
+        if len(stripped) == 1:
+            option = EvaluationCore._extract_option_value(stripped)
+            if option is not None:
+                return option
         if EvaluationCore._looks_like_numeric(stripped):
             numeric = EvaluationCore._extract_numeric_value(stripped)
             if numeric is not None:
                 return numeric
-        if EvaluationCore._looks_like_option(stripped):
-            option = EvaluationCore._extract_option_value(stripped)
-            if option is not None:
-                return option
         if (
             "  " in stripped
             or "\t" in stripped


### PR DESCRIPTION
## Summary
- Fast-path single-character option answers in `EvaluationCore._normalized_answer()` before numeric shape detection.
- Add a scoped plan documenting the registered-probe slice and expected behavior parity.

## Plan or Spec
- `docs/plans/2026-05-16-evaluation-normalized-option-fastpath.md`
- Registered probe: `evaluation-answer-normalization-fast-path` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_helpers_cover_numeric_option_and_normalization_paths services/mlx-worker-python/tests/test_evaluation_core.py::test_normalized_answer_skips_extractors_for_free_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_answer_normalization_probe_command_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `python3 /tmp/run_registered_probe.py` (executes the registered `evaluation-answer-normalization-fast-path` probe command from `infra/perf/pr_scoped_probes.json`)

## Coverage and Metrics
- Focused pytest: 5 passed.
- Changed-scope coverage: `TOTAL 4 0 100%` for changed executable lines.
- Local Linux registered probe (new): `elapsed_ms_mean=262.847562`, `numeric_extract_calls_mean=300.0`, `option_extract_calls_mean=300.0`.
- Local before/after probe comparison with the same workload:
  - old `elapsed_ms_mean=273.047448`
  - new `elapsed_ms_mean=259.433553`
  - delta `-13.613895 ms` (~4.99% faster)
- PR-scoped CI registered probe is required before merge.

## Known Gaps
- Local validation covers Python behavior and Linux probe metrics only.
- CI must confirm the registered PR-scoped performance workflow on GitHub Actions.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
