### PR TITLE
perf: fast-path exact probe policy modes

### DIFF
--- a/docs/plans/2026-05-17-probe-policy-exact-mode-fast-path.md
+++ b/docs/plans/2026-05-17-probe-policy-exact-mode-fast-path.md
@@ -1,0 +1,32 @@
+# Probe Policy Exact Mode Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to `ProbePolicy.from_value` in
+`services/mlx-worker-python/worker/productization/probe_policy.py`. The goal is
+to reduce hot-path overhead when callers pass already-normalized probe mode
+strings such as `"minimal"`, `"off"`, or `"evidence"`.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`. The
+entry includes focused `test_command`, `coverage_command`, and `probe_command`
+fields and measures the no-op policy path plus valid and invalid mode parsing.
+
+## Implementation Plan
+
+1. Keep existing fallback semantics for blank, invalid, non-string, and
+   whitespace/case-normalized values.
+2. Add an exact string lookup before normalization so supported lowercase values
+   reuse the cached policy without calling `strip()` or `lower()`.
+3. Add a focused regression assertion that exact supported string values bypass
+   normalization.
+4. Run the registered focused tests, changed-scope coverage command, and local
+   registered probe on Linux before opening the PR.
+
+## Validation Boundary
+
+This slice touches Python-only code and is locally verifiable on Linux. The
+hosted PR-scoped performance workflow remains the merge gate for the registered
+probe report in CI.

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -40,6 +40,12 @@ def test_probe_policy_exact_lowercase_strings_keep_source_value() -> None:
         assert policy.fallback_applied is False
         assert ProbePolicy.from_value(mode) is policy
 
+    class ExactModeString(str):
+        def strip(self, chars: str | None = None) -> str:  # pragma: no cover - should not run
+            raise AssertionError("exact supported modes should skip string normalization")
+
+    assert ProbePolicy.from_value(ExactModeString(ProbeMode.MINIMAL.value)).mode is ProbeMode.MINIMAL
+
     invalid_policy = ProbePolicy.from_value("definitely-not-valid")
     assert invalid_policy.mode is ProbeMode.MINIMAL
     assert invalid_policy.source_value == "definitely-not-valid"

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -58,7 +58,13 @@ class ProbePolicy:
     ) -> ProbePolicy:
         if isinstance(value, ProbeMode):
             return _PROBE_POLICY_BY_VALUE[value.value]
-        raw_value = str(value or "").strip().lower()
+        if isinstance(value, str):
+            policy = _PROBE_POLICY_BY_VALUE.get(value)
+            if policy is not None:
+                return policy
+            raw_value = value.strip().lower()
+        else:
+            raw_value = str(value or "").strip().lower()
         if not raw_value:
             return cls(mode=default_mode)
         policy = _PROBE_POLICY_BY_VALUE.get(raw_value)


### PR DESCRIPTION
## Summary
- Fast-path exact lowercase `ProbePolicy.from_value` strings through the cached policy map before normalization.
- Add a focused regression assertion that exact supported strings skip normalization.
- Document the slice and registered probe boundary in a plan note.

## Plan or Spec
- `docs/plans/2026-05-17-probe-policy-exact-mode-fast-path.md`
- Registered probe: `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 14 passed.
- Changed-scope coverage: 100.00% (8/8 measurable changed lines covered).
- Local registered probe before change: `mode_parse_valid_call_ms_mean=0.000396164`, `threshold_passed=1.0`.
- Local registered probe after change: `mode_parse_valid_call_ms_mean=0.000276954`, `threshold_passed=1.0`.
- Local delta: `mode_parse_valid_call_ms_mean` improved by about 30.1% (`-0.000119210 ms/call`).

## Known Gaps
- Python-only slice validated locally on Linux. Hosted PR-scoped performance CI is still required as the merge gate for the registered probe report.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path and exposes test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Local registered probe produced a positive metric delta.
- [ ] GitHub Actions, including PR-scoped performance, completed successfully.
