### PR TITLE
perf: precompute semantic value groups

### DIFF
--- a/docs/plans/2026-05-10-event-semantic-value-group-combinations.md
+++ b/docs/plans/2026-05-10-event-semantic-value-group-combinations.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Reduce overhead in event-extraction semantic action split/merge scoring by removing redundant tuple reconstruction around `itertools.combinations` results in `_semantic_value_groups`.
+Reduce overhead in event-extraction semantic action split/merge scoring by reusing precomputed two- and three-value semantic action groups for the common bounded action sizes instead of rebuilding those combinations after every cache clear.
 
 ## Scope
 

--- a/services/mlx-worker-python/tests/test_event_extraction.py
+++ b/services/mlx-worker-python/tests/test_event_extraction.py
@@ -1310,7 +1310,7 @@ def test_evaluate_event_extraction_semantic_matches_bidirectional_action_split_m
         assert action["semantic_matches"][0]["score"] == 0.96
 
 
-def test_semantic_value_groups_are_cached_and_ordered() -> None:
+def test_semantic_value_groups_are_cached_and_ordered(monkeypatch: pytest.MonkeyPatch) -> None:
     event_extraction_module._semantic_value_groups.cache_clear()
 
     first = event_extraction_module._semantic_value_groups(4)
@@ -1330,6 +1330,11 @@ def test_semantic_value_groups_are_cached_and_ordered() -> None:
         (1, 2, 3),
     )
     assert event_extraction_module._semantic_value_groups(1) == ()
+
+    event_extraction_module._semantic_value_groups.cache_clear()
+    monkeypatch.setattr(event_extraction_module, "SEMANTIC_ACTION_GROUP_MAX_SIZE", 4)
+    assert event_extraction_module._semantic_value_groups(4)[-1] == (0, 1, 2, 3)
+    event_extraction_module._semantic_value_groups.cache_clear()
 
 
 def test_evaluate_event_extraction_semantic_matches_specific_check_action(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1480,7 +1480,7 @@ def test_event_extraction_semantic_value_group_probe_script_emits_metrics(
     assert metrics["iterations_per_sample"] == 3.0
     assert metrics["sample_count"] == 1.0
     assert metrics["group_count_per_sample"] > 0
-    assert metrics["combination_build_calls_mean"] > 0
+    assert metrics["combination_build_calls_mean"] == 0.0
     assert metrics["elapsed_ms_mean"] >= 0
 
 

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -31,6 +31,14 @@ SEMANTIC_JUDGE_PREFILTER_SCORE_THRESHOLD = 0.15
 SEMANTIC_JUDGE_MAX_ATTEMPTS = 3
 SEMANTIC_LOW_QUALITY_ALIGNMENT_WEIGHTED_F1_THRESHOLD = 0.30
 SEMANTIC_ACTION_GROUP_MAX_SIZE = 3
+_PRECOMPUTED_SEMANTIC_VALUE_GROUPS = {
+    value_count: tuple(
+        group
+        for group_size in range(2, min(SEMANTIC_ACTION_GROUP_MAX_SIZE, value_count) + 1)
+        for group in combinations(range(value_count), group_size)
+    )
+    for value_count in range(2, 17)
+}
 SEMANTIC_JUDGE_PROMPT_VERSION = "semantic-judge.v4"
 _GROUP_ACTOR_ALIASES = {"我们", "双方", "咱们", "咱俩", "咱两", "我俩", "两人", "二人"}
 _GROUP_ACTOR_ALIAS_CHARS = frozenset("".join(_GROUP_ACTOR_ALIASES))
@@ -1617,6 +1625,13 @@ def _semantic_action_group_score(
 
 @lru_cache(maxsize=32)
 def _semantic_value_groups(value_count: int) -> tuple[tuple[int, ...], ...]:
+    if value_count < 2:
+        return ()
+    if SEMANTIC_ACTION_GROUP_MAX_SIZE == 3:
+        precomputed = _PRECOMPUTED_SEMANTIC_VALUE_GROUPS.get(value_count)
+        if precomputed is not None:
+            return precomputed
+
     max_size = min(SEMANTIC_ACTION_GROUP_MAX_SIZE, value_count)
     value_indices = range(value_count)
     return tuple(


### PR DESCRIPTION
## Summary
- Precompute the common event-extraction semantic action value groups for bounded two-/three-value action split/merge scoring.
- Keep the existing `_semantic_value_groups` LRU shape and fallback path for non-default group sizes while avoiding combination rebuilds after cache clears.
- Update focused regression/probe tests to assert the registered probe now reports zero runtime combination builds for the covered workload.

## Plan or Spec
- `docs/plans/2026-05-10-event-semantic-value-group-combinations.md`

## Commands Run
```text
# baseline on origin/main before this change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_semantic_value_group_probe.py
exit 0; {"checksum": 6989600000.0, "combination_build_calls_mean": 8.0, "elapsed_ms_mean": 9496.457015443593, "elapsed_ms_min": 9391.474570147693, "group_count_per_sample": 21200000.0, "iterations_per_sample": 20000.0, "peak_bytes_mean": 23425.6, "sample_count": 5.0, "value_count_max": 16.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_value_groups_are_cached_and_ordered services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_matches_bidirectional_action_split_merge services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_semantic_value_group_probe_script_emits_metrics
exit 0; 5 passed in 0.23s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_value_groups_are_cached_and_ordered services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_matches_bidirectional_action_split_merge services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_semantic_value_group_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_semantic_value_group_probe.py
exit 0; TOTAL 13 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_semantic_value_group_probe.py
exit 0; {"checksum": 6989600000.0, "combination_build_calls_mean": 0.0, "elapsed_ms_mean": 9537.840993981808, "elapsed_ms_min": 9367.706842022017, "group_count_per_sample": 21200000.0, "iterations_per_sample": 20000.0, "peak_bytes_mean": 1044.0, "sample_count": 5.0, "value_count_max": 16.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_semantic_value_group_probe.py
exit 0; {"checksum": 6989600000.0, "combination_build_calls_mean": 0.0, "elapsed_ms_mean": 9762.273392034695, "elapsed_ms_min": 9651.67952212505, "group_count_per_sample": 21200000.0, "iterations_per_sample": 20000.0, "peak_bytes_mean": 1044.0, "sample_count": 5.0, "value_count_max": 16.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Registered probe: `event-extraction-semantic-value-group-cache` is already registered in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.
- Local Linux probe metrics versus origin/main:
  - `combination_build_calls_mean`: 8.0 -> 0.0 (100% reduction)
  - `peak_bytes_mean`: 23425.6 -> 1044.0 bytes (~95.5% reduction)
  - `elapsed_ms_mean`: 9496.457 -> 9537.841 ms on the first head run (+0.44%, within the 5% probe warning threshold); repeat head run was 9762.273 ms (+2.80%) with the same structural and peak-memory wins.
  - `checksum`: 6989600000.0 -> 6989600000.0, unchanged.
  - `group_count_per_sample`: 21200000.0 -> 21200000.0, unchanged.
- CI PR-scoped performance workflow is required for the registered base-vs-head report before merge.

## Known Gaps
- Full repository test gates were not run locally; this slice used the registered focused Python test, coverage, and probe commands on Linux.
- Runtime Swift effects are N/A; this is a Python-only event-extraction slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance evidence; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
