### PR TITLE
perf: bind lora reward summary hot helpers

### DIFF
--- a/docs/plans/2026-05-16-lora-reward-summary-performance.md
+++ b/docs/plans/2026-05-16-lora-reward-summary-performance.md
@@ -1,0 +1,34 @@
+# LoRA Reward Summary Candidate Hot-Loop Bindings
+
+## Scope
+
+This slice covers `services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py` and the registered PR-scoped probe `lora-reward-summary-candidate-minmax`.
+
+## Optimization
+
+`_reward_summary` performs a tight loop over LoRA alignment reward samples and candidate groups. It already avoids repeated `sum()`, `min()`, and `max()` passes by maintaining candidate group totals, square totals, min, and max in one pass.
+
+This slice keeps that behavior and binds the hot helpers used inside the reward-summary loop:
+
+- list `append`/`extend` methods used for score and margin accumulation
+- `float`, `isinstance`, `dict`, and `list` lookups used for candidate validation and score conversion
+
+This reduces repeated global/builtin and method lookup overhead in the inner candidate loop without changing the summary algorithm or output schema.
+
+Behavior remains unchanged:
+
+- all reward and candidate scores still participate in `reward_mean`, `reward_p50`, and `reward_p95`
+- candidate group margin and variance still use the same per-group min, max, total, square total, and count
+- non-dict candidates and candidates without `score` remain ignored
+
+A rejected experiment in this slice streamed candidate scores directly into the global score vector to remove the per-sample candidate list, but the registered local probe regressed from about 47.2 ms to 49-52 ms. The accepted change keeps the existing per-group list and only binds hot helpers.
+
+## Validation
+
+Use the registered probe entry in `infra/perf/pr_scoped_probes.json`:
+
+- focused LoRA alignment tests from `test_command`
+- changed-scope coverage from `coverage_command`
+- `scripts/lora_reward_summary_probe.py` from `probe_command`
+
+The Linux local run validates Python behavior and probe metrics for this slice.

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -532,26 +532,34 @@ def _alignment_manifest_payload(
 
 def _reward_summary(samples: list[dict[str, Any]]) -> dict[str, float | int]:
     scores: list[float] = []
+    scores_append = scores.append
+    scores_extend = scores.extend
+    to_float = float
+    is_instance = isinstance
+    dict_type = dict
+    list_type = list
     score_total = 0.0
     candidate_group_margins: list[float] = []
+    candidate_group_margins_append = candidate_group_margins.append
     candidate_group_margin_total = 0.0
     candidate_group_variance_total = 0.0
     for sample in samples:
         if "reward_score" in sample:
-            reward_score = float(sample["reward_score"])
-            scores.append(reward_score)
+            reward_score = to_float(sample["reward_score"])
+            scores_append(reward_score)
             score_total += reward_score
         candidates = sample.get("candidates")
         candidate_scores: list[float] = []
+        candidate_scores_append = candidate_scores.append
         candidate_score_min: float | None = None
         candidate_score_max: float | None = None
         candidate_score_total = 0.0
         candidate_score_square_total = 0.0
-        if isinstance(candidates, list):
+        if is_instance(candidates, list_type):
             for candidate in candidates:
-                if isinstance(candidate, dict) and "score" in candidate:
-                    candidate_score = float(candidate["score"])
-                    candidate_scores.append(candidate_score)
+                if is_instance(candidate, dict_type) and "score" in candidate:
+                    candidate_score = to_float(candidate["score"])
+                    candidate_scores_append(candidate_score)
                     candidate_score_total += candidate_score
                     candidate_score_square_total += candidate_score * candidate_score
                     if candidate_score_min is None or candidate_score < candidate_score_min:
@@ -559,7 +567,7 @@ def _reward_summary(samples: list[dict[str, Any]]) -> dict[str, float | int]:
                     if candidate_score_max is None or candidate_score > candidate_score_max:
                         candidate_score_max = candidate_score
         if candidate_scores:
-            scores.extend(candidate_scores)
+            scores_extend(candidate_scores)
             score_total += candidate_score_total
         candidate_score_count = len(candidate_scores)
         if candidate_score_count >= 2:
@@ -570,7 +578,7 @@ def _reward_summary(samples: list[dict[str, Any]]) -> dict[str, float | int]:
             candidate_group_variance = (
                 candidate_score_square_total / candidate_score_count
             ) - (group_mean * group_mean)
-            candidate_group_margins.append(candidate_group_margin)
+            candidate_group_margins_append(candidate_group_margin)
             candidate_group_margin_total += candidate_group_margin
             candidate_group_variance_total += candidate_group_variance
     if not scores:


### PR DESCRIPTION
## Summary
- Bind hot helpers in `_reward_summary` for LoRA alignment reward summaries.
- Keep the existing one-pass candidate min/max/variance behavior and output schema unchanged.
- Add a focused plan note for the registered `lora-reward-summary-candidate-minmax` slice.

## Plan or Spec
- `docs/plans/2026-05-16-lora-reward-summary-performance.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alias services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file
# 9 passed in 1.89s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_reward_summary_probe.py
# 9 passed in 3.39s; TOTAL 16 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/lora_reward_summary_probe.py
# baseline origin/main samples: 46.753900, 47.615720, 47.185650 ms; mean=47.185090 ms
# branch samples: 44.434254, 45.775345, 44.988048, 46.934115, 50.369874 ms; five-run mean=46.500327 ms
```

## Coverage and Metrics
- Registered probe: `lora-reward-summary-candidate-minmax` in `infra/perf/pr_scoped_probes.json`.
- Changed-scope coverage: `TOTAL 16 0 100%`.
- Local Linux probe comparison:
  - `old_mean=47.185090 ms`
  - `new_mean=46.500327 ms`
  - `delta_ms=-0.684763 ms`
  - `speedup≈1.0147x`
- CI is required for the registered PR-scoped performance workflow validation.

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime effect is claimed.
- Probe timing is noisy in this environment; the rejected direct-streaming experiment is documented in the plan.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
