### PR TITLE
perf: fast-path code eval python tag matching

### DIFF
--- a/scripts/code_eval_code_block_extract_probe.py
+++ b/scripts/code_eval_code_block_extract_probe.py
@@ -18,8 +18,9 @@ from worker.engine import code_eval_runner
 def _build_response(block_count: int) -> str:
     blocks = []
     for index in range(block_count):
+        tag = "PyThOn" if index % 2 else "python"
         blocks.append(
-            f"analysis chunk {index}\n```python\ndef candidate_{index}():\n    return {index}\n```"
+            f"analysis chunk {index}\n```{tag}\ndef candidate_{index}():\n    return {index}\n```"
         )
     trailing_commentary = "\n".join(f"post answer note {index}" for index in range(block_count))
     return "\n\n".join(blocks) + "\n" + trailing_commentary

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -23,6 +23,10 @@ def test_extract_candidate_code_handles_empty_plaintext_and_code_blocks() -> Non
         "print('case')",
         "parsed_code_block",
     )
+    assert code_eval_runner.extract_candidate_code("```pYtHoN\nprint('case2')\n```") == (
+        "print('case2')",
+        "parsed_code_block",
+    )
     assert code_eval_runner.extract_candidate_code("```python\nprint('hi')\n```   \n\t") == (
         "print('hi')",
         "parsed_code_block",

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -16,7 +16,25 @@ import textwrap
 _DEFAULT_STDIO_LIMIT_BYTES = 32_768
 _JSON_LOADS = json.loads
 _JSON_DECODE_ERROR = json.JSONDecodeError
-_COMMON_PYTHON_CODE_BLOCK_TAGS = ("python", "Python", "PYTHON")
+_PYTHON_CODE_BLOCK_TAG_LENGTH = len("python")
+_PYTHON_CODE_BLOCK_TAG_VARIANTS = (
+    "python",
+    "Python",
+    "PYTHON",
+    "PyThOn",
+    "pYtHoN",
+    *(
+        variant
+        for variant in (
+            "".join(
+                upper if bitmask & (1 << offset) else lower
+                for offset, (lower, upper) in enumerate(zip("python", "PYTHON"))
+            )
+            for bitmask in range(1 << _PYTHON_CODE_BLOCK_TAG_LENGTH)
+        )
+        if variant not in {"python", "Python", "PYTHON", "PyThOn", "pYtHoN"}
+    ),
+)
 
 
 @dataclass(frozen=True)
@@ -64,10 +82,8 @@ def extract_candidate_code(raw_response: str) -> tuple[str, str]:
 
 
 def _code_block_content_start(text: str, start: int) -> int:
-    if text.startswith(_COMMON_PYTHON_CODE_BLOCK_TAGS, start):
-        start += 6
-    elif text[start : start + 6].lower() == "python":
-        start += 6
+    if text.startswith(_PYTHON_CODE_BLOCK_TAG_VARIANTS, start):
+        start += _PYTHON_CODE_BLOCK_TAG_LENGTH
     while start < len(text) and text[start].isspace():
         start += 1
     return start


### PR DESCRIPTION
## Summary
- Fast-path code-evaluation Python code-fence tag matching with a precomputed ASCII-case variant tuple.
- Update the code-block extraction probe workload to include mixed-case `PyThOn` tags so the registered probe covers this hot path.
- Add a focused parser regression for an additional mixed-case Python tag spelling.

## Plan or Spec
- `docs/plans/2026-05-16-code-eval-code-block-tag-case-fast-path.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# exit 0; 4 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py
# exit 0; TOTAL 6 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py
# exit 0; {"block_count": 2500.0, "elapsed_ms_mean": 0.029354855152113096, "extracted_chars_mean": 37.0, "peak_bytes_mean": 245.0, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
# local old-vs-new probe harness against the same mixed-case workload
PY
# exit 0; old_mean=0.02796173406143983 ms; new_mean=0.02494414026538531 ms; speedup=1.120974054986453; delta=-0.00301759379605452 ms

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 6 0 100%` for `code_eval_runner.py`, `test_code_eval_runner.py`, `test_pr_scoped_performance.py`, and `code_eval_code_block_extract_probe.py`.
- Registered local probe (`code-eval-code-block-last-match-streaming` workload via `scripts/code_eval_code_block_extract_probe.py`): `elapsed_ms_mean=0.029354855152113096`, `peak_bytes_mean=245.0`, `block_count=2500`, `sample_count=7`.
- Local old-vs-new mixed-case harness: `old_mean=0.02796173406143983 ms`, `new_mean=0.02494414026538531 ms`, `speedup=1.120974054986453`, `delta_ms=-0.00301759379605452`.
- CI PR-scoped performance workflow is required for registered probe validation before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift/macOS runtime effect is involved.
- Awaiting GitHub Actions PR-scoped performance report before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
