### PR TITLE
perf: fast-path empty probe policy env

### DIFF
--- a/docs/plans/2026-05-17-probe-policy-env-empty-fast-path.md
+++ b/docs/plans/2026-05-17-probe-policy-env-empty-fast-path.md
@@ -1,0 +1,48 @@
+# Probe Policy Empty Environment Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to `ProbePolicy.from_env(...)` in
+`services/mlx-worker-python/worker/productization/probe_policy.py` and the
+registered no-op probe-policy overhead measurement path.
+
+The common production default path has no `MELIX_PROBE_MODE` value set. Before
+this slice, `from_env({})` still delegated through `from_value("")`, adding an
+extra classmethod call on the no-env hot path even though the default policy is a
+cached singleton.
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped performance probe
+`probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`. That entry
+already includes focused `test_command`, `coverage_command`, and
+`probe_command` fields for:
+
+- `services/mlx-worker-python/worker/productization/probe_policy.py`
+- `services/mlx-worker-python/worker/productization/probe_policy_overhead.py`
+- `services/mlx-worker-python/tests/test_probe_policy.py`
+- `scripts/probe_policy_noop_overhead_probe.py`
+
+This slice extends the probe metrics with `env_parse_empty_call_ms_mean` so the
+registered local and CI probe report measures the optimized path directly. The
+probe also reports `mode_parse_empty_call_ms_mean` alongside the existing valid
+and invalid parse metrics, and the empty-env probe sample reuses a preallocated
+empty mapping so the metric isolates `from_env(...)` rather than per-iteration
+dictionary allocation.
+
+## Implementation Plan
+
+1. Preserve existing behavior for valid, invalid, whitespace-normalized, and
+   explicit default-mode inputs.
+2. Return the cached default-mode policy directly when `from_env(...)` sees a
+   missing or falsey `MELIX_PROBE_MODE` value.
+3. Add focused regression assertions for empty env maps, explicit falsey env
+   values, and non-minimal default modes.
+4. Run the registered focused tests, changed-scope coverage, and local registered
+   probe on Linux before opening the PR.
+5. Use the GitHub Actions PR-scoped performance workflow as the final merge gate.
+
+## Validation Boundary
+
+This slice is Python-only and locally verifiable on Linux. No Swift runtime
+performance claim is made.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3614,6 +3614,12 @@
         "warn_abs": 2e-05
       },
       {
+        "key": "mode_parse_empty_call_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_abs": 2e-05
+      },
+      {
         "key": "mode_parse_valid_call_ms_mean",
         "unit": "ms",
         "direction": "lower_is_better",
@@ -3621,6 +3627,12 @@
       },
       {
         "key": "mode_parse_invalid_call_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_abs": 2e-05
+      },
+      {
+        "key": "env_parse_empty_call_ms_mean",
         "unit": "ms",
         "direction": "lower_is_better",
         "warn_abs": 2e-05

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2417,8 +2417,10 @@ def test_probe_policy_noop_overhead_probe_script_emits_metrics(
     assert "no_op_policy_check_overhead_pct" in metrics
     assert "no_op_reason_overhead_pct" in metrics
     assert "no_op_reason_call_ms_mean" in metrics
+    assert "mode_parse_empty_call_ms_mean" in metrics
     assert "mode_parse_valid_call_ms_mean" in metrics
     assert "mode_parse_invalid_call_ms_mean" in metrics
+    assert "env_parse_empty_call_ms_mean" in metrics
     assert "mode_parse_invalid_overhead_pct" in metrics
 
 

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -81,12 +81,15 @@ def test_probe_policy_empty_values_reuse_default_policy_cache() -> None:
 
     assert ProbePolicy.from_value(None) is minimal_policy
     assert probe_policy_from_env({}) is minimal_policy
+    assert ProbePolicy.from_env({}) is minimal_policy
+    assert ProbePolicy.from_env({"MELIX_PROBE_MODE": None}) is minimal_policy  # type: ignore[dict-item]
     assert minimal_policy.source_value == ""
     assert minimal_policy.fallback_applied is False
     assert minimal_policy is not ProbePolicy.from_value(ProbeMode.MINIMAL)
 
     debug_policy = ProbePolicy.from_value("", default_mode=ProbeMode.DEBUG)
     assert ProbePolicy.from_value(None, default_mode=ProbeMode.DEBUG) is debug_policy
+    assert ProbePolicy.from_env({}, default_mode=ProbeMode.DEBUG) is debug_policy
     assert debug_policy.mode is ProbeMode.DEBUG
     assert debug_policy.source_value == ""
     assert debug_policy.telemetry_enabled is True
@@ -146,6 +149,7 @@ def test_no_op_probe_policy_overhead_metrics_are_thresholded() -> None:
     assert "mode_parse_empty_call_ms_mean" in payload
     assert "mode_parse_valid_call_ms_mean" in payload
     assert "mode_parse_invalid_call_ms_mean" in payload
+    assert "env_parse_empty_call_ms_mean" in payload
     assert "evidence_policy_call_ms_mean" in payload
     assert "debug_policy_call_ms_mean" in payload
     assert "mode_parse_invalid_delta_ms" in payload
@@ -154,6 +158,7 @@ def test_no_op_probe_policy_overhead_metrics_are_thresholded() -> None:
     assert payload["mode_parse_empty_call_ms_mean"] >= 0.0
     assert payload["mode_parse_valid_call_ms_mean"] >= 0.0
     assert payload["mode_parse_invalid_call_ms_mean"] >= 0.0
+    assert payload["env_parse_empty_call_ms_mean"] >= 0.0
     assert payload["evidence_policy_call_ms_mean"] >= 0.0
     assert payload["debug_policy_call_ms_mean"] >= 0.0
     assert payload["absolute_tolerance_ms"] > 0.0

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -48,6 +48,8 @@ class ProbePolicy:
     ) -> ProbePolicy:
         values = os.environ if env is None else env
         raw_value = values.get(MELIX_PROBE_MODE_ENV, "")
+        if not raw_value:
+            return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
         return cls.from_value(raw_value, default_mode=default_mode)
 
     @classmethod

--- a/services/mlx-worker-python/worker/productization/probe_policy_overhead.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy_overhead.py
@@ -29,6 +29,7 @@ class ProbeOverheadMetrics:
     mode_parse_empty_call_ms_mean: float
     mode_parse_valid_call_ms_mean: float
     mode_parse_invalid_call_ms_mean: float
+    env_parse_empty_call_ms_mean: float
     evidence_policy_call_ms_mean: float
     debug_policy_call_ms_mean: float
     no_op_recorder_overhead_pct: float
@@ -58,6 +59,7 @@ class ProbeOverheadMetrics:
             "mode_parse_empty_call_ms_mean": self.mode_parse_empty_call_ms_mean,
             "mode_parse_valid_call_ms_mean": self.mode_parse_valid_call_ms_mean,
             "mode_parse_invalid_call_ms_mean": self.mode_parse_invalid_call_ms_mean,
+            "env_parse_empty_call_ms_mean": self.env_parse_empty_call_ms_mean,
             "evidence_policy_call_ms_mean": self.evidence_policy_call_ms_mean,
             "debug_policy_call_ms_mean": self.debug_policy_call_ms_mean,
             "no_op_recorder_overhead_pct": self.no_op_recorder_overhead_pct,
@@ -121,6 +123,12 @@ def measure_no_op_probe_policy_overhead(
         iterations=iteration_count,
         samples=sample_count,
     )
+    empty_env: dict[str, str] = {}
+    env_parse_empty_samples = _sample_call_ms(
+        lambda: ProbePolicy.from_env(empty_env),
+        iterations=iteration_count,
+        samples=sample_count,
+    )
     evidence_policy_samples = _sample_call_ms(
         ProbePolicy.evidence,
         iterations=iteration_count,
@@ -138,6 +146,7 @@ def measure_no_op_probe_policy_overhead(
     parse_empty_mean = _mean(parse_empty_samples)
     parse_valid_mean = _mean(parse_valid_samples)
     parse_invalid_mean = _mean(parse_invalid_samples)
+    env_parse_empty_mean = _mean(env_parse_empty_samples)
     evidence_policy_mean = _mean(evidence_policy_samples)
     debug_policy_mean = _mean(debug_policy_samples)
     recorder_overhead_pct = _overhead_pct(recorder_mean, baseline_mean)
@@ -162,6 +171,7 @@ def measure_no_op_probe_policy_overhead(
         mode_parse_empty_call_ms_mean=parse_empty_mean,
         mode_parse_valid_call_ms_mean=parse_valid_mean,
         mode_parse_invalid_call_ms_mean=parse_invalid_mean,
+        env_parse_empty_call_ms_mean=env_parse_empty_mean,
         evidence_policy_call_ms_mean=evidence_policy_mean,
         debug_policy_call_ms_mean=debug_policy_mean,
         no_op_recorder_overhead_pct=recorder_overhead_pct,


### PR DESCRIPTION
## Summary
- Fast-path empty `MELIX_PROBE_MODE` handling in `ProbePolicy.from_env(...)` by returning the cached default policy directly.
- Extend no-op probe-policy overhead metrics with `env_parse_empty_call_ms_mean` so the registered probe measures the optimized path.
- Add regression coverage and a governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-05-17-probe-policy-env-empty-fast-path.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=300000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py
# exit 0; baseline before change: no env metric yet; no-op threshold passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 16 passed in 0.68s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py
# exit 0; 16 passed; TOTAL 10 0 100%

python3 - <<'PY'
# Ad-hoc origin/main vs head from_env({}) microbenchmark, 500000 iterations x 5 samples.
PY
# exit 0; old_mean_ms=0.00042998799858614807, new_mean_ms=0.00019596607154235245, speedup=2.1941961442709155, delta_ms=-0.00023402192704379563

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=300000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py
# exit 0; env_parse_empty_call_ms_mean=0.000205494; threshold_passed=1.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py
# exit 0; registered probe script locally, env_parse_empty_call_ms_mean=0.000202863; threshold_passed=1.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 10 0 100%`).
- Registered probe path: `probe-policy-noop-overhead` is already registered with focused `test_command`, `coverage_command`, and `probe_command` entries.
- Local ad-hoc base-vs-head metric for the optimized path: `old_mean_ms=0.00042998799858614807`, `new_mean_ms=0.00019596607154235245`, `speedup=2.1941961442709155`, `delta_ms=-0.00023402192704379563` for `ProbePolicy.from_env({})` over 500000 iterations x 5 samples.
- Local registered probe script metric on head: `env_parse_empty_call_ms_mean=0.000202863`, `threshold_passed=1.0`, `iteration_count=1000000.0`, `sample_count=5.0`.
- CI PR-scoped performance is required as the final registered probe validation before merge.

## Known Gaps
- Linux local verification only; this slice is Python-only and makes no Swift runtime performance claim.
- The PR-scoped performance workflow report is the merge gate for registered probe validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
