### PR TITLE
perf: specialize serving diagnostics decode event JSON

### DIFF
--- a/docs/plans/2026-05-17-serving-diagnostics-decode-completed-prefix.md
+++ b/docs/plans/2026-05-17-serving-diagnostics-decode-completed-prefix.md
@@ -1,0 +1,30 @@
+# Serving diagnostics decode/completed event prefix slice
+
+## Scope
+
+This Python-only performance slice targets the debug serving diagnostics JSONL fast
+path in `services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+The affected path is covered by the registered PR-scoped probe
+`serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`,
+which has focused test, coverage, and probe commands.
+
+## Change
+
+Keep empty-attribute event JSONL output byte-for-byte compatible while adding a
+more specific fast path for the common debug probe shape: `phase == "decode"` and
+`status == "completed"`. The branch reuses prebuilt byte fragments for the static
+JSON prefixes/suffixes and falls back to the generic string-literal path for all
+other phases and statuses.
+
+## Verification plan
+
+- Run focused serving diagnostics tests and PR-scoped probe selection tests.
+- Run changed-scope coverage through the registered `coverage_command`.
+- Run the registered serving diagnostics queue probe locally on Linux and compare
+  `serialization_elapsed_ms_mean` against `origin/main` using the same sample
+  count.
+
+## Linux validation boundary
+
+This slice is entirely Python and locally verifiable on Linux. No Swift runtime
+performance claims are made.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -411,6 +411,21 @@ def test_serving_diagnostics_jsonl_fast_path_reuses_event_index_literal_cache() 
     assert cache_info.hits == 2
 
 
+def test_serving_diagnostics_jsonl_fast_path_preserves_generic_phase_status() -> None:
+    event = ServingDiagnosticsEvent(
+        request_id="req-generic-phase-status",
+        phase="prefill",
+        event_index=13,
+        status="started",
+        duration_ms=0.5,
+    )
+
+    line = serving_diagnostics_module._empty_attribute_event_json_line_bytes(event)
+
+    assert line is not None
+    assert json.loads(line) == event.to_dict()
+
+
 def test_serving_diagnostics_jsonl_fast_path_direct_helper_preserves_fallback() -> None:
     event = ServingDiagnosticsEvent(
         request_id="req-direct-fallback",

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -22,6 +22,14 @@ _JSON_COMPACT_SEPARATORS = (",", ":")
 _JSONL_ENCODER = json.JSONEncoder(sort_keys=True, separators=_JSON_COMPACT_SEPARATORS)
 _JSON_STRING_ENCODER = json.encoder.encode_basestring_ascii
 _SET_FROZEN_ATTR = object.__setattr__
+_EMPTY_EVENT_JSON_DECODE_COMPLETED_PREFIX = b'{"attributes":{},"duration_ms":'
+_EMPTY_EVENT_JSON_DECODE_COMPLETED_MID = b',"event_index":'
+_EMPTY_EVENT_JSON_DECODE_COMPLETED_REQUEST_PREFIX = (
+    b',"phase":"decode","request_id":'
+)
+_EMPTY_EVENT_JSON_DECODE_COMPLETED_SUFFIX = (
+    b',"schema_version":"melix.serving_diagnostics.event.v1","status":"completed"}'
+)
 
 
 @lru_cache(maxsize=1024)
@@ -536,16 +544,6 @@ def _empty_attribute_event_json_line_bytes(
     phase = event.phase
     request_id = event.request_id
     status = event.status
-    encoded_phase = (
-        b'"decode"'
-        if phase == "decode"
-        else _json_string_literal(phase).encode("utf-8")
-    )
-    encoded_status = (
-        b'"completed"'
-        if status == "completed"
-        else _json_string_literal(status).encode("utf-8")
-    )
     if request_id_literals is None:
         encoded_request_id = _json_string_literal(request_id).encode("utf-8")
     else:
@@ -553,6 +551,20 @@ def _empty_attribute_event_json_line_bytes(
         if encoded_request_id is None:
             encoded_request_id = _json_string_literal(request_id).encode("utf-8")
             request_id_literals[request_id] = encoded_request_id
+    if phase == "decode" and status == "completed":
+        return b"".join(
+            (
+                _EMPTY_EVENT_JSON_DECODE_COMPLETED_PREFIX,
+                _ascii_float_literal(duration_ms),
+                _EMPTY_EVENT_JSON_DECODE_COMPLETED_MID,
+                _ascii_int_literal(event_index),
+                _EMPTY_EVENT_JSON_DECODE_COMPLETED_REQUEST_PREFIX,
+                encoded_request_id,
+                _EMPTY_EVENT_JSON_DECODE_COMPLETED_SUFFIX,
+            )
+        )
+    encoded_phase = _json_string_literal(phase).encode("utf-8")
+    encoded_status = _json_string_literal(status).encode("utf-8")
     return b"".join(
         (
             b'{"attributes":{},"duration_ms":',


### PR DESCRIPTION
## Summary
- Specialize the serving diagnostics empty-attribute JSONL fast path for the common `decode` / `completed` event shape.
- Reuse prebuilt static byte fragments while preserving the generic phase/status fallback path.
- Add a regression test for non-common phase/status serialization parity.

## Plan or Spec
- `docs/plans/2026-05-17-serving-diagnostics-decode-completed-prefix.md`
- Registered probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 41 passed in 0.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# TOTAL 13 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=100 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# {"capacity": 64.0, "dropped_count": 4032.0, "elapsed_ms_mean": 5.740866, "event_count": 4096.0, "retained_count": 64.0, "sample_count": 100.0, "serialization_checksum": 260064.0, "serialization_elapsed_ms_mean": 1.005271, "serialized_bytes": 10944.0}

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 13 0 100%`).
- Local Linux registered probe comparison (`MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=100`):
  - `origin/main`: `serialization_elapsed_ms_mean=1.068275 ms`, `elapsed_ms_mean=6.036932 ms`, `serialized_bytes=10944`
  - branch final: `serialization_elapsed_ms_mean=1.005271 ms`, `elapsed_ms_mean=5.740866 ms`, `serialized_bytes=10944`
  - serialization delta: `-0.063004 ms` (~5.90% lower); total elapsed delta `-0.296066 ms` (~4.90% lower); serialized bytes/checksum unchanged.
- CI PR-scoped performance is required as the registered probe validation source before merge.

## Known Gaps
- Local evidence is Linux-only. This PR does not claim Swift runtime performance effects.
- The optimization intentionally targets the common `decode` / `completed` debug event shape; generic phase/status output is preserved by fallback coverage.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
