### PR TITLE
perf: stabilize probe policy overhead probe

### DIFF
--- a/docs/plans/2026-05-17-probe-policy-factory-cache.md
+++ b/docs/plans/2026-05-17-probe-policy-factory-cache.md
@@ -21,4 +21,4 @@ The first helper-cache slice exposed a direct CI regression on the same register
 
 ## Verification plan
 
-Run the focused probe-policy tests, changed-scope coverage, and the registered probe locally on Linux. Compare the registered probe output against an `origin/main` baseline captured in the same worktree before pushing.
+Run the focused probe-policy tests, changed-scope coverage, and the registered probe locally on Linux. Compare the registered probe output against an `origin/main` baseline captured in the same worktree before pushing. The probe script defaults to 1,000,000 iterations so the sub-microsecond factory-helper timings are less sensitive to scheduler noise.

--- a/scripts/probe_policy_noop_overhead_probe.py
+++ b/scripts/probe_policy_noop_overhead_probe.py
@@ -15,7 +15,7 @@ from worker.productization.probe_policy_overhead import measure_no_op_probe_poli
 
 
 def main() -> int:
-    iterations = int(os.environ.get("MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS", "200000"))
+    iterations = int(os.environ.get("MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS", "1000000"))
     samples = int(os.environ.get("MELIX_PROBE_POLICY_OVERHEAD_SAMPLES", "5"))
     threshold_pct = float(os.environ.get("MELIX_PROBE_POLICY_OVERHEAD_THRESHOLD_PCT", "5.0"))
     metrics = measure_no_op_probe_policy_overhead(


### PR DESCRIPTION
## Summary
- Rebased the probe-policy helper slice onto current `origin/main`, where the helper-cache optimization and valid-mode lookup follow-up are already merged.
- Keep this PR scoped to the remaining probe-stability slice: raise `probe_policy_noop_overhead_probe.py` default iterations from 200,000 to 1,000,000 so sub-microsecond registered metrics are less noisy in local and CI PR-scoped reports.
- Update the governing plan to document the higher default iteration count.

## Plan or Spec
- Updated `docs/plans/2026-05-17-probe-policy-factory-cache.md` verification notes.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/probe_policy_noop_overhead_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py`

## Coverage and Metrics
- Focused tests: `16 passed`.
- Changed-scope coverage after rebase: `TOTAL 0 0 100%`.
- Registered local probe (head after rebase): `threshold_passed=1.0`, `iteration_count=1000000`, `evidence_policy_call_ms_mean=0.000043083`, `debug_policy_call_ms_mean=0.000043142`, `mode_parse_valid_call_ms_mean=0.000165064`.
- Earlier local baseline/head helper comparison before rebase showed the helper-cache optimization now present on `origin/main`: baseline `evidence=0.001482616`, `debug=0.001548600`; optimized head `evidence=0.000333929`, `debug=0.000333560`.
- PR-scoped performance CI must validate the registered probe for this PR before merge.

## Known Gaps
- This is a Python-only probe-stability slice verified locally on Linux. No Swift runtime effect is claimed.
- The actual factory-helper cache optimization landed on `origin/main` before this PR was rebased; this PR intentionally keeps only the iteration-count stabilization needed for reliable registered probe reporting.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused Python tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions completed successfully, including PR-scoped performance.
