### PR TITLE
perf: cache serving diagnostics duration literals

### DIFF
--- a/docs/plans/2026-05-17-serving-diagnostics-duration-literal-cache.md
+++ b/docs/plans/2026-05-17-serving-diagnostics-duration-literal-cache.md
@@ -1,0 +1,36 @@
+# Serving diagnostics duration literal cache
+
+## Scope
+
+This Python-only performance slice is limited to the serving diagnostics empty-attribute JSONL fast path in `services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped registered probe `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`. The probe already defines focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/serving_diagnostics.py`
+- `services/mlx-worker-python/tests/test_serving_diagnostics.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/serving_diagnostics_queue_probe.py`
+
+## Optimization
+
+Cache the ASCII bytes literal for repeated finite `duration_ms` float values while constructing the optimized empty-attribute event JSONL line. Serving diagnostics debug queues commonly emit repeated small duration values in synthetic and batched debug traces, so avoiding repeated `str(duration_ms).encode("ascii")` work reduces serialization overhead without changing the JSON payload.
+
+## Behavior preservation
+
+- The fast path still applies only to events with the shared empty-attributes sentinel, exact `int` event indexes, exact `float` finite durations, and JSON-safe strings.
+- Non-empty attributes and non-exact numeric types still fall back to the stable dictionary encoder path.
+- Serialized JSONL bytes remain byte-for-byte compatible for covered events.
+
+## Verification plan
+
+Run the focused local Linux checks before opening the PR:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
+```
+
+The GitHub PR-scoped performance workflow remains the source of registered probe validation before merge.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -365,6 +365,29 @@ def test_serving_diagnostics_jsonl_fast_path_builds_direct_bytes() -> None:
     assert json.loads(line)["request_id"] == "req-direct-bytes"
 
 
+def test_serving_diagnostics_jsonl_fast_path_reuses_duration_literal_cache() -> None:
+    serving_diagnostics_module._ascii_float_literal.cache_clear()
+    rows = tuple(
+        ServingDiagnosticsEvent(
+            request_id="req-duration-cache",
+            phase="decode",
+            event_index=event_index,
+            status="completed",
+            duration_ms=0.001,
+        )
+        for event_index in range(3)
+    )
+
+    for row in rows:
+        line = serving_diagnostics_module._empty_attribute_event_json_line_bytes(row)
+        assert line is not None
+        assert json.loads(line)["duration_ms"] == 0.001
+
+    cache_info = serving_diagnostics_module._ascii_float_literal.cache_info()
+    assert cache_info.misses == 1
+    assert cache_info.hits == 2
+
+
 def test_serving_diagnostics_jsonl_fast_path_direct_helper_preserves_fallback() -> None:
     event = ServingDiagnosticsEvent(
         request_id="req-direct-fallback",

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -29,6 +29,11 @@ def _json_string_literal(value: str) -> str:
     return _JSON_STRING_ENCODER(value)
 
 
+@lru_cache(maxsize=1024)
+def _ascii_float_literal(value: float) -> bytes:
+    return str(value).encode("ascii")
+
+
 class ServingDiagnosticsComparisonError(ValueError):
     pass
 
@@ -545,7 +550,7 @@ def _empty_attribute_event_json_line_bytes(
             request_id_literals[request_id] = encoded_request_id
     return (
         b'{"attributes":{},"duration_ms":'
-        + str(duration_ms).encode("ascii")
+        + _ascii_float_literal(duration_ms)
         + b',"event_index":'
         + str(event_index).encode("ascii")
         + b',"phase":'


### PR DESCRIPTION
## Summary
- Cache repeated finite `duration_ms` ASCII byte literals in the serving diagnostics empty-attribute JSONL fast path.
- Add a focused regression test proving the duration literal cache is exercised while preserving JSON payloads.
- Document the slice and registered probe boundary in a new plan file.

## Plan or Spec
- `docs/plans/2026-05-17-serving-diagnostics-duration-literal-cache.md`
- Existing registered PR-scoped probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands` → 39 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py` → TOTAL 13 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` ×3
- Expanded local comparison: `MELIX_SERVING_DIAGNOSTICS_QUEUE_CAPACITY=4096 MELIX_SERVING_DIAGNOSTICS_QUEUE_EVENTS=4096 MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=10 ... scripts/serving_diagnostics_queue_probe.py` ×3 on old and new worktrees
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 13 0 100%`).
- Registered-probe local runs (`capacity=64`, `events=4096`, `samples=20`): old serialization mean across 5 recent main runs `1.056089 ms`; new mean across 3 branch runs `0.940605 ms`; delta `-0.115484 ms` (`10.94%` faster). Serialized bytes and checksum unchanged.
- Expanded retained-event comparison (`capacity=4096`, `events=4096`, `samples=10`): old serialization mean `18.437609 ms`; new mean `17.290138 ms`; delta `-1.147471 ms` (`6.22%` faster). Serialized bytes and checksum unchanged.
- CI PR-scoped performance workflow is required for registered probe validation before merge.

## Known Gaps
- Linux local validation covers the Python serving diagnostics path only.
- Micro-benchmark timings have normal VM jitter; payload invariants (`serialized_bytes`, checksum, retained/dropped counts) stayed stable.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage met the 95% requirement.
- [x] Registered probe was run locally on Linux.
- [ ] GitHub Actions / PR-scoped performance report completed successfully.
