### PR TITLE
perf: avoid full probe scan for sparse scope selection

### DIFF
--- a/docs/plans/2026-05-17-pr-scoped-sparse-selection.md
+++ b/docs/plans/2026-05-17-pr-scoped-sparse-selection.md
@@ -1,0 +1,33 @@
+# PR-Scoped Performance Sparse Selection
+
+## Context
+
+The PR-scoped performance scope builder loads the registered probe registry and
+matches changed paths to probe indexes before returning the selected probe
+payload. Most pull requests touch a small set of paths, so the matched probe set
+is usually much smaller than the full registry.
+
+The affected path is already covered by the registered
+`pr-scoped-performance-registry-cache` probe in `infra/perf/pr_scoped_probes.json`.
+That probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+and `services/mlx-worker-python/tests/test_pr_scoped_performance.py`.
+
+## Slice
+
+Use the already-computed matched probe indexes directly when materializing
+`selected_probes` and `matched_probe_ids` for non-force-all scope reports. This
+keeps registry order by sorting the index set once and avoids scanning the full
+probe tuple again for sparse matches.
+
+## Verification
+
+- Focused unit coverage verifies sparse selections still preserve registry order
+  for both `matched_probe_ids` and `selected_probes`.
+- The registered `pr-scoped-performance-registry-cache` probe measures local
+  `build_scope_report` performance on Linux and is the required PR-scoped CI
+  probe for this path.
+
+## Boundaries
+
+This is a Python-only optimization slice. No Swift runtime validation is claimed.

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1168,7 +1168,7 @@ def test_scope_report_selects_dev_up_mlx_metal_dist_info_probe() -> None:
     assert "dev-up-mlx-metal-dist-info-scandir" in probe_ids
 
 
-def test_scope_report_selects_registry_cache_probe() -> None:
+def test_scope_report_selects_registry_cache_probe(tmp_path: Path) -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
         changed_files=["services/mlx-worker-python/worker/productization/pr_scoped_performance.py"],
@@ -1176,6 +1176,33 @@ def test_scope_report_selects_registry_cache_probe() -> None:
 
     probe_ids = {probe["id"] for probe in scope["selected_probes"]}
     assert "pr-scoped-performance-registry-cache" in probe_ids
+
+    registry_path = tmp_path / "registry.json"
+    registry_payload = []
+    for probe_id, watch_globs in (
+        ("alpha", ["src/a.py"]),
+        ("beta", ["src/b.py"]),
+        ("gamma", ["src/c.py"]),
+    ):
+        registry_payload.append(
+            {
+                "id": probe_id,
+                "name": probe_id.title(),
+                "watch_globs": watch_globs,
+                "test_command": "true",
+                "coverage_command": "true",
+                "probe_impl": "command_json",
+                "probe_command": "python3 -c 'print({})'",
+                "metrics": [{"key": "elapsed_ms_mean", "direction": "lower_is_better"}],
+            }
+        )
+    registry_path.write_text(json.dumps(registry_payload), encoding="utf-8")
+
+    sparse_scope = build_scope_report(registry_path=registry_path, changed_files=["src/c.py", "src/a.py"])
+
+    assert sparse_scope["matched_probe_ids"] == ["alpha", "gamma"]
+    assert [probe["id"] for probe in sparse_scope["selected_probes"]] == ["alpha", "gamma"]
+    assert sparse_scope["selected_count"] == 2
 
 
 def test_scope_report_force_selects_all_on_infra_change() -> None:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -237,11 +237,12 @@ def build_scope_report(
         if not direct_changed_path_set
         else _match_probe_indexes(changed_paths=direct_changed_path_set, probes=probes)
     )
+    matched_probe_indexes_ordered = tuple(sorted(matched_probe_indexes))
     if force_all:
         selected = probes
     else:
-        selected = tuple(probe for index, probe in enumerate(probes) if index in matched_probe_indexes)
-    matched_probe_ids = [probe.probe_id for index, probe in enumerate(probes) if index in matched_probe_indexes]
+        selected = tuple(probes[index] for index in matched_probe_indexes_ordered)
+    matched_probe_ids = [probes[index].probe_id for index in matched_probe_indexes_ordered]
     changed_paths = tuple(sorted(changed_path_set))
     return {
         "schema_version": _SCOPE_SCHEMA_VERSION,


### PR DESCRIPTION
## Summary
- Optimizes PR-scoped performance scope construction by reusing the already matched probe index set when materializing sparse `selected_probes` and `matched_probe_ids`.
- Adds sparse-selection regression coverage that preserves registry order.

## Plan or Spec
- `docs/plans/2026-05-17-pr-scoped-sparse-selection.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_uses_absolute_cache_key_without_resolving services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_build_scope_report_reuses_scope_cached_registry_without_double_stat services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_refreshes_cache_when_file_changes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_registry_cache_probe
# exit 0; 7 passed in 1.68s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; TOTAL 13 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
from pathlib import Path
from worker.productization.pr_scoped_performance import run_probe_job
result, success = run_probe_job(registry_path=Path('infra/perf/pr_scoped_probes.json'), probe_id='pr-scoped-performance-registry-cache', base_repo=Path('/root/.hermes/profiles/coder/workspace/worktrees/melix-base-pr-scope-registry-dict-build-20260517'), head_repo=Path.cwd())
raise SystemExit(0 if success else 1)
PY
# exit 0; registered probe head verification and base/head probe succeeded

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 13 0 100%`).
- Registered local probe: `pr-scoped-performance-registry-cache`.
- Metrics (base -> head):
  - `build_scope_report_ms_mean`: 8.604425 ms -> 7.968801 ms (delta -0.635624 ms, -7.387%).
  - `load_probe_registry_ms_mean`: 7.136778 ms -> 7.058459 ms (delta -0.078319 ms, -1.097%).
  - `cold_load_probe_registry_ms_mean`: 167.542533 ms -> 169.243179 ms (delta +1.700646 ms, +1.015%; below configured 10 ms absolute warning threshold and not the optimized path).
- CI PR-scoped performance workflow is required for registered probe validation before merge.

## Known Gaps
- Python-only Linux validation; no Swift runtime effect is claimed.
- CI must complete the registered PR-scoped performance report before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
