### PR TITLE
perf: stream serving diagnostics jsonl bytes

### DIFF
--- a/docs/plans/2026-05-17-serving-diagnostics-jsonl-bytearray.md
+++ b/docs/plans/2026-05-17-serving-diagnostics-jsonl-bytearray.md
@@ -1,0 +1,49 @@
+# Serving diagnostics JSONL bytearray assembly
+
+## Scope
+
+This Python-only performance slice targets the serving diagnostics event JSONL
+writer in `services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+The current path accumulates one Python `str` per event row, joins the list, and
+then encodes the entire joined string before writing `events.jsonl`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.
+The registered probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for the serving diagnostics module, tests, and
+`scripts/serving_diagnostics_queue_probe.py`.
+
+## Optimization plan
+
+- Preserve compact JSONL byte layout, key order, ASCII escaping, and fallback
+  behavior for non-fast-path events.
+- Replace the intermediate list-of-strings plus final `join().encode()` with a
+  single `bytearray` buffer that appends encoded rows and newline bytes as rows
+  are produced.
+- Keep the existing direct event fast path and request-id string literal cache
+  unchanged.
+
+## Validation plan
+
+1. Run the focused serving diagnostics tests and PR-scoped performance registry
+   tests for this probe.
+2. Run changed-scope coverage for the changed source path, focused tests, and
+   registered probe script.
+3. Run the registered probe locally on Linux against `origin/main` and this
+   branch before pushing.
+4. Use PR-scoped performance CI as the final registered probe gate before merge.
+
+## Local result
+
+Local Linux registered probe (`serving-diagnostics-debug-queue-bounds`, registry
+sample count 20):
+
+- base (`origin/main`): `serialization_elapsed_ms_mean=0.989865`,
+  `elapsed_ms_mean=5.498727`
+- head: `serialization_elapsed_ms_mean=0.963142`, `elapsed_ms_mean=5.494370`
+- serialization delta: `-0.026723 ms` (`-2.70%`)
+- checksum and serialized byte count unchanged:
+  `serialization_checksum=260064`, `serialized_bytes=10944`
+- focused tests and changed-scope coverage passed with 100% changed-line coverage.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -622,6 +622,55 @@ def test_serving_diagnostics_events_jsonl_streams_default_attribute_rows(
     )
 
 
+def test_serving_diagnostics_events_jsonl_writes_bytearray_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = ServingDiagnosticsRequestSummary(
+        request_id="req-bytearray-jsonl",
+        task_kind="text-generation",
+        model_id="melix-dev-text",
+        runtime_kind="deterministic",
+        acceleration_mode="baseline",
+        prompt_protocol_id="chat.completions.v1",
+        prompt_digest="sha256:prompt",
+        prompt_template_digest="sha256:template",
+        generation_config={},
+        status="completed",
+        finish_reason="stop",
+    )
+    event = ServingDiagnosticsEvent(
+        request_id="req-bytearray-jsonl",
+        phase="decode",
+        event_index=8,
+        status="completed",
+        duration_ms=0.25,
+    )
+    observed_payload_types: list[type[object]] = []
+    original_write_bytes = Path.write_bytes
+
+    def tracked_write_bytes(path: Path, data: bytes) -> int:
+        if path.name == "events.jsonl":
+            observed_payload_types.append(type(data))
+        return original_write_bytes(path, data)
+
+    monkeypatch.setattr(Path, "write_bytes", tracked_write_bytes)
+
+    paths = write_serving_diagnostics_bundle(
+        output_root=tmp_path,
+        bundle_id="diag-bytearray-jsonl",
+        invocation={},
+        effective_config={},
+        model_refs={},
+        request_summary=summary,
+        events=(event,),
+        diagnostics_mode="debug",
+    )
+
+    assert observed_payload_types == [bytearray]
+    assert paths["events"].read_text(encoding="utf-8").endswith('"status":"completed"}\n')
+
+
 def test_serving_diagnostics_events_jsonl_falls_back_for_non_exact_numeric_fields(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -484,18 +484,21 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
 
 def _write_jsonl(path: Path, rows: Any) -> None:
     encode = _JSONL_ENCODER.encode
-    lines: list[str] = []
-    append_line = lines.append
+    payload = bytearray()
+    append_line = payload.extend
+    newline = b"\n"
     request_id_literals: dict[str, str] = {}
     for row in rows:
         if isinstance(row, ServingDiagnosticsEvent):
             fast_line = _empty_attribute_event_json_line(row, request_id_literals)
             if fast_line is not None:
-                append_line(fast_line + "\n")
+                append_line(fast_line.encode("utf-8"))
+                append_line(newline)
                 continue
             row = row.to_dict()
-        append_line(encode(row) + "\n")
-    path.write_bytes("".join(lines).encode("utf-8"))
+        append_line(encode(row).encode("utf-8"))
+        append_line(newline)
+    path.write_bytes(payload)
 
 
 def _empty_attribute_event_json_line(


### PR DESCRIPTION
## Summary
- Stream serving diagnostics JSONL output through a single `bytearray` buffer instead of collecting per-row strings and joining before encoding.
- Add a focused regression test proving the events writer now hands a bytearray payload to `Path.write_bytes` while preserving existing compact JSONL output.
- Document the slice and local probe result under `docs/plans/2026-05-17-serving-diagnostics-jsonl-bytearray.md`.

## Plan or Spec
- `docs/plans/2026-05-17-serving-diagnostics-jsonl-bytearray.md`
- Registered probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 36 passed in 0.75s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# exit 0; 36 passed; TOTAL 21 0 100%

MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=30 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id serving-diagnostics-debug-queue-bounds --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-serving-diagnostics-jsonl-bytearray-20260517 --head-repo "$PWD" --output /tmp/serving_diagnostics_jsonl_bytearray_probe.json
# exit 0; registry command uses sample_count=20

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python ruff check services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py scripts/serving_diagnostics_queue_probe.py
# exit 0; All checks passed

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 21 0 100%`).
- Local registered probe (`serving-diagnostics-debug-queue-bounds`, sample count 20):
  - base `serialization_elapsed_ms_mean=0.989865`, `elapsed_ms_mean=5.498727`
  - head `serialization_elapsed_ms_mean=0.963142`, `elapsed_ms_mean=5.494370`
  - serialization delta `-0.026723 ms` (`-2.70%`)
  - checksum/size unchanged: `serialization_checksum=260064`, `serialized_bytes=10944`
- PR-scoped performance CI is still required as the final registered probe validation gate.

## Known Gaps
- Linux local validation only; no Swift/runtime effect is claimed.
- The registered CI probe report must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Debug diagnostics path; no observability mode change.
- [x] Deferred work and known gaps are stated explicitly.
