### PR TITLE
perf: cache probe policy factory helpers

### DIFF
--- a/docs/plans/2026-05-17-probe-policy-factory-cache.md
+++ b/docs/plans/2026-05-17-probe-policy-factory-cache.md
@@ -1,0 +1,20 @@
+# Probe policy factory cache optimization
+
+## Slice
+
+This Python-only performance slice keeps probe policy semantics unchanged while removing repeated `ProbePolicy` dataclass construction from the `ProbePolicy.evidence()` and `ProbePolicy.debug()` helper methods. Both helpers now return the existing immutable cached policy instances used by `ProbePolicy.from_value(...)`.
+
+## Registered probe
+
+The affected paths are already covered by the registered PR-scoped probe `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/probe_policy.py`
+- `services/mlx-worker-python/worker/productization/probe_policy_overhead.py`
+- `services/mlx-worker-python/tests/test_probe_policy.py`
+- `scripts/probe_policy_noop_overhead_probe.py`
+
+This slice extends the existing probe metrics with `evidence_policy_*` and `debug_policy_*` timings so the factory-helper cache effect is visible in local and CI PR-scoped reports. It also adds the same `0.00002 ms` absolute tolerance already used by the runtime threshold to the microsecond-level parse/read metrics so scheduler noise around unchanged sub-microsecond calls does not mask the targeted factory-helper metric.
+
+## Verification plan
+
+Run the focused probe-policy tests, changed-scope coverage, and the registered probe locally on Linux. Compare the registered probe output against an `origin/main` baseline captured in the same worktree before pushing.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3610,20 +3610,45 @@
       {
         "key": "no_op_reason_call_ms_mean",
         "unit": "ms",
-        "direction": "lower_is_better"
+        "direction": "lower_is_better",
+        "warn_abs": 2e-05
       },
       {
         "key": "mode_parse_valid_call_ms_mean",
         "unit": "ms",
-        "direction": "lower_is_better"
+        "direction": "lower_is_better",
+        "warn_abs": 2e-05
       },
       {
         "key": "mode_parse_invalid_call_ms_mean",
         "unit": "ms",
-        "direction": "lower_is_better"
+        "direction": "lower_is_better",
+        "warn_abs": 2e-05
       },
       {
         "key": "mode_parse_invalid_overhead_pct",
+        "unit": "pct",
+        "direction": "informational"
+      },
+      {
+        "key": "evidence_policy_call_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_abs": 2e-05
+      },
+      {
+        "key": "debug_policy_call_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_abs": 2e-05
+      },
+      {
+        "key": "evidence_policy_overhead_pct",
+        "unit": "pct",
+        "direction": "informational"
+      },
+      {
+        "key": "debug_policy_overhead_pct",
         "unit": "pct",
         "direction": "informational"
       },

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -92,6 +92,11 @@ def test_probe_policy_empty_values_reuse_default_policy_cache() -> None:
     assert debug_policy.telemetry_enabled is True
 
 
+def test_probe_policy_factory_helpers_reuse_cached_instances() -> None:
+    assert ProbePolicy.evidence() is ProbePolicy.from_value(ProbeMode.EVIDENCE)
+    assert ProbePolicy.debug() is ProbePolicy.from_value(ProbeMode.DEBUG)
+
+
 def test_probe_policy_telemetry_enabled_only_for_sampling_modes() -> None:
     assert ProbePolicy(mode=ProbeMode.OFF).telemetry_enabled is False
     assert ProbePolicy(mode=ProbeMode.MINIMAL).telemetry_enabled is False
@@ -141,9 +146,15 @@ def test_no_op_probe_policy_overhead_metrics_are_thresholded() -> None:
     assert "mode_parse_empty_call_ms_mean" in payload
     assert "mode_parse_valid_call_ms_mean" in payload
     assert "mode_parse_invalid_call_ms_mean" in payload
+    assert "evidence_policy_call_ms_mean" in payload
+    assert "debug_policy_call_ms_mean" in payload
     assert "mode_parse_invalid_delta_ms" in payload
+    assert "evidence_policy_delta_ms" in payload
+    assert "debug_policy_delta_ms" in payload
     assert payload["mode_parse_empty_call_ms_mean"] >= 0.0
     assert payload["mode_parse_valid_call_ms_mean"] >= 0.0
     assert payload["mode_parse_invalid_call_ms_mean"] >= 0.0
+    assert payload["evidence_policy_call_ms_mean"] >= 0.0
+    assert payload["debug_policy_call_ms_mean"] >= 0.0
     assert payload["absolute_tolerance_ms"] > 0.0
     assert payload["threshold_passed"] == 1.0

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -75,11 +75,11 @@ class ProbePolicy:
 
     @classmethod
     def evidence(cls) -> ProbePolicy:
