### PR TITLE
perf: fast-path direct hub size hints

### DIFF
--- a/docs/plans/2026-05-17-hub-catalog-direct-size-hint-integer-fast-path.md
+++ b/docs/plans/2026-05-17-hub-catalog-direct-size-hint-integer-fast-path.md
@@ -1,0 +1,22 @@
+# Hub Catalog Direct Size Hint Integer Fast Path
+
+## Scope
+
+This Python performance slice targets the direct `cardData.model_size` parsing path in `services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`. The registry entry already includes focused `test_command`, `coverage_command`, and `probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+
+## Change
+
+Fast-path common integer direct size hints such as `128 MB`, `4 GB`, and `512 KB` before falling back to the existing whitespace-split and float parser. This keeps decimal values, lowercase units, extra whitespace, and invalid strings on the existing general parser while avoiding list allocation and float conversion for the common integer uppercase-unit card metadata shape.
+
+## Local verification plan
+
+Run the registered focused test command, changed-scope coverage command, and registered local probe on Linux before opening the PR. Hosted PR-scoped performance CI remains the merge gate for the registered probe report.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -720,6 +720,7 @@ def test_size_hint_bytes_falls_back_for_labeled_direct_card_model_size(
 
 
 def test_size_hint_parsers_cover_units_and_invalid_values() -> None:
+    assert hub_catalog_module._direct_size_hint_from_text("512 KB") == 512 * KB
     assert hub_catalog_module._direct_size_hint_from_text("512 kb") == 512 * KB
     assert hub_catalog_module._direct_size_hint_from_text("1.5 MB") == int(1.5 * MB)
     assert hub_catalog_module._direct_size_hint_from_text("2 GB") == 2 * GB

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -622,6 +622,18 @@ def _size_hint_bytes(payload: dict[str, Any]) -> int:
 
 
 def _direct_size_hint_from_text(text: str) -> int:
+    if text.endswith(" MB"):
+        value_text = text[:-3]
+        if value_text.isdecimal():
+            return int(value_text) * _SIZE_HINT_MB
+    if text.endswith(" GB"):
+        value_text = text[:-3]
+        if value_text.isdecimal():
+            return int(value_text) * _SIZE_HINT_GB
+    if text.endswith(" KB"):
+        value_text = text[:-3]
+        if value_text.isdecimal():
+            return int(value_text) * _SIZE_HINT_KB
     try:
         value_text, unit_text = text.split()
     except ValueError:


### PR DESCRIPTION
## Summary
- Fast-path common integer `cardData.model_size` hints (`KB`, `MB`, `GB`) before the existing split/float fallback.
- Preserve the general parser for decimal values, lowercase units, extra whitespace, labeled values, and invalid inputs.
- Add regression coverage for the uppercase `KB` direct fast path.

## Plan or Spec
- `docs/plans/2026-05-17-hub-catalog-direct-size-hint-integer-fast-path.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 52 passed in 0.21s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# 52 passed in 0.55s; TOTAL 13 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# before: {"elapsed_ms_mean": 1474.0688836667687, "peak_bytes_mean": 1833.0, "size_hint_calls_mean": 40000.0, "matched_hint_count": 80000.0, "sample_count": 5.0}
# after:  {"elapsed_ms_mean": 1428.979690792039, "peak_bytes_mean": 1833.0, "size_hint_calls_mean": 40000.0, "matched_hint_count": 80000.0, "sample_count": 5.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Local registered probe (`hub_catalog_size_hint_probe.py`, Linux): `elapsed_ms_mean` improved from `1474.0688836667687` to `1428.979690792039` ms (`-45.089192874729745` ms, about `1.03x` faster / `3.06%` lower). `peak_bytes_mean` remained `1833.0`.
- CI is required for the hosted registered PR-scoped performance report before merge.

## Known Gaps
- None for the Python slice. This PR does not change Swift/runtime behavior.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode changes; existing PR-scoped probe reused.
- [x] Deferred work and known gaps are stated explicitly.
