### PR TITLE
perf: cache empty probe policy defaults

### DIFF
--- a/docs/plans/2026-05-17-probe-policy-empty-default-cache.md
+++ b/docs/plans/2026-05-17-probe-policy-empty-default-cache.md
@@ -1,0 +1,43 @@
+# Probe Policy Empty Default Cache Slice
+
+## Goal
+
+Avoid allocating a new `ProbePolicy` instance on the hot empty/default probe-mode
+path while preserving the existing distinction between an unset source value and
+an explicit lower-case mode string.
+
+## Scope
+
+- `services/mlx-worker-python/worker/productization/probe_policy.py`
+- `services/mlx-worker-python/worker/productization/probe_policy_overhead.py`
+- `services/mlx-worker-python/tests/test_probe_policy.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe
+`probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`. The entry has
+focused `test_command`, `coverage_command`, and `probe_command` values. This
+slice extends the probe payload with the empty/default parse metric because that
+is the directly optimized path; the registry metric gate remains scoped to the
+pre-existing stable no-op overhead metrics so base/head comparisons remain
+comparable on `origin/main`.
+
+## Plan
+
+1. Add a cached policy lookup for empty/unset values keyed by default mode.
+2. Keep explicit string modes mapped to the existing source-preserving cached
+   policies.
+3. Add regression coverage proving empty/default calls reuse cached policy
+   objects without changing source/fallback semantics.
+4. Extend the local/CI probe to report `mode_parse_empty_call_ms_mean`.
+5. Run focused tests, changed-scope coverage, and the registered probe locally on
+   Linux before opening the PR.
+
+## Acceptance
+
+- Empty/default probe-mode parsing returns a cached policy object.
+- Explicit mode parsing and invalid fallback behavior remain unchanged.
+- Focused test and changed-scope coverage commands pass.
+- Registered probe shows the optimized empty/default metric and passes the
+  threshold gate.

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -60,6 +60,22 @@ def test_probe_policy_empty_env_uses_production_default() -> None:
     assert policy.telemetry_enabled is False
 
 
+def test_probe_policy_empty_values_reuse_default_policy_cache() -> None:
+    minimal_policy = ProbePolicy.from_value("")
+
+    assert ProbePolicy.from_value(None) is minimal_policy
+    assert probe_policy_from_env({}) is minimal_policy
+    assert minimal_policy.source_value == ""
+    assert minimal_policy.fallback_applied is False
+    assert minimal_policy is not ProbePolicy.from_value(ProbeMode.MINIMAL)
+
+    debug_policy = ProbePolicy.from_value("", default_mode=ProbeMode.DEBUG)
+    assert ProbePolicy.from_value(None, default_mode=ProbeMode.DEBUG) is debug_policy
+    assert debug_policy.mode is ProbeMode.DEBUG
+    assert debug_policy.source_value == ""
+    assert debug_policy.telemetry_enabled is True
+
+
 def test_probe_policy_telemetry_enabled_only_for_sampling_modes() -> None:
     assert ProbePolicy(mode=ProbeMode.OFF).telemetry_enabled is False
     assert ProbePolicy(mode=ProbeMode.MINIMAL).telemetry_enabled is False
@@ -106,9 +122,11 @@ def test_no_op_probe_policy_overhead_metrics_are_thresholded() -> None:
     assert "no_op_recorder_delta_ms" in payload
     assert "no_op_policy_check_delta_ms" in payload
     assert "no_op_reason_delta_ms" in payload
+    assert "mode_parse_empty_call_ms_mean" in payload
     assert "mode_parse_valid_call_ms_mean" in payload
     assert "mode_parse_invalid_call_ms_mean" in payload
     assert "mode_parse_invalid_delta_ms" in payload
+    assert payload["mode_parse_empty_call_ms_mean"] >= 0.0
     assert payload["mode_parse_valid_call_ms_mean"] >= 0.0
     assert payload["mode_parse_invalid_call_ms_mean"] >= 0.0
     assert payload["absolute_tolerance_ms"] > 0.0

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -60,7 +60,7 @@ class ProbePolicy:
             return _PROBE_POLICY_BY_VALUE[value.value]
         raw_value = str(value or "").strip().lower()
         if not raw_value:
-            return cls(mode=default_mode)
+            return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
         policy = _PROBE_POLICY_BY_VALUE.get(raw_value)
         if policy is not None:
             return policy
@@ -81,6 +81,9 @@ class ProbePolicy:
 
 _PROBE_POLICY_BY_VALUE: dict[str, ProbePolicy] = {
     mode.value: ProbePolicy(mode=mode, source_value=mode.value) for mode in ProbeMode
+}
+_PROBE_POLICY_BY_DEFAULT_MODE: dict[ProbeMode, ProbePolicy] = {
+    mode: ProbePolicy(mode=mode) for mode in ProbeMode
 }
 
 

--- a/services/mlx-worker-python/worker/productization/probe_policy_overhead.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy_overhead.py
@@ -26,6 +26,7 @@ class ProbeOverheadMetrics:
     no_op_recorder_call_ms_mean: float
     no_op_policy_check_call_ms_mean: float
     no_op_reason_call_ms_mean: float
+    mode_parse_empty_call_ms_mean: float
     mode_parse_valid_call_ms_mean: float
     mode_parse_invalid_call_ms_mean: float
     no_op_recorder_overhead_pct: float
@@ -48,6 +49,7 @@ class ProbeOverheadMetrics:
             "no_op_recorder_call_ms_mean": self.no_op_recorder_call_ms_mean,
             "no_op_policy_check_call_ms_mean": self.no_op_policy_check_call_ms_mean,
             "no_op_reason_call_ms_mean": self.no_op_reason_call_ms_mean,
+            "mode_parse_empty_call_ms_mean": self.mode_parse_empty_call_ms_mean,
             "mode_parse_valid_call_ms_mean": self.mode_parse_valid_call_ms_mean,
             "mode_parse_invalid_call_ms_mean": self.mode_parse_invalid_call_ms_mean,
             "no_op_recorder_overhead_pct": self.no_op_recorder_overhead_pct,
@@ -92,6 +94,11 @@ def measure_no_op_probe_policy_overhead(
         iterations=iteration_count,
         samples=sample_count,
     )
+    parse_empty_samples = _sample_call_ms(
+        lambda: ProbePolicy.from_value(""),
+        iterations=iteration_count,
+        samples=sample_count,
+    )
     parse_valid_samples = _sample_call_ms(
         lambda: ProbePolicy.from_value("debug"),
         iterations=iteration_count,
@@ -106,6 +113,7 @@ def measure_no_op_probe_policy_overhead(
     recorder_mean = _mean(recorder_samples)
     policy_mean = _mean(policy_samples)
     reason_mean = _mean(reason_samples)
+    parse_empty_mean = _mean(parse_empty_samples)
     parse_valid_mean = _mean(parse_valid_samples)
     parse_invalid_mean = _mean(parse_invalid_samples)
     recorder_overhead_pct = _overhead_pct(recorder_mean, baseline_mean)
@@ -123,6 +131,7 @@ def measure_no_op_probe_policy_overhead(
         no_op_recorder_call_ms_mean=recorder_mean,
         no_op_policy_check_call_ms_mean=policy_mean,
         no_op_reason_call_ms_mean=reason_mean,
+        mode_parse_empty_call_ms_mean=parse_empty_mean,
         mode_parse_valid_call_ms_mean=parse_valid_mean,
         mode_parse_invalid_call_ms_mean=parse_invalid_mean,
         no_op_recorder_overhead_pct=recorder_overhead_pct,


### PR DESCRIPTION
## Summary
- Cache `ProbePolicy.from_value("")` / unset env defaults by `ProbeMode` to avoid per-call dataclass allocation on the empty/default hot path.
- Add regression coverage for cached empty defaults while preserving explicit-mode `source_value` semantics.
- Extend the registered `probe-policy-noop-overhead` probe metrics with `mode_parse_empty_call_ms_mean`.

## Plan or Spec
- Added `docs/plans/2026-05-17-probe-policy-empty-default-cache.md` for this performance slice.
- Existing registered PR-scoped probe: `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY' ... old-vs-new empty/default microbenchmark ... PY`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `15 passed`.
- Changed-scope coverage: `TOTAL 19 0 100%`.
- Registered local probe: `threshold_passed=1.0`, `mode_parse_empty_call_ms_mean=0.000332768`, `mode_parse_valid_call_ms_mean=0.000386983`, `mode_parse_invalid_call_ms_mean=0.001869585`.
- Local old-vs-new microbenchmark for empty/default parsing: `old_empty_construct_ms_mean=0.00143908`, `new_empty_cached_ms_mean=0.000322521`, `delta_ms=-0.001116559`, `speedup=4.462x`.

## Known Gaps
- This is a Python-only slice and was locally verified on Linux.
- The registered PR-scoped performance workflow must validate the probe in CI before merge.

## Evidence Checklist
- [x] Registered probe covers the changed Python path.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe reports metrics and passes threshold.
- [ ] GitHub Actions / PR-scoped performance probe completed successfully.
