### PR TITLE
perf: reduce stream assembler boundary allocations

### DIFF
--- a/docs/plans/2026-05-17-stream-assembler-structural-boundary-allocation.md
+++ b/docs/plans/2026-05-17-stream-assembler-structural-boundary-allocation.md
@@ -1,0 +1,25 @@
+# Stream Assembler Structural Boundary Allocation Slice
+
+## Goal
+
+Reduce per-drain allocation overhead in the Python request stream assembler's structural-boundary lookup path without changing parsing semantics.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/stream_assembler.py`
+- `services/mlx-worker-python/tests/test_stream_assembler.py`
+
+## Registered Probe
+
+The affected file is covered by the PR-scoped registered probe `stream-assembler-parser-mode-cache` in `infra/perf/pr_scoped_probes.json`. That entry includes focused `test_command`, `coverage_command`, and `probe_command` fields and runs on `ubuntu-latest`.
+
+## Implementation Plan
+
+1. Preserve behavior around enabled structural boundaries with focused tests for `_next_structural_tag_after()`.
+2. Replace short-lived list construction in `_earliest_structural_tag()` and `_next_structural_tag_after()` with direct candidate comparisons.
+3. Run the registered focused tests, changed-scope coverage, and registered probe locally on Linux.
+4. Use the PR-scoped performance workflow as the merge gate for the registered probe report.
+
+## Metrics
+
+Primary metric: `stream-assembler-parser-mode-cache` `elapsed_ms_mean` (lower is better).

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -113,6 +113,42 @@ def test_next_structural_tag_prefers_earliest_pipe_channel_tag() -> None:
     )
 
 
