### PR TITLE
perf: cache probe policy mode instances

### DIFF
--- a/docs/plans/2026-05-17-probe-policy-string-fastpath.md
+++ b/docs/plans/2026-05-17-probe-policy-string-fastpath.md
@@ -1,0 +1,27 @@
+# Probe policy string fast path
+
+## Scope
+
+This Python-only performance slice keeps `ProbePolicy.from_value(...)` behavior unchanged while reusing immutable policy instances for supported probe modes.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped performance probe `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes focused entries for:
+
+- `test_command`: probe-policy unit coverage and registry dispatch checks.
+- `coverage_command`: changed-scope coverage over `probe_policy.py`, `probe_policy_overhead.py`, focused tests, and the probe script.
+- `probe_command`: command-json execution of `scripts/probe_policy_noop_overhead_probe.py`.
+
+## Implementation plan
+
+1. Add focused regression coverage showing exact lowercase valid and invalid strings preserve the same source-value and fallback semantics.
+2. Keep the existing `ProbeMode` object fast path.
+3. Reuse immutable cached `ProbePolicy` instances for supported modes after normalization while preserving fallback construction for invalid values.
+4. Run focused pytest, changed-scope coverage, and the registered probe locally on Linux.
+5. Use PR-scoped performance CI as the final registered probe gate before merge.
+
+## Validation boundary
+
+This slice is Python-only and locally verifiable on Linux. No Swift runtime performance claim is made.

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -32,6 +32,25 @@ def test_probe_policy_parses_modes_with_cached_value_lookup() -> None:
         assert policy.fallback_applied is False
 
 
+def test_probe_policy_exact_lowercase_strings_keep_source_value() -> None:
+    for mode in ProbeMode:
+        policy = ProbePolicy.from_value(mode.value)
+        assert policy.mode is mode
+        assert policy.source_value == mode.value
+        assert policy.fallback_applied is False
+        assert ProbePolicy.from_value(mode) is policy
+
+    invalid_policy = ProbePolicy.from_value("definitely-not-valid")
+    assert invalid_policy.mode is ProbeMode.MINIMAL
+    assert invalid_policy.source_value == "definitely-not-valid"
+    assert invalid_policy.fallback_applied is True
+
+    non_string_policy = ProbePolicy.from_value(123)  # type: ignore[arg-type]
+    assert non_string_policy.mode is ProbeMode.MINIMAL
+    assert non_string_policy.source_value == "123"
+    assert non_string_policy.fallback_applied is True
+
+
 def test_probe_policy_empty_env_uses_production_default() -> None:
     policy = probe_policy_from_env({"MELIX_PROBE_MODE": ""})
 

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -17,9 +17,6 @@ class ProbeMode(StrEnum):
     DEBUG = "debug"
 
 
-_PROBE_MODE_BY_VALUE: dict[str, ProbeMode] = {mode.value: mode for mode in ProbeMode}
-
-
 @dataclass(frozen=True, slots=True)
 class ProbePolicy:
     mode: ProbeMode = ProbeMode.MINIMAL
@@ -60,13 +57,13 @@ class ProbePolicy:
         default_mode: ProbeMode = ProbeMode.MINIMAL,
     ) -> ProbePolicy:
         if isinstance(value, ProbeMode):
-            return cls(mode=value, source_value=value.value)
+            return _PROBE_POLICY_BY_VALUE[value.value]
         raw_value = str(value or "").strip().lower()
         if not raw_value:
             return cls(mode=default_mode)
-        mode = _PROBE_MODE_BY_VALUE.get(raw_value)
-        if mode is not None:
-            return cls(mode=mode, source_value=raw_value)
+        policy = _PROBE_POLICY_BY_VALUE.get(raw_value)
+        if policy is not None:
+            return policy
         return cls(
             mode=default_mode,
             source_value=raw_value,
@@ -80,6 +77,11 @@ class ProbePolicy:
     @classmethod
     def debug(cls) -> ProbePolicy:
         return cls(mode=ProbeMode.DEBUG, source_value=ProbeMode.DEBUG.value)
+
+
+_PROBE_POLICY_BY_VALUE: dict[str, ProbePolicy] = {
+    mode.value: ProbePolicy(mode=mode, source_value=mode.value) for mode in ProbeMode
+}
 
 
 def probe_policy_from_env(env: Mapping[str, str] | None = None) -> ProbePolicy:


### PR DESCRIPTION
## Summary
- Reuse immutable `ProbePolicy` instances for supported probe modes in `ProbePolicy.from_value(...)`.
- Add focused regression coverage for exact lowercase mode strings, `ProbeMode` inputs, invalid strings, and non-string fallbacks.
- Document the Python-only slice plan and registered probe boundary.

## Plan or Spec
- `docs/plans/2026-05-17-probe-policy-string-fastpath.md`
- Registered PR-scoped probe: `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` → 14 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json ... && python3 scripts/changed_scope_coverage.py ...` → changed-scope coverage 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (`aggregate_measurable_changed_lines=20`, `aggregate_covered_changed_lines=20`).
- Local registered probe baseline before change: `mode_parse_valid_call_ms_mean=0.001585900`, `mode_parse_invalid_call_ms_mean=0.001892762`, `threshold_passed=1.0`.
- Local registered probe after change: `mode_parse_valid_call_ms_mean=0.000389127`, `mode_parse_invalid_call_ms_mean=0.001849526`, `threshold_passed=1.0`.
- Local valid-mode parse delta: `-0.001196773 ms` (~4.08x faster for the registered valid parse metric).
- PR-scoped performance CI is required as the final registered probe validation source before merge.

## Known Gaps
- Linux local validation covers the Python worker path only; no Swift runtime performance claim is made.
- The invalid-mode parse metric is mostly unchanged and remains informational for this slice; the targeted win is supported-mode policy reuse.

## Evidence Checklist
- [x] Synced from `origin/main` before starting the slice.
- [x] Confirmed affected path has a registered PR-scoped probe with test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe runs locally on Linux.
- [ ] GitHub Actions and PR-scoped performance workflow are green.
