### PR TITLE
perf: cache serving diagnostics queue append

### DIFF
--- a/docs/plans/2026-05-17-serving-diagnostics-append-local-bindings.md
+++ b/docs/plans/2026-05-17-serving-diagnostics-append-local-bindings.md
@@ -1,0 +1,25 @@
+# Serving Diagnostics Append Local Bindings Slice
+
+## Goal
+
+Reduce per-event overhead in `BoundedServingDiagnosticsEventQueue.append(...)` while preserving debug diagnostics queue retention and overflow semantics.
+
+## Scope
+
+- `services/mlx-worker-python/worker/productization/serving_diagnostics.py`
+- `services/mlx-worker-python/tests/test_serving_diagnostics.py`
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and runs on `ubuntu-latest`.
+
+## Implementation Plan
+
+1. Preserve queue append return semantics, retained snapshot length, and dropped-count behavior with existing focused serving diagnostics tests.
+2. Hoist repeated saturated-append attribute lookups in `BoundedServingDiagnosticsEventQueue.append(...)` into local variables while keeping the same lock and `deque(maxlen=...)` behavior.
+3. Run the registered focused tests, changed-scope coverage, and registered probe locally on Linux.
+4. Use the PR-scoped performance workflow as the merge gate for the registered probe report.
+
+## Metrics
+
+Primary metric: `serving-diagnostics-debug-queue-bounds` `elapsed_ms_mean` (lower is better). Secondary metric: `serialization_elapsed_ms_mean` should not regress because serialization behavior is unchanged.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -219,6 +219,7 @@ def test_serving_diagnostics_queue_append_uses_retained_count_without_len() -> N
     queue = BoundedServingDiagnosticsEventQueue(max_events=2)
     buffer = NoLenBuffer()
     queue._events = buffer  # type: ignore[assignment]
+    queue._append_event = buffer.append  # type: ignore[method-assign]
 
     assert queue.append(event) is True
     assert buffer.events == [event]
@@ -351,6 +352,7 @@ def test_serving_diagnostics_bounded_queue_serializes_append_during_snapshot() -
     queue = BoundedServingDiagnosticsEventQueue(max_events=8)
     instrumented = InstrumentedBuffer()
     queue._events = instrumented  # type: ignore[assignment]
+    queue._append_event = instrumented.append  # type: ignore[method-assign]
     errors: list[BaseException] = []
     snapshots: list[tuple[int, ...]] = []
 

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -41,6 +41,7 @@ class ServingDiagnosticsQueueSnapshot:
 
 class BoundedServingDiagnosticsEventQueue:
     __slots__ = (
+        "_append_event",
         "_dropped_count",
         "_events",
         "_is_saturated",
@@ -52,6 +53,7 @@ class BoundedServingDiagnosticsEventQueue:
     def __init__(self, *, max_events: int = 256) -> None:
         self._max_events = max(int(max_events), 1)
         self._events: deque[ServingDiagnosticsEvent] = deque(maxlen=self._max_events)
+        self._append_event = self._events.append
         self._dropped_count = 0
         self._is_saturated = False
         self._retained_count = 0
@@ -61,12 +63,10 @@ class BoundedServingDiagnosticsEventQueue:
         lock = self._lock
         lock.acquire()
         try:
-            events = self._events
+            self._append_event(event)
             if self._is_saturated:
                 self._dropped_count += 1
-                events.append(event)
                 return False
-            events.append(event)
             retained_count = self._retained_count + 1
             self._retained_count = retained_count
             self._is_saturated = retained_count >= self._max_events


### PR DESCRIPTION
## Summary
- Cache the serving diagnostics queue's deque append bound method during queue initialization.
- Keep existing lock, retained-count, dropped-count, and snapshot semantics unchanged.
- Update internal queue tests that swap the private buffer so they also refresh the cached append callback.

## Plan or Spec
- `docs/plans/2026-05-17-serving-diagnostics-append-local-bindings.md`
- Registered probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands` → 33 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py` → TOTAL 4 0 100%
- Base probe: `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=50 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` at `origin/main` → `elapsed_ms_mean=5.78388`, `serialization_elapsed_ms_mean=1.058816`
- Head probe: `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=50 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` → `elapsed_ms_mean=5.351513`, `serialization_elapsed_ms_mean=0.893134`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 4 0 100%`).
- Local Linux registered-probe comparison: `elapsed_ms_mean` improved from `5.78388 ms` to `5.351513 ms` (`-0.432367 ms`, about `7.48%` faster).
- `serialization_elapsed_ms_mean` improved from `1.058816 ms` to `0.893134 ms`; serialization code was not changed, so this is treated as supportive/no-regression evidence rather than the primary slice claim.

## Known Gaps
- Local validation is Linux-only for this Python slice.
- CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage met the 95% requirement.
- [x] Registered probe was run locally with a base/head comparison.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