-        return cls(mode=ProbeMode.EVIDENCE, source_value=ProbeMode.EVIDENCE.value)
+        return _PROBE_POLICY_BY_VALUE[ProbeMode.EVIDENCE.value]
 
     @classmethod
     def debug(cls) -> ProbePolicy:
-        return cls(mode=ProbeMode.DEBUG, source_value=ProbeMode.DEBUG.value)
+        return _PROBE_POLICY_BY_VALUE[ProbeMode.DEBUG.value]
 
 
 _PROBE_POLICY_BY_VALUE: dict[str, ProbePolicy] = {

--- a/services/mlx-worker-python/worker/productization/probe_policy_overhead.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy_overhead.py
@@ -29,14 +29,20 @@ class ProbeOverheadMetrics:
     mode_parse_empty_call_ms_mean: float
     mode_parse_valid_call_ms_mean: float
     mode_parse_invalid_call_ms_mean: float
+    evidence_policy_call_ms_mean: float
+    debug_policy_call_ms_mean: float
     no_op_recorder_overhead_pct: float
     no_op_policy_check_overhead_pct: float
     no_op_reason_overhead_pct: float
     mode_parse_invalid_overhead_pct: float
+    evidence_policy_overhead_pct: float
+    debug_policy_overhead_pct: float
     no_op_recorder_delta_ms: float
     no_op_policy_check_delta_ms: float
     no_op_reason_delta_ms: float
     mode_parse_invalid_delta_ms: float
+    evidence_policy_delta_ms: float
+    debug_policy_delta_ms: float
     threshold_pct: float
     absolute_tolerance_ms: float
     threshold_passed: bool
@@ -52,14 +58,20 @@ class ProbeOverheadMetrics:
             "mode_parse_empty_call_ms_mean": self.mode_parse_empty_call_ms_mean,
             "mode_parse_valid_call_ms_mean": self.mode_parse_valid_call_ms_mean,
             "mode_parse_invalid_call_ms_mean": self.mode_parse_invalid_call_ms_mean,
+            "evidence_policy_call_ms_mean": self.evidence_policy_call_ms_mean,
+            "debug_policy_call_ms_mean": self.debug_policy_call_ms_mean,
             "no_op_recorder_overhead_pct": self.no_op_recorder_overhead_pct,
             "no_op_policy_check_overhead_pct": self.no_op_policy_check_overhead_pct,
             "no_op_reason_overhead_pct": self.no_op_reason_overhead_pct,
             "mode_parse_invalid_overhead_pct": self.mode_parse_invalid_overhead_pct,
+            "evidence_policy_overhead_pct": self.evidence_policy_overhead_pct,
+            "debug_policy_overhead_pct": self.debug_policy_overhead_pct,
             "no_op_recorder_delta_ms": self.no_op_recorder_delta_ms,
             "no_op_policy_check_delta_ms": self.no_op_policy_check_delta_ms,
             "no_op_reason_delta_ms": self.no_op_reason_delta_ms,
             "mode_parse_invalid_delta_ms": self.mode_parse_invalid_delta_ms,
+            "evidence_policy_delta_ms": self.evidence_policy_delta_ms,
+            "debug_policy_delta_ms": self.debug_policy_delta_ms,
             "threshold_pct": self.threshold_pct,
             "absolute_tolerance_ms": self.absolute_tolerance_ms,
             "threshold_passed": 1.0 if self.threshold_passed else 0.0,
@@ -109,6 +121,16 @@ def measure_no_op_probe_policy_overhead(
         iterations=iteration_count,
         samples=sample_count,
     )
+    evidence_policy_samples = _sample_call_ms(
+        ProbePolicy.evidence,
+        iterations=iteration_count,
+        samples=sample_count,
+    )
+    debug_policy_samples = _sample_call_ms(
+        ProbePolicy.debug,
+        iterations=iteration_count,
+        samples=sample_count,
+    )
     baseline_mean = _mean(baseline_samples)
     recorder_mean = _mean(recorder_samples)
     policy_mean = _mean(policy_samples)
@@ -116,14 +138,20 @@ def measure_no_op_probe_policy_overhead(
     parse_empty_mean = _mean(parse_empty_samples)
     parse_valid_mean = _mean(parse_valid_samples)
     parse_invalid_mean = _mean(parse_invalid_samples)
+    evidence_policy_mean = _mean(evidence_policy_samples)
+    debug_policy_mean = _mean(debug_policy_samples)
     recorder_overhead_pct = _overhead_pct(recorder_mean, baseline_mean)
     policy_overhead_pct = _overhead_pct(policy_mean, baseline_mean)
     reason_overhead_pct = _overhead_pct(reason_mean, baseline_mean)
     parse_invalid_overhead_pct = _overhead_pct(parse_invalid_mean, baseline_mean)
+    evidence_policy_overhead_pct = _overhead_pct(evidence_policy_mean, baseline_mean)
+    debug_policy_overhead_pct = _overhead_pct(debug_policy_mean, baseline_mean)
     recorder_delta_ms = round(recorder_mean - baseline_mean, 9)
     policy_delta_ms = round(policy_mean - baseline_mean, 9)
     reason_delta_ms = round(reason_mean - baseline_mean, 9)
     parse_invalid_delta_ms = round(parse_invalid_mean - baseline_mean, 9)
+    evidence_policy_delta_ms = round(evidence_policy_mean - baseline_mean, 9)
+    debug_policy_delta_ms = round(debug_policy_mean - baseline_mean, 9)
     return ProbeOverheadMetrics(
         sample_count=sample_count,
         iteration_count=iteration_count,
@@ -134,14 +162,20 @@ def measure_no_op_probe_policy_overhead(
         mode_parse_empty_call_ms_mean=parse_empty_mean,
         mode_parse_valid_call_ms_mean=parse_valid_mean,
         mode_parse_invalid_call_ms_mean=parse_invalid_mean,
+        evidence_policy_call_ms_mean=evidence_policy_mean,
+        debug_policy_call_ms_mean=debug_policy_mean,
         no_op_recorder_overhead_pct=recorder_overhead_pct,
         no_op_policy_check_overhead_pct=policy_overhead_pct,
         no_op_reason_overhead_pct=reason_overhead_pct,
         mode_parse_invalid_overhead_pct=parse_invalid_overhead_pct,
+        evidence_policy_overhead_pct=evidence_policy_overhead_pct,
+        debug_policy_overhead_pct=debug_policy_overhead_pct,
         no_op_recorder_delta_ms=recorder_delta_ms,
         no_op_policy_check_delta_ms=policy_delta_ms,
         no_op_reason_delta_ms=reason_delta_ms,
         mode_parse_invalid_delta_ms=parse_invalid_delta_ms,
+        evidence_policy_delta_ms=evidence_policy_delta_ms,
+        debug_policy_delta_ms=debug_policy_delta_ms,
         threshold_pct=float(threshold_pct),
         absolute_tolerance_ms=float(absolute_tolerance_ms),
         threshold_passed=recorder_overhead_pct <= threshold_pct


### PR DESCRIPTION
## Summary
- Cache `ProbePolicy.evidence()` and `ProbePolicy.debug()` by returning the existing immutable policy instances instead of constructing new dataclasses on each call.
- Extend the probe-policy overhead metrics with `evidence_policy_*` and `debug_policy_*` timings so the registered PR-scoped probe captures this slice directly.
- Add a short plan note for the slice under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-05-17-probe-policy-factory-cache.md`
- Registered probe: `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json` already covers the affected Python paths and has focused test, coverage, and probe commands.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=200000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py scripts/probe_policy_noop_overhead_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=200000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py`
- Baseline/head direct helper microprobe against `origin/main` and this branch with `python3`.
- `git diff --check`

## Coverage and Metrics
- Focused tests: `15 passed in 0.62s`.
- Changed-scope coverage: `TOTAL 25 0 100%`.
- Registered local probe after change: `threshold_passed=1.0`, `no_op_recorder_overhead_pct=-1.750373`, `evidence_policy_call_ms_mean=0.000192319`, `debug_policy_call_ms_mean=0.000188866`.
- Direct baseline/head helper microprobe (7 samples x 200000 iterations):
  - `ProbePolicy.evidence()`: old `0.001449816 ms`, new `0.000190754 ms`, delta `-0.001259062 ms`, speedup `7.600x`.
  - `ProbePolicy.debug()`: old `0.001498436 ms`, new `0.000188714 ms`, delta `-0.001309723 ms`, speedup `7.940x`.
- CI PR-scoped registered probe is required before merge.

## Known Gaps
- Linux local validation covers the Python slice only; no Swift runtime validation is claimed or needed for this change.
- The `origin/main` registered probe did not include the new factory-helper metrics, so the direct helper microprobe was used for old/new factory timing while the branch registered probe now exposes those metrics for CI.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Confirmed registered PR-scoped probe coverage for the affected paths.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions / PR-scoped performance probe completed successfully.
