### PR TITLE
perf: reuse embedding digest unpacker

### DIFF
--- a/docs/plans/2026-05-05-deterministic-embedding-projection-allocation.md
+++ b/docs/plans/2026-05-05-deterministic-embedding-projection-allocation.md
@@ -22,6 +22,10 @@ This slice is Python-only under `services/mlx-worker-python` and is verifiable o
 
 Compute the repeated-pattern L2 norm from the eight digest-derived base values, then emit the normalized output directly from the base pattern. This preserves ordering and rounding semantics while avoiding the full pre-normalization vector materialization.
 
+## Follow-up unpack-cache slice
+
+A later narrow slice keeps the same digest projection semantics but binds the fixed `struct.Struct("<8I").unpack` callable at module import time. `_project_digest(...)` unpacks exactly eight uint32 values for every projection, so reusing the precompiled `Struct` removes repeated format parsing and trims a small amount of per-call allocation in the registered projection probe.
+
 ## Performance probe
 
 Register `deterministic-embedding-project-digest-allocation` as a `command_json` PR-scoped probe.

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -6,6 +6,8 @@ import math
 import struct
 import unicodedata
 
+_UNPACK_DIGEST_UINT32 = struct.Struct("<8I").unpack
+
 
 @dataclass(frozen=True)
 class EmbeddingBackendDescriptor:
@@ -45,7 +47,7 @@ class DeterministicEmbeddingBackend:
         digest = hashlib.sha256(seed_text.encode("utf-8")).digest()
         base_values: list[float] = []
         base_squared_sum = 0.0
-        for raw in struct.unpack("<8I", digest):
+        for raw in _UNPACK_DIGEST_UINT32(digest):
             value = (raw / 0xFFFFFFFF) * 2.0 - 1.0
             base_values.append(value)
             base_squared_sum += value * value


### PR DESCRIPTION
## Summary
- Reuse a precompiled `struct.Struct("<8I").unpack` callable in deterministic embedding digest projection.
- Keep embedding output semantics unchanged while avoiding repeated fixed-format unpack setup in the hot projection helper.

## Plan or Spec
- `docs/plans/2026-05-05-deterministic-embedding-projection-allocation.md`
- Registered PR-scoped probe: `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
# 17 passed in 14.77s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
# 17 passed in 44.44s; TOTAL 2 0 100%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Local Linux registered probe (`scripts/deterministic_embedding_project_digest_probe.py`, 3 base/head runs):
  - `elapsed_ms_mean`: base `18.140957 ms`, head `17.569727 ms`, delta `-0.571230 ms` (`-3.149%`, `1.032512x`).
  - `peak_bytes_mean`: base `66882.333333`, head `66747.666667`, delta `-134.666666 bytes`.
  - Guard metrics unchanged: `checksum=0.348915`, `dimensions=4096`, `vector_count=500`.
- CI PR-scoped performance workflow is required as the final registered probe validation gate before merge.

## Known Gaps
- Local verification is Linux/Python only; no Swift runtime path is changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: existing PR-scoped performance evidence only; no runtime observability mode change.
- [x] Deferred work and known gaps are stated explicitly.
