### PR TITLE
perf: fast-path stream assembler no-marker tails

### DIFF
--- a/docs/plans/2026-05-17-stream-assembler-next-boundary-marker-fastpath.md
+++ b/docs/plans/2026-05-17-stream-assembler-next-boundary-marker-fastpath.md
@@ -1,0 +1,25 @@
+# Stream Assembler Next Boundary Marker Fast Path
+
+## Goal
+
+Reduce repeated structural-boundary scans in `RequestStreamAssembler._next_structural_tag_after(...)` when a pipe-channel body has no further markup after the current body start.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/stream_assembler.py`
+- `services/mlx-worker-python/tests/test_stream_assembler.py`
+
+## Registered Probe
+
+The affected runtime file is covered by registered PR-scoped stream assembler probes in `infra/perf/pr_scoped_probes.json`, including `stream-assembler-parser-mode-cache`. Those entries include focused `test_command`, `coverage_command`, and `probe_command` fields and run on `ubuntu-latest`.
+
+## Implementation Plan
+
+1. Add a focused regression test for `_next_structural_tag_after(...)` returning `-1` when no `<` marker remains after the requested start offset.
+2. Add a single-character marker precheck before the more specific structural tag searches.
+3. Run focused tests, changed-scope coverage, and the registered probe locally on Linux.
+4. Use the PR-scoped performance workflow report as the merge gate.
+
+## Metrics
+
+Primary registered metric: `stream-assembler-parser-mode-cache` `elapsed_ms_mean` (lower is better). Local acceptance also records a focused micro-probe for `_next_structural_tag_after(...)` on no-boundary pipe-channel tails because this slice targets that helper directly.

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -149,6 +149,18 @@ def test_next_structural_tag_after_can_return_regular_tool_boundary() -> None:
     assert assembler._next_structural_tag_after(0) == 8
 
 
+def test_next_structural_tag_after_returns_without_marker_tail_scans() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-after-no-marker-tail",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+    assembler._buffer = "prefix <think>hidden</think> plain visible tail"
+
+    assert assembler._next_structural_tag_after(29) == -1
+
+
 def test_plain_buffer_without_tag_marker_flushes_without_structural_scans(monkeypatch) -> None:
     assembler = RequestStreamAssembler(
         request_id="req-no-marker-fast-path",

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -596,6 +596,8 @@ class RequestStreamAssembler:
 
     def _next_structural_tag_after(self, start: int) -> int:
         buffer = self._buffer
+        if buffer.find("<", start) < 0:
+            return -1
         earliest = buffer.find(self._THINK_OPEN, start)
         pipe_channel_index = buffer.find(self._PIPE_CHANNEL_OPEN, start)
         if pipe_channel_index >= 0 and (earliest < 0 or pipe_channel_index < earliest):


### PR DESCRIPTION
## Summary
- Add a no-marker fast path to `RequestStreamAssembler._next_structural_tag_after(...)` so plain pipe-channel tails return before running every structural tag search.
- Add focused regression coverage for no-marker tails after an earlier structural block.
- Document the slice plan and validation boundary under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-05-17-stream-assembler-next-boundary-marker-fastpath.md`
- Existing registered PR-scoped probe coverage: `stream-assembler-parser-mode-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- Registered probe command from `stream-assembler-parser-mode-cache`.
- Focused no-marker-tail micro-probe comparing the previous helper logic against the new helper logic.
- `git diff --check`

## Coverage and Metrics
- Focused tests: `80 passed in 0.28s`.
- Changed-scope coverage: `TOTAL 6 0 100%`.
- Registered local probe (`stream-assembler-parser-mode-cache`): `elapsed_ms_mean=3.542247402947396`, `raw_char_count=14323.0`, `tool_call_count=10.0`.
- Focused no-marker-tail micro-probe: `old_mean_ms=26018.336937263874`, `new_mean_ms=216.69264729799968`, `delta_ms=-25801.644289965872`, `speedup=120.07023432356236` over 7 samples x 200000 iterations.
- CI PR-scoped performance report: `Status: ok`, regressions `0`, verification failures `0`; selected direct probes `3/3` completed. Registered parser-mode cache was neutral (`base=4.071`, `head=4.186`, `delta=+0.115ms`, `+2.84%`), while this slice's direct no-marker-tail micro-probe showed the expected targeted improvement.

## Known Gaps
- Local validation is Linux/Python-only. The registered PR-scoped performance workflow is the CI validation source and completed successfully.

## Evidence Checklist
- [x] Registered PR-scoped probe exists for the affected path with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe ran successfully.
- [x] Focused before/after performance evidence captured.
- [x] GitHub Actions PR-scoped performance report completed successfully.
