### PR TITLE
perf: cache serving diagnostics request id literals

### DIFF
--- a/docs/plans/2026-05-17-serving-diagnostics-request-id-json-cache.md
+++ b/docs/plans/2026-05-17-serving-diagnostics-request-id-json-cache.md
@@ -1,0 +1,31 @@
+# Serving Diagnostics Request-ID JSON Cache
+
+## Scope
+
+This Python-only performance slice targets the serving diagnostics debug queue JSONL serialization path in `services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+
+The slice is limited to repeated request-id string literal encoding inside `_write_jsonl` / `_empty_attribute_event_json_line` for retained debug queue events. It does not change the diagnostics bundle schema, queue capacity semantics, event ordering, dropped-event accounting, or generated artifacts.
+
+## Probe Coverage
+
+The affected path is already covered by the registered PR-scoped performance probe `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe provides:
+
+- `test_command` for focused serving diagnostics tests and PR-scoped probe-selection tests.
+- `coverage_command` for changed-scope coverage on the production path, tests, registry selection, and probe script.
+- `probe_command` via `scripts/serving_diagnostics_queue_probe.py`, measuring queue append and JSONL serialization metrics.
+
+## Implementation Plan
+
+1. Add a focused regression test proving repeated empty-attribute event serialization reuses encoded request-id literals while preserving JSONL payloads.
+2. Thread a per-write request-id literal cache through the fast JSONL event serializer.
+3. Keep the fallback `to_dict` serialization path unchanged for events with non-empty attributes, non-float durations, non-int indexes, or non-finite durations.
+4. Run focused tests, changed-scope coverage, and the registered local probe on Linux before opening the PR.
+5. Use the PR-scoped performance GitHub Actions report as the CI merge gate.
+
+## Expected Metrics
+
+Primary metric: lower `serialization_elapsed_ms_mean` for `serving-diagnostics-debug-queue-bounds`.
+
+Secondary constraints: `elapsed_ms_mean`, `dropped_count`, `retained_count`, `serialization_checksum`, and `serialized_bytes` should remain stable except for normal timing noise.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -299,6 +299,57 @@ def test_serving_diagnostics_empty_event_attributes_skip_stable_json_object(
     assert event.to_dict()["attributes"] == {}
 
 
+def test_serving_diagnostics_jsonl_fast_path_reuses_request_id_literal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    original_encoder = serving_diagnostics_module._json_string_literal
+
+    def counting_encoder(value: str) -> str:
+        calls.append(value)
+        return original_encoder(value)
+
+    monkeypatch.setattr(
+        serving_diagnostics_module,
+        "_json_string_literal",
+        counting_encoder,
+    )
+    rows = tuple(
+        ServingDiagnosticsEvent(
+            request_id="req-shared-fast-path",
+            phase="decode",
+            event_index=event_index,
+            status="completed",
+            duration_ms=0.001,
+        )
+        for event_index in range(3)
+    )
+    path = tmp_path / "events.jsonl"
+
+    serving_diagnostics_module._write_jsonl(path, rows)
+
+    payloads = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    assert [payload["event_index"] for payload in payloads] == [0, 1, 2]
+    assert {payload["request_id"] for payload in payloads} == {"req-shared-fast-path"}
+    assert calls == ["req-shared-fast-path"]
+
+
+def test_serving_diagnostics_jsonl_fast_path_preserves_direct_helper_call() -> None:
+    event = ServingDiagnosticsEvent(
+        request_id="req-direct-fast-path",
+        phase="decode",
+        event_index=7,
+        status="completed",
+        duration_ms=0.001,
+    )
+
+    line = serving_diagnostics_module._empty_attribute_event_json_line(event)
+
+    assert line is not None
+    assert json.loads(line)["request_id"] == "req-direct-fast-path"
+
+
 def test_serving_diagnostics_event_to_dict_preserves_numeric_coercion() -> None:
     event = ServingDiagnosticsEvent(
         request_id="req-numeric-coercion",

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -486,9 +486,10 @@ def _write_jsonl(path: Path, rows: Any) -> None:
     encode = _JSONL_ENCODER.encode
     lines: list[str] = []
     append_line = lines.append
+    request_id_literals: dict[str, str] = {}
     for row in rows:
         if isinstance(row, ServingDiagnosticsEvent):
-            fast_line = _empty_attribute_event_json_line(row)
+            fast_line = _empty_attribute_event_json_line(row, request_id_literals)
             if fast_line is not None:
                 append_line(fast_line + "\n")
                 continue
@@ -497,7 +498,10 @@ def _write_jsonl(path: Path, rows: Any) -> None:
     path.write_bytes("".join(lines).encode("utf-8"))
 
 
-def _empty_attribute_event_json_line(event: ServingDiagnosticsEvent) -> str | None:
+def _empty_attribute_event_json_line(
+    event: ServingDiagnosticsEvent,
+    request_id_literals: dict[str, str] | None = None,
+) -> str | None:
     if event.attributes is not _EMPTY_EVENT_ATTRIBUTES:
         return None
     event_index = event.event_index
@@ -512,6 +516,13 @@ def _empty_attribute_event_json_line(event: ServingDiagnosticsEvent) -> str | No
     status = event.status
     encoded_phase = '"decode"' if phase == "decode" else encode_string(phase)
     encoded_status = '"completed"' if status == "completed" else encode_string(status)
+    if request_id_literals is None:
+        encoded_request_id = encode_string(request_id)
+    else:
+        encoded_request_id = request_id_literals.get(request_id)
+        if encoded_request_id is None:
+            encoded_request_id = encode_string(request_id)
+            request_id_literals[request_id] = encoded_request_id
     return (
         '{"attributes":{},"duration_ms":'
         f"{duration_ms}"
@@ -520,7 +531,7 @@ def _empty_attribute_event_json_line(event: ServingDiagnosticsEvent) -> str | No
         ',"phase":'
         f"{encoded_phase}"
         ',"request_id":'
-        f"{encode_string(request_id)}"
+        f"{encoded_request_id}"
         ',"schema_version":"melix.serving_diagnostics.event.v1","status":'
         f"{encoded_status}"
         "}"


### PR DESCRIPTION
## Summary
- Cache encoded request-id JSON string literals within each serving diagnostics JSONL write.
- Add focused tests proving repeated debug-queue event serialization reuses the literal while preserving payloads.
- Add the governing slice plan for the registered serving diagnostics queue performance probe.

## Plan or Spec
- `docs/plans/2026-05-17-serving-diagnostics-request-id-json-cache.md`
- Registered PR-scoped probe: `serving-diagnostics-debug-queue-bounds`

## Commands Run
- `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` (baseline before code change)
- `uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py`
- `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` (head after code change)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 35 passed.
- Changed-scope coverage: `TOTAL 28 0 100%`.
- Local Linux probe baseline: `elapsed_ms_mean=5.329010`, `serialization_elapsed_ms_mean=1.074427`, `dropped_count=4032`, `retained_count=64`, `serialization_checksum=260064`, `serialized_bytes=10944`.
- Local Linux probe head: `elapsed_ms_mean=5.249284`, `serialization_elapsed_ms_mean=0.894433`, `dropped_count=4032`, `retained_count=64`, `serialization_checksum=260064`, `serialized_bytes=10944`.
- Local delta: `serialization_elapsed_ms_mean -0.179994 ms` (~16.75% faster); append `elapsed_ms_mean -0.079726 ms` (~1.50% faster/no regression).
- CI PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- This is a Python-only slice verified locally on Linux. No Swift runtime behavior is changed.
- Local measurements are synthetic; GitHub Actions PR-scoped performance remains the authoritative registered probe validation before merge.

## Evidence Checklist
- [x] Governing plan/spec updated.
- [x] Affected path has registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage met the 95% requirement.
- [x] Local registered probe showed serialization improvement with stable semantic counters.
- [ ] PR-scoped performance CI completed successfully.
