### PR TITLE
perf: join serving diagnostics event JSON segments

### DIFF
--- a/docs/plans/2026-05-17-serving-diagnostics-event-line-join.md
+++ b/docs/plans/2026-05-17-serving-diagnostics-event-line-join.md
@@ -1,0 +1,28 @@
+# Serving diagnostics event-line join slice
+
+## Scope
+
+This Python-only performance slice targets the debug serving diagnostics JSONL fast
+path in `services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+The affected path already has the registered PR-scoped probe
+`serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json` with
+focused test, coverage, and probe commands.
+
+## Change
+
+Keep the empty-attribute event JSONL output byte-for-byte compatible while reducing
+intermediate bytes concatenation in `_empty_attribute_event_json_line_bytes` by
+assembling the known segments through a single `bytes.join` call.
+
+## Verification plan
+
+- Run focused serving diagnostics tests and PR-scoped probe selection tests.
+- Run changed-scope coverage through the registered `coverage_command`.
+- Run the registered serving diagnostics queue probe locally on Linux and compare
+  `serialization_elapsed_ms_mean` against `origin/main` using the same sample
+  count.
+
+## Linux validation boundary
+
+This slice is entirely Python and locally verifiable on Linux. No Swift runtime
+performance claims are made.

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -553,16 +553,18 @@ def _empty_attribute_event_json_line_bytes(
         if encoded_request_id is None:
             encoded_request_id = _json_string_literal(request_id).encode("utf-8")
             request_id_literals[request_id] = encoded_request_id
-    return (
-        b'{"attributes":{},"duration_ms":'
-        + _ascii_float_literal(duration_ms)
-        + b',"event_index":'
-        + _ascii_int_literal(event_index)
-        + b',"phase":'
-        + encoded_phase
-        + b',"request_id":'
-        + encoded_request_id
-        + b',"schema_version":"melix.serving_diagnostics.event.v1","status":'
-        + encoded_status
-        + b"}"
+    return b"".join(
+        (
+            b'{"attributes":{},"duration_ms":',
+            _ascii_float_literal(duration_ms),
+            b',"event_index":',
+            _ascii_int_literal(event_index),
+            b',"phase":',
+            encoded_phase,
+            b',"request_id":',
+            encoded_request_id,
+            b',"schema_version":"melix.serving_diagnostics.event.v1","status":',
+            encoded_status,
+            b"}",
+        )
     )


### PR DESCRIPTION
## Summary
- Optimize the serving diagnostics empty-attribute event JSONL fast path by joining known byte segments in one `bytes.join` call.
- Add a short plan doc documenting the Python-only slice and registered probe boundary.

## Plan or Spec
- `docs/plans/2026-05-17-serving-diagnostics-event-line-join.md`
- Registered probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `uv run --project services/mlx-worker-python python3 /tmp/run_melix_pytest.py` → 40 passed
- `uv run --project services/mlx-worker-python python3 /tmp/run_melix_coverage.py` → 40 passed
- `uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py` → TOTAL 1 0 100%
- `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=100 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% for the single measurable changed line.
- Local Linux registered probe comparison (`MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=100`):
  - `origin/main`: `serialization_elapsed_ms_mean=1.014385 ms`, `elapsed_ms_mean=5.591812 ms`, `serialized_bytes=10944`
  - branch final: `serialization_elapsed_ms_mean=0.976816 ms`, `elapsed_ms_mean=5.766855 ms`, `serialized_bytes=10944`
  - serialization delta: `-0.037569 ms` (~3.70% lower); serialized bytes unchanged.
- CI PR-scoped performance is required as the registered probe validation source before merge.

## Known Gaps
- Local evidence is Linux-only. This PR does not claim Swift runtime performance effects.
- Queue append timing is noisy and not the optimized subpath; the targeted serialization metric improved locally while preserving output size and checksum.

## Evidence Checklist
- [x] Registered PR-scoped probe exists for the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage was measured locally.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions and PR-scoped performance probe completed successfully.
