### PR TITLE
perf: cache serving diagnostics event index literals

### DIFF
--- a/docs/plans/2026-05-17-serving-diagnostics-event-index-literal-cache.md
+++ b/docs/plans/2026-05-17-serving-diagnostics-event-index-literal-cache.md
@@ -1,0 +1,51 @@
+# Serving diagnostics event-index literal cache
+
+## Goal
+
+Reduce JSONL serialization overhead in the serving diagnostics debug queue path by caching ASCII byte literals for repeated integer event indexes.
+
+## Scope
+
+This slice is Python-only under `services/mlx-worker-python` and can be verified locally on Linux. It touches:
+
+- `services/mlx-worker-python/worker/productization/serving_diagnostics.py`
+- `services/mlx-worker-python/tests/test_serving_diagnostics.py`
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped registered probe `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`. The probe defines focused `test_command`, `coverage_command`, and `probe_command` entries and reports append, serialization, retained/dropped count, checksum, and serialized-byte metrics.
+
+## Optimization hypothesis
+
+`_empty_attribute_event_json_line_bytes()` serializes retained queue event indexes with `str(event_index).encode("ascii")` for every JSONL row. The registered probe keeps the same retained event indexes across repeated samples, so caching the integer-to-ASCII bytes conversion should reduce repeated allocation and conversion work while preserving byte-for-byte JSON output.
+
+## Verification plan
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_serving_diagnostics.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_serving_diagnostics.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/productization/serving_diagnostics.py \
+  services/mlx-worker-python/tests/test_serving_diagnostics.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/serving_diagnostics_queue_probe.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
+```
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage is at least 95%.
+- Local registered probe preserves `serialization_checksum`, `retained_count`, `dropped_count`, and `serialized_bytes` while improving or staying within noise for `serialization_elapsed_ms_mean`.
+- Hosted PR-scoped performance CI completes `serving-diagnostics-debug-queue-bounds` successfully before merge.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -388,6 +388,29 @@ def test_serving_diagnostics_jsonl_fast_path_reuses_duration_literal_cache() -> 
     assert cache_info.hits == 2
 
 
+def test_serving_diagnostics_jsonl_fast_path_reuses_event_index_literal_cache() -> None:
+    serving_diagnostics_module._ascii_int_literal.cache_clear()
+    rows = tuple(
+        ServingDiagnosticsEvent(
+            request_id=f"req-index-cache-{sample_index}",
+            phase="decode",
+            event_index=4032,
+            status="completed",
+            duration_ms=0.001,
+        )
+        for sample_index in range(3)
+    )
+
+    for row in rows:
+        line = serving_diagnostics_module._empty_attribute_event_json_line_bytes(row)
+        assert line is not None
+        assert json.loads(line)["event_index"] == 4032
+
+    cache_info = serving_diagnostics_module._ascii_int_literal.cache_info()
+    assert cache_info.misses == 1
+    assert cache_info.hits == 2
+
+
 def test_serving_diagnostics_jsonl_fast_path_direct_helper_preserves_fallback() -> None:
     event = ServingDiagnosticsEvent(
         request_id="req-direct-fallback",

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -34,6 +34,11 @@ def _ascii_float_literal(value: float) -> bytes:
     return str(value).encode("ascii")
 
 
+@lru_cache(maxsize=4096)
+def _ascii_int_literal(value: int) -> bytes:
+    return str(value).encode("ascii")
+
+
 class ServingDiagnosticsComparisonError(ValueError):
     pass
 
@@ -552,7 +557,7 @@ def _empty_attribute_event_json_line_bytes(
         b'{"attributes":{},"duration_ms":'
         + _ascii_float_literal(duration_ms)
         + b',"event_index":'
-        + str(event_index).encode("ascii")
+        + _ascii_int_literal(event_index)
         + b',"phase":'
         + encoded_phase
         + b',"request_id":'


### PR DESCRIPTION
## Summary
- Cache ASCII byte literals for serving diagnostics event indexes in the JSONL fast path.
- Add a regression test proving repeated event indexes reuse the new cache.
- Document the Python-only performance slice and its registered probe evidence path.

## Plan or Spec
- `docs/plans/2026-05-17-serving-diagnostics-event-index-literal-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 40 passed in 0.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# exit 0; aggregate changed-line coverage 100.00% (13/13)

for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py; done
# exit 0; head serialization_elapsed_ms_mean samples: 0.977319, 1.077639, 0.959323 ms

git diff --check
# exit 0
```

## Coverage and Metrics
- Registered probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json` covers this path and has focused `test_command`, `coverage_command`, and `probe_command` entries.
- Changed-scope coverage: 100.00% (13/13 changed measurable lines).
- Local Linux probe comparison (3 repeated runs, `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20`):
  - Base serialization mean: 1.059598 ms from samples 0.951649, 0.985710, 1.241435.
  - Head serialization mean: 1.004760 ms from samples 0.977319, 1.077639, 0.959323.
  - Delta: -0.054838 ms, about 5.18% lower / 1.0546x faster.
  - Invariant metrics preserved: `serialization_checksum=260064`, `retained_count=64`, `dropped_count=4032`, `serialized_bytes=10944`.
- CI is required for the hosted registered PR-scoped probe validation before merge.

## Known Gaps
- Local validation is Linux-only for this Python slice; hosted PR-scoped performance CI is still required as the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; runtime behavior unchanged.
- [x] Deferred work and known gaps are stated explicitly.
