### PR TITLE
perf: return early for OCR single-image token count

### DIFF
--- a/docs/plans/2026-05-17-ocr-single-image-token-count-return.md
+++ b/docs/plans/2026-05-17-ocr-single-image-token-count-return.md
@@ -1,0 +1,35 @@
+# OCR Single-image Token Count Return Slice
+
+## Goal
+
+Trim the deterministic OCR prompt token-count hot path for the common single-image
+request by returning immediately after combining prompt tokens with the precomputed
+image input byte count.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py`
+- Existing focused OCR token-count tests in `services/mlx-worker-python/tests/test_vision_runtime.py`
+- Existing PR-scoped probe `deterministic-ocr-token-count-scan`
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe
+`deterministic-ocr-token-count-scan` in `infra/perf/pr_scoped_probes.json`. The
+entry includes focused `test_command`, `coverage_command`, and `probe_command`
+values for the deterministic OCR token-count workload.
+
+## Plan
+
+1. Keep token-count semantics unchanged for single-image and multi-image OCR
+   requests.
+2. Avoid assigning an intermediate `image_tokens` variable on the common
+   single-image path and return the final bounded total directly.
+3. Run the registered focused tests, changed-scope coverage, and local registered
+   probe on Linux before opening the PR.
+4. Use the GitHub PR-scoped performance workflow as the final base-vs-head gate.
+
+## Validation boundary
+
+This slice is Python-only and locally verifiable on Linux. No Swift runtime
+performance claim is made.

--- a/services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py
@@ -65,12 +65,14 @@ class DeterministicOCRRuntime:
         return prepared
 
     def prompt_token_count(self, prepared_request: PreparedVisionRequest) -> int:
-        prompt_tokens = _whitespace_token_count(prepared_request.prompt_text)
         images = prepared_request.images
+        prompt_tokens = _whitespace_token_count(prepared_request.prompt_text)
         if len(images) == 1 and not prepared_request.videos:
-            image_tokens = max(1, prepared_request.preprocess_input_bytes // 8)
-        else:
-            image_tokens = sum(max(1, image.byte_length // 8) for image in images)
+            return max(
+                1,
+                prompt_tokens + max(1, prepared_request.preprocess_input_bytes // 8),
+            )
+        image_tokens = sum(max(1, image.byte_length // 8) for image in images)
         return max(1, prompt_tokens + image_tokens)
 
     def generate_tokens(


### PR DESCRIPTION
## Summary
- Return directly from the deterministic OCR single-image token-count path after combining prompt tokens with the precomputed input-byte token estimate.
- Add a focused plan documenting the Python-only performance slice and the registered probe boundary.

## Plan or Spec
- `docs/plans/2026-05-17-ocr-single-image-token-count-return.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_OCR_TOKEN_COUNT_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py
# origin/main baseline: exit 0; elapsed_ms_mean=243.544223, peak_bytes_mean=160.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_ocr_text_from_inline_image_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics
# exit 0; 6 passed in 1.56s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_ocr_text_from_inline_image_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py services/mlx-worker-python/worker/runtime/token_counting.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_ocr_token_count_probe.py
# exit 0; 6 passed in 0.70s; TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_OCR_TOKEN_COUNT_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py
# head direct probe: exit 0; elapsed_ms_mean=233.100263, peak_bytes_mean=160.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_OCR_TOKEN_COUNT_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-ocr-token-count-scan --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/ocr_token_count_probe_result.json
# exit 0; base elapsed_ms_mean=259.792023; head elapsed_ms_mean=239.343758; coverage 100%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Registered local PR-scoped probe `deterministic-ocr-token-count-scan`: base `elapsed_ms_mean=259.792023`, head `elapsed_ms_mean=239.343758`, delta `-20.448265 ms` (~7.87% faster), `peak_bytes_mean` unchanged at `160.0`.
- Direct local probe comparison captured baseline `243.544223 ms` and head `233.100263 ms` (~4.29% faster). CI PR-scoped performance remains the final registered base-vs-head gate.

## Known Gaps
- None. This is Python-only and locally verified on Linux; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode N/A: this uses an existing PR-scoped performance probe and does not change runtime observability behavior.
- [x] Deferred work and known gaps are stated explicitly.
