### PR TITLE
perf: cache invalid probe policy fallbacks

### DIFF
--- a/docs/plans/2026-05-17-probe-policy-invalid-cache.md
+++ b/docs/plans/2026-05-17-probe-policy-invalid-cache.md
@@ -1,0 +1,30 @@
+# Probe Policy Invalid Fallback Cache
+
+## Scope
+
+This slice covers `services/mlx-worker-python/worker/productization/probe_policy.py` and the registered PR-scoped probe `probe-policy-noop-overhead`.
+
+## Registered probe
+
+The affected path is already covered by `infra/perf/pr_scoped_probes.json` through:
+
+- focused probe-policy tests in `test_command`
+- changed-scope coverage in `coverage_command`
+- `scripts/probe_policy_noop_overhead_probe.py` in `probe_command`
+
+## Optimization
+
+`ProbePolicy.from_value()` already reuses singleton instances for exact supported modes and empty default-mode lookups. Repeated invalid mode strings still constructed a new frozen dataclass instance every call after string normalization.
+
+This slice adds a small bounded `lru_cache` for invalid normalized fallback policies keyed by `(raw_value, default_mode)`. The behavior remains unchanged: invalid inputs still set `fallback_applied=True`, preserve the normalized source value, and respect the requested default mode.
+
+## Verification plan
+
+- Focused probe-policy tests from the registered probe entry.
+- Changed-scope coverage command from the registered probe entry.
+- Local Linux registered probe execution before push.
+- GitHub Actions PR-scoped performance workflow after PR creation.
+
+## Expected outcome
+
+Reduce repeated invalid mode parse overhead in the registered no-op probe policy overhead path without changing supported-mode parsing or default-mode fallback semantics.

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -50,6 +50,16 @@ def test_probe_policy_exact_lowercase_strings_keep_source_value() -> None:
     assert invalid_policy.mode is ProbeMode.MINIMAL
     assert invalid_policy.source_value == "definitely-not-valid"
     assert invalid_policy.fallback_applied is True
+    assert ProbePolicy.from_value("definitely-not-valid") is invalid_policy
+    assert ProbePolicy.from_value(" definitely-not-valid ") is invalid_policy
+
+    debug_invalid_policy = ProbePolicy.from_value(
+        "definitely-not-valid",
+        default_mode=ProbeMode.DEBUG,
+    )
+    assert debug_invalid_policy is not invalid_policy
+    assert debug_invalid_policy.mode is ProbeMode.DEBUG
+    assert debug_invalid_policy.fallback_applied is True
 
     non_string_policy = ProbePolicy.from_value(123)  # type: ignore[arg-type]
     assert non_string_policy.mode is ProbeMode.MINIMAL

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from enum import StrEnum
+from functools import lru_cache
 from typing import Mapping
 
 
@@ -70,11 +71,7 @@ class ProbePolicy:
         policy = _PROBE_POLICY_BY_VALUE.get(raw_value)
         if policy is not None:
             return policy
-        return cls(
-            mode=default_mode,
-            source_value=raw_value,
-            fallback_applied=True,
-        )
+        return _invalid_probe_policy(raw_value, default_mode)
 
     @classmethod
     def evidence(cls) -> ProbePolicy:
@@ -91,6 +88,15 @@ _PROBE_POLICY_BY_VALUE: dict[str, ProbePolicy] = {
 _PROBE_POLICY_BY_DEFAULT_MODE: dict[ProbeMode, ProbePolicy] = {
     mode: ProbePolicy(mode=mode) for mode in ProbeMode
 }
+
+
+@lru_cache(maxsize=64)
+def _invalid_probe_policy(raw_value: str, default_mode: ProbeMode) -> ProbePolicy:
+    return ProbePolicy(
+        mode=default_mode,
+        source_value=raw_value,
+        fallback_applied=True,
+    )
 
 
 def probe_policy_from_env(env: Mapping[str, str] | None = None) -> ProbePolicy:


### PR DESCRIPTION
## Summary
- Cache normalized invalid `ProbePolicy.from_value()` fallbacks with a bounded LRU cache.
- Add regression coverage that repeated invalid strings reuse the fallback instance while preserving default-mode separation.
- Document the slice plan for the registered `probe-policy-noop-overhead` probe.

## Plan or Spec
- `docs/plans/2026-05-17-probe-policy-invalid-cache.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py` (baseline on `origin/main` and repeated on this branch)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 15 passed.
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Registered local probe (`probe-policy-noop-overhead`) baseline on `origin/main`: `mode_parse_invalid_call_ms_mean=0.002034322`, `mode_parse_invalid_delta_ms=0.001986332`.
- Registered local probe on this branch (3 runs):
  - run 1: `mode_parse_invalid_call_ms_mean=0.000513285`, `mode_parse_invalid_delta_ms=0.000475901`
  - run 2: `mode_parse_invalid_call_ms_mean=0.000484624`, `mode_parse_invalid_delta_ms=0.000448654`
  - run 3: `mode_parse_invalid_call_ms_mean=0.000485843`, `mode_parse_invalid_delta_ms=0.000450202`
- Best branch delta vs baseline: `0.002034322 -> 0.000484624` ms/call (`-0.001549698` ms, ~76.18% lower).
- CI PR-scoped performance report is required as the merge gate for registered probe validation.

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime effect is claimed or touched.
- Microprobe timings vary by host load, so the PR-scoped CI registered probe is the authoritative post-push validation.

## Evidence Checklist
- [x] Registered probe exists for the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally and showed improvement.
- [ ] GitHub Actions / PR-scoped performance workflow completed successfully.
