### PR TITLE
perf: reduce code eval assert count stack work

### DIFF
--- a/docs/plans/2026-05-16-code-eval-assert-node-loop.md
+++ b/docs/plans/2026-05-16-code-eval-assert-node-loop.md
@@ -16,11 +16,15 @@ registry entry includes focused `test_command`, `coverage_command`, and
 
 ## Optimization
 
-`_count_assert_nodes()` previously used `ast.walk()`, which creates and manages
-an internal queue while yielding every AST node. This slice replaces it with a
-single explicit stack over `ast.iter_child_nodes()`. The traversal order is not
-observable because the helper only counts `ast.Assert` nodes, and behavior stays
-unchanged for nested asserts and modules without asserts.
+`_count_assert_nodes()` already avoids `ast.walk()` by using a single explicit
+stack over statement container nodes. This follow-up counts top-level assert
+nodes while seeding the stack, avoiding stack push/pop work for common flat test
+modules, then keeps the existing stack traversal for nested statement
+containers. It also removes the per-container generator expression passed to
+`stack.extend(...)` and appends matching child statement containers directly.
+The traversal order is not observable because the helper only counts
+`ast.Assert` nodes, and behavior stays unchanged for nested asserts and modules
+without asserts.
 
 ## Verification Plan
 

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -256,18 +256,25 @@ def _count_assert_nodes(
     _isinstance=isinstance,
 ) -> int:
     count = 0
-    stack = list(getattr(module, "body", ()))
+    stack: list[ast.AST] = []
+    stack_append = stack.append
+    for node in getattr(module, "body", ()):
+        if _isinstance(node, _assert_type):
+            count += 1
+        elif _isinstance(node, _stmt_container_types):
+            stack_append(node)
+    stack_pop = stack.pop
     while stack:
-        node = stack.pop()
+        node = stack_pop()
         if _isinstance(node, _assert_type):
             count += 1
             continue
         for field_name in node._fields:
             child = getattr(node, field_name, None)
             if _isinstance(child, list):
-                stack.extend(
-                    item for item in child if _isinstance(item, _stmt_container_types)
-                )
+                for item in child:
+                    if _isinstance(item, _stmt_container_types):
+                        stack_append(item)
     return count
 
 


### PR DESCRIPTION
## Summary
- Reduce `_count_assert_nodes()` stack churn by counting top-level `ast.Assert` nodes while seeding the traversal stack.
- Replace the per-child generator passed to `stack.extend(...)` with direct appends for nested statement containers.
- Update the active code-eval assert-node performance plan to reflect this follow-up slice.

## Plan or Spec
- `docs/plans/2026-05-16-code-eval-assert-node-loop.md`
- Registered PR-scoped probe: `code-eval-count-tests-line-scan` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
# Baseline direct probe on origin/main worktree, three runs before the code change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_count_tests_probe.py
exit 0; assert_elapsed_ms_mean: 72.5708, 66.5906, 70.5313; peak_bytes_mean: 80470.5714 each

# Head direct probe on this branch, three runs after the final code change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_count_tests_probe.py
exit 0; assert_elapsed_ms_mean: 64.2792, 64.1735, 61.6042; peak_bytes_mean: 25143.7143 each

# Focused registered test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_reuses_cached_counts_for_repeated_payloads services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_assert_nodes_counts_nested_asserts services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_fallback_avoids_splitlines_materialization services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_avoids_splitlines_materialization services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fast_path_skips_ast_parse services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_count_tests_probe_script_emits_metrics
exit 0; 10 passed in 1.41s

# Registered coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_count_tests_probe.py
exit 0; 10 passed in 6.77s; TOTAL 12 0 100%

# Registered local base-vs-head probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-count-tests-line-scan --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/code_eval_assert_stack_probe2.json
exit 0

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%`.
- Registered local base-vs-head probe (`/tmp/code_eval_assert_stack_probe2.json`):
  - `elapsed_ms_mean`: base `2.2119842137` ms → head `1.7901443810` ms (`-0.421840` ms, ~19.1% lower).
  - `peak_bytes_mean`: base `80470.5714` bytes → head `25143.7143` bytes (`-55326.8571` bytes, ~68.8% lower).
  - Assert-specific informational metric: `assert_elapsed_ms_mean` base `68.6757` ms → head `66.0171` ms (`-2.6586` ms, ~3.9% lower).
- Direct three-run probe means for the targeted assert loop:
  - base `assert_elapsed_ms_mean` mean: ~69.8976 ms
  - head `assert_elapsed_ms_mean` mean: ~63.3523 ms
  - approximate delta: `-6.5453` ms (~9.4% lower)
- Observability mode: N/A; this is a local helper/performance slice and does not add production observability.
- Probe overhead: N/A; no new observability or runtime probe instrumentation was added.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this PR is scoped to the registered Python code-eval probe and focused tests.
- GitHub Actions PR-scoped performance is still the merge gate for the registered probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