+def test_next_structural_tag_after_returns_earliest_enabled_boundary() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-after-earliest",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+    assembler._buffer = "body <think>hidden</think> text <|tool_call>call:search()</tool_call>"
+
+    assert assembler._next_structural_tag_after(6) == 32
+
+
+def test_next_structural_tag_after_ignores_tool_boundary_when_parser_disabled() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-after-parser-disabled",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="",
+    )
+    assembler._buffer = "body <tool_call>{}</tool_call> text"
+
+    assert assembler._next_structural_tag_after(0) == -1
+
+
+def test_next_structural_tag_after_can_return_regular_tool_boundary() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-after-regular-tool",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+    assembler._buffer = "visible <tool_call>{}</tool_call> <|tool_call>call:search()"
+
+    assert assembler._next_structural_tag_after(0) == 8
+
+
 def test_plain_buffer_without_tag_marker_flushes_without_structural_scans(monkeypatch) -> None:
     assembler = RequestStreamAssembler(
         request_id="req-no-marker-fast-path",

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -573,44 +573,41 @@ class RequestStreamAssembler:
                 return None if think_index < 0 else (self._THINK_OPEN, think_index)
 
             tool_index = buffer.find(self._TOOL_OPEN)
-            return self._earliest_structural_tag(
-                ((self._THINK_OPEN, think_index), (self._TOOL_OPEN, tool_index))
-            )
+            if tool_index >= 0 and (think_index < 0 or tool_index < think_index):
+                return (self._TOOL_OPEN, tool_index)
+            return None if think_index < 0 else (self._THINK_OPEN, think_index)
 
-        candidates = [
-            (self._THINK_OPEN, think_index),
-            (self._PIPE_CHANNEL_OPEN, buffer.find(self._PIPE_CHANNEL_OPEN)),
-        ]
+        pipe_channel_index = buffer.find(self._PIPE_CHANNEL_OPEN)
+        earliest_tag = self._THINK_OPEN
+        earliest_index = think_index
+        if pipe_channel_index >= 0 and (earliest_index < 0 or pipe_channel_index < earliest_index):
+            earliest_tag = self._PIPE_CHANNEL_OPEN
+            earliest_index = pipe_channel_index
         if self._tool_parsing_enabled_value:
-            candidates.extend(
-                (
-                    (self._TOOL_OPEN, buffer.find(self._TOOL_OPEN)),
-                    (self._PIPE_TOOL_OPEN, buffer.find(self._PIPE_TOOL_OPEN)),
-                )
-            )
-        return self._earliest_structural_tag(candidates)
-
-    @staticmethod
-    def _earliest_structural_tag(
-        candidates: list[tuple[str, int]] | tuple[tuple[str, int], ...],
-    ) -> tuple[str, int] | None:
-        matches = [candidate for candidate in candidates if candidate[1] >= 0]
-        return min(matches, key=lambda item: item[1]) if matches else None
+            tool_index = buffer.find(self._TOOL_OPEN)
+            if tool_index >= 0 and (earliest_index < 0 or tool_index < earliest_index):
+                earliest_tag = self._TOOL_OPEN
+                earliest_index = tool_index
+            pipe_tool_index = buffer.find(self._PIPE_TOOL_OPEN)
+            if pipe_tool_index >= 0 and (earliest_index < 0 or pipe_tool_index < earliest_index):
+                earliest_tag = self._PIPE_TOOL_OPEN
+                earliest_index = pipe_tool_index
+        return None if earliest_index < 0 else (earliest_tag, earliest_index)
 
     def _next_structural_tag_after(self, start: int) -> int:
-        candidates = [
-            index
-            for index in (
-                self._buffer.find(self._THINK_OPEN, start),
-                self._buffer.find(self._PIPE_CHANNEL_OPEN, start),
-                self._buffer.find(self._TOOL_OPEN, start)
-                if self._tool_parsing_enabled_value else -1,
-                self._buffer.find(self._PIPE_TOOL_OPEN, start)
-                if self._tool_parsing_enabled_value else -1,
-            )
-            if index >= 0
-        ]
-        return min(candidates) if candidates else -1
+        buffer = self._buffer
+        earliest = buffer.find(self._THINK_OPEN, start)
+        pipe_channel_index = buffer.find(self._PIPE_CHANNEL_OPEN, start)
+        if pipe_channel_index >= 0 and (earliest < 0 or pipe_channel_index < earliest):
+            earliest = pipe_channel_index
+        if self._tool_parsing_enabled_value:
+            tool_index = buffer.find(self._TOOL_OPEN, start)
+            if tool_index >= 0 and (earliest < 0 or tool_index < earliest):
+                earliest = tool_index
+            pipe_tool_index = buffer.find(self._PIPE_TOOL_OPEN, start)
+            if pipe_tool_index >= 0 and (earliest < 0 or pipe_tool_index < earliest):
+                earliest = pipe_tool_index
+        return earliest
 
     def _has_partial_structural_tag_suffix(self) -> bool:
         return bool(self._partial_structural_tag_suffix())


### PR DESCRIPTION
## Summary
- Reduce allocation overhead in the Python stream assembler structural boundary scan path.
- Replace short-lived candidate lists/min scans with direct earliest-boundary comparisons.
- Add focused parity tests for `_next_structural_tag_after()` enabled/disabled tool boundaries.

## Plan or Spec
- `docs/plans/2026-05-17-stream-assembler-structural-boundary-allocation.md`

## Commands Run
```text
# Baseline registered probe on origin/main before edit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 76 passed in 0.86s

# Baseline registered probe (single run on origin/main)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 <stream-assembler-parser-mode-cache probe>
# exit 0; {"elapsed_ms_mean": 4.054186720168218, "raw_char_count": 14323.0, "tool_call_count": 10.0}

# Focused registered tests after change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 79 passed in 0.15s

# Changed-scope coverage after change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; TOTAL 43 0 100%

# Registered probe, 3 paired runs (origin/main vs branch)
# origin/main elapsed_ms_mean: 4.22854270436801, 4.0755994559731334, 4.148308304138482
# branch elapsed_ms_mean: 4.00466489372775, 4.157151241088286, 3.6515427054837346
# old_mean=4.150817, new_mean=3.937786, delta_ms=-0.213031, speedup=1.054099x, improvement=5.13%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 43 0 100%`.
- Registered local probe: `stream-assembler-parser-mode-cache`.
- Metrics: `old_mean=4.150817ms`, `new_mean=3.937786ms`, `delta_ms=-0.213031`, `speedup=1.054099x`, `improvement=5.13%`.
- CI must run the registered PR-scoped performance workflow before merge.

## Known Gaps
- Local validation is Linux/Python only; CI remains the source of truth for the registered PR-scoped probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
