### PR TITLE
perf: speed up probe policy valid mode lookup

### DIFF
--- a/docs/plans/2026-05-17-probe-policy-factory-cache.md
+++ b/docs/plans/2026-05-17-probe-policy-factory-cache.md
@@ -15,6 +15,10 @@ The affected paths are already covered by the registered PR-scoped probe `probe-
 
 This slice extends the existing probe metrics with `evidence_policy_*` and `debug_policy_*` timings so the factory-helper cache effect is visible in local and CI PR-scoped reports. It also adds the same `0.00002 ms` absolute tolerance already used by the runtime threshold to the microsecond-level parse/read metrics so scheduler noise around unchanged sub-microsecond calls does not mask the targeted factory-helper metric.
 
+## Follow-up slice: valid-mode lookup cache
+
+The first helper-cache slice exposed a direct CI regression on the same registered probe: exact valid mode parsing (`ProbePolicy.from_value("debug")`) drifted above the microbenchmark warning threshold. The follow-up slice keeps the same behavior and registered probe, but avoids repeated global dictionary `.get` lookups and enum-value indexing by binding the policy lookup callable and enum-to-policy cache at module load time. It also checks exact `str` inputs before the `ProbeMode` `isinstance` branch so the common environment-string path does not pay the `StrEnum` type check cost.
+
 ## Verification plan
 
 Run the focused probe-policy tests, changed-scope coverage, and the registered probe locally on Linux. Compare the registered probe output against an `origin/main` baseline captured in the same worktree before pushing.

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -57,10 +57,15 @@ class ProbePolicy:
         *,
         default_mode: ProbeMode = ProbeMode.MINIMAL,
     ) -> ProbePolicy:
-        if isinstance(value, ProbeMode):
-            return _PROBE_POLICY_BY_VALUE[value.value]
-        if isinstance(value, str):
-            policy = _PROBE_POLICY_BY_VALUE.get(value)
+        if type(value) is str:
+            policy = _PROBE_POLICY_BY_VALUE_GET(value)
+            if policy is not None:
+                return policy
+            raw_value = value.strip().lower()
+        elif isinstance(value, ProbeMode):
+            return _PROBE_POLICY_BY_MODE[value]
+        elif isinstance(value, str):
+            policy = _PROBE_POLICY_BY_VALUE_GET(value)
             if policy is not None:
                 return policy
             raw_value = value.strip().lower()
@@ -68,26 +73,32 @@ class ProbePolicy:
             raw_value = str(value or "").strip().lower()
         if not raw_value:
             return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
-        policy = _PROBE_POLICY_BY_VALUE.get(raw_value)
+        policy = _PROBE_POLICY_BY_VALUE_GET(raw_value)
         if policy is not None:
             return policy
         return _invalid_probe_policy(raw_value, default_mode)
 
     @classmethod
     def evidence(cls) -> ProbePolicy:
-        return _PROBE_POLICY_BY_VALUE[ProbeMode.EVIDENCE.value]
+        return _EVIDENCE_PROBE_POLICY
 
     @classmethod
     def debug(cls) -> ProbePolicy:
-        return _PROBE_POLICY_BY_VALUE[ProbeMode.DEBUG.value]
+        return _DEBUG_PROBE_POLICY
 
 
 _PROBE_POLICY_BY_VALUE: dict[str, ProbePolicy] = {
     mode.value: ProbePolicy(mode=mode, source_value=mode.value) for mode in ProbeMode
 }
+_PROBE_POLICY_BY_VALUE_GET = _PROBE_POLICY_BY_VALUE.get
+_PROBE_POLICY_BY_MODE: dict[ProbeMode, ProbePolicy] = {
+    mode: _PROBE_POLICY_BY_VALUE[mode.value] for mode in ProbeMode
+}
 _PROBE_POLICY_BY_DEFAULT_MODE: dict[ProbeMode, ProbePolicy] = {
     mode: ProbePolicy(mode=mode) for mode in ProbeMode
 }
+_EVIDENCE_PROBE_POLICY = _PROBE_POLICY_BY_MODE[ProbeMode.EVIDENCE]
+_DEBUG_PROBE_POLICY = _PROBE_POLICY_BY_MODE[ProbeMode.DEBUG]
 
 
 @lru_cache(maxsize=64)


### PR DESCRIPTION
## Summary
- Speed up `ProbePolicy.from_value("debug")` and other exact string mode lookups by checking exact `str` inputs before the `ProbeMode` `StrEnum` branch.
- Bind the policy dictionary lookup and enum-to-policy cache at module load time so helper factories and parsing avoid repeated global dictionary method lookups.
- Update the probe-policy performance plan with the follow-up regression-fix slice.

## Plan or Spec
- `docs/plans/2026-05-17-probe-policy-factory-cache.md`
- Registered probe: `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json` already covers `services/mlx-worker-python/worker/productization/probe_policy.py` and includes focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
15 passed in 0.10s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py
15 passed in 0.19s; TOTAL 16 0 100%

$ MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=200000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=9 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py
base and head outputs captured locally; see Coverage and Metrics.

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 16 0 100%`.
- Local registered probe (`probe-policy-noop-overhead`, 200000 iterations, 9 samples, same Linux host):
  - `mode_parse_valid_call_ms_mean`: base `0.000294180`, head `0.000168258`, delta `-0.000125922 ms` (`~42.80%` faster).
  - `mode_parse_empty_call_ms_mean`: base `0.000354739`, head `0.000213944`, delta `-0.000140795 ms` (`~39.69%` faster).
  - `mode_parse_invalid_call_ms_mean`: base `0.000476775`, head `0.000382341`, delta `-0.000094434 ms` (`~19.81%` faster).
  - `evidence_policy_call_ms_mean`: base `0.000183189`, head `0.000043667`, delta `-0.000139522 ms` (`~76.16%` faster).
  - `debug_policy_call_ms_mean`: base `0.000185905`, head `0.000044997`, delta `-0.000140908 ms` (`~75.80%` faster).
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Linux local verification covers the Python probe-policy path only; no Swift runtime effect is involved.
- CI is still required for the authoritative registered PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
