### PR TITLE
perf: bind evaluation latency stat helpers

### DIFF
--- a/docs/plans/2026-05-03-evaluation-latency-percentile-vector-reuse.md
+++ b/docs/plans/2026-05-03-evaluation-latency-percentile-vector-reuse.md
@@ -27,9 +27,10 @@ The probe must be base-compatible so `origin/main` still runs successfully durin
 ## Success Metrics
 
 - `_latency_stats()` performs one sort per invocation instead of two.
+- A follow-up micro-slice may keep the same behavior and one-sort invariant while removing repeated class attribute lookups from the return-path by binding `_round_ms` and `_ordered_percentile` once per call.
 - Latency summary outputs (`mean`, `p50`, `p95`, `max`) remain unchanged.
 - Focused changed-scope coverage for touched executable files is at least 95%.
-- Local probe shows lower elapsed time and fewer sort calls versus `origin/main`.
+- The registered local probe must show stable or lower `elapsed_ms_mean` versus `origin/main`; `sorted_calls_mean` must remain `1.0`.
 
 ## Verification Commands
 

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -1758,11 +1758,13 @@ class EvaluationCore:
             return {"mean": 0.0, "p50": 0.0, "p95": 0.0, "max": 0.0}
         sorted_values = sorted(values)
         value_count = len(sorted_values)
+        round_ms = cls._round_ms
+        ordered_percentile = cls._ordered_percentile
         return {
-            "mean": cls._round_ms(sum(sorted_values) / value_count),
-            "p50": cls._round_ms(cls._ordered_percentile(sorted_values, 50.0)),
-            "p95": cls._round_ms(cls._ordered_percentile(sorted_values, 95.0)),
-            "max": cls._round_ms(sorted_values[-1]),
+            "mean": round_ms(sum(sorted_values) / value_count),
+            "p50": round_ms(ordered_percentile(sorted_values, 50.0)),
+            "p95": round_ms(ordered_percentile(sorted_values, 95.0)),
+            "max": round_ms(sorted_values[-1]),
         }
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Bind `_round_ms` and `_ordered_percentile` once inside `EvaluationCore._latency_stats()` to avoid repeated class attribute lookups on the latency summary hot path.
- Preserve the existing one-sort percentile vector behavior and output semantics.
- Update the latency percentile plan with the follow-up micro-slice success criteria.

## Plan or Spec
- `docs/plans/2026-05-03-evaluation-latency-percentile-vector-reuse.md`
- Registered probe: `evaluation-latency-percentile-vector-reuse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_percentile_preserves_interpolated_results services/mlx-worker-python/tests/test_evaluation_core.py::test_latency_stats_reuse_single_sorted_vector services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_latency_percentile_probe_command_emits_metrics services/mlx-worker-python/tests/test_event_extraction.py::test_event_extraction_dialogue_diagnostics_uses_top_k_for_slowest_dialogues`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_percentile_preserves_interpolated_results services/mlx-worker-python/tests/test_evaluation_core.py::test_latency_stats_reuse_single_sorted_vector services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_latency_percentile_probe_command_emits_metrics services/mlx-worker-python/tests/test_event_extraction.py::test_event_extraction_dialogue_diagnostics_uses_top_k_for_slowest_dialogues`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-latency-percentile-vector-reuse --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/eval-latency-local-bindings-probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 5 passed.
- Changed-scope coverage: `TOTAL 2 0 100%` for the touched executable lines.
- Local registered probe (`evaluation-latency-percentile-vector-reuse`): base `elapsed_ms_mean=240.548152`, head `elapsed_ms_mean=230.153402`, delta `-10.394750 ms`, speedup `1.045164x`; `sorted_calls_mean` remained `1.0 -> 1.0`.

## Known Gaps
- This is a Python-only slice verified locally on Linux. GitHub Actions must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe produced base-vs-head metrics.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
