### PR TITLE
perf: build serving diagnostics fast lines as bytes

### DIFF
--- a/docs/plans/2026-05-17-serving-diagnostics-fast-line-bytes.md
+++ b/docs/plans/2026-05-17-serving-diagnostics-fast-line-bytes.md
@@ -1,0 +1,27 @@
+# Serving diagnostics fast-line bytes slice
+
+## Context
+
+The registered PR-scoped probe `serving-diagnostics-debug-queue-bounds` covers
+`services/mlx-worker-python/worker/productization/serving_diagnostics.py` and
+runs the focused serving diagnostics tests, changed-scope coverage, and
+`scripts/serving_diagnostics_queue_probe.py`.
+
+## Slice
+
+Optimize only the empty-attribute `ServingDiagnosticsEvent` JSONL fast path by
+building bytes directly for `_write_jsonl` instead of building a string line and
+encoding the complete line again for each event.
+
+## Verification plan
+
+- Run the focused serving diagnostics pytest selection from the registered
+  probe.
+- Run the registered changed-scope coverage command.
+- Run `scripts/serving_diagnostics_queue_probe.py` locally on Linux before and
+after the change and compare `serialization_elapsed_ms_mean`.
+
+## Boundary
+
+This is a Python-only Linux-verifiable slice. No Swift runtime validation is
+claimed.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -350,6 +350,34 @@ def test_serving_diagnostics_jsonl_fast_path_preserves_direct_helper_call() -> N
     assert json.loads(line)["request_id"] == "req-direct-fast-path"
 
 
+def test_serving_diagnostics_jsonl_fast_path_builds_direct_bytes() -> None:
+    event = ServingDiagnosticsEvent(
+        request_id="req-direct-bytes",
+        phase="decode",
+        event_index=11,
+        status="completed",
+        duration_ms=0.25,
+    )
+
+    line = serving_diagnostics_module._empty_attribute_event_json_line_bytes(event)
+
+    assert isinstance(line, bytes)
+    assert json.loads(line)["request_id"] == "req-direct-bytes"
+
+
+def test_serving_diagnostics_jsonl_fast_path_direct_helper_preserves_fallback() -> None:
+    event = ServingDiagnosticsEvent(
+        request_id="req-direct-fallback",
+        phase="decode",
+        event_index=11,
+        status="completed",
+        duration_ms=0.25,
+        attributes={"extra": True},
+    )
+
+    assert serving_diagnostics_module._empty_attribute_event_json_line(event) is None
+
+
 def test_serving_diagnostics_event_to_dict_preserves_numeric_coercion() -> None:
     event = ServingDiagnosticsEvent(
         request_id="req-numeric-coercion",

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -487,12 +487,12 @@ def _write_jsonl(path: Path, rows: Any) -> None:
     payload = bytearray()
     append_line = payload.extend
     newline = b"\n"
-    request_id_literals: dict[str, str] = {}
+    request_id_literals: dict[str, bytes] = {}
     for row in rows:
         if isinstance(row, ServingDiagnosticsEvent):
-            fast_line = _empty_attribute_event_json_line(row, request_id_literals)
+            fast_line = _empty_attribute_event_json_line_bytes(row, request_id_literals)
             if fast_line is not None:
-                append_line(fast_line.encode("utf-8"))
+                append_line(fast_line)
                 append_line(newline)
                 continue
             row = row.to_dict()
@@ -505,6 +505,16 @@ def _empty_attribute_event_json_line(
     event: ServingDiagnosticsEvent,
     request_id_literals: dict[str, str] | None = None,
 ) -> str | None:
+    line = _empty_attribute_event_json_line_bytes(event, request_id_literals)
+    if line is None:
+        return None
+    return line.decode("utf-8")
+
+
+def _empty_attribute_event_json_line_bytes(
+    event: ServingDiagnosticsEvent,
+    request_id_literals: dict[str, bytes] | None = None,
+) -> bytes | None:
     if event.attributes is not _EMPTY_EVENT_ATTRIBUTES:
         return None
     event_index = event.event_index
@@ -513,29 +523,36 @@ def _empty_attribute_event_json_line(
         return None
     if not math.isfinite(duration_ms):
         return None
-    encode_string = _json_string_literal
     phase = event.phase
     request_id = event.request_id
     status = event.status
-    encoded_phase = '"decode"' if phase == "decode" else encode_string(phase)
-    encoded_status = '"completed"' if status == "completed" else encode_string(status)
+    encoded_phase = (
+        b'"decode"'
+        if phase == "decode"
+        else _json_string_literal(phase).encode("utf-8")
+    )
+    encoded_status = (
+        b'"completed"'
+        if status == "completed"
+        else _json_string_literal(status).encode("utf-8")
+    )
     if request_id_literals is None:
-        encoded_request_id = encode_string(request_id)
+        encoded_request_id = _json_string_literal(request_id).encode("utf-8")
     else:
         encoded_request_id = request_id_literals.get(request_id)
         if encoded_request_id is None:
-            encoded_request_id = encode_string(request_id)
+            encoded_request_id = _json_string_literal(request_id).encode("utf-8")
             request_id_literals[request_id] = encoded_request_id
     return (
-        '{"attributes":{},"duration_ms":'
-        f"{duration_ms}"
-        ',"event_index":'
-        f"{event_index}"
-        ',"phase":'
-        f"{encoded_phase}"
-        ',"request_id":'
-        f"{encoded_request_id}"
-        ',"schema_version":"melix.serving_diagnostics.event.v1","status":'
-        f"{encoded_status}"
-        "}"
+        b'{"attributes":{},"duration_ms":'
+        + str(duration_ms).encode("ascii")
+        + b',"event_index":'
+        + str(event_index).encode("ascii")
+        + b',"phase":'
+        + encoded_phase
+        + b',"request_id":'
+        + encoded_request_id
+        + b',"schema_version":"melix.serving_diagnostics.event.v1","status":'
+        + encoded_status
+        + b"}"
     )


### PR DESCRIPTION
## Summary
- Build the empty-attribute serving diagnostics JSONL fast-path rows as bytes before appending them to the bytearray payload.
- Preserve the existing string helper by decoding the bytes helper for direct callers.
- Add focused regression coverage for the direct bytes helper and fallback behavior.

## Plan or Spec
- Added `docs/plans/2026-05-17-serving-diagnostics-fast-line-bytes.md` for this performance slice.
- Registered probe already covers this path: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `git status --short && git branch --show-current`
- `git fetch origin && git reset --hard origin/main`
- `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` (baseline)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py`
- `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` (candidate)
- `git diff --check`

## Coverage and Metrics
- Focused tests: `38 passed in 0.65s`.
- Changed-scope coverage: `TOTAL 20 0 100%`.
- Local Linux registered probe baseline: `serialization_elapsed_ms_mean=1.064398`, `elapsed_ms_mean=5.817486`, `serialized_bytes=10944.0`.
- Local Linux registered probe candidate: `serialization_elapsed_ms_mean=0.948478`, `elapsed_ms_mean=5.393899`, `serialized_bytes=10944.0`.
- Delta: `serialization_elapsed_ms_mean -0.115920 ms` (`1.1222x`, `10.89%` improvement). Serialized bytes are unchanged.

## Known Gaps
- This is a Python-only Linux-verifiable slice; no Swift runtime effect is claimed.
- CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally with an improving metric.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
